### PR TITLE
feat(python): compile_context + context tools parity on MemoryService [EPIC-P-071/US-001]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Node** (`@wiscale/velesdb-memory-node`): `compileContext(request)` —
   pure conversion, ids as decimal strings; ships the
   `velesdb-context-optimizer` agent skill in the npm package.
+- **Python** (`velesdb`): context-compiler parity on `MemoryService` —
+  `compile_context` / `retrieve_context_source` / `context_savings` /
+  `save_working_context` / `load_working_context`, same wire shapes as the
+  MCP tools; ids cross as exact native Python ints (vs decimal strings on
+  Node). [EPIC-P-071/US-001]
 - **Benchmark**: `examples/context_savings`, reproducible (75–82 % estimated
   token savings on the committed corpus in ~2 ms; figures are local
   estimates, not billed tokens — cross-checked against a real cl100k
@@ -75,6 +80,17 @@ account).
 - **Graph cluster held as a shared `Arc<GraphStore>` handle** (R1.2b —
   internal-only): graph state can be shared with `GraphCollection` without an
   exclusive move; field access and locking are unchanged.
+
+### Fixed
+
+- **python: integers greater than `i64::MAX` now round-trip exactly as `int`**
+  (previously silently converted to a lossy `float`). Affects every surface
+  sharing the binding's JSON converters — payloads, search results, VelesQL
+  params, graph properties, memory metadata — and is required by the context
+  compiler's content-addressed ids (FNV-1a 64, uniform over `u64`, so ~50%
+  exceed `i64::MAX`). Integers outside `[i64::MIN, u64::MAX]` now raise an
+  explicit `ValueError` stating the supported range instead of silently losing
+  precision. [EPIC-P-071/US-001]
 
 ## [3.12.0] — 2026-07-15
 

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -21,8 +21,11 @@ crate-type = ["cdylib"]
 velesdb-core = { workspace = true }
 # The high-level memory wedge (MemoryService: remember/recall/relate/forget/why
 # + remember_extracted). `default-features = false` drops the MCP server stack
-# (rmcp/tokio-server); `ollama`+`extract` enable real embeddings and extraction.
-velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract"] }
+# (rmcp/tokio-server); `ollama`+`extract` enable real embeddings and extraction;
+# `context` enables the deterministic context compiler (EPIC-P-071/US-001) —
+# zero new dependencies (`context = []` in velesdb-memory), same feature set
+# velesdb-node already builds with.
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract", "context"] }
 pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
 serde_json = { workspace = true }
 numpy = "0.29"

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -28,6 +28,120 @@ mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason �
 
 Full runnable demo: [`examples/agent_memory/why_across_sessions.py`](https://github.com/cyberlife-coder/VelesDB/blob/develop/examples/agent_memory/why_across_sessions.py). The same wedge ships for [Node](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) and as a local [MCP server](https://github.com/cyberlife-coder/VelesDB/tree/develop/crates/velesdb-memory).
 
+## Context Compiler: token-budgeted, provenance-audited prompt context
+
+Your agent burns most of its tokens re-reading redundant context.
+`MemoryService.compile_context` compresses it **deterministically** (no LLM,
+no cloud, zero new logic in the binding — it delegates straight to the same
+`velesdb_memory::context` bridge the MCP server and the Node binding use): the
+same request always compiles to the same bytes, duplicates drop, repeated log
+lines collapse with counts, code / URLs / numbers / negative constraints
+survive verbatim (`metadata={"verbatim": True}` forces it), a stable
+cache-friendly prefix can be pinned (`metadata={"cache": True}`), and
+over-budget content becomes a recoverable `ctx://source/<hash>` handle —
+never a silent loss.
+
+```python
+mem = MemoryService("./agent_memory")
+
+compiled = mem.compile_context({
+    "query": "deploy pipeline safety",
+    "token_budget": 2000,
+    "project": "veles",
+    "fragments": [
+        {"content": "The deploy pipeline runs clippy before tests."},
+        {"content": "The deploy pipeline runs clippy before tests."},  # duplicate, dropped
+        {"content": "Never restart the primary during a rebalance.",
+         "metadata": {"verbatim": True}},
+    ],
+})
+compiled["content"]    # the compiled prompt context (fits the budget)
+compiled["risk"]       # "low" | "medium" | "high" -- "high" means critical content did not fit
+compiled["decisions"]  # one auditable decision per fragment (rule_id, reason, risk)
+compiled["insights"]   # {"tokens_in", "tokens_out", "tokens_saved", ...} -- local estimates
+
+# What did not fit stays recoverable, byte for byte:
+handle = compiled["sources"][0]["handle"]        # "ctx://source/18021940868160883968"
+mem.retrieve_context_source(handle)              # -> the original fragment text
+
+# Aggregate savings across every compile_context call (optionally per project):
+mem.context_savings(project="veles")             # {"events", "tokens_saved", ...}
+
+# Persist/reload an agent's distilled working state across sessions:
+wid = mem.save_working_context("veles", "session-1", {
+    "goal": "ship the release",
+    "active_constraints": [{"text": "never restart during rebalance"}],
+    "verified_facts": [], "open_hypotheses": [], "decisions": [],
+    "exact_evidence": [], "pending_actions": ["run smoke tests"],
+})
+mem.load_working_context("veles", "session-1")   # -> the same dict, or None if never saved
+```
+
+The request/result JSON matches the MCP `compile_context` / `context_savings`
+tools field for field, with one documented difference: every u64 id
+(`fragment_id`, `content_hash`, `memory_id`, entries of `fragment_ids`, and
+input `fragments[].id`) crosses as a **native Python int** (unlimited
+precision) here, versus a decimal string on the [Node
+binding](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) — both
+are faithful renderings of the same value, never truncated (ids are FNV-1a
+64-bit hashes, uniformly spread over the full `u64` range, so roughly half of
+them exceed `i64::MAX` — see `handle` above). `tokens_saved` is a local
+estimate, not billed tokens.
+
+<details>
+<summary>Wiring into LangChain (executed, no mocks)</summary>
+
+```python
+from langchain_core.documents import Document
+from langchain_core.runnables import RunnableLambda
+from velesdb import MemoryService
+
+mem = MemoryService("./agent_memory")
+
+
+def compile_docs(inputs: dict) -> str:
+    fragments = [{"content": d.page_content} for d in inputs["docs"]]
+    compiled = mem.compile_context(
+        {"query": inputs["query"], "token_budget": 2000, "fragments": fragments}
+    )
+    return compiled["content"]
+
+
+compile_step = RunnableLambda(compile_docs)
+docs = [
+    Document(page_content="The deploy pipeline runs clippy before tests."),
+    Document(page_content="The deploy pipeline runs clippy before tests."),
+    Document(page_content="Never restart the primary during a rebalance."),
+]
+compile_step.invoke({"query": "deploy pipeline safety", "docs": docs})
+# -> "The deploy pipeline runs clippy before tests.\n\nNever restart the primary during a rebalance."
+```
+
+</details>
+
+<details>
+<summary>Wiring into LlamaIndex (executed, no mocks)</summary>
+
+```python
+from llama_index.core import Document
+from velesdb import MemoryService
+
+mem = MemoryService("./agent_memory")
+docs = [
+    Document(text="The deploy pipeline runs clippy before tests."),
+    Document(text="The deploy pipeline runs clippy before tests."),
+    Document(text="Never restart the primary during a rebalance."),
+]
+fragments = [{"content": d.text} for d in docs]
+compiled = mem.compile_context(
+    {"query": "deploy pipeline safety", "token_budget": 2000, "fragments": fragments}
+)
+compiled["content"]                    # same deduped, budgeted context
+compiled["insights"]["tokens_saved"]   # 13
+```
+
+</details>
+
 ## Features
 
 - **Dense + Sparse Vector Search**: HNSW index with SIMD-optimized distance, plus inverted-index sparse search and hybrid dense+sparse fusion

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2523,6 +2523,104 @@ class MemoryService:
         """
         ...
 
+    def compile_context(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Compile context fragments into a token-budgeted, provenance-audited
+        prompt context — deterministic, no LLM call.
+
+        Delegates directly to the same ``velesdb_memory::context`` bridge the
+        MCP ``compile_context`` tool and the Node binding use (no logic is
+        reimplemented in the binding).
+
+        Args:
+            request: Same JSON shape as the MCP tool's input: ``{"query": str,
+                "fragments": [{"content": str, "id"?: int, "kind"?: str,
+                "priority"?: int, "metadata"?: dict}], "token_budget": int,
+                "project"?: str, "target_model"?: str, "memory_scope"?: dict,
+                "policy"?: dict}``.
+
+        Returns:
+            Same shape as the MCP tool's output: ``{"content": str,
+            "sections": [...], "decisions": [...], "sources": [...],
+            "retrieval_handles": [...], "insights": dict, "risk": str}``.
+            Every u64 id (``fragment_id``, ``content_hash``, ``memory_id``,
+            entries of ``fragment_ids``) is a native Python int (unlimited
+            precision) — unlike the Node binding, which crosses ids as
+            decimal strings.
+
+        Raises:
+            ValueError: If the request is malformed or the token budget
+                cannot fit any content (e.g. ``token_budget=0``).
+        """
+        ...
+
+    def retrieve_context_source(self, handle: str) -> str:
+        """Fetch back the exact original content behind a
+        ``ctx://source/<hash>`` handle from a :meth:`compile_context` result.
+
+        Args:
+            handle: A ``ctx://source/<hash>`` handle from a compiled context.
+
+        Returns:
+            The original fragment content, byte for byte.
+
+        Raises:
+            KeyError: If the handle is malformed or nothing is stored under it.
+        """
+        ...
+
+    def context_savings(self, project: Optional[str] = None) -> Dict[str, Any]:
+        """Aggregate the token (and cost) savings of past
+        :meth:`compile_context` calls, optionally narrowed to one ``project``.
+
+        Args:
+            project: Restrict the aggregation to this project facet.
+
+        Returns:
+            ``{"events": int, "tokens_in": int, "tokens_out": int,
+            "tokens_saved": int, "cost_saved_micros_by_currency": Dict[str,
+            int], "truncated": bool}``. ``truncated`` is ``True`` when the
+            sweep hit the recall cap.
+        """
+        ...
+
+    def save_working_context(
+        self,
+        project: str,
+        session: str,
+        working: Dict[str, Any],
+    ) -> int:
+        """Persist ``working`` under ``project`` + ``session`` (idempotent
+        upsert: saving again replaces the previous state).
+
+        Args:
+            project: Project facet.
+            session: Session identifier.
+            working: Same JSON shape as ``WorkingContext`` on the wire:
+                ``{"goal"?: str, "active_constraints": [...],
+                "verified_facts": [...], "open_hypotheses": [...],
+                "decisions": [...], "exact_evidence": [...],
+                "pending_actions": [str]}``.
+
+        Returns:
+            The stored system fact id (native Python int, unlimited precision).
+        """
+        ...
+
+    def load_working_context(
+        self, project: str, session: str
+    ) -> Optional[Dict[str, Any]]:
+        """The working context previously saved under ``project`` + ``session``.
+
+        Args:
+            project: Project facet.
+            session: Session identifier.
+
+        Returns:
+            The same dict shape passed to :meth:`save_working_context`, or
+            ``None`` when nothing was saved under this ``project``/``session``.
+        """
+        ...
+
 
 # ---------------------------------------------------------------------------
 # Typed options dataclasses (Wave 3 Commit 10)

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -12,6 +12,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
+use velesdb_memory::context::{
+    CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextSavings, WorkingContext,
+};
 use velesdb_memory::{
     format_dated_context, limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation,
     FusionOptions, HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder,
@@ -20,6 +23,32 @@ use velesdb_memory::{
 
 use crate::collection::query::convert_params;
 use crate::utils::{json_to_python, opt_field, python_to_json};
+
+/// Serialize a context-compiler output value to its Python dict — the exact
+/// same JSON shape the MCP tools and the Node binding serialize, going
+/// through `serde_json` + the crate's manual [`json_to_python`] converter
+/// rather than hand-rolled field-by-field construction. `to_value` failure is
+/// an internal bug (every field here is JSON-representable), never a caller
+/// input problem, hence `RuntimeError`.
+macro_rules! serde_to_python {
+    ($py:expr, $value:expr, $what:literal) => {{
+        let json = serde_json::to_value($value).map_err(|err| {
+            PyRuntimeError::new_err(format!(concat!("failed to serialize ", $what, ": {}"), err))
+        })?;
+        json_to_python($py, &json)
+    }};
+}
+
+/// Deserialize a Python dict (the same JSON shape as the corresponding MCP
+/// tool input) into a context-compiler request type.
+macro_rules! python_to_serde {
+    ($py:expr, $obj:expr, $what:literal) => {{
+        let json = python_to_json($py, $obj)?;
+        serde_json::from_value(json).map_err(|err| {
+            PyValueError::new_err(format!(concat!("invalid ", $what, ": {}"), err))
+        })?
+    }};
+}
 
 /// Map a [`MemoryError`] to the most specific Python exception, driven by its
 /// transport-neutral [`ErrorCategory`] so the taxonomy stays identical to the
@@ -372,5 +401,86 @@ impl PyMemoryService {
                 .remember_extracted(text, &extractor, metadata.as_ref())
                 .map_err(to_py_err)
         })
+    }
+
+    /// Compile context fragments into a token-budgeted, provenance-audited
+    /// prompt context — deterministic, no LLM call. Delegates directly to the
+    /// same `velesdb_memory::context` bridge the MCP `compile_context` tool
+    /// and the Node binding use (zero new logic here). `request` is the same
+    /// JSON shape as the MCP tool's input (`{query, fragments, token_budget,
+    /// project?, target_model?, memory_scope?, policy?}`); the result is the
+    /// same shape as its output (`{content, sections, decisions, sources,
+    /// retrieval_handles, insights, risk}`). One documented difference from
+    /// the Node binding: every u64 id (`fragment_id`, `content_hash`,
+    /// `memory_id`, entries of `fragment_ids`) crosses as a **native Python
+    /// int** (unlimited precision), not a decimal string — both are faithful
+    /// renderings of the same value, never truncated.
+    fn compile_context(&self, py: Python<'_>, request: Py<PyAny>) -> PyResult<Py<PyAny>> {
+        let request: CompileRequest = python_to_serde!(py, &request, "compile request");
+        let compiled: CompiledContext = py.detach(|| {
+            self.svc
+                .compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
+                .map_err(to_py_err)
+        })?;
+        Ok(serde_to_python!(py, &compiled, "compiled context"))
+    }
+
+    /// Fetch back the exact original content behind a `ctx://source/<hash>`
+    /// handle from a [`compile_context`](Self::compile_context) result —
+    /// what was externalized or partially packed is recoverable, not lost.
+    fn retrieve_context_source(&self, py: Python<'_>, handle: &str) -> PyResult<String> {
+        py.detach(|| self.svc.retrieve_context_source(handle).map_err(to_py_err))
+    }
+
+    /// Aggregate the token (and cost) savings of past
+    /// [`compile_context`](Self::compile_context) calls, optionally narrowed
+    /// to one `project`. Figures are local estimates recorded per
+    /// compilation (metadata only, never fragment content); `truncated`
+    /// reports when the sweep hit the recall cap.
+    #[pyo3(signature = (project = None))]
+    fn context_savings(&self, py: Python<'_>, project: Option<&str>) -> PyResult<Py<PyAny>> {
+        let savings: ContextSavings =
+            py.detach(|| self.svc.context_savings(project).map_err(to_py_err))?;
+        Ok(serde_to_python!(py, &savings, "context savings"))
+    }
+
+    /// Persist `working` (the same JSON shape as `WorkingContext` on the
+    /// wire: `{goal?, active_constraints, verified_facts, open_hypotheses,
+    /// decisions, exact_evidence, pending_actions}`) under `project` +
+    /// `session`. Saving again under the same pair replaces the previous
+    /// state (idempotent upsert). Returns the stored system fact id.
+    fn save_working_context(
+        &self,
+        py: Python<'_>,
+        project: &str,
+        session: &str,
+        working: Py<PyAny>,
+    ) -> PyResult<u64> {
+        let working: WorkingContext = python_to_serde!(py, &working, "working context");
+        py.detach(|| {
+            self.svc
+                .save_working_context(project, session, &working)
+                .map_err(to_py_err)
+        })
+    }
+
+    /// The working context previously saved under `project` + `session` (see
+    /// [`save_working_context`](Self::save_working_context)), or `None` when
+    /// there is none.
+    fn load_working_context(
+        &self,
+        py: Python<'_>,
+        project: &str,
+        session: &str,
+    ) -> PyResult<Py<PyAny>> {
+        let working = py.detach(|| {
+            self.svc
+                .load_working_context(project, session)
+                .map_err(to_py_err)
+        })?;
+        match working {
+            None => Ok(py.None()),
+            Some(working) => Ok(serde_to_python!(py, &working, "working context")),
+        }
     }
 }

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -127,6 +127,14 @@ pub fn python_to_json(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<serde_json::V
     if let Ok(i) = obj.extract::<i64>(py) {
         return Ok(serde_json::Value::Number(i.into()));
     }
+    // A Python int outside i64's range (up to u64::MAX) still round-trips
+    // exactly as a JSON number — needed for u64 ids (e.g. the context
+    // compiler's FNV-1a `stable_id`, which is uniform over u64 and so
+    // exceeds i64::MAX roughly half the time). Falling through to f64 here
+    // would silently truncate precision instead of erroring or round-tripping.
+    if let Ok(u) = obj.extract::<u64>(py) {
+        return Ok(serde_json::Value::Number(u.into()));
+    }
     if let Ok(f) = obj.extract::<f64>(py) {
         return serde_json::Number::from_f64(f)
             .map(serde_json::Value::Number)
@@ -191,6 +199,11 @@ pub fn json_to_python(py: Python<'_>, value: &serde_json::Value) -> Py<PyAny> {
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
                 to_pyobject(py, i)
+            } else if let Some(u) = n.as_u64() {
+                // A u64 that does not fit i64 (e.g. a `stable_id` above
+                // i64::MAX) — convert directly instead of falling through to
+                // f64, which would silently lose precision.
+                to_pyobject(py, u)
             } else if let Some(f) = n.as_f64() {
                 to_pyobject(py, f)
             } else {

--- a/crates/velesdb-python/src/utils.rs
+++ b/crates/velesdb-python/src/utils.rs
@@ -135,6 +135,18 @@ pub fn python_to_json(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<serde_json::V
     if let Ok(u) = obj.extract::<u64>(py) {
         return Ok(serde_json::Value::Number(u.into()));
     }
+    // Any remaining Python int is outside [i64::MIN, u64::MAX] (unbounded
+    // precision on the Python side). Reject it explicitly: letting it fall
+    // through to the f64 branch below would silently round it — exactly the
+    // lossy degradation the u64 branch above exists to prevent.
+    if obj.bind(py).is_instance_of::<pyo3::types::PyInt>() {
+        return Err(PyValueError::new_err(format!(
+            "Integer out of the supported range [{}, {}] (i64::MIN to u64::MAX); \
+             larger values would silently lose precision",
+            i64::MIN,
+            u64::MAX
+        )));
+    }
     if let Ok(f) = obj.extract::<f64>(py) {
         return serde_json::Number::from_f64(f)
             .map(serde_json::Value::Number)

--- a/crates/velesdb-python/tests/test_context_compiler.py
+++ b/crates/velesdb-python/tests/test_context_compiler.py
@@ -1,0 +1,228 @@
+"""Tests for the context compiler parity on `MemoryService` (EPIC-P-071/US-001).
+
+Exercises `compile_context` / `retrieve_context_source` / `context_savings` /
+`save_working_context` / `load_working_context` — thin bindings over the exact
+same `velesdb_memory::context` bridge the MCP server and the Node binding use
+(zero new logic here, see `crates/velesdb-python/src/agent_memory_service.rs`).
+
+The offline `hash` embedder keeps these deterministic and network-free, same
+convention as `test_memory_service.py`.
+"""
+
+import pytest
+from velesdb import MemoryService
+
+
+@pytest.fixture()
+def mem(tmp_path):
+    return MemoryService(str(tmp_path / "store"))
+
+
+# --- compile_context: minimal round trip ------------------------------------
+
+
+def test_compile_context_minimal_round_trip(mem):
+    req = {
+        "query": "deploy pipeline",
+        "token_budget": 10_000,
+        "fragments": [{"content": "Never restart the primary during a rebalance."}],
+    }
+    out = mem.compile_context(req)
+    assert "Never restart the primary during a rebalance." in out["content"]
+    assert len(out["decisions"]) == 1
+    assert out["decisions"][0]["action"] in {
+        "preserve",
+        "abstract",
+        "retrieve",
+        "drop",
+        "cache",
+    }
+    assert isinstance(out["insights"], dict)
+
+
+# --- compile_context: verbatim / cache fragment metadata --------------------
+
+
+def test_compile_context_verbatim_and_cache_fragments(mem):
+    req = {
+        "query": "q",
+        "token_budget": 10_000,
+        "fragments": [
+            {"content": "critical constraint text", "metadata": {"verbatim": True}},
+            {"content": "stable prefix text", "metadata": {"cache": True}},
+        ],
+    }
+    out = mem.compile_context(req)
+    actions = {d["action"] for d in out["decisions"]}
+    assert "preserve" in actions
+    assert "cache" in actions
+
+
+# --- retrieve_context_source: round trip + unknown handle -------------------
+
+
+def test_retrieve_context_source_round_trips_a_compiled_fragment(mem):
+    content_text = "Never restart the primary during a rebalance."
+    req = {"query": "q", "token_budget": 10_000, "fragments": [{"content": content_text}]}
+    out = mem.compile_context(req)
+    handle = out["sources"][0]["handle"]
+    assert handle.startswith("ctx://source/")
+    assert mem.retrieve_context_source(handle) == content_text
+
+
+def test_retrieve_context_source_unknown_handle_raises_key_error(mem):
+    with pytest.raises(KeyError):
+        mem.retrieve_context_source("ctx://source/999999999999999999")
+
+
+def test_retrieve_context_source_malformed_handle_raises_key_error(mem):
+    with pytest.raises(KeyError):
+        mem.retrieve_context_source("not-a-handle")
+
+
+# --- context_savings: aggregates after a compile -----------------------------
+
+
+def test_context_savings_aggregates_after_a_compile(mem):
+    req = {
+        "query": "deploy pipeline",
+        "token_budget": 10_000,
+        "project": "veles-ctx-test",
+        "fragments": [
+            {"content": "The deploy pipeline runs clippy before tests."},
+            {"content": "The deploy pipeline runs clippy before tests."},
+            {"content": "Never restart the primary during a rebalance."},
+        ],
+    }
+    mem.compile_context(req)
+    savings = mem.context_savings(project="veles-ctx-test")
+    assert savings["events"] == 1
+    assert savings["tokens_saved"] > 0
+
+
+def test_context_savings_with_no_project_filter_returns_a_dict(mem):
+    mem.compile_context(
+        {"query": "q", "token_budget": 10_000, "fragments": [{"content": "a fact"}]}
+    )
+    savings = mem.context_savings()
+    assert isinstance(savings, dict)
+    assert savings["events"] >= 1
+
+
+# --- save/load_working_context: round trip -----------------------------------
+
+
+def test_save_and_load_working_context_round_trips(mem):
+    working = {
+        "goal": "ship the release",
+        "active_constraints": [{"text": "never restart during rebalance"}],
+        "verified_facts": [],
+        "open_hypotheses": [],
+        "decisions": [],
+        "exact_evidence": [],
+        "pending_actions": ["run smoke tests"],
+    }
+    wid = mem.save_working_context("veles", "session-1", working)
+    assert isinstance(wid, int)
+
+    loaded = mem.load_working_context("veles", "session-1")
+    assert loaded["goal"] == "ship the release"
+    assert loaded["pending_actions"] == ["run smoke tests"]
+    assert loaded["active_constraints"][0]["text"] == "never restart during rebalance"
+
+
+def test_save_working_context_is_an_idempotent_upsert(mem):
+    first = {"goal": "first goal", "active_constraints": [], "verified_facts": [],
+             "open_hypotheses": [], "decisions": [], "exact_evidence": [],
+             "pending_actions": []}
+    second = {"goal": "second goal", "active_constraints": [], "verified_facts": [],
+              "open_hypotheses": [], "decisions": [], "exact_evidence": [],
+              "pending_actions": []}
+    id1 = mem.save_working_context("veles", "session-2", first)
+    id2 = mem.save_working_context("veles", "session-2", second)
+    assert id1 == id2
+    loaded = mem.load_working_context("veles", "session-2")
+    assert loaded["goal"] == "second goal"
+
+
+def test_load_working_context_returns_none_when_absent(mem):
+    assert mem.load_working_context("veles", "no-such-session") is None
+
+
+# --- typed errors -------------------------------------------------------------
+
+
+def test_compile_context_zero_budget_raises_value_error(mem):
+    req = {"query": "x", "token_budget": 0, "fragments": [{"content": "y"}]}
+    with pytest.raises(ValueError):
+        mem.compile_context(req)
+
+
+# --- wire parity: same JSON shape as the MCP `compile_context`/`context_savings`
+# tools (crates/velesdb-memory/src/mcp/context_tools.rs), whose shape is itself
+# exercised end-to-end by
+# crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py.
+# The single source of truth for field names is
+# crates/velesdb-memory/src/context/model.rs (CompiledContext, ContextSavings).
+# Documented, tolerated difference from the Node binding: ids cross as native
+# Python ints (unlimited precision) here, vs decimal strings there — both are
+# faithful renderings of the same u64, never truncated (see the precision test
+# below).
+# ------------------------------------------------------------------------------
+
+
+def test_compile_context_result_shape_matches_the_mcp_wire_contract(mem):
+    req = {
+        "query": "deploy pipeline",
+        "token_budget": 10_000,
+        "project": "veles",
+        "fragments": [
+            {"content": "The deploy pipeline runs clippy before tests."},
+            {"content": "The deploy pipeline runs clippy before tests."},
+            {"content": "Never restart the primary during a rebalance."},
+        ],
+    }
+    out = mem.compile_context(req)
+    assert set(out) == {
+        "content",
+        "sections",
+        "decisions",
+        "sources",
+        "retrieval_handles",
+        "insights",
+        "risk",
+    }
+    assert len(out["decisions"]) == 3
+    drop = next(d for d in out["decisions"] if d["action"] == "drop")
+    assert drop["rule_id"] == "drop.duplicate"
+    assert isinstance(drop["fragment_id"], int)
+    assert isinstance(drop["content_hash"], int)
+    assert out["insights"]["tokens_saved"] > 0
+    handle = out["sources"][0]["handle"]
+    assert handle.startswith("ctx://source/")
+
+    savings = mem.context_savings(project="veles")
+    assert set(savings) == {
+        "events",
+        "tokens_in",
+        "tokens_out",
+        "tokens_saved",
+        "cost_saved_micros_by_currency",
+        "truncated",
+    }
+    assert savings["events"] == 1
+
+
+def test_compile_context_ids_survive_full_u64_precision(mem):
+    # stable_id (FNV-1a 64) ids are uniform over u64, so ~50% exceed
+    # i64::MAX; the binding must carry them as native Python ints, never a
+    # lossy float (this is the "unlimited precision" id contract).
+    big_id = 18_446_744_073_709_551_615  # u64::MAX
+    req = {
+        "query": "large id probe",
+        "token_budget": 10_000,
+        "fragments": [{"content": "x" * 40, "id": big_id}],
+    }
+    out = mem.compile_context(req)
+    decision = out["decisions"][0]
+    assert decision["fragment_id"] == big_id

--- a/crates/velesdb-python/tests/test_context_compiler.py
+++ b/crates/velesdb-python/tests/test_context_compiler.py
@@ -213,6 +213,51 @@ def test_compile_context_result_shape_matches_the_mcp_wire_contract(mem):
     assert savings["events"] == 1
 
 
+# --- numeric boundary round-trips through the shared converters ---------------
+# The u64 fix in src/utils.rs changes the whole binding's observable behavior
+# (payloads, search, VelesQL, graph props all share python_to_json /
+# json_to_python): ints in (i64::MAX, u64::MAX] now round-trip exactly as int
+# instead of silently degrading to a lossy float. These pin the boundary
+# contract: exact ints inside [i64::MIN, u64::MAX], floats stay float, bools
+# stay bool (bool is an int subclass in Python — order of checks matters), and
+# anything outside the range is an explicit ValueError, never silent precision
+# loss.
+# ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(2**64 - 1, id="u64-max"),
+        pytest.param(2**63, id="i64-max-plus-1"),
+        pytest.param(1.5, id="float-stays-float"),
+        pytest.param(True, id="bool-stays-bool-not-int"),
+    ],
+)
+def test_metadata_boundary_values_round_trip_exactly(mem, value):
+    fid = mem.remember("numeric boundary probe", metadata={"v": value})
+    hits = mem.recall("numeric boundary probe", k=5)
+    hit = next(h for h in hits if h["id"] == fid)
+    got = hit["metadata"]["v"]
+    assert got == value
+    # `True == 1` and `1 == 1.0` in Python, so equality alone cannot catch a
+    # bool→int or int→float degradation — the exact type must survive too.
+    assert type(got) is type(value)
+
+
+def test_metadata_int_above_u64_max_raises_value_error(mem):
+    # 2**64 fits neither i64 nor u64; before the fix it silently fell through
+    # to a lossy f64 (1.8446744073709552e19) — it must be an explicit error.
+    with pytest.raises(ValueError):
+        mem.remember("too big", metadata={"v": 2**64})
+
+
+def test_metadata_int_below_i64_min_raises_value_error(mem):
+    # Same guard on the low side: -(2**63) - 1 is below i64::MIN.
+    with pytest.raises(ValueError):
+        mem.remember("too small", metadata={"v": -(2**63) - 1})
+
+
 def test_compile_context_ids_survive_full_u64_precision(mem):
     # stable_id (FNV-1a 64) ids are uniform over u64, so ~50% exceed
     # i64::MAX; the binding must carry them as native Python ints, never a


### PR DESCRIPTION
## Summary

- Python parity for the context compiler (EPIC-P-070/US-002's memory bridge): `MemoryService` gains `compile_context`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context` — the same 5 operations the MCP server and the Node binding already expose.
- Zero new logic: every method is a thin dict↔serde conversion around `velesdb_memory::context::MemoryService::*` (the exact bridge the MCP tools call), using the file's existing manual `json_to_python`/`python_to_json` helpers.
- Fixes those two shared helpers to round-trip a `u64` outside `i64`'s range instead of silently falling through to a lossy `f64` — required so `compile_context`'s ids (FNV-1a 64-bit `stable_id` hashes, uniform over `u64`, so ~50% exceed `i64::MAX`) cross as exact native Python ints. Confirmed against a real value in manual testing: `ctx://source/18021940868160883968`.
- Enables the `velesdb-memory` `context` feature for `velesdb-python` (`context = []`, zero new dependencies — same feature set `velesdb-node` already builds with); without it `compile_context` and friends are unreachable at all.
- README: new "Context Compiler" section with a real executed round trip, plus LangChain and LlamaIndex integration snippets — both actually run against the built extension in this session, output pasted verbatim (no unexecuted code documented).
- `__init__.pyi`: stub signatures + docstrings for the 5 new methods (not otherwise enforced by `test_stub_parity.py`, but keeps typed callers accurate).

## Documented design decisions (per plan)

- Ids cross as **native Python ints** (unlimited precision), not decimal strings like the Node binding — a deliberate, documented wire-shape difference (semantic parity, not literal parity).
- Errors map through the file's existing `to_py_err`/`ErrorCategory` taxonomy — no new exception types. `token_budget=0` → `MemoryError::ContextBudget` → `ValueError`; unknown/malformed `ctx://source/` handle → `MemoryError::UnknownHandle` → `KeyError`.
- `MemoryService` is re-exported as-is by `python/velesdb/__init__.py` (no wrapper class), so the 5 new `#[pymethods]` are automatically visible there — verified, no adapter change needed.

## TDD evidence

RED (`tests/test_context_compiler.py`, before implementation — all 13 fail with `AttributeError`, methods don't exist yet):

```
FAILED tests/test_context_compiler.py::test_compile_context_minimal_round_trip
FAILED tests/test_context_compiler.py::test_compile_context_verbatim_and_cache_fragments
FAILED tests/test_context_compiler.py::test_retrieve_context_source_round_trips_a_compiled_fragment
FAILED tests/test_context_compiler.py::test_retrieve_context_source_unknown_handle_raises_key_error
FAILED tests/test_context_compiler.py::test_retrieve_context_source_malformed_handle_raises_key_error
FAILED tests/test_context_compiler.py::test_context_savings_aggregates_after_a_compile
FAILED tests/test_context_compiler.py::test_context_savings_with_no_project_filter_returns_a_dict
FAILED tests/test_context_compiler.py::test_save_and_load_working_context_round_trips
FAILED tests/test_context_compiler.py::test_save_working_context_is_an_idempotent_upsert
FAILED tests/test_context_compiler.py::test_load_working_context_returns_none_when_absent
FAILED tests/test_context_compiler.py::test_compile_context_zero_budget_raises_value_error
FAILED tests/test_context_compiler.py::test_compile_context_result_shape_matches_the_mcp_wire_contract
FAILED tests/test_context_compiler.py::test_compile_context_ids_survive_full_u64_precision
13 failed in 0.41s
```

GREEN (after implementation):

```
13 passed in 0.64s
```

Full suite (non-regression): `505 passed, 23 skipped` (skip count unchanged from baseline).

## Gates (all green)

```
cargo fmt --all --check                                    # OK
cargo clippy -p velesdb-python -- -D warnings               # OK, zero warnings
RUSTFLAGS=-Dwarnings cargo check -p velesdb-python           # OK
  (adapted from the plan's `--features persistence,ollama,extract`:
   those are velesdb-memory's features, not velesdb-python's own —
   velesdb-python's own feature list is default/gpu/update-check/loom;
   it pulls velesdb-memory with persistence+ollama+extract+context
   unconditionally via its Cargo.toml, so plain `cargo check -p velesdb-python`
   already exercises that full feature set)
cd crates/velesdb-python && pytest tests/ -q                # 505 passed, 23 skipped
```

`cargo test -p velesdb-python` was not run as a gate (not in the plan's gate list) — it fails to link on this machine even on a clean baseline checkout (pre-existing: PyO3 `extension-module` cdylib crates can't resolve `libpython` symbols outside an actual Python process on macOS; confirmed by stashing this PR's changes and re-running the same command against `develop`).

## Test plan

- [x] RED captured before implementation (13/13 fail with `AttributeError`)
- [x] GREEN after implementation (13/13 pass)
- [x] Full `pytest tests/` non-regression (505 passed, 23 skipped, same skip count as baseline)
- [x] `cargo fmt`, `clippy -D warnings`, `cargo check` all clean
- [x] README LangChain/LlamaIndex snippets actually executed against the built extension
- [x] `docs/openapi.json`/`.yaml` untouched (never regenerated by this build)