### PR TITLE
feat(memory): wire-safe ids opt-in, positional explain, installable skills bundle [EPIC-P-071]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,39 @@ jobs:
             *.deb
 
   # ===========================================================================
+  # 2b. Package the agent skills (installable without cloning the repo)
+  # ===========================================================================
+  package-skills:
+    name: Package skills bundle
+    runs-on: ubuntu-latest
+    needs: validate
+    if: github.event_name == 'push' || inputs.publish_binaries
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build velesdb-skills.tar.gz
+        # One folder per skill at the archive root, so
+        # `tar -xz -C ~/.claude/skills/` drops each skill straight into
+        # place — the one-line install README documents. Staged in a temp
+        # dir first (the two skills live under different source trees) so
+        # the tar entries carry no leading path noise.
+        run: |
+          set -euo pipefail
+          stage="$(mktemp -d)"
+          cp -r crates/velesdb-memory/skill/velesdb-memory "$stage/"
+          cp -r skills/velesdb-context-optimizer "$stage/"
+          tar -czf velesdb-skills.tar.gz -C "$stage" velesdb-memory velesdb-context-optimizer
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # `binaries-*` on purpose: the GitHub Release job downloads every
+          # artifact matching that pattern and attaches it as-is, so this
+          # rides the same collection step the platform binaries use
+          # without needing a second download/attach path.
+          name: binaries-skills
+          path: velesdb-skills.tar.gz
+
+  # ===========================================================================
   # 3. Publish to crates.io (each crate independently)
   # ===========================================================================
   publish-crates:
@@ -629,12 +662,13 @@ jobs:
   github-release:
     name: GitHub Release
     runs-on: ubuntu-latest
-    needs: [validate, build]
+    needs: [validate, build, package-skills]
     if: |
       always() &&
       needs.validate.result == 'success' &&
       (github.event_name == 'push' || inputs.publish_github) &&
-      (needs.build.result == 'success' || needs.build.result == 'skipped')
+      (needs.build.result == 'success' || needs.build.result == 'skipped') &&
+      (needs.package-skills.result == 'success' || needs.package-skills.result == 'skipped')
     permissions:
       contents: write
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`RUN_BILLED_MEASURE=1` + an API key never asked for by the harness), the
   provider's own billed `usage` on a real minimal-cost call.
   [EPIC-P-071/US-007]
+- **MCP**: `CompilePolicy.ids_as_strings` (default `false`) — opts the
+  `compile_context` / `explain_compilation` response into decimal-string ids
+  (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`), reusing the
+  same tree walk the Node/WASM bindings already apply, for raw MCP clients
+  without u64-safe JSON number parsing. `fragments[].id` on input now also
+  accepts either a JSON number or a decimal string, and the advertised tool
+  schemas type every such field `["integer", "string"]` so schema-validating
+  clients accept the opt-in form. [EPIC-P-071]
+- **MCP**: `explain_compilation` gains an optional `fragment_index` (0-based
+  position in `request.fragments`), so byte-identical fragments — which
+  share a content-addressed `fragment_id` — can be disambiguated instead of
+  always resolving to the deduplication survivor's decision. Default
+  behavior (no `fragment_index`) is unchanged. [EPIC-P-071]
+- **Release**: every GitHub Release now attaches `velesdb-skills.tar.gz`
+  (the `velesdb-memory` and `velesdb-context-optimizer` agent skills, one
+  folder per skill at the archive root) — `curl -L … | tar -xz -C
+  ~/.claude/skills/` installs both without cloning the repo. [EPIC-P-071]
 
 R1 `Collection`-internals train: resolves and **closes the god-object EPIC
 ([#1384](https://github.com/cyberlife-coder/VelesDB/issues/1384))**. The
@@ -187,21 +204,6 @@ account).
   exceed `i64::MAX`). Integers outside `[i64::MIN, u64::MAX]` now raise an
   explicit `ValueError` stating the supported range instead of silently losing
   precision. [EPIC-P-071/US-001]
-- **MCP**: `CompilePolicy.ids_as_strings` (default `false`) — opts the
-  `compile_context` / `explain_compilation` response into decimal-string ids
-  (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`), reusing the
-  same tree walk the Node/WASM bindings already apply, for raw MCP clients
-  without u64-safe JSON number parsing. `fragments[].id` on input now also
-  accepts either a JSON number or a decimal string. [EPIC-P-071]
-- **MCP**: `explain_compilation` gains an optional `fragment_index` (0-based
-  position in `request.fragments`), so byte-identical fragments — which
-  share a content-addressed `fragment_id` — can be disambiguated instead of
-  always resolving to the deduplication survivor's decision. Default
-  behavior (no `fragment_index`) is unchanged. [EPIC-P-071]
-- **Release**: every GitHub Release now attaches `velesdb-skills.tar.gz`
-  (the `velesdb-memory` and `velesdb-context-optimizer` agent skills, one
-  folder per skill at the archive root) — `curl -L … | tar -xz -C
-  ~/.claude/skills/` installs both without cloning the repo. [EPIC-P-071]
 
 ## [3.12.0] — 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,21 @@ account).
   exceed `i64::MAX`). Integers outside `[i64::MIN, u64::MAX]` now raise an
   explicit `ValueError` stating the supported range instead of silently losing
   precision. [EPIC-P-071/US-001]
+- **MCP**: `CompilePolicy.ids_as_strings` (default `false`) — opts the
+  `compile_context` / `explain_compilation` response into decimal-string ids
+  (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`), reusing the
+  same tree walk the Node/WASM bindings already apply, for raw MCP clients
+  without u64-safe JSON number parsing. `fragments[].id` on input now also
+  accepts either a JSON number or a decimal string. [EPIC-P-071]
+- **MCP**: `explain_compilation` gains an optional `fragment_index` (0-based
+  position in `request.fragments`), so byte-identical fragments — which
+  share a content-addressed `fragment_id` — can be disambiguated instead of
+  always resolving to the deduplication survivor's decision. Default
+  behavior (no `fragment_index`) is unchanged. [EPIC-P-071]
+- **Release**: every GitHub Release now attaches `velesdb-skills.tar.gz`
+  (the `velesdb-memory` and `velesdb-context-optimizer` agent skills, one
+  folder per skill at the archive root) — `curl -L … | tar -xz -C
+  ~/.claude/skills/` installs both without cloning the repo. [EPIC-P-071]
 
 ## [3.12.0] — 2026-07-15
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Agents burn most of their budget re-reading redundant context. The memory layer 
 
 **Compiler surfaces today: MCP server, Node, Rust, and Python** — `compile_context` and its companions ship on every binding (`MemoryService.compile_context` in Python since 0.8.x parity), and MCP covers any other client.
 
+**Install both bundled skills without cloning the repo** — every
+[GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)
+attaches `velesdb-skills.tar.gz` (`velesdb-memory` + `velesdb-context-optimizer`,
+one folder per skill):
+
+```bash
+curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz \
+  | tar -xz -C ~/.claude/skills/
+```
+
 **Quickstart (3 steps):**
 
 ```bash

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -323,6 +323,15 @@ cp -r skills/velesdb-context-optimizer ~/.claude/skills/
 [`skills/velesdb-context-optimizer/SKILL.md`](https://github.com/cyberlife-coder/VelesDB/blob/main/skills/velesdb-context-optimizer/SKILL.md)
 — see [The context compiler tools](#the-context-compiler-tools) below.
 
+**No repo clone needed:** every [GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)
+attaches `velesdb-skills.tar.gz` — both skills, one folder per skill at the
+archive root — so a one-liner installs them straight from the release:
+
+```bash
+curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz \
+  | tar -xz -C ~/.claude/skills/
+```
+
 ## Using the tools
 
 Once configured, your agent discovers the tools automatically (via MCP
@@ -449,10 +458,34 @@ retrieve_context_source { "handle": "ctx://source/1234567890" }
 explain_compilation { "request": { …same request… }, "fragment_id": 1234567890 }
 → { "action": "drop", "rule_id": "drop.duplicate", "reason": "…", "risk": "low", … }
 
+// explain_compilation — byte-identical fragments share a content-addressed
+//   fragment_id, so a plain fragment_id lookup always resolves to the
+//   deduplication survivor. Pass fragment_index (0-based position in
+//   request.fragments) to target one specific fragment instead:
+explain_compilation { "request": { …fragments: [a, a]… }, "fragment_id": 1234567890,
+                       "fragment_index": 1 }
+→ { "action": "drop", "rule_id": "drop.duplicate", … }   // the SECOND "a", not the survivor
+
 // context_savings — aggregate recorded savings, optionally per project
 context_savings { "project": "veles" }
 → { "events": 12, "tokens_in": …, "tokens_saved": …, "truncated": false }
 ```
+
+> **JS clients talking raw MCP (no Node binding): watch `fragment_id` /
+> `content_hash` / `memory_id` precision.** Every id in a `compile_context` or
+> `explain_compilation` response is a `u64`. The [`velesdb-node`
+> binding](https://www.npmjs.com/package/velesdb-node) always crosses ids as
+> decimal strings, so it is unaffected — but a plain MCP client speaking JSON
+> straight over stdio/SSE (no binding in between) gets a JSON *number*, and
+> `JSON.parse` in JS represents that as an IEEE-754 double: ids above
+> `2^53 − 1` (`9007199254740991`) silently lose precision. Set
+> `"policy": { "ids_as_strings": true }` on the request to opt every id field
+> of that response into decimal-string form instead (same rewrite the Node
+> binding applies internally, reused — not reimplemented). Default `false`:
+> existing clients keep today's numeric response unless they opt in.
+> `fragments[].id` on the way IN already accepts either a JSON number or a
+> decimal string, so a caller can resubmit an id it received stringified
+> without converting it back.
 
 Preservation rules (stable ids, first match wins): `preserve.marked_verbatim`,
 `cache.stable_prefix` (cache-marked fragments form a stable prefix for

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -56,8 +56,16 @@ pub enum FidelityRisk {
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub struct ContextFragment {
     /// Caller-side identifier. When absent, the compiler derives a stable
-    /// content-addressed id (see [`super::fragment_id`]).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// content-addressed id (see [`super::fragment_id`]). Accepts a JSON
+    /// number or a decimal string on input (see
+    /// [`super::wire::deserialize_optional_id`]) — a caller that got a
+    /// `fragment_id` back as a string (e.g. under
+    /// [`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::deserialize_optional_id"
+    )]
     pub id: Option<u64>,
     /// The fragment text.
     pub content: String,
@@ -221,6 +229,18 @@ pub struct CompilePolicy {
     /// byte-exact grouping keep it unless they ask. See the crate README's
     /// "Normalizing timestamped logs" section for the exact patterns.
     pub normalize_log_timestamps: bool,
+    /// Wire-compat opt-in for the MCP context tools (`compile_context`,
+    /// `explain_compilation`): when `true`, every [`super::wire::ID_KEYS`]
+    /// field of the RESPONSE (`fragment_id`, `content_hash`, `memory_id`,
+    /// `fragment_ids`) is rewritten into its decimal-string form, through
+    /// the exact same tree walk the Node and WASM bindings already apply on
+    /// every response ([`super::wire::stringify_id_fields`]). A raw MCP
+    /// client — one that talks JSON-RPC directly, without either binding —
+    /// parses ids as JS `number`s (IEEE-754 doubles), which silently lose
+    /// precision above 2^53; string ids round-trip exactly. Default
+    /// `false`: existing MCP clients keep today's byte-identical numeric
+    /// response unless they opt in.
+    pub ids_as_strings: bool,
 }
 
 impl Default for CompilePolicy {
@@ -237,6 +257,7 @@ impl Default for CompilePolicy {
             pricing: None,
             importance: ImportanceWeights::default(),
             normalize_log_timestamps: false,
+            ids_as_strings: false,
         }
     }
 }

--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -125,9 +125,42 @@ pub fn parse_fragment_id_strings(request: &mut Value) -> Result<(), String> {
     Ok(())
 }
 
-fn parse_u64(text: &str) -> Result<u64, String> {
+pub(crate) fn parse_u64(text: &str) -> Result<u64, String> {
     text.parse()
         .map_err(|_| format!("invalid id '{text}' (expected a decimal u64 string)"))
+}
+
+/// Serde `deserialize_with` for [`super::model::ContextFragment::id`]:
+/// accepts either a JSON number or a decimal string, so a caller who
+/// received an id as a string (e.g. echoing back a `fragment_id` handed out
+/// under [`super::model::CompilePolicy::ids_as_strings`], or any client that
+/// serializes `u64` as a JS-safe string by convention) can resubmit it
+/// as-is. Reuses [`parse_u64`] — the same decimal-parsing rule
+/// [`parse_fragment_id_strings`] and [`parse_ids_in`] already apply,
+/// centralized once.
+///
+/// # Errors
+/// Returns a deserialize error if a string value does not parse as a
+/// decimal `u64`.
+pub(crate) fn deserialize_optional_id<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum IdOrString {
+        Id(u64),
+        Text(String),
+    }
+
+    Option::<IdOrString>::deserialize(deserializer)?
+        .map(|value| match value {
+            IdOrString::Id(id) => Ok(id),
+            IdOrString::Text(text) => parse_u64(&text).map_err(serde::de::Error::custom),
+        })
+        .transpose()
 }
 
 #[cfg(test)]

--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -137,28 +137,28 @@ pub(crate) fn parse_u64(text: &str) -> Result<u64, String> {
 /// serializes `u64` as a JS-safe string by convention) can resubmit it
 /// as-is. Reuses [`parse_u64`] — the same decimal-parsing rule
 /// [`parse_fragment_id_strings`] and [`parse_ids_in`] already apply,
-/// centralized once.
+/// centralized once. Matched by hand over a [`Value`] (not an untagged
+/// enum) so a rejected value gets a message naming it and the accepted
+/// forms, instead of serde's opaque "did not match any variant".
 ///
 /// # Errors
-/// Returns a deserialize error if a string value does not parse as a
-/// decimal `u64`.
+/// Returns a deserialize error naming the offending value if it is neither
+/// a `u64` JSON number nor a decimal-`u64` string.
 pub(crate) fn deserialize_optional_id<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
+    use serde::de::Error;
     use serde::Deserialize;
 
-    #[derive(serde::Deserialize)]
-    #[serde(untagged)]
-    enum IdOrString {
-        Id(u64),
-        Text(String),
-    }
-
-    Option::<IdOrString>::deserialize(deserializer)?
+    let expected = "expected a u64 number or a decimal u64 string";
+    Option::<Value>::deserialize(deserializer)?
         .map(|value| match value {
-            IdOrString::Id(id) => Ok(id),
-            IdOrString::Text(text) => parse_u64(&text).map_err(serde::de::Error::custom),
+            Value::Number(number) => number
+                .as_u64()
+                .ok_or_else(|| Error::custom(format!("invalid id {number} ({expected})"))),
+            Value::String(text) => parse_u64(&text).map_err(Error::custom),
+            other => Err(Error::custom(format!("invalid id {other} ({expected})"))),
         })
         .transpose()
 }

--- a/crates/velesdb-memory/src/context/wire_tests.rs
+++ b/crates/velesdb-memory/src/context/wire_tests.rs
@@ -88,3 +88,62 @@ fn round_trip_stringify_then_parse_is_identity_for_id_keys() {
 
     assert_eq!(value, original);
 }
+
+// --- deserialize_optional_id (`ContextFragment.id` on the typed wire) -------
+
+use crate::context::ContextFragment;
+
+#[test]
+fn deserialize_optional_id_accepts_a_json_number() {
+    // The 0.8.0 wire form: a plain JSON number, including full-u64 range.
+    let fragment: ContextFragment = serde_json::from_value(json!({
+        "id": 18_446_744_073_709_551_615u64,
+        "content": "a",
+    }))
+    .expect("numeric ids are the historical wire form and must keep working");
+
+    assert_eq!(fragment.id, Some(u64::MAX));
+}
+
+#[test]
+fn deserialize_optional_id_accepts_a_decimal_string() {
+    let fragment: ContextFragment = serde_json::from_value(json!({
+        "id": "9007199254740993",
+        "content": "a",
+    }))
+    .expect("decimal-string ids are the JS-safe wire form");
+
+    assert_eq!(fragment.id, Some(9_007_199_254_740_993));
+}
+
+#[test]
+fn deserialize_optional_id_rejects_a_non_numeric_string_with_a_clear_message() {
+    let err = serde_json::from_value::<ContextFragment>(json!({
+        "id": "abc",
+        "content": "a",
+    }))
+    .expect_err("a non-numeric id string cannot silently pass");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("abc") && message.contains("u64"),
+        "the error names the offending value and the expected forms, \
+         not an opaque untagged-enum mismatch: {message}"
+    );
+}
+
+#[test]
+fn deserialize_optional_id_rejects_a_non_integer_number_with_a_clear_message() {
+    let err = serde_json::from_value::<ContextFragment>(json!({
+        "id": 1.5,
+        "content": "a",
+    }))
+    .expect_err("a fractional id cannot silently pass");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("1.5") && message.contains("u64"),
+        "the error names the offending value and the expected forms, \
+         not an opaque untagged-enum mismatch: {message}"
+    );
+}

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -10,17 +10,40 @@
 
 use std::sync::Arc;
 
+use rmcp::handler::server::tool::schema_for_output;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::ErrorCode;
 use rmcp::{tool, tool_router, ErrorData};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde_json::Value;
 
 use super::{join_error, to_error, McpServer};
+use crate::context::wire::stringify_id_fields;
 use crate::context::{
     CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextDecision,
     ContextSavings, WorkingContext,
 };
+
+/// Serialize `payload`, opt-in rewriting every id field into decimal-string
+/// form ([`CompilePolicy::ids_as_strings`]) — the shared response-side half
+/// of the wire-compat contract, reused by both `compile_context` and
+/// `explain_compilation` so the id rewrite is expressed exactly once.
+fn to_wire_value<T: serde::Serialize>(
+    payload: &T,
+    ids_as_strings: bool,
+) -> Result<Value, ErrorData> {
+    let mut value = serde_json::to_value(payload).map_err(|err| {
+        ErrorData::internal_error(
+            format!("Failed to serialize structured content: {err}"),
+            None,
+        )
+    })?;
+    if ids_as_strings {
+        stringify_id_fields(&mut value);
+    }
+    Ok(value)
+}
 
 // --- Thin request envelopes --------------------------------------------------
 
@@ -38,8 +61,22 @@ pub(super) struct ExplainCompilationParams {
     /// The compile request to explain (compilation is deterministic, so
     /// re-submitting the request reproduces the exact decisions).
     pub request: CompileRequest,
-    /// The fragment whose decision to return.
+    /// The fragment whose decision to return. Looked up by matching
+    /// `ContextDecision::fragment_id`, UNLESS `fragment_index` is also
+    /// given (see there) — still required even then, since it is the only
+    /// disambiguator when `fragment_index` is absent.
     pub fragment_id: u64,
+    /// Optional, 0-based position of the fragment in `request.fragments`.
+    /// When given, TAKES PRIORITY over `fragment_id` for locating the
+    /// decision: `compile_context` records exactly one decision per input
+    /// fragment, in order, so `decisions[fragment_index]` is unambiguous
+    /// even when several fragments are byte-identical and therefore share
+    /// the same content-addressed `fragment_id` — a plain `fragment_id`
+    /// lookup always returns the FIRST such decision (the deduplication
+    /// survivor), never a dropped twin's. Absent (the default): behavior is
+    /// unchanged, the decision is found by `fragment_id` alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fragment_index: Option<usize>,
 }
 
 /// Input of the `retrieve_context_source` tool.
@@ -106,12 +143,15 @@ pub(super) struct LoadWorkingContextResult {
 impl McpServer {
     #[tool(
         name = "compile_context",
-        description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, and token-savings insights."
+        description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, and token-savings insights. `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
+        output_schema = schema_for_output::<CompiledContext>()
+            .unwrap_or_else(|e| panic!("Invalid output schema for `CompiledContext`: {e}"))
     )]
     async fn compile_context(
         &self,
         Parameters(request): Parameters<CompileRequest>,
-    ) -> Result<Json<CompiledContext>, ErrorData> {
+    ) -> Result<Json<Value>, ErrorData> {
+        let ids_as_strings = request.policy.as_ref().is_some_and(|p| p.ids_as_strings);
         let service = Arc::clone(&self.service);
         let compiled = tokio::task::spawn_blocking(move || {
             service.compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
@@ -119,7 +159,7 @@ impl McpServer {
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(compiled))
+        Ok(Json(to_wire_value(&compiled, ids_as_strings)?))
     }
 
     #[tool(
@@ -141,17 +181,33 @@ impl McpServer {
 
     #[tool(
         name = "explain_compilation",
-        description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was."
+        description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
+        output_schema = schema_for_output::<ContextDecision>()
+            .unwrap_or_else(|e| panic!("Invalid output schema for `ContextDecision`: {e}"))
     )]
     async fn explain_compilation(
         &self,
         Parameters(params): Parameters<ExplainCompilationParams>,
-    ) -> Result<Json<ContextDecision>, ErrorData> {
+    ) -> Result<Json<Value>, ErrorData> {
         let service = Arc::clone(&self.service);
         let ExplainCompilationParams {
             request,
             fragment_id,
+            fragment_index,
         } = params;
+        if let Some(index) = fragment_index {
+            let fragment_count = request.fragments.len();
+            if index >= fragment_count {
+                return Err(ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    format!(
+                        "fragment_index {index} is out of bounds: request.fragments has {fragment_count} entries"
+                    ),
+                    None,
+                ));
+            }
+        }
+        let ids_as_strings = request.policy.as_ref().is_some_and(|p| p.ids_as_strings);
         let compiled = tokio::task::spawn_blocking(move || {
             // Explanation must not re-record an event or re-store sources:
             // it is a read-only question about a deterministic function.
@@ -165,18 +221,25 @@ impl McpServer {
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        compiled
-            .decisions
-            .into_iter()
-            .find(|decision| decision.fragment_id == fragment_id)
-            .map(Json)
-            .ok_or_else(|| {
-                ErrorData::new(
-                    ErrorCode::INVALID_PARAMS,
-                    format!("the request contains no fragment with id {fragment_id}"),
-                    None,
-                )
-            })
+        let decision = if let Some(index) = fragment_index {
+            // Bounds were already validated against `request.fragments`
+            // above; memory-pulled fragments only ever append, so
+            // `compiled.decisions` is at least as long.
+            compiled.decisions.into_iter().nth(index)
+        } else {
+            compiled
+                .decisions
+                .into_iter()
+                .find(|decision| decision.fragment_id == fragment_id)
+        };
+        let decision = decision.ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                format!("the request contains no fragment with id {fragment_id}"),
+                None,
+            )
+        })?;
+        Ok(Json(to_wire_value(&decision, ids_as_strings)?))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -10,16 +10,16 @@
 
 use std::sync::Arc;
 
-use rmcp::handler::server::tool::schema_for_output;
+use rmcp::handler::server::tool::{schema_for_input, schema_for_output};
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::ErrorCode;
+use rmcp::model::{ErrorCode, JsonObject};
 use rmcp::{tool, tool_router, ErrorData};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
 use super::{join_error, to_error, McpServer};
-use crate::context::wire::stringify_id_fields;
+use crate::context::wire::{stringify_id_fields, ID_KEYS};
 use crate::context::{
     CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextDecision,
     ContextSavings, WorkingContext,
@@ -43,6 +43,43 @@ fn to_wire_value<T: serde::Serialize>(
         stringify_id_fields(&mut value);
     }
     Ok(value)
+}
+
+/// The advertised-schema half of the [`CompilePolicy::ids_as_strings`]
+/// contract: the response may carry each [`ID_KEYS`] field as an integer OR
+/// a decimal string, and the official MCP SDKs validate `structuredContent`
+/// against the advertised `outputSchema` (spec 2025-06-18) — so those
+/// fields must be typed `["integer", "string"]`, or every opted-in response
+/// would fail client-side validation for exactly the clients the option
+/// exists for.
+fn wire_safe_output_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
+    let schema = schema_for_output::<T>().unwrap_or_else(|e| {
+        panic!(
+            "Invalid output schema for {}: {e}",
+            std::any::type_name::<T>()
+        )
+    });
+    let mut map = (*schema).clone();
+    crate::schema::widen_id_properties(&mut map, ID_KEYS);
+    Arc::new(map)
+}
+
+/// Input-side counterpart: `fragments[].id` accepts an integer or a decimal
+/// string ([`crate::context::wire::deserialize_optional_id`]), so the
+/// advertised input schema announces both — a client generating requests
+/// from the schema must be able to discover the string form. Scoped to the
+/// `id` property only: `explain_compilation`'s own `fragment_id` parameter
+/// deserializes as a strict `u64` and stays typed `integer`.
+fn wire_safe_input_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
+    let schema = schema_for_input::<Parameters<T>>().unwrap_or_else(|e| {
+        panic!(
+            "Invalid input schema for {}: {e}",
+            std::any::type_name::<T>()
+        )
+    });
+    let mut map = (*schema).clone();
+    crate::schema::widen_id_properties(&mut map, &["id"]);
+    Arc::new(map)
 }
 
 // --- Thin request envelopes --------------------------------------------------
@@ -144,8 +181,8 @@ impl McpServer {
     #[tool(
         name = "compile_context",
         description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, and token-savings insights. `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
-        output_schema = schema_for_output::<CompiledContext>()
-            .unwrap_or_else(|e| panic!("Invalid output schema for `CompiledContext`: {e}"))
+        input_schema = wire_safe_input_schema::<CompileRequest>(),
+        output_schema = wire_safe_output_schema::<CompiledContext>()
     )]
     async fn compile_context(
         &self,
@@ -182,8 +219,8 @@ impl McpServer {
     #[tool(
         name = "explain_compilation",
         description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
-        output_schema = schema_for_output::<ContextDecision>()
-            .unwrap_or_else(|e| panic!("Invalid output schema for `ContextDecision`: {e}"))
+        input_schema = wire_safe_input_schema::<ExplainCompilationParams>(),
+        output_schema = wire_safe_output_schema::<ContextDecision>()
     )]
     async fn explain_compilation(
         &self,

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -43,6 +43,18 @@ fn request(query: &str, fragments: Vec<ContextFragment>, budget: u64) -> Compile
     }
 }
 
+/// `compile_context`/`explain_compilation` now return the wire `Value`
+/// directly (so `policy.ids_as_strings` can rewrite it before it leaves the
+/// process) — deserialize back into the domain type for tests that assert
+/// on typed fields, exactly mirroring what a Rust MCP client would do.
+fn compiled_context_of(value: serde_json::Value) -> CompiledContext {
+    serde_json::from_value(value).expect("valid CompiledContext wire value")
+}
+
+fn decision_of(value: serde_json::Value) -> ContextDecision {
+    serde_json::from_value(value).expect("valid ContextDecision wire value")
+}
+
 #[tokio::test]
 async fn test_compile_context_tool_returns_compiled_context_and_insights() {
     // Given a server and a compile request with a duplicate
@@ -54,10 +66,11 @@ async fn test_compile_context_tool_returns_compiled_context_and_insights() {
     );
 
     // When calling the compile_context tool
-    let Json(out) = srv
+    let Json(value) = srv
         .compile_context(Parameters(req))
         .await
         .expect("compile_context");
+    let out = compiled_context_of(value);
 
     // Then the compiled context carries content, decisions, and insights
     assert!(out.content.contains("a fact"));
@@ -84,10 +97,11 @@ async fn test_compile_context_tool_pulls_memory_scope() {
     });
 
     // When compiling through the tool
-    let Json(out) = srv
+    let Json(value) = srv
         .compile_context(Parameters(req))
         .await
         .expect("compile_context");
+    let out = compiled_context_of(value);
 
     // Then the memory is pulled in with provenance
     assert!(out.content.contains("runs clippy before tests"));
@@ -131,13 +145,15 @@ async fn test_explain_compilation_tool_returns_decision_for_fragment() {
     let wanted = fragment_id("a fact");
 
     // When asking why that fragment was treated the way it was
-    let Json(decision) = srv
+    let Json(value) = srv
         .explain_compilation(Parameters(ExplainCompilationParams {
             request: req,
             fragment_id: wanted,
+            fragment_index: None,
         }))
         .await
         .expect("explain_compilation");
+    let decision = decision_of(value);
 
     // Then the decision is returned with its rule and reason
     assert_eq!(decision.fragment_id, wanted);
@@ -154,6 +170,7 @@ async fn test_explain_compilation_tool_unknown_fragment_is_invalid_params() {
         .explain_compilation(Parameters(ExplainCompilationParams {
             request: req,
             fragment_id: 424_242,
+            fragment_index: None,
         }))
         .await
     else {
@@ -162,16 +179,216 @@ async fn test_explain_compilation_tool_unknown_fragment_is_invalid_params() {
     assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
 }
 
+// --- ids_as_strings (wire-compat, EPIC-P-071 wave 5 / 5.1) -----------------
+
+/// A fragment id above 2^53 — the point where a raw JS `number` (IEEE-754
+/// double) silently loses precision. `2^53 = 9_007_199_254_740_992`.
+const ID_ABOVE_JS_SAFE_INTEGER: u64 = 9_007_199_254_740_993;
+
+#[tokio::test]
+async fn test_compile_context_tool_ids_as_strings_stringifies_response_ids() {
+    // Given a fragment whose caller-supplied id exceeds 2^53
+    let (_dir, srv) = server();
+    let mut fragment = fragment("a fact above the safe integer range");
+    fragment.id = Some(ID_ABOVE_JS_SAFE_INTEGER);
+    let mut req = request("deploy", vec![fragment], 10_000);
+    req.policy = Some(CompilePolicy {
+        ids_as_strings: true,
+        ..CompilePolicy::default()
+    });
+
+    // When compiling with the option active
+    let Json(value) = srv
+        .compile_context(Parameters(req))
+        .await
+        .expect("compile_context");
+
+    // Then every id field on the wire is a decimal string, not a number —
+    // a raw JS client parses this losslessly.
+    let decision_id = &value["decisions"][0]["fragment_id"];
+    assert_eq!(
+        decision_id.as_str(),
+        Some(ID_ABOVE_JS_SAFE_INTEGER.to_string().as_str()),
+        "fragment_id must be a JSON string when ids_as_strings is active: {value}"
+    );
+    assert!(
+        !decision_id.is_number(),
+        "fragment_id must not still be a JSON number: {value}"
+    );
+}
+
+#[tokio::test]
+async fn test_compile_context_tool_ids_as_strings_default_false_is_byte_identical() {
+    // Given the exact same request compiled with the option left at its
+    // default (false) and explicitly set to false
+    let (_dir, srv) = server();
+    let fragment_a = {
+        let mut f = fragment("a fact above the safe integer range");
+        f.id = Some(ID_ABOVE_JS_SAFE_INTEGER);
+        f
+    };
+    let fragment_b = fragment_a.clone();
+    let req_default = request("deploy", vec![fragment_a], 10_000);
+    let mut req_explicit_false = request("deploy", vec![fragment_b], 10_000);
+    req_explicit_false.policy = Some(CompilePolicy {
+        ids_as_strings: false,
+        ..CompilePolicy::default()
+    });
+
+    // When compiling both
+    let Json(default_value) = srv
+        .compile_context(Parameters(req_default))
+        .await
+        .expect("compile_context (default policy)");
+    let Json(explicit_value) = srv
+        .compile_context(Parameters(req_explicit_false))
+        .await
+        .expect("compile_context (ids_as_strings: false)");
+
+    // Then the response keeps ids as JSON numbers, byte-identical either way
+    assert!(default_value["decisions"][0]["fragment_id"].is_number());
+    assert_eq!(default_value, explicit_value);
+}
+
+#[tokio::test]
+async fn test_explain_compilation_tool_ids_as_strings_stringifies_response_ids() {
+    // Given a request whose policy opts into string ids
+    let (_dir, srv) = server();
+    let mut fragment = fragment("a fact above the safe integer range");
+    fragment.id = Some(ID_ABOVE_JS_SAFE_INTEGER);
+    let mut req = request("deploy", vec![fragment], 10_000);
+    req.policy = Some(CompilePolicy {
+        ids_as_strings: true,
+        ..CompilePolicy::default()
+    });
+
+    // When explaining that fragment's decision
+    let Json(value) = srv
+        .explain_compilation(Parameters(ExplainCompilationParams {
+            request: req,
+            fragment_id: ID_ABOVE_JS_SAFE_INTEGER,
+            fragment_index: None,
+        }))
+        .await
+        .expect("explain_compilation");
+
+    // Then fragment_id and content_hash are decimal strings on the wire
+    assert_eq!(
+        value["fragment_id"].as_str(),
+        Some(ID_ABOVE_JS_SAFE_INTEGER.to_string().as_str())
+    );
+    assert!(value["content_hash"].is_string());
+}
+
+#[tokio::test]
+async fn test_compile_context_tool_accepts_fragment_id_as_decimal_string_on_input() {
+    // Given a fragment whose id is supplied as a decimal string (e.g. a
+    // client resubmitting an id it previously received stringified)
+    let (_dir, srv) = server();
+    let mut req_value = serde_json::to_value(request(
+        "deploy",
+        vec![fragment("a fact above the safe integer range")],
+        10_000,
+    ))
+    .expect("serialize request");
+    req_value["fragments"][0]["id"] =
+        serde_json::Value::String(ID_ABOVE_JS_SAFE_INTEGER.to_string());
+    let req: CompileRequest =
+        serde_json::from_value(req_value).expect("fragment id accepts a decimal string");
+
+    // When compiling
+    let Json(value) = srv
+        .compile_context(Parameters(req))
+        .await
+        .expect("compile_context");
+
+    // Then the fragment id round-trips exactly (as a number by default)
+    assert_eq!(
+        value["decisions"][0]["fragment_id"].as_u64(),
+        Some(ID_ABOVE_JS_SAFE_INTEGER)
+    );
+}
+
+// --- fragment_index (positional disambiguation, EPIC-P-071 wave 5 / 5.2) ---
+
+#[tokio::test]
+async fn test_explain_compilation_tool_fragment_index_disambiguates_byte_identical_twins() {
+    // Given two byte-identical fragments (same content ⇒ same
+    // content-addressed fragment_id, since neither sets a caller id)
+    let (_dir, srv) = server();
+    let req = request(
+        "deploy",
+        vec![fragment("duplicate payload"), fragment("duplicate payload")],
+        10_000,
+    );
+    let shared_id = fragment_id("duplicate payload");
+
+    // When asking for the decision by fragment_id alone (today's behavior)
+    let Json(survivor_value) = srv
+        .explain_compilation(Parameters(ExplainCompilationParams {
+            request: req.clone(),
+            fragment_id: shared_id,
+            fragment_index: None,
+        }))
+        .await
+        .expect("explain_compilation (by id)");
+    let survivor = decision_of(survivor_value);
+
+    // And when asking for the SECOND fragment's decision by position
+    let Json(twin_value) = srv
+        .explain_compilation(Parameters(ExplainCompilationParams {
+            request: req,
+            fragment_id: shared_id,
+            fragment_index: Some(1),
+        }))
+        .await
+        .expect("explain_compilation (by index)");
+    let twin = decision_of(twin_value);
+
+    // Then the id-based lookup returns the deduplication survivor (kept,
+    // verbatim), while the positional lookup returns the dropped twin's own
+    // decision — not the same decision.
+    assert!(matches!(survivor.action, ContextAction::Preserve));
+    assert!(matches!(twin.action, ContextAction::Drop));
+    assert_eq!(twin.rule_id, "drop.duplicate");
+    assert_eq!(twin.fragment_id, shared_id);
+}
+
+#[tokio::test]
+async fn test_explain_compilation_tool_fragment_index_out_of_bounds_is_invalid_params() {
+    // Given a request with only one fragment
+    let (_dir, srv) = server();
+    let req = request("deploy", vec![fragment("a fact")], 10_000);
+    let wanted = fragment_id("a fact");
+
+    // When asking for an index beyond the fragment list
+    let Err(err) = srv
+        .explain_compilation(Parameters(ExplainCompilationParams {
+            request: req,
+            fragment_id: wanted,
+            fragment_index: Some(5),
+        }))
+        .await
+    else {
+        panic!("fragment_index 5 has no fragment — the tool must fail");
+    };
+
+    // Then the tool reports an invalid-params error with a clear reason
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("fragment_index"));
+}
+
 #[tokio::test]
 async fn test_retrieve_context_source_tool_round_trips_original() {
     // Given a compiled fragment whose source was stored
     let (_dir, srv) = server();
     let original = "Never restart the primary node during a rebalance.";
     let req = request("rebalance", vec![fragment(original)], 10_000);
-    let Json(out) = srv
+    let Json(value) = srv
         .compile_context(Parameters(req))
         .await
         .expect("compile_context");
+    let out = compiled_context_of(value);
     let handle = out.sources[0].handle.clone();
 
     // When retrieving through the tool

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -309,6 +309,156 @@ async fn test_compile_context_tool_accepts_fragment_id_as_decimal_string_on_inpu
     );
 }
 
+// --- advertised schemas match the ids_as_strings wire contract -------------
+// The official MCP SDKs (TS/Python, spec 2025-06-18) validate a tool's
+// `structuredContent` against its advertised `outputSchema`. If the schema
+// typed the id fields `integer` only, every `ids_as_strings: true` response
+// would fail validation for exactly the clients the option exists for — so
+// the advertised schemas must type each id field `["integer", "string"]`.
+
+/// Recursively collect the type of every property named in `keys` across
+/// the whole schema tree (`$defs` included), resolving array-typed
+/// properties to their `items` type — so the assertions below cover every
+/// occurrence, not just a hand-picked path.
+fn collect_id_property_types(
+    value: &serde_json::Value,
+    keys: &[&str],
+    found: &mut Vec<(String, serde_json::Value)>,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::Object(properties)) = map.get("properties") {
+                for (name, subschema) in properties {
+                    if keys.contains(&name.as_str()) {
+                        let leaf = if subschema.get("type") == Some(&serde_json::json!("array")) {
+                            subschema
+                                .get("items")
+                                .unwrap_or_else(|| panic!("array property {name} declares items"))
+                        } else {
+                            subschema
+                        };
+                        found.push((name.clone(), leaf["type"].clone()));
+                    }
+                }
+            }
+            for entry in map.values() {
+                collect_id_property_types(entry, keys, found);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_id_property_types(item, keys, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Every collected id type must advertise BOTH `integer` and `string`.
+fn assert_ids_widened(found: &[(String, serde_json::Value)]) {
+    for (name, type_value) in found {
+        let types = type_value
+            .as_array()
+            .unwrap_or_else(|| panic!("{name} must type a list of forms, got {type_value}"));
+        assert!(
+            types.contains(&serde_json::json!("integer"))
+                && types.contains(&serde_json::json!("string")),
+            "{name} must advertise integer|string on the wire, got {type_value}"
+        );
+    }
+}
+
+#[test]
+fn test_compile_context_output_schema_advertises_string_ids() {
+    let tool = McpServer::compile_context_tool_attr();
+    let schema = serde_json::to_value(
+        tool.output_schema
+            .expect("compile_context declares an output schema"),
+    )
+    .expect("schema serializes");
+
+    let mut found = Vec::new();
+    collect_id_property_types(&schema, crate::context::wire::ID_KEYS, &mut found);
+
+    let names: std::collections::BTreeSet<&str> =
+        found.iter().map(|(name, _)| name.as_str()).collect();
+    for expected in ["fragment_id", "content_hash", "memory_id", "fragment_ids"] {
+        assert!(
+            names.contains(expected),
+            "the compile_context output schema must carry {expected}; found {names:?}"
+        );
+    }
+    assert_ids_widened(&found);
+}
+
+#[test]
+fn test_explain_compilation_output_schema_advertises_string_ids() {
+    let tool = McpServer::explain_compilation_tool_attr();
+    let schema = serde_json::to_value(
+        tool.output_schema
+            .expect("explain_compilation declares an output schema"),
+    )
+    .expect("schema serializes");
+
+    let mut found = Vec::new();
+    collect_id_property_types(&schema, crate::context::wire::ID_KEYS, &mut found);
+
+    let names: std::collections::BTreeSet<&str> =
+        found.iter().map(|(name, _)| name.as_str()).collect();
+    for expected in ["fragment_id", "content_hash", "memory_id"] {
+        assert!(
+            names.contains(expected),
+            "the explain_compilation output schema must carry {expected}; found {names:?}"
+        );
+    }
+    assert_ids_widened(&found);
+}
+
+#[test]
+fn test_compile_context_input_schema_advertises_string_fragment_id() {
+    // fragments[].id accepts a decimal string on input (see
+    // wire::deserialize_optional_id) — a client generating requests from the
+    // advertised schema must be able to discover that.
+    let tool = McpServer::compile_context_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+
+    let id_type = &schema["$defs"]["ContextFragment"]["properties"]["id"]["type"];
+    let types = id_type
+        .as_array()
+        .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
+    for expected in ["integer", "string", "null"] {
+        assert!(
+            types.contains(&serde_json::json!(expected)),
+            "fragments[].id must advertise {expected} on input, got {id_type}"
+        );
+    }
+}
+
+#[test]
+fn test_explain_compilation_input_schema_keeps_top_level_fragment_id_strict() {
+    // The widening is scoped to fragments[].id: the tool's own fragment_id
+    // parameter is deserialized as a strict u64 (a string is rejected), so
+    // its advertised type must stay integer-only — announcing a string there
+    // would over-promise.
+    let tool = McpServer::explain_compilation_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+
+    assert_eq!(
+        schema["properties"]["fragment_id"]["type"],
+        serde_json::json!("integer"),
+        "top-level fragment_id stays integer-only"
+    );
+    // …while the nested fragments[].id is widened, like compile_context's.
+    let id_type = &schema["$defs"]["ContextFragment"]["properties"]["id"]["type"];
+    let types = id_type
+        .as_array()
+        .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
+    assert!(
+        types.contains(&serde_json::json!("string")),
+        "request.fragments[].id must advertise string on input, got {id_type}"
+    );
+}
+
 // --- fragment_index (positional disambiguation, EPIC-P-071 wave 5 / 5.2) ---
 
 #[tokio::test]

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -37,6 +37,83 @@ fn strip_in_value(value: &mut Value) {
     }
 }
 
+/// Recursively widen every property named in `keys` (resolving the `items`
+/// of array-typed ones) from `integer` to `["integer", "string"]`, across
+/// the whole schema tree — `$defs` included.
+///
+/// The advertised-schema counterpart of the `context::wire` id contract:
+/// under `CompilePolicy::ids_as_strings` a response id field crosses as a
+/// decimal string, and `fragments[].id` accepts one on input — and the
+/// official MCP SDKs validate `structuredContent` against the advertised
+/// `outputSchema` (spec 2025-06-18), so a schema typing those fields
+/// `integer` only would make every opted-in response fail validation for
+/// exactly the clients the option exists for. Same shape of tree walk as
+/// [`strip_int_formats`], but keyed: only the named properties widen.
+///
+/// `mcp`-gated: the advertised tool schemas are its only consumer.
+#[cfg(feature = "mcp")]
+pub(crate) fn widen_id_properties(map: &mut Map<String, Value>, keys: &[&str]) {
+    if let Some(Value::Object(properties)) = map.get_mut("properties") {
+        for (name, subschema) in properties.iter_mut() {
+            if keys.contains(&name.as_str()) {
+                widen_id_schema(subschema);
+            }
+        }
+    }
+    for value in map.values_mut() {
+        widen_in_value(value, keys);
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn widen_in_value(value: &mut Value, keys: &[&str]) {
+    match value {
+        Value::Object(map) => widen_id_properties(map, keys),
+        Value::Array(items) => items.iter_mut().for_each(|item| widen_in_value(item, keys)),
+        _ => {}
+    }
+}
+
+/// Widen one id property's schema: `integer` → `["integer", "string"]`
+/// (keeping any `null` of an optional field), recursing into `items` for an
+/// array of ids. `minimum: 0` may stay — JSON Schema numeric keywords apply
+/// to numbers only, so the string form is unaffected.
+#[cfg(feature = "mcp")]
+fn widen_id_schema(schema: &mut Value) {
+    let Value::Object(map) = schema else {
+        return;
+    };
+    match map.get("type").cloned() {
+        Some(Value::String(kind)) if kind == "integer" => {
+            map.insert(
+                "type".to_owned(),
+                Value::Array(vec![
+                    Value::String("integer".to_owned()),
+                    Value::String("string".to_owned()),
+                ]),
+            );
+        }
+        Some(Value::String(kind)) if kind == "array" => {
+            if let Some(items) = map.get_mut("items") {
+                widen_id_schema(items);
+            }
+        }
+        Some(Value::Array(mut kinds)) => {
+            let has_integer = kinds.iter().any(|kind| kind == "integer");
+            let has_string = kinds.iter().any(|kind| kind == "string");
+            if has_integer && !has_string {
+                let after = kinds
+                    .iter()
+                    .position(|kind| kind == "integer")
+                    .map_or(kinds.len(), |position| position + 1);
+                kinds.insert(after, Value::String("string".to_owned()));
+                map.insert("type".to_owned(), Value::Array(kinds));
+            }
+        }
+        _ => {}
+    }
+}
+
 fn is_rust_int_format(format: &str) -> bool {
     matches!(
         format,


### PR DESCRIPTION
## Summary

Wave 5 (5.1 + 5.2 + 5.3, S each) of the EPIC-P-071 backlog solde:

- **5.1 — wire-safe MCP ids (opt-in strings).** `CompilePolicy.ids_as_strings` (default `false`) rewrites every id field (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`) of the `compile_context` / `explain_compilation` MCP response into a decimal string — reuses the existing `context::wire::stringify_id_fields` tree walk (the exact one Node/WASM already apply), no duplication. Protects a raw MCP JS client (no binding) from silent u64 precision loss above `2^53`. Input side: `fragments[].id` now also accepts a decimal string (in addition to a JSON number), via a shared deserializer reusing `wire::parse_u64`.
- **5.2 — `explain_compilation` positional lookup.** New optional `fragment_index` (0-based position in `request.fragments`), in addition to `fragment_id`. Byte-identical fragments share a content-addressed `fragment_id`, so a plain id lookup always resolves to the deduplication survivor's decision — `fragment_index` disambiguates by position instead. Out-of-bounds index → `INVALID_PARAMS` with a clear reason. Default behavior (no `fragment_index`) is unchanged.
- **5.3 — installable skills bundle.** `.github/workflows/release.yml` gains a `package-skills` job that tars `velesdb-memory` + `velesdb-context-optimizer` (one folder per skill at the archive root) into `velesdb-skills.tar.gz` and attaches it to every GitHub Release, so both skills install with `curl -L .../velesdb-skills.tar.gz | tar -xz -C ~/.claude/skills/` — no repo clone required.

## TDD evidence (red → green)

**5.1** — `test_compile_context_tool_ids_as_strings_stringifies_response_ids`, `test_explain_compilation_tool_ids_as_strings_stringifies_response_ids` (RED before the `ids_as_strings` wiring: stringify was stubbed to a no-op, both failed asserting `fragment_id` was still a JSON number). `test_compile_context_tool_ids_as_strings_default_false_is_byte_identical` pins the inactive case. `test_compile_context_tool_accepts_fragment_id_as_decimal_string_on_input` covers the input side.

**5.2** — `test_explain_compilation_tool_fragment_index_disambiguates_byte_identical_twins` (RED before wiring: `fragment_index` lookup was stubbed to always return `None`, so the call errored instead of returning the dropped twin's decision). `test_explain_compilation_tool_fragment_index_out_of_bounds_is_invalid_params` covers the bounds check.

Both reds captured by temporarily stubbing the new code paths, confirmed failing, then restored — full sequence re-run green (17/17 `mcp::context_tools` tests).

**5.3** — verified locally: staged both skill directories into a temp dir, ran the exact `tar -czf ... -C stage velesdb-memory velesdb-context-optimizer` command from the workflow, extracted into a fresh temp dir, confirmed the structure:
```
velesdb-memory/SKILL.md
velesdb-context-optimizer/SKILL.md
```
YAML validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`. No release triggered (workflow untouched otherwise; `package-skills` only runs on the existing push-tag / `publish_binaries` dispatch gate, same as the binaries job).

## Gates (all green)

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic`
- `cargo clippy -p velesdb-node --lib -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context`
- `cargo test -p velesdb-memory` — 179 unit + 173 BDD/property/doc tests, 0 failed
- `cargo build --release -p velesdb-memory` + `python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py` — OK (6 tools exercised over real stdio)

## Notes / deviations

- `compile_context` / `explain_compilation` now return the wire `Value` directly (instead of `Json<CompiledContext>` / `Json<ContextDecision>`) so the id rewrite can run before serialization completes; the advertised MCP `output_schema` is preserved unchanged via an explicit `output_schema = schema_for_output::<T>()` attribute (byte-identical to what the macro auto-derived before). A handful of existing unit tests were updated to deserialize the returned `Value` back into the typed struct before asserting on fields — same assertions, no behavior change.
- Skill name check: no top-level `skills/velesdb-memory*` exists in this repo — the memory skill lives at `crates/velesdb-memory/skill/velesdb-memory/SKILL.md` (singular `skill/`). The bundle step reads it from that path; `skills/velesdb-context-optimizer/` is unchanged. No `SKILL.md` content was modified, so the two existing copies (`skills/velesdb-context-optimizer` and `crates/velesdb-node/skills/velesdb-context-optimizer`) stay byte-identical, unaffected by this PR.

## Test plan

- [x] `cargo test -p velesdb-memory` green
- [x] `mcp_e2e.py` green against the release-built binary
- [x] tar structure verified locally (one folder per skill at archive root)
- [x] YAML validated
- [ ] CI on this PR (not triggered by this change; branch protection / CI config unaffected)