### PR TITLE
docs: unify positioning on the explainable memory-engine frame + refresh stale versions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,9 @@ This document is the **15-minute read** an engineer or a technical due-diligence
 
 ## TL;DR — three sentences
 
-VelesDB is a **single-binary, embeddable database** that fuses a **vector index (HNSW)**, a **graph engine** (nodes + edges + traversal), and a **typed columnstore** behind a **shared SQL-like query language called VelesQL**. The target use case is local-first AI agents and RAG pipelines that today have to stitch together pgvector + Neo4j + PostgreSQL by hand. The whole engine ships as a single ~9 MB binary (6–13 MB depending on platform and binary, measured on v1.18.0 release artifacts), runs on Linux/macOS/Windows/iOS/Android/WASM, and persists to a directory on disk that the user controls.
+VelesDB is **the explainable, local-first memory engine for AI agents**: a **single-binary, embeddable database** that fuses a **vector index (HNSW)**, a **graph engine** (nodes + edges + traversal), and a **typed columnstore** behind a **shared SQL-like query language called VelesQL**. The target use case is local-first AI agents and RAG pipelines that today have to stitch together pgvector + Neo4j + PostgreSQL by hand. The whole engine ships as a single ~9 MB binary (6–13 MB depending on platform and binary, measured on v1.18.0 release artifacts), runs on Linux/macOS/Windows/iOS/Android/WASM, and persists to a directory on disk that the user controls.
+
+Because the graph and columnstore live in the same address space as the vectors, the high-level `MemoryService` can answer **`why()`** — returning not just an answer but the *evidence path* behind every recall (which facts it used and how they connect). That auditable recall trail is the kind of traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation-timeline/) (enforceable from Aug 2026) asks of AI systems; running fully local, VelesDB **helps meet** those data-residency and explainability expectations rather than claiming certified compliance.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document is the **15-minute read** an engineer or a technical due-diligence reviewer should start with. It tells you what VelesDB is, how it is shaped, and where to dig deeper.
 
-> **Last updated:** 2026-06-12 — applies to v2.0.x and onward.
+> **Last updated:** 2026-06-12 — applies to v3.x and onward.
 
 ---
 

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -4,7 +4,7 @@ This document specifies the **explicit, enforceable thresholds** below which Vel
 
 These gates are not aspirational. They are enforced via CI workflows, scripts, and explicit pre-merge protocols. Each gate listed here links to its enforcement mechanism so that the gate can be inspected, contested, or extended publicly.
 
-> **Last updated:** 2026-06-12 — applies to v2.0.x and onward.
+> **Last updated:** 2026-06-12 — applies to v3.x and onward.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,16 @@
   <img src="velesdb_icon_pack/favicon/favicon-32x32.png" alt="" width="32" height="32" style="vertical-align: middle;"/> VelesDB
 </h1>
 <h3 align="center">
-  Your AI agents forget everything. VelesDB fixes that.
+  The explainable, local-first memory engine for AI agents.
 </h3>
 <p align="center">
-  <strong>One ~9 MB binary. Three engines. One query language. Zero cloud dependency.</strong><br/>
-  <em>Vector + Graph + ColumnStore — unified under <a href="docs/VELESQL_SPEC.md">VelesQL</a></em><br/><br/>
-  The <strong>explainable</strong> agent memory: <code>why()</code> returns the evidence path behind every recall —<br/>
+  <strong>One ~9 MB binary fuses vector + graph + columnar under <a href="docs/VELESQL_SPEC.md">VelesQL</a>. Zero cloud.</strong><br/>
+  <code>why()</code> returns the evidence path behind every recall.<br/><br/>
+  <em>Your AI agents forget everything — VelesDB fixes that, and shows its work:</em><br/>
   <a href="crates/velesdb-memory/BENCHMARK.md"><strong>measured on public benchmarks</strong></a>, not vibes.
+</p>
+<p align="center">
+  <sub><em>The name nods to <strong>Veles</strong>, a deity of old Slavic myth — a keeper of hidden knowledge and boundaries.</em></sub>
 </p>
 <p align="center">
   <a href="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml"><img src="https://github.com/cyberlife-coder/VelesDB/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -532,7 +535,8 @@ We ship weekly. This is the arc; the committed, dated plan lives in [ROADMAP.md]
 | **v3.4 → v3.7** | The `why()` wedge **everywhere** — Node binding (`velesdb-memory-node`), Python `MemoryService`, MCP `recall_fused`, browser / WASM + TypeScript-SDK `MemoryService`, durable TTL, dated-context recall, indexed prefilter for filtered recall | ✅ Shipped |
 | **v3.8** | u64 point-id precision-safety completed across the REST surface + OpenAPI spec | ✅ Shipped |
 | **v3.9.0 → v3.9.1** | v3.9.0: `DatabaseObserver` read-path control-plane hook (`QueryAccessContext`) — the seam premium uses to enforce access, narrow-only. v3.9.1: `velesdb-memory` 0.7.0 RL Memory (MCP `feedback` tool + learned-confidence recall re-ranking); zero-friction Docker onboarding; release-pipeline harmonisation gate | ✅ Shipped |
-| **v3.9.1 → v3.10.0** *(current: `v3.10.0`)* | Read-path gate now covers **every** HTTP search route (dense/text/hybrid/sparse/batch/multi-query/ids/graph-embedding/`MATCH`), not just VelesQL `SELECT`/`MATCH`; Python SDK observer gained a read-path veto (`on_query_request` on direct `.search()` and variants). No breaking API changes — but any embedder relying on the observer being inert on REST reads (previously true) must account for it now actually enforcing. | ✅ Shipped |
+| **v3.9.1 → v3.10.0** | Read-path gate now covers **every** HTTP search route (dense/text/hybrid/sparse/batch/multi-query/ids/graph-embedding/`MATCH`), not just VelesQL `SELECT`/`MATCH`; Python SDK observer gained a read-path veto (`on_query_request` on direct `.search()` and variants). No breaking API changes — but any embedder relying on the observer being inert on REST reads (previously true) must account for it now actually enforcing. | ✅ Shipped |
+| **v3.11 → v3.12** *(current: `v3.12.0`)* | Chief-engineer audit resolution (soundness, quality-gate coverage across all crates, opt-in fail-closed observer mode); pre-release hardening — WAL replay recovers writes stranded behind a corrupt frame, Python governance read-gate parity, and HNSW stores each vector once (~⅓ less resident memory on large indices). No breaking API changes. | ✅ Shipped |
 | **Next** | Concurrent WAL writer; WASM SIMD128 kernels + 3+ hop `MATCH`; Dual-Precision (VSAG) engine integration; side-by-side Docker-Compose ANN benchmark vs Qdrant / Chroma / FAISS | 🔜 Tracked |
 
 > VelesDB Core is source-available (readable, modifiable, redistributable under the VelesDB Core License 1.0 — not an OSI-approved license; see [docs/LICENSING.md](docs/LICENSING.md)). Enterprise features (distributed replication, managed cloud, RBAC) are available separately via [VelesDB Premium](https://velesdb.com).
@@ -710,6 +714,6 @@ VelesDB Core License 1.0 (based on ELv2). Free for production use, including com
 ---
 
 <p align="center">
-  <strong>VelesDB</strong> &mdash; The Local Knowledge Engine for AI Agents<br/>
+  <strong>VelesDB</strong> &mdash; The explainable, local-first memory engine for AI agents<br/>
   <a href="https://velesdb.com">velesdb.com</a> &bull; <a href="https://github.com/cyberlife-coder/VelesDB">GitHub</a>
 </p>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported |
 |---------|-----------|
-| 2.0.x   | Yes       |
-| 1.18.x  | Security fixes only |
-| 1.17.x  | Security fixes only |
-| < 1.17  | No        |
+| 3.12.x  | Yes       |
+| 3.11.x  | Security fixes only |
+| 3.10.x  | Security fixes only |
+| < 3.10  | No        |
 
 > VelesDB ships weekly; this table is updated at every minor release. The latest minor always receives full support, and the two previous minors receive security fixes.
 

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -5,6 +5,8 @@
 
 A Tauri plugin for **VelesDB** — Vector search in desktop applications.
 
+> The desktop engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the [`why()`](../velesdb-memory/README.md) recall trail returns the evidence path behind every answer.
+
 ## Features
 
 - **Fast Vector Search** — Microsecond latency similarity search (HNSW + AVX2/AVX-512)

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -6,6 +6,8 @@
 
 Interactive VelesQL REPL and CLI for VelesDB.
 
+> The command line for **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the [`why()`](../velesdb-memory/README.md) recall trail returns the evidence path behind every answer.
+
 ## Table of Contents
 
 - [Installation](#installation)

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -7,6 +7,8 @@
 
 High-performance vector database engine written in Rust.
 
+> The engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the high-level [`MemoryService` / `why()`](../velesdb-memory/README.md) returns the evidence path behind every recall.
+
 ## Features
 
 - **Blazing Fast**: Native HNSW with AVX-512/AVX2/NEON SIMD — 450µs p50 end-to-end (10K/384D, WAL ON, recall>=96%); 55µs HNSW index-only micro-benchmark (5K/768D, k=10); 21.7ns dot product (768D AVX2). See `docs/BENCHMARKS.md` for measurement context.

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -7,18 +7,23 @@
 [![MCP registry](https://img.shields.io/badge/MCP_registry-io.github.cyberlife--coder%2Fvelesdb--memory-1f6feb?logo=modelcontextprotocol&logoColor=white)](https://registry.modelcontextprotocol.io)
 [![license: VelesDB Core 1.0](https://img.shields.io/badge/license-VelesDB_Core_1.0_(source--available)-e8702a)](https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE)
 
-**Local-first memory for AI agents — a single MCP server.** Give your coding
-agent durable memory that never leaves your machine: it remembers decisions,
-recalls them semantically, and — the differentiator — **connects** them so it
-can answer *why* a decision was made, not just retrieve look-alike text.
+**The explainable, local-first memory engine for AI agents — as a single MCP
+server.** Give your coding agent durable memory that never leaves your machine:
+it remembers decisions, recalls them semantically, and — the differentiator —
+**connects** them so it can answer *why* a decision was made, not just retrieve
+look-alike text. That auditable `why()` recall trail is the kind of
+traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation-timeline/)
+(enforceable from Aug 2026) asks of AI systems; running fully local, it **helps
+meet** those data-residency and explainability expectations rather than claiming
+certified compliance.
 
-> **Release 0.6.0 — 2026-07-06.** `velesdb-memory` **0.6.0** ships on
+> **Release 0.7.0 — 2026-07-12.** `velesdb-memory` **0.7.0** ships on
 > [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.6.0**
-> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.8.0**.
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.7.0**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**.
 > **`cargo install velesdb-memory` installs the latest published release.**
 
 Built on [VelesDB](https://velesdb.com)'s in-core Agent Memory SDK, which fuses

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -6,6 +6,8 @@ Native bindings for **iOS** (Swift) and **Android** (Kotlin) via [UniFFI](https:
 
 VelesDB Mobile brings microsecond vector search to edge devices - perfect for on-device AI, semantic search, and RAG applications.
 
+> The mobile engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the [`why()`](../velesdb-memory/README.md) recall trail returns the evidence path behind every answer.
+
 ## Features
 
 - **Native Performance**: Direct Rust bindings, minimal FFI overhead

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -1,8 +1,9 @@
 # @wiscale/velesdb-memory-node
 
-Local-first **agent memory** for Node.js — the VelesDB memory wedge as an
-in-process native addon (napi-rs). Same hardened Rust as the MCP server and the
-Python binding; no network service.
+**The explainable, local-first memory engine for AI agents — as an in-process
+Node.js addon (napi-rs).** Same hardened Rust as the MCP server and the Python
+binding; no network service. Under the hood it fuses vector + graph + columnar,
+which is *how* it remembers, connects, and explains.
 
 `remember` / `recall` / `recallWhere` / `relate` / `forget` / `why` /
 `rememberExtracted`. The differentiator is **`why()`**: it answers a question with

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -7,6 +7,8 @@
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 
+> The Python engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the [`why()`](#agent-memory-the-why-wedge) wedge below returns the evidence path behind every recall.
+
 ## Agent memory: the `why()` wedge
 
 Beyond raw vector search, VelesDB ships a high-level **`MemoryService`** — local-first agent memory whose differentiator is **`why()`**: it answers a question with the best-matching memory *plus the connected subgraph* reachable through typed links — context that shares **no words** with the question, which a plain vector recall is blind to. The store is on disk, so it works across process restarts.

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -5,6 +5,8 @@
 
 REST API server for VelesDB - a high-performance vector database.
 
+> The engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It fuses vector + graph + columnar under VelesQL; the [`why()`](../velesdb-memory/README.md) recall trail returns the evidence path behind every answer.
+
 ## Features
 
 - **Vector + Sparse + Hybrid search** with RRF/RSF fusion

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -5,6 +5,8 @@
 
 WebAssembly build of [VelesDB](https://github.com/cyberlife-coder/VelesDB) - vector search in the browser.
 
+> The browser engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the full `remember`/`recall`/`relate`/`forget`/[`why()`](../velesdb-memory/README.md) memory wedge in-memory, client-side — `why()` returns the evidence path behind every recall.
+
 ## Features
 
 - **In-browser vector search** - No server required

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # 📚 VelesDB Documentation
 
+> **VelesDB — the explainable, local-first memory engine for AI agents.** One ~9 MB binary fuses vector + graph + columnar under VelesQL; [`why()`](./guides/AGENT_MEMORY.md) returns the evidence path behind every recall. Zero cloud.
+
 Welcome to the VelesDB documentation. This guide will help you get started and make the most of VelesDB.
 
 ---
@@ -45,7 +47,7 @@ In-depth technical documentation:
 | Reference | Description |
 |-----------|-------------|
 | [Architecture](./reference/ARCHITECTURE.md) | System design and internals |
-| [VelesQL Specification](./VELESQL_SPEC.md) | Query language grammar and syntax (v3.10.0, canonical) |
+| [VelesQL Specification](./VELESQL_SPEC.md) | Query language grammar and syntax (v3.12.0, canonical) |
 | [VelesQL Cheat Sheet](./reference/VELESQL_CHEATSHEET.md) | One-page quick reference: search, filter, graph MATCH, fusion, sparse, EXPLAIN |
 | [VelesQL Contract](./reference/VELESQL_CONTRACT.md) | Canonical REST contract (`/query`, `/match`, error model) |
 | [VelesQL Conformance](./reference/VELESQL_CONFORMANCE_MATRIX.md) | Cross-ecosystem conformance matrix |
@@ -123,4 +125,4 @@ Each crate has its own README with specific documentation:
 
 ---
 
-*VelesDB — Vector Search in Microseconds*
+*VelesDB — the explainable, local-first memory engine for AI agents. (Microsecond vector search is the proof, not the pitch.)*

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -1,6 +1,8 @@
 # Why VelesDB?
 
-VelesDB is a local-first vector database that combines Vector, Graph, and ColumnStore engines into a single, embeddable library. It is designed for AI agent workloads such as RAG, semantic search, and knowledge graphs, with sub-millisecond query latency.
+VelesDB is **the explainable, local-first memory engine for AI agents.** Under the hood it fuses Vector, Graph, and ColumnStore engines into a single embeddable ~9 MB binary, queried through VelesQL — the multi-engine design is *how* it delivers memory that survives restarts, connects facts, and stays on your machine. It targets AI agent workloads such as RAG, semantic search, and knowledge graphs, with sub-millisecond query latency.
+
+The differentiator is **`why()`**: instead of returning only an answer, VelesDB returns the *evidence path* behind every recall — which facts it used and how they connect, by walking typed links to context that shares no words with your question. That built-in, auditable recall trail is exactly the kind of traceability that regulations such as the [EU AI Act](https://artificialintelligenceact.eu/implementation-timeline/) (enforceable from Aug 2026) ask of AI systems; running fully local, VelesDB **helps meet** those data-residency and explainability expectations rather than claiming certified compliance.
 
 ---
 

--- a/integrations/haystack/README.md
+++ b/integrations/haystack/README.md
@@ -1,7 +1,9 @@
 # haystack-velesdb
 
 A Haystack 2.x `DocumentStore` backed by [VelesDB](https://github.com/cyberlife-coder/VelesDB) —
-the local-first, microsecond-latency vector database.
+**the explainable, local-first memory engine for AI agents** (microsecond vector
+search is the proof, not the pitch). For the connected `why()` recall trail
+across typed links, see [velesdb-memory](../../crates/velesdb-memory/README.md).
 
 This integration joins the existing [LangChain](../langchain/) and [LlamaIndex](../llamaindex/)
 connectors, completing the trio of major Python RAG frameworks supported by VelesDB.

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,6 +1,6 @@
 # langchain-velesdb
 
-LangChain integration for [VelesDB](https://github.com/cyberlife-coder/VelesDB) vector database.
+LangChain `VectorStore` for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — **the explainable, local-first memory engine for AI agents.** Vector recall here; for the connected `why()` recall trail across typed links, see [velesdb-memory](../../crates/velesdb-memory/README.md) and the [LangGraph integration](../langgraph/README.md).
 
 ## Installation
 

--- a/integrations/llamaindex/README.md
+++ b/integrations/llamaindex/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/llama-index-vector-stores-velesdb)](https://pypi.org/project/llama-index-vector-stores-velesdb/)
 [![License](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
 
-VelesDB vector store integration for [LlamaIndex](https://www.llamaindex.ai/).
+VelesDB vector store integration for [LlamaIndex](https://www.llamaindex.ai/) — the vector-recall face of **VelesDB, the explainable, local-first memory engine for AI agents.** For the connected `why()` recall trail across typed links, see [velesdb-memory](../../crates/velesdb-memory/README.md) and the [LangGraph integration](../langgraph/README.md).
 
 ## Features
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,6 +2,8 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
+> The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall.
+
 **v3.12.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.6.0


### PR DESCRIPTION
## What & why

Unifies VelesDB's public documentation on a single canonical frame — **the explainable, local-first memory engine for AI agents** — with the multi-engine design (vector + graph + columnar under VelesQL) positioned as the *how*, not the pitch. Also refreshes stale version references now that the repo is at 3.12.0. Docs-only; no code.

### (a) Frame applied

Canonical one-liner cascaded across every product/agent surface:
> **VelesDB — the explainable, local-first memory engine for AI agents.** One ~9 MB binary fuses vector + graph + columnar under VelesQL. `why()` returns the evidence path behind every recall. Zero cloud.

- **Product/agent surfaces** (root README hero + footer, `docs/README.md`, `docs/WHY_VELESDB.md`, `crates/velesdb-memory`, `crates/velesdb-node`, integration READMEs): memory engine leads the title, DB multi-engine is the supporting line.
- **Infra/SDK surfaces** (`velesdb-core`, `-server`, `-cli`, `-wasm`, `-python`, `-mobile`, `tauri-plugin`, `sdks/typescript`): technical title kept, second line + `why()` pointer added — install/API docs untouched.
- Orphan slogans harmonized: "Vector Search in Microseconds", "microsecond-latency vector database", "The Local Knowledge Engine" now sit under the frame with microsecond perf reframed as *proof, not pitch*.
- Added a short, honest **Veles** brand note (deity of old Slavic myth) near the README title.
- Pushed the `why()`/EU AI Act traceability angle (worded "**helps meet**", never "compliant"/"certified") into `WHY_VELESDB.md`, `velesdb-memory`, and `ARCHITECTURE.md`.

### (b) Surfaces modified

ARCHITECTURE.md, SECURITY.md, QUALITY_BAR.md, README.md, docs/README.md, docs/WHY_VELESDB.md, and READMEs for velesdb-core / -server / -cli / -wasm / -python / -mobile / -node / -memory / tauri-plugin, sdks/typescript, and integrations langchain / llamaindex / haystack.

### (c) Freshness corrected

| File | Before | After |
|------|--------|-------|
| SECURITY.md | Supported: 2.0.x / 1.18.x / 1.17.x | 3.12.x / 3.11.x / 3.10.x (per stated policy) |
| README.md roadmap | current: `v3.10.0` | added v3.11 → v3.12 row, current: `v3.12.0` |
| QUALITY_BAR.md | applies to v2.0.x and onward | applies to v3.x and onward |
| ARCHITECTURE.md | applies to v2.0.x and onward | applies to v3.x and onward |
| docs/README.md | VelesQL Spec v3.10.0 | v3.12.0 (matches spec source of truth) |
| velesdb-memory README | Release 0.6.0 / Node 0.6.0 / Python 3.8.0 | 0.7.0 / 0.7.0 / 3.12.0 (date 2026-07-12) |

Binary-size label in ARCHITECTURE.md kept at **v1.18.0** (no 3.x measurement to relabel to). `WHY_VELESDB.md` comparison "as of March 2026" left untouched (competitor table not re-verified).

### (d) No benchmark invented or relabeled

Confirmed: **no perf/benchmark figure was invented, moved to a version where it wasn't measured, or given a new run date.** All measurement provenances (450 µs i9-14900KF, Apple Silicon runs, v1.18.0 binary size, 5-min onboarding) are unchanged.

### Gates

`check-version-sync.py`, `check-feature-claims.py`, `check-perf-claims.py --no-criterion` — all **PASS**. Added relative links verified to resolve; Python `why()` anchor verified.
