### PR TITLE
refactor(collection): group Collection god-object fields into 6 concern sub-structs (R1.1)

### DIFF
--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -61,7 +61,7 @@ impl Collection {
         // pre-batch value; duplicates get None so the old value is decremented
         // exactly once.
         let old_payloads: Vec<Option<serde_json::Value>> = if payloads.is_some() {
-            let storage = self.payload_storage.read();
+            let storage = self.storage.payload_storage.read();
             let mut seen = HashSet::new();
             ids.iter()
                 .map(|&id| {
@@ -93,7 +93,7 @@ impl Collection {
         self.update_secondary_indexes_from_raw(ids, payloads, &old_payloads);
 
         let inserted = self.bulk_index_or_defer(&vector_refs);
-        self.config.write().point_count = self.vector_storage.read().len();
+        self.storage.config.write().point_count = self.storage.vector_storage.read().len();
 
         self.maintain_histograms_for_raw(ids, payloads, &old_payloads);
 
@@ -190,7 +190,7 @@ impl Collection {
                 )));
             }
         }
-        let collection_dim = self.config.read().dimension;
+        let collection_dim = self.storage.config.read().dimension;
         validate_dimension_match(collection_dim, dimension)?;
         self.enforce_raw_upsert_limits(ids, payloads)?;
         Ok(())
@@ -214,9 +214,12 @@ impl Collection {
             return Ok(());
         }
         if fsync {
-            self.payload_storage.write().store_batch(entries)?;
+            self.storage.payload_storage.write().store_batch(entries)?;
         } else {
-            self.payload_storage.write().store_batch_deferred(entries)?;
+            self.storage
+                .payload_storage
+                .write()
+                .store_batch_deferred(entries)?;
         }
         Ok(())
     }
@@ -272,7 +275,7 @@ impl Collection {
         old_payloads: &[Option<serde_json::Value>],
     ) {
         let Some(ps) = payloads else { return };
-        if self.secondary_indexes.read().is_empty() {
+        if self.query.secondary_indexes.read().is_empty() {
             return;
         }
         for (i, opt) in ps.iter().enumerate() {
@@ -307,12 +310,12 @@ impl Collection {
                 if !text.is_empty() {
                     #[cfg(feature = "persistence")]
                     self.append_bm25_wal_add(ids[i], &text)?;
-                    self.text_index.add_document(ids[i], &text);
+                    self.storage.text_index.add_document(ids[i], &text);
                 }
             } else {
                 #[cfg(feature = "persistence")]
                 self.append_bm25_wal_remove(ids[i])?;
-                self.text_index.remove_document(ids[i]);
+                self.storage.text_index.remove_document(ids[i]);
             }
         }
         Ok(())
@@ -336,7 +339,7 @@ impl Collection {
         if !has_labels {
             return;
         }
-        let mut label_idx = self.label_index.write();
+        let mut label_idx = self.graph.label_index.write();
         for (i, opt) in ps.iter().enumerate() {
             if let Some(payload) = opt {
                 label_idx.index_from_payload(ids[i], payload);

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -26,7 +26,7 @@ impl Collection {
     /// attempting to insert vectors into a metadata-only collection.
     pub fn upsert(&self, points: impl IntoIterator<Item = Point>) -> Result<()> {
         let points: Vec<Point> = points.into_iter().collect();
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let dimension = config.dimension;
         let storage_mode = config.storage_mode;
 
@@ -155,7 +155,7 @@ impl Collection {
         // Collect old payloads under the payload write lock, then release.
         // The write lock prevents concurrent payload mutations during the read.
         let old_payloads = {
-            let payload_storage = self.payload_storage.write();
+            let payload_storage = self.storage.payload_storage.write();
             let result = Self::collect_old_payloads(points, &payload_storage);
             drop(payload_storage);
             result
@@ -195,7 +195,7 @@ impl Collection {
     /// Issue #425: Accepts a pre-computed `dedup_map` to avoid rebuilding
     /// the last-writer-wins map redundantly.
     fn write_and_flush_payloads(&self, points: &[Point], dedup_map: &DedupMap) -> Result<()> {
-        let mut payload_storage = self.payload_storage.write();
+        let mut payload_storage = self.storage.payload_storage.write();
         Self::write_deduped_payloads(points, &mut payload_storage, dedup_map)?;
         payload_storage.flush()?;
         Ok(())
@@ -276,13 +276,13 @@ impl Collection {
             .map(|(_, p)| (p.id, p.vector.as_slice()))
             .collect();
 
-        let mut vector_storage = self.vector_storage.write();
+        let mut vector_storage = self.storage.vector_storage.write();
         vector_storage.store_batch(&deduped)?;
         let point_count = vector_storage.len();
         vector_storage.flush()?;
         drop(vector_storage);
 
-        self.config.write().point_count = point_count;
+        self.storage.config.write().point_count = point_count;
         Ok(())
     }
 
@@ -300,14 +300,14 @@ impl Collection {
         }
 
         // Secondary indexes require per-point old/new payload diffing
-        let no_secondary = self.secondary_indexes.read().is_empty();
+        let no_secondary = self.query.secondary_indexes.read().is_empty();
         if !no_secondary {
             return false;
         }
 
         // BM25 text index: skip only when the index is empty AND no point
         // carries a payload (nothing to add, nothing to remove)
-        let bm25_empty = self.text_index.is_empty();
+        let bm25_empty = self.storage.text_index.is_empty();
         let any_payload = points.iter().any(|p| p.payload.is_some());
         if !bm25_empty || any_payload {
             return false;
@@ -315,7 +315,7 @@ impl Collection {
 
         // Label index: when populated, old payloads may contain `_labels`
         // that need cleanup. Phase 2 must run to call `apply_label_updates`.
-        if !self.label_index.read().is_empty() {
+        if !self.graph.label_index.read().is_empty() {
             return false;
         }
 
@@ -385,7 +385,8 @@ impl Collection {
         let mut sparse_batch = Vec::new();
         let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> =
             HashMap::with_capacity(points.len());
-        let skip_bm25 = self.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
+        let skip_bm25 =
+            self.storage.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
         let needs_label_updates = Self::needs_label_updates(points, old_payloads);
         let mut label_updates = Self::alloc_label_buffer(needs_label_updates, points.len());
 
@@ -410,7 +411,7 @@ impl Collection {
             seen_payloads.insert(point.id, point.payload.as_ref());
         }
 
-        Self::apply_label_updates(&self.label_index, &label_updates);
+        Self::apply_label_updates(&self.graph.label_index, &label_updates);
         Ok(sparse_batch)
     }
 
@@ -431,8 +432,8 @@ impl Collection {
         self.enforce_upsert_limits(&points)?;
 
         // LOCK ORDER: payload_storage(3) → label_index(7).
-        let mut payload_storage = self.payload_storage.write();
-        let mut label_idx = self.label_index.write();
+        let mut payload_storage = self.storage.payload_storage.write();
+        let mut label_idx = self.graph.label_index.write();
 
         // Collect old payloads for histogram decrements before they are overwritten.
         // Bug #46: use collect_old_payloads to deduplicate by ID — only the
@@ -451,7 +452,7 @@ impl Collection {
         drop(payload_storage);
 
         // config(1) only — payload_storage(3) and label_index(7) both released above.
-        self.config.write().point_count = point_count;
+        self.storage.config.write().point_count = point_count;
 
         // Incremental histogram maintenance for metadata-only collections
         // (Bug #47 + Bug #49): dedup by id and replace histograms in one

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -72,7 +72,7 @@ impl Collection {
 
         // Parity item E + dimension validation at the cold boundary, before any
         // storage lock / WAL write (shared with the single-upsert path).
-        let dimension = self.config.read().dimension;
+        let dimension = self.storage.config.read().dimension;
         self.validate_vector_upsert_batch(points, dimension)?;
 
         let vector_refs: Vec<(u64, &[f32])> =
@@ -83,7 +83,8 @@ impl Collection {
         // bypasses RaBitQPrecisionHnsw::insert — on a RaBitQ backend that
         // would desynchronize the positional encoding store from the node
         // ids. RaBitQ collections always take the standard path.
-        let use_v2 = self.async_index_builder.is_some() && !self.index.is_rabitq_backend();
+        let use_v2 =
+            self.streaming.async_index_builder.is_some() && !self.storage.index.is_rabitq_backend();
         let count = if use_v2 {
             self.upsert_bulk_v2_path(&vector_refs, points, &sparse_batch, fsync)?
         } else {
@@ -111,7 +112,7 @@ impl Collection {
         sparse_batch: &BTreeMap<String, Vec<(u64, crate::index::sparse::SparseVector)>>,
         fsync: bool,
     ) -> Result<usize> {
-        let Some(aib) = self.async_index_builder.as_ref() else {
+        let Some(aib) = self.streaming.async_index_builder.as_ref() else {
             return Err(Error::Config(
                 "bulk v2 path requires async index builder".to_string(),
             ));
@@ -119,7 +120,7 @@ impl Collection {
 
         // Collect pre-batch payloads before overwriting — used for histogram decrements.
         let old_payloads = {
-            let storage = self.payload_storage.read();
+            let storage = self.storage.payload_storage.read();
             Self::collect_old_payloads(points, &storage)
         };
 
@@ -129,7 +130,7 @@ impl Collection {
         // Write directly to the graph's ContiguousVectors so vectors are
         // immediately visible to rerank/brute-force while HNSW construction
         // is deferred.
-        let writer = DirectVectorWriter::new(&self.index);
+        let writer = DirectVectorWriter::new(&self.storage.index);
         writer.write_batch_direct(vector_refs)?;
 
         // Enqueue for deferred HNSW construction.
@@ -140,7 +141,7 @@ impl Collection {
 
         if needs_flush {
             // Buffer reached merge_threshold — flush synchronously.
-            aib.flush_sync(&self.index)?;
+            aib.flush_sync(&self.storage.index)?;
         }
 
         let count = vector_refs.len();
@@ -148,7 +149,8 @@ impl Collection {
 
         // Track inserts for periodic HNSW save (Issue #423 Component 3).
         #[allow(clippy::cast_possible_truncation)]
-        self.inserts_since_last_hnsw_save
+        self.generations
+            .inserts_since_last_hnsw_save
             .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
 
         tracing::debug!(
@@ -168,7 +170,7 @@ impl Collection {
     ) -> Result<usize> {
         // Collect pre-batch payloads before overwriting — used for histogram decrements.
         let old_payloads = {
-            let storage = self.payload_storage.read();
+            let storage = self.storage.payload_storage.read();
             Self::collect_old_payloads(points, &storage)
         };
 
@@ -189,7 +191,7 @@ impl Collection {
         old_payloads: &[Option<serde_json::Value>],
         sparse_batch: &BTreeMap<String, Vec<(u64, crate::index::sparse::SparseVector)>>,
     ) -> Result<()> {
-        self.config.write().point_count = self.vector_storage.read().len();
+        self.storage.config.write().point_count = self.storage.vector_storage.read().len();
         self.apply_sparse_batch_bulk(sparse_batch)?;
         // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
         // so only the final payload counts, then atomic decrement + increment.
@@ -259,7 +261,7 @@ impl Collection {
     /// `BufWriter` but `flush()` is skipped entirely. The mmap write is
     /// still performed so the data is immediately readable in-process.
     fn bulk_store_vectors_inner(&self, vectors: &[(u64, &[f32])], fsync: bool) -> Result<()> {
-        let mut storage = self.vector_storage.write();
+        let mut storage = self.storage.vector_storage.write();
         storage.store_batch(vectors)?;
         if fsync {
             storage.flush()?;
@@ -281,9 +283,10 @@ impl Collection {
             .collect();
 
         if fsync {
-            self.payload_storage.write().store_batch(&entries)?;
+            self.storage.payload_storage.write().store_batch(&entries)?;
         } else {
-            self.payload_storage
+            self.storage
+                .payload_storage
                 .write()
                 .store_batch_deferred(&entries)?;
         }
@@ -292,7 +295,7 @@ impl Collection {
         // index is empty, skip the text index loop entirely. The bulk path
         // inserts fresh points (no old documents to remove), so the loop
         // body would be a no-op for every point.
-        if !entries.is_empty() || !self.text_index.is_empty() {
+        if !entries.is_empty() || !self.storage.text_index.is_empty() {
             for point in points {
                 self.update_text_index(point)?;
             }
@@ -303,7 +306,7 @@ impl Collection {
         // per_point_updates for the single-upsert path). Without this,
         // MATCH queries with label patterns (e.g., `(d:Doc)`) return
         // empty results for points inserted via upsert_bulk / REST API.
-        Self::update_label_index_bulk(&self.label_index, points);
+        Self::update_label_index_bulk(&self.graph.label_index, points);
 
         Ok(())
     }
@@ -344,7 +347,7 @@ impl Collection {
                     .map(move |(point_id, sv)| (name.as_str(), *point_id, sv))
             }))?;
         }
-        let mut indexes = self.sparse_indexes.write();
+        let mut indexes = self.query.sparse_indexes.write();
         for (name, docs) in sparse_batch {
             let idx = indexes.entry(name.clone()).or_default();
             idx.insert_batch_chunk(docs);

--- a/crates/velesdb-core/src/collection/core/crud_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/crud_helpers.rs
@@ -31,10 +31,11 @@ impl<'a> QuantizationGuards<'a> {
     /// Acquires all quantization cache guards matching `mode`.
     pub(super) fn acquire(collection: &'a Collection, mode: StorageMode) -> Self {
         Self {
-            sq8: matches!(mode, StorageMode::SQ8).then(|| collection.sq8_cache.write()),
-            binary: matches!(mode, StorageMode::Binary).then(|| collection.binary_cache.write()),
+            sq8: matches!(mode, StorageMode::SQ8).then(|| collection.storage.sq8_cache.write()),
+            binary: matches!(mode, StorageMode::Binary)
+                .then(|| collection.storage.binary_cache.write()),
             pq: matches!(mode, StorageMode::ProductQuantization)
-                .then(|| collection.pq_cache.write()),
+                .then(|| collection.storage.pq_cache.write()),
         }
     }
 
@@ -47,7 +48,7 @@ impl<'a> QuantizationGuards<'a> {
             sq8: None,
             binary: None,
             pq: matches!(mode, StorageMode::ProductQuantization)
-                .then(|| collection.pq_cache.write()),
+                .then(|| collection.storage.pq_cache.write()),
         }
     }
 }
@@ -99,11 +100,11 @@ impl Collection {
         point: &Point,
         pq_cache: Option<&mut std::collections::HashMap<u64, PQVector>>,
     ) {
-        let mut quantizer_guard = self.pq_quantizer.write();
+        let mut quantizer_guard = self.storage.pq_quantizer.write();
         let mut backfill_samples: Vec<(u64, Vec<f32>)> = Vec::new();
 
         if quantizer_guard.is_none() {
-            let mut buffer = self.pq_training_buffer.write();
+            let mut buffer = self.storage.pq_training_buffer.write();
             buffer.push_back((point.id, point.vector.clone()));
             if buffer.len() >= PQ_TRAINING_SAMPLES {
                 let training: Vec<Vec<f32>> =
@@ -117,7 +118,7 @@ impl Collection {
                 .ok();
                 #[cfg(feature = "persistence")]
                 if let Some(ref pq) = trained {
-                    let _ = pq.save_codebook(&self.path);
+                    let _ = pq.save_codebook(&self.storage.path);
                 }
                 *quantizer_guard = trained;
                 backfill_samples = buffer.drain(..).collect();
@@ -144,7 +145,7 @@ impl Collection {
         old_payload: Option<&serde_json::Value>,
         new_payload: Option<&serde_json::Value>,
     ) {
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         for (field, index) in indexes.iter() {
             if let Some(old_value) = old_payload
                 .and_then(|p| p.get(field))
@@ -170,7 +171,7 @@ impl Collection {
         let Some(payload) = old_payload else {
             return;
         };
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         for (field, index) in indexes.iter() {
             if let Some(old_value) = payload.get(field).and_then(JsonValue::from_json) {
                 self.remove_from_secondary_index(index, &old_value, id);
@@ -228,7 +229,7 @@ impl Collection {
             .par_iter()
             .map(|p| (p.id, QuantizedVector::from_f32(&p.vector)))
             .collect();
-        let mut cache = self.sq8_cache.write();
+        let mut cache = self.storage.sq8_cache.write();
         for (id, qv) in quantized {
             cache.insert(id, qv);
         }
@@ -244,7 +245,7 @@ impl Collection {
             .par_iter()
             .map(|p| (p.id, BinaryQuantizedVector::from_f32(&p.vector)))
             .collect();
-        let mut cache = self.binary_cache.write();
+        let mut cache = self.storage.binary_cache.write();
         for (id, bqv) in quantized {
             cache.insert(id, bqv);
         }

--- a/crates/velesdb-core/src/collection/core/crud_histogram.rs
+++ b/crates/velesdb-core/src/collection/core/crud_histogram.rs
@@ -29,8 +29,8 @@ impl Collection {
         old_payloads: &[Option<serde_json::Value>],
         new_payloads: &[Option<serde_json::Value>],
     ) {
-        let stats_path = self.path.join("collection.stats.json");
-        let _guard = self.stats_io_mutex.lock();
+        let stats_path = self.storage.path.join("collection.stats.json");
+        let _guard = self.query.stats_io_mutex.lock();
 
         let Some(mut stats) = Self::read_persisted_stats(&stats_path) else {
             return;
@@ -57,10 +57,10 @@ impl Collection {
         payloads: &[Option<serde_json::Value>],
         increment: bool,
     ) {
-        let stats_path = self.path.join("collection.stats.json");
+        let stats_path = self.storage.path.join("collection.stats.json");
 
         // LOCK ORDER: stats_io_mutex (12) — no other lock held.
-        let _guard = self.stats_io_mutex.lock();
+        let _guard = self.query.stats_io_mutex.lock();
 
         let Some(mut stats) = Self::read_persisted_stats(&stats_path) else {
             return;
@@ -164,8 +164,8 @@ impl Collection {
     /// race with incremental histogram updates (Bug #51). Returns `Ok(())`
     /// on success, or an I/O / serialisation error.
     pub fn write_stats_guarded(&self, stats: &CollectionStats) -> crate::error::Result<()> {
-        let stats_path = self.path.join("collection.stats.json");
-        let _guard = self.stats_io_mutex.lock();
+        let stats_path = self.storage.path.join("collection.stats.json");
+        let _guard = self.query.stats_io_mutex.lock();
 
         let serialized = serde_json::to_vec_pretty(stats).map_err(|e| {
             crate::error::Error::Serialization(format!("failed to serialize stats: {e}"))

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -148,12 +148,12 @@ impl Collection {
             if !text.is_empty() {
                 #[cfg(feature = "persistence")]
                 self.append_bm25_wal_add(point.id, &text)?;
-                self.text_index.add_document(point.id, &text);
+                self.storage.text_index.add_document(point.id, &text);
             }
         } else {
             #[cfg(feature = "persistence")]
             self.append_bm25_wal_remove(point.id)?;
-            self.text_index.remove_document(point.id);
+            self.storage.text_index.remove_document(point.id);
         }
         Ok(())
     }
@@ -166,7 +166,7 @@ impl Collection {
     #[cfg(feature = "persistence")]
     #[inline]
     pub(super) fn append_bm25_wal_add(&self, id: u64, text: &str) -> Result<()> {
-        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.storage.path);
         crate::index::bm25_persistence_wal::wal_append_add_document(&wal_path, id, text)
     }
 
@@ -174,7 +174,7 @@ impl Collection {
     #[cfg(feature = "persistence")]
     #[inline]
     pub(super) fn append_bm25_wal_remove(&self, id: u64) -> Result<()> {
-        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.storage.path);
         crate::index::bm25_persistence_wal::wal_append_remove_document(&wal_path, id)
     }
 
@@ -206,7 +206,7 @@ impl Collection {
         for (name, point_id, sv) in entries {
             if cached.as_ref().map(|(cached_name, _)| *cached_name) != Some(name) {
                 let wal_path =
-                    crate::index::sparse::persistence::wal_path_for_name(&self.path, name);
+                    crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
                 cached = Some((name, wal_path));
             }
             let Some((_, wal_path)) = cached.as_ref() else {
@@ -233,7 +233,7 @@ impl Collection {
                     .map(move |(name, sv)| (name.as_str(), *point_id, sv))
             }))?;
         }
-        let mut indexes = self.sparse_indexes.write();
+        let mut indexes = self.query.sparse_indexes.write();
         for (point_id, sv_map) in sparse_batch {
             for (name, sv) in sv_map {
                 let idx = indexes.entry(name.clone()).or_default();
@@ -249,27 +249,30 @@ impl Collection {
     /// explicitly maintain the mirror must invalidate it so stale columnar
     /// data can never serve queries (it is rebuilt lazily on demand).
     pub(super) fn invalidate_caches_and_bump_generation(&self) {
-        *self.cached_stats.lock() = None;
-        self.payload_mirror.invalidate();
-        self.write_generation
+        *self.query.cached_stats.lock() = None;
+        self.storage.payload_mirror.invalidate();
+        self.generations
+            .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Like [`Self::invalidate_caches_and_bump_generation`], but keeps the
     /// payload mirror warm by applying the upserted points incrementally.
     pub(super) fn bump_generation_with_mirror_upserts(&self, points: &[crate::point::Point]) {
-        *self.cached_stats.lock() = None;
-        self.payload_mirror.apply_upserts(points);
-        self.write_generation
+        *self.query.cached_stats.lock() = None;
+        self.storage.payload_mirror.apply_upserts(points);
+        self.generations
+            .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Like [`Self::invalidate_caches_and_bump_generation`], but keeps the
     /// payload mirror warm by tombstoning the deleted ids incrementally.
     pub(super) fn bump_generation_with_mirror_deletes(&self, ids: &[u64]) {
-        *self.cached_stats.lock() = None;
-        self.payload_mirror.apply_deletes(ids);
-        self.write_generation
+        *self.query.cached_stats.lock() = None;
+        self.storage.payload_mirror.apply_deletes(ids);
+        self.generations
+            .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
@@ -280,7 +283,7 @@ impl Collection {
         if drained.is_empty() {
             return;
         }
-        let storage = self.vector_storage.read();
+        let storage = self.storage.vector_storage.read();
         let valid: Vec<(u64, &[f32])> = drained
             .iter()
             .filter(|(id, _)| storage.retrieve(*id).ok().flatten().is_some())
@@ -291,7 +294,7 @@ impl Collection {
         if valid.is_empty() {
             return;
         }
-        let inserted = self.index.insert_batch_parallel(valid);
+        let inserted = self.storage.index.insert_batch_parallel(valid);
         if inserted < expected {
             tracing::warn!("merge_deferred_batch: inserted {inserted}/{expected} vectors");
         }
@@ -301,7 +304,7 @@ impl Collection {
     pub(super) fn bulk_index_or_defer(&self, vector_refs: &[(u64, &[f32])]) -> usize {
         let count = vector_refs.len();
         #[cfg(feature = "persistence")]
-        if let Some(ref di) = self.deferred_indexer {
+        if let Some(ref di) = self.streaming.deferred_indexer {
             // PERF3: the per-vector `to_vec()` copy is intrinsic to the
             // deferred contract — `vector_refs` borrows the caller's data and
             // does not outlive this call, while the deferred buffer must own
@@ -315,15 +318,18 @@ impl Collection {
                 self.merge_deferred_batch(di);
             }
             #[allow(clippy::cast_possible_truncation)]
-            self.inserts_since_last_hnsw_save
+            self.generations
+                .inserts_since_last_hnsw_save
                 .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
             return count;
         }
         let inserted = self
+            .storage
             .index
             .insert_batch_parallel(vector_refs.iter().copied());
         #[allow(clippy::cast_possible_truncation)]
-        self.inserts_since_last_hnsw_save
+        self.generations
+            .inserts_since_last_hnsw_save
             .fetch_add(count as u64, std::sync::atomic::Ordering::Relaxed);
         inserted
     }

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -36,11 +36,11 @@ impl Collection {
     /// after a restart, so `auto_expire` could never reclaim their storage.
     #[must_use]
     pub(crate) fn get_raw(&self, ids: &[u64]) -> Vec<Option<Point>> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let is_metadata_only = config.metadata_only;
         drop(config);
 
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         if is_metadata_only {
             // For metadata-only collections, only retrieve payload
@@ -57,7 +57,7 @@ impl Collection {
                 .collect()
         } else {
             // For vector collections, retrieve both vector and payload
-            let vector_storage = self.vector_storage.read();
+            let vector_storage = self.storage.vector_storage.read();
             ids.iter()
                 .map(|&id| {
                     let vector = vector_storage.retrieve(id).ok().flatten()?;
@@ -82,7 +82,7 @@ impl Collection {
         // Collect old payloads for incremental histogram maintenance.
         let old_payloads = self.collect_payloads_for_histogram(ids);
 
-        if self.config.read().metadata_only {
+        if self.storage.config.read().metadata_only {
             self.delete_metadata_only(ids)?;
         } else {
             self.delete_vector_points(ids)?;
@@ -122,32 +122,34 @@ impl Collection {
         // Cascade whenever edges exist — the graph dimension is first-class
         // on every collection type (agent-memory relations live on vector
         // collections). Empty stores (the common case) return immediately.
-        if self.edge_store.is_empty() {
+        if self.graph.edge_store.is_empty() {
             return Ok(());
         }
         let mut removed_any = false;
         for &id in ids {
             // Both directions: `remove_node_edges` clears outgoing AND incoming
             // edges so no dangling edge references the deleted node.
-            let before = self.edge_store.outgoing_degree(id) + self.edge_store.incoming_degree(id);
+            let before = self.graph.edge_store.outgoing_degree(id)
+                + self.graph.edge_store.incoming_degree(id);
             if before > 0 {
                 // WAL-before-apply (crash durability): log the cascade remove
                 // before mutating the store so a crash replays the tombstone.
                 // The WAL lock spans append + apply (see `add_edge`).
-                let _wal_guard = self.edge_wal_lock.lock();
+                let _wal_guard = self.graph.edge_wal_lock.lock();
                 #[cfg(feature = "persistence")]
                 crate::collection::graph::edge_wal::wal_append_remove_node(
-                    &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                    &crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path),
                     id,
                 )?;
-                self.edge_store.remove_node_edges(id);
+                self.graph.edge_store.remove_node_edges(id);
                 removed_any = true;
             }
         }
         if removed_any {
             // Bump write generation so cached query plans referencing the now
             // removed edges are invalidated on the next query (CACHE-01).
-            self.write_generation
+            self.generations
+                .write_generation
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         Ok(())
@@ -155,7 +157,7 @@ impl Collection {
 
     /// Collects current payloads for the given IDs (for histogram decrements on delete).
     fn collect_payloads_for_histogram(&self, ids: &[u64]) -> Vec<Option<serde_json::Value>> {
-        let storage = self.payload_storage.read();
+        let storage = self.storage.payload_storage.read();
         ids.iter()
             .map(|&id| storage.retrieve(id).ok().flatten())
             .collect()
@@ -164,8 +166,8 @@ impl Collection {
     /// Deletes metadata-only points.
     fn delete_metadata_only(&self, ids: &[u64]) -> Result<()> {
         // LOCK ORDER: payload_storage(3) → label_index(7).
-        let mut payload_storage = self.payload_storage.write();
-        let mut label_idx = self.label_index.write();
+        let mut payload_storage = self.storage.payload_storage.write();
+        let mut label_idx = self.graph.label_index.write();
         for &id in ids {
             let old_payload = payload_storage.retrieve(id).ok().flatten();
             payload_storage.delete(id)?;
@@ -173,7 +175,7 @@ impl Collection {
             // recovery replays the remove.
             #[cfg(feature = "persistence")]
             self.append_bm25_wal_remove(id)?;
-            self.text_index.remove_document(id);
+            self.storage.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {
                 label_idx.remove_from_payload(id, old);
@@ -182,7 +184,7 @@ impl Collection {
         let point_count = payload_storage.ids().len();
         drop(label_idx);
         drop(payload_storage);
-        self.config.write().point_count = point_count;
+        self.storage.config.write().point_count = point_count;
         Ok(())
     }
 
@@ -197,18 +199,18 @@ impl Collection {
     /// Removes points from vector/payload storage, HNSW index, caches, and label index.
     fn delete_vector_core_stores(&self, ids: &[u64]) -> Result<()> {
         // LOCK ORDER: vector_storage(2) → payload_storage(3) → caches(4) → label_index(7).
-        let mut vector_storage = self.vector_storage.write();
-        let mut payload_storage = self.payload_storage.write();
-        let mut sq8_cache = self.sq8_cache.write();
-        let mut binary_cache = self.binary_cache.write();
-        let mut pq_cache = self.pq_cache.write();
-        let mut label_idx = self.label_index.write();
+        let mut vector_storage = self.storage.vector_storage.write();
+        let mut payload_storage = self.storage.payload_storage.write();
+        let mut sq8_cache = self.storage.sq8_cache.write();
+        let mut binary_cache = self.storage.binary_cache.write();
+        let mut pq_cache = self.storage.pq_cache.write();
+        let mut label_idx = self.graph.label_index.write();
 
         for &id in ids {
             let old_payload = payload_storage.retrieve(id).ok().flatten();
             vector_storage.delete(id)?;
             payload_storage.delete(id)?;
-            self.index.remove(id);
+            self.storage.index.remove(id);
             sq8_cache.remove(&id);
             binary_cache.remove(&id);
             pq_cache.remove(&id);
@@ -216,7 +218,7 @@ impl Collection {
             // recovery replays the remove.
             #[cfg(feature = "persistence")]
             self.append_bm25_wal_remove(id)?;
-            self.text_index.remove_document(id);
+            self.storage.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {
                 label_idx.remove_from_payload(id, old);
@@ -230,7 +232,7 @@ impl Collection {
         drop(sq8_cache);
         drop(binary_cache);
         drop(pq_cache);
-        self.config.write().point_count = point_count;
+        self.storage.config.write().point_count = point_count;
         Ok(())
     }
 
@@ -240,12 +242,12 @@ impl Collection {
         // Lock order: delta_buffer(10) acquired after sparse_indexes(9) released.
         #[cfg(feature = "persistence")]
         for &id in ids {
-            self.delta_buffer.remove(id);
+            self.streaming.delta_buffer.remove(id);
         }
 
         // Lock order: deferred_indexer(11) acquired after delta_buffer(10).
         #[cfg(feature = "persistence")]
-        if let Some(ref di) = self.deferred_indexer {
+        if let Some(ref di) = self.streaming.deferred_indexer {
             for &id in ids {
                 di.remove(id);
             }
@@ -256,16 +258,16 @@ impl Collection {
     fn delete_from_sparse_indexes(&self, ids: &[u64]) -> Result<()> {
         #[cfg(feature = "persistence")]
         {
-            let indexes = self.sparse_indexes.read();
+            let indexes = self.query.sparse_indexes.read();
             for name in indexes.keys() {
                 let wal_path =
-                    crate::index::sparse::persistence::wal_path_for_name(&self.path, name);
+                    crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
                 for &id in ids {
                     crate::index::sparse::persistence::wal_append_delete(&wal_path, id)?;
                 }
             }
         }
-        let indexes = self.sparse_indexes.read();
+        let indexes = self.query.sparse_indexes.read();
         for idx in indexes.values() {
             for &id in ids {
                 idx.delete(id);
@@ -284,7 +286,7 @@ impl Collection {
     /// Perf: Uses cached `point_count` from config instead of acquiring storage lock.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.config.read().point_count
+        self.storage.config.read().point_count
     }
 
     /// Returns true if the collection is empty.
@@ -293,7 +295,7 @@ impl Collection {
     /// the storage count rather than the HNSW-indexed count.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.config.read().point_count == 0
+        self.storage.config.read().point_count == 0
     }
 
     /// Returns all point IDs in the collection.
@@ -303,7 +305,7 @@ impl Collection {
     /// of IDs, use [`all_point_ids`](Self::all_point_ids).
     #[must_use]
     pub fn all_ids(&self) -> Vec<u64> {
-        self.payload_storage.read().ids()
+        self.storage.payload_storage.read().ids()
     }
 
     /// Returns all point IDs from both vector and payload storage.
@@ -317,9 +319,14 @@ impl Collection {
     /// so callers (e.g. `scroll_batch`) need not sort separately.
     #[must_use]
     pub fn all_point_ids(&self) -> Vec<u64> {
-        let mut ids: std::collections::BTreeSet<u64> =
-            self.vector_storage.read().ids().into_iter().collect();
-        for id in self.payload_storage.read().ids() {
+        let mut ids: std::collections::BTreeSet<u64> = self
+            .storage
+            .vector_storage
+            .read()
+            .ids()
+            .into_iter()
+            .collect();
+        for id in self.storage.payload_storage.read().ids() {
             ids.insert(id);
         }
         ids.into_iter().collect()

--- a/crates/velesdb-core/src/collection/core/crud_tests.rs
+++ b/crates/velesdb-core/src/collection/core/crud_tests.rs
@@ -46,11 +46,11 @@ fn test_upsert_product_quantization_after_training_backfills_cache() {
 
     // ASSERT
     assert!(
-        collection.pq_quantizer.read().is_some(),
+        collection.storage.pq_quantizer.read().is_some(),
         "quantizer should be trained after reaching sample threshold"
     );
     assert_eq!(
-        collection.pq_cache.read().len(),
+        collection.storage.pq_cache.read().len(),
         128,
         "all training samples should be backfilled in PQ cache"
     );
@@ -283,7 +283,7 @@ fn test_upsert_batch_produces_searchable_results() {
     let query: Vec<f32> = (0..16).map(|d| d as f32 * 0.01).collect();
     let results = coll.search(&query, 10).expect("search should succeed");
     assert_eq!(results.len(), 10, "search should return k results");
-    assert_eq!(coll.config.read().point_count, 200);
+    assert_eq!(coll.storage.config.read().point_count, 200);
 }
 
 /// Regression test: `upsert()` throughput should be close to `upsert_bulk()`.
@@ -507,7 +507,7 @@ fn test_upsert_intra_batch_wal_dedup_reduces_entries() {
 
     // The payload WAL should contain exactly 1 store entry (not 3)
     // Verify by counting IDs in the payload storage index
-    let payload_ids = coll.payload_storage.read().ids();
+    let payload_ids = coll.storage.payload_storage.read().ids();
     assert_eq!(payload_ids.len(), 1, "should have 1 unique payload ID");
     assert!(
         payload_ids.contains(&1),
@@ -515,7 +515,7 @@ fn test_upsert_intra_batch_wal_dedup_reduces_entries() {
     );
 
     // Verify correctness: last writer wins
-    let payload = coll.payload_storage.read().retrieve(1).unwrap();
+    let payload = coll.storage.payload_storage.read().retrieve(1).unwrap();
     assert_eq!(payload, Some(serde_json::json!({"v": "C"})));
 }
 
@@ -973,7 +973,7 @@ fn test_phase2_runs_when_secondary_indexes_exist() {
     coll.upsert(points).unwrap();
 
     // Verify the secondary index was populated
-    let indexes = coll.secondary_indexes.read();
+    let indexes = coll.query.secondary_indexes.read();
     let cat_index = indexes.get("category").expect("index should exist");
     match cat_index {
         crate::index::SecondaryIndex::BTree(tree) => {
@@ -1083,7 +1083,7 @@ fn test_bulk_bm25_skip_does_not_lose_text() {
 
     // BM25 should have indexed the text from point 1
     assert!(
-        !coll.text_index.is_empty(),
+        !coll.storage.text_index.is_empty(),
         "BM25 index should contain the document from bulk insert"
     );
 }
@@ -1155,7 +1155,7 @@ fn test_phase2_runs_for_sq8_storage_mode() {
 
     // SQ8 cache should have been populated by Phase 2
     assert_eq!(
-        coll.sq8_cache.read().len(),
+        coll.storage.sq8_cache.read().len(),
         1,
         "SQ8 cache should be populated — Phase 2 must not skip"
     );
@@ -1187,7 +1187,7 @@ fn test_parallel_sq8_quantization_correctness() {
     coll.upsert(points.clone()).unwrap();
 
     // Verify all 50 entries are in the SQ8 cache
-    let cache = coll.sq8_cache.read();
+    let cache = coll.storage.sq8_cache.read();
     assert_eq!(
         cache.len(),
         50,
@@ -1249,7 +1249,7 @@ fn test_parallel_binary_quantization_correctness() {
         .collect();
     coll.upsert(points.clone()).unwrap();
 
-    let cache = coll.binary_cache.read();
+    let cache = coll.storage.binary_cache.read();
     assert_eq!(
         cache.len(),
         50,
@@ -1415,7 +1415,7 @@ fn test_upsert_removes_stale_labels_from_label_index() {
     collection.upsert(vec![p1]).expect("upsert with labels");
 
     // Verify label is indexed
-    let label_idx = collection.label_index.read();
+    let label_idx = collection.graph.label_index.read();
     assert!(
         label_idx.lookup("Person").is_some_and(|b| b.contains(1)),
         "Person label should be indexed for node 1"
@@ -1433,7 +1433,7 @@ fn test_upsert_removes_stale_labels_from_label_index() {
         .expect("upsert without labels");
 
     // Verify stale label is removed
-    let label_idx = collection.label_index.read();
+    let label_idx = collection.graph.label_index.read();
     let still_has = label_idx.lookup("Person").is_some_and(|b| b.contains(1));
     assert!(
         !still_has,
@@ -1464,7 +1464,7 @@ fn test_can_skip_phase2_respects_populated_label_index() {
     collection.upsert(vec![p1]).expect("upsert with labels");
 
     // Verify label index is populated.
-    let label_idx = collection.label_index.read();
+    let label_idx = collection.graph.label_index.read();
     assert!(
         label_idx.lookup("Person").is_some_and(|b| b.contains(1)),
         "Person label should be indexed for node 1"
@@ -1480,7 +1480,7 @@ fn test_can_skip_phase2_respects_populated_label_index() {
         .expect("upsert without payload");
 
     // Verify stale label is removed — Phase 2 must have run.
-    let label_idx = collection.label_index.read();
+    let label_idx = collection.graph.label_index.read();
     let still_has = label_idx.lookup("Person").is_some_and(|b| b.contains(1));
     assert!(
         !still_has,
@@ -1522,7 +1522,7 @@ fn test_full_scan_fallback_filters_by_labels() {
         .expect("upsert large-ID nodes");
 
     // Confirm the label index has large_ids set and no indexed entries.
-    let label_idx = collection.label_index.read();
+    let label_idx = collection.graph.label_index.read();
     assert!(
         label_idx.has_large_ids(),
         "has_large_ids should be true after indexing nodes with ID > u32::MAX"

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -33,8 +33,8 @@ impl Collection {
         // Issue #423: vector_storage.flush() is now a fast path (WAL + mmap
         // only, no vectors.idx serialization). The WAL provides crash recovery
         // even with a stale index file.
-        self.vector_storage.write().flush()?;
-        self.payload_storage.write().flush()?;
+        self.storage.vector_storage.write().flush()?;
+        self.storage.payload_storage.write().flush()?;
         // Drain delta buffer into HNSW before persisting the index.
         // Lock order: delta_buffer(10) is acquired after vector_storage(2)
         // and payload_storage(3) — both already released above.
@@ -66,7 +66,7 @@ impl Collection {
         self.flush_core_storage()?;
         self.flush_derived_indexes()?;
         // Write the deferred vectors.idx AFTER all other flush steps.
-        self.vector_storage.read().flush_index()?;
+        self.storage.vector_storage.read().flush_index()?;
         Ok(())
     }
 
@@ -76,14 +76,15 @@ impl Collection {
     /// after adding the BM25 snapshot/WAL step (#389).
     fn flush_core_storage(&self) -> Result<()> {
         self.save_config()?;
-        self.vector_storage.write().flush()?;
-        self.payload_storage.write().flush()?;
+        self.storage.vector_storage.write().flush()?;
+        self.storage.payload_storage.write().flush()?;
         self.drain_delta_into_index();
         self.drain_deferred_into_index();
         self.drain_async_index_builder()?;
         // Always save HNSW on full flush and reset the counter.
-        self.index.save(&self.path)?;
-        self.inserts_since_last_hnsw_save
+        self.storage.index.save(&self.storage.path)?;
+        self.generations
+            .inserts_since_last_hnsw_save
             .store(0, std::sync::atomic::Ordering::Relaxed);
         self.flush_pq_codebook()?;
         self.flush_rabitq_quantizer()?;
@@ -108,11 +109,14 @@ impl Collection {
     /// created, so a pre-existing (non-BM25) collection reopened by
     /// newer code does not gain a spurious empty snapshot.
     fn flush_bm25_index(&self) -> Result<()> {
-        if self.text_index.is_empty() {
+        if self.storage.text_index.is_empty() {
             return Ok(());
         }
-        crate::index::bm25_persistence::save_snapshot(&self.path, &self.text_index)?;
-        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.path);
+        crate::index::bm25_persistence::save_snapshot(
+            &self.storage.path,
+            &self.storage.text_index,
+        )?;
+        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.storage.path);
         crate::index::bm25_persistence_wal::wal_truncate(&wal_path)?;
         Ok(())
     }
@@ -124,13 +128,13 @@ impl Collection {
     /// so this covers the lazy-training case to prevent codebook loss on restart.
     #[cfg(feature = "persistence")]
     fn flush_pq_codebook(&self) -> Result<()> {
-        let guard = self.pq_quantizer.read();
+        let guard = self.storage.pq_quantizer.read();
         let Some(ref pq) = *guard else {
             return Ok(());
         };
-        pq.save_codebook(&self.path)?;
+        pq.save_codebook(&self.storage.path)?;
         if pq.rotation.is_some() {
-            pq.save_rotation(&self.path)?;
+            pq.save_rotation(&self.storage.path)?;
         }
         Ok(())
     }
@@ -149,10 +153,10 @@ impl Collection {
     /// quantizer survives a restart instead of silently degrading to f32.
     #[cfg(feature = "persistence")]
     fn flush_rabitq_quantizer(&self) -> Result<()> {
-        let Some(rabitq) = self.index.rabitq_quantizer() else {
+        let Some(rabitq) = self.storage.index.rabitq_quantizer() else {
             return Ok(());
         };
-        rabitq.save(&self.path)?;
+        rabitq.save(&self.storage.path)?;
         Ok(())
     }
 
@@ -167,11 +171,13 @@ impl Collection {
     /// time for high-throughput workloads.
     fn save_hnsw_if_threshold_exceeded(&self) -> Result<()> {
         let count = self
+            .generations
             .inserts_since_last_hnsw_save
             .load(std::sync::atomic::Ordering::Relaxed);
         if count > Self::HNSW_SAVE_THRESHOLD {
-            self.index.save(&self.path)?;
-            self.inserts_since_last_hnsw_save
+            self.storage.index.save(&self.storage.path)?;
+            self.generations
+                .inserts_since_last_hnsw_save
                 .store(0, std::sync::atomic::Ordering::Relaxed);
         }
         Ok(())
@@ -182,7 +188,7 @@ impl Collection {
     /// No-op when the delta buffer is inactive (no rebuild in progress).
     #[cfg(feature = "persistence")]
     fn drain_delta_into_index(&self) {
-        let drained = self.delta_buffer.deactivate_and_drain();
+        let drained = self.streaming.delta_buffer.deactivate_and_drain();
         self.filter_and_insert_valid(&drained);
     }
 
@@ -195,7 +201,7 @@ impl Collection {
     /// No-op when deferred indexing is not configured.
     #[cfg(feature = "persistence")]
     fn drain_deferred_into_index(&self) {
-        if let Some(ref di) = self.deferred_indexer {
+        if let Some(ref di) = self.streaming.deferred_indexer {
             let drained = di.drain_all();
             self.filter_and_insert_valid(&drained);
         }
@@ -220,7 +226,7 @@ impl Collection {
         if drained.is_empty() {
             return;
         }
-        let storage = self.vector_storage.read();
+        let storage = self.storage.vector_storage.read();
         let valid: Vec<(u64, &[f32])> = drained
             .iter()
             .filter(|(id, _)| storage.retrieve(*id).ok().flatten().is_some())
@@ -228,7 +234,7 @@ impl Collection {
             .collect();
         drop(storage);
         if !valid.is_empty() {
-            self.index.insert_batch_parallel(valid);
+            self.storage.index.insert_batch_parallel(valid);
         }
     }
 
@@ -248,8 +254,8 @@ impl Collection {
     /// `warn` level before propagation so that operational dashboards can
     /// alert on repeated failures.
     fn drain_async_index_builder(&self) -> Result<()> {
-        if let Some(ref aib) = self.async_index_builder {
-            match aib.flush_sync(&self.index) {
+        if let Some(ref aib) = self.streaming.async_index_builder {
+            match aib.flush_sync(&self.storage.index) {
                 Ok(count) if count > 0 => {
                     tracing::debug!("flush: drained {count} vectors from async index builder");
                 }
@@ -265,13 +271,17 @@ impl Collection {
 
     /// Persists property index, range index, and edge store (EPIC-009 US-005).
     fn flush_secondary_indexes(&self) -> Result<()> {
-        let property_index_path = self.path.join("property_index.bin");
-        self.property_index
+        let property_index_path = self.storage.path.join("property_index.bin");
+        self.graph
+            .property_index
             .read()
             .save_to_file(&property_index_path)?;
 
-        let range_index_path = self.path.join("range_index.bin");
-        self.range_index.read().save_to_file(&range_index_path)?;
+        let range_index_path = self.storage.path.join("range_index.bin");
+        self.graph
+            .range_index
+            .read()
+            .save_to_file(&range_index_path)?;
 
         // Save the EdgeStore snapshot for ANY collection that uses the graph
         // dimension (edges now WAL-persist on every collection type, so the
@@ -279,20 +289,20 @@ impl Collection {
         // edge WAL grows without bound and a torn tail never heals). The
         // `edge_store.bin exists` arm keeps persisting deletions down to an
         // empty store.
-        let edge_store_path = self.path.join("edge_store.bin");
-        if !self.edge_store.is_empty() || edge_store_path.exists() {
-            self.edge_store.save_to_file(&edge_store_path)?;
+        let edge_store_path = self.storage.path.join("edge_store.bin");
+        if !self.graph.edge_store.is_empty() || edge_store_path.exists() {
+            self.graph.edge_store.save_to_file(&edge_store_path)?;
             // The snapshot now contains every edge, so the edge WAL delta is
             // redundant — truncate it AFTER the snapshot is durably written so
             // a crash between the two still replays the edges (never loses
             // them). Mirrors the BM25 snapshot → wal_truncate contract.
             #[cfg(feature = "persistence")]
             crate::collection::graph::edge_wal::wal_truncate(
-                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+                &crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path),
             )?;
             // Rebuild CSR read snapshot after flush so that subsequent reads
             // benefit from zero-copy neighbor lookups (EPIC-020 US-004).
-            self.edge_store.build_read_snapshot();
+            self.graph.edge_store.build_read_snapshot();
         }
 
         Ok(())
@@ -300,9 +310,9 @@ impl Collection {
 
     /// Compacts all named sparse indexes to disk (EPIC-062 / SPARSE-04).
     fn flush_sparse_indexes(&self) -> Result<()> {
-        let indexes = self.sparse_indexes.read();
+        let indexes = self.query.sparse_indexes.read();
         for (name, idx) in indexes.iter() {
-            crate::index::sparse::persistence::compact_named(&self.path, name, idx)?;
+            crate::index::sparse::persistence::compact_named(&self.storage.path, name, idx)?;
         }
         Ok(())
     }
@@ -337,9 +347,9 @@ impl Collection {
             }
         }
 
-        let config = self.config.read();
-        let config_path = self.path.join("config.json");
-        let tmp_path = self.path.join("config.json.tmp");
+        let config = self.storage.config.read();
+        let config_path = self.storage.path.join("config.json");
+        let tmp_path = self.storage.path.join("config.json.tmp");
         let config_data = serde_json::to_string_pretty(&*config)
             .map_err(|e| Error::Serialization(e.to_string()))?;
 
@@ -366,7 +376,8 @@ impl Collection {
     /// Returns an error if the underlying HNSW vacuum fails (for
     /// instance, when vector storage is disabled on the index).
     pub(crate) fn vacuum_hnsw_index(&self) -> Result<usize> {
-        self.index
+        self.storage
+            .index
             .vacuum()
             .map_err(|e| Error::Index(format!("HNSW vacuum failed: {e}")))
     }
@@ -381,6 +392,7 @@ impl Collection {
     /// Returns an error if the compaction I/O fails.
     pub(crate) fn compact_vector_storage(&self) -> Result<usize> {
         let reclaimed = self
+            .storage
             .vector_storage
             .write()
             .compact()
@@ -389,8 +401,9 @@ impl Collection {
         // the delta since the last HNSW save. Re-save the index to restore
         // the invariant "WAL ⊇ writes since last index save" that open-time
         // reconciliation relies on.
-        self.index.save(&self.path)?;
-        self.inserts_since_last_hnsw_save
+        self.storage.index.save(&self.storage.path)?;
+        self.generations
+            .inserts_since_last_hnsw_save
             .store(0, std::sync::atomic::Ordering::Relaxed);
         Ok(reclaimed)
     }
@@ -424,7 +437,7 @@ impl Collection {
         async_index_builder: Option<Option<crate::collection::streaming::AsyncIndexBuilderConfig>>,
     ) -> Result<()> {
         {
-            let mut config = self.config.write();
+            let mut config = self.storage.config.write();
             if let Some(rescore) = pq_rescore_oversampling {
                 config.pq_rescore_oversampling = rescore;
             }

--- a/crates/velesdb-core/src/collection/core/flush_defer_tests.rs
+++ b/crates/velesdb-core/src/collection/core/flush_defer_tests.rs
@@ -101,7 +101,7 @@ fn test_flush_full_saves_hnsw_to_disk() {
     drop(coll);
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
     assert_eq!(
-        reopened.index.len(),
+        reopened.storage.index.len(),
         5,
         "HNSW should have 5 vectors after flush_full + reopen"
     );
@@ -123,7 +123,7 @@ fn test_flush_full_then_reopen_has_no_gap() {
     // Reopen — HNSW should already have all vectors (no gap to recover).
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
     assert_eq!(
-        reopened.index.len(),
+        reopened.storage.index.len(),
         10,
         "HNSW should have all vectors (saved by flush_full)"
     );
@@ -138,7 +138,8 @@ fn test_flush_saves_hnsw_when_insert_threshold_exceeded() {
         Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine).expect("create");
 
     // Artificially set the counter above the threshold.
-    coll.inserts_since_last_hnsw_save
+    coll.generations
+        .inserts_since_last_hnsw_save
         .store(10_001, std::sync::atomic::Ordering::Relaxed);
 
     coll.upsert(make_points(0, 5)).expect("upsert");
@@ -152,7 +153,8 @@ fn test_flush_saves_hnsw_when_insert_threshold_exceeded() {
 
     // Counter should be reset after the save.
     assert_eq!(
-        coll.inserts_since_last_hnsw_save
+        coll.generations
+            .inserts_since_last_hnsw_save
             .load(std::sync::atomic::Ordering::Relaxed),
         0,
         "counter should be reset after HNSW save"
@@ -168,12 +170,14 @@ fn test_upsert_increments_hnsw_save_counter() {
 
     coll.upsert(make_points(0, 5)).expect("upsert");
     let count = coll
+        .generations
         .inserts_since_last_hnsw_save
         .load(std::sync::atomic::Ordering::Relaxed);
     assert_eq!(count, 5, "counter should be 5 after inserting 5 vectors");
 
     coll.upsert(make_points(10, 3)).expect("upsert2");
     let count = coll
+        .generations
         .inserts_since_last_hnsw_save
         .load(std::sync::atomic::Ordering::Relaxed);
     assert_eq!(count, 8, "counter should be 8 after inserting 3 more");

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -60,21 +60,22 @@ impl Collection {
         // the store-apply order (replay must resolve id collisions exactly
         // like live execution) and concurrent appends can never interleave
         // a multi-write entry.
-        let _wal_guard = self.edge_wal_lock.lock();
+        let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         crate::collection::graph::edge_wal::wal_append_add(
-            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path),
             &edge,
         )?;
 
-        self.edge_store.add_edge(edge)?;
+        self.graph.edge_store.add_edge(edge)?;
 
         // Populate edge property indexes (EPIC-047).
         self.index_edge_properties(edge_id, &rel_type, &properties);
 
         // Bump write generation so any cached plan for this collection is
         // invalidated on the next query (CACHE-01).
-        self.write_generation
+        self.generations
+            .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
@@ -109,10 +110,10 @@ impl Collection {
         // Unconditional WAL (see add_edge): writing edges implies wanting
         // them back after a restart, whatever the collection type. The WAL
         // lock spans append + apply (see add_edge).
-        let _wal_guard = self.edge_wal_lock.lock();
+        let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         crate::collection::graph::edge_wal::wal_append_add_batch(
-            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path),
             &edges,
         )?;
 
@@ -123,14 +124,15 @@ impl Collection {
             .map(|e| (e.id(), e.label().to_string(), e.properties().clone()))
             .collect();
 
-        let count = self.edge_store.add_edges_batch(edges);
+        let count = self.graph.edge_store.add_edges_batch(edges);
 
         for (edge_id, rel_type, properties) in &index_meta {
             self.index_edge_properties(*edge_id, rel_type, properties);
         }
 
         if count > 0 {
-            self.write_generation
+            self.generations
+                .write_generation
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         Ok(count)
@@ -140,10 +142,10 @@ impl Collection {
     /// re-running edge-property indexing for replayed ADD entries.
     ///
     /// Called from `Collection::open` AFTER `assemble`, so the snapshot is
-    /// already loaded into `self.edge_store`. A missing WAL file is a cheap
+    /// already loaded into `self.graph.edge_store`. A missing WAL file is a cheap
     /// no-op (legacy DBs predate this feature). The edge store is mutated
     /// in place via its `&self` methods; the closure indexes edge
-    /// properties into `self.edge_range_indexes`.
+    /// properties into `self.graph.edge_range_indexes`.
     ///
     /// # Errors
     ///
@@ -151,8 +153,8 @@ impl Collection {
     #[cfg(feature = "persistence")]
     pub(crate) fn replay_edge_wal(&self) -> Result<u64> {
         use crate::collection::graph::edge_wal::{wal_path_for_edges, wal_replay, ReplayOp};
-        let wal_path = wal_path_for_edges(&self.path);
-        let replayed = wal_replay(&wal_path, &self.edge_store, |op| {
+        let wal_path = wal_path_for_edges(&self.storage.path);
+        let replayed = wal_replay(&wal_path, &self.graph.edge_store, |op| {
             if let ReplayOp::Add(edge) = op {
                 if !edge.properties().is_empty() {
                     self.index_edge_properties(edge.id(), edge.label(), edge.properties());
@@ -161,7 +163,7 @@ impl Collection {
         })?;
         if replayed > 0 {
             // Refresh the CSR read snapshot so traversals see replayed edges.
-            self.edge_store.build_read_snapshot();
+            self.graph.edge_store.build_read_snapshot();
         }
         Ok(replayed)
     }
@@ -178,7 +180,7 @@ impl Collection {
     /// Returns `Error::SchemaValidation` if any label in `_labels` is not
     /// declared in the strict schema.
     fn validate_node_labels_against_schema(&self, payload: &serde_json::Value) -> Result<()> {
-        let schema = match self.config.read().graph_schema.clone() {
+        let schema = match self.storage.config.read().graph_schema.clone() {
             Some(s) if !s.is_schemaless() => s,
             _ => return Ok(()),
         };
@@ -200,7 +202,7 @@ impl Collection {
     /// Returns `Error::SchemaValidation` if an endpoint node is missing, has no
     /// `_labels`, or the edge violates the schema's edge-type constraints.
     fn validate_edge_referential_integrity(&self, edge: &GraphEdge) -> Result<()> {
-        let schema = match self.config.read().graph_schema.clone() {
+        let schema = match self.storage.config.read().graph_schema.clone() {
             Some(s) if !s.is_schemaless() => s,
             _ => return Ok(()),
         };
@@ -218,7 +220,7 @@ impl Collection {
     /// Returns `Error::SchemaValidation` if the node has no stored payload
     /// (referential integrity violation) or the payload declares no `_labels`.
     fn endpoint_node_type(&self, node_id: u64) -> Result<String> {
-        let payload = self.payload_storage.read().retrieve(node_id)?;
+        let payload = self.storage.payload_storage.read().retrieve(node_id)?;
         let Some(payload) = payload else {
             return Err(Error::SchemaValidation(format!(
                 "edge references non-existent node {node_id}"
@@ -241,7 +243,7 @@ impl Collection {
     /// Vector of all edges in the graph (cloned).
     #[must_use]
     pub fn get_all_edges(&self) -> Vec<GraphEdge> {
-        self.edge_store.all_edges()
+        self.graph.edge_store.all_edges()
     }
 
     /// Gets edges filtered by label.
@@ -255,7 +257,7 @@ impl Collection {
     /// Vector of edges with the specified label (cloned).
     #[must_use]
     pub fn get_edges_by_label(&self, label: &str) -> Vec<GraphEdge> {
-        self.edge_store.get_edges_by_label(label)
+        self.graph.edge_store.get_edges_by_label(label)
     }
 
     /// Gets outgoing edges from a specific node.
@@ -269,7 +271,7 @@ impl Collection {
     /// Vector of edges originating from the specified node (cloned).
     #[must_use]
     pub fn get_outgoing_edges(&self, node_id: u64) -> Vec<GraphEdge> {
-        self.edge_store.get_outgoing(node_id)
+        self.graph.edge_store.get_outgoing(node_id)
     }
 
     /// Gets incoming edges to a specific node.
@@ -283,7 +285,7 @@ impl Collection {
     /// Vector of edges pointing to the specified node (cloned).
     #[must_use]
     pub fn get_incoming_edges(&self, node_id: u64) -> Vec<GraphEdge> {
-        self.edge_store.get_incoming(node_id)
+        self.graph.edge_store.get_incoming(node_id)
     }
 
     /// Traverses the graph using BFS from a source node.
@@ -335,7 +337,7 @@ impl Collection {
         limit: usize,
     ) -> TraversalParams<'a> {
         TraversalParams {
-            store: &self.edge_store,
+            store: &self.graph.edge_store,
             filter,
             limit,
             max_depth,
@@ -393,8 +395,8 @@ impl Collection {
     /// Tuple of (`in_degree`, `out_degree`).
     #[must_use]
     pub fn get_node_degree(&self, node_id: u64) -> (usize, usize) {
-        let in_degree = self.edge_store.incoming_degree(node_id);
-        let out_degree = self.edge_store.outgoing_degree(node_id);
+        let in_degree = self.graph.edge_store.incoming_degree(node_id);
+        let out_degree = self.graph.edge_store.outgoing_degree(node_id);
         (in_degree, out_degree)
     }
 
@@ -412,7 +414,7 @@ impl Collection {
         // Cheap pre-check: a remove of a non-existent id must not create or
         // grow the WAL with junk tombstones (a racing remove between this
         // check and the append still replays as a harmless no-op).
-        if !self.edge_store.contains_edge(edge_id) {
+        if !self.graph.edge_store.contains_edge(edge_id) {
             return false;
         }
         // WAL-before-apply (crash durability): log the remove intent before
@@ -420,10 +422,10 @@ impl Collection {
         // mutate the store and report `false` (no panic — matches the
         // no-unwrap policy and the bool return contract). Unconditional for
         // the same reason as add_edge; the WAL lock spans append + apply.
-        let _wal_guard = self.edge_wal_lock.lock();
+        let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         if let Err(e) = crate::collection::graph::edge_wal::wal_append_remove(
-            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.path),
+            &crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path),
             edge_id,
         ) {
             tracing::error!("Edge WAL append remove failed for edge {edge_id}: {e}");
@@ -431,9 +433,10 @@ impl Collection {
         }
 
         // Atomic check-and-remove — no TOCTOU race.
-        let removed = self.edge_store.remove_edge(edge_id);
+        let removed = self.graph.edge_store.remove_edge(edge_id);
         if removed {
-            self.write_generation
+            self.generations
+                .write_generation
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
         removed
@@ -442,17 +445,17 @@ impl Collection {
     /// Returns the total number of edges in the graph.
     #[must_use]
     pub fn edge_count(&self) -> usize {
-        self.edge_store.len()
+        self.graph.edge_store.len()
     }
 
     /// Returns the highest edge id in the graph, if any (no edge cloning).
     pub(crate) fn max_edge_id(&self) -> Option<u64> {
-        self.edge_store.max_edge_id()
+        self.graph.edge_store.max_edge_id()
     }
 
     /// Returns `true` when an edge with `edge_id` exists.
     pub(crate) fn edge_exists(&self, edge_id: u64) -> bool {
-        self.edge_store.contains_edge(edge_id)
+        self.graph.edge_store.contains_edge(edge_id)
     }
 
     /// Rebuilds edge property indexes from edges already in the store.
@@ -463,7 +466,7 @@ impl Collection {
     /// indexed at write time and silently lost once the WAL was truncated
     /// into the snapshot.
     pub(crate) fn reindex_edge_properties_from_store(&self) {
-        for edge in self.edge_store.all_edges() {
+        for edge in self.graph.edge_store.all_edges() {
             if !edge.properties().is_empty() {
                 self.index_edge_properties(edge.id(), edge.label(), edge.properties());
             }
@@ -477,20 +480,20 @@ impl Collection {
     /// Returns the graph schema stored in the collection config, if any.
     #[must_use]
     pub fn graph_schema(&self) -> Option<GraphSchema> {
-        self.config.read().graph_schema.clone()
+        self.storage.config.read().graph_schema.clone()
     }
 
     /// Returns `true` if this collection was created as a graph collection.
     #[must_use]
     #[allow(dead_code)] // Reason: Called via GraphCollection inner delegation + tests
     pub fn is_graph(&self) -> bool {
-        self.config.read().graph_schema.is_some()
+        self.storage.config.read().graph_schema.is_some()
     }
 
     /// Returns `true` if this graph collection stores node embeddings.
     #[must_use]
     pub fn has_embeddings(&self) -> bool {
-        self.config.read().embedding_dimension.is_some()
+        self.storage.config.read().embedding_dimension.is_some()
     }
 
     // -------------------------------------------------------------------------
@@ -521,17 +524,17 @@ impl Collection {
         // LOCK ORDER: payload_storage(3) → label_index(7) → graph_range_indexes(7).
         self.validate_node_labels_against_schema(payload)?;
 
-        let mut storage = self.payload_storage.write();
+        let mut storage = self.storage.payload_storage.write();
 
         // Remove old labels and property indexes if this is an update.
-        let mut label_idx = self.label_index.write();
+        let mut label_idx = self.graph.label_index.write();
         if let Ok(Some(old_payload)) = storage.retrieve(node_id) {
             label_idx.remove_from_payload(node_id, &old_payload);
             // Release label_index before touching graph property indexes
             // (both are at lock order 7, no ordering between them).
             drop(label_idx);
             self.deindex_node_properties(node_id, &old_payload);
-            label_idx = self.label_index.write();
+            label_idx = self.graph.label_index.write();
         }
 
         storage.store(node_id, payload)?;
@@ -544,11 +547,12 @@ impl Collection {
 
         // Node payload writes bypass the upsert mirror hooks — drop the
         // payload mirror so it can never serve stale columnar data.
-        self.payload_mirror.invalidate();
+        self.storage.payload_mirror.invalidate();
 
         // Bump write generation so any cached plan for this collection is
         // invalidated on the next query (CACHE-01).
-        self.write_generation
+        self.generations
+            .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         Ok(())
     }
@@ -559,7 +563,7 @@ impl Collection {
     ///
     /// Returns an error if retrieval fails.
     pub fn get_node_payload(&self, node_id: u64) -> Result<Option<serde_json::Value>> {
-        Ok(self.payload_storage.read().retrieve(node_id)?)
+        Ok(self.storage.payload_storage.read().retrieve(node_id)?)
     }
 
     // -------------------------------------------------------------------------
@@ -577,7 +581,8 @@ impl Collection {
     ) -> Vec<TraversalResult> {
         let start = std::time::Instant::now();
         let results = self.traverse_bfs_config_inner(source_id, config);
-        self.edge_store
+        self.graph
+            .edge_store
             .metrics()
             .record_traversal(start.elapsed(), results.len() as u64);
         results
@@ -598,9 +603,9 @@ impl Collection {
         // snapshot is stale-but-below-threshold we serve from the
         // authoritative per-shard streaming path instead of rebuilding on
         // every read — correct results, no stale data, no rebuild.
-        if self.edge_store.csr_is_authoritative() || self.edge_store.csr_rebuild_due() {
+        if self.graph.edge_store.csr_is_authoritative() || self.graph.edge_store.csr_rebuild_due() {
             // Prefer the lock-free CSR snapshot path when available (Issue #491).
-            let snapshot = self.edge_store.get_csr_snapshot();
+            let snapshot = self.graph.edge_store.get_csr_snapshot();
             // Guard: only use the CSR path when the snapshot has been populated
             // (node_count > 0). An empty snapshot means no edges have been
             // ingested yet, so we fall through to the per-shard streaming BFS.
@@ -618,7 +623,7 @@ impl Collection {
             max_visited_size: MAX_VISITED_SIZE,
             deadline: config.deadline,
         };
-        concurrent_bfs_stream(&self.edge_store, source_id, streaming)
+        concurrent_bfs_stream(&self.graph.edge_store, source_id, streaming)
             .filter(|result| result.depth >= config.min_depth)
             .take(config.limit)
             .collect()
@@ -635,7 +640,8 @@ impl Collection {
     ) -> Vec<TraversalResult> {
         let start = std::time::Instant::now();
         let results = self.traverse_dfs_config_inner(source_id, config);
-        self.edge_store
+        self.graph
+            .edge_store
             .metrics()
             .record_traversal(start.elapsed(), results.len() as u64);
         results
@@ -696,7 +702,7 @@ impl Collection {
                     max_pending: crate::collection::graph::MAX_VISITED_SIZE,
                 };
                 expand_dfs_neighbors(
-                    &self.edge_store,
+                    &self.graph.edge_store,
                     node_id,
                     depth,
                     &rel_filter,
@@ -730,7 +736,7 @@ impl Collection {
             .with_limit(config.limit);
 
         let traverser = ParallelTraverser::with_config(par_config);
-        let edge_store = &self.edge_store;
+        let edge_store = &self.graph.edge_store;
 
         let rel_types = &config.rel_types;
         let adjacency = |node: u64| -> Vec<(u64, u64)> {
@@ -764,7 +770,7 @@ impl Collection {
     /// Returns `Error::VectorNotAllowed` if no embeddings are configured,
     /// or `Error::DimensionMismatch` if the query dimension is wrong.
     pub fn search_by_embedding(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let emb_dim = config
             .embedding_dimension
             .ok_or_else(|| Error::VectorNotAllowed(config.name.clone()))?;
@@ -780,14 +786,14 @@ impl Collection {
         // Reason: we reuse the existing HNSW index (dimension == emb_dim when created
         // via create_graph_collection_with_embeddings). For graph-without-embeddings
         // the HNSW has dimension 0 and the guard above already rejected the call.
-        let metric = self.config.read().metric;
-        let ids = self.index.search(query, k);
+        let metric = self.storage.config.read().metric;
+        let ids = self.storage.index.search(query, k);
         let ids = self.merge_delta(ids, query, k, metric);
 
         // Acquire each lock once: collect vector data, then collect payload data.
         // This avoids holding vector_storage while locking payload_storage per item.
         let vectors: Vec<(u64, f32, Option<Vec<f32>>)> = {
-            let vector_storage = self.vector_storage.read();
+            let vector_storage = self.storage.vector_storage.read();
             ids.into_iter()
                 .map(|sr| {
                     let vec = vector_storage.retrieve(sr.id).ok().flatten();
@@ -796,7 +802,7 @@ impl Collection {
                 .collect()
         };
         let results = {
-            let payload_storage = self.payload_storage.read();
+            let payload_storage = self.storage.payload_storage.read();
             vectors
                 .into_iter()
                 .filter_map(|(id, score, vector)| {

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -452,12 +452,12 @@ mod tests {
         let (collection, _temp) = create_test_collection();
         build_chain(&collection);
 
-        let before = collection.edge_store.metrics().traversals_total();
+        let before = collection.graph.edge_store.metrics().traversals_total();
         let config = TraversalConfig::with_range(1, 3).with_limit(100);
         let results = collection.traverse_bfs_config(1, &config);
         assert!(!results.is_empty());
 
-        let metrics = collection.edge_store.metrics();
+        let metrics = collection.graph.edge_store.metrics();
         assert_eq!(
             metrics.traversals_total(),
             before + 1,
@@ -478,12 +478,12 @@ mod tests {
         let (collection, _temp) = create_test_collection();
         build_chain(&collection);
 
-        let before = collection.edge_store.metrics().traversals_total();
+        let before = collection.graph.edge_store.metrics().traversals_total();
         let config = TraversalConfig::with_range(1, 3).with_limit(100);
         let _ = collection.traverse_dfs_config(1, &config);
 
         assert_eq!(
-            collection.edge_store.metrics().traversals_total(),
+            collection.graph.edge_store.metrics().traversals_total(),
             before + 1,
             "DFS config traversal increments the counter"
         );
@@ -772,7 +772,7 @@ mod tests {
             max_pending,
         };
         expand_dfs_neighbors(
-            collection.edge_store.as_ref(),
+            collection.graph.edge_store.as_ref(),
             0,
             0,
             &rel_filter,

--- a/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
+++ b/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
@@ -60,7 +60,7 @@ impl Collection {
 
         // Populate range indexes
         {
-            let mut range_indexes = self.graph_range_indexes.write();
+            let mut range_indexes = self.graph.graph_range_indexes.write();
             for label in &labels {
                 for &(prop_name, prop_value) in &properties {
                     let key = range_index_key(label, prop_name);
@@ -76,7 +76,7 @@ impl Collection {
 
         // Populate composite indexes
         {
-            let mut composite_mgr = self.composite_index_manager.write();
+            let mut composite_mgr = self.graph.composite_index_manager.write();
             for label in &labels {
                 let props_map: HashMap<String, Value> = properties
                     .iter()
@@ -97,7 +97,7 @@ impl Collection {
         }
 
         {
-            let mut range_indexes = self.graph_range_indexes.write();
+            let mut range_indexes = self.graph.graph_range_indexes.write();
             for label in &labels {
                 for &(prop_name, prop_value) in &properties {
                     let key = range_index_key(label, prop_name);
@@ -109,7 +109,7 @@ impl Collection {
         }
 
         {
-            let mut composite_mgr = self.composite_index_manager.write();
+            let mut composite_mgr = self.graph.composite_index_manager.write();
             for label in &labels {
                 let props_map: HashMap<String, Value> = properties
                     .iter()
@@ -131,7 +131,7 @@ impl Collection {
             return;
         }
 
-        let mut edge_indexes = self.edge_range_indexes.write();
+        let mut edge_indexes = self.graph.edge_range_indexes.write();
         for (prop_name, prop_value) in properties {
             let key = edge_index_key(rel_type, prop_name);
             edge_indexes
@@ -161,7 +161,8 @@ impl Collection {
             predicates,
         };
 
-        self.query_pattern_tracker
+        self.graph
+            .query_pattern_tracker
             .write()
             .record(pattern, execution_time_ms);
     }
@@ -170,8 +171,8 @@ impl Collection {
     #[must_use]
     #[allow(dead_code)] // Reason: Public API for query evaluator — called when MATCH pipeline integrates auto-suggestion
     pub(crate) fn index_suggestions(&self) -> Vec<IndexSuggestion> {
-        let tracker = self.query_pattern_tracker.read();
-        self.index_advisor.read().suggest(&tracker)
+        let tracker = self.graph.query_pattern_tracker.read();
+        self.graph.index_advisor.read().suggest(&tracker)
     }
 
     /// Looks up node IDs matching a greater-than predicate.
@@ -183,7 +184,7 @@ impl Collection {
         value: &Value,
     ) -> Option<Vec<u64>> {
         let key = range_index_key(label, property);
-        let indexes = self.graph_range_indexes.read();
+        let indexes = self.graph.graph_range_indexes.read();
         indexes
             .get(&key)
             .map(|idx: &CompositeRangeIndex| idx.lookup_gt(value))
@@ -198,7 +199,7 @@ impl Collection {
         value: &Value,
     ) -> Option<Vec<u64>> {
         let key = range_index_key(label, property);
-        let indexes = self.graph_range_indexes.read();
+        let indexes = self.graph.graph_range_indexes.read();
         indexes
             .get(&key)
             .map(|idx: &CompositeRangeIndex| idx.lookup_lt(value))
@@ -214,7 +215,7 @@ impl Collection {
         upper: Option<&Value>,
     ) -> Option<Vec<u64>> {
         let key = range_index_key(label, property);
-        let indexes = self.graph_range_indexes.read();
+        let indexes = self.graph.graph_range_indexes.read();
         indexes
             .get(&key)
             .map(|idx: &CompositeRangeIndex| idx.lookup_range(lower, upper))
@@ -229,7 +230,7 @@ impl Collection {
         value: &Value,
     ) -> Option<Vec<u64>> {
         let key = range_index_key(label, property);
-        let indexes = self.graph_range_indexes.read();
+        let indexes = self.graph.graph_range_indexes.read();
         indexes
             .get(&key)
             .map(|idx: &CompositeRangeIndex| idx.lookup_exact(value).to_vec())
@@ -243,7 +244,7 @@ impl Collection {
         properties: &[&str],
         values: &[Value],
     ) -> Option<Vec<u64>> {
-        let mgr = self.composite_index_manager.read();
+        let mgr = self.graph.composite_index_manager.read();
         let covering = mgr.find_covering_indexes(label, properties);
         let index_name = covering.first()?;
         let idx = mgr.get(index_name)?;

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -50,6 +50,7 @@ impl Collection {
         // the end of this statement, before `save_config` takes a read guard
         // (parking_lot RwLock is non-reentrant).
         let newly_tracked = self
+            .storage
             .config
             .write()
             .indexed_fields
@@ -68,7 +69,7 @@ impl Collection {
     /// where the config set is already the authority, so neither path rewrites
     /// `config.json` during an open-time restore.
     pub(crate) fn build_and_backfill_secondary_index(&self, field_name: &str) {
-        let mut indexes = self.secondary_indexes.write();
+        let mut indexes = self.query.secondary_indexes.write();
         let is_new = !indexes.contains_key(field_name);
         indexes
             .entry(field_name.to_string())
@@ -88,9 +89,9 @@ impl Collection {
     fn backfill_secondary_index(&self, field_name: &str, is_new: bool) {
         use crate::storage::PayloadStorage;
 
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let ids = PayloadStorage::ids(&*payload_storage);
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         let Some(index) = indexes.get(field_name) else {
             return;
         };
@@ -148,8 +149,18 @@ impl Collection {
     /// [`CollectionConfig::indexed_fields`]: crate::collection::types::CollectionConfig::indexed_fields
     #[must_use]
     pub fn drop_secondary_index(&self, field_name: &str) -> bool {
-        let removed_from_map = self.secondary_indexes.write().remove(field_name).is_some();
-        let untracked = self.config.write().indexed_fields.remove(field_name);
+        let removed_from_map = self
+            .query
+            .secondary_indexes
+            .write()
+            .remove(field_name)
+            .is_some();
+        let untracked = self
+            .storage
+            .config
+            .write()
+            .indexed_fields
+            .remove(field_name);
         if untracked {
             if let Err(e) = self.save_config() {
                 tracing::warn!(
@@ -166,7 +177,7 @@ impl Collection {
     /// Checks whether a secondary metadata index exists for a field.
     #[must_use]
     pub fn has_secondary_index(&self, field_name: &str) -> bool {
-        self.secondary_indexes.read().contains_key(field_name)
+        self.query.secondary_indexes.read().contains_key(field_name)
     }
 
     /// Recommends secondary indexes for scalar `ORDER BY <field>` queries
@@ -196,7 +207,11 @@ impl Collection {
         use crate::collection::order_by_advisor::OrderByIndexSuggestion;
         // Snapshot under the advisor lock, release it before touching the
         // secondary-index lock so only one lock is ever held at a time.
-        let observed = self.order_by_advisor.read().observed(min_observations);
+        let observed = self
+            .graph
+            .order_by_advisor
+            .read()
+            .observed(min_observations);
         observed
             .into_iter()
             .filter_map(|(field, observed_count)| {
@@ -221,7 +236,7 @@ impl Collection {
     ) -> Option<crate::collection::order_by_advisor::OrderByIndexState> {
         use crate::collection::order_by_advisor::OrderByIndexState;
         let point_count = self.len();
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         match indexes.get(field) {
             None => Some(OrderByIndexState::Missing),
             Some(index)
@@ -244,7 +259,12 @@ impl Collection {
     /// Returns an empty set for collections with no indexes registered.
     #[must_use]
     pub fn indexed_field_names(&self) -> std::collections::HashSet<String> {
-        self.secondary_indexes.read().keys().cloned().collect()
+        self.query
+            .secondary_indexes
+            .read()
+            .keys()
+            .cloned()
+            .collect()
     }
 
     /// Returns the top `limit` point IDs for `field_name` in index order
@@ -263,7 +283,7 @@ impl Collection {
         limit: usize,
     ) -> Option<Vec<u64>> {
         let point_count = self.len();
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         indexes
             .get(field_name)?
             .ordered_ids_if_covered(descending, limit, point_count)
@@ -286,7 +306,7 @@ impl Collection {
         min_rows: usize,
     ) -> Option<Vec<u64>> {
         let point_count = self.len();
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         indexes
             .get(field_name)?
             .ordered_prefix_if_covered(descending, min_rows, point_count)
@@ -295,7 +315,7 @@ impl Collection {
     /// Looks up matching point IDs for an indexed field value.
     #[must_use]
     pub fn secondary_index_lookup(&self, field_name: &str, value: &JsonValue) -> Option<Vec<u64>> {
-        let indexes = self.secondary_indexes.read();
+        let indexes = self.query.secondary_indexes.read();
         let index = indexes.get(field_name)?;
         match index {
             SecondaryIndex::BTree(tree) => tree.read().get(value).cloned(),
@@ -314,7 +334,7 @@ impl Collection {
         &self,
         filter: &crate::filter::Filter,
     ) -> Option<roaring::RoaringBitmap> {
-        Self::bitmap_from_condition(&self.secondary_indexes, &filter.condition)
+        Self::bitmap_from_condition(&self.query.secondary_indexes, &filter.condition)
     }
 
     /// Recursively extracts bitmaps from conditions backed by secondary indexes.
@@ -511,7 +531,7 @@ impl Collection {
     /// Returns Ok(()) on success. Index creation is idempotent.
     #[allow(clippy::unnecessary_wraps)] // Reason: Public API contract — callers expect Result
     pub fn create_property_index(&self, label: &str, property: &str) -> Result<()> {
-        let mut index = self.property_index.write();
+        let mut index = self.graph.property_index.write();
         index.create_index(label, property);
         Ok(())
     }
@@ -528,7 +548,7 @@ impl Collection {
     /// Returns Ok(()) on success. Index creation is idempotent.
     #[allow(clippy::unnecessary_wraps)] // Reason: Public API contract — callers expect Result
     pub fn create_range_index(&self, label: &str, property: &str) -> Result<()> {
-        let mut index = self.range_index.write();
+        let mut index = self.graph.range_index.write();
         index.create_index(label, property);
         Ok(())
     }
@@ -536,13 +556,13 @@ impl Collection {
     /// Check if a property index exists.
     #[must_use]
     pub fn has_property_index(&self, label: &str, property: &str) -> bool {
-        self.property_index.read().has_index(label, property)
+        self.graph.property_index.read().has_index(label, property)
     }
 
     /// Check if a range index exists.
     #[must_use]
     pub fn has_range_index(&self, label: &str, property: &str) -> bool {
-        self.range_index.read().has_index(label, property)
+        self.graph.range_index.read().has_index(label, property)
     }
 
     /// List all indexes on this collection.
@@ -551,7 +571,7 @@ impl Collection {
         let mut indexes = Vec::new();
 
         // Secondary indexes (metadata field indexes created via create_index)
-        let sec_indexes = self.secondary_indexes.read();
+        let sec_indexes = self.query.secondary_indexes.read();
         for (field, index) in sec_indexes.iter() {
             let cardinality = match index {
                 crate::index::SecondaryIndex::BTree(tree) => tree.read().len(),
@@ -568,7 +588,7 @@ impl Collection {
 
         // LOCK ORDER: property_index(7) read — then range_index(7) read.
         // Same level, reads-only; canonical order prevents deadlock.
-        let prop_index = self.property_index.read();
+        let prop_index = self.graph.property_index.read();
         for (label, property) in prop_index.indexed_properties() {
             let cardinality = prop_index.cardinality(&label, &property).unwrap_or(0);
             indexes.push(IndexInfo {
@@ -581,7 +601,7 @@ impl Collection {
         }
 
         // List range indexes
-        let range_idx = self.range_index.read();
+        let range_idx = self.graph.range_index.read();
         for (label, property) in range_idx.indexed_properties() {
             indexes.push(IndexInfo {
                 label,
@@ -612,13 +632,17 @@ impl Collection {
     #[allow(clippy::unnecessary_wraps)] // Reason: Public API contract — callers expect Result
     pub fn drop_index(&self, label: &str, property: &str) -> Result<bool> {
         // Try property index first
-        let dropped_prop = self.property_index.write().drop_index(label, property);
+        let dropped_prop = self
+            .graph
+            .property_index
+            .write()
+            .drop_index(label, property);
         if dropped_prop {
             return Ok(true);
         }
 
         // Try range index
-        let dropped_range = self.range_index.write().drop_index(label, property);
+        let dropped_range = self.graph.range_index.write().drop_index(label, property);
         Ok(dropped_range)
     }
 
@@ -627,8 +651,8 @@ impl Collection {
     pub fn indexes_memory_usage(&self) -> usize {
         // LOCK ORDER: property_index(7) read — then range_index(7) read.
         // Same level, reads-only; canonical order prevents deadlock.
-        let prop_mem = self.property_index.read().memory_usage();
-        let range_mem = self.range_index.read().memory_usage();
+        let prop_mem = self.graph.property_index.read().memory_usage();
+        let range_mem = self.graph.range_index.read().memory_usage();
         prop_mem + range_mem
     }
 
@@ -653,6 +677,6 @@ impl Collection {
     ///
     /// Returns an error if vector storage reordering fails.
     pub fn reorder_for_locality(&self) -> Result<()> {
-        self.index.reorder_for_locality()
+        self.storage.index.reorder_for_locality()
     }
 }

--- a/crates/velesdb-core/src/collection/core/index_management_tests.rs
+++ b/crates/velesdb-core/src/collection/core/index_management_tests.rs
@@ -209,7 +209,7 @@ mod tests {
 
         // Manually populate the secondary index
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -245,7 +245,7 @@ mod tests {
 
         // Populate both indexes
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -296,7 +296,7 @@ mod tests {
     /// mapped to point IDs 1, 2, 3, 4, 5 respectively.
     fn populate_price_index(collection: &Collection) {
         use crate::index::secondary::F64Key;
-        let indexes = collection.secondary_indexes.read();
+        let indexes = collection.query.secondary_indexes.read();
         if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("price") {
             let mut t = tree.write();
             for (price, id) in [(10, 1u64), (20, 2), (30, 3), (40, 4), (50, 5)] {
@@ -491,7 +491,7 @@ mod tests {
             .expect("test: index creation");
 
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -541,7 +541,7 @@ mod tests {
             .expect("test: index creation");
 
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -601,7 +601,7 @@ mod tests {
 
         // Manually populate: 3 tech (IDs 1,5,10) + 2 science (IDs 2,7)
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -644,7 +644,7 @@ mod tests {
         populate_price_index(&collection);
 
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(
@@ -706,7 +706,7 @@ mod tests {
     /// Helper: populates a "category" secondary index with tech=[1,5,10],
     /// science=[2,7], art=[3].
     fn populate_category_index(collection: &Collection) {
-        let indexes = collection.secondary_indexes.read();
+        let indexes = collection.query.secondary_indexes.read();
         if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
             let mut t = tree.write();
             t.insert(
@@ -866,7 +866,7 @@ mod tests {
 
         let large_id = u64::from(u32::MAX) + 1;
         {
-            let indexes = collection.secondary_indexes.read();
+            let indexes = collection.query.secondary_indexes.read();
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("category") {
                 let mut t = tree.write();
                 t.insert(

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -79,52 +79,66 @@ impl Collection {
         let async_index_builder = Self::build_async_index_builder(&parts.config);
 
         Self {
-            path: parts.path,
-            config: Arc::new(RwLock::new(parts.config)),
-            vector_storage: parts.vector_storage,
-            payload_storage: parts.payload_storage,
-            index: parts.index,
-            text_index: parts.text_index,
-            sq8_cache: Arc::new(RwLock::new(HashMap::new())),
-            binary_cache: Arc::new(RwLock::new(HashMap::new())),
-            pq_cache: Arc::new(RwLock::new(HashMap::new())),
-            pq_quantizer: Arc::new(RwLock::new(None)),
-            pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
-            property_index: Arc::new(RwLock::new(parts.property_index)),
-            label_index: Arc::new(RwLock::new(parts.label_index)),
-            range_index: Arc::new(RwLock::new(parts.range_index)),
-            graph_range_indexes: Arc::new(RwLock::new(HashMap::new())),
-            edge_range_indexes: Arc::new(RwLock::new(HashMap::new())),
-            composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
-            query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
-            index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
-            order_by_advisor: Arc::new(RwLock::new(
-                crate::collection::order_by_advisor::OrderByIndexAdvisor::default(),
-            )),
-            edge_store: Arc::new(parts.edge_store),
-            edge_wal_lock: Arc::new(Mutex::new(())),
-            sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
-            secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
-            payload_mirror: Arc::new(crate::collection::payload_mirror::PayloadMirror::default()),
-            guard_rails: Arc::new(GuardRails::default()),
-            runtime_limits: Arc::new(RwLock::new(
-                crate::collection::types::RuntimeLimits::default(),
-            )),
-            query_planner: Arc::new(QueryPlanner::new()),
-            query_cache: Arc::new(QueryCache::new(256)),
-            cached_stats: Arc::new(Mutex::new(None)),
-            stats_io_mutex: Arc::new(Mutex::new(())),
-            write_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            analyze_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            inserts_since_last_hnsw_save: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            #[cfg(feature = "persistence")]
-            stream_ingester: Arc::new(RwLock::new(None)),
-            #[cfg(feature = "persistence")]
-            delta_buffer: Arc::new(crate::collection::streaming::delta::DeltaBuffer::new()),
-            #[cfg(feature = "persistence")]
-            deferred_indexer,
-            async_index_builder,
-            auto_reindex: Arc::new(RwLock::new(None)),
+            storage: crate::collection::types::StorageState {
+                path: parts.path,
+                config: Arc::new(RwLock::new(parts.config)),
+                vector_storage: parts.vector_storage,
+                payload_storage: parts.payload_storage,
+                index: parts.index,
+                text_index: parts.text_index,
+                sq8_cache: Arc::new(RwLock::new(HashMap::new())),
+                binary_cache: Arc::new(RwLock::new(HashMap::new())),
+                pq_cache: Arc::new(RwLock::new(HashMap::new())),
+                pq_quantizer: Arc::new(RwLock::new(None)),
+                pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
+                payload_mirror: Arc::new(
+                    crate::collection::payload_mirror::PayloadMirror::default(),
+                ),
+            },
+            graph: crate::collection::types::GraphState {
+                property_index: Arc::new(RwLock::new(parts.property_index)),
+                label_index: Arc::new(RwLock::new(parts.label_index)),
+                range_index: Arc::new(RwLock::new(parts.range_index)),
+                graph_range_indexes: Arc::new(RwLock::new(HashMap::new())),
+                edge_range_indexes: Arc::new(RwLock::new(HashMap::new())),
+                composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
+                query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
+                index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
+                order_by_advisor: Arc::new(RwLock::new(
+                    crate::collection::order_by_advisor::OrderByIndexAdvisor::default(),
+                )),
+                edge_store: Arc::new(parts.edge_store),
+                edge_wal_lock: Arc::new(Mutex::new(())),
+            },
+            query: crate::collection::types::QueryState {
+                sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
+                secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
+                query_planner: Arc::new(QueryPlanner::new()),
+                query_cache: Arc::new(QueryCache::new(256)),
+                cached_stats: Arc::new(Mutex::new(None)),
+                stats_io_mutex: Arc::new(Mutex::new(())),
+            },
+            generations: crate::collection::types::GenerationCounters {
+                write_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                analyze_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                inserts_since_last_hnsw_save: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            },
+            streaming: crate::collection::types::StreamingState {
+                #[cfg(feature = "persistence")]
+                stream_ingester: Arc::new(RwLock::new(None)),
+                #[cfg(feature = "persistence")]
+                delta_buffer: Arc::new(crate::collection::streaming::delta::DeltaBuffer::new()),
+                #[cfg(feature = "persistence")]
+                deferred_indexer,
+                async_index_builder,
+                auto_reindex: Arc::new(RwLock::new(None)),
+            },
+            runtime: crate::collection::types::RuntimeGuards {
+                guard_rails: Arc::new(GuardRails::default()),
+                runtime_limits: Arc::new(RwLock::new(
+                    crate::collection::types::RuntimeLimits::default(),
+                )),
+            },
         }
     }
 
@@ -260,7 +274,7 @@ impl Collection {
     /// Returns true if this is a metadata-only collection.
     #[must_use]
     pub fn is_metadata_only(&self) -> bool {
-        self.config.read().metadata_only
+        self.storage.config.read().metadata_only
     }
 
     /// Opens an existing collection from the specified path.
@@ -351,7 +365,14 @@ impl Collection {
     ///
     /// [`CollectionConfig::indexed_fields`]: crate::collection::types::CollectionConfig::indexed_fields
     fn restore_secondary_indexes_from_config(&self) {
-        let fields: Vec<String> = self.config.read().indexed_fields.iter().cloned().collect();
+        let fields: Vec<String> = self
+            .storage
+            .config
+            .read()
+            .indexed_fields
+            .iter()
+            .cloned()
+            .collect();
         for field in fields {
             self.build_and_backfill_secondary_index(&field);
         }
@@ -365,7 +386,7 @@ impl Collection {
     /// be re-attached manually after every open
     /// (see `docs/CORE_WIRING_DEBT.md` entry 2).
     fn restore_auto_reindex_from_config(&self) {
-        let cfg = self.config.read().auto_reindex_config.clone();
+        let cfg = self.storage.config.read().auto_reindex_config.clone();
         if let Some(cfg) = cfg {
             let manager = Arc::new(crate::collection::auto_reindex::AutoReindexManager::new(
                 cfg,
@@ -667,39 +688,39 @@ impl Collection {
     /// Returns a reference to the collection's guard rails.
     #[must_use]
     pub fn guard_rails(&self) -> &std::sync::Arc<crate::guardrails::GuardRails> {
-        &self.guard_rails
+        &self.runtime.guard_rails
     }
 
     /// Returns the collection configuration.
     #[must_use]
     pub fn config(&self) -> CollectionConfig {
-        self.config.read().clone()
+        self.storage.config.read().clone()
     }
 
     /// Returns a reference to the collection's data path.
     #[must_use]
     pub(crate) fn data_path(&self) -> &std::path::Path {
-        &self.path
+        &self.storage.path
     }
 
     /// Returns a write guard on the collection config for mutation.
     pub(crate) fn config_write(
         &self,
     ) -> parking_lot::RwLockWriteGuard<'_, crate::collection::types::CollectionConfig> {
-        self.config.write()
+        self.storage.config.write()
     }
 
     /// Returns a write guard on the PQ quantizer slot.
     pub(crate) fn pq_quantizer_write(
         &self,
     ) -> parking_lot::RwLockWriteGuard<'_, Option<crate::quantization::ProductQuantizer>> {
-        self.pq_quantizer.write()
+        self.storage.pq_quantizer.write()
     }
 
     /// Returns a read guard on the PQ quantizer slot.
     pub(crate) fn pq_quantizer_read(
         &self,
     ) -> parking_lot::RwLockReadGuard<'_, Option<crate::quantization::ProductQuantizer>> {
-        self.pq_quantizer.read()
+        self.storage.pq_quantizer.read()
     }
 }

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -300,23 +300,29 @@ fn test_flush_drains_delta_buffer_into_hnsw() {
     //    are persisted to storage before being delta-buffered).
     {
         use crate::storage::VectorStorage;
-        let mut vs = collection.vector_storage.write();
+        let mut vs = collection.storage.vector_storage.write();
         vs.store(10, &[0.5, 0.5, 0.0, 0.0]).expect("store 10");
         vs.store(11, &[0.0, 0.0, 0.5, 0.5]).expect("store 11");
     }
 
     // 3. Activate delta buffer (simulates an HNSW rebuild starting)
-    collection.delta_buffer.activate();
+    collection.streaming.delta_buffer.activate();
     assert!(
-        collection.delta_buffer.is_active(),
+        collection.streaming.delta_buffer.is_active(),
         "delta should be active"
     );
 
     // 4. Push vectors into the delta buffer (simulates upserts during rebuild)
-    collection.delta_buffer.push(10, vec![0.5, 0.5, 0.0, 0.0]);
-    collection.delta_buffer.push(11, vec![0.0, 0.0, 0.5, 0.5]);
+    collection
+        .streaming
+        .delta_buffer
+        .push(10, vec![0.5, 0.5, 0.0, 0.0]);
+    collection
+        .streaming
+        .delta_buffer
+        .push(11, vec![0.0, 0.0, 0.5, 0.5]);
     assert_eq!(
-        collection.delta_buffer.len(),
+        collection.streaming.delta_buffer.len(),
         2,
         "delta should hold 2 entries"
     );
@@ -326,16 +332,16 @@ fn test_flush_drains_delta_buffer_into_hnsw() {
 
     // 6. Verify: delta buffer is now empty and inactive
     assert!(
-        !collection.delta_buffer.is_active(),
+        !collection.streaming.delta_buffer.is_active(),
         "delta buffer must be inactive after flush"
     );
     assert!(
-        collection.delta_buffer.is_empty(),
+        collection.streaming.delta_buffer.is_empty(),
         "delta buffer must be empty after flush"
     );
 
     // 7. Verify: the drained vectors are now in the HNSW index (searchable)
-    let results = collection.index.search(&[0.5, 0.5, 0.0, 0.0], 5);
+    let results = collection.storage.index.search(&[0.5, 0.5, 0.0, 0.0], 5);
     let result_ids: Vec<u64> = results.iter().map(|r| r.id).collect();
     assert!(
         result_ids.contains(&10),
@@ -361,7 +367,7 @@ fn test_flush_with_inactive_delta_buffer_is_noop() {
     collection.upsert(points).expect("upsert");
 
     // Delta buffer is NOT active — flush should behave normally
-    assert!(!collection.delta_buffer.is_active());
+    assert!(!collection.streaming.delta_buffer.is_active());
 
     collection
         .flush()

--- a/crates/velesdb-core/src/collection/core/open_reload_tests.rs
+++ b/crates/velesdb-core/src/collection/core/open_reload_tests.rs
@@ -54,7 +54,7 @@ fn test_reopen_reconciles_stale_wal_upsert_into_loaded_index() {
     // B consumes idx 1. A rebuilt-from-scratch index would stop at next_idx
     // 1, so this proves the persisted graph was LOADED, not rebuilt.
     assert_eq!(
-        reopened.index.mappings.next_idx(),
+        reopened.storage.index.mappings.next_idx(),
         2,
         "stale re-upsert must run on the LOADED index (not a rebuild)"
     );
@@ -215,14 +215,14 @@ fn test_alpha_round_trip_through_reopen() {
             params,
         )
         .expect("create");
-        assert_eq!(coll.index.inner.read().alpha(), 1.5);
+        assert_eq!(coll.storage.index.inner.read().alpha(), 1.5);
         coll.upsert(make_points(0, 3)).expect("upsert");
         coll.flush_full().expect("flush_full");
     }
 
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
     assert_eq!(
-        reopened.index.inner.read().alpha(),
+        reopened.storage.index.inner.read().alpha(),
         1.5,
         "custom alpha must survive the save/load round-trip"
     );

--- a/crates/velesdb-core/src/collection/core/quantizer_restore.rs
+++ b/crates/velesdb-core/src/collection/core/quantizer_restore.rs
@@ -26,7 +26,7 @@ impl Collection {
     /// codebook/index). Encode failures on individual vectors degrade
     /// gracefully (logged, vector keeps full-precision scoring).
     pub(crate) fn restore_persisted_quantizers(&self) -> Result<()> {
-        let mode = self.config.read().storage_mode;
+        let mode = self.storage.config.read().storage_mode;
         match mode {
             StorageMode::ProductQuantization => self.restore_persisted_pq(),
             StorageMode::RaBitQ => self.restore_persisted_rabitq(),
@@ -40,16 +40,16 @@ impl Collection {
     /// Lock order: `vector_storage` (2) → `pq_cache` (4) → `pq_quantizer` (5),
     /// acquired sequentially and never inverted.
     fn restore_persisted_pq(&self) -> Result<()> {
-        if self.pq_quantizer.read().is_some() {
+        if self.storage.pq_quantizer.read().is_some() {
             return Ok(());
         }
-        let Some(mut pq) = ProductQuantizer::load_codebook(&self.path)? else {
+        let Some(mut pq) = ProductQuantizer::load_codebook(&self.storage.path)? else {
             return Ok(());
         };
         // Warn-and-degrade like the RaBitQ restore below: a stale or foreign
         // codebook would fail to encode every vector (empty cache + silent
         // f32 fallback), so reject it once here instead.
-        let dimension = self.config.read().dimension;
+        let dimension = self.storage.config.read().dimension;
         if pq.codebook.dimension != dimension {
             tracing::warn!(
                 codebook_dim = pq.codebook.dimension,
@@ -61,7 +61,7 @@ impl Collection {
         // codebook.pq serializes the rotation when trained via OPQ; the
         // standalone rotation.opq artifact covers codebooks saved without it.
         if pq.rotation.is_none() {
-            pq.rotation = ProductQuantizer::load_rotation(&self.path)?;
+            pq.rotation = ProductQuantizer::load_rotation(&self.storage.path)?;
         }
 
         let cache = self.encode_pq_cache(&pq);
@@ -69,8 +69,8 @@ impl Collection {
             entries = cache.len(),
             "restored PQ quantizer from codebook.pq; cache rebuilt on open"
         );
-        *self.pq_cache.write() = cache;
-        *self.pq_quantizer.write() = Some(pq);
+        *self.storage.pq_cache.write() = cache;
+        *self.storage.pq_quantizer.write() = Some(pq);
         Ok(())
     }
 
@@ -80,7 +80,7 @@ impl Collection {
     /// Vectors that fail to encode are skipped with a warning — they keep
     /// their HNSW score in the ADC rescore path (cache-miss semantics).
     fn encode_pq_cache(&self, pq: &ProductQuantizer) -> HashMap<u64, PQVector> {
-        let storage = self.vector_storage.read();
+        let storage = self.storage.vector_storage.read();
         let ids = storage.ids();
         let mut cache = HashMap::with_capacity(ids.len());
         for id in ids {
@@ -107,7 +107,11 @@ impl Collection {
     /// backend). Search then stays on exact f32 distances, which is correct
     /// but unaccelerated.
     fn restore_persisted_rabitq(&self) -> Result<()> {
-        preinstall_persisted_rabitq(&self.path, self.config.read().dimension, &self.index)
+        preinstall_persisted_rabitq(
+            &self.storage.path,
+            self.storage.config.read().dimension,
+            &self.storage.index,
+        )
     }
 
     /// Installs a freshly trained `RaBitQ` quantizer into the live index.
@@ -120,20 +124,20 @@ impl Collection {
     ///
     /// Returns an error if re-encoding a stored vector fails.
     pub(crate) fn install_rabitq_quantizer(&self, rabitq: Arc<RaBitQIndex>) -> Result<bool> {
-        self.index.install_trained_rabitq(rabitq)
+        self.storage.index.install_trained_rabitq(rabitq)
     }
 
     /// Returns true when the HNSW backend is `RaBitQ` with a trained
     /// quantizer (test introspection).
     #[cfg(test)]
     pub(crate) fn is_rabitq_quantizer_trained(&self) -> bool {
-        self.index.is_rabitq_quantizer_trained()
+        self.storage.index.is_rabitq_quantizer_trained()
     }
 
     /// Number of entries in the PQ cache (test introspection).
     #[cfg(test)]
     pub(crate) fn pq_cache_len(&self) -> usize {
-        self.pq_cache.read().len()
+        self.storage.pq_cache.read().len()
     }
 }
 

--- a/crates/velesdb-core/src/collection/core/recovery_tests.rs
+++ b/crates/velesdb-core/src/collection/core/recovery_tests.rs
@@ -29,7 +29,8 @@ fn test_no_gap_returns_zero() {
     coll.upsert(make_points(5)).expect("upsert");
 
     let recovered =
-        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+        recovery::recover_hnsw_gap(&coll.storage.vector_storage, &coll.storage.index, 4)
+            .expect("recovery");
     assert_eq!(recovered, 0);
 }
 
@@ -40,7 +41,8 @@ fn test_empty_collection_no_recovery() {
         Collection::create(PathBuf::from(temp.path()), 4, DistanceMetric::Cosine).expect("create");
 
     let recovered =
-        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+        recovery::recover_hnsw_gap(&coll.storage.vector_storage, &coll.storage.index, 4)
+            .expect("recovery");
     assert_eq!(recovered, 0);
 }
 
@@ -59,22 +61,23 @@ fn test_crash_gap_detected_and_recovered() {
     // Simulate crash gap: write 2 vectors to storage ONLY, bypassing HNSW.
     // Use orthogonal directions to avoid cosine ambiguity with existing points.
     {
-        let mut vs = coll.vector_storage.write();
+        let mut vs = coll.storage.vector_storage.write();
         vs.store(100, &[0.0, 0.0, 1.0, 0.0]).expect("store 100");
         vs.store(101, &[0.0, 0.0, 0.0, 1.0]).expect("store 101");
     }
 
-    assert_eq!(coll.vector_storage.read().len(), 5);
-    assert_eq!(coll.index.len(), 3);
+    assert_eq!(coll.storage.vector_storage.read().len(), 5);
+    assert_eq!(coll.storage.index.len(), 3);
 
     let recovered =
-        recovery::recover_hnsw_gap(&coll.vector_storage, &coll.index, 4).expect("recovery");
+        recovery::recover_hnsw_gap(&coll.storage.vector_storage, &coll.storage.index, 4)
+            .expect("recovery");
 
     assert_eq!(recovered, 2);
-    assert_eq!(coll.index.len(), 5);
+    assert_eq!(coll.storage.index.len(), 5);
 
     // Verify recovered vectors are searchable via HNSW.
-    let results = coll.index.search(&[0.0, 0.0, 1.0, 0.0], 1);
+    let results = coll.storage.index.search(&[0.0, 0.0, 1.0, 0.0], 1);
     assert_eq!(results[0].id, 100, "recovered vector should be searchable");
 }
 
@@ -97,7 +100,7 @@ fn test_gap_recovery_on_collection_reopen() {
         // Simulate gap: store vectors directly without HNSW indexing.
         // Use orthogonal directions to avoid cosine ambiguity.
         {
-            let mut vs = coll.vector_storage.write();
+            let mut vs = coll.storage.vector_storage.write();
             vs.store(100, &[0.0, 0.0, 1.0, 0.0]).expect("store 100");
             vs.store(101, &[0.0, 0.0, 0.0, 1.0]).expect("store 101");
             vs.flush().expect("flush storage");
@@ -110,7 +113,7 @@ fn test_gap_recovery_on_collection_reopen() {
     // Phase 2: Reopen — should auto-recover gap vectors.
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
     assert_eq!(
-        reopened.index.len(),
+        reopened.storage.index.len(),
         5,
         "HNSW should include 3 original + 2 recovered vectors"
     );
@@ -140,7 +143,7 @@ fn test_metadata_only_skips_recovery() {
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
 
     // Metadata-only has dimension 0, no vectors, no HNSW content.
-    assert_eq!(reopened.config.read().dimension, 0);
+    assert_eq!(reopened.storage.config.read().dimension, 0);
 }
 
 // =========================================================================
@@ -162,7 +165,12 @@ fn test_no_gap_after_flush_and_reopen() {
     let reopened = Collection::open(PathBuf::from(temp.path())).expect("reopen");
     // After a full flush + clean reopen there must be no gap.
     let recovered =
-        recovery::recover_hnsw_gap(&reopened.vector_storage, &reopened.index, 4).expect("recover");
+        recovery::recover_hnsw_gap(&reopened.storage.vector_storage, &reopened.storage.index, 4)
+            .expect("recover");
     assert_eq!(recovered, 0, "no gap after clean flush+reopen");
-    assert_eq!(reopened.index.len(), 8, "all vectors present in HNSW");
+    assert_eq!(
+        reopened.storage.index.len(),
+        8,
+        "all vectors present in HNSW"
+    );
 }

--- a/crates/velesdb-core/src/collection/core/scroll.rs
+++ b/crates/velesdb-core/src/collection/core/scroll.rs
@@ -74,12 +74,12 @@ impl Collection {
         batch_size: usize,
         filter: Option<&Filter>,
     ) -> Vec<Point> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let is_metadata_only = config.metadata_only;
         drop(config);
 
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let now_secs = now_unix_secs();
 
         let mut points = Vec::with_capacity(batch_size);

--- a/crates/velesdb-core/src/collection/core/statistics.rs
+++ b/crates/velesdb-core/src/collection/core/statistics.rs
@@ -51,7 +51,7 @@ impl Collection {
         // Basic counts from config
         // Note: deleted_count and column_stats are placeholders for future tombstone tracking
         // and per-column cardinality analysis (EPIC-046 future work)
-        let config = self.config.read();
+        let config = self.storage.config.read();
         collector.set_row_count(saturating_u64(config.point_count));
         drop(config);
 
@@ -75,13 +75,13 @@ impl Collection {
         }
 
         // HNSW index statistics
-        let hnsw_len = self.index.len();
+        let hnsw_len = self.storage.index.len();
         let hnsw_stats =
             IndexStats::new("hnsw_primary", "HNSW").with_entry_count(saturating_u64(hnsw_len));
         collector.add_index_stats(hnsw_stats);
 
         // BM25 index statistics - use len() if available
-        let bm25_len = self.text_index.len();
+        let bm25_len = self.storage.text_index.len();
         if bm25_len > 0 {
             let bm25_stats =
                 IndexStats::new("bm25_text", "BM25").with_entry_count(saturating_u64(bm25_len));
@@ -105,7 +105,7 @@ impl Collection {
         let mut null_counts: HashMap<String, u64> = HashMap::new();
         let mut payload_size_bytes = 0u64;
 
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let ids = payload_storage.ids();
         for id in ids.into_iter().take(1_000) {
             let Ok(Some(payload)) = payload_storage.retrieve(id) else {
@@ -153,7 +153,7 @@ impl Collection {
     /// collected, sorted lexicographically, deduplicated, and each string is
     /// mapped to its 0-based index in the sorted unique list.
     fn sample_column_values_for_histograms(&self, max_samples: usize) -> HashMap<String, Vec<f64>> {
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let ids = payload_storage.ids();
 
         // First pass: collect raw values per column
@@ -239,7 +239,7 @@ impl Collection {
     /// Use `analyze()` directly if error handling is required.
     #[must_use]
     pub fn get_stats(&self) -> CollectionStats {
-        let mut cached = self.cached_stats.lock();
+        let mut cached = self.query.cached_stats.lock();
         if let Some((ref stats, ts)) = *cached {
             if ts.elapsed() < STATS_TTL {
                 return stats.clone();

--- a/crates/velesdb-core/src/collection/e2e_integration_tests.rs
+++ b/crates/velesdb-core/src/collection/e2e_integration_tests.rs
@@ -69,7 +69,7 @@ fn test_execute_query_str_caches_repeated_calls() {
     let params = HashMap::new();
     let sql = "SELECT * FROM col LIMIT 3;";
 
-    let stats_before = col.query_cache.stats();
+    let stats_before = col.query.query_cache.stats();
     // First call — parsed and cached
     let r1 = col
         .execute_query_str(sql, &params)
@@ -85,11 +85,11 @@ fn test_execute_query_str_caches_repeated_calls() {
     );
     // The second identical call must be a cache hit, not a re-parse:
     assert_eq!(
-        col.query_cache.len(),
+        col.query.query_cache.len(),
         1,
         "identical SQL must yield a single cache entry"
     );
-    let hits = col.query_cache.stats().hits - stats_before.hits;
+    let hits = col.query.query_cache.stats().hits - stats_before.hits;
     assert!(
         hits >= 1,
         "second identical call should register a cache hit, got {hits}"
@@ -142,7 +142,7 @@ fn test_e2e_guardrails_cardinality_respected() {
         max_cardinality: 3, // only 3 results allowed
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let params = HashMap::new();
     let result = col.execute_query_str("SELECT * FROM col LIMIT 10;", &params);
@@ -161,7 +161,7 @@ fn test_e2e_guardrails_timeout_zero_disables_check() {
 
     // timeout_ms = 0 is the "disabled" sentinel — the guard-rail must never fire.
     // Reason: 0 means no timeout (batch/offline workloads), not "0 ms budget".
-    col.guard_rails = Arc::new(GuardRails::with_limits(QueryLimits {
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(QueryLimits {
         timeout_ms: 0,
         ..QueryLimits::default()
     }));
@@ -178,7 +178,7 @@ fn test_e2e_guardrails_timeout_zero_disables_check() {
 fn test_e2e_guardrails_circuit_breaker_state() {
     let (_dir, mut col) = make_collection();
 
-    col.guard_rails = Arc::new(GuardRails::with_limits(QueryLimits {
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(QueryLimits {
         max_cardinality: 1, // forces failures
         circuit_failure_threshold: 2,
         circuit_recovery_seconds: 60,
@@ -190,7 +190,7 @@ fn test_e2e_guardrails_circuit_breaker_state() {
     let _ = col.execute_query_str(sql, &params); // failure 1
     let _ = col.execute_query_str(sql, &params); // failure 2
 
-    let state = col.guard_rails.circuit_breaker.state();
+    let state = col.runtime.guard_rails.circuit_breaker.state();
     assert_eq!(
         state,
         crate::guardrails::CircuitState::Open,

--- a/crates/velesdb-core/src/collection/graph/property_index_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index_tests.rs
@@ -328,17 +328,22 @@ fn test_property_index_persists_across_collection_reopen() {
 
         // Create a property index
         collection
+            .graph
             .property_index
             .write()
             .create_index("Person", "email");
-        collection
-            .property_index
-            .write()
-            .insert("Person", "email", &json!("alice@example.com"), 1);
-        collection
-            .property_index
-            .write()
-            .insert("Person", "email", &json!("bob@example.com"), 2);
+        collection.graph.property_index.write().insert(
+            "Person",
+            "email",
+            &json!("alice@example.com"),
+            1,
+        );
+        collection.graph.property_index.write().insert(
+            "Person",
+            "email",
+            &json!("bob@example.com"),
+            2,
+        );
 
         // Flush to persist
         collection.flush().unwrap();
@@ -349,7 +354,7 @@ fn test_property_index_persists_across_collection_reopen() {
         let collection = Collection::open(path).unwrap();
 
         // Verify index exists and data is preserved
-        let index = collection.property_index.read();
+        let index = collection.graph.property_index.read();
         assert!(
             index.has_index("Person", "email"),
             "Property index should be loaded from disk"

--- a/crates/velesdb-core/src/collection/guardrails_integration_tests.rs
+++ b/crates/velesdb-core/src/collection/guardrails_integration_tests.rs
@@ -45,7 +45,7 @@ fn test_execute_query_pre_check_rate_limit() {
         rate_limit_qps: 2,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "SELECT * FROM col LIMIT 5;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -74,7 +74,7 @@ fn test_execute_query_cardinality_enforced() {
         max_cardinality: 3, // collection has 10 points
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "SELECT * FROM col LIMIT 100;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -103,7 +103,7 @@ fn test_execute_query_timeout_disabled_at_zero() {
         timeout_ms: 0,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "SELECT * FROM col LIMIT 10;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -152,7 +152,7 @@ fn test_execute_query_circuit_breaker_opens_after_failures() {
         circuit_recovery_seconds: 60,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "SELECT * FROM col LIMIT 10;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -163,7 +163,7 @@ fn test_execute_query_circuit_breaker_opens_after_failures() {
     let _ = col.execute_query(&query, &params); // failure 2 → circuit opens
 
     // After 2 cardinality violations, the circuit breaker should be Open
-    let state = col.guard_rails.circuit_breaker.state();
+    let state = col.runtime.guard_rails.circuit_breaker.state();
     assert_eq!(
         state,
         CircuitState::Open,
@@ -186,7 +186,7 @@ fn test_execute_query_normal_query_records_success() {
 
     // Circuit breaker stays closed after successful query
     assert_eq!(
-        col.guard_rails.circuit_breaker.state(),
+        col.runtime.guard_rails.circuit_breaker.state(),
         CircuitState::Closed
     );
 }
@@ -211,7 +211,7 @@ fn test_not_similarity_query_cardinality_enforced() {
         max_cardinality: 3, // collection has 10 points; NOT-sim returns ~all
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     // Build NOT (similarity(vector, $v) > 0.99) programmatically.
     // The parser does not yet support NOT-wrapping similarity (EPIC-005 planned),
@@ -263,7 +263,7 @@ fn test_union_query_cardinality_enforced() {
         max_cardinality: 3, // collection has 10 points; union returns ~all
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     // Build similarity(vector, $v) > 0.0 OR idx >= 0
     // One side has similarity, the other is metadata → triggers union path.
@@ -328,7 +328,7 @@ fn test_match_cardinality_enforced_below_100_iterations() {
         max_cardinality: 2,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "MATCH (a)-[r]->(b) RETURN b LIMIT 10;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -365,7 +365,7 @@ fn test_match_query_ordered_cardinality_enforced() {
         max_cardinality: 2, // 3 results > 2 → must be rejected
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let match_clause = Parser::parse("MATCH (a)-[r]->(b) RETURN b ORDER BY depth LIMIT 10;")
         .expect("parse failed")
@@ -393,7 +393,7 @@ fn test_per_client_rate_limiting_is_independent() {
         rate_limit_qps: 1,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     let sql = "SELECT * FROM col LIMIT 5;";
     let query = Parser::parse(sql).expect("parse failed");
@@ -429,7 +429,7 @@ fn test_execute_match_depth_limit_enforced() {
         max_depth: 0,
         ..QueryLimits::default()
     };
-    col.guard_rails = Arc::new(GuardRails::with_limits(limits));
+    col.runtime.guard_rails = Arc::new(GuardRails::with_limits(limits));
 
     // Add a simple edge so traversal actually runs
     let edge =

--- a/crates/velesdb-core/src/collection/payload_mirror/mirror_tests.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mirror_tests.rs
@@ -49,7 +49,7 @@ fn query_ids(col: &Collection, query: &str) -> Vec<u64> {
 }
 
 fn mirror_built(col: &Collection) -> bool {
-    col.payload_mirror.state.read().is_some()
+    col.storage.payload_mirror.state.read().is_some()
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn test_mirror_builds_after_scan_debt_and_preserves_results() {
     // First query takes the sequential scan path and accrues scan debt.
     let scan_ids = query_ids(&col, query);
     assert!(!mirror_built(&col), "mirror must not build on first scan");
-    assert!(col.payload_mirror.scan_debt() >= ROWS as u64);
+    assert!(col.storage.payload_mirror.scan_debt() >= ROWS as u64);
 
     // Second query crosses the debt threshold, builds the mirror, and must
     // return exactly the same rows.
@@ -130,7 +130,7 @@ fn test_mirror_stays_in_sync_after_upsert_and_delete() {
 
 /// Returns `(row_count, deleted_row_count)` of the mirror's `ColumnStore`.
 fn mirror_store_counts(col: &Collection) -> (usize, usize) {
-    let guard = col.payload_mirror.state.read();
+    let guard = col.storage.payload_mirror.state.read();
     let state = guard.as_ref().expect("mirror must be built");
     (state.store.row_count(), state.store.deleted_row_count())
 }
@@ -252,7 +252,7 @@ fn test_apply_upserts_batch_is_atomic_for_concurrent_readers() {
     let done = AtomicBool::new(false);
 
     std::thread::scope(|s| {
-        let mirror = &col.payload_mirror;
+        let mirror = &col.storage.payload_mirror;
         let done_ref = &done;
         s.spawn(move || {
             for gen in 1..=GENS {
@@ -288,7 +288,7 @@ fn test_apply_upserts_batch_is_atomic_for_concurrent_readers() {
     });
 
     // Once the writer is done, the last generation must be fully visible.
-    match col.payload_mirror.candidate_ids(&gen_eq(GENS)) {
+    match col.storage.payload_mirror.candidate_ids(&gen_eq(GENS)) {
         MirrorAnswer::Ids(ids) => assert_eq!(ids.len(), BATCH),
         _ => panic!("mirror must still be built and answer the Eq probe"),
     }

--- a/crates/velesdb-core/src/collection/payload_mirror/mod.rs
+++ b/crates/velesdb-core/src/collection/payload_mirror/mod.rs
@@ -376,7 +376,7 @@ impl crate::collection::types::Collection {
         &self,
         condition: &crate::filter::Condition,
     ) -> Option<Vec<u64>> {
-        match self.payload_mirror.candidate_ids(condition) {
+        match self.storage.payload_mirror.candidate_ids(condition) {
             MirrorAnswer::Ids(ids) => return Some(ids),
             MirrorAnswer::Unsupported => return None,
             MirrorAnswer::NotBuilt => {}
@@ -385,7 +385,7 @@ impl crate::collection::types::Collection {
             return None;
         }
         self.build_payload_mirror();
-        match self.payload_mirror.candidate_ids(condition) {
+        match self.storage.payload_mirror.candidate_ids(condition) {
             MirrorAnswer::Ids(ids) => Some(ids),
             MirrorAnswer::Unsupported | MirrorAnswer::NotBuilt => None,
         }
@@ -393,8 +393,8 @@ impl crate::collection::types::Collection {
 
     /// Whether accumulated scan debt justifies the one-off build cost.
     fn mirror_build_due(&self) -> bool {
-        let rows = self.config.read().point_count;
-        rows >= MIRROR_MIN_ROWS && self.payload_mirror.scan_debt() >= rows as u64
+        let rows = self.storage.config.read().point_count;
+        rows >= MIRROR_MIN_ROWS && self.storage.payload_mirror.scan_debt() >= rows as u64
     }
 
     /// Builds the mirror from storage under the mirror write lock.
@@ -405,15 +405,15 @@ impl crate::collection::types::Collection {
     /// here during the build and re-apply their batch afterwards (idempotent),
     /// keeping the mirror complete.
     pub(crate) fn build_payload_mirror(&self) {
-        let mut guard = self.payload_mirror.state.write();
+        let mut guard = self.storage.payload_mirror.state.write();
         if guard.is_some() {
             return; // another query won the build race
         }
         let vector_ids = {
-            let vectors = self.vector_storage.read();
+            let vectors = self.storage.vector_storage.read();
             vectors.ids()
         };
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let mut state = MirrorState::default();
         let mut seen: FxHashSet<u64> = FxHashSet::default();
         for id in vector_ids.into_iter().chain(payload_storage.ids()) {
@@ -426,7 +426,10 @@ impl crate::collection::types::Collection {
             }
         }
         drop(payload_storage);
-        self.payload_mirror.scan_debt.store(0, Ordering::Relaxed);
+        self.storage
+            .payload_mirror
+            .scan_debt
+            .store(0, Ordering::Relaxed);
         *guard = Some(state);
     }
 }

--- a/crates/velesdb-core/src/collection/search/batch.rs
+++ b/crates/velesdb-core/src/collection/search/batch.rs
@@ -41,7 +41,7 @@ impl Collection {
         }
 
         let (dimension, metric) = {
-            let cfg = self.config.read();
+            let cfg = self.storage.config.read();
             (cfg.dimension, cfg.metric)
         };
         for query in queries {
@@ -50,12 +50,14 @@ impl Collection {
 
         let candidates_k = k.saturating_mul(4).max(k + 10);
         let higher_is_better = metric.higher_is_better();
-        let index_results =
-            self.index
-                .search_batch_parallel(queries, candidates_k, SearchQuality::Balanced)?;
+        let index_results = self.storage.index.search_batch_parallel(
+            queries,
+            candidates_k,
+            SearchQuality::Balanced,
+        )?;
 
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         // Pre-merge delta per query (requires &self, safe for rayon via shared ref)
         let merged: Vec<_> = index_results
@@ -139,7 +141,7 @@ impl Collection {
         k: usize,
     ) -> Result<Vec<Vec<SearchResult>>> {
         let (dimension, metric) = {
-            let cfg = self.config.read();
+            let cfg = self.storage.config.read();
             (cfg.dimension, cfg.metric)
         };
 
@@ -150,7 +152,8 @@ impl Collection {
 
         // Perf: Use parallel HNSW search (P0 optimization)
         let index_results =
-            self.index
+            self.storage
+                .index
                 .search_batch_parallel(queries, k, SearchQuality::Balanced)?;
 
         // Pre-merge delta per query (requires &self)
@@ -161,8 +164,8 @@ impl Collection {
             .collect();
 
         // Parallel result resolution across queries (P0 QPS optimization)
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let vs: &dyn VectorStorage = &*vector_storage;
         let ps: &dyn PayloadStorage = &*payload_storage;
 
@@ -235,7 +238,7 @@ impl Collection {
             )));
         }
 
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let dimension = config.dimension;
         let metric = config.metric;
         drop(config);
@@ -269,7 +272,7 @@ impl Collection {
         overfetch_k: usize,
         metric: crate::DistanceMetric,
     ) -> Result<Vec<Vec<(u64, f32)>>> {
-        let batch_results = self.index.search_batch_parallel(
+        let batch_results = self.storage.index.search_batch_parallel(
             vectors,
             overfetch_k,
             crate::SearchQuality::Balanced,
@@ -296,7 +299,7 @@ impl Collection {
         let Some(f) = filter else {
             return batch_results;
         };
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         batch_results
             .into_iter()
             .map(|query_results| {
@@ -316,8 +319,8 @@ impl Collection {
 
     /// Fetches full point data for the top-k fused results.
     fn hydrate_fused_results(&self, fused: &[(u64, f32)], top_k: usize) -> Vec<SearchResult> {
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         resolve::resolve_id_score_pairs(fused, top_k, &*vector_storage, &*payload_storage)
     }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -64,8 +64,8 @@ impl Collection {
         let filter = Self::build_static_filter(where_clause, use_runtime, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let ids = vector_storage.ids();
         let mut graph_cache = GraphMatchEvalCache::default();
         let mut groups: HashMap<GroupKey, Aggregator> = HashMap::new();

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -210,8 +210,8 @@ impl Collection {
         let filter = Self::build_static_filter(where_clause, use_runtime_where_eval, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let ids: Vec<u64> = vector_storage.ids();
 
         if ids.len() >= PARALLEL_THRESHOLD && !use_runtime_where_eval {

--- a/crates/velesdb-core/src/collection/search/query/early_return.rs
+++ b/crates/velesdb-core/src/collection/search/query/early_return.rs
@@ -160,8 +160,8 @@ impl Collection {
         early: &EarlyReturnCtx<'_>,
         graph_cache: &mut super::where_eval::GraphMatchEvalCache,
     ) -> Result<Vec<SearchResult>> {
-        let mut results =
-            execute_fn(self).inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+        let mut results = execute_fn(self)
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         if early.has_graph_predicates {
             results = self
                 .apply_where_condition_to_results_with_cache(
@@ -171,7 +171,7 @@ impl Collection {
                     &early.stmt.from_alias,
                     graph_cache,
                 )
-                .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+                .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         }
         self.finalize_early_results(results, early)
     }
@@ -188,7 +188,7 @@ impl Collection {
         }
         if let Some(ref order_by) = early.stmt.order_by {
             self.apply_order_by(&mut results, order_by, early.params)
-                .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+                .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         }
         // SQL-standard: OFFSET applied after ORDER BY, before LIMIT.
         if let Some(offset) = early.stmt.offset {
@@ -205,7 +205,7 @@ impl Collection {
         .min(MAX_LIMIT);
         results.truncate(final_limit);
         self.check_guardrails_and_record(early.ctx, results.len())?;
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(results)
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -256,7 +256,7 @@ impl Collection {
                     self.search_with_filter_and_opts(vector, cbo_search_k, filter, search_opts),
                 );
                 let vector_results = vector_results?;
-                let higher = self.config.read().metric.higher_is_better();
+                let higher = self.storage.config.read().metric.higher_is_better();
                 Ok(merge_select_parallel_results(
                     graph_results,
                     vector_results,
@@ -533,7 +533,10 @@ impl Collection {
         }
 
         // Use BM25 text index to find candidates (over-fetch 10× for post-filter headroom).
-        let text_results = self.text_index.search(word, limit.saturating_mul(10));
+        let text_results = self
+            .storage
+            .text_index
+            .search(word, limit.saturating_mul(10));
         if text_results.is_empty() {
             return None;
         }

--- a/crates/velesdb-core/src/collection/search/query/extraction.rs
+++ b/crates/velesdb-core/src/collection/search/query/extraction.rs
@@ -263,7 +263,7 @@ impl Collection {
         }
 
         // Use the collection's configured metric for consistent behavior
-        let metric = self.config.read().metric;
+        let metric = self.storage.config.read().metric;
         metric.calculate(a, b)
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
+++ b/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
@@ -155,7 +155,7 @@ impl Collection {
                 super::super::vector_filter::compute_oversampled_k(limit, f)
             })
             .min(super::MAX_LIMIT);
-        let index_results = self.index.search_with_quality_and_bitmap(
+        let index_results = self.storage.index.search_with_quality_and_bitmap(
             vector,
             candidates_k,
             crate::SearchQuality::default(),

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -215,7 +215,7 @@ impl Collection {
                 anchors,
             )?
         } else {
-            let indexes = self.sparse_indexes.read(); // lock 9 only (no payload needed)
+            let indexes = self.query.sparse_indexes.read(); // lock 9 only (no payload needed)
             let index = indexes
                 .get(index_name)
                 .ok_or_else(|| resolve::sparse_index_not_found(index_name))?;
@@ -242,8 +242,8 @@ impl Collection {
         metadata_filter: Option<&crate::filter::Filter>,
         anchors: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<crate::sparse_index::ScoredDoc>> {
-        let payload_storage = metadata_filter.map(|_| self.payload_storage.read()); // lock 3
-        let indexes = self.sparse_indexes.read(); // lock 9
+        let payload_storage = metadata_filter.map(|_| self.storage.payload_storage.read()); // lock 3
+        let indexes = self.query.sparse_indexes.read(); // lock 9
         let index = indexes
             .get(index_name)
             .ok_or_else(|| resolve::sparse_index_not_found(index_name))?;
@@ -404,8 +404,8 @@ impl Collection {
                 || {
                     if let Some(filter) = metadata_filter {
                         // LOCK ORDER: payload_storage(3) before sparse_indexes(9).
-                        let payload_storage = self.payload_storage.read();
-                        let indexes = self.sparse_indexes.read();
+                        let payload_storage = self.storage.payload_storage.read();
+                        let indexes = self.query.sparse_indexes.read();
                         let Some(index) = indexes.get(index_name) else {
                             return Vec::new();
                         };
@@ -416,7 +416,7 @@ impl Collection {
                         };
                         sparse_search_filtered(index, sparse_query, candidate_k, Some(&filter_fn))
                     } else {
-                        let indexes = self.sparse_indexes.read();
+                        let indexes = self.query.sparse_indexes.read();
                         let Some(index) = indexes.get(index_name) else {
                             return Vec::new();
                         };
@@ -438,8 +438,8 @@ impl Collection {
                 .collect();
             let sparse = if let Some(filter) = metadata_filter {
                 // LOCK ORDER: payload_storage(3) before sparse_indexes(9).
-                let payload_storage = self.payload_storage.read();
-                let indexes = self.sparse_indexes.read();
+                let payload_storage = self.storage.payload_storage.read();
+                let indexes = self.query.sparse_indexes.read();
                 if let Some(index) = indexes.get(index_name) {
                     let filter_fn = |id: u64| {
                         let payload = payload_storage.retrieve(id).ok().flatten();
@@ -451,7 +451,7 @@ impl Collection {
                     Vec::new()
                 }
             } else {
-                let indexes = self.sparse_indexes.read();
+                let indexes = self.query.sparse_indexes.read();
                 if let Some(index) = indexes.get(index_name) {
                     sparse_search(index, sparse_query, candidate_k)
                 } else {
@@ -476,8 +476,8 @@ impl Collection {
         limit: usize,
         capacity_hint: usize,
     ) -> Vec<SearchResult> {
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
         let mut out = Vec::with_capacity(capacity_hint.min(limit));

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -30,13 +30,13 @@ impl Collection {
         &self,
     ) -> crate::velesql::match_planner::CollectionStats {
         let total_nodes = self.len();
-        let total_edges = self.edge_store.len();
+        let total_edges = self.graph.edge_store.len();
         let avg_degree = if total_nodes > 0 {
             total_edges as f64 / total_nodes as f64
         } else {
             0.0
         };
-        let label_count = self.edge_store.label_count();
+        let label_count = self.graph.edge_store.label_count();
         let label_selectivity = if label_count > 0 {
             1.0 / label_count as f64
         } else {
@@ -91,10 +91,11 @@ impl Collection {
         match_clause: &crate::velesql::MatchClause,
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<super::match_exec::MatchResult>> {
-        self.guard_rails
+        self.runtime
+            .guard_rails
             .pre_check("default")
             .map_err(crate::error::Error::from)?;
-        let ctx = self.guard_rails.create_context();
+        let ctx = self.runtime.guard_rails.create_context();
         self.dispatch_match_ordered(match_clause, params, &ctx)
     }
 
@@ -256,7 +257,7 @@ impl Collection {
         let vector_results = vector_results?;
 
         // Merge by node_id (union, best score wins per metric polarity).
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let higher_is_better = config.metric.higher_is_better();
         drop(config);
 
@@ -280,29 +281,30 @@ impl Collection {
     ) -> Result<Vec<SearchResult>> {
         ctx.check_timeout()
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
 
         let mut sorted = match_results;
         self.apply_match_order_by(&mut sorted, match_clause, params)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
 
         let mut results = self
             .match_results_to_search_results(sorted)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         // Final cardinality check for MATCH path (EPIC-048 US-003).
         ctx.check_cardinality(results.len())
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         if let Some(limit) = match_return_limit(match_clause) {
             results.truncate(limit);
         }
         // Reason: u128->u64 cast; query durations < u64::MAX µs (~585 millennia)
         #[allow(clippy::cast_possible_truncation)]
         let graph_latency_us = ctx.elapsed().as_micros() as u64;
-        self.query_planner
+        self.query
+            .query_planner
             .stats()
             .update_graph_latency(graph_latency_us);
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(results)
     }
 
@@ -322,22 +324,22 @@ impl Collection {
     ) -> Result<Vec<super::match_exec::MatchResult>> {
         ctx.check_timeout()
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
 
         let mut sorted = match_results;
         self.apply_match_order_by(&mut sorted, match_clause, params)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
 
         // Final cardinality check for MATCH path (EPIC-048 US-003), matching
         // `finalize_match_results` so the ordered surface rejects oversized
         // result sets identically to the SQL path.
         ctx.check_cardinality(sorted.len())
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         if let Some(limit) = match_return_limit(match_clause) {
             sorted.truncate(limit);
         }
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(sorted)
     }
 
@@ -682,14 +684,14 @@ mod tests {
             params.insert("v".to_string(), serde_json::json!([1.0, 0.0]));
 
             // Leg 1 in isolation: GraphFirst (execute_match_with_context).
-            let graph_ctx = col.guard_rails.create_context();
+            let graph_ctx = col.runtime.guard_rails.create_context();
             col.execute_match_with_context(&mc, &params, Some(&graph_ctx))
                 .expect("graph leg");
             let graph_nodes = graph_ctx.traversal_nodes_visited();
             let graph_edges = graph_ctx.traversal_edges_traversed();
 
             // Leg 2 in isolation: VectorFirst (execute_match_vector_first).
-            let vec_ctx = col.guard_rails.create_context();
+            let vec_ctx = col.runtime.guard_rails.create_context();
             col.execute_match_vector_first(&mc, &params, &vec_ctx, "a", 10, 0.0)
                 .expect("vector leg");
             let vec_nodes = vec_ctx.traversal_nodes_visited();
@@ -700,7 +702,7 @@ mod tests {
             assert!(vec_nodes > 0, "vector leg must evaluate candidates");
 
             // Parallel run accumulates BOTH legs into one shared context.
-            let par_ctx = col.guard_rails.create_context();
+            let par_ctx = col.runtime.guard_rails.create_context();
             col.execute_match_parallel(&mc, &params, &par_ctx, &hint)
                 .expect("parallel run");
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -266,7 +266,7 @@ impl Collection {
         let mut reported_cardinality: usize = 0;
 
         // Hoist payload_storage lock once for the entire query.
-        let payload_guard = self.payload_storage.read();
+        let payload_guard = self.storage.payload_storage.read();
 
         for pattern in &match_clause.patterns {
             if all_results.len() >= limit {
@@ -278,7 +278,7 @@ impl Collection {
                 params,
                 ctx,
                 &payload_guard,
-                &self.edge_store,
+                &self.graph.edge_store,
                 limit,
                 &mut all_results,
                 &mut iteration_count,

--- a/crates/velesdb-core/src/collection/search/query/match_exec/order_by.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/order_by.rs
@@ -93,11 +93,11 @@ impl Collection {
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<()> {
         let query_vector = Self::resolve_vector(&sim.vector, params)?;
-        let metric = self.config.read().metric;
+        let metric = self.storage.config.read().metric;
         let higher_is_better = metric.higher_is_better();
         // `alias.property` => score the node bound to `alias`; bare => the anchor.
         let alias = parse_property_path(&sim.field).map(|(alias, _)| alias);
-        let vector_storage = self.vector_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         results.sort_by(|a, b| {
             let score = |r: &MatchResult| -> f32 {
                 let Some(node_id) = resolve_scored_node_id(r, alias) else {
@@ -130,7 +130,7 @@ impl Collection {
         arith: &ArithmeticExpr,
         descending: bool,
     ) {
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         results.sort_by(|a, b| {
             let score = |r: &MatchResult| -> f32 {
                 let payload = payload_storage.retrieve(r.node_id).ok().flatten();

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -165,7 +165,7 @@ impl Collection {
         item: &crate::velesql::ReturnItem,
         projected: &mut HashMap<String, serde_json::Value>,
     ) {
-        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+        let Some(edge) = self.graph.edge_store.get_edge(edge_id) else {
             return;
         };
         let Some(value) = super::where_eval::edge_property_path(&edge, property) else {
@@ -187,7 +187,8 @@ impl Collection {
         let values: Vec<serde_json::Value> = edge_ids
             .iter()
             .map(|&edge_id| {
-                self.edge_store
+                self.graph
+                    .edge_store
                     .get_edge(edge_id)
                     .as_ref()
                     .and_then(|edge| super::where_eval::edge_property_path(edge, property).cloned())
@@ -322,7 +323,7 @@ impl Collection {
             return Ok(results);
         }
 
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let metric = config.metric;
         let expected_dimension = config.dimension;
         drop(config);
@@ -330,8 +331,8 @@ impl Collection {
         validate_dimension_match(expected_dimension, query_vector.len())?;
 
         // Hoist both storage locks once for the entire scoring loop.
-        let payload_guard = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_guard = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let higher_is_better = metric.higher_is_better();
 
         let mut scored_results = self.score_match_results(
@@ -452,7 +453,7 @@ impl Collection {
                  (use similarity(), depth, or alias.property)"
             )));
         };
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         results.sort_by(|a, b| {
             let get_value = |r: &MatchResult| -> Option<serde_json::Value> {
                 let node_id = *r.bindings.get(alias)?;
@@ -481,8 +482,8 @@ impl Collection {
         &self,
         match_results: Vec<MatchResult>,
     ) -> Result<Vec<SearchResult>> {
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
 
         let mut results = Vec::new();
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
@@ -39,7 +39,7 @@ impl Collection {
 
         // Fast path: use label index when labels are specified.
         if !first_node.labels.is_empty() {
-            let has_large = self.label_index.read().has_large_ids();
+            let has_large = self.graph.label_index.read().has_large_ids();
             let indexed = self.find_start_nodes_indexed(first_node);
 
             if has_large {
@@ -81,7 +81,7 @@ impl Collection {
         &self,
         first_node: &crate::velesql::NodePattern,
     ) -> Vec<(u64, HashMap<String, u64>)> {
-        let label_idx = self.label_index.read();
+        let label_idx = self.graph.label_index.read();
         let bitmap = label_idx.lookup_intersection(&first_node.labels);
         drop(label_idx);
 
@@ -96,7 +96,7 @@ impl Collection {
                 .collect();
         }
 
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         bitmap
             .iter()
             .filter(|&id| {
@@ -115,8 +115,8 @@ impl Collection {
         &self,
         first_node: &crate::velesql::NodePattern,
     ) -> Vec<(u64, HashMap<String, u64>)> {
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let needs_payload = !first_node.properties.is_empty() || !first_node.labels.is_empty();
 
         let mut all_ids: std::collections::HashSet<u64> =

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -53,7 +53,7 @@ impl Collection {
 
         let candidates = self.search(&query_vector, top_k)?;
 
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let higher_is_better = config.metric.higher_is_better();
         drop(config);
 
@@ -89,7 +89,7 @@ impl Collection {
         limit: usize,
         higher_is_better: bool,
     ) -> Result<Vec<MatchResult>> {
-        let payload_guard = self.payload_storage.read();
+        let payload_guard = self.storage.payload_storage.read();
         let mut results = Vec::new();
         let mut examined = 0u64;
 
@@ -258,7 +258,7 @@ impl Collection {
             bindings.insert(alias.clone(), node_id);
         }
 
-        for hit in concurrent_bfs_stream(&self.edge_store, node_id, config) {
+        for hit in concurrent_bfs_stream(&self.graph.edge_store, node_id, config) {
             // Each BFS hit is a node reached by following edges (EXPLAIN ANALYZE).
             ctx.add_traversal(1, 1);
             if let Some(target_pattern) = pattern.nodes.get(hit.depth as usize) {

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -305,7 +305,7 @@ impl Collection {
         cmp: &crate::velesql::Comparison,
         params: &HashMap<String, serde_json::Value>,
     ) -> Result<bool> {
-        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+        let Some(edge) = self.graph.edge_store.get_edge(edge_id) else {
             return Ok(false);
         };
         let property = cmp.column.split_once('.').map_or("", |(_, rest)| rest);
@@ -383,7 +383,7 @@ impl Collection {
         condition: &crate::velesql::Condition,
         ctx: &MatchWhereCtx<'_>,
     ) -> Result<bool> {
-        let Some(edge) = self.edge_store.get_edge(edge_id) else {
+        let Some(edge) = self.graph.edge_store.get_edge(edge_id) else {
             return Ok(false);
         };
         let payload = serde_json::Value::Object(
@@ -418,7 +418,7 @@ impl Collection {
             return Ok(false);
         }
 
-        let vector_storage = self.vector_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let Some(node_vector) = vector_storage.retrieve(node_id)? else {
             return Ok(false);
         };
@@ -427,7 +427,7 @@ impl Collection {
             return Ok(false);
         }
 
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let metric = config.metric;
         let higher_is_better = metric.higher_is_better();
         drop(config);

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -324,6 +324,7 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<SearchResult>> {
         let query = self
+            .query
             .query_cache
             .parse(sql)
             .map_err(|e| crate::error::Error::Query(e.to_string()))?;

--- a/crates/velesdb-core/src/collection/search/query/multi_vector.rs
+++ b/crates/velesdb-core/src/collection/search/query/multi_vector.rs
@@ -35,12 +35,12 @@ impl Collection {
     ) -> Result<Option<Vec<f32>>> {
         if field == "vector" {
             // Primary vector store
-            let storage = self.vector_storage.read();
+            let storage = self.storage.vector_storage.read();
             return Ok(storage.retrieve(point_id)?);
         }
 
         // Named vector from payload JSON field
-        let payload_storage = self.payload_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let Some(payload) = payload_storage.retrieve(point_id)? else {
             return Ok(None);
         };

--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -75,7 +75,7 @@ impl Collection {
             return Ok(None);
         };
         self.check_guardrails_and_record(ctx, results.len())?;
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(Some(results))
     }
 
@@ -98,7 +98,7 @@ impl Collection {
         let (limit, fetch_limit) = Self::compute_fetch_limit(stmt);
         let Some(ids) = self.ordered_ids_if_covered(field, order_descending(stmt), fetch_limit)
         else {
-            self.order_by_advisor.write().observe(field);
+            self.graph.order_by_advisor.write().observe(field);
             return None;
         };
         let hydrated: Vec<crate::point::Point> = self.get(&ids).into_iter().flatten().collect();
@@ -145,7 +145,7 @@ impl Collection {
         // release before hydrating.
         let Some(ids) = self.ordered_ids_if_covered(field, order_descending(stmt), point_count)
         else {
-            self.order_by_advisor.write().observe(field);
+            self.graph.order_by_advisor.write().observe(field);
             return None;
         };
         let predicate =
@@ -180,7 +180,7 @@ impl Collection {
         let Some(ids) =
             self.ordered_prefix_if_covered(lead_field, order_descending(stmt), fetch_limit)
         else {
-            self.order_by_advisor.write().observe(lead_field);
+            self.graph.order_by_advisor.write().observe(lead_field);
             return None;
         };
         let mut hydrated: Vec<SearchResult> = self

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -123,7 +123,7 @@ impl Collection {
         }
 
         let similarity_scores_map = self.precompute_similarity_scores(results, order_by, params)?;
-        let higher_is_better = self.config.read().metric.higher_is_better();
+        let higher_is_better = self.storage.config.read().metric.higher_is_better();
 
         let mut indices: Vec<usize> = (0..results.len()).collect();
         indices.sort_unstable_by(|&i, &j| {
@@ -207,7 +207,7 @@ impl Collection {
         field: &str,
         order_vec: &[f32],
     ) -> Result<Vec<f32>> {
-        let worst = if self.config.read().metric.higher_is_better() {
+        let worst = if self.storage.config.read().metric.higher_is_better() {
             f32::NEG_INFINITY
         } else {
             f32::INFINITY

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -149,11 +149,12 @@ impl Collection {
         query: &crate::velesql::Query,
         client_id: &str,
     ) -> Result<crate::guardrails::QueryContext> {
-        self.guard_rails
+        self.runtime
+            .guard_rails
             .pre_check(client_id)
             .map_err(crate::error::Error::from)?;
 
-        let mut ctx = self.guard_rails.create_context();
+        let mut ctx = self.runtime.guard_rails.create_context();
 
         // WITH (timeout_ms=N) overrides the collection-level timeout for this query.
         if let Some(override_ms) = query
@@ -196,7 +197,8 @@ impl Collection {
             // Reason: u128->u64 cast; query durations < u64::MAX µs (~585 millennia)
             #[allow(clippy::cast_possible_truncation)]
             let vector_latency_us = elapsed.as_micros() as u64;
-            self.query_planner
+            self.query
+                .query_planner
                 .stats()
                 .update_vector_latency(vector_latency_us);
 
@@ -209,10 +211,11 @@ impl Collection {
                 .as_ref()
                 .and_then(crate::velesql::WithClause::get_ef_search)
                 .unwrap_or(100);
-            self.query_planner
+            self.query
+                .query_planner
                 .record_cbo_feedback(dataset_size, ef_search, actual_ms);
         }
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(())
     }
 
@@ -355,10 +358,10 @@ impl Collection {
     ) -> Result<()> {
         ctx.check_timeout()
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         ctx.check_cardinality(result_count)
             .map_err(crate::error::Error::from)
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())?;
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())?;
         Ok(())
     }
 
@@ -393,9 +396,11 @@ impl Collection {
 
         // Issue #469 Phase 2: attach EMA-calibrated ms_per_cost_unit if the
         // feedback loop is warm (≥ MIN_SAMPLES observations on this collection).
-        if let Some(ms_per_unit) = self.query_planner.adjusted_ms_per_cost_unit() {
-            output = output
-                .with_feedback_calibration(ms_per_unit, self.query_planner.cbo_sample_count());
+        if let Some(ms_per_unit) = self.query.query_planner.adjusted_ms_per_cost_unit() {
+            output = output.with_feedback_calibration(
+                ms_per_unit,
+                self.query.query_planner.cbo_sample_count(),
+            );
         }
 
         Ok(output)

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -47,11 +47,10 @@ impl Collection {
             return self.cbo_strategy_for_order_by_similarity(effective_filter, limit);
         }
         let col_stats = self.get_stats();
-        let result = self.query_planner.choose_strategy_with_cbo_and_overfetch(
-            &col_stats,
-            effective_filter,
-            limit,
-        );
+        let result = self
+            .query
+            .query_planner
+            .choose_strategy_with_cbo_and_overfetch(&col_stats, effective_filter, limit);
         tracing::debug!(
             strategy = ?result.0, over_fetch = result.1,
             "CBO selected execution strategy (calibrated cost path)"
@@ -164,7 +163,7 @@ impl Collection {
         // equivalent values; `u64::try_from(usize)` never fails on 64-bit
         // targets and saturates on 32-bit.
         let limit_u64 = u64::try_from(limit).unwrap_or(u64::MAX);
-        let plan = self.query_planner.choose_hybrid_strategy(
+        let plan = self.query.query_planner.choose_hybrid_strategy(
             true, // has_order_by_similarity
             filter_condition.is_some(),
             Some(limit_u64),
@@ -291,7 +290,7 @@ impl Collection {
             cbo_strategy,
             cbo_over_fetch,
         )
-        .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+        .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())
     }
 
     /// Applies the exact WHERE post-filter when graph predicates are present,
@@ -313,7 +312,7 @@ impl Collection {
             &stmt.from_alias,
             graph_cache,
         )
-        .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+        .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())
     }
 
     /// Attempts the GraphFirst anchored fetch for the main SELECT path.

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -58,7 +58,7 @@ impl Collection {
         threshold: f64,
         limit: usize,
     ) -> Vec<SearchResult> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let higher_is_better = config.metric.higher_is_better();
         drop(config);
 
@@ -130,7 +130,7 @@ impl Collection {
                 sorted.sort_unstable();
                 sorted
             }
-            None => self.vector_storage.read().ids(),
+            None => self.storage.vector_storage.read().ids(),
         };
         let total_count = all_ids.len();
         Self::guard_not_similarity_scan(total_count)?;
@@ -140,7 +140,7 @@ impl Collection {
         let filter = metadata_filter
             .map(|cond| crate::filter::Filter::new(crate::filter::Condition::from(cond)));
 
-        let higher_is_better = self.config.read().metric.higher_is_better();
+        let higher_is_better = self.storage.config.read().metric.higher_is_better();
 
         #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
         let threshold_f32 = sim_threshold as f32;
@@ -190,7 +190,13 @@ impl Collection {
         ) {
             return None; // excluded by the NOT-similarity threshold
         }
-        let payload = self.payload_storage.read().retrieve(id).ok().flatten();
+        let payload = self
+            .storage
+            .payload_storage
+            .read()
+            .retrieve(id)
+            .ok()
+            .flatten();
         if is_payload_expired(payload.as_ref(), now_unix_secs()) {
             return None;
         }
@@ -353,8 +359,8 @@ impl Collection {
         }
 
         // Full sequential scan (slow fallback for non-indexed conditions).
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
 
         let vector_ids = vector_storage.ids();
         let ids: Vec<u64> = if vector_ids.is_empty() {
@@ -376,7 +382,7 @@ impl Collection {
             filter,
             limit,
         );
-        self.payload_mirror.add_scan_debt(scanned);
+        self.storage.payload_mirror.add_scan_debt(scanned);
         // `scanned` counts visited ids out of `total_ids`; on 64-bit targets
         // the conversion is lossless (falls back to "all visited" otherwise).
         let visited = usize::try_from(scanned).unwrap_or(total_ids);
@@ -477,8 +483,8 @@ impl Collection {
         filter: &crate::filter::Filter,
         limit: usize,
     ) -> TrackedScan {
-        let payload_storage = self.payload_storage.read();
-        let vector_storage = self.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
         let mut scanned: usize = 0;
         let results = Self::collect_filtered_scan(
             &*payload_storage,

--- a/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/sparse_dispatch.rs
@@ -70,7 +70,7 @@ impl Collection {
             limit,
             Some(anchor_ids),
         )
-        .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+        .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())
     }
 
     /// Computes the GraphFirst anchor set for a sparse-only fetch.
@@ -119,7 +119,7 @@ impl Collection {
                 execution_limit,
                 &fusion_strategy,
             )
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())
         } else {
             self.execute_sparse_search(
                 svs,
@@ -127,7 +127,7 @@ impl Collection {
                 extracted.filter_condition.as_ref(),
                 execution_limit,
             )
-            .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure())
+            .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure())
         }
     }
 
@@ -150,7 +150,7 @@ impl Collection {
                     &stmt.from_alias,
                     cache,
                 )
-                .inspect_err(|_| self.guard_rails.circuit_breaker.record_failure()),
+                .inspect_err(|_| self.runtime.guard_rails.circuit_breaker.record_failure()),
             None => Ok(results),
         }
     }
@@ -186,7 +186,7 @@ impl Collection {
                 .unwrap_or(MAX_LIMIT)
                 .min(MAX_LIMIT);
         results.truncate(final_limit);
-        self.guard_rails.circuit_breaker.record_success();
+        self.runtime.guard_rails.circuit_breaker.record_success();
         Ok(results)
     }
 

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -261,7 +261,7 @@ impl Collection {
         };
         let query_vec = Self::resolve_vector(&sim.vector, params)?;
         let score = self.compute_metric_score(record_vector, &query_vec);
-        let metric = self.config.read().metric;
+        let metric = self.storage.config.read().metric;
         #[allow(clippy::cast_possible_truncation)]
         // Reason: similarity thresholds are approximate floating bounds.
         let threshold = sim.threshold as f32;

--- a/crates/velesdb-core/src/collection/search/sparse.rs
+++ b/crates/velesdb-core/src/collection/search/sparse.rs
@@ -39,7 +39,7 @@ impl Collection {
         k: usize,
         index_name: &str,
     ) -> Result<Vec<SearchResult>> {
-        let indexes = self.sparse_indexes.read();
+        let indexes = self.query.sparse_indexes.read();
         let index = indexes
             .get(index_name)
             .ok_or_else(|| resolve::sparse_index_not_found(index_name))?;

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -61,9 +61,12 @@ fn compute_hybrid_scored(
     rustc_hash::FxHashMap<u64, (f32, f32)>,
 ) {
     use crate::index::VectorIndex;
-    let raw = collection.index.search(vector_query, overfetch_k);
+    let raw = collection.storage.index.search(vector_query, overfetch_k);
     let vec_res = collection.merge_delta(raw, vector_query, overfetch_k, metric);
-    let text_res = collection.text_index.search(text_query, overfetch_k);
+    let text_res = collection
+        .storage
+        .text_index
+        .search(text_query, overfetch_k);
     Collection::compute_rrf_scores_with_components(
         &vec_res,
         &text_res,
@@ -103,10 +106,10 @@ impl Collection {
     /// Returns an error if storage retrieval fails.
     #[allow(clippy::unnecessary_wraps)] // Reason: Public API contract — callers expect Result
     pub fn text_search(&self, query: &str, k: usize) -> Result<Vec<SearchResult>> {
-        let bm25_results = self.text_index.search(query, k);
+        let bm25_results = self.storage.text_index.search(query, k);
 
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         let mut results = resolve::resolve_id_score_pairs(
             &bm25_results,
@@ -145,10 +148,10 @@ impl Collection {
     ) -> Result<Vec<SearchResult>> {
         // Retrieve more candidates for filtering
         let candidates_k = k.saturating_mul(4).max(k + 10);
-        let bm25_results = self.text_index.search(query, candidates_k);
+        let bm25_results = self.storage.text_index.search(query, candidates_k);
 
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
         Ok(bm25_results
@@ -218,7 +221,7 @@ impl Collection {
         vector_weight: Option<f32>,
         rrf_k: Option<u32>,
     ) -> Result<Vec<SearchResult>> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let (metric, weight, text_weight, rrf_constant) =
             validated_hybrid_params(&config, vector_query, vector_weight, rrf_k)?;
         drop(config);
@@ -309,8 +312,8 @@ impl Collection {
         scored_ids: &[(u64, f32)],
         component_map: &rustc_hash::FxHashMap<u64, (f32, f32)>,
     ) -> Vec<SearchResult> {
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
         scored_ids
@@ -355,7 +358,7 @@ impl Collection {
         filter: &crate::filter::Filter,
         rrf_k: Option<u32>,
     ) -> Result<Vec<SearchResult>> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let (metric, weight, text_weight, rrf_constant) =
             validated_hybrid_params(&config, vector_query, vector_weight, rrf_k)?;
         drop(config);
@@ -436,7 +439,7 @@ impl Collection {
         anchor_ids: &HashSet<u64>,
         overfetch_k: usize,
     ) -> Result<AnchoredHybridStreams> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         validate_dimension_match(config.dimension, vector_query.len())?;
         drop(config);
 
@@ -449,7 +452,7 @@ impl Collection {
             .collect();
 
         // BM25 branch: over-fetch then restrict to anchor set.
-        let bm25_all = self.text_index.search(text_query, overfetch_k);
+        let bm25_all = self.storage.text_index.search(text_query, overfetch_k);
         let text_results: Vec<(u64, f32)> = bm25_all
             .into_iter()
             .filter(|(id, _)| anchor_ids.contains(id))
@@ -466,8 +469,8 @@ impl Collection {
         k: usize,
         component_map: &rustc_hash::FxHashMap<u64, (f32, f32)>,
     ) -> Vec<SearchResult> {
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
         scored_ids

--- a/crates/velesdb-core/src/collection/search/text_fusion.rs
+++ b/crates/velesdb-core/src/collection/search/text_fusion.rs
@@ -164,14 +164,14 @@ impl Collection {
     ) -> Result<(ScoreStream, ScoreStream)> {
         use crate::index::VectorIndex;
         let metric = {
-            let config = self.config.read();
+            let config = self.storage.config.read();
             crate::validation::validate_dimension_match(config.dimension, vector_query.len())?;
             config.metric
         };
-        let raw = self.index.search(vector_query, candidate_k);
+        let raw = self.storage.index.search(vector_query, candidate_k);
         let vec_res = self.merge_delta(raw, vector_query, candidate_k, metric);
         let vector_stream: Vec<(u64, f32)> = vec_res.iter().map(|sr| (sr.id, sr.score)).collect();
-        let text_stream = self.text_index.search(text_query, candidate_k);
+        let text_stream = self.storage.text_index.search(text_query, candidate_k);
         Ok((vector_stream, text_stream))
     }
 }

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -43,7 +43,7 @@ pub(super) fn tag_vector_component_scores(results: &mut [SearchResult]) {
 
 impl Collection {
     fn search_ids_with_adc_if_pq(&self, query: &[f32], k: usize) -> Vec<ScoredResult> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let is_pq = matches!(config.storage_mode, StorageMode::ProductQuantization);
         let higher_is_better = config.metric.higher_is_better();
         let metric = config.metric;
@@ -53,12 +53,12 @@ impl Collection {
         drop(config);
 
         if !is_pq || oversampling == 0 {
-            let results = self.index.search(query, k);
+            let results = self.storage.index.search(query, k);
             return self.merge_delta(results, query, k, metric);
         }
 
         let candidates_k = k.saturating_mul(oversampling).max(k + 32);
-        let index_results = self.index.search(query, candidates_k);
+        let index_results = self.storage.index.search(query, candidates_k);
         let rescored =
             self.rescore_pq_candidates(query, k, metric, higher_is_better, index_results);
         self.merge_delta(rescored, query, k, metric)
@@ -77,8 +77,8 @@ impl Collection {
         higher_is_better: bool,
         index_results: Vec<ScoredResult>,
     ) -> Vec<ScoredResult> {
-        let pq_cache = self.pq_cache.read();
-        let quantizer = self.pq_quantizer.read();
+        let pq_cache = self.storage.pq_cache.read();
+        let quantizer = self.storage.pq_quantizer.read();
         let Some(quantizer) = quantizer.as_ref() else {
             return index_results.into_iter().take(k).collect();
         };
@@ -109,7 +109,7 @@ impl Collection {
     ) -> Vec<ScoredResult> {
         let after_delta = crate::collection::streaming::merge_with_delta_scored(
             results,
-            &self.delta_buffer,
+            &self.streaming.delta_buffer,
             query,
             k,
             metric,
@@ -128,7 +128,7 @@ impl Collection {
         k: usize,
         metric: DistanceMetric,
     ) -> Vec<ScoredResult> {
-        let Some(ref di) = self.deferred_indexer else {
+        let Some(ref di) = self.streaming.deferred_indexer else {
             return results;
         };
         if !di.is_searchable() {
@@ -263,7 +263,7 @@ impl Collection {
     /// `#[inline]` preserves pre-refactor inlining (Phase 3.2 learning).
     #[inline]
     pub(super) fn validate_query_and_read_metric(&self, query: &[f32]) -> Result<DistanceMetric> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         if config.metadata_only {
             return Err(Error::SearchNotSupported(config.name.clone()));
         }
@@ -288,8 +288,8 @@ impl Collection {
     ) -> Vec<SearchResult> {
         let index_results = self.merge_delta(index_results, query, k, metric);
 
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         let mut results =
             resolve::resolve_scored_results(&index_results, &*vector_storage, &*payload_storage);
@@ -306,7 +306,7 @@ impl Collection {
     /// Returns an error if the query vector dimension doesn't match the collection,
     /// or if this is a metadata-only collection (use `query()` instead).
     pub fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
-        let config = self.config.read();
+        let config = self.storage.config.read();
 
         // Metadata-only collections don't support vector search
         if config.metadata_only {
@@ -319,8 +319,8 @@ impl Collection {
         // Use HNSW index for fast ANN search
         let index_results = self.search_ids_with_adc_if_pq(query, k);
 
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
 
         let mut results =
             resolve::resolve_scored_results(&index_results, &*vector_storage, &*payload_storage);
@@ -347,7 +347,7 @@ impl Collection {
         // Convert ef_search to a value-preserving SearchQuality.
         let quality = super::vector_filter::ef_to_quality(ef_search);
 
-        let index_results = self.index.search_with_quality(query, k, quality)?;
+        let index_results = self.storage.index.search_with_quality(query, k, quality)?;
         Ok(self.finalize_search_results(query, k, metric, index_results))
     }
 
@@ -370,7 +370,7 @@ impl Collection {
             return Ok(());
         }
         let cap = self.runtime_limits().max_perfect_mode_vectors;
-        let size = self.index.len();
+        let size = self.storage.index.len();
         if size > cap {
             return Err(Error::GuardRail(format!(
                 "Perfect (brute-force) search rejected: collection has {size} vectors, \
@@ -398,7 +398,7 @@ impl Collection {
         let metric = self.validate_query_and_read_metric(query)?;
         self.enforce_perfect_mode_limit(quality)?;
 
-        let index_results = self.index.search_with_quality(query, k, quality)?;
+        let index_results = self.storage.index.search_with_quality(query, k, quality)?;
         Ok(self.finalize_search_results(query, k, metric, index_results))
     }
 
@@ -453,6 +453,7 @@ impl Collection {
 
         let rerank_k = k.saturating_mul(4).max(k + 32);
         let index_results = self
+            .storage
             .index
             .search_with_rerank_quality(query, k, rerank_k, quality)?;
         Ok(self.finalize_search_results(query, k, metric, index_results))
@@ -475,8 +476,8 @@ impl Collection {
         // a smaller ef than search_with_quality on >10K datasets, breaking the
         // implicit contract that "no rerank" only suppresses reranking, not the
         // candidate-pool sizing.
-        let ef_search = quality.ef_search_for_scale(k, self.index.len());
-        let index_results = self.index.search_hnsw_only(query, k, ef_search);
+        let ef_search = quality.ef_search_for_scale(k, self.storage.index.len());
+        let index_results = self.storage.index.search_hnsw_only(query, k, ef_search);
         Ok(self.finalize_search_results(query, k, metric, index_results))
     }
 
@@ -552,9 +553,12 @@ impl Collection {
     ) -> Vec<ScoredResult> {
         if let Some(bitmap) = self.build_prefilter_bitmap(filter) {
             let ef_search = candidates_k.max(k * 10);
-            let results =
-                self.index
-                    .search_hnsw_only_filtered(query, candidates_k, ef_search, &bitmap);
+            let results = self.storage.index.search_hnsw_only_filtered(
+                query,
+                candidates_k,
+                ef_search,
+                &bitmap,
+            );
             return self.merge_delta(results, query, candidates_k, metric);
         }
         self.search_ids_with_adc_if_pq(query, candidates_k)

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -40,7 +40,7 @@ impl Collection {
             return self.search_with_filter(query, k, filter);
         }
 
-        let config = self.config.read();
+        let config = self.storage.config.read();
         validate_dimension_match(config.dimension, query.len())?;
         let higher_is_better = config.metric.higher_is_better();
         let metric = config.metric;
@@ -78,21 +78,25 @@ impl Collection {
         metric: crate::DistanceMetric,
         bitmap: &roaring::RoaringBitmap,
     ) -> Result<Vec<ScoredResult>> {
-        let selectivity = super::vector::estimate_real_selectivity(bitmap, self.index.len());
+        let selectivity =
+            super::vector::estimate_real_selectivity(bitmap, self.storage.index.len());
 
         if selectivity > SELECTIVITY_HIGH_THRESHOLD {
             return self.search_post_filter(query, k, filter, quality, metric);
         }
 
         if selectivity <= SELECTIVITY_THRESHOLD {
-            let results = self.index.full_scan_with_bitmap(query, k, bitmap)?;
+            let results = self.storage.index.full_scan_with_bitmap(query, k, bitmap)?;
             return Ok(self.merge_delta(results, query, k, metric));
         }
 
         let candidates_k = compute_oversampled_k(k, filter);
-        let results =
-            self.index
-                .search_with_quality_and_bitmap(query, candidates_k, quality, bitmap)?;
+        let results = self.storage.index.search_with_quality_and_bitmap(
+            query,
+            candidates_k,
+            quality,
+            bitmap,
+        )?;
         Ok(self.merge_delta(results, query, candidates_k, metric))
     }
 
@@ -107,6 +111,7 @@ impl Collection {
     ) -> Result<Vec<ScoredResult>> {
         let candidates_k = compute_oversampled_k(k, filter);
         let index_results = self
+            .storage
             .index
             .search_with_quality(query, candidates_k, quality)?;
         Ok(self.merge_delta(index_results, query, candidates_k, metric))
@@ -120,8 +125,8 @@ impl Collection {
         k: usize,
         higher_is_better: bool,
     ) -> Vec<SearchResult> {
-        let vector_storage = self.vector_storage.read();
-        let payload_storage = self.payload_storage.read();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
         let mut results: Vec<SearchResult> = index_results

--- a/crates/velesdb-core/src/collection/streaming/ingester.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester.rs
@@ -341,7 +341,7 @@ async fn flush_batch(collection: &Collection, batch: &mut Vec<Point>) {
 
     // Snapshot vectors for delta buffer before moving points into upsert.
     // Only allocate if delta is active (common case: delta is inactive).
-    let delta_entries: Vec<(u64, Vec<f32>)> = if collection.delta_buffer.is_active() {
+    let delta_entries: Vec<(u64, Vec<f32>)> = if collection.streaming.delta_buffer.is_active() {
         points.iter().map(|p| (p.id, p.vector.clone())).collect()
     } else {
         Vec::new()
@@ -357,7 +357,7 @@ async fn flush_batch(collection: &Collection, batch: &mut Vec<Point>) {
             // The upsert wrote to storage+WAL; delta is an additional runtime
             // copy so search can find these vectors before HNSW is rebuilt.
             if !delta_entries.is_empty() {
-                collection.delta_buffer.extend(delta_entries);
+                collection.streaming.delta_buffer.extend(delta_entries);
             }
         }
         Ok(Err(e)) => {

--- a/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
+++ b/crates/velesdb-core/src/collection/streaming/ingester_tests.rs
@@ -309,7 +309,7 @@ async fn test_stream_delta_drain_loop_routes_to_delta_when_active() {
     };
     let coll_clone = coll.clone();
 
-    coll.delta_buffer.activate();
+    coll.streaming.delta_buffer.activate();
 
     let ingester = StreamIngester::new(coll, config);
 
@@ -323,13 +323,13 @@ async fn test_stream_delta_drain_loop_routes_to_delta_when_active() {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         let found = coll_clone.get(&[1, 2, 3, 4]).iter().flatten().count();
-        if found == 4 && coll_clone.delta_buffer.len() == 4 {
+        if found == 4 && coll_clone.streaming.delta_buffer.len() == 4 {
             break;
         }
         assert!(
             tokio::time::Instant::now() < deadline,
             "timed out waiting for delta drain flush (storage={found}/4, delta={})",
-            coll_clone.delta_buffer.len()
+            coll_clone.streaming.delta_buffer.len()
         );
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
     }
@@ -339,7 +339,7 @@ async fn test_stream_delta_drain_loop_routes_to_delta_when_active() {
     assert_eq!(found, 4, "upsert should write all points to storage");
 
     assert_eq!(
-        coll_clone.delta_buffer.len(),
+        coll_clone.streaming.delta_buffer.len(),
         4,
         "delta buffer should contain the streamed points when active"
     );
@@ -409,8 +409,8 @@ async fn test_stream_delta_rebuild_no_data_loss() {
         .collect();
     coll.upsert(initial_points).expect("upsert initial points");
 
-    coll.delta_buffer.activate();
-    assert!(coll.delta_buffer.is_active());
+    coll.streaming.delta_buffer.activate();
+    assert!(coll.streaming.delta_buffer.is_active());
 
     let config = StreamingConfig {
         buffer_size: 100,
@@ -467,8 +467,8 @@ async fn test_stream_delta_rebuild_no_data_loss() {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
-    let drained = coll_clone.delta_buffer.deactivate_and_drain();
-    assert!(!coll_clone.delta_buffer.is_active());
+    let drained = coll_clone.streaming.delta_buffer.deactivate_and_drain();
+    assert!(!coll_clone.streaming.delta_buffer.is_active());
     assert_eq!(drained.len(), 5, "delta should have had 5 entries");
 
     ingester.shutdown().await;

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -199,22 +199,34 @@ impl Default for RuntimeLimits {
 //  11. deferred_indexer / async_index_builder (internal locks)
 //  12. stats_io_mutex                         (disk I/O only, no other lock held)
 
-/// A collection of vectors with associated metadata.
+/// Vector + payload storage, quantization caches and the columnar mirror.
 ///
-/// Internal executor type — external callers should use `VectorCollection`,
-/// `GraphCollection`, or `MetadataCollection` instead.
+/// Concern cluster **storage** of `Collection` (R1.1 of the god-object split,
+/// EPIC #1384). Grouping is a pure declaration/access-path change: no lock is
+/// added, removed, merged, or re-ordered — the runtime acquisition order is
+/// dictated by code, never by field placement. Lock-order positions of the
+/// individual fields are preserved verbatim below.
+///
+/// `Clone` for the same reason `Collection` is: every field is an `Arc`, so a
+/// clone shares state and stays cheap.
 #[derive(Clone)]
-pub(crate) struct Collection {
+pub(crate) struct StorageState {
     /// Path to the collection data.
     pub(super) path: PathBuf,
 
     /// Collection configuration.
+    ///
+    /// Lock order position: **1**.
     pub(super) config: Arc<RwLock<CollectionConfig>>,
 
     /// Vector storage (on-disk, memory-mapped).
+    ///
+    /// Lock order position: **2**.
     pub(super) vector_storage: Arc<RwLock<MmapStorage>>,
 
     /// Payload storage (on-disk, log-structured).
+    ///
+    /// Lock order position: **3**.
     pub(super) payload_storage: Arc<RwLock<LogPayloadStorage>>,
 
     /// HNSW index for fast approximate nearest neighbor search.
@@ -224,22 +236,50 @@ pub(crate) struct Collection {
     pub(super) text_index: Arc<Bm25Index>,
 
     /// SQ8 quantized vectors cache (for SQ8 storage mode).
+    ///
+    /// Lock order position: **4**.
     pub(super) sq8_cache: Arc<RwLock<HashMap<u64, QuantizedVector>>>,
 
     /// Binary quantized vectors cache (for Binary storage mode).
+    ///
+    /// Lock order position: **4**.
     pub(super) binary_cache: Arc<RwLock<HashMap<u64, BinaryQuantizedVector>>>,
 
     /// PQ quantized vectors cache (for ProductQuantization storage mode).
+    ///
+    /// Lock order position: **4**.
     pub(super) pq_cache: Arc<RwLock<HashMap<u64, PQVector>>>,
 
     /// Trained ProductQuantizer (lazy-trained on first inserted vectors).
+    ///
+    /// Lock order position: **5** (`pq_quantizer` → `pq_training_buffer`).
     pub(super) pq_quantizer: Arc<RwLock<Option<ProductQuantizer>>>,
 
     /// Buffer of first vectors used to train PQ codebooks.
     /// Stores `(point_id, vector)` so trained quantizers can backfill cache entries.
+    ///
+    /// Lock order position: **5** (`pq_quantizer` → `pq_training_buffer`).
     pub(super) pq_training_buffer: Arc<RwLock<VecDeque<PqTrainingSample>>>,
 
+    /// Columnar mirror of top-level scalar payload fields (`ColumnStore`).
+    ///
+    /// Lazily built when full-scan debt warrants it; consulted by
+    /// `dispatch_metadata_filter` before the JSON scan fallback.
+    /// Lock order position: **1b** — held while acquiring `vector_storage`
+    /// (2) and `payload_storage` (3) during the lazy build; mutation hooks
+    /// and queries acquire it with no other collection lock held.
+    pub(crate) payload_mirror: Arc<crate::collection::payload_mirror::PayloadMirror>,
+}
+
+/// Graph node/edge indexes, advisors and the edge store.
+///
+/// Concern cluster **graph** of `Collection` (R1.1, EPIC #1384). See
+/// [`StorageState`] for the lock-order-preservation rationale.
+#[derive(Clone)]
+pub(crate) struct GraphState {
     /// Property index for O(1) equality lookups on graph nodes (EPIC-009).
+    ///
+    /// Lock order position: **7**.
     pub(super) property_index: Arc<RwLock<PropertyIndex>>,
 
     /// Label index for O(1) label-based node lookups (Issue #486).
@@ -252,6 +292,8 @@ pub(crate) struct Collection {
     pub(super) label_index: Arc<RwLock<LabelIndex>>,
 
     /// Range index for O(log n) range queries on graph nodes (EPIC-009).
+    ///
+    /// Lock order position: **7**.
     pub(super) range_index: Arc<RwLock<RangeIndex>>,
 
     /// Graph node property range indexes keyed by `"label.property"` (EPIC-047).
@@ -306,37 +348,24 @@ pub(crate) struct Collection {
     /// held; the edge store's internal `edge_ids → shards` chain is acquired
     /// while holding it.
     pub(super) edge_wal_lock: Arc<Mutex<()>>,
+}
 
+/// Secondary/sparse payload indexes and the query-execution engine state.
+///
+/// Concern cluster **query** of `Collection` (R1.1, EPIC #1384). See
+/// [`StorageState`] for the lock-order-preservation rationale.
+#[derive(Clone)]
+pub(crate) struct QueryState {
     /// Named sparse inverted indexes for sparse vector search (EPIC-062).
     /// Key is the sparse vector name (e.g., `""` for default, `"title"`, `"body"`).
+    ///
+    /// Lock order position: **9**.
     pub(super) sparse_indexes: Arc<RwLock<BTreeMap<String, SparseInvertedIndex>>>,
 
     /// Secondary indexes for metadata payload fields.
+    ///
+    /// Lock order position: **6**.
     pub(super) secondary_indexes: Arc<RwLock<HashMap<String, SecondaryIndex>>>,
-
-    /// Columnar mirror of top-level scalar payload fields (`ColumnStore`).
-    ///
-    /// Lazily built when full-scan debt warrants it; consulted by
-    /// `dispatch_metadata_filter` before the JSON scan fallback.
-    /// Lock order position: **1b** — held while acquiring `vector_storage`
-    /// (2) and `payload_storage` (3) during the lazy build; mutation hooks
-    /// and queries acquire it with no other collection lock held.
-    pub(crate) payload_mirror: Arc<crate::collection::payload_mirror::PayloadMirror>,
-
-    /// Guard-rails for query execution (EPIC-048).
-    pub(crate) guard_rails: Arc<GuardRails>,
-
-    /// Runtime ingest/search limits pushed from the live
-    /// [`VelesConfig::limits`](crate::config::LimitsConfig) at `Database`
-    /// registration time (parity item E).
-    ///
-    /// Defaults to the permissive [`RuntimeLimits::default`] so direct
-    /// `Collection::create`/`open` callers are unaffected; the `Database`
-    /// registration paths overwrite it via [`Collection::set_runtime_limits`].
-    /// `Arc<RwLock<_>>` so every `Collection` clone shares the same value and
-    /// the setter can run after the registry has cloned the collection.
-    /// **Not persisted** — re-pushed on every open.
-    pub(crate) runtime_limits: Arc<RwLock<RuntimeLimits>>,
 
     /// Query planner for cost-based optimization (EPIC-046).
     pub(crate) query_planner: Arc<QueryPlanner>,
@@ -353,7 +382,14 @@ pub(crate) struct Collection {
     /// at 11). Protects only disk I/O — no other lock is held while this one is
     /// held, so it cannot participate in a deadlock chain.
     pub(super) stats_io_mutex: Arc<Mutex<()>>,
+}
 
+/// Monotonic generation counters that gate compiled-plan cache invalidation.
+///
+/// Concern cluster **generations** of `Collection` (R1.1, EPIC #1384). These
+/// are lock-free atomics; grouping them changes no synchronization.
+#[derive(Clone)]
+pub(crate) struct GenerationCounters {
     /// Monotonic write generation counter (CACHE-01).
     ///
     /// Incremented once per mutation batch (upsert, `upsert_bulk`, `upsert_metadata`, delete).
@@ -376,7 +412,17 @@ pub(crate) struct Collection {
     /// When this counter exceeds `HNSW_SAVE_THRESHOLD`, `flush()` saves the
     /// HNSW graph as a safety measure. `flush_full()` always saves and resets.
     pub(crate) inserts_since_last_hnsw_save: Arc<std::sync::atomic::AtomicU64>,
+}
 
+/// Streaming ingestion, delta buffering and deferred/async/auto indexing.
+///
+/// Concern cluster **streaming** of `Collection` (R1.1, EPIC #1384). Three of
+/// the five fields are `#[cfg(feature = "persistence")]`; the cfg attributes
+/// stay on the individual fields so the struct compiles (and derives `Clone`)
+/// under both `--features persistence` and `--no-default-features`. See
+/// [`StorageState`] for the lock-order-preservation rationale.
+#[derive(Clone)]
+pub(crate) struct StreamingState {
     /// Streaming ingestion handle (STREAM-01).
     ///
     /// `None` when streaming is not configured. Wrapped in `RwLock` so that
@@ -434,11 +480,65 @@ pub(crate) struct Collection {
         Arc<RwLock<Option<Arc<crate::collection::auto_reindex::AutoReindexManager>>>>,
 }
 
+/// Query-execution guard-rails and the runtime ingest/search limits.
+///
+/// Concern cluster **runtime** of `Collection` (R1.1, EPIC #1384).
+#[derive(Clone)]
+pub(crate) struct RuntimeGuards {
+    /// Guard-rails for query execution (EPIC-048).
+    pub(crate) guard_rails: Arc<GuardRails>,
+
+    /// Runtime ingest/search limits pushed from the live
+    /// [`VelesConfig::limits`](crate::config::LimitsConfig) at `Database`
+    /// registration time (parity item E).
+    ///
+    /// Defaults to the permissive [`RuntimeLimits::default`] so direct
+    /// `Collection::create`/`open` callers are unaffected; the `Database`
+    /// registration paths overwrite it via [`Collection::set_runtime_limits`].
+    /// `Arc<RwLock<_>>` so every `Collection` clone shares the same value and
+    /// the setter can run after the registry has cloned the collection.
+    /// **Not persisted** — re-pushed on every open.
+    pub(crate) runtime_limits: Arc<RwLock<RuntimeLimits>>,
+}
+
+/// A collection of vectors with associated metadata.
+///
+/// Internal executor type — external callers should use `VectorCollection`,
+/// `GraphCollection`, or `MetadataCollection` instead.
+///
+/// The ~39 shared fields are grouped into six concern sub-structs
+/// ([`StorageState`], [`GraphState`], [`QueryState`], [`GenerationCounters`],
+/// [`StreamingState`], [`RuntimeGuards`]) as the foundation of the god-object
+/// split (R1.1 of EPIC #1384). This is a pure structural regrouping: the lock
+/// ordering documented above is unchanged (no lock added, removed, merged, or
+/// re-ordered), every field keeps its original visibility and `cfg`, and the
+/// public API is untouched.
+#[derive(Clone)]
+pub(crate) struct Collection {
+    /// Vector + payload storage, quantization caches and columnar mirror.
+    pub(crate) storage: StorageState,
+
+    /// Graph node/edge indexes, advisors and the edge store.
+    pub(crate) graph: GraphState,
+
+    /// Secondary/sparse payload indexes and query-execution engine state.
+    pub(crate) query: QueryState,
+
+    /// Monotonic generation counters for plan-cache invalidation.
+    pub(crate) generations: GenerationCounters,
+
+    /// Streaming ingestion, delta buffering and deferred/async/auto indexing.
+    pub(crate) streaming: StreamingState,
+
+    /// Query-execution guard-rails and runtime ingest/search limits.
+    pub(crate) runtime: RuntimeGuards,
+}
+
 impl Collection {
     /// Returns a reference to the named sparse indexes lock (EPIC-062 sparse integration).
     #[allow(dead_code)] // Reason: Used in tests for sparse index verification
     pub(crate) fn sparse_indexes(&self) -> &Arc<RwLock<BTreeMap<String, SparseInvertedIndex>>> {
-        &self.sparse_indexes
+        &self.query.sparse_indexes
     }
 
     /// Overwrites the runtime ingest/search limits (parity item E).
@@ -447,12 +547,12 @@ impl Collection {
     /// [`VelesConfig::limits`](crate::config::LimitsConfig) into the
     /// collection. The value is **not** persisted — each open re-pushes it.
     pub(crate) fn set_runtime_limits(&self, limits: RuntimeLimits) {
-        *self.runtime_limits.write() = limits;
+        *self.runtime.runtime_limits.write() = limits;
     }
 
     /// Returns the current runtime limits snapshot (`Copy`, no lock retained).
     pub(crate) fn runtime_limits(&self) -> RuntimeLimits {
-        *self.runtime_limits.read()
+        *self.runtime.runtime_limits.read()
     }
 
     /// Enforces the runtime ingest limits at the cold upsert boundary
@@ -550,7 +650,8 @@ impl Collection {
     /// The counter starts at 0 and increments once per mutation batch.
     #[must_use]
     pub(crate) fn write_generation(&self) -> u64 {
-        self.write_generation
+        self.generations
+            .write_generation
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -562,7 +663,8 @@ impl Collection {
     /// mutation has bumped `write_generation`.
     #[must_use]
     pub(crate) fn analyze_generation(&self) -> u64 {
-        self.analyze_generation
+        self.generations
+            .analyze_generation
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -573,7 +675,8 @@ impl Collection {
     /// on every query dispatch; observing a slightly stale counter on a
     /// concurrent reader at most causes one extra cache miss (self-healing).
     pub(crate) fn bump_analyze_generation(&self) {
-        self.analyze_generation
+        self.generations
+            .analyze_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
@@ -592,7 +695,7 @@ impl Collection {
     /// Returns [`BackpressureError`] on buffer-full or not-configured.
     #[cfg(feature = "persistence")]
     pub fn stream_insert(&self, point: Point) -> Result<(), BackpressureError> {
-        let guard = self.stream_ingester.read();
+        let guard = self.streaming.stream_ingester.read();
         match guard.as_ref() {
             Some(ingester) => ingester.try_send(point),
             None => Err(BackpressureError::NotConfigured),
@@ -611,7 +714,7 @@ impl Collection {
     /// Returns [`BackpressureError`] on buffer-full, drain-dead, or not-configured.
     #[cfg(feature = "persistence")]
     pub fn stream_insert_batch(&self, points: Vec<Point>) -> Result<usize, BackpressureError> {
-        let guard = self.stream_ingester.read();
+        let guard = self.streaming.stream_ingester.read();
         match guard.as_ref() {
             Some(ingester) => ingester.try_send_batch(points),
             None => Err(BackpressureError::NotConfigured),
@@ -632,7 +735,7 @@ impl Collection {
     pub fn enable_streaming(&self, config: crate::collection::streaming::StreamingConfig) {
         use crate::collection::streaming::StreamIngester;
         let ingester = StreamIngester::new(self.clone(), config);
-        *self.stream_ingester.write() = Some(ingester);
+        *self.streaming.stream_ingester.write() = Some(ingester);
     }
 
     /// Pushes entries into the delta buffer if it is currently active.
@@ -643,8 +746,9 @@ impl Collection {
     /// No-op when the delta buffer is inactive.
     #[cfg(feature = "persistence")]
     pub fn push_to_delta_if_active(&self, entries: &[(u64, Vec<f32>)]) {
-        if self.delta_buffer.is_active() {
-            self.delta_buffer
+        if self.streaming.delta_buffer.is_active() {
+            self.streaming
+                .delta_buffer
                 .extend(entries.iter().map(|(id, v)| (*id, v.clone())));
         }
     }
@@ -667,8 +771,8 @@ impl Collection {
     ) {
         // Mirror the policy into the persisted config first (config lock
         // released before the auto_reindex lock at position 11 is taken).
-        self.config.write().auto_reindex_config = Some(manager.config());
-        *self.auto_reindex.write() = Some(manager);
+        self.storage.config.write().auto_reindex_config = Some(manager.config());
+        *self.streaming.auto_reindex.write() = Some(manager);
     }
 
     /// Detaches the currently attached auto-reindex manager, if any.
@@ -680,8 +784,8 @@ impl Collection {
     pub(crate) fn detach_auto_reindex(
         &self,
     ) -> Option<Arc<crate::collection::auto_reindex::AutoReindexManager>> {
-        self.config.write().auto_reindex_config = None;
-        self.auto_reindex.write().take()
+        self.storage.config.write().auto_reindex_config = None;
+        self.streaming.auto_reindex.write().take()
     }
 
     /// Returns a clone of the currently attached auto-reindex manager, if any.
@@ -692,7 +796,7 @@ impl Collection {
     pub(crate) fn auto_reindex_manager(
         &self,
     ) -> Option<Arc<crate::collection::auto_reindex::AutoReindexManager>> {
-        self.auto_reindex.read().as_ref().map(Arc::clone)
+        self.streaming.auto_reindex.read().as_ref().map(Arc::clone)
     }
 
     /// Returns a [`DivergenceCheck`](crate::collection::auto_reindex::DivergenceCheck)
@@ -733,7 +837,7 @@ impl Collection {
         let (params, size, dimension) = self.auto_reindex_inputs();
         if manager.should_reindex(&params, size, dimension) {
             tracing::info!(
-                collection = %self.config.read().name,
+                collection = %self.storage.config.read().name,
                 current_size = size,
                 dimension = dimension,
                 "auto-reindex manager reports divergence — reindex recommended"
@@ -750,11 +854,11 @@ impl Collection {
     /// and [`Self::notify_auto_reindex_after_bulk`] share the same source
     /// of truth instead of drifting.
     fn auto_reindex_inputs(&self) -> (crate::index::hnsw::HnswParams, usize, usize) {
-        let config = self.config.read();
+        let config = self.storage.config.read();
         let params = config.hnsw_params.unwrap_or_default();
         let dimension = config.dimension;
         drop(config);
-        let size = self.vector_storage.read().len();
+        let size = self.storage.vector_storage.read().len();
         (params, size, dimension)
     }
 }

--- a/crates/velesdb-core/src/collection/vector_collection/search.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search.rs
@@ -281,7 +281,7 @@ impl VectorCollection {
         k: usize,
         index_name: &str,
     ) -> Result<Vec<SearchResult>> {
-        let indexes = self.inner.sparse_indexes.read();
+        let indexes = self.inner.query.sparse_indexes.read();
         let index = indexes.get(index_name).ok_or_else(|| {
             crate::error::Error::Config(format!(
                 "Sparse index '{}' not found",
@@ -485,7 +485,7 @@ impl VectorCollection {
     #[cfg(feature = "persistence")]
     #[must_use]
     pub fn is_delta_active(&self) -> bool {
-        self.inner.delta_buffer.is_active()
+        self.inner.streaming.delta_buffer.is_active()
     }
 
     /// Enables streaming ingestion on this collection.


### PR DESCRIPTION
## R1.1 — foundation of the `Collection` god-object split (EPIC #1384)

**Pure structural regrouping. Zero public-API change, zero behavior change, lock ordering unchanged.**

The internal `Collection` executor carried ~39 shared `Arc<...>` fields. This PR groups them into **6 concern sub-structs** declared in `collection/types.rs`, making the follow-up steps (R1.2/R1.3) mechanical.

### Field → sub-struct mapping

| Sub-struct | Fields |
|---|---|
| **StorageState** (12) | path, config, vector_storage, payload_storage, index, text_index, sq8_cache, binary_cache, pq_cache, pq_quantizer, pq_training_buffer, payload_mirror |
| **GraphState** (11) | property_index, label_index, range_index, graph_range_indexes, edge_range_indexes, composite_index_manager, query_pattern_tracker, index_advisor, order_by_advisor, edge_store, edge_wal_lock |
| **QueryState** (6) | sparse_indexes, secondary_indexes, query_planner, query_cache, cached_stats, stats_io_mutex |
| **GenerationCounters** (3) | write_generation, analyze_generation, inserts_since_last_hnsw_save |
| **StreamingState** (5) | stream_ingester\*, delta_buffer\*, deferred_indexer\*, async_index_builder, auto_reindex |
| **RuntimeGuards** (2) | guard_rails, runtime_limits |

\* `#[cfg(feature = "persistence")]` — the gate stays on the individual field inside `StreamingState`, so the struct compiles and derives `Clone` under both `--features persistence` and `--no-default-features`.

`Collection` now holds six `pub(crate)` group fields (`storage`, `graph`, `query`, `generations`, `streaming`, `runtime`). Access sites `self.<field>` → `self.<group>.<field>`; facade `.inner.<field>` and test bindings updated likewise. The single struct literal in `Collection::assemble` became nested sub-struct literals (still the one construction point).

### Invariants preserved
- **Lock ordering unchanged.** Grouping only moves field *declarations* and rewrites *access paths* — no lock is added, removed, merged, or re-ordered, and no lock-acquisition statement (`.read()`/`.write()`) changed position. Field placement never dictates runtime acquisition order; that is dictated by code, which is untouched. The `=== LOCK ORDERING ===` canonical block and every per-field "Lock order position" comment are preserved (moved with their fields). No two distinct `RwLock`/`Mutex` were merged.
- **Visibility.** Every field keeps its exact `pub(super)`/`pub(crate)`. Group containers are `pub(crate)`, but `pub(super)` inner fields stay module-restricted (reachable only from within `crate::collection`) — no widening.
- **`Clone`.** Each sub-struct derives `Clone` (all fields are `Arc`), so `Collection: Clone` stays cheap.
- **Public API untouched** — the `VectorCollection`/`GraphCollection`/`MetadataCollection` newtypes and `into_vector_facade` are unchanged (R1.4 territory).

### Gates & verification
- `cargo fmt --all --check`: clean
- `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings -D clippy::pedantic` (after `cargo clean -p`): clean
- `scripts/check_prod_unwraps.py`: passed
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1`: **5277 passed, 0 failed** ✅
- `cargo test -p velesdb-core --lib --no-default-features -- --test-threads=1`: **2174 passed, 0 failed** ✅
- `velesdb-server` / `velesdb-cli` compile (public API unchanged)

**Confirmation: lock order unchanged, API unchanged, 2 configs green.**

Refs #1384