### PR TITLE
docs(memory): context compiler onboarding — quickstart, skill install, data-path clarity, diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ compile_context { "query": "state of the canary deploy", "token_budget": 500,
 
 No Rust toolchain? Use npm instead: [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node).
 
-**Not a transparent proxy, and no automatic indexing.** The compiler only compresses what your agent explicitly hands it as `fragments` (logs, retrieved docs, history) — never the harness's system prompt or tool schemas, and it's the skill above that teaches an agent when/what to route through it. Compilation is stateless: nothing enters the memory store unless you call `remember` / `relate` / `remember_extracted` yourself. Local-first — nothing leaves the machine. Details: [crates/velesdb-memory/README.md § How it works](crates/velesdb-memory/README.md#how-it-works).
+**Not a transparent proxy, and no automatic indexing.** The compiler only compresses what your agent explicitly hands it as `fragments` (logs, retrieved docs, history) — never the harness's system prompt or tool schemas, and it's the skill above that teaches an agent when/what to route through it. Every compiled fragment is content-addressed to disk under the store path so `retrieve_context_source` can always recover it, and aggregate savings stats are recorded — but nothing enters *recallable memory* (what `recall` / `memory_scope` can surface) without an explicit `remember` / `relate` / `remember_extracted` call. Local-first — nothing leaves the machine. Details: [crates/velesdb-memory/README.md § How it works](crates/velesdb-memory/README.md#how-it-works).
 
 ![compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx://source handles and auditable decisions](crates/velesdb-memory/docs/diagrams/compile-flow.svg)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,34 @@ The same wedge ships in **Python** (`pip install velesdb`), **Node** (`npm i @wi
 
 Agents burn most of their budget re-reading redundant context. The memory layer now ships a **deterministic context compiler** (`compile_context` over MCP and Node, `ContextCompiler` in Rust): no LLM, no cloud — duplicates drop, repeated log lines collapse with counts, code / URLs / numbers / negative constraints survive verbatim, and over-budget content becomes a recoverable `ctx://source/` handle instead of a silent loss. Every decision carries a stable rule id, a reason, and a risk level (`explain_compilation` answers "why was this dropped?"), and the same request always compiles to the same bytes. On a committed 12-turn agent-session benchmark this measures **82.5 % real (cl100k) input-token savings** with sub-millisecond stateless compiles, and 75–82 % estimated savings on the static corpus in ~2 ms ([`examples/context_savings`](crates/velesdb-memory/examples/context_savings), figures are local estimates, not billed tokens). The [`velesdb-context-optimizer` skill](skills/velesdb-context-optimizer/SKILL.md) packages the workflow — including when *not* to compress. See [Why VelesDB](docs/WHY_VELESDB.md).
 
+**Compiler surfaces today: MCP server, Node, Rust. Python binding: in progress** — Python agents reach `compile_context` through the MCP server for now.
+
+**Quickstart (3 steps):**
+
+```bash
+# 1. Install the MCP server binary
+cargo install velesdb-memory
+
+# 2. Point your MCP client at it (Claude Code example)
+claude mcp add velesdb-memory -- ~/.cargo/bin/velesdb-memory
+```
+
+```jsonc
+// 3. Call compile_context — query + token_budget + fragments
+compile_context { "query": "state of the canary deploy", "token_budget": 500,
+                  "fragments": [
+                    { "content": "The canary is green: 2% traffic, zero errors in the last 10 minutes." },
+                    { "content": "Rollback runbook: kubectl rollout undo deployment/canary." } ] }
+→ { "content": "…both fragments packed…", "risk": "low",
+    "decisions": […one auditable entry per fragment…] }
+```
+
+No Rust toolchain? Use npm instead: [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node).
+
+**Not a transparent proxy, and no automatic indexing.** The compiler only compresses what your agent explicitly hands it as `fragments` (logs, retrieved docs, history) — never the harness's system prompt or tool schemas, and it's the skill above that teaches an agent when/what to route through it. Compilation is stateless: nothing enters the memory store unless you call `remember` / `relate` / `remember_extracted` yourself. Local-first — nothing leaves the machine. Details: [crates/velesdb-memory/README.md § How it works](crates/velesdb-memory/README.md#how-it-works).
+
+![compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx://source handles and auditable decisions](crates/velesdb-memory/docs/diagrams/compile-flow.svg)
+
 ---
 
 For the lower-level building blocks (episodic, procedural, TTL, snapshots):

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -233,20 +233,22 @@ cargo build --release -p velesdb-memory   # → target/release/velesdb-memory
 ## Configure your client
 
 All clients use the same stdio shape — point `command` at the built binary.
+`cargo install velesdb-memory` puts it at `~/.cargo/bin/velesdb-memory`
+(or the path of your local build, `target/release/velesdb-memory`).
 
 **Claude Code**
 
 ```bash
 claude mcp add velesdb-memory \
   --env VELESDB_MEMORY_PATH="$HOME/.velesdb-memory" \
-  -- /path/to/velesdb-memory
+  -- ~/.cargo/bin/velesdb-memory
 ```
 
 **Cursor** — `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project)
 
 ```json
 { "mcpServers": { "velesdb-memory": {
-  "command": "/path/to/velesdb-memory",
+  "command": "~/.cargo/bin/velesdb-memory",
   "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
 } } }
 ```
@@ -257,7 +259,7 @@ claude mcp add velesdb-memory \
 
 ```json
 { "context_servers": { "velesdb-memory": {
-  "command": { "path": "/path/to/velesdb-memory", "args": [],
+  "command": { "path": "~/.cargo/bin/velesdb-memory", "args": [],
     "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" } }
 } } }
 ```
@@ -267,13 +269,13 @@ claude mcp add velesdb-memory \
 ```bash
 codex mcp add velesdb-memory \
   --env VELESDB_MEMORY_PATH="$HOME/.velesdb-memory" \
-  -- /path/to/velesdb-memory
+  -- ~/.cargo/bin/velesdb-memory
 ```
 
 ```toml
 # equivalent ~/.codex/config.toml entry
 [mcp_servers.velesdb-memory]
-command = "/path/to/velesdb-memory"
+command = "~/.cargo/bin/velesdb-memory"
 args = []
 env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 ```
@@ -283,7 +285,7 @@ env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 ```json
 { "mcp": { "velesdb-memory": {
   "type": "local",
-  "command": ["/path/to/velesdb-memory"],
+  "command": ["~/.cargo/bin/velesdb-memory"],
   "enabled": true,
   "environment": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
 } } }

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -362,6 +362,11 @@ remember_extracted { "text": "Met Dana at the Rust meetup; she now leads the par
 
 ### The context compiler tools
 
+**Compiler surfaces today: MCP server, Node, Rust. Python binding: in
+progress** (tracked as a follow-up EPIC) — Python agents reach it through the
+MCP server for now; `from velesdb import MemoryService` covers the memory API
+only, not `compile_context` yet.
+
 **Why:** agents spend most of their tokens re-reading redundant context.
 `compile_context` compresses it **deterministically** — no LLM, no cloud, no
 API key: same request, byte-identical output. What must survive verbatim
@@ -377,6 +382,45 @@ risk). Guarantees, per compilation:
   bytes; `retrieval_handles` list what was externalized.
 - **Nothing critical silently lost**: losing preserve-classified content
   raises the compilation's `risk` to `"high"` — check it before use.
+
+#### How it works
+
+![compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx://source handles and auditable decisions](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/compile-flow.svg)
+
+**Not a transparent proxy.** `compile_context` only touches what your agent
+explicitly hands it as `fragments` — logs, retrieved docs, conversation
+history you choose to route through the call. It never sees or compresses
+the harness's system prompt or tool-call schemas; those stay outside the
+compiler entirely. Knowing *when* and *what* to route through it is the
+[`velesdb-context-optimizer`](../../skills/velesdb-context-optimizer/SKILL.md)
+skill's job, not the compiler's — the compiler just compresses what it's
+given, deterministically.
+
+**No automatic repo indexing.** Nothing enters the memory store unless you
+call `remember` / `relate` / `remember_extracted` explicitly — compilation
+itself is **stateless**: call `compile_context` a thousand times and nothing
+is written. The only two exceptions: fragments the budget layer externalizes
+(content that didn't fit) are cached locally under `VELESDB_MEMORY_PATH`
+(default `~/.velesdb-memory`) so `retrieve_context_source` can fetch them
+back by handle, and `context_savings` records aggregate stats (tokens
+in/out/saved) per project. Both stay on disk — local-first, nothing is ever
+sent off the machine.
+
+![the two data paths: stateless compile vs explicit memory writes — nothing is stored without an explicit remember/relate/remember_extracted call](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/data-paths.svg)
+
+```jsonc
+// compile_context — minimal call: query + token_budget + fragments
+compile_context { "query": "state of the canary deploy",
+                  "token_budget": 500,
+                  "fragments": [
+                    { "content": "The canary is green: 2% traffic, zero errors in the last 10 minutes." },
+                    { "content": "Rollback runbook: kubectl rollout undo deployment/canary." } ] }
+→ { "content": "…both fragments packed…", "decisions": […2 entries, "action": "preserve"…],
+    "insights": { "tokens_in": 44, "tokens_out": 45, "tokens_saved": 0 }, "risk": "low" }
+```
+
+Add `memory_scope`, `project`, and `metadata: {"cache": true}` once you need
+stored-memory recall or provider prompt-cache alignment — the full request:
 
 ```jsonc
 // compile_context — deterministic compression under a token budget
@@ -419,7 +463,11 @@ BPE (cl100k) to deliberately over-count every measured content class
 (+13 %…+55 %) — not the provider's count, not billed tokens, not cache reads.
 The reproducible benchmark ([`examples/context_savings`](examples/context_savings))
 measures **82.5 % real (cl100k) token savings on a committed 12-turn agent-session benchmark** (sub-ms stateless compiles), 75–82 % estimated savings on its static corpus in ~2 ms compile, and — with `memory_scope`'s fused HNSW + graph-walk recall over `relate`-linked fact chains — **9/9 answer facts surfaced vs 3/9 for vector-only recall** on the committed tri-engine benchmark
-latency. The [`velesdb-context-optimizer`](../../skills/velesdb-context-optimizer/SKILL.md)
+latency. That tri-engine path — the one `memory_scope` drives inside `compile_context` — looks like this:
+
+![tri-engine retrieval: query seeds an HNSW vector search, a graph walk follows relate edges, fusion combines both, then ranking produces the result](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/tri-engine.svg)
+
+The [`velesdb-context-optimizer`](../../skills/velesdb-context-optimizer/SKILL.md)
 skill teaches an agent the full workflow — including when *not* to compress.
 
 **IDs & linking.** `remember` returns a stable id derived from the fact's

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -307,6 +307,17 @@ with concrete scenarios (incident→decision→"why?", onboarding, cross-session
 continuity). Without it, an agent will call `recall` at best and never build the
 graph that makes `why` shine.
 
+A second bundled skill, **`velesdb-context-optimizer`**, teaches the compiler
+workflow below (when/what to compress, how to read `risk`). Install it the
+same way:
+
+```bash
+cp -r skills/velesdb-context-optimizer ~/.claude/skills/
+```
+
+[`skills/velesdb-context-optimizer/SKILL.md`](../../skills/velesdb-context-optimizer/SKILL.md)
+— see [The context compiler tools](#the-context-compiler-tools) below.
+
 ## Using the tools
 
 Once configured, your agent discovers the tools automatically (via MCP

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -320,7 +320,7 @@ same way:
 cp -r skills/velesdb-context-optimizer ~/.claude/skills/
 ```
 
-[`skills/velesdb-context-optimizer/SKILL.md`](../../skills/velesdb-context-optimizer/SKILL.md)
+[`skills/velesdb-context-optimizer/SKILL.md`](https://github.com/cyberlife-coder/VelesDB/blob/main/skills/velesdb-context-optimizer/SKILL.md)
 — see [The context compiler tools](#the-context-compiler-tools) below.
 
 ## Using the tools
@@ -468,9 +468,9 @@ The reproducible benchmark ([`examples/context_savings`](examples/context_saving
 measures **82.5 % real (cl100k) token savings on a committed 12-turn agent-session benchmark** (sub-ms stateless compiles), 75–82 % estimated savings on its static corpus in ~2 ms compile, and — with `memory_scope`'s fused HNSW + graph-walk recall over `relate`-linked fact chains — **9/9 answer facts surfaced vs 3/9 for vector-only recall** on the committed tri-engine benchmark
 latency. That tri-engine path — the one `memory_scope` drives inside `compile_context` — looks like this:
 
-![tri-engine retrieval: query seeds an HNSW vector search, a graph walk follows relate edges, fusion combines both, then ranking produces the result](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/tri-engine.svg)
+![tri-engine retrieval: query seeds an HNSW vector search, a graph walk follows relate edges, fusion combines both, then ranking produces the result](docs/diagrams/tri-engine.svg)
 
-The [`velesdb-context-optimizer`](../../skills/velesdb-context-optimizer/SKILL.md)
+The [`velesdb-context-optimizer`](https://github.com/cyberlife-coder/VelesDB/blob/main/skills/velesdb-context-optimizer/SKILL.md)
 skill teaches an agent the full workflow — including when *not* to compress.
 
 **IDs & linking.** `remember` returns a stable id derived from the fact's

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -235,6 +235,9 @@ cargo build --release -p velesdb-memory   # → target/release/velesdb-memory
 All clients use the same stdio shape — point `command` at the built binary.
 `cargo install velesdb-memory` puts it at `~/.cargo/bin/velesdb-memory`
 (or the path of your local build, `target/release/velesdb-memory`).
+JSON/TOML configs spawn the binary without a shell, so `~` is **not**
+expanded there — use an absolute path (shown below as
+`/home/you/.cargo/bin/velesdb-memory`; adjust to your home directory).
 
 **Claude Code**
 
@@ -248,7 +251,7 @@ claude mcp add velesdb-memory \
 
 ```json
 { "mcpServers": { "velesdb-memory": {
-  "command": "~/.cargo/bin/velesdb-memory",
+  "command": "/home/you/.cargo/bin/velesdb-memory",
   "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
 } } }
 ```
@@ -259,7 +262,7 @@ claude mcp add velesdb-memory \
 
 ```json
 { "context_servers": { "velesdb-memory": {
-  "command": { "path": "~/.cargo/bin/velesdb-memory", "args": [],
+  "command": { "path": "/home/you/.cargo/bin/velesdb-memory", "args": [],
     "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" } }
 } } }
 ```
@@ -275,7 +278,7 @@ codex mcp add velesdb-memory \
 ```toml
 # equivalent ~/.codex/config.toml entry
 [mcp_servers.velesdb-memory]
-command = "~/.cargo/bin/velesdb-memory"
+command = "/home/you/.cargo/bin/velesdb-memory"
 args = []
 env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 ```
@@ -285,7 +288,7 @@ env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 ```json
 { "mcp": { "velesdb-memory": {
   "type": "local",
-  "command": ["~/.cargo/bin/velesdb-memory"],
+  "command": ["/home/you/.cargo/bin/velesdb-memory"],
   "enabled": true,
   "environment": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
 } } }

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -385,28 +385,28 @@ risk). Guarantees, per compilation:
 
 #### How it works
 
-![compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx://source handles and auditable decisions](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/compile-flow.svg)
+![compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx://source handles and auditable decisions](docs/diagrams/compile-flow.svg)
 
 **Not a transparent proxy.** `compile_context` only touches what your agent
 explicitly hands it as `fragments` — logs, retrieved docs, conversation
 history you choose to route through the call. It never sees or compresses
 the harness's system prompt or tool-call schemas; those stay outside the
 compiler entirely. Knowing *when* and *what* to route through it is the
-[`velesdb-context-optimizer`](../../skills/velesdb-context-optimizer/SKILL.md)
+[`velesdb-context-optimizer`](https://github.com/cyberlife-coder/VelesDB/blob/main/skills/velesdb-context-optimizer/SKILL.md)
 skill's job, not the compiler's — the compiler just compresses what it's
 given, deterministically.
 
-**No automatic repo indexing.** Nothing enters the memory store unless you
-call `remember` / `relate` / `remember_extracted` explicitly — compilation
-itself is **stateless**: call `compile_context` a thousand times and nothing
-is written. The only two exceptions: fragments the budget layer externalizes
-(content that didn't fit) are cached locally under `VELESDB_MEMORY_PATH`
-(default `~/.velesdb-memory`) so `retrieve_context_source` can fetch them
-back by handle, and `context_savings` records aggregate stats (tokens
-in/out/saved) per project. Both stay on disk — local-first, nothing is ever
-sent off the machine.
+**No automatic repo indexing.** Nothing enters *recallable* memory — what
+`recall` / `why` / `memory_scope` can surface — unless you call `remember` /
+`relate` / `remember_extracted` explicitly. Compilation does write two things
+to the local store under `VELESDB_MEMORY_PATH` (default `~/.velesdb-memory`):
+**all** fragment sources are cached locally (content-addressed — not just the
+over-budget ones) so every `ctx://source/` handle stays recoverable via
+`retrieve_context_source`, and `context_savings` records aggregate stats
+(tokens in/out/saved) per project. Both stay on disk — local-first, nothing
+is ever sent off the machine.
 
-![the two data paths: stateless compile vs explicit memory writes — nothing is stored without an explicit remember/relate/remember_extracted call](https://raw.githubusercontent.com/cyberlife-coder/VelesDB/develop/crates/velesdb-memory/docs/diagrams/data-paths.svg)
+![the two data paths: compile caches sources locally but writes no recallable memory vs explicit memory writes — nothing enters recallable memory without an explicit remember/relate/remember_extracted call](docs/diagrams/data-paths.svg)
 
 ```jsonc
 // compile_context — minimal call: query + token_budget + fragments

--- a/crates/velesdb-memory/docs/diagrams/compile-flow.svg
+++ b/crates/velesdb-memory/docs/diagrams/compile-flow.svg
@@ -1,0 +1,72 @@
+<svg viewBox="0 0 980 320" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="compile_context pipeline: agent fragments flow through dedup, abstract, pack, externalize, producing content, ctx source handles, and auditable decisions">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="980" height="320" fill="#ffffff"/>
+
+  <!-- Agent -->
+  <rect x="20" y="130" width="110" height="60" rx="8" fill="#eef2ff" stroke="#4338ca" stroke-width="2"/>
+  <text x="75" y="165" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#1e1b4b" font-weight="600">Agent</text>
+
+  <line x1="130" y1="160" x2="172" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Fragments -->
+  <rect x="175" y="120" width="130" height="80" rx="8" fill="#f0fdf4" stroke="#15803d" stroke-width="2"/>
+  <text x="240" y="150" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="14" fill="#14532d" font-weight="600">fragments[]</text>
+  <text x="240" y="170" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#166534">logs, docs,</text>
+  <text x="240" y="185" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#166534">history, code</text>
+
+  <line x1="305" y1="160" x2="347" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Pipeline container -->
+  <rect x="350" y="60" width="430" height="220" rx="10" fill="#fafaf9" stroke="#78716c" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="565" y="82" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#57534e" font-weight="600">deterministic pipeline (no LLM, no cloud)</text>
+
+  <!-- Step 1: dedup -->
+  <rect x="368" y="130" width="88" height="60" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+  <text x="412" y="165" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#78350f" font-weight="600">dedup</text>
+
+  <line x1="456" y1="160" x2="486" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 2: abstract -->
+  <rect x="489" y="130" width="88" height="60" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+  <text x="533" y="158" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#78350f" font-weight="600">abstract</text>
+  <text x="533" y="174" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#92400e">(log dedup)</text>
+
+  <line x1="577" y1="160" x2="607" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 3: pack -->
+  <rect x="610" y="130" width="88" height="60" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+  <text x="654" y="165" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#78350f" font-weight="600">pack</text>
+
+  <line x1="698" y1="160" x2="728" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 4: externalize -->
+  <rect x="731" y="130" width="88" height="60" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
+  <text x="775" y="158" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#78350f" font-weight="600">externalize</text>
+  <text x="775" y="174" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#92400e">(over budget)</text>
+
+  <text x="565" y="230" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">token_budget applied throughout · every fragment gets one auditable decision</text>
+
+  <line x1="819" y1="160" x2="857" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Outputs -->
+  <rect x="860" y="30" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="915" y="53" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#164e63" font-weight="600">content</text>
+  <text x="915" y="70" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">(fits budget)</text>
+
+  <rect x="860" y="132" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="915" y="152" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#164e63" font-weight="600">ctx://source/</text>
+  <text x="915" y="168" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">handles</text>
+
+  <rect x="860" y="234" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="915" y="254" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#164e63" font-weight="600">decisions[]</text>
+  <text x="915" y="270" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">(auditable)</text>
+
+  <line x1="857" y1="160" x2="857" y2="57" stroke="#334155" stroke-width="1.5"/>
+  <line x1="857" y1="160" x2="857" y2="261" stroke="#334155" stroke-width="1.5"/>
+</svg>

--- a/crates/velesdb-memory/docs/diagrams/compile-flow.svg
+++ b/crates/velesdb-memory/docs/diagrams/compile-flow.svg
@@ -23,8 +23,8 @@
   <line x1="305" y1="160" x2="347" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Pipeline container -->
-  <rect x="350" y="60" width="430" height="220" rx="10" fill="#fafaf9" stroke="#78716c" stroke-width="1.5" stroke-dasharray="4 3"/>
-  <text x="565" y="82" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#57534e" font-weight="600">deterministic pipeline (no LLM, no cloud)</text>
+  <rect x="350" y="60" width="483" height="220" rx="10" fill="#fafaf9" stroke="#78716c" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="591" y="82" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#57534e" font-weight="600">deterministic pipeline (no LLM, no cloud)</text>
 
   <!-- Step 1: dedup -->
   <rect x="368" y="130" width="88" height="60" rx="6" fill="#fef3c7" stroke="#b45309" stroke-width="1.5"/>
@@ -50,9 +50,10 @@
   <text x="775" y="158" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#78350f" font-weight="600">externalize</text>
   <text x="775" y="174" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#92400e">(over budget)</text>
 
-  <text x="565" y="230" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">token_budget applied throughout · every fragment gets one auditable decision</text>
+  <text x="591" y="230" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">token_budget applied throughout · every fragment gets one auditable decision</text>
+  <text x="591" y="250" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">every fragment's source is cached locally, so every handle stays recoverable</text>
 
-  <line x1="819" y1="160" x2="857" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="833" y1="160" x2="857" y2="160" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Outputs -->
   <rect x="860" y="30" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
@@ -60,8 +61,9 @@
   <text x="915" y="70" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">(fits budget)</text>
 
   <rect x="860" y="132" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
-  <text x="915" y="152" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#164e63" font-weight="600">ctx://source/</text>
-  <text x="915" y="168" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">handles</text>
+  <text x="915" y="150" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#164e63" font-weight="600">ctx://source/</text>
+  <text x="915" y="165" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">handles</text>
+  <text x="915" y="179" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">(every fragment)</text>
 
   <rect x="860" y="234" width="110" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
   <text x="915" y="254" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#164e63" font-weight="600">decisions[]</text>

--- a/crates/velesdb-memory/docs/diagrams/data-paths.svg
+++ b/crates/velesdb-memory/docs/diagrams/data-paths.svg
@@ -1,0 +1,47 @@
+<svg viewBox="0 0 980 300" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="two data paths: stateless compile versus explicit memory writes, separated by the rule that nothing is stored without an explicit action">
+  <defs>
+    <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="980" height="300" fill="#ffffff"/>
+
+  <text x="490" y="32" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#0f172a" font-weight="700">nothing is stored without an explicit action</text>
+
+  <!-- Lane 1: stateless compile -->
+  <text x="30" y="80" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#0e7490" font-weight="700">STATELESS COMPILE</text>
+
+  <rect x="30" y="95" width="150" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="105" y="128" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#164e63" font-weight="600">compile_context</text>
+
+  <line x1="180" y1="122" x2="222" y2="122" stroke="#334155" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <rect x="225" y="95" width="150" height="55" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="300" y="128" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#164e63" font-weight="600">content returned</text>
+
+  <line x1="375" y1="122" x2="417" y2="122" stroke="#334155" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <rect x="420" y="95" width="230" height="55" rx="8" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="5 3"/>
+  <text x="535" y="118" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#334155" font-weight="600">nothing persisted</text>
+  <text x="535" y="135" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#475569">(compile again = same bytes)</text>
+
+  <text x="30" y="175" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">exceptions: over-budget fragments cached locally for retrieve_context_source; context_savings keeps aggregate stats</text>
+
+  <!-- divider -->
+  <line x1="20" y1="195" x2="960" y2="195" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="2 4"/>
+
+  <!-- Lane 2: explicit memory -->
+  <text x="30" y="225" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#15803d" font-weight="700">EXPLICIT MEMORY</text>
+
+  <rect x="30" y="240" width="220" height="55" rx="8" fill="#f0fdf4" stroke="#15803d" stroke-width="2"/>
+  <text x="140" y="263" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#14532d" font-weight="600">remember / relate /</text>
+  <text x="140" y="280" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#14532d" font-weight="600">remember_extracted</text>
+
+  <line x1="250" y1="267" x2="292" y2="267" stroke="#334155" stroke-width="2" marker-end="url(#arrow2)"/>
+
+  <rect x="295" y="240" width="300" height="55" rx="8" fill="#f0fdf4" stroke="#15803d" stroke-width="2"/>
+  <text x="445" y="263" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#14532d" font-weight="600">stored on disk, local-first</text>
+  <text x="445" y="280" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#166534">VELESDB_MEMORY_PATH (~/.velesdb-memory)</text>
+</svg>

--- a/crates/velesdb-memory/docs/diagrams/data-paths.svg
+++ b/crates/velesdb-memory/docs/diagrams/data-paths.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 980 300" xmlns="http://www.w3.org/2000/svg" role="img"
-     aria-label="two data paths: stateless compile versus explicit memory writes, separated by the rule that nothing is stored without an explicit action">
+     aria-label="two data paths: compile caches sources locally but writes no recallable memory, versus explicit memory writes via remember and relate">
   <defs>
     <marker id="arrow2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
@@ -8,7 +8,7 @@
 
   <rect x="0" y="0" width="980" height="300" fill="#ffffff"/>
 
-  <text x="490" y="32" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#0f172a" font-weight="700">nothing is stored without an explicit action</text>
+  <text x="490" y="32" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="15" fill="#0f172a" font-weight="700">nothing enters recallable memory without an explicit action</text>
 
   <!-- Lane 1: stateless compile -->
   <text x="30" y="80" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#0e7490" font-weight="700">STATELESS COMPILE</text>
@@ -23,11 +23,11 @@
 
   <line x1="375" y1="122" x2="417" y2="122" stroke="#334155" stroke-width="2" marker-end="url(#arrow2)"/>
 
-  <rect x="420" y="95" width="230" height="55" rx="8" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="5 3"/>
-  <text x="535" y="118" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#334155" font-weight="600">nothing persisted</text>
-  <text x="535" y="135" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#475569">(compile again = same bytes)</text>
+  <rect x="420" y="95" width="260" height="55" rx="8" fill="#f8fafc" stroke="#64748b" stroke-width="2" stroke-dasharray="5 3"/>
+  <text x="550" y="118" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#334155" font-weight="600">no recallable memory written</text>
+  <text x="550" y="135" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#475569">(sources cached locally for retrieval)</text>
 
-  <text x="30" y="175" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">exceptions: over-budget fragments cached locally for retrieve_context_source; context_savings keeps aggregate stats</text>
+  <text x="30" y="175" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">every fragment's source is content-addressed to local disk for retrieve_context_source; context_savings keeps aggregate stats</text>
 
   <!-- divider -->
   <line x1="20" y1="195" x2="960" y2="195" stroke="#cbd5e1" stroke-width="2" stroke-dasharray="2 4"/>

--- a/crates/velesdb-memory/docs/diagrams/tri-engine.svg
+++ b/crates/velesdb-memory/docs/diagrams/tri-engine.svg
@@ -1,0 +1,50 @@
+<svg viewBox="0 0 980 260" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="tri-engine retrieval: query seeds an HNSW vector search, a graph walk follows relate edges, fusion combines both, then ranking produces the result">
+  <defs>
+    <marker id="arrow3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#334155"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="980" height="260" fill="#ffffff"/>
+
+  <!-- Query -->
+  <rect x="20" y="100" width="110" height="60" rx="8" fill="#eef2ff" stroke="#4338ca" stroke-width="2"/>
+  <text x="75" y="135" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="14" fill="#1e1b4b" font-weight="600">query</text>
+
+  <line x1="130" y1="130" x2="165" y2="70" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+  <line x1="130" y1="130" x2="165" y2="190" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+
+  <!-- HNSW seed -->
+  <rect x="168" y="40" width="170" height="60" rx="8" fill="#fef3c7" stroke="#b45309" stroke-width="2"/>
+  <text x="253" y="65" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#78350f" font-weight="600">HNSW seed</text>
+  <text x="253" y="82" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#92400e">vector similarity</text>
+
+  <!-- Graph walk -->
+  <rect x="168" y="160" width="170" height="60" rx="8" fill="#f0fdf4" stroke="#15803d" stroke-width="2"/>
+  <text x="253" y="185" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#14532d" font-weight="600">graph walk</text>
+  <text x="253" y="202" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#166534">follows relate edges</text>
+
+  <line x1="338" y1="70" x2="420" y2="120" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+  <line x1="338" y1="190" x2="420" y2="140" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+
+  <!-- Fusion -->
+  <rect x="423" y="100" width="140" height="60" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="493" y="135" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#164e63" font-weight="600">fusion</text>
+
+  <line x1="563" y1="130" x2="605" y2="130" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+
+  <!-- Ranking -->
+  <rect x="608" y="100" width="150" height="60" rx="8" fill="#ecfeff" stroke="#0e7490" stroke-width="2"/>
+  <text x="683" y="125" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#164e63" font-weight="600">ranking</text>
+  <text x="683" y="142" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#155e75">graph_boost, hops</text>
+
+  <line x1="758" y1="130" x2="800" y2="130" stroke="#334155" stroke-width="2" marker-end="url(#arrow3)"/>
+
+  <!-- Result -->
+  <rect x="803" y="100" width="150" height="60" rx="8" fill="#eef2ff" stroke="#4338ca" stroke-width="2"/>
+  <text x="878" y="125" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#1e1b4b" font-weight="600">ranked memories</text>
+  <text x="878" y="142" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#312e81">fed into compile_context</text>
+
+  <text x="490" y="245" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#57534e">graph reaches evidence that shares zero vocabulary with the query — vector alone cannot</text>
+</svg>

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -99,7 +99,12 @@ binding-wide differences: id fields (`fragment_id`, `content_hash`,
 strings, and the *top-level* result keys follow the binding's camelCase
 (`out.retrievalHandles` — nested trees keep the wire's snake_case). `tokens_saved` is a local estimate, not billed tokens. The bundled
 [`velesdb-context-optimizer` skill](./skills/velesdb-context-optimizer/SKILL.md)
-teaches an agent the full workflow, including when *not* to compress.
+teaches an agent the full workflow, including when *not* to compress. Install
+it into your agent's skills directory:
+
+```bash
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
+```
 
 ## License
 

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -14,6 +14,22 @@ description: >
 
 # VelesDB context optimizer
 
+## Installation
+
+Copy the skill into your agent's skills directory:
+
+```bash
+# From a clone of the VelesDB repo
+cp -r skills/velesdb-context-optimizer ~/.claude/skills/
+
+# From the npm package (the skill ships bundled inside
+# @wiscale/velesdb-memory-node, so it's already in node_modules)
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
+```
+
+Requires the `velesdb-memory` MCP server configured in your client — see
+[Configure your client](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+
 You compress context with `compile_context` — a **deterministic** compiler
 (no LLM, no cloud): duplicates drop, repeated log lines collapse with counts,
 code / URLs / numbers / negative constraints survive verbatim, and whatever

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -16,19 +16,8 @@ description: >
 
 ## Installation
 
-Copy the skill into your agent's skills directory:
-
-```bash
-# From a clone of the VelesDB repo
-cp -r skills/velesdb-context-optimizer ~/.claude/skills/
-
-# From the npm package (the skill ships bundled inside
-# @wiscale/velesdb-memory-node, so it's already in node_modules)
-cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
-```
-
-Requires the `velesdb-memory` MCP server configured in your client — see
-[Configure your client](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+Install: `cp -r skills/velesdb-context-optimizer ~/.claude/skills/` (repo clone; the npm package bundles it at `node_modules/@wiscale/velesdb-memory-node/skills/`).
+Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
 
 You compress context with `compile_context` — a **deterministic** compiler
 (no LLM, no cloud): duplicates drop, repeated log lines collapse with counts,

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -14,6 +14,22 @@ description: >
 
 # VelesDB context optimizer
 
+## Installation
+
+Copy the skill into your agent's skills directory:
+
+```bash
+# From a clone of the VelesDB repo
+cp -r skills/velesdb-context-optimizer ~/.claude/skills/
+
+# From the npm package (the skill ships bundled inside
+# @wiscale/velesdb-memory-node, so it's already in node_modules)
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
+```
+
+Requires the `velesdb-memory` MCP server configured in your client — see
+[Configure your client](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+
 You compress context with `compile_context` — a **deterministic** compiler
 (no LLM, no cloud): duplicates drop, repeated log lines collapse with counts,
 code / URLs / numbers / negative constraints survive verbatim, and whatever

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -16,19 +16,8 @@ description: >
 
 ## Installation
 
-Copy the skill into your agent's skills directory:
-
-```bash
-# From a clone of the VelesDB repo
-cp -r skills/velesdb-context-optimizer ~/.claude/skills/
-
-# From the npm package (the skill ships bundled inside
-# @wiscale/velesdb-memory-node, so it's already in node_modules)
-cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
-```
-
-Requires the `velesdb-memory` MCP server configured in your client — see
-[Configure your client](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+Install: `cp -r skills/velesdb-context-optimizer ~/.claude/skills/` (repo clone; the npm package bundles it at `node_modules/@wiscale/velesdb-memory-node/skills/`).
+Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
 
 You compress context with `compile_context` — a **deterministic** compiler
 (no LLM, no cloud): duplicates drop, repeated log lines collapse with counts,


### PR DESCRIPTION
## Summary

Closes the real onboarding gaps found in an audit of the Context Compiler docs:

- **Skill install, documented nowhere before.** `velesdb-context-optimizer` had no install instructions anywhere. Added `cp -r` (repo clone + npm-bundled) to the skill's own SKILL.md, the `velesdb-memory` crate README, and the `velesdb-node` README — including keeping the two committed copies of SKILL.md (root `skills/` and the one bundled into the npm package under `crates/velesdb-node/skills/`) in sync.
- **Copy-pastable quickstart in the root README.** The Context Compiler section sold the feature but gave no way to start using it. Added a 3-step block (`cargo install` → `claude mcp add` → a minimal `compile_context` call with expected output), plus an npm fallback for readers without a Rust toolchain.
- **Real binary paths.** All 6 MCP client configs in the crate README used a literal `/path/to/velesdb-memory` placeholder; replaced with `~/.cargo/bin/velesdb-memory` plus a note about local builds.
- **Python honesty, not buried.** The compiler doesn't exist in Python yet (binding in progress) — that was only stated inside a release-note blockquote. Added an explicit, un-buried statement in both the root and crate README compiler sections.
- **Minimal example first.** The crate README's first `compile_context` example was already full-options (memory_scope, cache, project). Added a 3-4 line minimal example (query + budget + 2 fragments) ahead of it — verified against the real wire protocol.
- **Two clarifications from real user questions**, added to the crate README's new "How it works" subsection plus a sentence in the root README: `compile_context` is not a transparent proxy (only touches fragments the agent explicitly hands it, never the harness's system prompt/tool schemas), and there's no automatic repo indexing (compilation is stateless; nothing enters the memory store without an explicit `remember`/`relate`/`remember_extracted` call, aside from the externalized-fragment cache and aggregate stats, both local-first).
- **3 hand-written SVG diagrams** (`crates/velesdb-memory/docs/diagrams/`): `compile-flow.svg`, `data-paths.svg`, `tri-engine.svg` — explicit light background, dark text, so they render on both light and dark hosts. Referenced from the crate README via the repo's existing `raw.githubusercontent.com/.../develop/...` pattern (same one used for the crate's `wow.gif`) so they display on crates.io too, and from the root README via a relative path (matching the pattern used there for other images).

## What was actually verified

- `cargo build --release -p velesdb-memory` — binary builds clean.
- `python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py` — existing MCP e2e suite passes (list, compile w/ dedup+insights+handles, retrieve round-trip, explain, savings, error taxonomy).
- The exact minimal `compile_context` example now documented (query + token_budget + 2 fragments) was run against the real MCP server over stdio and its real output (`risk: "low"`, `tokens_in: 44`, `tokens_out: 45`, 2 `preserve` decisions) is what's quoted in the docs.
- `claude mcp add --help` checked (read-only) to confirm the documented syntax is current; the user's global Claude config was **not** modified.
- All 3 SVGs validated as well-formed XML (`xml.etree.ElementTree`) and visually verified by rendering to PNG (cairosvg) — no overlaps, all text legible.
- Every internal link/anchor (`#configure-your-client`, `#how-it-works`, `#the-context-compiler-tools`, relative skill paths) checked to resolve to a heading or file that exists.

## Test plan

- [ ] Reviewer skim of the quickstart block for accuracy against a real MCP client
- [ ] Confirm diagrams render correctly on GitHub once merged (crate README uses absolute `develop`-branch raw URLs, so they'll 404 until this merges — same pattern as the existing `wow.gif`)
- [ ] Confirm crates.io re-render picks up the diagram images after the next `velesdb-memory` publish