### PR TITLE
feat(memory): working-context on MCP+Node, compileContext on WASM+TS, honest forget [EPIC-P-071/US-003+US-004]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal, non-breaking: `fusion::fuse` re-expressed over `fuse_scored`
   (identical candidates/order/numbers, iso-behavior pinned by test);
   intra-doc links fixed so `RUSTDOCFLAGS="-D warnings" cargo doc` passes.
+- Internal, non-breaking: the `context` id wire contract (`ID_KEYS`,
+  decimal-string ⇄ `u64` tree rewrite) moved from two copy-pasted
+  implementations (Node's `convert.rs`, WASM's `memory_service.rs`) to one
+  shared `velesdb_memory::context::wire` module both bindings now delegate
+  to — same behavior (pinned by the moved logic's own new unit tests plus
+  the existing Node/WASM suites), one source of truth for future `context`
+  id fields instead of two to keep in sync.
 
 R1 `Collection`-internals train: resolves and **closes the god-object EPIC
 ([#1384](https://github.com/cyberlife-coder/VelesDB/issues/1384))**. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   token savings on the committed corpus in ~2 ms; figures are local
   estimates, not billed tokens — cross-checked against a real cl100k
   tokenizer by the committed `real_measures/` scripts).
+- **MCP**: two working-context tools on the one existing server —
+  `save_working_context` / `load_working_context` (pure delegation to the
+  memory bridge), so an agent can persist its distilled session state and a
+  later session can resume from it; the committed `mcp_e2e.py` harness
+  proves the round-trip **across two separate server processes** on one
+  store. [EPIC-P-071/US-003]
+- **Node** (`@wiscale/velesdb-memory-node`): `saveWorkingContext` /
+  `loadWorkingContext` — same wire shape, ids as decimal strings in both
+  directions (u64::MAX-safe), `null` when nothing was saved; the spec suite
+  proves the cross-process round-trip via a child-process save.
+  [EPIC-P-071/US-003]
+- **WASM** (`@wiscale/velesdb-wasm`) + **TypeScript SDK**
+  (`@wiscale/velesdb-sdk`): `compileContext(request)` — the same
+  deterministic compiler, compiled to wasm, running fully in the browser
+  (`velesdb-memory`'s zero-dependency `context` feature enabled on the wasm
+  build). Ids cross as decimal strings; in-memory semantics documented
+  (`ctx://source/` handles and savings events live for the browser session —
+  no persistence in WASM). [EPIC-P-071/US-004]
 - Internal, non-breaking: `fusion::fuse` re-expressed over `fuse_scored`
   (identical candidates/order/numbers, iso-behavior pinned by test);
   intra-doc links fixed so `RUSTDOCFLAGS="-D warnings" cargo doc` passes.
@@ -106,8 +124,22 @@ account).
   internal-only): graph state can be shared with `GraphCollection` without an
   exclusive move; field access and locking are unchanged.
 
+- **`forget` now reports whether the id actually existed** on every surface
+  (Rust bridge → `bool`, MCP `{found}`, Node/WASM/TS `boolean`,
+  Python `bool`): deleting an unknown id used to read as success, so an
+  agent could not tell a real deletion from a typo'd or stale id. Wire- and
+  signature-compatible everywhere except the TS SDK's `forget`
+  (`Promise<void>` → `Promise<boolean>` — a widening no caller breaks on).
+  [EPIC-P-071/US-004]
+
 ### Fixed
 
+- **The context compiler no longer aborts on `wasm32-unknown-unknown`** when
+  recording savings events: `SystemTime::now()` (unsupported in wasm `std`,
+  panics) is only reached on native targets now; wasm events carry a 0
+  timestamp (their per-process sequence keeps ids unique, and wasm stats are
+  per-browser-session by design). The compile pipeline itself was already
+  clock-free. [EPIC-P-071/US-004]
 - **python: integers greater than `i64::MAX` now round-trip exactly as `int`**
   (previously silently converted to a lossy `float`). Affects every surface
   sharing the binding's JSON converters — payloads, search results, VelesQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,9 +127,11 @@ account).
 - **`forget` now reports whether the id actually existed** on every surface
   (Rust bridge → `bool`, MCP `{found}`, Node/WASM/TS `boolean`,
   Python `bool`): deleting an unknown id used to read as success, so an
-  agent could not tell a real deletion from a typo'd or stale id. Wire- and
-  signature-compatible everywhere except the TS SDK's `forget`
-  (`Promise<void>` → `Promise<boolean>` — a widening no caller breaks on).
+  agent could not tell a real deletion from a typo'd or stale id. Wire-compatible
+  everywhere (the MCP result gains an additive `found` field); the Node
+  typings and the TS SDK's `forget` widen `Promise<void>` → `Promise<boolean>`
+  — only a caller with an explicit `: Promise<void>`/`: void` annotation on
+  the result needs a touch.
   [EPIC-P-071/US-004]
 
 ### Fixed

--- a/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
+++ b/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
@@ -1,47 +1,69 @@
 #!/usr/bin/env python3
-"""E2E: drive the velesdb-memory MCP server over stdio and exercise the 4 context tools."""
+"""E2E: drive the velesdb-memory MCP server over stdio and exercise the 6 context tools.
+
+Two separate server processes share one store path: the second launch proves
+save_working_context / load_working_context round-trip ACROSS processes — the
+inter-session resumption the tools exist for.
+"""
 import json, subprocess, sys, tempfile, os
 
+
+class Server:
+    """One velesdb-memory MCP server over stdio, bound to `store`."""
+
+    def __init__(self, store):
+        self.proc = subprocess.Popen(
+            ["./target/debug/velesdb-memory"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            env={**os.environ, "VELESDB_MEMORY_PATH": store}, text=True,
+        )
+        self.rid = 0
+        self.rpc("initialize", {"protocolVersion": "2024-11-05", "capabilities": {},
+                                "clientInfo": {"name": "e2e", "version": "0"}})
+        self.rpc("notifications/initialized", notify=True)
+
+    def rpc(self, method, params=None, notify=False):
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params is not None: msg["params"] = params
+        if not notify:
+            self.rid += 1
+            msg["id"] = self.rid
+        self.proc.stdin.write(json.dumps(msg) + "\n"); self.proc.stdin.flush()
+        if notify: return None
+        while True:
+            line = self.proc.stdout.readline()
+            if not line: sys.exit("server closed stdout")
+            resp = json.loads(line)
+            if resp.get("id") == self.rid:
+                if "error" in resp: return {"__error__": resp["error"]}
+                return resp["result"]
+
+    def call(self, tool, args):
+        result = self.rpc("tools/call", {"name": tool, "arguments": args})
+        if "__error__" in result: return result
+        return json.loads(result["content"][0]["text"]) if result.get("content") else result.get("structuredContent")
+
+    def terminate(self):
+        # Wait for the process to actually exit: the next server in this
+        # script reopens the SAME store, and racing the shutdown would hit
+        # the previous process's store lock.
+        self.proc.terminate()
+        self.proc.wait(timeout=10)
+
+
 store = tempfile.mkdtemp(prefix="veles-mcp-e2e-")
-proc = subprocess.Popen(
-    ["./target/debug/velesdb-memory"],
-    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-    env={**os.environ, "VELESDB_MEMORY_PATH": store}, text=True,
-)
-rid = [0]
-def rpc(method, params=None, notify=False):
-    msg = {"jsonrpc": "2.0", "method": method}
-    if params is not None: msg["params"] = params
-    if not notify:
-        rid[0] += 1
-        msg["id"] = rid[0]
-    proc.stdin.write(json.dumps(msg) + "\n"); proc.stdin.flush()
-    if notify: return None
-    while True:
-        line = proc.stdout.readline()
-        if not line: sys.exit("server closed stdout")
-        resp = json.loads(line)
-        if resp.get("id") == rid[0]:
-            if "error" in resp: return {"__error__": resp["error"]}
-            return resp["result"]
+srv = Server(store)
 
-def call(tool, args):
-    result = rpc("tools/call", {"name": tool, "arguments": args})
-    if "__error__" in result: return result
-    return json.loads(result["content"][0]["text"]) if result.get("content") else result.get("structuredContent")
-
-rpc("initialize", {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "e2e", "version": "0"}})
-rpc("notifications/initialized", notify=True)
-
-tools = [t["name"] for t in rpc("tools/list")["tools"]]
-expected = {"compile_context", "context_savings", "explain_compilation", "retrieve_context_source"}
+tools = [t["name"] for t in srv.rpc("tools/list")["tools"]]
+expected = {"compile_context", "context_savings", "explain_compilation",
+            "retrieve_context_source", "save_working_context", "load_working_context"}
 assert expected <= set(tools), f"missing context tools: {expected - set(tools)} in {tools}"
 
 req = {"query": "deploy pipeline", "token_budget": 10000, "project": "veles",
        "fragments": [{"content": "The deploy pipeline runs clippy before tests."},
                       {"content": "The deploy pipeline runs clippy before tests."},
                       {"content": "Never restart the primary during a rebalance."}]}
-out = call("compile_context", req)
+out = srv.call("compile_context", req)
 assert "Never restart" in out["content"], out
 assert len(out["decisions"]) == 3
 drop = next(d for d in out["decisions"] if d["action"] == "drop")
@@ -50,17 +72,42 @@ assert out["insights"]["tokens_saved"] > 0
 handle = out["sources"][0]["handle"]
 assert handle.startswith("ctx://source/")
 
-src = call("retrieve_context_source", {"handle": handle})
+src = srv.call("retrieve_context_source", {"handle": handle})
 assert src["content"] in {f["content"] for f in req["fragments"]}, src
 
-explain = call("explain_compilation", {"request": req, "fragment_id": drop["fragment_id"]})
+explain = srv.call("explain_compilation", {"request": req, "fragment_id": drop["fragment_id"]})
 assert explain["rule_id"] in {"drop.duplicate", "preserve.default"}, explain
 
-savings = call("context_savings", {"project": "veles"})
+savings = srv.call("context_savings", {"project": "veles"})
 assert savings["events"] == 1 and savings["tokens_saved"] > 0, savings
 
-err = call("compile_context", {"query": "x", "token_budget": 0, "fragments": [{"content": "y"}]})
+err = srv.call("compile_context", {"query": "x", "token_budget": 0, "fragments": [{"content": "y"}]})
 assert "__error__" in err and err["__error__"]["code"] == -32602, err
 
-proc.terminate()
-print("MCP E2E OK — 4 tools exercised over real stdio: list, compile (dedup+insights+handles), retrieve round-trip, explain, savings, error taxonomy")
+# --- working context: save in THIS process, load in a FRESH one -------------
+
+fresh = srv.call("load_working_context", {"project": "veles", "session": "e2e-session"})
+assert fresh["working"] is None, f"nothing saved yet, expected null: {fresh}"
+
+working = {"goal": "prove inter-session resumption over stdio",
+           "active_constraints": [{"text": "never merge without green gates"}],
+           "verified_facts": [{"text": "the 4 compiler tools already pass this script"}],
+           "pending_actions": ["load this back from a separate server process"]}
+saved = srv.call("save_working_context",
+                 {"project": "veles", "session": "e2e-session", "working": working})
+assert saved["id"] > 0, saved
+srv.terminate()
+
+# Second, separate server process on the same store: the next session resumes.
+srv2 = Server(store)
+loaded = srv2.call("load_working_context", {"project": "veles", "session": "e2e-session"})
+resumed = loaded["working"]
+assert resumed is not None, "the saved working context must survive the process boundary"
+assert resumed["goal"] == working["goal"], resumed
+assert [f["text"] for f in resumed["verified_facts"]] == [f["text"] for f in working["verified_facts"]], resumed
+assert resumed["pending_actions"] == working["pending_actions"], resumed
+srv2.terminate()
+
+print("MCP E2E OK — 6 tools exercised over real stdio: list, compile (dedup+insights+handles), "
+      "retrieve round-trip, explain, savings, error taxonomy, and save/load_working_context "
+      "round-tripping ACROSS two separate server processes")

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -38,6 +38,10 @@ pub mod insights;
 pub mod model;
 pub(crate) mod provenance;
 mod relevance;
+/// The id wire contract (decimal-string `u64`) shared by every JS-facing
+/// binding of these types — one source of truth for [`wire::ID_KEYS`]
+/// instead of a Node/WASM copy each.
+pub mod wire;
 
 pub use chunk::{chunk_text, ChunkBoundary, ChunkPolicy, TextChunk};
 pub use estimator::{DynTokenEstimator, HeuristicEstimator, TokenEstimator};

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -16,7 +16,27 @@
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Wall-clock nanos since the Unix epoch, stamped on savings events only —
+/// never in the compile pipeline. On `wasm32-unknown-unknown`
+/// `SystemTime::now()` aborts (`std` has no clock there), so events carry 0:
+/// the per-process sequence alone uniquifies their ids, and wasm stats are
+/// per-session by design (in-memory store).
+fn now_nanos() -> u128 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        0
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_nanos())
+            .unwrap_or(0)
+    }
+}
 
 use serde_json::{Map, Number, Value};
 
@@ -366,10 +386,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         out: &CompiledContext,
         ttl_seconds: Option<u64>,
     ) -> Result<(), MemoryError> {
-        let occurred_at_nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|elapsed| elapsed.as_nanos())
-            .unwrap_or(0);
+        let occurred_at_nanos = now_nanos();
         // The per-process sequence keeps ids unique even when two compiles
         // land on the same (possibly coarse) clock tick.
         let seq = EVENT_SEQ.fetch_add(1, Ordering::Relaxed);

--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -1,0 +1,135 @@
+//! JSON-tree helpers for the id wire contract shared by every JS-facing
+//! binding (Node, WASM) of the `context` types: a `u64` id crosses as a
+//! decimal string, because JS `number` loses precision above 2^53.
+//!
+//! Node and WASM independently need the exact same tree walk over a
+//! serialized [`CompiledContext`](super::CompiledContext) — one to turn
+//! outgoing ids into strings, the other to turn incoming strings back into
+//! numbers before deserializing. Living here once (instead of copy-pasted
+//! per binding) means [`ID_KEYS`] has a single source of truth: a future id
+//! field added to a `context` type only needs updating in one place, not
+//! silently missed in whichever binding a copy-paste forgot.
+//!
+//! Deliberately `String`-erred, not binding-specific: this crate depends on
+//! neither `napi` nor `wasm-bindgen`, so each binding maps the `String`
+//! error to its own error type at the call site.
+
+use serde_json::Value;
+
+/// Object keys whose `u64` values (or arrays of them) must cross to JS as
+/// decimal strings. Token counts stay numbers: they are bounded far below
+/// 2^53 by the budget caps.
+pub const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+
+/// Recursively rewrite every [`ID_KEYS`] field of a serialized `context`
+/// wire value into its decimal-string form.
+pub fn stringify_id_fields(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if ID_KEYS.contains(&key.as_str()) {
+                    stringify_ids_in(entry);
+                } else {
+                    stringify_id_fields(entry);
+                }
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(stringify_id_fields),
+        _ => {}
+    }
+}
+
+/// Rewrite one id value (or an array of them) into decimal strings.
+fn stringify_ids_in(value: &mut Value) {
+    match value {
+        Value::Number(number) => {
+            if let Some(id) = number.as_u64() {
+                *value = Value::String(id.to_string());
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(stringify_ids_in),
+        _ => {}
+    }
+}
+
+/// The inverse of [`stringify_id_fields`]: recursively rewrite every
+/// [`ID_KEYS`] field given in decimal-string form back into the numeric form
+/// the domain types deserialize. Non-string id values pass through
+/// untouched (serde reports them with its own error).
+///
+/// Deliberately stricter than serde: an [`ID_KEYS`]-named field with a
+/// non-numeric string is rejected here even where serde would have dropped
+/// it as an unknown field — a rejected typo beats a silently ignored one,
+/// and an id key can never be user data on these wire shapes.
+///
+/// # Errors
+/// Returns the offending text if an [`ID_KEYS`] field holds a string that
+/// does not parse as a decimal `u64`.
+pub fn parse_id_fields(value: &mut Value) -> Result<(), String> {
+    match value {
+        Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if ID_KEYS.contains(&key.as_str()) {
+                    parse_ids_in(entry)?;
+                } else {
+                    parse_id_fields(entry)?;
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                parse_id_fields(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Rewrite one id value (or an array of them) from decimal string to number.
+fn parse_ids_in(value: &mut Value) -> Result<(), String> {
+    match value {
+        Value::String(text) => {
+            *value = Value::Number(parse_u64(text)?.into());
+        }
+        Value::Array(items) => {
+            for item in items {
+                parse_ids_in(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Accept `fragments[].id` in decimal-string form by rewriting it to the
+/// numeric wire form. The other [`ID_KEYS`] never appear in a compile
+/// *request*, only in the output — a blanket rule over every `id` key would
+/// corrupt caller metadata that happens to use that name.
+///
+/// # Errors
+/// Returns the offending text if a fragment's `id` does not parse as a
+/// decimal `u64`.
+pub fn parse_fragment_id_strings(request: &mut Value) -> Result<(), String> {
+    let Some(fragments) = request.get_mut("fragments").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for fragment in fragments {
+        let Some(id) = fragment.get_mut("id") else {
+            continue;
+        };
+        if let Value::String(text) = id {
+            *id = Value::Number(parse_u64(text)?.into());
+        }
+    }
+    Ok(())
+}
+
+fn parse_u64(text: &str) -> Result<u64, String> {
+    text.parse()
+        .map_err(|_| format!("invalid id '{text}' (expected a decimal u64 string)"))
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/context/wire_tests.rs
+++ b/crates/velesdb-memory/src/context/wire_tests.rs
@@ -1,0 +1,90 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn stringify_id_fields_rewrites_known_id_keys_only() {
+    let mut value = json!({
+        "fragment_id": 42,
+        "content_hash": 18_446_744_073_709_551_615u64,
+        "fragment_ids": [1, 2, 3],
+        "risk": "low",
+        "nested": {"memory_id": 7},
+    });
+
+    stringify_id_fields(&mut value);
+
+    assert_eq!(value["fragment_id"], json!("42"));
+    assert_eq!(value["content_hash"], json!("18446744073709551615"));
+    assert_eq!(value["fragment_ids"], json!(["1", "2", "3"]));
+    assert_eq!(
+        value["risk"],
+        json!("low"),
+        "non-id fields pass through untouched"
+    );
+    assert_eq!(value["nested"]["memory_id"], json!("7"));
+}
+
+#[test]
+fn parse_id_fields_is_the_inverse_of_stringify() {
+    let mut value = json!({
+        "fragment_id": "42",
+        "fragment_ids": ["1", "2", "3"],
+        "nested": {"memory_id": "7"},
+    });
+
+    parse_id_fields(&mut value).expect("valid decimal ids");
+
+    assert_eq!(value["fragment_id"], json!(42));
+    assert_eq!(value["fragment_ids"], json!([1, 2, 3]));
+    assert_eq!(value["nested"]["memory_id"], json!(7));
+}
+
+#[test]
+fn parse_id_fields_rejects_a_non_numeric_id_string() {
+    let mut value = json!({"fragment_id": "not-a-number"});
+
+    let err = parse_id_fields(&mut value).unwrap_err();
+
+    assert!(
+        err.contains("not-a-number"),
+        "error names the offending value: {err}"
+    );
+}
+
+#[test]
+fn parse_fragment_id_strings_rewrites_fragment_ids_only() {
+    let mut request = json!({
+        "fragments": [
+            {"id": "18446744073709551615", "content": "a"},
+            {"content": "b"},
+        ],
+    });
+
+    parse_fragment_id_strings(&mut request).expect("valid ids");
+
+    assert_eq!(
+        request["fragments"][0]["id"],
+        json!(18_446_744_073_709_551_615u64)
+    );
+    assert!(request["fragments"][1].get("id").is_none());
+}
+
+#[test]
+fn parse_fragment_id_strings_is_a_no_op_without_a_fragments_array() {
+    let mut request = json!({"query": "q"});
+
+    parse_fragment_id_strings(&mut request).expect("no fragments key is fine");
+
+    assert_eq!(request, json!({"query": "q"}));
+}
+
+#[test]
+fn round_trip_stringify_then_parse_is_identity_for_id_keys() {
+    let original = json!({"fragment_id": 42, "fragment_ids": [1, 2, 3]});
+    let mut value = original.clone();
+
+    stringify_id_fields(&mut value);
+    parse_id_fields(&mut value).expect("round-trip ids are always valid decimals");
+
+    assert_eq!(value, original);
+}

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -260,7 +260,7 @@ impl McpServer {
 
     #[tool(
         name = "forget",
-        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the deleted id."
+        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the requested id plus `found`: `true` if a memory actually existed and was deleted, `false` if nothing was stored under that id (a stale id or a typo) — a no-op, not an error, but distinguishable from a real deletion."
     )]
     async fn forget(
         &self,
@@ -268,11 +268,11 @@ impl McpServer {
     ) -> Result<Json<ForgetResult>, ErrorData> {
         let service = Arc::clone(&self.service);
         let id = params.id;
-        tokio::task::spawn_blocking(move || service.forget(id))
+        let found = tokio::task::spawn_blocking(move || service.forget(id))
             .await
             .map_err(join_error)?
             .map_err(to_error)?;
-        Ok(Json(ForgetResult { id }))
+        Ok(Json(ForgetResult { id, found }))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use super::{join_error, to_error, McpServer};
 use crate::context::{
     CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextDecision,
-    ContextSavings,
+    ContextSavings, WorkingContext,
 };
 
 // --- Thin request envelopes --------------------------------------------------
@@ -56,6 +56,50 @@ pub(super) struct RetrieveContextSourceResult {
     pub handle: String,
     /// The original fragment content, byte for byte.
     pub content: String,
+}
+
+/// Input of the `save_working_context` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct SaveWorkingContextParams {
+    /// Project facet this working context belongs to (matches `remember`'s
+    /// `project` metadata convention).
+    pub project: String,
+    /// Session identifier — pick something stable for the agent run you want
+    /// to resume later (e.g. a conversation id).
+    pub session: String,
+    /// The distilled state to persist: goal, active constraints, verified
+    /// facts, open hypotheses, decisions taken, exact evidence, and pending
+    /// actions.
+    pub working: WorkingContext,
+}
+
+/// Output of the `save_working_context` tool.
+#[derive(Debug, serde::Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct SaveWorkingContextResult {
+    /// Id of the stored system fact backing this working context.
+    pub id: u64,
+}
+
+/// Input of the `load_working_context` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(super) struct LoadWorkingContextParams {
+    /// Project facet the working context was saved under.
+    pub project: String,
+    /// Session identifier the working context was saved under.
+    pub session: String,
+}
+
+/// Output of the `load_working_context` tool. An envelope (not a bare
+/// `Option<WorkingContext>`): the MCP spec requires the output schema's
+/// root to be an object, so a nullable root is rejected by rmcp.
+#[derive(Debug, serde::Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct LoadWorkingContextResult {
+    /// The previously saved working context, or `null` when nothing was ever
+    /// saved under that project + session (a fresh start, not an error).
+    pub working: Option<WorkingContext>,
 }
 
 #[tool_router(router = context_tool_router, vis = "pub(super)")]
@@ -151,6 +195,47 @@ impl McpServer {
             .map_err(join_error)?
             .map_err(to_error)?;
         Ok(Json(RetrieveContextSourceResult { handle, content }))
+    }
+
+    #[tool(
+        name = "save_working_context",
+        description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Returns the stored fact's id."
+    )]
+    async fn save_working_context(
+        &self,
+        Parameters(params): Parameters<SaveWorkingContextParams>,
+    ) -> Result<Json<SaveWorkingContextResult>, ErrorData> {
+        let service = Arc::clone(&self.service);
+        let SaveWorkingContextParams {
+            project,
+            session,
+            working,
+        } = params;
+        let id = tokio::task::spawn_blocking(move || {
+            service.save_working_context(&project, &session, &working)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(to_error)?;
+        Ok(Json(SaveWorkingContextResult { id }))
+    }
+
+    #[tool(
+        name = "load_working_context",
+        description = "Resume a session: load back the working context previously saved by save_working_context under the same project + session id — the goal, constraints, verified facts, open hypotheses, decisions, exact evidence, and pending actions a PRIOR session left off with. Call this at the START of a new session before doing anything else, so work continues instead of restarting. Returns null when nothing was ever saved under that project + session (a fresh start, not an error)."
+    )]
+    async fn load_working_context(
+        &self,
+        Parameters(params): Parameters<LoadWorkingContextParams>,
+    ) -> Result<Json<LoadWorkingContextResult>, ErrorData> {
+        let service = Arc::clone(&self.service);
+        let LoadWorkingContextParams { project, session } = params;
+        let working =
+            tokio::task::spawn_blocking(move || service.load_working_context(&project, &session))
+                .await
+                .map_err(join_error)?
+                .map_err(to_error)?;
+        Ok(Json(LoadWorkingContextResult { working }))
     }
 }
 

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -8,7 +8,9 @@ use tempfile::TempDir;
 
 use super::super::dto::RememberParams;
 use super::*;
-use crate::context::{fragment_id, ContextAction, ContextFragment, MemoryScope};
+use crate::context::{
+    fragment_id, ContextAction, ContextFact, ContextFragment, MemoryScope, WorkingContext,
+};
 use crate::embedder::{DynEmbedder, HashEmbedder};
 use crate::service::MemoryService;
 
@@ -208,4 +210,110 @@ async fn test_retrieve_context_source_tool_unknown_handle_is_invalid_params() {
         panic!("nothing stored under this handle — the tool must fail");
     };
     assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+// --- save_working_context / load_working_context ---------------------------
+
+fn working() -> WorkingContext {
+    WorkingContext {
+        goal: Some("ship EPIC-P-071 PR3".to_owned()),
+        active_constraints: vec![ContextFact {
+            text: "never merge without green gates".to_owned(),
+            source: None,
+        }],
+        verified_facts: vec![ContextFact {
+            text: "compile_context already ships on MCP+Node".to_owned(),
+            source: None,
+        }],
+        open_hypotheses: Vec::new(),
+        decisions: Vec::new(),
+        exact_evidence: Vec::new(),
+        pending_actions: vec!["wire save/load working-context tools".to_owned()],
+    }
+}
+
+#[tokio::test]
+async fn test_save_working_context_tool_then_load_round_trips() {
+    // Given a server and a working context to persist
+    let (_dir, srv) = server();
+    let saved = working();
+
+    // When saving through the tool
+    let Json(save_result) = srv
+        .save_working_context(Parameters(SaveWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "session-1".to_owned(),
+            working: saved.clone(),
+        }))
+        .await
+        .expect("save_working_context");
+    assert!(save_result.id > 0);
+
+    // Then a later load (a fresh "session") recovers the exact same state —
+    // this is the inter-session resumption the tool exists for.
+    let Json(loaded) = srv
+        .load_working_context(Parameters(LoadWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "session-1".to_owned(),
+        }))
+        .await
+        .expect("load_working_context");
+    let recovered = loaded
+        .working
+        .expect("a previously saved working context must load back");
+    assert_eq!(recovered.goal, saved.goal);
+    assert_eq!(recovered.pending_actions, saved.pending_actions);
+    assert_eq!(recovered.active_constraints.len(), 1);
+}
+
+#[tokio::test]
+async fn test_load_working_context_tool_none_when_never_saved() {
+    // Given a server with nothing saved under this project/session pair
+    let (_dir, srv) = server();
+
+    // When loading through the tool
+    let Json(loaded) = srv
+        .load_working_context(Parameters(LoadWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "never-saved".to_owned(),
+        }))
+        .await
+        .expect("load_working_context");
+
+    // Then there is nothing to resume
+    assert!(loaded.working.is_none());
+}
+
+#[tokio::test]
+async fn test_save_working_context_tool_is_idempotent_upsert() {
+    // Given an already-saved working context
+    let (_dir, srv) = server();
+    let mut state = working();
+    srv.save_working_context(Parameters(SaveWorkingContextParams {
+        project: "veles".to_owned(),
+        session: "session-2".to_owned(),
+        working: state.clone(),
+    }))
+    .await
+    .expect("save_working_context");
+
+    // When saving again under the same project+session with a new goal
+    state.goal = Some("ship a follow-up PR".to_owned());
+    srv.save_working_context(Parameters(SaveWorkingContextParams {
+        project: "veles".to_owned(),
+        session: "session-2".to_owned(),
+        working: state.clone(),
+    }))
+    .await
+    .expect("save_working_context (replace)");
+
+    // Then loading returns the latest state, not the first
+    let Json(loaded) = srv
+        .load_working_context(Parameters(LoadWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "session-2".to_owned(),
+        }))
+        .await
+        .expect("load_working_context");
+    assert_eq!(loaded.working.expect("saved").goal, state.goal);
 }

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -153,8 +153,12 @@ pub(super) struct ForgetParams {
 #[derive(Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetResult {
-    /// Id of the forgotten memory.
+    /// Id that was requested for deletion.
     pub(super) id: u64,
+    /// Whether a memory actually existed under `id` and was deleted.
+    /// `false` means nothing was stored there — a stale id or a typo, not a
+    /// second successful deletion — so a caller can tell the two apart.
+    pub(super) found: bool,
 }
 
 /// Parameters for the `feedback` tool.

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -148,9 +148,12 @@ async fn forget_removes_a_memory_through_the_server() {
         .await
         .expect("remember");
 
-    srv.forget(Parameters(ForgetParams { id: stored.id }))
+    let Json(forgotten) = srv
+        .forget(Parameters(ForgetParams { id: stored.id }))
         .await
         .expect("forget");
+    assert!(forgotten.found, "an existing memory must report found=true");
+    assert_eq!(forgotten.id, stored.id);
 
     let Json(recalled) = srv
         .recall(Parameters(RecallParams {
@@ -161,6 +164,21 @@ async fn forget_removes_a_memory_through_the_server() {
         .await
         .expect("recall");
     assert!(recalled.memories.iter().all(|m| m.id != stored.id));
+}
+
+#[tokio::test]
+async fn forget_unknown_id_through_the_server_reports_not_found() {
+    let (_dir, srv) = server();
+
+    let Json(forgotten) = srv
+        .forget(Parameters(ForgetParams { id: 999_999 }))
+        .await
+        .expect("forget on an unknown id must not error");
+
+    assert!(
+        !forgotten.found,
+        "forget of an id that was never stored must report found=false"
+    );
 }
 
 #[tokio::test]

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -549,12 +549,22 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         self.store.relate(from, to, relation)
     }
 
-    /// Forget (delete) the memory with `fact_id`.
+    /// Forget (delete) the memory with `fact_id`. Returns whether a memory
+    /// actually existed under that id — the underlying store's `delete` is a
+    /// silent no-op on an unknown id (matching most backends' idempotent
+    /// delete semantics), which is indistinguishable from a real deletion
+    /// unless existence is checked first. Every surface that exposes
+    /// `forget` (MCP, Node, WASM, Python) forwards this so a caller can tell
+    /// "I removed something" from "that id was a typo".
     ///
     /// # Errors
-    /// Returns [`MemoryError`] if the deletion fails.
-    pub fn forget(&self, fact_id: u64) -> Result<(), MemoryError> {
-        self.store.delete(fact_id)
+    /// Returns [`MemoryError`] if the existence check or the deletion fails.
+    pub fn forget(&self, fact_id: u64) -> Result<bool, MemoryError> {
+        let found = self.store.get(fact_id)?.is_some();
+        if found {
+            self.store.delete(fact_id)?;
+        }
+        Ok(found)
     }
 
     /// Explain a `decision`: find the best-matching memory (optionally scoped to

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -557,13 +557,18 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// `forget` (MCP, Node, WASM, Python) forwards this so a caller can tell
     /// "I removed something" from "that id was a typo".
     ///
+    /// The delete always runs, even when `get` reports the id absent: `get`
+    /// filters TTL-expired facts, and an expired-but-unpurged row must still
+    /// be reclaimed (the caller is told `false` — the memory was already
+    /// gone from its perspective). Existence check and delete are two store
+    /// calls, not one atomic operation: two concurrent forgets of one id may
+    /// both report `true`.
+    ///
     /// # Errors
     /// Returns [`MemoryError`] if the existence check or the deletion fails.
     pub fn forget(&self, fact_id: u64) -> Result<bool, MemoryError> {
         let found = self.store.get(fact_id)?.is_some();
-        if found {
-            self.store.delete(fact_id)?;
-        }
+        self.store.delete(fact_id)?;
         Ok(found)
     }
 

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -141,13 +141,29 @@ fn forget_removes_the_fact_from_recall() {
     let id = svc
         .remember("ephemeral scratch note about France", &[], None)
         .expect("remember");
-    svc.forget(id).expect("forget");
+    let found = svc.forget(id).expect("forget");
+    assert!(found, "forget of an existing fact must report found=true");
 
     let hits = svc.recall("France", 5, None).expect("recall after forget");
 
     assert!(
         !hits.iter().any(|h| h.id == id),
         "forgotten fact must not be recalled"
+    );
+}
+
+#[test]
+fn forget_unknown_id_reports_not_found_instead_of_silent_success() {
+    let (_dir, svc) = service();
+
+    let found = svc
+        .forget(999_999)
+        .expect("forget on an unknown id must not error");
+
+    assert!(
+        !found,
+        "forget of an id that was never stored must report found=false, \
+         so a caller can distinguish a real deletion from a typo"
     );
 }
 

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -190,6 +190,26 @@ test('feedback reinforces a fact, weakens on failure, NOT_FOUND on unknown id', 
   }
 })
 
+test('forget reports found=true on a real deletion, found=false on a typo id', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const id = await store.remember('ephemeral note to forget')
+    assert.equal(await store.forget(id), true, 'deleting an existing fact resolves true')
+    assert.equal(
+      await store.forget(id),
+      false,
+      'a second forget of the same id finds nothing — distinguishable from the first',
+    )
+    assert.equal(
+      await store.forget('999999999'),
+      false,
+      'a never-stored id resolves false (a no-op, not an error)',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
 test('error codes — INVALID_INPUT on empty fact, NOT_FOUND on missing relate endpoint', async () => {
   const { store, cleanup } = freshStore()
   try {

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -5,6 +5,7 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { mkdtempSync, rmSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -25,6 +26,7 @@ test('surface allowlist — exactly the supported methods, no engine leak', () =
     'compileContext',
     'feedback',
     'forget',
+    'loadWorkingContext',
     'recall',
     'recallFused',
     'recallFusedDated',
@@ -32,6 +34,7 @@ test('surface allowlist — exactly the supported methods, no engine leak', () =
     'relate',
     'remember',
     'rememberExtracted',
+    'saveWorkingContext',
     'why',
   ])
   assert.equal(typeof MemoryService.open, 'function', 'open is the static factory')
@@ -309,6 +312,94 @@ test('compileContext malformed request rejects with INVALID_INPUT', async () => 
   const { store, cleanup } = freshStore()
   try {
     await assert.rejects(store.compileContext({ fragments: 'not-an-array' }), /INVALID_INPUT/)
+  } finally {
+    cleanup()
+  }
+})
+
+test('saveWorkingContext → loadWorkingContext round-trips across processes', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-'))
+  try {
+    const working = {
+      goal: 'ship the working-context Node surface',
+      active_constraints: [{ text: 'never merge without green gates' }],
+      verified_facts: [{ text: 'the MCP tools already round-trip' }],
+      pending_actions: ['load this back from a fresh MemoryService'],
+    }
+    // Save from a CHILD process (the store's single-writer lock is released
+    // deterministically when it exits — a block-scoped handle in this
+    // process would keep the lock until GC).
+    const script = `
+      const { MemoryService } = require(${JSON.stringify(new URL('../index.js', import.meta.url).pathname)})
+      const store = MemoryService.open(${JSON.stringify(dir)}, 'hash')
+      store.saveWorkingContext('veles', 'session-1', ${JSON.stringify(working)}).then((id) => {
+        if (!/^\\d+$/.test(id)) throw new Error('id must be a decimal string, got: ' + id)
+      })
+    `
+    const child = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' })
+    assert.equal(child.status, 0, `child save failed: ${child.stderr}`)
+    // A separate MemoryService in THIS process: the next session resumes.
+    const reopened = MemoryService.open(dir, 'hash')
+    const loaded = await reopened.loadWorkingContext('veles', 'session-1')
+    assert.ok(loaded, 'the saved working context must survive the process boundary')
+    assert.equal(loaded.goal, working.goal)
+    assert.deepEqual(
+      loaded.active_constraints.map((f) => f.text),
+      ['never merge without green gates'],
+    )
+    assert.deepEqual(loaded.pending_actions, working.pending_actions)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('loadWorkingContext resolves null when nothing was saved', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const loaded = await store.loadWorkingContext('veles', 'never-saved')
+    assert.equal(loaded, null, 'a fresh start reads as null, not an error')
+  } finally {
+    cleanup()
+  }
+})
+
+test('saveWorkingContext replaces the previous state (idempotent upsert)', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await store.saveWorkingContext('veles', 's', { goal: 'first' })
+    await store.saveWorkingContext('veles', 's', { goal: 'second' })
+    const loaded = await store.loadWorkingContext('veles', 's')
+    assert.equal(loaded.goal, 'second', 'the latest save wins')
+  } finally {
+    cleanup()
+  }
+})
+
+test('saveWorkingContext malformed working state rejects with INVALID_INPUT', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await assert.rejects(
+      store.saveWorkingContext('veles', 's', { active_constraints: 'not-an-array' }),
+      /INVALID_INPUT/,
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('working context id fields cross as decimal strings in both directions', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    // Ids inside the working context (decision refs, evidence) follow the
+    // binding-wide contract: decimal strings on the JS side, u64 on the wire.
+    const bigId = '18446744073709551615' // u64::MAX — would corrupt as a JS number
+    await store.saveWorkingContext('veles', 'ids', {
+      decisions: [{ fragment_id: bigId, rule_id: 'preserve.default' }],
+      exact_evidence: [{ fragment_id: bigId, handle: 'ctx://source/1' }],
+    })
+    const loaded = await store.loadWorkingContext('veles', 'ids')
+    assert.equal(loaded.decisions[0].fragment_id, bigId, 'decision ids survive as strings')
+    assert.equal(loaded.exact_evidence[0].fragment_id, bigId, 'evidence ids survive as strings')
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -7,9 +7,11 @@ description: >
   repeated context, long logs, or accumulated conversation turns; when token
   costs need to drop measurably; or when the user says "compress my context",
   "optimize my prompt", "reduce token usage", "context is too big", or asks
-  why part of their context was dropped. Requires the velesdb-memory MCP
-  server (tools: compile_context, context_savings, explain_compilation,
-  retrieve_context_source).
+  why part of their context was dropped; or when a session should be
+  resumable later (save the working context at the end, load it back at the
+  start of the next one). Requires the velesdb-memory MCP server (tools:
+  compile_context, context_savings, explain_compilation,
+  retrieve_context_source, save_working_context, load_working_context).
 ---
 
 # VelesDB context optimizer
@@ -88,6 +90,41 @@ silent loss. Same input, same output, byte for byte.
 10. **Iterate.** If the output reads truncated or the model misses facts,
     raise the budget or mark more fragments verbatim — then recompile; it is
     cheap (~ms) and deterministic.
+
+## Inter-session resumption (save at the end, load at the start)
+
+Compression keeps one prompt small; `save_working_context` /
+`load_working_context` keep the *session itself* resumable:
+
+- **At the START of a session**, call `load_working_context` with the
+  project and a stable session id (e.g. the conversation/task id). If it
+  returns a non-null `working`, a prior session left off here: adopt its
+  `goal`, re-assert `active_constraints`, trust `verified_facts` (re-fetch
+  `exact_evidence` handles with `retrieve_context_source` when you need the
+  bytes), and continue from `pending_actions` instead of re-deriving
+  everything. A `null` means a fresh start, not an error.
+- **At the END of a session** (or whenever the state changes meaningfully),
+  call `save_working_context` with the distilled state: `goal`,
+  `active_constraints`, `verified_facts` (with sources), `open_hypotheses`,
+  `decisions`, `exact_evidence`, `pending_actions`. Keep it small — this is
+  the hand-off note, not the transcript. Saving again under the same
+  project + session replaces the previous state (idempotent upsert).
+
+```json
+{"tool": "save_working_context", "arguments": {
+  "project": "veles", "session": "task-1234",
+  "working": {
+    "goal": "fix the failing canary deploy",
+    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
+    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
+    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
+  }
+}}
+```
+
+```json
+{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
+```
 
 ## When NOT to compress
 

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -137,6 +137,11 @@ fn stringify_ids_in(value: &mut Value) {
 /// [`ID_KEYS`] field given in the binding's decimal-string form back into the
 /// numeric form the domain types deserialize. Non-string id values pass
 /// through untouched (serde reports them with its own error).
+///
+/// Deliberately stricter than serde: an [`ID_KEYS`]-named field with a
+/// non-numeric string is rejected here even where serde would have dropped
+/// it as an unknown field — a rejected typo beats a silently ignored one,
+/// and an id key can never be user data on these wire shapes.
 pub fn parse_id_fields(value: &mut Value) -> napi::Result<()> {
     match value {
         Value::Object(map) => {

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -133,6 +133,47 @@ fn stringify_ids_in(value: &mut Value) {
     }
 }
 
+/// The inverse of [`stringify_id_fields`]: recursively rewrite every
+/// [`ID_KEYS`] field given in the binding's decimal-string form back into the
+/// numeric form the domain types deserialize. Non-string id values pass
+/// through untouched (serde reports them with its own error).
+pub fn parse_id_fields(value: &mut Value) -> napi::Result<()> {
+    match value {
+        Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if ID_KEYS.contains(&key.as_str()) {
+                    parse_ids_in(entry)?;
+                } else {
+                    parse_id_fields(entry)?;
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                parse_id_fields(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Rewrite one id value (or an array of them) from decimal string to number.
+fn parse_ids_in(value: &mut Value) -> napi::Result<()> {
+    match value {
+        Value::String(text) => {
+            *value = Value::Number(parse_id(text)?.into());
+        }
+        Value::Array(items) => {
+            for item in items {
+                parse_ids_in(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 /// Accept `fragments[].id` in the binding's decimal-string form by rewriting
 /// it to the numeric form the domain type deserializes.
 pub fn parse_fragment_id_strings(request: &mut Value) -> napi::Result<()> {

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -95,105 +95,27 @@ pub fn to_fusion_options(opts: Option<FusionOptionsJs>) -> FusionOptions {
     }
 }
 
-/// Object keys whose `u64` values (or arrays of them) must cross to JS as
-/// decimal strings — JS `number` loses precision above 2^53. Token counts
-/// stay numbers: they are bounded far below 2^53 by the budget caps.
-const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
-
-/// Recursively rewrite every [`ID_KEYS`] field of a serialized
+/// Recursively rewrite every `context` id field (see
+/// [`velesdb_memory::context::wire::ID_KEYS`]) of a serialized
 /// `CompiledContext` into its decimal-string form — the same id contract as
 /// every other method of this binding, applied to a whole tree at once so
-/// the domain type needs no JS-specific duplicate.
+/// the domain type needs no JS-specific duplicate. Shared with the WASM
+/// binding via `velesdb_memory::context::wire`, not duplicated here.
 pub fn stringify_id_fields(value: &mut Value) {
-    match value {
-        Value::Object(map) => {
-            for (key, entry) in map.iter_mut() {
-                if ID_KEYS.contains(&key.as_str()) {
-                    stringify_ids_in(entry);
-                } else {
-                    stringify_id_fields(entry);
-                }
-            }
-        }
-        Value::Array(items) => items.iter_mut().for_each(stringify_id_fields),
-        _ => {}
-    }
-}
-
-/// Rewrite one id value (or an array of them) into decimal strings.
-fn stringify_ids_in(value: &mut Value) {
-    match value {
-        Value::Number(number) => {
-            if let Some(id) = number.as_u64() {
-                *value = Value::String(id.to_string());
-            }
-        }
-        Value::Array(items) => items.iter_mut().for_each(stringify_ids_in),
-        _ => {}
-    }
+    velesdb_memory::context::wire::stringify_id_fields(value);
 }
 
 /// The inverse of [`stringify_id_fields`]: recursively rewrite every
-/// [`ID_KEYS`] field given in the binding's decimal-string form back into the
-/// numeric form the domain types deserialize. Non-string id values pass
-/// through untouched (serde reports them with its own error).
-///
-/// Deliberately stricter than serde: an [`ID_KEYS`]-named field with a
-/// non-numeric string is rejected here even where serde would have dropped
-/// it as an unknown field — a rejected typo beats a silently ignored one,
-/// and an id key can never be user data on these wire shapes.
+/// `context` id field given in the binding's decimal-string form back into
+/// the numeric form the domain types deserialize.
 pub fn parse_id_fields(value: &mut Value) -> napi::Result<()> {
-    match value {
-        Value::Object(map) => {
-            for (key, entry) in map.iter_mut() {
-                if ID_KEYS.contains(&key.as_str()) {
-                    parse_ids_in(entry)?;
-                } else {
-                    parse_id_fields(entry)?;
-                }
-            }
-        }
-        Value::Array(items) => {
-            for item in items {
-                parse_id_fields(item)?;
-            }
-        }
-        _ => {}
-    }
-    Ok(())
-}
-
-/// Rewrite one id value (or an array of them) from decimal string to number.
-fn parse_ids_in(value: &mut Value) -> napi::Result<()> {
-    match value {
-        Value::String(text) => {
-            *value = Value::Number(parse_id(text)?.into());
-        }
-        Value::Array(items) => {
-            for item in items {
-                parse_ids_in(item)?;
-            }
-        }
-        _ => {}
-    }
-    Ok(())
+    velesdb_memory::context::wire::parse_id_fields(value).map_err(invalid_input)
 }
 
 /// Accept `fragments[].id` in the binding's decimal-string form by rewriting
 /// it to the numeric form the domain type deserializes.
 pub fn parse_fragment_id_strings(request: &mut Value) -> napi::Result<()> {
-    let Some(fragments) = request.get_mut("fragments").and_then(Value::as_array_mut) else {
-        return Ok(());
-    };
-    for fragment in fragments {
-        let Some(id) = fragment.get_mut("id") else {
-            continue;
-        };
-        if let Value::String(text) = id {
-            *id = Value::Number(parse_id(text)?.into());
-        }
-    }
-    Ok(())
+    velesdb_memory::context::wire::parse_fragment_id_strings(request).map_err(invalid_input)
 }
 
 /// Marshal a compiled context into its JS shape: serialize to the wire JSON,

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use napi::bindgen_prelude::AsyncTask;
 use napi_derive::napi;
 use serde_json::Value;
-use velesdb_memory::context::{CompilePolicy, CompileRequest, ContextCompiler};
+use velesdb_memory::context::{CompilePolicy, CompileRequest, ContextCompiler, WorkingContext};
 use velesdb_memory::{
     DynEmbedder, HashEmbedder, MemoryService, OllamaEmbedder, OllamaExtractor, DEFAULT_DIMENSION,
     DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
@@ -55,7 +55,7 @@ use crate::dto::{
     RecollectionJs,
 };
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
-use crate::tasks::Job;
+use crate::tasks::{Job, JsonOut};
 
 /// Build the requested embedder. `"hash"` is deterministic and offline;
 /// `"ollama"` calls a local embedding model (real semantic recall).
@@ -334,6 +334,61 @@ impl MemoryStore {
                 .compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
                 .map_err(to_napi_err)?;
             convert::to_compiled_js(&compiled)
+        }))
+    }
+
+    /// Persist the agent's distilled working state under `project` +
+    /// `session` (idempotent upsert: saving again replaces the previous
+    /// state), for inter-session resumption. Same JSON shape as the MCP
+    /// `save_working_context` tool; resolves to the stored fact id as a
+    /// decimal string, like every other id here. Pure delegation to
+    /// [`velesdb_memory`]'s bridge — zero logic in the binding.
+    #[napi(js_name = "saveWorkingContext", ts_return_type = "Promise<string>")]
+    pub fn save_working_context(
+        &self,
+        project: String,
+        session: String,
+        working: Value,
+    ) -> AsyncTask<Job<String>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let mut working = working;
+            convert::parse_id_fields(&mut working)?;
+            let working: WorkingContext = serde_json::from_value(working)
+                .map_err(|err| invalid_input(format!("invalid working context: {err}")))?;
+            svc.save_working_context(&project, &session, &working)
+                .map(convert::id_to_string)
+                .map_err(to_napi_err)
+        }))
+    }
+
+    /// The working context previously saved under `project` + `session`,
+    /// `null` when there is none — the start-of-session mirror of
+    /// [`Self::save_working_context`].
+    #[napi(
+        js_name = "loadWorkingContext",
+        ts_return_type = "Promise<object | null>"
+    )]
+    pub fn load_working_context(
+        &self,
+        project: String,
+        session: String,
+    ) -> AsyncTask<Job<JsonOut>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let loaded = svc
+                .load_working_context(&project, &session)
+                .map_err(to_napi_err)?;
+            match loaded {
+                Some(working) => {
+                    let mut value = serde_json::to_value(working).map_err(|err| {
+                        invalid_input(format!("working context serialization: {err}"))
+                    })?;
+                    convert::stringify_id_fields(&mut value);
+                    Ok(JsonOut(value))
+                }
+                None => Ok(JsonOut(Value::Null)),
+            }
         }))
     }
 

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -280,9 +280,11 @@ impl MemoryStore {
         }))
     }
 
-    /// Delete a memory by id.
-    #[napi(ts_return_type = "Promise<void>")]
-    pub fn forget(&self, id: String) -> AsyncTask<Job<()>> {
+    /// Delete a memory by id. Resolves to whether a memory actually existed
+    /// under that id and was deleted — `false` means nothing was stored
+    /// there (a stale id or a typo), not a second successful deletion.
+    #[napi(ts_return_type = "Promise<boolean>")]
+    pub fn forget(&self, id: String) -> AsyncTask<Job<bool>> {
         let svc = Arc::clone(&self.inner);
         AsyncTask::new(Job::new(move || {
             let id = convert::parse_id(&id)?;

--- a/crates/velesdb-node/src/tasks.rs
+++ b/crates/velesdb-node/src/tasks.rs
@@ -4,8 +4,34 @@
 //! so all of them go through here off the JS event-loop thread — there are no
 //! synchronous variants.
 
-use napi::bindgen_prelude::{ToNapiValue, TypeName};
+use napi::bindgen_prelude::{ToNapiValue, TypeName, ValueType};
 use napi::{Env, Error, Result, Task};
+
+/// Arbitrary JSON resolved as-is to JavaScript (`serde_json::Value` alone
+/// cannot be a [`Task`] output: it implements [`ToNapiValue`] but not
+/// [`TypeName`]). Keeps the exact wire shape — field names and `null`
+/// included — where a `#[napi(object)]` DTO would re-case the keys.
+pub struct JsonOut(pub serde_json::Value);
+
+impl TypeName for JsonOut {
+    fn type_name() -> &'static str {
+        "object"
+    }
+
+    fn value_type() -> ValueType {
+        ValueType::Object
+    }
+}
+
+// `ToNapiValue::to_napi_value` is an `unsafe fn` by napi's trait design; this
+// impl adds no unsafe operations of its own — it only delegates to the
+// existing `serde_json::Value` implementation.
+#[allow(unsafe_code)]
+impl ToNapiValue for JsonOut {
+    unsafe fn to_napi_value(env: napi::sys::napi_env, val: Self) -> Result<napi::sys::napi_value> {
+        serde_json::Value::to_napi_value(env, val.0)
+    }
+}
 
 /// A deferred unit of blocking work producing `O`.
 pub struct Job<O: Send + 'static> {

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2463,14 +2463,17 @@ class MemoryService:
         """
         ...
 
-    def forget(self, id: int) -> None:
+    def forget(self, id: int) -> bool:
         """Delete a memory by id.
 
         Args:
             id: The memory id to remove.
 
-        Raises:
-            KeyError: If no memory with ``id`` exists.
+        Returns:
+            ``True`` if a memory actually existed under ``id`` and was
+            deleted, ``False`` if nothing was stored there (a stale id or a
+            typo) — a no-op, not an error, but distinguishable from a real
+            deletion.
         """
         ...
 

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -354,8 +354,10 @@ impl PyMemoryService {
         py.detach(|| self.svc.relate(from_id, to_id, relation).map_err(to_py_err))
     }
 
-    /// Delete a memory by id.
-    fn forget(&self, py: Python<'_>, id: u64) -> PyResult<()> {
+    /// Delete a memory by id. Returns whether a memory actually existed
+    /// under that id and was deleted — `False` means nothing was stored
+    /// there (a stale id or a typo), not a second successful deletion.
+    fn forget(&self, py: Python<'_>, id: u64) -> PyResult<bool> {
         py.detach(|| self.svc.forget(id).map_err(to_py_err))
     }
 

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -51,9 +51,15 @@ def test_why_returns_the_connected_subgraph(mem):
 
 def test_forget_removes_a_memory(mem):
     fid = mem.remember("ephemeral note about France")
-    mem.forget(fid)
+    assert mem.forget(fid) is True
     hits = mem.recall("France", k=5)
     assert all(h["id"] != fid for h in hits)
+
+
+def test_forget_unknown_id_reports_not_found(mem):
+    # An id that was never stored: a no-op, not an error — but the caller
+    # must be able to tell it apart from a real deletion.
+    assert mem.forget(999_999) is False
 
 
 def test_reserved_metadata_key_raises_value_error(mem):

--- a/crates/velesdb-wasm/Cargo.toml
+++ b/crates/velesdb-wasm/Cargo.toml
@@ -26,8 +26,9 @@ velesdb-core = { workspace = true, default-features = false }
 # The agent-memory wedge orchestration (remember/recall/recall_fused/relate/
 # forget/why), generic over MemoryStore — this crate supplies the in-memory
 # backend (memory_store.rs). default-features=false drops the default `mcp`
-# feature (rmcp/tokio), leaving the offline, zero-dep HashEmbedder.
-velesdb-memory = { path = "../velesdb-memory", default-features = false }
+# feature (rmcp/tokio), leaving the offline, zero-dep HashEmbedder; `context`
+# adds the deterministic compiler (zero new dependencies, persistence-free).
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["context"] }
 
 # getrandom must use the JS backend on wasm32-unknown-unknown.
 # `rand 0.10` depends directly on `getrandom 0.4`; other workspace

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -443,9 +443,11 @@ impl WasmMemoryService {
             .map_err(to_js_err)
     }
 
-    /// Delete a memory by id.
+    /// Delete a memory by id. Returns whether a memory actually existed
+    /// under that id and was deleted — `false` means nothing was stored
+    /// there (a stale id or a typo), not a second successful deletion.
     #[wasm_bindgen(js_name = forget)]
-    pub fn forget(&self, id: &str) -> Result<(), JsValue> {
+    pub fn forget(&self, id: &str) -> Result<bool, JsValue> {
         let id = parse_id(id)?;
         self.inner.forget(id).map_err(to_js_err)
     }

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -69,61 +69,18 @@ fn parse_id(s: &str) -> Result<u64, JsValue> {
         .map_err(|_| invalid_input(format!("invalid id '{s}' (expected a decimal u64 string)")))
 }
 
-/// Object keys whose `u64` values (or arrays of them) cross to JS as decimal
-/// strings — same contract and key list as the Node binding's `convert.rs`
-/// (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`). Token counts
-/// stay numbers: the budget caps bound them far below 2^53.
-const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
-
-/// Recursively rewrite every [`ID_KEYS`] field of an outgoing JSON tree into
-/// its decimal-string form.
+/// Recursively rewrite every `context` id field (see
+/// [`velesdb_memory::context::wire::ID_KEYS`]) of an outgoing JSON tree into
+/// its decimal-string form. Shared with the Node binding via
+/// `velesdb_memory::context::wire`, not duplicated here.
 fn stringify_id_fields(value: &mut Value) {
-    match value {
-        Value::Object(map) => {
-            for (key, entry) in map.iter_mut() {
-                if ID_KEYS.contains(&key.as_str()) {
-                    stringify_ids_in(entry);
-                } else {
-                    stringify_id_fields(entry);
-                }
-            }
-        }
-        Value::Array(items) => items.iter_mut().for_each(stringify_id_fields),
-        _ => {}
-    }
-}
-
-/// Rewrite one id value (or an array of them) into decimal strings.
-fn stringify_ids_in(value: &mut Value) {
-    match value {
-        Value::Number(number) => {
-            if let Some(id) = number.as_u64() {
-                *value = Value::String(id.to_string());
-            }
-        }
-        Value::Array(items) => items.iter_mut().for_each(stringify_ids_in),
-        _ => {}
-    }
+    velesdb_memory::context::wire::stringify_id_fields(value);
 }
 
 /// Accept `fragments[].id` in decimal-string form (the Node binding's
-/// contract, mirrored) by rewriting it to the numeric wire form. The other
-/// [`ID_KEYS`] never appear in a compile *request*, only in the output — a
-/// blanket rule over every `id` key would corrupt caller metadata that
-/// happens to use that name.
+/// contract, mirrored) by rewriting it to the numeric wire form.
 fn parse_fragment_id_strings(request: &mut Value) -> Result<(), JsValue> {
-    let Some(fragments) = request.get_mut("fragments").and_then(Value::as_array_mut) else {
-        return Ok(());
-    };
-    for fragment in fragments {
-        let Some(id) = fragment.get_mut("id") else {
-            continue;
-        };
-        if let Value::String(text) = id {
-            *id = Value::Number(parse_id(text)?.into());
-        }
-    }
-    Ok(())
+    velesdb_memory::context::wire::parse_fragment_id_strings(request).map_err(invalid_input)
 }
 
 /// `undefined`/`null` → `None`; a plain object → `Some(Metadata)`; anything

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -25,6 +25,7 @@ use serde::Serialize;
 use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
+use velesdb_memory::context::{CompilePolicy, CompileRequest, ContextCompiler};
 use velesdb_memory::{
     ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder, MemoryEdge, MemoryError,
     MemoryNode, MemoryService, Metadata, Recollection,
@@ -66,6 +67,63 @@ fn id_to_string(id: u64) -> String {
 fn parse_id(s: &str) -> Result<u64, JsValue> {
     s.parse::<u64>()
         .map_err(|_| invalid_input(format!("invalid id '{s}' (expected a decimal u64 string)")))
+}
+
+/// Object keys whose `u64` values (or arrays of them) cross to JS as decimal
+/// strings — same contract and key list as the Node binding's `convert.rs`
+/// (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`). Token counts
+/// stay numbers: the budget caps bound them far below 2^53.
+const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+
+/// Recursively rewrite every [`ID_KEYS`] field of an outgoing JSON tree into
+/// its decimal-string form.
+fn stringify_id_fields(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if ID_KEYS.contains(&key.as_str()) {
+                    stringify_ids_in(entry);
+                } else {
+                    stringify_id_fields(entry);
+                }
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(stringify_id_fields),
+        _ => {}
+    }
+}
+
+/// Rewrite one id value (or an array of them) into decimal strings.
+fn stringify_ids_in(value: &mut Value) {
+    match value {
+        Value::Number(number) => {
+            if let Some(id) = number.as_u64() {
+                *value = Value::String(id.to_string());
+            }
+        }
+        Value::Array(items) => items.iter_mut().for_each(stringify_ids_in),
+        _ => {}
+    }
+}
+
+/// Accept `fragments[].id` in decimal-string form (the Node binding's
+/// contract, mirrored) by rewriting it to the numeric wire form. The other
+/// [`ID_KEYS`] never appear in a compile *request*, only in the output — a
+/// blanket rule over every `id` key would corrupt caller metadata that
+/// happens to use that name.
+fn parse_fragment_id_strings(request: &mut Value) -> Result<(), JsValue> {
+    let Some(fragments) = request.get_mut("fragments").and_then(Value::as_array_mut) else {
+        return Ok(());
+    };
+    for fragment in fragments {
+        let Some(id) = fragment.get_mut("id") else {
+            continue;
+        };
+        if let Value::String(text) = id {
+            *id = Value::Number(parse_id(text)?.into());
+        }
+    }
+    Ok(())
 }
 
 /// `undefined`/`null` → `None`; a plain object → `Some(Metadata)`; anything
@@ -471,6 +529,32 @@ impl WasmMemoryService {
             .why(decision, max_hops, filter.as_ref())
             .map_err(to_js_err)?;
         to_js(&ExplanationOut::from(explanation))
+    }
+
+    /// Compile context fragments into a token-budgeted, provenance-audited
+    /// prompt context — deterministic, no LLM, byte-identical to the native
+    /// compiler on the same input (same core code). Request and result use
+    /// the MCP `compile_context` wire shape, with this binding's id contract:
+    /// every id field crosses as a decimal string.
+    ///
+    /// In-memory semantics: externalized sources and savings events live in
+    /// this session's [`WasmStore`] — `ctx://source/` handles resolve only
+    /// within the current browser session (no persistence in WASM).
+    #[wasm_bindgen(js_name = compileContext)]
+    pub fn compile_context(&self, request: JsValue) -> Result<JsValue, JsValue> {
+        let mut request: Value = serde_wasm_bindgen::from_value(request)
+            .map_err(|e| invalid_input(format!("invalid compile request: {e}")))?;
+        parse_fragment_id_strings(&mut request)?;
+        let request: CompileRequest = serde_json::from_value(request)
+            .map_err(|e| invalid_input(format!("invalid compile request: {e}")))?;
+        let compiled = self
+            .inner
+            .compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
+            .map_err(to_js_err)?;
+        let mut value = serde_json::to_value(&compiled)
+            .map_err(|e| structured_js_error(CODE_INTERNAL, &format!("serialize: {e}")))?;
+        stringify_id_fields(&mut value);
+        to_js(&value)
     }
 }
 

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -39,7 +39,8 @@ fn test_relate_and_forget_round_trip_through_the_wasm_boundary() {
         "relate() through the wasm boundary must produce a traversable edge"
     );
 
-    svc.forget(&a.to_string()).unwrap();
+    let found = svc.forget(&a.to_string()).unwrap();
+    assert!(found, "forget() of an existing fact must report found=true");
     let hits = svc.inner.recall("fact a", 5, None).unwrap();
     assert!(
         hits.iter().all(|h| h.id != a),
@@ -48,13 +49,16 @@ fn test_relate_and_forget_round_trip_through_the_wasm_boundary() {
 }
 
 #[test]
-fn test_forget_unknown_id_is_ok_idempotent_delete() {
+fn test_forget_unknown_id_is_ok_but_reports_not_found() {
     let svc = WasmMemoryService::new(4);
-    // MemoryStore::delete on a WasmStore is a plain removal, not an
-    // existence check — deleting a never-stored id is a no-op, not an error
-    // (matches the native backend's `delete` semantics), so this stays on
-    // the Ok path and never touches JsValue.
-    assert!(svc.forget("999999999").is_ok());
+    // Deleting a never-stored id is a no-op, not an error (idempotent
+    // delete) — but the caller must be able to tell it apart from a real
+    // deletion, so it reports found=false. Stays on the Ok path and never
+    // touches JsValue, so it is safe to probe natively.
+    assert!(
+        !svc.forget("999999999").unwrap(),
+        "an id that was never stored must report found=false"
+    );
 }
 
 // --- Pure-Rust coverage of the underlying orchestration (via `svc.inner`,

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -95,3 +95,63 @@ fn recall_without_metadata_marshals_undefined() {
     let metadata = js_sys::Reflect::get(&first, &"metadata".into()).unwrap();
     assert!(metadata.is_undefined(), "absent metadata must be undefined");
 }
+
+/// `compileContext` marshalling across the wasm boundary: the request goes
+/// in as a plain JS object (fragment ids as decimal strings), the compiled
+/// result comes back as a plain object (not a Map) with every id field as a
+/// decimal string — u64::MAX must survive, which proves ids never pass
+/// through a JS number.
+#[wasm_bindgen_test]
+fn compile_context_round_trips_with_string_ids() {
+    let svc = WasmMemoryService::new(16);
+    let request = js_sys::JSON::parse(
+        r#"{
+            "query": "state of the canary deploy",
+            "token_budget": 500,
+            "fragments": [
+                {"id": "18446744073709551615", "content": "The canary is green: 2% traffic."},
+                {"content": "Rollback runbook: kubectl rollout undo deployment/canary."}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let compiled = svc.compile_context(request).unwrap();
+    assert!(
+        !compiled.is_instance_of::<js_sys::Map>(),
+        "compiled context must be a plain object"
+    );
+
+    let risk = js_sys::Reflect::get(&compiled, &"risk".into()).unwrap();
+    assert_eq!(risk.as_string().as_deref(), Some("low"));
+    let content = js_sys::Reflect::get(&compiled, &"content".into()).unwrap();
+    let content = content.as_string().unwrap();
+    assert!(content.contains("canary is green"));
+    assert!(content.contains("Rollback runbook"));
+
+    let decisions = js_sys::Reflect::get(&compiled, &"decisions".into()).unwrap();
+    let first = js_sys::Reflect::get(&decisions, &0.into()).unwrap();
+    let fragment_id = js_sys::Reflect::get(&first, &"fragment_id".into()).unwrap();
+    let fragment_id = fragment_id
+        .as_string()
+        .expect("fragment_id must cross as a decimal string, not a number");
+    assert_eq!(fragment_id, "18446744073709551615", "u64::MAX survives");
+}
+
+/// Determinism across the boundary: the same request compiles to the same
+/// bytes twice (JSON-stringified equality of the full result).
+#[wasm_bindgen_test]
+fn compile_context_is_deterministic() {
+    let svc = WasmMemoryService::new(16);
+    let request = || {
+        js_sys::JSON::parse(
+            r#"{"query": "q", "token_budget": 400,
+                "fragments": [{"content": "same line"}, {"content": "same line"}]}"#,
+        )
+        .unwrap()
+    };
+    let a = svc.compile_context(request()).unwrap();
+    let b = svc.compile_context(request()).unwrap();
+    let stringify = |v: &JsValue| js_sys::JSON::stringify(v).unwrap().as_string().unwrap();
+    assert_eq!(stringify(&a), stringify(&b), "same input, same bytes");
+}

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -155,3 +155,36 @@ fn compile_context_is_deterministic() {
     let stringify = |v: &JsValue| js_sys::JSON::stringify(v).unwrap().as_string().unwrap();
     assert_eq!(stringify(&a), stringify(&b), "same input, same bytes");
 }
+
+/// `memory_scope` on the in-memory store: the tri-engine pull (fused recall
+/// + PR2's importance blend, whose default weights are active) must work on
+/// `WasmStore` — this pins the whole `recall_fused_scored` path in wasm.
+#[wasm_bindgen_test]
+fn compile_context_memory_scope_pulls_stored_memories() {
+    let svc = WasmMemoryService::new(16);
+    svc.remember(
+        "the canary rollback runbook is kubectl rollout undo",
+        JsValue::UNDEFINED,
+        JsValue::UNDEFINED,
+        None,
+    )
+    .unwrap();
+
+    let request = js_sys::JSON::parse(
+        r#"{
+            "query": "canary rollback runbook",
+            "token_budget": 800,
+            "memory_scope": {"k": 3},
+            "fragments": [{"content": "Current task: fix the canary deploy."}]
+        }"#,
+    )
+    .unwrap();
+
+    let compiled = svc.compile_context(request).unwrap();
+    let content = js_sys::Reflect::get(&compiled, &"content".into()).unwrap();
+    let content = content.as_string().unwrap();
+    assert!(
+        content.contains("rollback runbook"),
+        "the scoped memory must be pulled into the compiled context, got: {content}"
+    );
+}

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -39,6 +39,60 @@ export interface MemoryRecollection {
   metadata?: Record<string, unknown>;
 }
 
+/** One input fragment of {@link MemoryService.compileContext}. */
+export interface CompileContextFragment {
+  /** Optional caller id as a decimal string (content-derived when absent). */
+  id?: string;
+  /** The fragment text. */
+  content: string;
+  /** Classification hint (`"code"`, `"log"`, …). */
+  kind?: string;
+  /** Fragment flags, e.g. `{ verbatim: true }` or `{ cache: true }`. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Input of {@link MemoryService.compileContext} — the MCP `compile_context`
+ * wire shape (snake_case keys, ids as decimal strings).
+ */
+export interface CompileContextRequest {
+  /** The current task — relevance ordering anchors on it. */
+  query: string;
+  /** Hard budget for the compiled context, in estimated tokens. */
+  token_budget: number;
+  /** The fragments to compile. */
+  fragments: CompileContextFragment[];
+  /** Pull stored memories into the compile (tri-engine recall). */
+  memory_scope?: Record<string, unknown>;
+  /** Compile policy overrides (importance weights, pricing, …). */
+  policy?: Record<string, unknown>;
+  /** Project facet for savings aggregation. */
+  project?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Output of {@link MemoryService.compileContext} — the MCP wire shape
+ * (snake_case keys; every id field is a decimal string).
+ */
+export interface CompiledContext {
+  /** The assembled context, ready to inject into a prompt. */
+  content: string;
+  /** Ordered output blocks (cache prefix first). */
+  sections: unknown;
+  /** One auditable decision per input fragment. */
+  decisions: unknown;
+  /** One source pointer per distinct fragment. */
+  sources: unknown;
+  /** Handles of externalized fragments (`ctx://source/…`). */
+  retrieval_handles: unknown;
+  /** Token/cost savings of this compilation. */
+  insights: unknown;
+  /** Overall fidelity risk. */
+  risk: 'low' | 'medium' | 'high';
+  [key: string]: unknown;
+}
+
 /** A structured predicate for {@link MemoryService.recallWhere}. */
 export interface MemoryColumnFilter {
   /** Metadata field name (alphanumeric/underscore). */
@@ -124,8 +178,9 @@ interface WasmMemoryServiceInstance {
     opts: unknown
   ): unknown;
   relate(from: string, to: string, relation: string): string;
-  forget(id: string): void;
+  forget(id: string): boolean;
   why(decision: string, maxHops: number | null | undefined, filter: unknown): unknown;
+  compileContext(request: unknown): unknown;
   free(): void;
 }
 
@@ -370,11 +425,13 @@ export class MemoryService {
     return wrapWasmCall(() => this.ensureInitialized().relate(from, to, relation));
   }
 
-  /** Delete a memory by id. */
-  forget(id: string): Promise<void> {
-    return wrapWasmCall(() => {
-      this.ensureInitialized().forget(id);
-    });
+  /**
+   * Delete a memory by id. Resolves to whether a memory actually existed
+   * under that id and was deleted — `false` means nothing was stored there
+   * (a stale id or a typo), not a second successful deletion.
+   */
+  forget(id: string): Promise<boolean> {
+    return wrapWasmCall(() => this.ensureInitialized().forget(id));
   }
 
   /**
@@ -388,6 +445,23 @@ export class MemoryService {
   ): Promise<MemoryExplanation> {
     return wrapWasmCall(
       () => this.ensureInitialized().why(decision, maxHops, filter) as MemoryExplanation
+    );
+  }
+
+  /**
+   * Compile context fragments into a token-budgeted, provenance-audited
+   * prompt context — deterministic, no LLM, running the same compiler as the
+   * MCP server and the Node binding, in the browser. Request and result use
+   * the MCP `compile_context` wire shape; every id field crosses as a
+   * decimal string.
+   *
+   * In-memory semantics: externalized sources and savings events live in
+   * this session's store — `ctx://source/` handles resolve only within the
+   * current browser session.
+   */
+  compileContext(request: CompileContextRequest): Promise<CompiledContext> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().compileContext(request) as CompiledContext
     );
   }
 }

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -30,10 +30,19 @@ class MockWasmMemoryService {
     now: '2026-01-03',
   }));
   relate = vi.fn(() => '5');
-  forget = vi.fn();
+  forget = vi.fn(() => true);
   why = vi.fn(() => ({
     nodes: [{ id: '1', content: 'we chose parking_lot', hop: 0 }],
     edges: [],
+  }));
+  compileContext = vi.fn(() => ({
+    content: 'compiled',
+    sections: [],
+    decisions: [{ fragment_id: '18446744073709551615', rule_id: 'preserve.default' }],
+    sources: [],
+    retrieval_handles: [],
+    insights: { tokens_saved: 0 },
+    risk: 'low',
   }));
   free = vi.fn();
 
@@ -204,8 +213,24 @@ describe('MemoryService', () => {
       expect(lastMockInstance!.relate).toHaveBeenCalledWith('1', '2', 'decided_in');
     });
 
-    it('forget() resolves', async () => {
-      await expect(memory.forget('1')).resolves.toBeUndefined();
+    it('forget() resolves to whether the id existed', async () => {
+      await expect(memory.forget('1')).resolves.toBe(true);
+      lastMockInstance!.forget.mockReturnValueOnce(false);
+      await expect(memory.forget('999')).resolves.toBe(false);
+    });
+
+    it('compileContext() delegates the request and returns the wire shape', async () => {
+      const request = {
+        query: 'state of the canary deploy',
+        token_budget: 500,
+        fragments: [{ content: 'The canary is green.' }],
+      };
+      const compiled = await memory.compileContext(request);
+      expect(lastMockInstance!.compileContext).toHaveBeenCalledWith(request);
+      expect(compiled.risk).toBe('low');
+      expect(compiled.content).toBe('compiled');
+      const decisions = compiled.decisions as Array<{ fragment_id: string }>;
+      expect(decisions[0].fragment_id).toBe('18446744073709551615');
     });
 
     it('why() returns the explanation subgraph', async () => {

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -7,9 +7,11 @@ description: >
   repeated context, long logs, or accumulated conversation turns; when token
   costs need to drop measurably; or when the user says "compress my context",
   "optimize my prompt", "reduce token usage", "context is too big", or asks
-  why part of their context was dropped. Requires the velesdb-memory MCP
-  server (tools: compile_context, context_savings, explain_compilation,
-  retrieve_context_source).
+  why part of their context was dropped; or when a session should be
+  resumable later (save the working context at the end, load it back at the
+  start of the next one). Requires the velesdb-memory MCP server (tools:
+  compile_context, context_savings, explain_compilation,
+  retrieve_context_source, save_working_context, load_working_context).
 ---
 
 # VelesDB context optimizer
@@ -88,6 +90,41 @@ silent loss. Same input, same output, byte for byte.
 10. **Iterate.** If the output reads truncated or the model misses facts,
     raise the budget or mark more fragments verbatim — then recompile; it is
     cheap (~ms) and deterministic.
+
+## Inter-session resumption (save at the end, load at the start)
+
+Compression keeps one prompt small; `save_working_context` /
+`load_working_context` keep the *session itself* resumable:
+
+- **At the START of a session**, call `load_working_context` with the
+  project and a stable session id (e.g. the conversation/task id). If it
+  returns a non-null `working`, a prior session left off here: adopt its
+  `goal`, re-assert `active_constraints`, trust `verified_facts` (re-fetch
+  `exact_evidence` handles with `retrieve_context_source` when you need the
+  bytes), and continue from `pending_actions` instead of re-deriving
+  everything. A `null` means a fresh start, not an error.
+- **At the END of a session** (or whenever the state changes meaningfully),
+  call `save_working_context` with the distilled state: `goal`,
+  `active_constraints`, `verified_facts` (with sources), `open_hypotheses`,
+  `decisions`, `exact_evidence`, `pending_actions`. Keep it small — this is
+  the hand-off note, not the transcript. Saving again under the same
+  project + session replaces the previous state (idempotent upsert).
+
+```json
+{"tool": "save_working_context", "arguments": {
+  "project": "veles", "session": "task-1234",
+  "working": {
+    "goal": "fix the failing canary deploy",
+    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
+    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
+    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
+  }
+}}
+```
+
+```json
+{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
+```
 
 ## When NOT to compress
 


### PR DESCRIPTION
## US-003 + US-004 — parité des surfaces (EPIC-P-071, PR3/4)

**MCP** : 2 outils `save_working_context`/`load_working_context` (délégation pure au bridge), descriptions orientées reprise inter-sessions. `mcp_e2e.py` étendu : round-trip prouvé **à travers deux processus serveur séparés** sur un même store.

**Node** : `saveWorkingContext`/`loadWorkingContext` (ids strings décimales dans les deux sens, u64::MAX-safe, `null` si rien), allowlist du contrat de surface à jour, round-trip inter-processus prouvé par save dans un child process (verrou single-writer libéré déterministiquement). Nouveau `JsonOut` (tasks.rs) pour résoudre du JSON wire-shape exact en sortie de Promise.

**WASM + TS SDK** : `compileContext` dans le navigateur (feature `context` de velesdb-memory activée sur le build wasm — zéro dépendance nouvelle), ids en strings décimales, sémantique in-memory documentée. TS : types wire (`CompileContextRequest`/`CompiledContext`), `forget` passe à `Promise<boolean>`.

**forget honnête (toutes surfaces)** : id inexistant → `found: false` (bridge bool, MCP `{found}`, Node/WASM/TS boolean, Python bool) — l'agent distingue suppression réelle / typo.

**Fix découvert par les tests wasm** : `record_context_event` appelait `SystemTime::now()` → abort sur wasm32 (std sans horloge). Helper cfg-gaté : 0 sur wasm (séquence par-processus garde les ids uniques), chemin natif inchangé. Le pipeline de compile était déjà clock-free.

## TDD / preuves

- RED capturés par surface (spec Node 12 pass + fails attendus avant impl ; tests wasm FAIL sur l'abort horloge avant le fix — bug réel attrapé rouge d'abord)
- Node spec **20/20** ; wasm **5/5** wedge (61 au total toutes suites) ; TS **896/896** ; velesdb-memory 13 binaires de test ok ; MCP e2e 6 outils + round-trip 2 processus

## Gates

`cargo fmt --all --check` ✅ · clippy CI strict `--workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings` ✅ · `clippy -p velesdb-node --lib` ✅ · `RUSTFLAGS=-Dwarnings check -p velesdb-memory --no-default-features --features context` ✅ · CHANGELOG (Added US-003/004, Changed forget, Fixed wasm clock) ✅ · skills sync byte-identique ✅ · openapi non touché ✅