### PR TITLE
fix(core): traverse_bfs usable on VectorCollection (#1439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,13 @@ account).
   exceed `i64::MAX`). Integers outside `[i64::MIN, u64::MAX]` now raise an
   explicit `ValueError` stating the supported range instead of silently losing
   precision. [EPIC-P-071/US-001]
+- **`VectorCollection::traverse_bfs` is now usable** — edges are a
+  kind-agnostic feature (`add_edge`/`remove_edge`/`get_outgoing_edges` were
+  already shared, see `docs/ARCHITECTURE.md` §F2.2 R1.2c: REST `/relations`
+  and the agent-memory wedge create edges on any collection kind), but BFS
+  traversal was only reachable through `GraphCollection`. `VectorCollection`
+  now exposes `traverse_bfs`, delegating to the same shared edge store as
+  `GraphCollection::traverse_bfs`. (#1439)
 
 ## [3.12.0] — 2026-07-15
 

--- a/crates/velesdb-core/src/collection/vector_collection/crud.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/crud.rs
@@ -179,4 +179,24 @@ impl VectorCollection {
     pub fn edge_exists(&self, edge_id: u64) -> bool {
         self.inner.edge_exists(edge_id)
     }
+
+    /// Performs BFS traversal from a source node over the collection's
+    /// shared edge store.
+    ///
+    /// Edges are a first-class, kind-agnostic feature (see
+    /// [`Self::add_edge`] and `docs/ARCHITECTURE.md` §F2.2 R1.2c): they can
+    /// be created on any collection kind via REST `/relations` or the
+    /// agent-memory wedge (`velesdb-memory`), so traversal must be reachable
+    /// from `VectorCollection` too — mirroring
+    /// [`GraphCollection::traverse_bfs`](crate::GraphCollection::traverse_bfs).
+    ///
+    /// Traversal that finds nothing reachable returns an empty `Vec`.
+    #[must_use]
+    pub fn traverse_bfs(
+        &self,
+        source_id: u64,
+        config: &crate::collection::TraversalConfig,
+    ) -> Vec<crate::collection::TraversalResult> {
+        self.inner.traverse_bfs_config(source_id, config)
+    }
 }

--- a/crates/velesdb-core/src/collection/vector_collection/mod.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/mod.rs
@@ -10,6 +10,8 @@ mod lifecycle;
 mod search;
 #[cfg(test)]
 mod search_tests;
+#[cfg(test)]
+mod traverse_tests;
 
 use crate::collection::types::Collection;
 

--- a/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
@@ -1,0 +1,82 @@
+//! Tests for `VectorCollection::traverse_bfs` (issue #1439).
+//!
+//! `VectorCollection` shares its edge store with `GraphCollection` and
+//! `MetadataCollection` (docs/ARCHITECTURE.md F2.2, R1.2c): edges created via
+//! REST `/relations` or the agent-memory wedge (`velesdb-memory`) land on the
+//! backing `Collection`'s edge store regardless of the newtype used to reach
+//! it. `traverse_bfs` must therefore be usable on a `VectorCollection`,
+//! mirroring the already-shared edge primitives (`add_edge`, `remove_edge`,
+//! `get_outgoing_edges` — `collection/vector_collection/crud.rs`).
+
+use tempfile::TempDir;
+
+use crate::collection::graph::{GraphEdge, TraversalConfig};
+use crate::distance::DistanceMetric;
+use crate::quantization::StorageMode;
+use crate::VectorCollection;
+
+/// Creates a 4-dim `VectorCollection` backed by a temporary directory.
+fn create_test_vc() -> (VectorCollection, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("test_coll");
+    let coll = VectorCollection::create(path, "test", 4, DistanceMetric::Cosine, StorageMode::Full)
+        .unwrap();
+    (coll, dir)
+}
+
+#[test]
+fn test_traverse_bfs_reaches_edges_added_via_shared_edge_store() {
+    let (coll, _dir) = create_test_vc();
+
+    // Same path REST `/relations` and the memory wedge use: `add_edge`
+    // delegates to the shared `Collection` edge store.
+    coll.add_edge(GraphEdge::new(1, 1, 2, "KNOWS").unwrap())
+        .unwrap();
+    coll.add_edge(GraphEdge::new(2, 2, 3, "KNOWS").unwrap())
+        .unwrap();
+
+    let config = TraversalConfig {
+        max_depth: 3,
+        min_depth: 1,
+        ..TraversalConfig::default()
+    };
+    let results = coll.traverse_bfs(1, &config);
+
+    let target_ids: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
+    assert!(target_ids.contains(&2), "should reach node 2 at depth 1");
+    assert!(target_ids.contains(&3), "should reach node 3 at depth 2");
+}
+
+#[test]
+fn test_traverse_bfs_respects_max_depth_on_vector_collection() {
+    let (coll, _dir) = create_test_vc();
+
+    coll.add_edge(GraphEdge::new(1, 1, 2, "KNOWS").unwrap())
+        .unwrap();
+    coll.add_edge(GraphEdge::new(2, 2, 3, "KNOWS").unwrap())
+        .unwrap();
+
+    let config = TraversalConfig {
+        max_depth: 1,
+        min_depth: 1,
+        ..TraversalConfig::default()
+    };
+    let results = coll.traverse_bfs(1, &config);
+
+    let target_ids: std::collections::HashSet<u64> = results.iter().map(|r| r.target_id).collect();
+    assert!(target_ids.contains(&2));
+    assert!(
+        !target_ids.contains(&3),
+        "max_depth=1 should stop before node 3"
+    );
+}
+
+#[test]
+fn test_traverse_bfs_on_vector_collection_with_no_edges_returns_empty() {
+    let (coll, _dir) = create_test_vc();
+
+    let config = TraversalConfig::default();
+    let results = coll.traverse_bfs(1, &config);
+
+    assert!(results.is_empty());
+}


### PR DESCRIPTION
Closes #1439 (Wave 5, item 5.4).

## Diagnostic (root cause)

`traverse_bfs` exists at three layers, but the `VectorCollection` newtype never re-exported it:

- **Backing store** — `Collection::traverse_bfs` / `traverse_bfs_config` live in `crates/velesdb-core/src/collection/core/graph_api.rs` and operate on the shared `Arc<GraphStore>` edge store (R1.2b), which is kind-agnostic.
- **GraphCollection** — `crates/velesdb-core/src/collection/graph_collection.rs:314` delegates `traverse_bfs(source_id, &TraversalConfig)` to `inner.traverse_bfs_config`.
- **VectorCollection** — `crates/velesdb-core/src/collection/vector_collection/crud.rs` already re-exports the shared edge *write/read* primitives (`add_edge`, `remove_edge`, `get_outgoing_edges`, `max_edge_id`, `edge_exists` — kept shared by design, R1.2c in `docs/ARCHITECTURE.md` §F2.2), **but not the traversal**. There is no kind gating and no signature obstacle — the delegation was simply never added.

Net effect: edges are legitimately created on vector collections (REST `POST /collections/{name}/relations` works on any kind — `crates/velesdb-server/src/handlers/points/relations.rs`; the agent-memory wedge does the same — `crates/velesdb-memory/src/service.rs:317`), yet the exported `traverse_bfs` API was unreachable from the primary kind. The REST `/graph/traverse` endpoint even returns **409** for vector collections (`graph_preamble` → `get_graph_collection_or_404`), so there was no path at all to traverse edges held by a `VectorCollection` short of re-wrapping the store by hand.

## Fix (minimal, consistent with F2.2)

Add `VectorCollection::traverse_bfs(source_id, &TraversalConfig) -> Vec<TraversalResult>` delegating to `inner.traverse_bfs_config` — the exact pattern and signature of `GraphCollection::traverse_bfs`, placed next to the other shared edge primitives in `vector_collection/crud.rs`. No refactor, no new dependency, no behavior change anywhere else.

## TDD — RED → GREEN

New separate test file `crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs` (modeled on the existing graph tests): creates a `VectorCollection`, adds edges through the same `add_edge` path REST `/relations` uses, asserts BFS reach, `max_depth`, and empty-graph behavior.

**Captured RED** (before the fix — the method did not exist):

```
error[E0599]: no method named `traverse_bfs` found for struct `VectorCollection` in the current scope
  --> crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs:44:24
   |
44 |     let results = coll.traverse_bfs(1, &config);
   |                        ^^^^^^^^^^^^ method not found in `VectorCollection`
```

**GREEN** (after the one-method delegation):

```
test collection::vector_collection::traverse_tests::test_traverse_bfs_on_vector_collection_with_no_edges_returns_empty ... ok
test collection::vector_collection::traverse_tests::test_traverse_bfs_reaches_edges_added_via_shared_edge_store ... ok
test collection::vector_collection::traverse_tests::test_traverse_bfs_respects_max_depth_on_vector_collection ... ok
test result: ok. 25 passed; 0 failed  (all pre-existing traverse_bfs tests still green)
```

## Gates

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` — clean
- `cargo test -p velesdb-core --features persistence -- --test-threads=1` — full suite green
- `cargo test -p velesdb-memory` — green (wedge non-regression; the memory service creates edges on a vector-backed store)
- `cargo check -p velesdb-core --no-default-features` — clean. Note: workspace-wide `cargo check --no-default-features` fails in `velesdb-server` (feature-gated `apply_advanced_config` arity + `prometheus` module) — verified **identical on baseline `b9eb2ded`** via `git stash`; pre-existing and unrelated to this change.
- CHANGELOG root `[Unreleased]` → `Fixed` entry referencing #1439.

## Surfaces checked (parity)

- **REST**: `/graph/traverse` is gated on graph-kind by `graph_preamble` (409 on vector kind). Opening it to all kinds is a REST semantics change (contract + OpenAPI + 409 test updates) — out of scope for this minimal core fix; left documented here as follow-up material.
- **Python**: `traverse_bfs` is only exposed on `PyGraphCollection` (`crates/velesdb-python/src/graph_collection.rs`); the vector-facing `collection/` module exposes no edge ops at all, so nothing breaks and there is no trivial single-method delegation to add without also adding the edge primitives — follow-up if wanted.
- **Node / WASM**: no vector-collection `traverse_bfs` surface exists (`velesdb-wasm` exposes traversal only via its graph wrappers; `velesdb-node` is the memory SDK) — nothing to break.
