### PR TITLE
refactor(core): R1.2b — share graph state via Arc<GraphStore>

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -95,7 +95,7 @@ impl Collection {
                     crate::collection::payload_mirror::PayloadMirror::default(),
                 ),
             },
-            graph: crate::collection::types::GraphState {
+            graph: Arc::new(crate::collection::types::GraphStore {
                 property_index: Arc::new(RwLock::new(parts.property_index)),
                 label_index: Arc::new(RwLock::new(parts.label_index)),
                 range_index: Arc::new(RwLock::new(parts.range_index)),
@@ -106,7 +106,7 @@ impl Collection {
                 index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
                 edge_store: Arc::new(parts.edge_store),
                 edge_wal_lock: Arc::new(Mutex::new(())),
-            },
+            }),
             query: crate::collection::types::QueryState {
                 sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
                 secondary_indexes: Arc::new(RwLock::new(HashMap::new())),

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -275,8 +275,12 @@ pub(crate) struct StorageState {
 ///
 /// Concern cluster **graph** of `Collection` (R1.1, EPIC #1384). See
 /// [`StorageState`] for the lock-order-preservation rationale.
-#[derive(Clone)]
-pub(crate) struct GraphState {
+///
+/// Shared as a single `Arc<GraphStore>` handle from `Collection` (R1.2b,
+/// EPIC #1384) so graph state can later be shared with `GraphCollection`
+/// without an exclusive move; the `Arc` carries the `Clone` for `Collection`,
+/// so this struct itself no longer derives `Clone`.
+pub(crate) struct GraphStore {
     /// Property index for O(1) equality lookups on graph nodes (EPIC-009).
     ///
     /// Lock order position: **7**.
@@ -364,7 +368,8 @@ pub(crate) struct QueryState {
     /// an operator can be advised to create one. Recommendation-only — never
     /// mutates an index or a query result. A query-execution concern (reached
     /// by the generic `ORDER BY` scan on any collection kind), not graph state
-    /// — reclassified out of `GraphState` here (R1.2a, EPIC #1384).
+    /// — reclassified out of `GraphStore` (then `GraphState`) here (R1.2a,
+    /// EPIC #1384).
     ///
     /// Lock order position: **7** (acquired standalone; no other collection
     /// lock is held while it is held).
@@ -510,7 +515,7 @@ pub(crate) struct RuntimeGuards {
 /// `GraphCollection`, or `MetadataCollection` instead.
 ///
 /// The ~39 shared fields are grouped into six concern sub-structs
-/// ([`StorageState`], [`GraphState`], [`QueryState`], [`GenerationCounters`],
+/// ([`StorageState`], [`GraphStore`], [`QueryState`], [`GenerationCounters`],
 /// [`StreamingState`], [`RuntimeGuards`]) as the foundation of the god-object
 /// split (R1.1 of EPIC #1384). This is a pure structural regrouping: the lock
 /// ordering documented above is unchanged (no lock added, removed, merged, or
@@ -522,7 +527,13 @@ pub(crate) struct Collection {
     pub(crate) storage: StorageState,
 
     /// Graph node/edge indexes, advisors and the edge store.
-    pub(crate) graph: GraphState,
+    ///
+    /// Held as a shared `Arc<GraphStore>` (R1.2b) so the same graph state can
+    /// be handed to `GraphCollection` without an exclusive move. Field access
+    /// (`self.graph.<field>`) is unchanged — it resolves through the `Arc`'s
+    /// `Deref`; every inner field is itself `Arc`-wrapped, so nothing is
+    /// deep-copied.
+    pub(crate) graph: Arc<GraphStore>,
 
     /// Secondary/sparse payload indexes and query-execution engine state.
     pub(crate) query: QueryState,


### PR DESCRIPTION
R1.2b (Fowler Extract Class + Arc), comportement identique, prépare le partage d'ownership graphe sans retrait exclusif (R1.2d).

## Quoi
- Renomme le sous-struct `GraphState` → `GraphStore` (`collection/types.rs`).
- `Collection.graph: GraphState` → `Collection.graph: Arc<GraphStore>` (Wrap in Arc). L'`Arc` porte désormais le `Clone` de `Collection`, donc `GraphStore` ne dérive plus `Clone`.
- Site de construction unique (`collection/core/lifecycle.rs`) : littéral enveloppé dans `Arc::new(...)`.
- Accès `self.graph.<field>` inchangés : résolus par le `Deref` de l'`Arc`, tous les champs internes étant déjà `Arc<...>` (aucune copie profonde).

## Invariants préservés
- **Comportement identique** : pure indirection Arc, zéro changement fonctionnel.
- Ordre de verrous inchangé (commentaires `Lock order position` déplacés verbatim avec le struct renommé, aucun lock fusionné/déplacé).
- Visibilités, `cfg`, API newtypes/`AnyCollection` intouchées ; `into_vector_facade` intouché.

## Pourquoi
Donne un **handle graphe unique partageable** : R1.2d pourra en donner un clone à `GraphCollection` sans retrait exclusif, l'état graphe restant accessible à `Collection` pour l'exécution MATCH.

## Vérifications
- `cargo check` vert en `--features persistence` ET `--no-default-features`.
- Bindings verts : `velesdb-server`, `velesdb-cli`, `velesdb-mobile`.
- Clippy CI-exact (pedantic, `-D warnings`) vert après `cargo clean -p` ; fmt vert ; `check_prod_unwraps.py` PASSED.
- Tests `velesdb-core --lib` : **5277 verts** (persistence, `--test-threads=1`) et **2174 verts** (`--no-default-features`).

## Auto-revue adverse
- Aucun `self.graph = …` ni `&mut self.graph` (grep vide).
- Aucun littéral `GraphStore`/`GraphState` hors décl + site unique de construction.
- Aucun `.graph.clone()` (copie profonde) — le `Clone` de `Collection` clone maintenant l'`Arc` (superficiel), équivalent observable au field-clone d'Arcs précédent car `GraphStore` n'a aucun champ non-`Arc`.
- Lock-order intact.

EPIC #1384.