### PR TITLE
refactor(collection): reclassify order_by_advisor to QueryState (R1.2a)

### DIFF
--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -208,7 +208,7 @@ impl Collection {
         // Snapshot under the advisor lock, release it before touching the
         // secondary-index lock so only one lock is ever held at a time.
         let observed = self
-            .graph
+            .query
             .order_by_advisor
             .read()
             .observed(min_observations);

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -104,15 +104,15 @@ impl Collection {
                 composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
                 query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
                 index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
-                order_by_advisor: Arc::new(RwLock::new(
-                    crate::collection::order_by_advisor::OrderByIndexAdvisor::default(),
-                )),
                 edge_store: Arc::new(parts.edge_store),
                 edge_wal_lock: Arc::new(Mutex::new(())),
             },
             query: crate::collection::types::QueryState {
                 sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
                 secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
+                order_by_advisor: Arc::new(RwLock::new(
+                    crate::collection::order_by_advisor::OrderByIndexAdvisor::default(),
+                )),
                 query_planner: Arc::new(QueryPlanner::new()),
                 query_cache: Arc::new(QueryCache::new(256)),
                 cached_stats: Arc::new(Mutex::new(None)),

--- a/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordered_index_scan.rs
@@ -98,7 +98,7 @@ impl Collection {
         let (limit, fetch_limit) = Self::compute_fetch_limit(stmt);
         let Some(ids) = self.ordered_ids_if_covered(field, order_descending(stmt), fetch_limit)
         else {
-            self.graph.order_by_advisor.write().observe(field);
+            self.query.order_by_advisor.write().observe(field);
             return None;
         };
         let hydrated: Vec<crate::point::Point> = self.get(&ids).into_iter().flatten().collect();
@@ -145,7 +145,7 @@ impl Collection {
         // release before hydrating.
         let Some(ids) = self.ordered_ids_if_covered(field, order_descending(stmt), point_count)
         else {
-            self.graph.order_by_advisor.write().observe(field);
+            self.query.order_by_advisor.write().observe(field);
             return None;
         };
         let predicate =
@@ -180,7 +180,7 @@ impl Collection {
         let Some(ids) =
             self.ordered_prefix_if_covered(lead_field, order_descending(stmt), fetch_limit)
         else {
-            self.graph.order_by_advisor.write().observe(lead_field);
+            self.query.order_by_advisor.write().observe(lead_field);
             return None;
         };
         let mut hydrated: Vec<SearchResult> = self

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -323,16 +323,6 @@ pub(crate) struct GraphState {
     /// Lock order position: **7** (same tier as `property_index` / `range_index`).
     pub(crate) index_advisor: Arc<RwLock<IndexAdvisor>>,
 
-    /// Scalar `ORDER BY <field>` index advisor (EPIC-081 phase 3a).
-    ///
-    /// Records eligible `ORDER BY` queries that fell back to the exhaustive
-    /// sort because the sort field lacks a fully-covering secondary index, so
-    /// an operator can be advised to create one. Recommendation-only — never
-    /// mutates an index or a query result.
-    ///
-    /// Lock order position: **7** (same tier as `index_advisor`).
-    pub(crate) order_by_advisor: Arc<RwLock<OrderByIndexAdvisor>>,
-
     /// Concurrent edge store for knowledge graph relationships (EPIC-015).
     ///
     /// Uses sharded internal locking (256 shards) — no outer `RwLock` needed.
@@ -366,6 +356,19 @@ pub(crate) struct QueryState {
     ///
     /// Lock order position: **6**.
     pub(super) secondary_indexes: Arc<RwLock<HashMap<String, SecondaryIndex>>>,
+
+    /// Scalar `ORDER BY <field>` index advisor (EPIC-081 phase 3a).
+    ///
+    /// Records eligible `ORDER BY` queries that fell back to the exhaustive
+    /// sort because the sort field lacks a fully-covering secondary index, so
+    /// an operator can be advised to create one. Recommendation-only — never
+    /// mutates an index or a query result. A query-execution concern (reached
+    /// by the generic `ORDER BY` scan on any collection kind), not graph state
+    /// — reclassified out of `GraphState` here (R1.2a, EPIC #1384).
+    ///
+    /// Lock order position: **7** (acquired standalone; no other collection
+    /// lock is held while it is held).
+    pub(crate) order_by_advisor: Arc<RwLock<OrderByIndexAdvisor>>,
 
     /// Query planner for cost-based optimization (EPIC-046).
     pub(crate) query_planner: Arc<QueryPlanner>,


### PR DESCRIPTION
## Quoi (R1.2a)

Reclasse le champ `order_by_advisor` de `GraphState` vers `QueryState` dans `Collection` (types.rs). C'est un advisor `ORDER BY` **général** (atteint par le scan `ordered_index_scan` de n'importe quelle collection), pas de l'état graphe — il avait été bucketé dans `GraphState` à l'étape R1.1 (#1418) parce qu'il était déclaré entre les advisors graphe. Refacto **pure, comportement constant, ordre de verrous inchangé** (le champ garde sa position de lock ; il est acquis seul).

Fichiers : `collection/types.rs` (déf. déplacée GraphState→QueryState), `collection/core/lifecycle.rs` (construction déplacée dans le bloc `query`), `collection/search/query/ordered_index_scan.rs` (3 accès `self.graph.` → `self.query.`), `collection/core/index_management.rs` (1 accès).

## Pourquoi — investigation R1.2 (EPIC #1384, étape 2)

L'objectif R1.2 tel que formulé dans #1384 — « migrer l'état graph-only vers le propre store de `GraphCollection` » — s'est révélé **non réalisable en une PR à comportement constant** sur l'architecture actuelle. Investigation :

- **`GraphState` n'est pas graph-only.** Deux champs vivent dans des chemins partagés atteints par `VectorCollection`/`MetadataCollection` : (1) `order_by_advisor` (advisor ORDER BY général — corrigé par CETTE PR) ; (2) `label_index`, maintenu dans le **hot path CRUD vecteur partagé** (`crud.rs:414`, `crud_bulk.rs:309`, gardé par « index non vide », jamais par le type de collection) — donc **légitimement partagé** et à laisser sur le backing commun.
- **L'API graphe est `impl Collection`** dispatchée sur le backing partagé ; `AnyCollection::add_edge/...` (`any_collection.rs:185-211`) et `into_vector_facade` (`any_collection.rs:566`) exigent que l'état graphe reste sur `Collection`. Les 3 newtypes partagent physiquement le même `inner: Collection` (design « pure newtype, no dual-storage »).

**Découpage proposé pour la suite** (à séquencer avec revue humaine — chantier lourd, cf. estimation 2-4 sem de l'EPIC) :
- **R1.2a (cette PR)** — reclasser `order_by_advisor` → `QueryState`. Risque faible, comportement constant. ✅
- **R1.2b** — emballer le `GraphState` restant en `Arc<GraphStore>` sur `Collection` (handle unique, lectures via `Deref`, comportement constant). Risque faible.
- **R1.2c** — gater le dispatch graphe d'`AnyCollection` sur la variante `Graph` uniquement. **Dépend de R1.4** (retrait de `into_vector_facade`). Risque élevé (peut changer le comportement des non-graphe).
- **R1.2d** — déplacer l'`Arc<GraphStore>` dans `GraphCollection`, migrer les méthodes graphe de `impl Collection` vers `impl GraphCollection`. Risque élevé, large blast radius (`graph_api.rs`, `graph_property_index_wiring.rs`, `match_exec/*`).

`label_index` reste sur le backing partagé (état hybride vecteur+graphe légitime). Une revue humaine des ~15 modules `impl Collection` est conseillée avant R1.2d.

## Vérifications
- `cargo fmt --all --check`, clippy pedantic CI-exact (1.90, `cargo clean -p` avant), `check_prod_unwraps.py` : PASS
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1` et `--no-default-features` : verts
- Ordre de verrous inchangé (champ acquis seul, commentaire de position conservé) ; API des newtypes inchangée.