### PR TITLE
docs(node): the REST server is the full-engine path — wedge boundary made explicit [EPIC-P-071]

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Memories are permanent by default; `forget(id)` deletes one, and `remember(…, 
 
 The same wedge ships in **Python** (`pip install velesdb`), **Node** (`npm i @wiscale/velesdb-memory-node`), as a local **[MCP server](crates/velesdb-memory)**, and — in-memory only, no disk access under WASM — in the **[TypeScript SDK](sdks/typescript)** (`npm i @wiscale/velesdb-sdk`), running entirely in the browser or Node.js with no server.
 
+For Node/TypeScript: `@wiscale/velesdb-memory-node` is memory-semantics-only by license design ([why](crates/velesdb-node/README.md#need-the-full-engine)); the full engine (VelesQL, deep `MATCH`, administration) is reached from Node/TS via `velesdb-server` + the [TypeScript SDK](sdks/typescript)'s REST backend.
+
 **Four runnable ways to see it** — each shows what plain vector recall misses and `why()` recovers:
 
 | Demo | What it shows |

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -106,6 +106,50 @@ it into your agent's skills directory:
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
 ```
 
+## Need the full engine?
+
+This addon is the **memory wedge**: `remember` / `recall` / `relate` /
+`forget` / `why` / `compileContext` — memory semantics only, by design (see
+[License](#license) below). It does not expose raw VelesQL, deep graph
+`MATCH`, collection administration, or any other database-shaped capability —
+that would cross the
+[`VelesDB Core License 1.0`](https://github.com/cyberlife-coder/VelesDB/blob/develop/LICENSE)
+§1 "Substantial Set" line.
+
+For the full engine (VelesQL, multi-hop `MATCH`, collection/index
+administration) from Node/TypeScript, run the REST server and talk to it with
+[`@wiscale/velesdb-sdk`](https://www.npmjs.com/package/@wiscale/velesdb-sdk)
+instead:
+
+```bash
+# 1. Start the server (from source, or `cargo install velesdb-server`)
+velesdb-server --port 8080
+```
+
+```typescript
+// 2. Point the TypeScript SDK's REST backend at it.
+import { VelesDB } from '@wiscale/velesdb-sdk';
+
+const db = new VelesDB({ backend: 'rest', url: 'http://localhost:8080' });
+await db.init();
+
+await db.createCollection('docs', { dimension: 4, metric: 'cosine' });
+await db.upsert('docs', { id: 1, vector: [0.1, 0.2, 0.3, 0.4], payload: { title: 'Hello' } });
+
+// Raw VelesQL — not available through this wedge.
+const result = await db.query(
+  'docs',
+  'SELECT * FROM docs WHERE VECTOR NEAR $v LIMIT 5',
+  { v: [0.1, 0.2, 0.3, 0.4] },
+);
+```
+
+See the
+[server README](https://github.com/cyberlife-coder/VelesDB/blob/develop/crates/velesdb-server/README.md)
+for the full REST API (VelesQL, graph `MATCH`, auth, TLS) and the
+[TypeScript SDK README](https://github.com/cyberlife-coder/VelesDB/blob/develop/sdks/typescript/README.md)
+for the REST-backend client surface.
+
 ## License
 
 VelesDB Core License 1.0 (based on ELv2). See [LICENSE](./LICENSE). This addon

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -190,6 +190,15 @@ const results = await db.search('products', queryVector, { k: 10 });
 > are accepted for backward compatibility but are deprecated and will be removed
 > in a future major version. Always target `/v1/` in custom HTTP clients.
 
+> **This is the full-engine path.** If you came from
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node)
+> (the in-process agent-memory wedge — `remember`/`recall`/`relate`/`forget`/`why`/`compileContext`
+> only, by license design) and need raw VelesQL, multi-hop `MATCH`, or collection
+> administration, this REST backend against a running
+> [`velesdb-server`](https://github.com/cyberlife-coder/VelesDB/blob/develop/crates/velesdb-server/README.md)
+> is the way to reach it from Node/TypeScript — see `db.query()` under
+> [VelesQL Queries](#velesql-queries) below.
+
 ## Embedding helper
 
 The SDK ships an optional `OpenAIEmbedder` so you can turn text into vectors without


### PR DESCRIPTION
## Summary
- `@wiscale/velesdb-memory-node` exposes memory semantics only (`remember`/`recall`/`relate`/`forget`/`why`/`compileContext`), by VelesDB Core License 1.0 design (§1 "Substantial Set") — not a gap, a deliberate wedge boundary.
- Adds a "Need the full engine?" section to the Node README documenting what the wedge covers/doesn't and the verified path to the full engine (VelesQL, deep `MATCH`, administration) from Node/TypeScript: run `velesdb-server`, talk to it with `@wiscale/velesdb-sdk`'s REST backend.
- Cross-links the boundary from the TypeScript SDK README's REST-backend section, and states it in one sentence in the root README's Node/bindings paragraph.

## Test plan
- [x] Ran `target/debug/velesdb-server --port 18099` locally and hit `/health` + `/ready`.
- [x] Executed the exact copy-pasted example from the new Node README section against that server via the built `sdks/typescript/dist` package (REST backend, `createCollection` → `upsert` → `db.query('SELECT * FROM docs WHERE VECTOR NEAR $v LIMIT 5', ...)`) — returned the expected result.
- [x] Grepped for existing "full engine" / "REST" / "not supported" caveats across the touched READMEs to confirm no contradiction with the new section.
- [x] Verified all new cross-repo links resolve to real files/anchors (GitHub-slug checked for the new `## Need the full engine?` heading) and used absolute `github.com/.../develop/...` URLs for anything outside each package's published `files` list (matches the existing npm-safe-link convention already used in `crates/velesdb-python/README.md` and this file).

Not merging — for review first.