### PR TITLE
chore: R1-train review remediation — changelog the breaking facade removal, flatten Python discrimination, doc fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document is the **15-minute read** an engineer or a technical due-diligence reviewer should start with. It tells you what VelesDB is, how it is shaped, and where to dig deeper.
 
-> **Last updated:** 2026-06-12 — applies to v3.x and onward.
+> **Last updated:** 2026-07-16 — applies to v3.x and onward.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+R1 `Collection`-internals train: resolves and **closes the god-object EPIC
+([#1384](https://github.com/cyberlife-coder/VelesDB/issues/1384))**. The
+internals are organized to the maximum structurally sound point; full per-kind
+exclusive decomposition was investigated and documented as structurally
+infeasible (see the F2.2 entry in `docs/ARCHITECTURE.md` for the complete
+account).
+
+> **Note for the next release**: this train contains a **breaking Rust core
+> API change** (the `into_vector_facade` removal below). Per the declared
+> SemVer policy, tag the next release accordingly — a major bump, or an
+> explicitly documented exception in these release notes.
+
+### Removed — BREAKING (Rust core API)
+
+- **`AnyCollection::into_vector_facade` is removed** (R1.4). The facade —
+  introduced in 3.11.0 as the safe replacement for `into_vector_unchecked` —
+  coerced *any* variant into a `VectorCollection`, so the kind a caller
+  captured could diverge from the collection's real kind. *Migration*: use the
+  variant-checked `AnyCollection::into_vector()` (returns `Err(self)` on the
+  wrong variant so ownership is recovered); bindings that deliberately need
+  the **structural view** of a graph/metadata store behind the
+  `VectorCollection` newtype (single user-facing `Collection` type, vector-only
+  ops gated by a separately tracked kind) use
+  `GraphCollection::into_vector_view()` /
+  `MetadataCollection::into_vector_view()` instead.
+
+### Changed
+
+- **`Collection` internals regrouped into six named concern sub-structs**
+  (R1.1 — internal-only, `pub(crate)`, non-breaking): `StorageState`,
+  `GraphStore`, `QueryState`, `GenerationCounters`, `StreamingState`,
+  `RuntimeGuards`, with the lock ordering preserved verbatim.
+- **`order_by_advisor` reclassified out of the graph cluster into
+  `QueryState`** (R1.2a — internal-only): it is a generic `ORDER BY` scan
+  concern reached on any collection kind, not graph state.
+- **Graph cluster held as a shared `Arc<GraphStore>` handle** (R1.2b —
+  internal-only): graph state can be shared with `GraphCollection` without an
+  exclusive move; field access and locking are unchanged.
+
 ## [3.12.0] — 2026-07-15
 
 Pre-release hardening ("Vague D"): closes the remaining audit follow-ups
@@ -137,7 +176,10 @@ rushed on a released core.
   still enforced by the captured `CollectionKind` + `Collection::ensure_vector`.
   Removes the workspace's last logically-unsound `unsafe`. *Migration:* if you
   called `into_vector_unchecked` directly, rename to `into_vector_facade` and
-  drop the `unsafe` block (no behavior change). (Audit P0.)
+  drop the `unsafe` block (no behavior change). (Audit P0.) *(Note:
+  `into_vector_facade` was itself removed after 3.12.0 — see the Unreleased
+  section above; use the variant-checked `into_vector()` or, for the
+  structural view, `into_vector_view()`.)*
 - **Uniform `AnyCollection` dispatch** via a single private `inner()` accessor —
   the shared, identical-across-kinds methods no longer mix `c.method()` /
   `c.inner.method()` forwarding. No behavior change. (Audit P2.6.)

--- a/QUALITY_BAR.md
+++ b/QUALITY_BAR.md
@@ -4,7 +4,7 @@ This document specifies the **explicit, enforceable thresholds** below which Vel
 
 These gates are not aspirational. They are enforced via CI workflows, scripts, and explicit pre-merge protocols. Each gate listed here links to its enforcement mechanism so that the gate can be inspected, contested, or extended publicly.
 
-> **Last updated:** 2026-06-12 — applies to v3.x and onward.
+> **Last updated:** 2026-07-16 — applies to v3.x and onward.
 
 ---
 

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -85,12 +85,18 @@ impl GraphCollection {
     /// that the collection is vector-kind: invoking vector-specific methods on
     /// the result returns empty or misleading state.
     ///
-    /// It exists solely so the single-`Collection` SDK bindings (Python /
-    /// Mobile / Tauri), whose one user-facing collection type is backed by a
-    /// `VectorCollection`, can hold a graph collection behind that type while
-    /// gating vector-only operations on the real kind they track separately
-    /// (e.g. the Python `Collection::ensure_vector` guard). Callers that need
-    /// the graph surface must use the graph API, not this view.
+    /// It exists solely for the **Python binding**, whose single user-facing
+    /// `Collection` type is backed by a `VectorCollection`: the binding holds a
+    /// graph collection behind that type while gating vector-only operations on
+    /// the real kind it tracks separately (the Python
+    /// `Collection::ensure_vector` guard). The Mobile and Tauri bindings do
+    /// *not* use this view — they go through the variant-checked
+    /// [`AnyCollection::into_vector`](super::AnyCollection::into_vector) and
+    /// reject non-vector collections. Callers that need the graph surface must
+    /// use the graph API, not this view.
+    ///
+    /// [`MetadataCollection::into_vector_view`](super::MetadataCollection::into_vector_view)
+    /// is the exact mirror for metadata collections.
     #[must_use]
     pub fn into_vector_view(self) -> super::VectorCollection {
         super::VectorCollection { inner: self.inner }

--- a/crates/velesdb-core/src/collection/metadata_collection.rs
+++ b/crates/velesdb-core/src/collection/metadata_collection.rs
@@ -67,18 +67,10 @@ impl MetadataCollection {
     /// Consumes `self` and returns a [`VectorCollection`](super::VectorCollection)
     /// **structural view** over this metadata collection's shared `inner` store.
     ///
-    /// This is a purely structural re-wrap of the identical `inner: Collection`
-    /// backing store into the `VectorCollection` newtype — an ordinary value
-    /// move, **not** a `transmute` and not memory-unsafe. It does **not** assert
-    /// that the collection is vector-kind: invoking vector-specific methods on
-    /// the result returns empty or misleading state.
-    ///
-    /// It exists solely so the single-`Collection` SDK bindings (Python /
-    /// Mobile / Tauri), whose one user-facing collection type is backed by a
-    /// `VectorCollection`, can hold a metadata collection behind that type while
-    /// gating vector-only operations on the real kind they track separately
-    /// (e.g. the Python `Collection::ensure_vector` guard). Callers that need
-    /// the metadata surface must use the metadata API, not this view.
+    /// Exact mirror of
+    /// [`GraphCollection::into_vector_view`](super::GraphCollection::into_vector_view)
+    /// — see that method for the full contract (purely structural re-wrap, no
+    /// vector-kind assertion, Python-binding-only rationale).
     #[must_use]
     pub fn into_vector_view(self) -> super::VectorCollection {
         super::VectorCollection { inner: self.inner }

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -392,7 +392,10 @@ pub(crate) struct QueryState {
     pub(super) stats_io_mutex: Arc<Mutex<()>>,
 }
 
-/// Monotonic generation counters that gate compiled-plan cache invalidation.
+/// Monotonic generation counters that gate compiled-plan cache invalidation
+/// (`write_generation`, `analyze_generation`), plus the flush-threshold
+/// counter `inserts_since_last_hnsw_save` (HNSW save cadence, consumed by
+/// `flush()`).
 ///
 /// Concern cluster **generations** of `Collection` (R1.1, EPIC #1384). These
 /// are lock-free atomics; grouping them changes no synchronization.
@@ -491,6 +494,15 @@ pub(crate) struct StreamingState {
 /// Query-execution guard-rails and the runtime ingest/search limits.
 ///
 /// Concern cluster **runtime** of `Collection` (R1.1, EPIC #1384).
+///
+/// **Split criterion vs [`QueryState`]**: this cluster holds
+/// *operator-facing, config-driven runtime limits* — values pushed in from
+/// the outside (`update_guardrails`, [`VelesConfig::limits`](crate::config::VelesConfig)
+/// at registration time) that bound what the engine is *allowed* to do.
+/// [`QueryState`] holds the *internal query-execution machinery* (indexes,
+/// planner, caches, stats) — state the engine builds and consults itself to
+/// decide *how* to execute. Limits change via configuration; engine state
+/// changes via execution.
 #[derive(Clone)]
 pub(crate) struct RuntimeGuards {
     /// Guard-rails for query execution (EPIC-048).

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -14,7 +14,9 @@ use crate::options::{AutoReindexOptions, HnswOptions, VelesConfigOptions};
 use crate::utils::{self, parse_metric, parse_storage_mode};
 
 use velesdb_core::collection::auto_reindex::AutoReindexManager;
-use velesdb_core::{CollectionType, Database as CoreDatabase, DatabaseObserver, GraphSchema};
+use velesdb_core::{
+    AnyCollection, CollectionType, Database as CoreDatabase, DatabaseObserver, GraphSchema,
+};
 
 /// The full set of guardrail fields. `update_guardrails` is an explicit full
 /// replacement (matching the Mobile/Tauri typed structs), so the supplied dict
@@ -67,6 +69,49 @@ fn open_core(
         (None, Some(obs)) => CoreDatabase::open_with_observer(path, obs),
         (None, None) => CoreDatabase::open(path),
     }
+}
+
+/// Wraps an [`AnyCollection`] in the single Python-facing [`Collection`] type.
+///
+/// The Python SDK exposes one `Collection` class (backed by a core
+/// `VectorCollection`) over all collection kinds. A flat match discriminates
+/// the real variant, so the captured [`CollectionKind`] is derived from the
+/// actual collection and cannot diverge from it. Non-vector kinds share the
+/// same backing store and are exposed through the structural
+/// `into_vector_view()` re-wrap; vector-only methods remain gated by `kind`
+/// via `Collection::ensure_vector`, so they fail loud (F2.2) rather than
+/// returning misleading results.
+///
+/// `AnyCollection` is `#[non_exhaustive]`, which outside the defining crate
+/// merely requires a wildcard arm — the flat match here satisfies that, and
+/// the `_` arm doubles as the fail-closed path for any future variant. (The
+/// nested `into_vector()`/`into_graph()`/`into_metadata()` chain this
+/// replaces was never *required* by `#[non_exhaustive]`.)
+///
+/// Shared by [`Database::get_collection`] and
+/// [`Database::create_metadata_collection`] so both construct the wrapper
+/// through one path with identical errors.
+fn wrap_any_collection(
+    any_coll: AnyCollection,
+    db: &Arc<CoreDatabase>,
+    name: &str,
+) -> PyResult<Collection> {
+    let (vc, kind) = match any_coll {
+        AnyCollection::Vector(v) => (v, CollectionKind::Vector),
+        AnyCollection::Graph(g) => (g.into_vector_view(), CollectionKind::Graph),
+        AnyCollection::Metadata(m) => (m.into_vector_view(), CollectionKind::Metadata),
+        _ => {
+            return Err(PyRuntimeError::new_err(
+                "unsupported collection kind for the Python Collection view",
+            ));
+        }
+    };
+    Ok(Collection::new_with_kind(
+        vc,
+        Arc::clone(db),
+        name.to_string(),
+        kind,
+    ))
 }
 
 /// VelesDB Database - the main entry point for interacting with VelesDB.
@@ -355,42 +400,13 @@ impl Database {
     /// Returns the collection regardless of its type (vector, graph, or metadata).
     /// Returns None if the collection does not exist.
     fn get_collection(&self, name: &str) -> PyResult<Option<Collection>> {
-        match self.inner.get_any_collection(name) {
-            Some(any_coll) => {
-                // The Python SDK exposes a single `Collection` type (backed by a
-                // core `VectorCollection`) over all variants. Discriminate the
-                // real kind via the variant-checked `into_*` accessors, so the
-                // captured `kind` is derived from the actual collection and
-                // cannot diverge from it. Non-vector kinds share the same backing
-                // store and are exposed as a structural `VectorCollection` view;
-                // vector-only methods are still gated by `kind` via
-                // `Collection::ensure_vector`, so they fail loud (F2.2) rather
-                // than returning misleading results. (`AnyCollection` is
-                // `#[non_exhaustive]`, hence the ownership-recovering chain plus
-                // a fail-closed arm for any future variant.)
-                let (vc, kind) = match any_coll.into_vector() {
-                    Ok(v) => (v, CollectionKind::Vector),
-                    Err(other) => match other.into_graph() {
-                        Ok(g) => (g.into_vector_view(), CollectionKind::Graph),
-                        Err(other) => match other.into_metadata() {
-                            Ok(m) => (m.into_vector_view(), CollectionKind::Metadata),
-                            Err(_) => {
-                                return Err(PyRuntimeError::new_err(
-                                    "unsupported collection kind for the Python Collection view",
-                                ));
-                            }
-                        },
-                    },
-                };
-                Ok(Some(Collection::new_with_kind(
-                    vc,
-                    Arc::clone(&self.inner),
-                    name.to_string(),
-                    kind,
-                )))
-            }
-            None => Ok(None),
-        }
+        // Discrimination + wrapping live in `wrap_any_collection` (shared with
+        // `create_metadata_collection`): a flat match derives the kind from the
+        // actual variant, with a fail-closed `_` arm for future variants.
+        self.inner
+            .get_any_collection(name)
+            .map(|any_coll| wrap_any_collection(any_coll, &self.inner, name))
+            .transpose()
     }
 
     /// List all collection names in the database.
@@ -463,23 +479,11 @@ impl Database {
             .inner
             .get_any_collection(&name_owned)
             .ok_or_else(|| PyRuntimeError::new_err("Collection not found after creation"))?;
-        // Wrap the freshly-created metadata collection in the single Collection
-        // type (mirrors `get_collection` above). The variant-checked
-        // `into_metadata` asserts the just-created collection really is metadata,
-        // then `into_vector_view` re-wraps its shared store into the
-        // `VectorCollection` the Python `Collection` holds; the `Metadata` kind
-        // recorded below makes `Collection::ensure_vector` reject vector-only ops.
-        let collection = any
-            .into_metadata()
-            .map_err(|_| PyRuntimeError::new_err("expected a metadata collection after creation"))?
-            .into_vector_view();
-
-        Ok(Collection::new_with_kind(
-            collection,
-            Arc::clone(&self.inner),
-            name_owned,
-            CollectionKind::Metadata,
-        ))
+        // Wrap it through the same path as `get_collection`: the flat match in
+        // `wrap_any_collection` derives the kind from the actual variant, so the
+        // freshly-created collection records `CollectionKind::Metadata` and
+        // `Collection::ensure_vector` rejects vector-only ops on it.
+        wrap_any_collection(any, &self.inner, &name_owned)
     }
 
     /// Create an AgentMemory instance for AI agent workflows.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,8 +56,9 @@ idiom for enum-variant access:
    `into_vector_unchecked`, then (audit **P0**, PR #1383) the **safe**
    `into_vector_facade(self) -> VectorCollection`. That untyped facade — which
    coerced *any* variant into a `VectorCollection` — has now been removed
-   (R1.4). The Python binding's two call-sites discriminate the real variant
-   directly with a flat match (`match any_coll { AnyCollection::Vector(v) => …,
+   (R1.4). The Python binding's two call-sites (`get_collection`,
+   `create_metadata_collection`) share one wrapping helper that discriminates
+   the real variant with a flat match (`match any_coll { AnyCollection::Vector(v) => …,
    AnyCollection::Graph(g) => g.into_vector_view(), AnyCollection::Metadata(m)
    => m.into_vector_view(), _ => /* fail-closed error */ }`), so the
    captured `CollectionKind` is derived from the actual variant and can no

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,12 +57,14 @@ idiom for enum-variant access:
    `into_vector_facade(self) -> VectorCollection`. That untyped facade — which
    coerced *any* variant into a `VectorCollection` — has now been removed
    (R1.4). The Python binding's two call-sites discriminate the real variant
-   directly (`match any_coll { AnyCollection::Vector(c) => …, Graph(c) =>
-   c.into_vector_view(), Metadata(c) => c.into_vector_view() }`), so the
+   directly with a flat match (`match any_coll { AnyCollection::Vector(v) => …,
+   AnyCollection::Graph(g) => g.into_vector_view(), AnyCollection::Metadata(m)
+   => m.into_vector_view(), _ => /* fail-closed error */ }`), so the
    captured `CollectionKind` is derived from the actual variant and can no
-   longer diverge from it. The structural re-wrap of a graph/metadata store
-   into the `VectorCollection` newtype that the single Python `Collection` type
-   holds now lives on the concrete newtypes as
+   longer diverge from it (the `_` arm is the fail-closed path required by
+   `#[non_exhaustive]` for any future variant). The structural re-wrap of a
+   graph/metadata store into the `VectorCollection` newtype that the single
+   Python `Collection` type holds now lives on the concrete newtypes as
    `GraphCollection::into_vector_view` / `MetadataCollection::into_vector_view`
    — an ordinary value move over the shared `inner: Collection`, honestly
    scoped and *not* asserting vector kind. Vector-only ops remain gated by the
@@ -89,21 +91,14 @@ The SDK bindings would then expose a sum type (enum) or union
 interface that forces callers to discriminate the kind before
 invoking any operation. This is estimated at 2-4 weeks of core
 refactoring and is deliberately out of scope for the pre-seed
-remediation cycle. The untyped `into_vector_facade` coercion was already
-removed in R1.4 (the Python binding now discriminates the variant and uses
-the honestly-scoped `into_vector_view`); the remaining EPIC work is to have
-the binding hold a kind-discriminated collection directly instead of a
+remediation cycle. The untyped `into_vector_facade` coercion is already gone
+(R1.4 — see point 4 above for the full account); the remaining EPIC work is to
+have the binding hold a kind-discriminated collection directly instead of a
 `VectorCollection` newtype at all.
 
 **When to revisit**: post-seed, within the first 4 weeks of the
 architecture cleanup milestone. Concrete plan, blast radius, and incremental
 sequencing are captured in [issue #1384](https://github.com/cyberlife-coder/VelesDB/issues/1384).
-
-The untyped `into_vector_facade` escape hatch was retired in **R1.4** (see
-point 4 above); the remaining debt is that the Python `Collection` still holds
-a `VectorCollection` newtype (via the honestly-scoped `into_vector_view`)
-rather than a kind-discriminated sum type — the full separation of the shared
-backing store is still the F2.2 EPIC.
 
 **EPIC #1384 resolution (final)** — *organized to the maximum structurally
 sound point; per-kind exclusive ownership is infeasible and this is by design,


### PR DESCRIPTION
Remediates the 9 findings of the code review on the unreleased R1 train (develop tip 77d06790). All docs/factorization — zero correctness changes.

## Fixes

| # | Finding | What was done |
|---|---------|---------------|
| F1 | CHANGELOG missing the R1 train | `[Unreleased]` now documents the train: **BREAKING** removal of `AnyCollection::into_vector_facade` (migration: variant-checked `into_vector()`, or `GraphCollection`/`MetadataCollection::into_vector_view()` for the structural view), R1.1 internal regrouping (non-breaking), R1.2a/b, and the EPIC #1384 closure. The 3.11.0 `into_vector_facade` entry is annotated in place (facade itself removed after 3.12.0) without rewriting history. |
| F2 | Nested `into_*` discrimination chain | Replaced with a flat `match` over the variants; the `_` wildcard arm satisfies `#[non_exhaustive]` and is the fail-closed path (`crates/velesdb-python/src/database.rs`). |
| F3 | Comment/doc claimed the chain was required | Corrected in the helper's doc and in the `docs/ARCHITECTURE.md` F2.2 pseudo-code (now shows the flat match **with** the wildcard fail-closed arm). |
| F4 | `create_metadata_collection` duplicated the wrapping | Extracted private `wrap_any_collection(any, &Arc<CoreDatabase>, name) -> PyResult<Collection>`, used by `get_collection` **and** `create_metadata_collection`. |
| F5 | `into_vector_view` docs overstated consumers | Only the Python binding uses the view (Mobile/Tauri use `into_vector()` and reject non-vector). Canonical doc kept on `GraphCollection::into_vector_view`; `MetadataCollection`'s doc reduced to a mirror reference. |
| F6 | Stale timestamps | `ARCHITECTURE.md` and `QUALITY_BAR.md` → `Last updated: 2026-07-16`. |
| F7 | R1.4 resolution stated 3× in `docs/ARCHITECTURE.md` | Single full statement kept (point 4); the two restatements replaced by brief cross-references. |
| F8 | `GenerationCounters` doc incomplete | Now also names the flush-threshold counter `inserts_since_last_hnsw_save` (HNSW save cadence, consumed by `flush()`). Field not moved. |
| F9 | `RuntimeGuards` taxonomy undocumented | Split criterion documented: operator-facing, config-driven runtime limits (pushed from `update_guardrails` / `VelesConfig::limits`) vs `QueryState` = internal query-execution machinery. Fields not moved. |

## ⚠️ Release-tagging note (F1)

This train contains a **breaking Rust core API change** (`into_vector_facade` removed). Per the declared SemVer policy, the next release must be tagged accordingly — major bump, or an explicitly documented exception in the release notes.

## Behavior notes

- `wrap_any_collection` behaves identically to the previous code on every reachable path. One theoretical difference: `create_metadata_collection` previously asserted the just-created collection was metadata (`"expected a metadata collection after creation"`); the shared helper instead derives the kind from the actual variant. That branch is unreachable short of a core registry bug, and the derived kind can no longer diverge from reality by construction.

## Gates

- `cargo fmt --all` — clean
- CI-exact clippy (toolchain 1.90, `cargo clean -p velesdb-core` first, `--workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic`) — pass
- `cargo clippy -p velesdb-python --all-targets -- -D warnings -D clippy::pedantic` — pass
- `scripts/check_prod_unwraps.py` — pass
- `cargo test -p velesdb-core --lib --features persistence -- --test-threads=1` — **5277 passed, 0 failed, 14 ignored**
- `cargo test -p velesdb-core --lib --no-default-features -- --test-threads=1` — **2174 passed, 0 failed, 13 ignored**
- velesdb-python pytest (fresh venv + `maturin develop --release`) — **515 passed, 0 failed**