### PR TITLE
feat(memory): media fragments — atomic packing, byte dedup, image token cost [EPIC-P-071/US-009]

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Media fragments (experimental, PR1/3 of US-009 in EPIC-P-071)** —
+  `ContextFragment.media: Option<MediaRef>` lets a fragment carry an inline
+  base64-encoded image (`mime` + `bytes_b64`) alongside its text/caption
+  `content`. A media fragment packs as one atomic, unsplittable piece (never
+  chunked mid-image), is deduplicated on its *raw decoded bytes* (never the
+  caption text, and never near-duplicated), and its token cost comes from a
+  new dependency-free `ImageTokenEstimator` (PNG/JPEG header dimensions,
+  `ceil(width * height / 750)`; unsupported mimes or unreadable headers fall
+  back to a safe text-based over-count). Capped at 4 MiB of base64
+  (`limits::MAX_MEDIA_BYTES`), separate from the existing per-fragment text
+  cap; malformed base64 is rejected at validation time. PR1 ships no binary
+  retrieval store: a media fragment that cannot fit the budget is `drop`ped
+  with an explicit reason (`drop.media_unavailable`) rather than handed a
+  `ctx://source` handle that would not resolve — externalized-media storage,
+  screenshot expiry, and the Node/WASM/wire surface land in a later PR. Wire-
+  compatible: `media` is `#[serde(default)]`, so every existing request still
+  deserializes unchanged.
+
 ## [0.6.0] - 2026-07-06
 
 ### Changed

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -617,6 +617,35 @@ so an audit trail always shows *why* a log collapsed the way it did. Off by
 default: it changes what "duplicate" means for logs, so existing callers
 keep byte-exact grouping unless they opt in.
 
+#### Media fragments (experimental, PR1/3)
+
+A fragment may carry an inline image alongside its text: set
+`media: {"mime": "image/png", "bytes_b64": "<base64>"}` on a
+`ContextFragment`; `content` stays the caption (often empty for a bare
+screenshot). This is **PR1 of 3** for media support — honest about what it
+does and does not do yet:
+
+- **Atomic packing**: a media fragment is never chunked — it packs whole
+  under the budget or not at all, so an image can never be cut mid-stream.
+- **Token cost from the image itself**, not its base64 text: PNG/JPEG
+  dimensions are sniffed from the header (`ceil(width * height / 750)`, a
+  published Claude image-token constant); an unsupported mime or an
+  unreadable header falls back to a safe over-count of the base64 text.
+- **Dedup on raw bytes**: two fragments with byte-identical decoded media
+  are deduplicated regardless of their caption text (screenshots are often
+  captionless, so caption-text dedup would false-positive on "" == "").
+  Media is never near-duplicated.
+- **Capped at 4 MiB of base64** (`limits::MAX_MEDIA_BYTES`, ≈3 MiB decoded),
+  independent of the text-content cap; malformed base64 is rejected at
+  validation.
+- **No binary retrieval store yet.** A media fragment that does not fit the
+  budget is `drop`ped with an explicit reason
+  (`decision.rule_id == "drop.media_unavailable"`) instead of being handed a
+  `ctx://source/` handle — PR1 has nowhere to persist the bytes behind such a
+  handle, so it does not pretend one exists. Externalized-media storage,
+  screenshot expiry, and the Node/WASM/wire surface are **not yet built**;
+  they land in PR2/PR3.
+
 #### Source TTL & disk growth
 
 `policy.source_ttl_seconds` (`None` by default) controls how long a

--- a/crates/velesdb-memory/benches/context_compiler_benchmark.rs
+++ b/crates/velesdb-memory/benches/context_compiler_benchmark.rs
@@ -45,6 +45,7 @@ fn plain_fragments(n: usize) -> Vec<ContextFragment> {
             kind: None,
             priority: None,
             metadata: None,
+            media: None,
         })
         .collect()
 }
@@ -61,6 +62,7 @@ fn duplicate_heavy_fragments(n: usize) -> Vec<ContextFragment> {
                 kind: None,
                 priority: None,
                 metadata: None,
+                media: None,
             }
         })
         .collect()
@@ -140,6 +142,7 @@ fn bench_oversized_fragment(c: &mut Criterion) {
                 kind: None,
                 priority: None,
                 metadata: None,
+                media: None,
             }],
             budget,
         );

--- a/crates/velesdb-memory/examples/context_savings/main.rs
+++ b/crates/velesdb-memory/examples/context_savings/main.rs
@@ -106,6 +106,7 @@ fn to_fragments(fixtures: &[Fixture]) -> Vec<ContextFragment> {
             kind: fixture.kind.map(str::to_owned),
             priority: None,
             metadata: None,
+            media: None,
         })
         .collect()
 }

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -364,10 +364,18 @@ fn validate(request: &CompileRequest, policy: &CompilePolicy) -> Result<u64, Mem
 /// payload never reaches the pipeline (fail fast, same `INVALID_PARAMS`
 /// shape as every other cap in [`validate`]).
 fn validate_media(fragments: &[ContextFragment]) -> Result<(), MemoryError> {
+    let mut total_media_bytes: usize = 0;
     for (seq, fragment) in fragments.iter().enumerate() {
         let Some(media_ref) = &fragment.media else {
             continue;
         };
+        total_media_bytes = total_media_bytes.saturating_add(media_ref.bytes_b64.len());
+        if total_media_bytes > limits::MAX_TOTAL_MEDIA_BYTES {
+            return Err(MemoryError::ContextOverLimit(format!(
+                "total media payload exceeds the request cap of {} base64 bytes",
+                limits::MAX_TOTAL_MEDIA_BYTES
+            )));
+        }
         if media_ref.bytes_b64.len() > limits::MAX_MEDIA_BYTES {
             return Err(MemoryError::ContextOverLimit(format!(
                 "fragment #{seq} media payload of {} base64 bytes exceeds the cap of {} bytes",
@@ -692,14 +700,26 @@ fn dup_verdict(
     };
     let twin_full = emissions.get(&twin.seq).is_some_and(Emission::is_full);
     if twin_full {
+        // Media dedup keys on the image bytes alone: the twin carries the
+        // image, but a caption that differs from the twin's does NOT
+        // survive — say so instead of claiming full survival.
+        let caption_diverges = analysis.media.is_some() && analysis.original != twin.original;
+        let reason = if caption_diverges {
+            format!(
+                "{variant} of fragment #{} — image survives through it; this fragment's differing caption does not",
+                dup.kept_seq
+            )
+        } else {
+            format!(
+                "{variant} of fragment #{} — content survives through it",
+                dup.kept_seq
+            )
+        };
         return (
             ContextAction::Drop,
             rule_id.to_owned(),
             FidelityRisk::Low,
-            format!(
-                "{variant} of fragment #{} — content survives through it",
-                dup.kept_seq
-            ),
+            reason,
             Some(provenance::handle_for(analysis.content_hash)),
         );
     }

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -36,6 +36,7 @@ mod dedup;
 pub mod estimator;
 pub mod insights;
 mod log_normalize;
+mod media;
 pub mod model;
 pub(crate) mod provenance;
 mod relevance;
@@ -50,8 +51,8 @@ pub use insights::{CompilationInsights, ModelPricing, PricingTable};
 pub use model::{
     CompilePolicy, CompileRequest, CompiledContext, CompiledSection, ContextAction,
     ContextDecision, ContextDecisionRef, ContextFact, ContextFragment, ContextSavings,
-    FidelityRisk, ImportanceWeights, MemoryScope, RetrievalHandle, SectionKind, SourceReference,
-    WorkingContext,
+    FidelityRisk, ImportanceWeights, MediaRef, MemoryScope, RetrievalHandle, SectionKind,
+    SourceReference, WorkingContext,
 };
 pub use relevance::DeterministicReranker;
 
@@ -91,6 +92,7 @@ pub fn fragment_id(content: &str) -> u64 {
 ///             kind: None,
 ///             priority: None,
 ///             metadata: None,
+///             media: None,
 ///         }],
 ///         project: None,
 ///         target_model: None,
@@ -210,7 +212,20 @@ impl ContextCompiler {
             .iter()
             .map(|analysis| analysis.tokens)
             .fold(0, u64::saturating_add);
-        let tokens_out = estimator.estimate(content);
+        // `content` already carries every emitted fragment's TEXT — for a
+        // media fragment (US-009, PR1) that means its caption only, since
+        // raw media bytes are never turned into packed text (see `pieces`).
+        // The image's own cost has to be added on top, but only for media
+        // that actually made it into the output (an emissions entry exists)
+        // — a dropped image (see `media_unavailable_verdict`) contributed
+        // nothing and must not appear here either.
+        let media_tokens_out: u64 = analyses
+            .iter()
+            .filter(|analysis| emissions.contains_key(&analysis.seq))
+            .filter_map(|analysis| analysis.media.as_ref())
+            .map(|media| media.image_tokens)
+            .fold(0, u64::saturating_add);
+        let tokens_out = estimator.estimate(content).saturating_add(media_tokens_out);
         let tokens_saved = tokens_in.saturating_sub(tokens_out);
         let mut insights = CompilationInsights {
             tokens_in,
@@ -271,6 +286,26 @@ struct Analysis<'a> {
     /// grouping (ventilated into the decision `reason`). Computed once here
     /// so [`pieces`] and [`decision`] never redo the line-scan.
     abstract_collapse: Option<(String, bool)>,
+    /// Set when the fragment carries inline media (US-009, PR1): its
+    /// dedup identity and precomputed image token cost, computed once here
+    /// (decoding is not free) and reused by dedup, packing, and insights.
+    media: Option<media::MediaAnalysis>,
+}
+
+/// A media fragment's total precomputed token cost: the image alone (from
+/// [`media::MediaAnalysis::image_tokens`]) plus its caption's own (usually
+/// tiny, often zero for a blank caption) text cost. Shared by [`analyze`]
+/// (feeds [`Analysis::tokens`]) and [`pieces`] (feeds the packed piece's
+/// cost) so the two can never drift apart — the same total is what gets
+/// budgeted and what gets reported as "emitted" once packed.
+fn media_fragment_tokens(
+    media: &media::MediaAnalysis,
+    caption: &str,
+    estimator: &dyn TokenEstimator,
+) -> u64 {
+    media
+        .image_tokens
+        .saturating_add(estimator.estimate(caption))
 }
 
 /// What actually got emitted for one packed fragment.
@@ -311,6 +346,7 @@ fn validate(request: &CompileRequest, policy: &CompilePolicy) -> Result<u64, Mem
             limits::MAX_FRAGMENT_BYTES
         )));
     }
+    validate_media(&request.fragments)?;
     let budget = limits::clamp_token_budget(request.token_budget);
     let usable = budget.saturating_sub(policy.response_reserve_tokens);
     if usable == 0 {
@@ -320,6 +356,32 @@ fn validate(request: &CompileRequest, policy: &CompilePolicy) -> Result<u64, Mem
         });
     }
     Ok(usable)
+}
+
+/// Reject a fragment whose media payload violates
+/// [`limits::MAX_MEDIA_BYTES`] or is not well-formed base64 — checked eagerly
+/// here, before any decoding/hashing/estimation downstream, so a malformed
+/// payload never reaches the pipeline (fail fast, same `INVALID_PARAMS`
+/// shape as every other cap in [`validate`]).
+fn validate_media(fragments: &[ContextFragment]) -> Result<(), MemoryError> {
+    for (seq, fragment) in fragments.iter().enumerate() {
+        let Some(media_ref) = &fragment.media else {
+            continue;
+        };
+        if media_ref.bytes_b64.len() > limits::MAX_MEDIA_BYTES {
+            return Err(MemoryError::ContextOverLimit(format!(
+                "fragment #{seq} media payload of {} base64 bytes exceeds the cap of {} bytes",
+                media_ref.bytes_b64.len(),
+                limits::MAX_MEDIA_BYTES
+            )));
+        }
+        if !media::is_valid_base64(&media_ref.bytes_b64) {
+            return Err(MemoryError::ContextOverLimit(format!(
+                "fragment #{seq} media payload is not valid base64"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Run classification, relevance scoring, and duplicate detection over the
@@ -334,14 +396,27 @@ fn analyze<'a>(
         .iter()
         .map(|fragment| fragment.content.as_str())
         .collect();
-    let duplicates = dedup::find_duplicates(&contents, policy.near_dup_dedup);
+    // Decode/analyze media exactly once per fragment (decoding is not
+    // free), reused below both to feed dedup's media namespace and to build
+    // each Analysis's own `media` field.
+    let media_analyses: Vec<Option<media::MediaAnalysis>> = request
+        .fragments
+        .iter()
+        .map(|fragment| fragment.media.as_ref().map(media::analyze))
+        .collect();
+    let media_hashes: Vec<Option<u64>> = media_analyses
+        .iter()
+        .map(|analysis| analysis.as_ref().map(|analysis| analysis.raw_hash))
+        .collect();
+    let duplicates = dedup::find_duplicates(&contents, policy.near_dup_dedup, &media_hashes);
     let query_terms = relevance::terms(&request.query);
     let mut analyses: Vec<Analysis<'a>> = request
         .fragments
         .iter()
         .zip(duplicates)
+        .zip(media_analyses)
         .enumerate()
-        .map(|(seq, (fragment, dup))| {
+        .map(|(seq, ((fragment, dup), media_analysis))| {
             let content_hash = stable_id(&fragment.content);
             let rule = classify::classify(fragment, policy);
             let abstract_collapse = (rule.action == ContextAction::Abstract).then(|| {
@@ -350,17 +425,22 @@ fn analyze<'a>(
                     policy.normalize_log_timestamps,
                 )
             });
+            let tokens = media_analysis.as_ref().map_or_else(
+                || estimator.estimate(&fragment.content),
+                |media| media_fragment_tokens(media, &fragment.content, estimator),
+            );
             Analysis {
                 seq,
                 fragment_id: fragment.id.unwrap_or(content_hash),
                 content_hash,
                 original: &fragment.content,
-                tokens: estimator.estimate(&fragment.content),
+                tokens,
                 rule,
                 relevance: relevance::lexical_relevance(&query_terms, &fragment.content),
                 priority: fragment.priority.unwrap_or(0),
                 dup,
                 abstract_collapse,
+                media: media_analysis,
             }
         })
         .collect();
@@ -407,19 +487,45 @@ fn pack_items(
             critical: analysis.rule.critical,
             priority: analysis.priority,
             relevance: analysis.relevance,
-            pieces: pieces(analysis, &chunk_policy),
+            pieces: pieces(analysis, &chunk_policy, estimator),
         })
         .collect()
 }
 
 /// The emission pieces of one fragment.
-fn pieces(analysis: &Analysis, chunk_policy: &ChunkPolicy) -> Vec<String> {
+///
+/// A media fragment (US-009, PR1) is always exactly one atomic, all-or-
+/// nothing piece — never passed to [`chunk_text`], mirroring the
+/// `abstract.log_dedup` case below: packing can take it whole or not at all,
+/// never a byte-range prefix, so an image can never be cut mid-stream. Its
+/// text is only the caption (raw media bytes never become packable "piece"
+/// text); its cost is the precomputed [`media_fragment_tokens`] total, so
+/// packing never re-derives a media fragment's cost from `estimator.estimate`
+/// over an empty or near-empty caption.
+fn pieces(
+    analysis: &Analysis,
+    chunk_policy: &ChunkPolicy,
+    estimator: &dyn TokenEstimator,
+) -> Vec<budget::Piece> {
+    if let Some(media) = &analysis.media {
+        let cost = media_fragment_tokens(media, analysis.original, estimator);
+        return vec![budget::Piece {
+            text: analysis.original.to_owned(),
+            cost: Some(cost),
+        }];
+    }
     if let Some((collapsed, _normalized)) = &analysis.abstract_collapse {
-        return vec![collapsed.clone()];
+        return vec![budget::Piece {
+            text: collapsed.clone(),
+            cost: None,
+        }];
     }
     chunk_text(analysis.original, chunk_policy)
         .into_iter()
-        .map(|chunk| chunk.text)
+        .map(|chunk| budget::Piece {
+            text: chunk.text,
+            cost: None,
+        })
         .collect()
 }
 
@@ -475,7 +581,10 @@ fn emissions(items: &[PackItem], taken: &[usize]) -> BTreeMap<usize, Emission> {
             (
                 item.seq,
                 Emission {
-                    text: item.pieces[..count].concat(),
+                    text: item.pieces[..count]
+                        .iter()
+                        .map(|piece| piece.text.as_str())
+                        .collect(),
                     taken: count,
                     total: item.pieces.len(),
                 },
@@ -529,6 +638,13 @@ fn decision(
         (Some(dup), _) => dup_verdict(analysis, *dup, &all[dup.kept_seq], emissions),
         (None, Some(emission)) if emission.is_full() => full_verdict(analysis),
         (None, Some(emission)) => partial_verdict(analysis, emission),
+        // A media fragment's single atomic piece is always taken whole or
+        // not at all (see `pieces`), so a missing emission for one means
+        // "did not fit" — never "took none of what was offered" from a
+        // multi-piece fragment. PR1 has no binary retrieval store, so
+        // externalizing it behind a `ctx://source` handle would promise a
+        // fetch that cannot succeed; drop it instead, honestly.
+        (None, None) if analysis.media.is_some() => media_unavailable_verdict(analysis),
         (None, None) => externalized_verdict(analysis),
     };
     ContextDecision {
@@ -575,20 +691,65 @@ fn dup_verdict(
         DupKind::Near => ("drop.near_duplicate", "near-duplicate"),
     };
     let twin_full = emissions.get(&twin.seq).is_some_and(Emission::is_full);
-    let (risk, fate) = if twin_full {
-        (FidelityRisk::Low, "content survives through it")
-    } else {
-        (
+    if twin_full {
+        return (
+            ContextAction::Drop,
+            rule_id.to_owned(),
+            FidelityRisk::Low,
+            format!(
+                "{variant} of fragment #{} — content survives through it",
+                dup.kept_seq
+            ),
+            Some(provenance::handle_for(analysis.content_hash)),
+        );
+    }
+    if analysis.media.is_some() {
+        // Same PR1 honesty gap as `media_unavailable_verdict`: the twin
+        // itself did not fully pack, and there is no binary retrieval store
+        // yet, so this duplicate is not recoverable through a handle either
+        // — unlike the text case below, do not hand out one that would not
+        // resolve.
+        return (
+            ContextAction::Drop,
+            rule_id.to_owned(),
             critical_risk(analysis.rule.critical),
-            "but that twin was not fully emitted — recover via the handle",
-        )
-    };
+            format!(
+                "{variant} of fragment #{} — that twin was not fully emitted, and media \
+                 externalization lands in the next PR, so this duplicate is not retrievable either",
+                dup.kept_seq
+            ),
+            None,
+        );
+    }
     (
         ContextAction::Drop,
         rule_id.to_owned(),
-        risk,
-        format!("{variant} of fragment #{} — {fate}", dup.kept_seq),
+        critical_risk(analysis.rule.critical),
+        format!(
+            "{variant} of fragment #{} — but that twin was not fully emitted — recover via the handle",
+            dup.kept_seq
+        ),
         Some(provenance::handle_for(analysis.content_hash)),
+    )
+}
+
+/// A media fragment (US-009, PR1) that did not fit the budget: `drop`ped
+/// with an explicit, honest reason instead of the generic
+/// [`externalized_verdict`] — PR1 ships no binary retrieval store, so
+/// handing out a `ctx://source` handle here would promise a fetch that can
+/// never resolve. A future PR that lands media externalization changes this
+/// verdict, not the atomic-packing or dedup behavior around it.
+fn media_unavailable_verdict(analysis: &Analysis) -> Verdict {
+    (
+        ContextAction::Drop,
+        "drop.media_unavailable".to_owned(),
+        critical_risk(analysis.rule.critical),
+        format!(
+            "did not fit the budget ({}); media externalization lands in the next PR, so it is \
+             dropped rather than given a retrieval handle that would not resolve",
+            analysis.rule.reason
+        ),
+        None,
     )
 }
 
@@ -669,6 +830,30 @@ fn retrieval_handles(analyses: &[Analysis], decisions: &[ContextDecision]) -> Ve
         .collect()
 }
 
+/// Tokens actually reflected in the output for one fragment. For an
+/// ordinary fragment this is the injected estimator over whatever prefix of
+/// pieces was emitted (unchanged pre-media behavior). For a media fragment
+/// (US-009, PR1) packing is atomic (see `pieces`): an emission's mere
+/// presence already means the *whole* precomputed cost (image +
+/// caption — [`media_fragment_tokens`], the same total [`Analysis::tokens`]
+/// holds) was spent, never a partial text-estimate of the caption alone —
+/// which would misreport a fully preserved image as almost entirely
+/// "saved" whenever its caption happens to be blank.
+fn emitted_tokens(
+    analysis: &Analysis,
+    emissions: &BTreeMap<usize, Emission>,
+    estimator: &dyn TokenEstimator,
+) -> u64 {
+    let Some(emission) = emissions.get(&analysis.seq) else {
+        return 0;
+    };
+    if analysis.media.is_some() {
+        analysis.tokens
+    } else {
+        estimator.estimate(&emission.text)
+    }
+}
+
 /// Attribute saved tokens to the rule that saved them. A fully emitted
 /// verbatim fragment saves nothing, so every attribution comes from drops,
 /// abstractions, externalizations, and partial packs — and the per-rule map
@@ -681,9 +866,7 @@ fn saved_by_rule(
 ) -> BTreeMap<String, u64> {
     let mut by_rule = BTreeMap::new();
     for (analysis, decision) in analyses.iter().zip(decisions) {
-        let emitted = emissions
-            .get(&analysis.seq)
-            .map_or(0, |emission| estimator.estimate(&emission.text));
+        let emitted = emitted_tokens(analysis, emissions, estimator);
         let saved = analysis.tokens.saturating_sub(emitted);
         if saved > 0 {
             *by_rule.entry(decision.rule_id.clone()).or_insert(0) += saved;
@@ -691,6 +874,10 @@ fn saved_by_rule(
     }
     by_rule
 }
+
+#[cfg(test)]
+#[path = "context/media_pipeline_tests.rs"]
+mod media_pipeline_tests;
 
 #[cfg(test)]
 mod chunk_policy_tests {

--- a/crates/velesdb-memory/src/context/budget.rs
+++ b/crates/velesdb-memory/src/context/budget.rs
@@ -17,6 +17,19 @@ use super::estimator::TokenEstimator;
 /// and the emitted bytes can never drift apart.
 pub(crate) const JOINER: &str = "\n\n";
 
+/// One emission piece: its text, and — for a piece whose token cost is
+/// precomputed outside the injected estimator (a media fragment's single
+/// atomic piece, US-009 PR1) — that fixed cost. `None` (every non-media
+/// piece) means "measure `text` with the injected estimator", the unchanged
+/// pre-media behavior; `Some` must never be re-derived from `text` (for
+/// media, `text` is only the caption, which on its own would grossly
+/// under-price the piece).
+#[derive(Debug, Clone)]
+pub(crate) struct Piece {
+    pub text: String,
+    pub cost: Option<u64>,
+}
+
 /// One packable fragment: its emission pieces plus its selection keys.
 #[derive(Debug)]
 pub(crate) struct PackItem {
@@ -30,7 +43,7 @@ pub(crate) struct PackItem {
     pub relevance: f32,
     /// The fragment's text, pre-cut into orderly pieces (chunks); packing
     /// takes a prefix of them.
-    pub pieces: Vec<String>,
+    pub pieces: Vec<Piece>,
 }
 
 /// How many leading pieces of each item fit under `usable` tokens. The
@@ -66,9 +79,10 @@ fn selection_order(items: &[PackItem]) -> Vec<usize> {
 }
 
 /// Greedily take leading pieces while they fit; the first piece also pays
-/// the fragment's joiner cost.
+/// the fragment's joiner cost. A piece's own cost is its precomputed
+/// [`Piece::cost`] when set, otherwise the injected estimator over its text.
 fn take_pieces(
-    pieces: &[String],
+    pieces: &[Piece],
     remaining: &mut u64,
     joiner_tokens: u64,
     estimator: &dyn TokenEstimator,
@@ -76,7 +90,10 @@ fn take_pieces(
     let mut count = 0_usize;
     for piece in pieces {
         let joiner = if count == 0 { joiner_tokens } else { 0 };
-        let cost = estimator.estimate(piece).saturating_add(joiner);
+        let base = piece
+            .cost
+            .unwrap_or_else(|| estimator.estimate(&piece.text));
+        let cost = base.saturating_add(joiner);
         if cost > *remaining {
             break;
         }

--- a/crates/velesdb-memory/src/context/budget_tests.rs
+++ b/crates/velesdb-memory/src/context/budget_tests.rs
@@ -9,7 +9,28 @@ fn item(seq: usize, critical: bool, priority: u8, relevance: f32, pieces: &[&str
         critical,
         priority,
         relevance,
-        pieces: pieces.iter().map(|p| (*p).to_owned()).collect(),
+        pieces: pieces
+            .iter()
+            .map(|p| Piece {
+                text: (*p).to_owned(),
+                cost: None,
+            })
+            .collect(),
+    }
+}
+
+/// A single atomic piece with a precomputed cost, ignoring its text's own
+/// estimated cost entirely — the media packing shape (US-009, PR1).
+fn media_item(seq: usize, critical: bool, precomputed_cost: u64) -> PackItem {
+    PackItem {
+        seq,
+        critical,
+        priority: 0,
+        relevance: 0.0,
+        pieces: vec![Piece {
+            text: String::new(),
+            cost: Some(precomputed_cost),
+        }],
     }
 }
 
@@ -96,4 +117,38 @@ fn test_pack_zero_budget_takes_nothing() {
 #[test]
 fn test_pack_empty_items_yields_empty_result() {
     assert!(pack(&[], 100, &HeuristicEstimator).is_empty());
+}
+
+#[test]
+fn test_pack_uses_a_piece_precomputed_cost_instead_of_estimating_its_text() {
+    // The piece's text is empty (would estimate to 0 tokens); its
+    // precomputed cost of 900 must still be what's charged against the
+    // budget — proving `take_pieces` never falls back to `estimator.estimate`
+    // when `Piece::cost` is set.
+    let items = vec![media_item(0, false, 900)];
+    // Budget covers the precomputed cost (900) + 1 joiner token, not more.
+    let joiner = HeuristicEstimator.estimate(JOINER);
+    let taken = pack(&items, 900 + joiner, &HeuristicEstimator);
+    assert_eq!(
+        taken,
+        vec![1],
+        "the precomputed-cost piece must fit exactly"
+    );
+    let too_tight = pack(&items, 900 + joiner - 1, &HeuristicEstimator);
+    assert_eq!(
+        too_tight,
+        vec![0],
+        "one token under the precomputed cost must not fit"
+    );
+}
+
+#[test]
+fn test_pack_precomputed_cost_piece_is_atomic_never_partially_taken() {
+    // A media item always has exactly one piece, so `taken` can only ever be
+    // 0 or 1 — there is no partial state to assert against, but this pins
+    // that a too-small budget takes nothing rather than some fractional
+    // amount.
+    let items = vec![media_item(0, true, 1_000_000)];
+    let taken = pack(&items, 10, &HeuristicEstimator);
+    assert_eq!(taken, vec![0]);
 }

--- a/crates/velesdb-memory/src/context/classify.rs
+++ b/crates/velesdb-memory/src/context/classify.rs
@@ -39,6 +39,13 @@ struct Rule {
 /// unconditional last entry, so classification always yields a rule.
 const RULES: &[Rule] = &[
     Rule {
+        id: "media.atomic",
+        action: ContextAction::Preserve,
+        critical: true,
+        reason: "media fragment packs as one atomic, unsplittable piece",
+        applies: is_media,
+    },
+    Rule {
         id: "preserve.marked_verbatim",
         action: ContextAction::Preserve,
         critical: true,
@@ -120,6 +127,17 @@ fn to_match(rule: &Rule) -> RuleMatch {
         critical: rule.critical,
         reason: rule.reason,
     }
+}
+
+/// The fragment carries an inline media payload (US-009, PR1). Checked
+/// first, unconditionally: a media fragment's classification must never
+/// depend on its (often empty) caption text — a caption that happens to
+/// contain a code fence, a URL, or a `verbatim`/`cache` metadata flag must
+/// not steer a screenshot away from atomic packing. This also guarantees no
+/// text-scanning rule below ever needs to consider `bytes_b64` — by the time
+/// any of them run, a media fragment has already matched here.
+fn is_media(fragment: &ContextFragment, _policy: &CompilePolicy) -> bool {
+    fragment.media.is_some()
 }
 
 /// `metadata.verbatim == true`.

--- a/crates/velesdb-memory/src/context/classify_tests.rs
+++ b/crates/velesdb-memory/src/context/classify_tests.rs
@@ -12,6 +12,7 @@ fn fragment(content: &str) -> ContextFragment {
         kind: None,
         priority: None,
         metadata: None,
+        media: None,
     }
 }
 
@@ -230,4 +231,67 @@ fn test_classify_plain_prose_gets_default_rule() {
     assert_eq!(matched.id, "preserve.default");
     assert_eq!(matched.action, ContextAction::Preserve);
     assert!(!matched.critical);
+}
+
+fn media_fragment(caption: &str) -> ContextFragment {
+    ContextFragment {
+        media: Some(crate::context::model::MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: "iVBORw0KGgo=".to_owned(),
+        }),
+        ..fragment(caption)
+    }
+}
+
+#[test]
+fn test_classify_media_fragment_gets_its_own_atomic_rule() {
+    let matched = classify_default(&media_fragment(""));
+    assert_eq!(matched.id, "media.atomic");
+    assert_eq!(matched.action, ContextAction::Preserve);
+    assert!(matched.critical);
+}
+
+#[test]
+fn test_classify_media_fragment_wins_over_every_text_rule() {
+    // A caption that would otherwise match code/url/negative-constraint/
+    // value-dense rules must still classify as media.atomic — the media
+    // rule never lets a fragment's own text content steer its
+    // classification away from atomic packing.
+    let matched = classify_default(&media_fragment(
+        "```rust\nfn f() {}\n``` never do this http://x 1 2 3",
+    ));
+    assert_eq!(matched.id, "media.atomic");
+}
+
+#[test]
+fn test_classify_media_fragment_wins_even_over_marked_verbatim_and_cache() {
+    let mut meta = Map::new();
+    meta.insert("cache".to_owned(), Value::Bool(true));
+    let frag = ContextFragment {
+        metadata: Some(meta),
+        ..media_fragment("caption")
+    };
+    assert_eq!(classify_default(&frag).id, "media.atomic");
+}
+
+#[test]
+fn test_classify_media_atomic_rule_can_be_disabled() {
+    let policy = CompilePolicy {
+        disabled_rules: vec!["media.atomic".to_owned()],
+        ..CompilePolicy::default()
+    };
+    // With the rule disabled, an otherwise-plain-prose caption falls through
+    // to the next matching rule exactly like any other disabled rule.
+    assert_eq!(
+        classify(&media_fragment("plain caption"), &policy).id,
+        "preserve.default"
+    );
+}
+
+#[test]
+fn test_classify_non_media_fragment_is_unaffected_by_the_media_rule() {
+    assert_ne!(
+        classify_default(&fragment("plain prose")).id,
+        "media.atomic"
+    );
 }

--- a/crates/velesdb-memory/src/context/dedup.rs
+++ b/crates/velesdb-memory/src/context/dedup.rs
@@ -5,6 +5,19 @@
 //! content, near-duplicates hash a normalized form (lowercased, whitespace
 //! runs collapsed). The **first** occurrence survives; later ones are marked
 //! duplicates of it. Deterministic by construction: input order decides.
+//!
+//! **Media fragments** (US-009, PR1) opt out of this entirely: a media
+//! fragment's identity is its *raw decoded media bytes*
+//! ([`crate::context::media::MediaAnalysis::raw_hash`]), never its caption
+//! text — captions are often empty, and two distinct screenshots with blank
+//! captions would otherwise collide under the text-content check. Media
+//! identity lives in its own namespace (`media_seen`, keyed on the caller-
+//! supplied `media_hashes` slice) and is Exact-only: near-duplication (case/
+//! whitespace normalization) is a *text* notion and never applies to media.
+//! A media fragment neither reads nor writes the text-content tables, so it
+//! can never be mistaken for — or mistakenly anchor — a plain-text
+//! fragment's dedup chain, even when both have identical (often empty)
+//! content strings.
 
 use std::collections::BTreeMap;
 
@@ -31,13 +44,34 @@ pub(crate) struct Duplicate {
 /// For each content (in input order): `None` if it is a first occurrence,
 /// `Some(duplicate)` if an earlier fragment already covers it. Near-duplicate
 /// detection is skipped when `near` is `false`.
-pub(crate) fn find_duplicates(contents: &[&str], near: bool) -> Vec<Option<Duplicate>> {
+///
+/// `media_hashes[i]` is `Some(raw_hash)` when fragment `i` carries media
+/// (its identity — see the module doc), `None` for an ordinary text
+/// fragment; it must be the same length as `contents` (one entry per
+/// fragment, same input order).
+pub(crate) fn find_duplicates(
+    contents: &[&str],
+    near: bool,
+    media_hashes: &[Option<u64>],
+) -> Vec<Option<Duplicate>> {
     let mut exact_seen: BTreeMap<u64, usize> = BTreeMap::new();
     let mut near_seen: BTreeMap<u64, usize> = BTreeMap::new();
+    let mut media_seen: BTreeMap<u64, usize> = BTreeMap::new();
     contents
         .iter()
+        .zip(media_hashes)
         .enumerate()
-        .map(|(seq, content)| {
+        .map(|(seq, (content, media_hash))| {
+            if let Some(&hash) = media_hash.as_ref() {
+                // Media's own namespace: Exact-only, never reads or writes
+                // the text-content tables below (see the module doc).
+                let verdict = media_seen.get(&hash).map(|&kept_seq| Duplicate {
+                    kind: DupKind::Exact,
+                    kept_seq,
+                });
+                media_seen.entry(hash).or_insert(seq);
+                return verdict;
+            }
             let exact_hash = stable_id(content);
             // Skip the normalize+hash pass entirely when near-dup detection
             // is off — the value would never be read.

--- a/crates/velesdb-memory/src/context/dedup_tests.rs
+++ b/crates/velesdb-memory/src/context/dedup_tests.rs
@@ -2,9 +2,15 @@
 
 use super::*;
 
+/// No fragment carries media — the pre-US-009 shape every existing test
+/// exercises.
+fn no_media(len: usize) -> Vec<Option<u64>> {
+    vec![None; len]
+}
+
 #[test]
 fn test_find_duplicates_exact_marks_second_occurrence() {
-    let verdicts = find_duplicates(&["a fact", "other", "a fact"], true);
+    let verdicts = find_duplicates(&["a fact", "other", "a fact"], true, &no_media(3));
     assert!(verdicts[0].is_none());
     assert!(verdicts[1].is_none());
     let dup = verdicts[2].expect("third entry duplicates the first");
@@ -14,7 +20,11 @@ fn test_find_duplicates_exact_marks_second_occurrence() {
 
 #[test]
 fn test_find_duplicates_near_matches_case_and_spacing() {
-    let verdicts = find_duplicates(&["The Server restarts.", "the  server   restarts."], true);
+    let verdicts = find_duplicates(
+        &["The Server restarts.", "the  server   restarts."],
+        true,
+        &no_media(2),
+    );
     let dup = verdicts[1].expect("second entry near-duplicates the first");
     assert_eq!(dup.kind, DupKind::Near);
     assert_eq!(dup.kept_seq, 0);
@@ -22,19 +32,23 @@ fn test_find_duplicates_near_matches_case_and_spacing() {
 
 #[test]
 fn test_find_duplicates_near_detection_can_be_disabled() {
-    let verdicts = find_duplicates(&["The Server restarts.", "the  server   restarts."], false);
+    let verdicts = find_duplicates(
+        &["The Server restarts.", "the  server   restarts."],
+        false,
+        &no_media(2),
+    );
     assert!(verdicts[1].is_none(), "near detection was disabled");
 }
 
 #[test]
 fn test_find_duplicates_exact_still_found_when_near_disabled() {
-    let verdicts = find_duplicates(&["same", "same"], false);
+    let verdicts = find_duplicates(&["same", "same"], false, &no_media(2));
     assert_eq!(verdicts[1].expect("exact duplicate").kind, DupKind::Exact);
 }
 
 #[test]
 fn test_find_duplicates_distinct_contents_are_all_kept() {
-    let verdicts = find_duplicates(&["alpha", "beta", "gamma"], true);
+    let verdicts = find_duplicates(&["alpha", "beta", "gamma"], true, &no_media(3));
     assert!(verdicts.iter().all(Option::is_none));
 }
 
@@ -47,7 +61,11 @@ fn test_find_duplicates_exact_copy_of_a_near_duplicate_reports_exact() {
     // at #0 would let downstream code (`dup_verdict`) assume #2's exact
     // bytes survive whenever #0 is emitted verbatim — false whenever #0 and
     // #1/#2 differ, which is exactly why they were only a *near* match.
-    let verdicts = find_duplicates(&["Hello World", "hello  world", "hello  world"], true);
+    let verdicts = find_duplicates(
+        &["Hello World", "hello  world", "hello  world"],
+        true,
+        &no_media(3),
+    );
     let dup = verdicts[2].expect("third entry duplicates the second");
     assert_eq!(
         dup.kind,
@@ -69,13 +87,88 @@ fn test_find_duplicates_near_dup_still_anchors_the_near_chain_at_the_root() {
     let verdicts = find_duplicates(
         &["Hello World", "hello  world", "hello  world", "HELLO WORLD"],
         true,
+        &no_media(4),
     );
     assert_eq!(verdicts[3].expect("near dup").kept_seq, 0);
 }
 
 #[test]
 fn test_find_duplicates_chain_points_to_first_occurrence() {
-    let verdicts = find_duplicates(&["x", "x", "x"], true);
+    let verdicts = find_duplicates(&["x", "x", "x"], true, &no_media(3));
+    assert_eq!(verdicts[1].expect("dup").kept_seq, 0);
+    assert_eq!(verdicts[2].expect("dup").kept_seq, 0);
+}
+
+// --- Media dedup (US-009, PR1): identity is the raw decoded bytes, never
+// the caption text, and never near-duplicated. ---
+
+#[test]
+fn test_find_duplicates_media_with_identical_raw_hash_is_exact_duplicate() {
+    let media = vec![Some(42_u64), Some(42_u64)];
+    let verdicts = find_duplicates(&["", ""], true, &media);
+    let dup = verdicts[1].expect("same raw hash duplicates the first");
+    assert_eq!(dup.kind, DupKind::Exact);
+    assert_eq!(dup.kept_seq, 0);
+}
+
+#[test]
+fn test_find_duplicates_media_with_different_raw_hash_is_not_a_duplicate() {
+    let media = vec![Some(1_u64), Some(2_u64)];
+    let verdicts = find_duplicates(&["same caption", "same caption"], true, &media);
+    assert!(
+        verdicts[1].is_none(),
+        "different images must never dedup on caption text alone"
+    );
+}
+
+#[test]
+fn test_find_duplicates_media_fragments_with_blank_captions_never_false_positive_dedup() {
+    // Two distinct screenshots, both with the empty caption that is typical
+    // for a bare screenshot: under plain text-content dedup these would be
+    // an exact match ("" == ""); media identity must ignore that entirely.
+    let media = vec![Some(111_u64), Some(222_u64)];
+    let verdicts = find_duplicates(&["", ""], true, &media);
+    assert!(verdicts[1].is_none());
+}
+
+#[test]
+fn test_find_duplicates_media_never_marked_near_duplicate() {
+    // Even a contrived setup that resembles a near-dup pattern must still
+    // resolve as Exact-or-none for media — DupKind::Near never appears when
+    // a media hash is present.
+    let media = vec![Some(7_u64), Some(7_u64)];
+    let verdicts = find_duplicates(&["Hello World", "hello  world"], true, &media);
+    assert_eq!(verdicts[1].expect("dup").kind, DupKind::Exact);
+}
+
+#[test]
+fn test_find_duplicates_media_fragment_does_not_pollute_text_dedup_of_others() {
+    // A media fragment with a blank caption must not register "" into the
+    // text-content dedup tables — a later, unrelated plain-text fragment
+    // with empty content must NOT be marked a duplicate of the media
+    // fragment merely because both "contents" are blank.
+    let media = vec![Some(999_u64), None];
+    let verdicts = find_duplicates(&["", ""], true, &media);
+    assert!(
+        verdicts[1].is_none(),
+        "a plain-text empty fragment must not dedup against a media fragment's blank caption"
+    );
+}
+
+#[test]
+fn test_find_duplicates_media_and_text_dedup_use_independent_namespaces() {
+    // Fragment #0 is plain text "shared", #1 is media whose caption also
+    // happens to be "shared" but with a distinct raw hash — must not dedup
+    // against #0 via the text namespace.
+    let media = vec![None, Some(1_u64)];
+    let verdicts = find_duplicates(&["shared", "shared"], true, &media);
+    assert!(verdicts[1].is_none());
+}
+
+#[test]
+fn test_find_duplicates_media_chain_points_to_first_occurrence() {
+    let media = vec![Some(5_u64), Some(5_u64), Some(5_u64)];
+    let verdicts = find_duplicates(&["", "", ""], true, &media);
     assert_eq!(verdicts[1].expect("dup").kept_seq, 0);
     assert_eq!(verdicts[2].expect("dup").kept_seq, 0);
 }

--- a/crates/velesdb-memory/src/context/estimator.rs
+++ b/crates/velesdb-memory/src/context/estimator.rs
@@ -113,6 +113,121 @@ fn is_cjk(ch: char) -> bool {
     )
 }
 
+/// Header-only image dimension sniff + a single token-cost formula for
+/// inline media fragments (US-009, PR1: images only).
+///
+/// This is deliberately *not* a [`TokenEstimator`] impl: it does not take
+/// text, it takes a mime and raw decoded bytes, and its cost model has
+/// nothing in common with the char-class heuristic. It parses just enough of
+/// PNG (the `IHDR` chunk) and JPEG (the first `SOF0`/`SOF2` marker) to read
+/// pixel dimensions — no other chunks/markers, no color data, no CRC
+/// verification. The cost formula (`ceil(width * height / 750)`) is Claude's
+/// published image-token constant; picking one formula at launch is a
+/// deliberate simplification — a per-provider cost model is a documented
+/// future seam, not built here.
+///
+/// Any mime this module does not recognize, or bytes whose header cannot be
+/// read (too short, bad signature, no `SOF` marker found), fall back to the
+/// crate's default text estimator run over `bytes_b64` — the base64 text is
+/// always longer than a tight token count would be, so this is a safe
+/// over-count, never a silent under-count of a real image's cost.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ImageTokenEstimator;
+
+/// Claude's published pixels-per-token constant for image inputs.
+const CLAUDE_PIXELS_PER_TOKEN: u64 = 750;
+
+impl ImageTokenEstimator {
+    /// Estimated prompt-token cost of one image fragment. `bytes` are the
+    /// *decoded* raw media; `bytes_b64` is the original base64 text, read
+    /// only by the fallback path.
+    #[must_use]
+    pub fn estimate(mime: &str, bytes: &[u8], bytes_b64: &str) -> u64 {
+        match image_dimensions(mime, bytes) {
+            Some((width, height)) => {
+                let pixels = u64::from(width).saturating_mul(u64::from(height));
+                pixels.div_ceil(CLAUDE_PIXELS_PER_TOKEN)
+            }
+            None => HeuristicEstimator.estimate(bytes_b64),
+        }
+    }
+}
+
+/// Sniff pixel dimensions from a mime-tagged image payload, or `None` when
+/// the mime is unsupported or the header cannot be parsed.
+fn image_dimensions(mime: &str, bytes: &[u8]) -> Option<(u32, u32)> {
+    match mime {
+        "image/png" => png_dimensions(bytes),
+        "image/jpeg" | "image/jpg" => jpeg_dimensions(bytes),
+        _ => None,
+    }
+}
+
+/// Read `(width, height)` from a PNG's leading `IHDR` chunk. Bounds-checked
+/// throughout (`slice::get`, never a panicking index) — a truncated or
+/// corrupt payload yields `None`, never a panic, since this runs over
+/// caller-controlled bytes.
+fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    const SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    if bytes.get(0..8)? != SIGNATURE {
+        return None;
+    }
+    // Chunk layout: 4-byte length, 4-byte type ("IHDR" for the first chunk),
+    // then IHDR's own data: 4-byte width, 4-byte height (both big-endian),
+    // followed by bit depth/color type/etc. (unread here).
+    if bytes.get(12..16)? != b"IHDR" {
+        return None;
+    }
+    let width = u32::from_be_bytes(bytes.get(16..20)?.try_into().ok()?);
+    let height = u32::from_be_bytes(bytes.get(20..24)?.try_into().ok()?);
+    Some((width, height))
+}
+
+/// Read `(width, height)` from a JPEG's first baseline (`SOF0`, `0xC0`) or
+/// progressive (`SOF2`, `0xC2`) marker segment, walking past any other
+/// marker segment (`APPn`, `DQT`, `DHT`, …) that precedes it. Bounds-checked
+/// throughout; a truncated, malformed, or `SOF`-less stream yields `None`.
+fn jpeg_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    const SOF0: u8 = 0xC0;
+    const SOF2: u8 = 0xC2;
+    if bytes.get(0..2)? != [0xFF, 0xD8] {
+        return None;
+    }
+    let mut pos = 2_usize;
+    while let Some(&marker_byte) = bytes.get(pos) {
+        if marker_byte != 0xFF {
+            return None;
+        }
+        let marker = *bytes.get(pos + 1)?;
+        // Standalone markers (RSTn, and the SOI/EOI we may re-encounter)
+        // carry no length or payload.
+        if (0xD0..=0xD9).contains(&marker) {
+            pos += 2;
+            continue;
+        }
+        let seg_len = usize::from(u16::from_be_bytes(
+            bytes.get(pos + 2..pos + 4)?.try_into().ok()?,
+        ));
+        if seg_len < 2 {
+            return None;
+        }
+        if marker == SOF0 || marker == SOF2 {
+            // Payload: 1-byte precision, 2-byte height, 2-byte width
+            // (both big-endian) — component data follows, unread here.
+            let payload = bytes.get(pos + 4..pos + 9)?;
+            let height = u16::from_be_bytes([payload[1], payload[2]]);
+            let width = u16::from_be_bytes([payload[3], payload[4]]);
+            return Some((u32::from(width), u32::from(height)));
+        }
+        pos += 2 + seg_len;
+    }
+    None
+}
+
 #[cfg(test)]
 #[path = "estimator_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "image_estimator_tests.rs"]
+mod image_estimator_tests;

--- a/crates/velesdb-memory/src/context/estimator.rs
+++ b/crates/velesdb-memory/src/context/estimator.rs
@@ -180,6 +180,12 @@ fn png_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
     }
     let width = u32::from_be_bytes(bytes.get(16..20)?.try_into().ok()?);
     let height = u32::from_be_bytes(bytes.get(20..24)?.try_into().ok()?);
+    // A forged zero dimension would price a multi-MiB payload at 0 tokens —
+    // a silent under-count. Treat it as unparseable: the caller falls back
+    // to the safe over-counting text estimate.
+    if width == 0 || height == 0 {
+        return None;
+    }
     Some((width, height))
 }
 
@@ -217,6 +223,12 @@ fn jpeg_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
             let payload = bytes.get(pos + 4..pos + 9)?;
             let height = u16::from_be_bytes([payload[1], payload[2]]);
             let width = u16::from_be_bytes([payload[3], payload[4]]);
+            // height == 0 is legal JPEG (DNL-deferred) but unpriceable, and
+            // width == 0 is forged either way: fall back to the safe
+            // over-counting text estimate rather than a 0-token under-count.
+            if width == 0 || height == 0 {
+                return None;
+            }
             return Some((u32::from(width), u32::from(height)));
         }
         pos += 2 + seg_len;

--- a/crates/velesdb-memory/src/context/image_estimator_tests.rs
+++ b/crates/velesdb-memory/src/context/image_estimator_tests.rs
@@ -157,3 +157,50 @@ fn test_image_token_estimator_is_deterministic() {
     let b = ImageTokenEstimator::estimate("image/png", PNG_1024X768, "x");
     assert_eq!(a, b);
 }
+
+/// A forged IHDR declaring width = 0 (multi-MiB payload could hide behind
+/// it): must be treated as unparseable so the safe over-counting fallback
+/// prices it, never 0 tokens.
+const PNG_0X768: &[u8] = &[
+    137, 80, 78, 71, 13, 10, 26, 10, // signature
+    0, 0, 0, 13, // IHDR length = 13
+    73, 72, 68, 82, // "IHDR"
+    0, 0, 0, 0, // width = 0 (forged)
+    0, 0, 3, 0, // height = 768
+    8, 6, 0, 0, 0, // bit depth, color type, compression, filter, interlace
+    0, 0, 0, 0, // crc (unchecked)
+];
+
+/// A JPEG SOF0 declaring height = 0 (legal DNL-deferred form): unpriceable
+/// by the pixel formula — must fall back to the over-counting estimate.
+const JPEG_SOF0_800X0: &[u8] = &[
+    255, 216, // SOI
+    255, 192, // SOF0
+    0, 17, // segment length = 17
+    8,  // precision
+    0, 0, // height = 0 (DNL-deferred)
+    3, 32, // width = 800
+    3,  // num components
+    1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1, // component specs
+    255, 217, // EOI
+];
+
+#[test]
+fn test_zero_dimension_png_falls_back_to_overcounting_text_estimate() {
+    let bytes_b64 = "a-large-payload-stand-in";
+    let cost = ImageTokenEstimator::estimate("image/png", PNG_0X768, bytes_b64);
+    assert_eq!(
+        cost,
+        HeuristicEstimator.estimate(bytes_b64),
+        "a forged zero dimension must never price a payload at 0 tokens"
+    );
+    assert!(cost > 0);
+}
+
+#[test]
+fn test_zero_dimension_jpeg_falls_back_to_overcounting_text_estimate() {
+    let bytes_b64 = "another-large-payload-stand-in";
+    let cost = ImageTokenEstimator::estimate("image/jpeg", JPEG_SOF0_800X0, bytes_b64);
+    assert_eq!(cost, HeuristicEstimator.estimate(bytes_b64));
+    assert!(cost > 0);
+}

--- a/crates/velesdb-memory/src/context/image_estimator_tests.rs
+++ b/crates/velesdb-memory/src/context/image_estimator_tests.rs
@@ -1,0 +1,159 @@
+//! Unit tests for [`ImageTokenEstimator`] — PNG/JPEG header sniffing and the
+//! image token-cost formula (US-009, PR1). Every fixture is a synthetic,
+//! minimal header built by hand (byte literals) — no binary files are
+//! committed.
+
+use super::*;
+
+/// A synthetic PNG signature + IHDR chunk declaring 1024x768, 8-bit RGBA.
+/// CRC bytes are zeroed — the decoder only reads IHDR's declared dimensions,
+/// it never verifies the chunk CRC.
+const PNG_1024X768: &[u8] = &[
+    137, 80, 78, 71, 13, 10, 26, 10, // signature
+    0, 0, 0, 13, // IHDR length = 13
+    73, 72, 68, 82, // "IHDR"
+    0, 0, 4, 0, // width = 1024
+    0, 0, 3, 0, // height = 768
+    8, 6, 0, 0, 0, // bit depth, color type, compression, filter, interlace
+    0, 0, 0, 0, // crc (unchecked)
+];
+
+/// A synthetic baseline JPEG (SOI + SOF0 + EOI) declaring 800x600.
+const JPEG_SOF0_800X600: &[u8] = &[
+    255, 216, // SOI
+    255, 192, // SOF0
+    0, 17, // segment length = 17
+    8,  // precision
+    2, 88, // height = 600
+    3, 32, // width = 800
+    3,  // num components
+    1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1, // component specs
+    255, 217, // EOI
+];
+
+/// A synthetic progressive JPEG (SOI + APP0/JFIF + SOF2 + EOI) declaring
+/// 640x480 — proves the scanner walks *past* a non-SOF marker segment
+/// (APP0) instead of assuming SOF0 is always first.
+const JPEG_APP0_SOF2_640X480: &[u8] = &[
+    255, 216, // SOI
+    255, 224, 0, 16, 74, 70, 73, 70, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, // APP0/JFIF
+    255, 194, // SOF2 (progressive)
+    0, 17, // segment length = 17
+    8,  // precision
+    1, 224, // height = 480
+    2, 128, // width = 640
+    3,   // num components
+    1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1, // component specs
+    255, 217, // EOI
+];
+
+#[test]
+fn test_png_dimensions_reads_ihdr_width_and_height() {
+    assert_eq!(png_dimensions(PNG_1024X768), Some((1024, 768)));
+}
+
+#[test]
+fn test_png_dimensions_rejects_bad_signature() {
+    let mut bad = PNG_1024X768.to_vec();
+    bad[0] = 0x00;
+    assert_eq!(png_dimensions(&bad), None);
+}
+
+#[test]
+fn test_png_dimensions_rejects_truncated_input() {
+    assert_eq!(png_dimensions(&PNG_1024X768[..10]), None);
+}
+
+#[test]
+fn test_png_dimensions_rejects_missing_ihdr_tag() {
+    let mut bad = PNG_1024X768.to_vec();
+    bad[12..16].copy_from_slice(b"IDAT");
+    assert_eq!(png_dimensions(&bad), None);
+}
+
+#[test]
+fn test_jpeg_dimensions_reads_sof0_baseline() {
+    assert_eq!(jpeg_dimensions(JPEG_SOF0_800X600), Some((800, 600)));
+}
+
+#[test]
+fn test_jpeg_dimensions_skips_leading_app0_and_reads_sof2_progressive() {
+    assert_eq!(jpeg_dimensions(JPEG_APP0_SOF2_640X480), Some((640, 480)));
+}
+
+#[test]
+fn test_jpeg_dimensions_rejects_bad_soi() {
+    let mut bad = JPEG_SOF0_800X600.to_vec();
+    bad[0] = 0x00;
+    assert_eq!(jpeg_dimensions(&bad), None);
+}
+
+#[test]
+fn test_jpeg_dimensions_rejects_truncated_input() {
+    assert_eq!(jpeg_dimensions(&JPEG_SOF0_800X600[..4]), None);
+}
+
+#[test]
+fn test_jpeg_dimensions_returns_none_without_a_sof_marker() {
+    // SOI immediately followed by EOI — well-formed, but no dimensions ever
+    // appear.
+    assert_eq!(jpeg_dimensions(&[255, 216, 255, 217]), None);
+}
+
+#[test]
+fn test_jpeg_dimensions_rejects_a_non_0xff_byte_mid_stream() {
+    // A well-formed SOI, then a byte that is not the 0xFF every marker must
+    // start with — a corrupt/desynced marker stream.
+    assert_eq!(jpeg_dimensions(&[255, 216, 0x00, 0x00]), None);
+}
+
+#[test]
+fn test_jpeg_dimensions_rejects_a_segment_length_under_two() {
+    // A marker segment's length field includes its own 2 bytes, so any
+    // value under 2 is malformed — must not be walked past.
+    assert_eq!(jpeg_dimensions(&[255, 216, 255, 0xE0, 0x00, 0x01]), None);
+}
+
+#[test]
+fn test_image_token_estimator_png_cost_is_pixels_over_750_ceiling() {
+    // 1024 * 768 = 786_432; /750 = 1048.576 -> ceil = 1049.
+    let bytes_b64 = "irrelevant-when-dimensions-are-known";
+    let cost = ImageTokenEstimator::estimate("image/png", PNG_1024X768, bytes_b64);
+    assert_eq!(cost, 786_432_u64.div_ceil(750));
+}
+
+#[test]
+fn test_image_token_estimator_jpeg_cost_is_pixels_over_750_ceiling() {
+    // 800 * 600 = 480_000; /750 = 640 exactly.
+    let bytes_b64 = "irrelevant-when-dimensions-are-known";
+    let cost = ImageTokenEstimator::estimate("image/jpeg", JPEG_SOF0_800X600, bytes_b64);
+    assert_eq!(cost, 640);
+}
+
+#[test]
+fn test_image_token_estimator_falls_back_to_text_estimate_for_unsupported_mime() {
+    let bytes_b64 = "AAAA";
+    let cost = ImageTokenEstimator::estimate("image/gif", b"whatever bytes", bytes_b64);
+    assert_eq!(cost, HeuristicEstimator.estimate(bytes_b64));
+}
+
+#[test]
+fn test_image_token_estimator_falls_back_to_text_estimate_for_unreadable_png_header() {
+    let bytes_b64 = "not-a-real-header-payload-here";
+    let cost = ImageTokenEstimator::estimate("image/png", b"too short", bytes_b64);
+    assert_eq!(cost, HeuristicEstimator.estimate(bytes_b64));
+}
+
+#[test]
+fn test_image_token_estimator_falls_back_to_text_estimate_for_unreadable_jpeg_header() {
+    let bytes_b64 = "another-fallback-b64-string";
+    let cost = ImageTokenEstimator::estimate("image/jpeg", b"too short", bytes_b64);
+    assert_eq!(cost, HeuristicEstimator.estimate(bytes_b64));
+}
+
+#[test]
+fn test_image_token_estimator_is_deterministic() {
+    let a = ImageTokenEstimator::estimate("image/png", PNG_1024X768, "x");
+    let b = ImageTokenEstimator::estimate("image/png", PNG_1024X768, "x");
+    assert_eq!(a, b);
+}

--- a/crates/velesdb-memory/src/context/media.rs
+++ b/crates/velesdb-memory/src/context/media.rs
@@ -33,7 +33,10 @@ pub(crate) struct MediaAnalysis {
 ///
 /// Called only after [`validate_media`] has already confirmed `bytes_b64` is
 /// well-formed and within [`crate::limits::MAX_MEDIA_BYTES`] for every
-/// fragment in the request — a decode failure here would mean that check has
+/// fragment in the request (so each payload is decoded twice — once to
+/// validate, once here; bounded by
+/// [`crate::limits::MAX_TOTAL_MEDIA_BYTES`], a deliberate simplicity
+/// trade-off over threading decoded bytes through the pipeline) — a decode failure here would mean that check has
 /// a bug, so this degrades to an empty payload (zero dimensions, the text
 /// fallback cost) rather than panicking on what is, by this point, trusted
 /// input.

--- a/crates/velesdb-memory/src/context/media.rs
+++ b/crates/velesdb-memory/src/context/media.rs
@@ -1,0 +1,135 @@
+//! Inline media handling for context fragments (US-009, PR1).
+//!
+//! Two responsibilities, kept separate from the rest of the pipeline so they
+//! stay independently testable: a dependency-free base64 decoder (the
+//! `context` feature ships zero new dependencies by design — see its doc in
+//! `src/context.rs` — so this stays local rather than pulling in the
+//! `base64` crate), and the per-fragment analysis ([`analyze`]) that reduces
+//! a decoded payload to exactly what the compiler pipeline needs: a
+//! raw-bytes dedup identity and a precomputed image token cost.
+
+use crate::id::stable_id_bytes;
+
+use super::estimator::ImageTokenEstimator;
+use super::model::MediaRef;
+
+/// Everything the pipeline needs from one fragment's media payload, computed
+/// once per fragment and reused by dedup, packing, and insights.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MediaAnalysis {
+    /// FNV-1a 64 ([`stable_id_bytes`]) of the *decoded* raw bytes — the
+    /// dedup identity for media (byte-identical only; media is never
+    /// near-duplicated, see [`super::dedup::find_duplicates`]).
+    pub raw_hash: u64,
+    /// Precomputed image token cost from [`ImageTokenEstimator`]. This is
+    /// the image's cost alone — it does not include the fragment's caption
+    /// text; callers fold that in separately (see
+    /// `context::media_fragment_tokens`) so the two concerns stay
+    /// independently testable.
+    pub image_tokens: u64,
+}
+
+/// Decode and analyze one fragment's media payload.
+///
+/// Called only after [`validate_media`] has already confirmed `bytes_b64` is
+/// well-formed and within [`crate::limits::MAX_MEDIA_BYTES`] for every
+/// fragment in the request — a decode failure here would mean that check has
+/// a bug, so this degrades to an empty payload (zero dimensions, the text
+/// fallback cost) rather than panicking on what is, by this point, trusted
+/// input.
+pub(crate) fn analyze(media: &MediaRef) -> MediaAnalysis {
+    let bytes = decode_base64(&media.bytes_b64).unwrap_or_default();
+    MediaAnalysis {
+        raw_hash: stable_id_bytes(&bytes),
+        image_tokens: ImageTokenEstimator::estimate(&media.mime, &bytes, &media.bytes_b64),
+    }
+}
+
+/// Whether `bytes_b64` is well-formed base64 — used at validation time to
+/// reject a malformed payload before any decode-dependent work happens.
+pub(crate) fn is_valid_base64(bytes_b64: &str) -> bool {
+    decode_base64(bytes_b64).is_ok()
+}
+
+/// Base64 decoding failed: wrong length, an invalid character, or
+/// misplaced/excess padding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DecodeError;
+
+/// A minimal, dependency-free base64 decoder: standard alphabet
+/// (`A-Za-z0-9+/`), `=` padding, no line breaks or whitespace tolerance (the
+/// wire payload is a single JSON string, never a formatted block). Not
+/// constant-time — this decodes opaque wire-format media, not a secret.
+pub(crate) fn decode_base64(input: &str) -> Result<Vec<u8>, DecodeError> {
+    let bytes = input.as_bytes();
+    if bytes.is_empty() {
+        return Ok(Vec::new());
+    }
+    if !bytes.len().is_multiple_of(4) {
+        return Err(DecodeError);
+    }
+    let quad_count = bytes.len() / 4;
+    let mut out = Vec::with_capacity(quad_count * 3);
+    for (index, quad) in bytes.chunks_exact(4).enumerate() {
+        let pad = decode_quad(quad, &mut out)?;
+        // Padding may only terminate the stream: a quad with padding that
+        // is not the last quad means an earlier segment was truncated.
+        if pad > 0 && index + 1 != quad_count {
+            return Err(DecodeError);
+        }
+    }
+    Ok(out)
+}
+
+/// Decode one 4-character quad into up to 3 output bytes, returning the
+/// number of trailing `=` padding characters (0, 1, or 2) it carried.
+fn decode_quad(quad: &[u8], out: &mut Vec<u8>) -> Result<usize, DecodeError> {
+    let pad = quad.iter().rev().take_while(|&&b| b == b'=').count();
+    if pad > 2 {
+        return Err(DecodeError);
+    }
+    let mut sextets = [0_u8; 4];
+    for (index, &byte) in quad.iter().enumerate() {
+        sextets[index] = if byte == b'=' {
+            // A '=' is only valid in the trailing `pad` positions; one
+            // appearing before that (a data position) is malformed.
+            if index < 4 - pad {
+                return Err(DecodeError);
+            }
+            0
+        } else {
+            sextet(byte).ok_or(DecodeError)?
+        };
+    }
+    let word = (u32::from(sextets[0]) << 18)
+        | (u32::from(sextets[1]) << 12)
+        | (u32::from(sextets[2]) << 6)
+        | u32::from(sextets[3]);
+    #[allow(clippy::cast_possible_truncation)]
+    out.push((word >> 16) as u8);
+    if pad < 2 {
+        #[allow(clippy::cast_possible_truncation)]
+        out.push((word >> 8) as u8);
+    }
+    if pad < 1 {
+        #[allow(clippy::cast_possible_truncation)]
+        out.push(word as u8);
+    }
+    Ok(pad)
+}
+
+/// One base64 character's 6-bit value, or `None` outside the alphabet.
+fn sextet(byte: u8) -> Option<u8> {
+    match byte {
+        b'A'..=b'Z' => Some(byte - b'A'),
+        b'a'..=b'z' => Some(byte - b'a' + 26),
+        b'0'..=b'9' => Some(byte - b'0' + 52),
+        b'+' => Some(62),
+        b'/' => Some(63),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[path = "media_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/context/media_pipeline_tests.rs
+++ b/crates/velesdb-memory/src/context/media_pipeline_tests.rs
@@ -1,0 +1,387 @@
+//! Unit tests for the media-fragment plumbing private to `context.rs`
+//! (US-009, PR1): budget validation, the caption+image token formula, atomic
+//! piece construction, and the drop-vs-preserve verdict routing.
+//!
+//! End-to-end behavior through the public `ContextCompiler::compile` API —
+//! the shape callers actually see — is covered by
+//! `tests/context_compiler_bdd.rs`; these tests exercise the private
+//! plumbing directly so a regression here fails close to its cause, and so
+//! branches unreachable from a single `compile()` call (e.g. a duplicate
+//! whose twin also failed to pack) still get pinned.
+
+use super::*;
+use crate::context::classify::RuleMatch;
+use crate::context::estimator::HeuristicEstimator;
+use crate::context::media;
+use crate::context::model::MediaRef;
+
+/// A syntactically valid (well-formed base64), tiny PNG header — 64x48
+/// pixels, IHDR only. Its exact bytes don't matter to most tests here; only
+/// [`media::analyze`] needs something [`media::decode_base64`] accepts.
+const PNG_64X48_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAYAAAAAAAAA";
+
+fn media_ref() -> MediaRef {
+    MediaRef {
+        mime: "image/png".to_owned(),
+        bytes_b64: PNG_64X48_B64.to_owned(),
+    }
+}
+
+fn plain_fragment(content: &str) -> ContextFragment {
+    ContextFragment {
+        id: None,
+        content: content.to_owned(),
+        kind: None,
+        priority: None,
+        metadata: None,
+        media: None,
+    }
+}
+
+fn fragment_with_media(content: &str) -> ContextFragment {
+    ContextFragment {
+        media: Some(media_ref()),
+        ..plain_fragment(content)
+    }
+}
+
+fn rule_match(id: &'static str) -> RuleMatch {
+    RuleMatch {
+        id,
+        action: ContextAction::Preserve,
+        critical: true,
+        reason: "test rule",
+    }
+}
+
+/// A minimal, hand-built `Analysis` — every field but the ones a given test
+/// cares about is a harmless default (seq 0, no dup, no log collapse).
+fn analysis_for(
+    seq: usize,
+    original: &str,
+    media: Option<media::MediaAnalysis>,
+    tokens: u64,
+) -> Analysis<'_> {
+    Analysis {
+        seq,
+        fragment_id: u64::try_from(seq).unwrap_or(0),
+        content_hash: 0,
+        original,
+        tokens,
+        rule: rule_match("media.atomic"),
+        relevance: 0.0,
+        priority: 0,
+        dup: None,
+        abstract_collapse: None,
+        media,
+    }
+}
+
+// --- validate_media ----------------------------------------------------
+
+#[test]
+fn test_validate_media_accepts_a_well_formed_payload_within_the_cap() {
+    assert!(validate_media(&[fragment_with_media("a caption")]).is_ok());
+}
+
+#[test]
+fn test_validate_media_ignores_fragments_without_media() {
+    assert!(validate_media(&[plain_fragment("no media here")]).is_ok());
+}
+
+#[test]
+fn test_validate_media_rejects_a_payload_over_the_byte_cap() {
+    let oversized = "A".repeat(limits::MAX_MEDIA_BYTES + 4);
+    let fragment = ContextFragment {
+        media: Some(MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: oversized,
+        }),
+        ..plain_fragment("x")
+    };
+    match validate_media(&[fragment]) {
+        Err(MemoryError::ContextOverLimit(message)) => {
+            assert!(message.contains("exceeds the cap"), "{message}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_validate_media_rejects_malformed_base64() {
+    let fragment = ContextFragment {
+        media: Some(MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: "not valid base64!!".to_owned(),
+        }),
+        ..plain_fragment("x")
+    };
+    match validate_media(&[fragment]) {
+        Err(MemoryError::ContextOverLimit(message)) => {
+            assert!(message.contains("not valid base64"), "{message}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_validate_media_reports_the_offending_fragment_index() {
+    let fragments = vec![
+        fragment_with_media("ok"),
+        ContextFragment {
+            media: Some(MediaRef {
+                mime: "image/png".to_owned(),
+                bytes_b64: "!!!!".to_owned(),
+            }),
+            ..plain_fragment("bad")
+        },
+    ];
+    match validate_media(&fragments) {
+        Err(MemoryError::ContextOverLimit(message)) => {
+            assert!(message.contains("#1"), "{message}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+// --- media_fragment_tokens ----------------------------------------------
+
+#[test]
+fn test_media_fragment_tokens_sums_image_cost_and_caption_text_cost() {
+    let media = media::MediaAnalysis {
+        raw_hash: 0,
+        image_tokens: 100,
+    };
+    let caption = "some caption text";
+    let expected = 100 + HeuristicEstimator.estimate(caption);
+    assert_eq!(
+        media_fragment_tokens(&media, caption, &HeuristicEstimator),
+        expected
+    );
+}
+
+#[test]
+fn test_media_fragment_tokens_with_blank_caption_is_just_the_image_cost() {
+    let media = media::MediaAnalysis {
+        raw_hash: 0,
+        image_tokens: 250,
+    };
+    assert_eq!(media_fragment_tokens(&media, "", &HeuristicEstimator), 250);
+}
+
+// --- pieces --------------------------------------------------------------
+
+#[test]
+fn test_pieces_media_fragment_yields_one_atomic_piece_with_precomputed_cost() {
+    let media_analysis = media::analyze(&media_ref());
+    let caption = "a screenshot";
+    let expected_cost = media_fragment_tokens(&media_analysis, caption, &HeuristicEstimator);
+    let analysis = analysis_for(0, caption, Some(media_analysis), expected_cost);
+    let chunk_policy = ChunkPolicy::default();
+    let result = pieces(&analysis, &chunk_policy, &HeuristicEstimator);
+    assert_eq!(
+        result.len(),
+        1,
+        "a media fragment must pack as exactly one atomic piece"
+    );
+    assert_eq!(result[0].text, caption);
+    assert_eq!(result[0].cost, Some(expected_cost));
+}
+
+#[test]
+fn test_pieces_media_fragment_is_never_split_even_when_caption_exceeds_chunk_size() {
+    let media_analysis = media::analyze(&media_ref());
+    let long_caption = "x".repeat(10_000);
+    let analysis = analysis_for(0, &long_caption, Some(media_analysis), 999);
+    let tiny_chunk_policy = ChunkPolicy {
+        max_chunk_bytes: 256,
+        overlap_bytes: 0,
+        boundary: ChunkBoundary::Fixed,
+    };
+    let result = pieces(&analysis, &tiny_chunk_policy, &HeuristicEstimator);
+    assert_eq!(
+        result.len(),
+        1,
+        "a media fragment must never be cut, regardless of caption length or chunk policy"
+    );
+}
+
+#[test]
+fn test_pieces_non_media_fragment_is_unaffected() {
+    let analysis = analysis_for(0, "plain text over the chunk boundary", None, 10);
+    let tiny_chunk_policy = ChunkPolicy {
+        max_chunk_bytes: 4,
+        overlap_bytes: 0,
+        boundary: ChunkBoundary::Fixed,
+    };
+    let result = pieces(&analysis, &tiny_chunk_policy, &HeuristicEstimator);
+    assert!(
+        result.len() > 1,
+        "an ordinary fragment must still be chunked as before"
+    );
+    assert!(result.iter().all(|piece| piece.cost.is_none()));
+}
+
+// --- decision routing: media fragments never get a dangling handle ------
+
+#[test]
+fn test_decision_routes_an_unfit_media_fragment_to_drop_not_retrieve() {
+    let media_analysis = media::MediaAnalysis {
+        raw_hash: 1,
+        image_tokens: 500,
+    };
+    let analysis = analysis_for(0, "", Some(media_analysis), 500);
+    let all: Vec<Analysis<'_>> = Vec::new();
+    let emissions: BTreeMap<usize, Emission> = BTreeMap::new();
+    let recorded = decision(&analysis, &all, &emissions);
+    assert_eq!(recorded.action, ContextAction::Drop);
+    assert_eq!(recorded.rule_id, "drop.media_unavailable");
+    assert_eq!(recorded.risk, FidelityRisk::High);
+    assert!(
+        recorded.handle.is_none(),
+        "no binary retrieval store exists yet in PR1 — no handle must be promised"
+    );
+    assert!(recorded.reason.contains("next PR"));
+}
+
+#[test]
+fn test_decision_routes_a_fitting_media_fragment_to_preserve() {
+    let media_analysis = media::MediaAnalysis {
+        raw_hash: 1,
+        image_tokens: 5,
+    };
+    let analysis = analysis_for(0, "caption", Some(media_analysis), 10);
+    let all: Vec<Analysis<'_>> = Vec::new();
+    let mut emissions = BTreeMap::new();
+    emissions.insert(
+        0,
+        Emission {
+            text: "caption".to_owned(),
+            taken: 1,
+            total: 1,
+        },
+    );
+    let recorded = decision(&analysis, &all, &emissions);
+    assert_eq!(recorded.action, ContextAction::Preserve);
+    assert_eq!(recorded.rule_id, "media.atomic");
+    assert_eq!(recorded.risk, FidelityRisk::Low);
+    assert!(recorded.handle.is_none());
+}
+
+// --- dup_verdict: media duplicates never get a dangling handle either ---
+
+#[test]
+fn test_dup_verdict_media_duplicate_whose_twin_is_also_unfit_gets_no_handle() {
+    let twin = analysis_for(
+        0,
+        "",
+        Some(media::MediaAnalysis {
+            raw_hash: 1,
+            image_tokens: 500,
+        }),
+        500,
+    );
+    let dup_analysis = analysis_for(
+        1,
+        "",
+        Some(media::MediaAnalysis {
+            raw_hash: 1,
+            image_tokens: 500,
+        }),
+        500,
+    );
+    let emissions: BTreeMap<usize, Emission> = BTreeMap::new(); // twin never packed either
+    let dup = Duplicate {
+        kind: DupKind::Exact,
+        kept_seq: 0,
+    };
+    let (action, rule_id, risk, reason, handle) =
+        dup_verdict(&dup_analysis, dup, &twin, &emissions);
+    assert_eq!(action, ContextAction::Drop);
+    assert_eq!(rule_id, "drop.duplicate");
+    assert_eq!(risk, FidelityRisk::High);
+    assert!(handle.is_none());
+    assert!(reason.contains("next PR"));
+}
+
+#[test]
+fn test_dup_verdict_media_duplicate_whose_twin_fits_gets_low_risk_and_a_handle() {
+    let twin = analysis_for(
+        0,
+        "",
+        Some(media::MediaAnalysis {
+            raw_hash: 1,
+            image_tokens: 5,
+        }),
+        5,
+    );
+    let dup_analysis = analysis_for(
+        1,
+        "",
+        Some(media::MediaAnalysis {
+            raw_hash: 1,
+            image_tokens: 5,
+        }),
+        5,
+    );
+    let mut emissions = BTreeMap::new();
+    emissions.insert(
+        0,
+        Emission {
+            text: String::new(),
+            taken: 1,
+            total: 1,
+        },
+    );
+    let dup = Duplicate {
+        kind: DupKind::Exact,
+        kept_seq: 0,
+    };
+    let (action, _rule_id, risk, _reason, handle) =
+        dup_verdict(&dup_analysis, dup, &twin, &emissions);
+    assert_eq!(action, ContextAction::Drop);
+    assert_eq!(risk, FidelityRisk::Low);
+    assert!(
+        handle.is_some(),
+        "the kept twin survives, so the handle is informational, same as text duplicates"
+    );
+}
+
+// --- emitted_tokens: atomic all-or-nothing accounting --------------------
+
+#[test]
+fn test_emitted_tokens_media_fragment_with_an_emission_returns_the_full_precomputed_total() {
+    let media_analysis = media::MediaAnalysis {
+        raw_hash: 1,
+        image_tokens: 500,
+    };
+    let analysis = analysis_for(0, "cap", Some(media_analysis), 505);
+    let mut emissions = BTreeMap::new();
+    emissions.insert(
+        0,
+        Emission {
+            text: "cap".to_owned(),
+            taken: 1,
+            total: 1,
+        },
+    );
+    assert_eq!(
+        emitted_tokens(&analysis, &emissions, &HeuristicEstimator),
+        505,
+        "must be the whole precomputed total, not a text-estimate of the caption alone"
+    );
+}
+
+#[test]
+fn test_emitted_tokens_media_fragment_without_an_emission_is_zero() {
+    let media_analysis = media::MediaAnalysis {
+        raw_hash: 1,
+        image_tokens: 500,
+    };
+    let analysis = analysis_for(0, "cap", Some(media_analysis), 505);
+    let emissions: BTreeMap<usize, Emission> = BTreeMap::new();
+    assert_eq!(
+        emitted_tokens(&analysis, &emissions, &HeuristicEstimator),
+        0
+    );
+}

--- a/crates/velesdb-memory/src/context/media_tests.rs
+++ b/crates/velesdb-memory/src/context/media_tests.rs
@@ -1,0 +1,171 @@
+//! Unit tests for the dependency-free base64 decoder and media analysis
+//! (US-009, PR1).
+
+use super::*;
+use crate::context::model::MediaRef;
+
+#[test]
+fn test_decode_base64_empty_string_yields_empty_bytes() {
+    assert_eq!(decode_base64("").expect("empty is valid"), Vec::<u8>::new());
+}
+
+#[test]
+fn test_decode_base64_decodes_known_vector_hello() {
+    assert_eq!(
+        decode_base64("aGVsbG8=").expect("valid b64"),
+        b"hello".to_vec()
+    );
+}
+
+#[test]
+fn test_decode_base64_decodes_known_vector_hello_world() {
+    assert_eq!(
+        decode_base64("aGVsbG8gd29ybGQ=").expect("valid b64"),
+        b"hello world".to_vec()
+    );
+}
+
+#[test]
+fn test_decode_base64_decodes_single_padding_char() {
+    // "Ma" -> "TWE=" (one padding char, 2 output bytes)
+    assert_eq!(decode_base64("TWE=").expect("valid b64"), b"Ma".to_vec());
+}
+
+#[test]
+fn test_decode_base64_decodes_double_padding_chars() {
+    // "M" -> "TQ==" (two padding chars, 1 output byte)
+    assert_eq!(decode_base64("TQ==").expect("valid b64"), b"M".to_vec());
+}
+
+#[test]
+fn test_decode_base64_round_trips_arbitrary_binary_bytes() {
+    // Bytes including NUL and 0xFF — never valid UTF-8, proving the decoder
+    // stays byte-oriented rather than accidentally routing through `str`.
+    assert_eq!(
+        decode_base64("AAEC//4=").expect("valid b64"),
+        vec![0x00, 0x01, 0x02, 0xFF, 0xFE]
+    );
+}
+
+#[test]
+fn test_decode_base64_decodes_a_png_signature() {
+    // The 8-byte PNG magic number, exactly as it appears at the front of any
+    // real PNG file.
+    assert_eq!(
+        decode_base64("iVBORw0KGgo=").expect("valid b64"),
+        vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]
+    );
+}
+
+#[test]
+fn test_decode_base64_decodes_plus_and_slash_alphabet_characters() {
+    // `\xfb\xff\xbf` -> "+/+/" — exercises both non-alphanumeric base64
+    // characters, which no other fixture in this file happens to use.
+    assert_eq!(
+        decode_base64("+/+/").expect("valid b64"),
+        vec![0xFB, 0xFF, 0xBF]
+    );
+}
+
+#[test]
+fn test_decode_base64_rejects_length_not_a_multiple_of_four() {
+    assert!(decode_base64("abcde").is_err());
+}
+
+#[test]
+fn test_decode_base64_rejects_invalid_character() {
+    assert!(decode_base64("ab$d").is_err());
+}
+
+#[test]
+fn test_decode_base64_rejects_padding_before_the_final_quad() {
+    // Padding must only terminate the stream, never appear mid-stream.
+    assert!(decode_base64("TWE=AAAA").is_err());
+}
+
+#[test]
+fn test_decode_base64_rejects_padding_in_a_data_position() {
+    // '=' followed by a non-'=' data character within the same quad.
+    assert!(decode_base64("T=EA").is_err());
+}
+
+#[test]
+fn test_decode_base64_rejects_three_padding_chars() {
+    assert!(decode_base64("T===").is_err());
+}
+
+fn media(mime: &str, raw: &[u8]) -> MediaRef {
+    MediaRef {
+        mime: mime.to_owned(),
+        bytes_b64: encode_for_test(raw),
+    }
+}
+
+/// Minimal test-only encoder (the inverse of [`decode_base64`]) so tests can
+/// build media fixtures from raw bytes without hardcoding base64 strings
+/// everywhere. Not exposed outside `cfg(test)` — the pipeline never needs to
+/// *encode* media, only decode caller-supplied payloads.
+fn encode_for_test(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8) | u32::from(b2);
+        out.push(ALPHABET[(n >> 18) as usize & 0x3F] as char);
+        out.push(ALPHABET[(n >> 12) as usize & 0x3F] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(n >> 6) as usize & 0x3F] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[n as usize & 0x3F] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[test]
+fn test_test_encoder_round_trips_through_decode_base64() {
+    let raw = b"round trip me, including \x00\xffbytes";
+    assert_eq!(
+        decode_base64(&encode_for_test(raw)).expect("valid"),
+        raw.to_vec()
+    );
+}
+
+#[test]
+fn test_analyze_raw_hash_matches_stable_id_bytes_of_decoded_content() {
+    let raw = vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    let media = media("image/png", &raw);
+    let analysis = analyze(&media);
+    assert_eq!(analysis.raw_hash, crate::id::stable_id_bytes(&raw));
+}
+
+#[test]
+fn test_analyze_is_deterministic() {
+    let media = media("image/png", b"same bytes twice");
+    assert_eq!(analyze(&media).raw_hash, analyze(&media).raw_hash);
+    assert_eq!(analyze(&media).image_tokens, analyze(&media).image_tokens);
+}
+
+#[test]
+fn test_analyze_different_bytes_yield_different_raw_hash() {
+    let a = analyze(&media("image/png", b"aaaa"));
+    let b = analyze(&media("image/png", b"bbbb"));
+    assert_ne!(a.raw_hash, b.raw_hash);
+}
+
+#[test]
+fn test_is_valid_base64_accepts_well_formed_input() {
+    assert!(is_valid_base64("aGVsbG8="));
+}
+
+#[test]
+fn test_is_valid_base64_rejects_malformed_input() {
+    assert!(!is_valid_base64("not valid base64!!"));
+}

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -551,6 +551,7 @@ impl MemoryCandidate {
                 kind: Some("memory".to_owned()),
                 priority: None,
                 metadata: None,
+                media: None,
             },
             memory_id: self.memory_id,
             relevance,

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -51,6 +51,33 @@ pub enum FidelityRisk {
     High,
 }
 
+/// Inline media payload attached to a [`ContextFragment`] (US-009, PR1:
+/// screenshots/images only). `ContextFragment::content` stays the
+/// text/caption — often empty for a bare screenshot — while the pixels live
+/// here, base64-encoded so the JSON wire never needs a binary frame.
+///
+/// PR1 scope: the fragment packs atomically (see [`super::pieces`] in the
+/// compiler) and its token cost comes from
+/// [`super::estimator::ImageTokenEstimator`], but there is no externalized
+/// binary store yet — a media fragment that cannot fit the budget is
+/// `drop`ped with an explicit reason rather than handed a `ctx://source`
+/// handle that would not actually resolve. See the crate README's "media
+/// fragments" section.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MediaRef {
+    /// Declared MIME type (e.g. `"image/png"`, `"image/jpeg"`). Only PNG and
+    /// JPEG headers are sniffed for dimensions; any other value (or an
+    /// unreadable header) falls back to a deterministic, safe over-count
+    /// (see [`super::estimator::ImageTokenEstimator`]) — never rejected for
+    /// an unrecognized mime alone.
+    pub mime: String,
+    /// The raw media bytes, base64-encoded (standard alphabet, padded).
+    /// Capped at [`crate::limits::MAX_MEDIA_BYTES`] and validated for
+    /// well-formedness at compile time — a request carrying an oversized or
+    /// malformed payload is rejected before any other work.
+    pub bytes_b64: String,
+}
+
 /// One unit of caller-supplied context to compile.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
@@ -81,6 +108,11 @@ pub struct ContextFragment {
     /// [`ContextAction::Cache`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Map<String, Value>>,
+    /// Inline media payload (US-009, PR1). `None` (the default) keeps every
+    /// pre-0.9.0 request wire-compatible. When set, the fragment packs as one
+    /// atomic piece — see [`MediaRef`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media: Option<MediaRef>,
 }
 
 /// Which memories the compiler may pull in alongside the caller's fragments.

--- a/crates/velesdb-memory/src/id.rs
+++ b/crates/velesdb-memory/src/id.rs
@@ -18,7 +18,16 @@ const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 /// Derive a stable `u64` id from arbitrary text via FNV-1a 64-bit.
 #[must_use]
 pub fn stable_id(text: &str) -> u64 {
-    text.bytes().fold(FNV_OFFSET, |hash, byte| {
+    stable_id_bytes(text.as_bytes())
+}
+
+/// Derive a stable `u64` id from arbitrary bytes via FNV-1a 64-bit — the
+/// same scheme as [`stable_id`], generalized to raw bytes so binary payloads
+/// (e.g. decoded media, US-009) can be content-addressed without a lossy
+/// round-trip through `String`.
+#[must_use]
+pub fn stable_id_bytes(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(FNV_OFFSET, |hash, &byte| {
         (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME)
     })
 }
@@ -40,5 +49,17 @@ mod tests {
     #[test]
     fn empty_string_yields_offset_basis() {
         assert_eq!(stable_id(""), FNV_OFFSET);
+    }
+
+    #[test]
+    fn stable_id_bytes_agrees_with_stable_id_on_valid_utf8() {
+        assert_eq!(stable_id_bytes("hello".as_bytes()), stable_id("hello"));
+    }
+
+    #[test]
+    fn stable_id_bytes_hashes_non_utf8_bytes() {
+        let bytes = [0xFFu8, 0x00, 0x89, 0x50, 0x4E, 0x47];
+        assert_eq!(stable_id_bytes(&bytes), stable_id_bytes(&bytes));
+        assert_ne!(stable_id_bytes(&bytes), stable_id_bytes(&bytes[1..]));
     }
 }

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -29,6 +29,16 @@ pub const MAX_FRAGMENT_BYTES: usize = 1_048_576;
 /// single call can demand across every adapter.
 pub const MAX_FRAGMENTS: usize = 1_024;
 
+/// Maximum accepted size of a fragment's base64-encoded media payload
+/// (US-009, PR1: inline images) — 4 MiB of base64 text, roughly 3 MiB of raw
+/// bytes once decoded. Deliberately separate from [`MAX_FRAGMENT_BYTES`],
+/// which only ever measures [`crate::context::model::ContextFragment::content`]
+/// (the caption): a screenshot is not text, and capping it at the 1 MiB text
+/// ceiling would reject ordinary screenshots outright. Measured against
+/// `bytes_b64.len()` (the encoded string), so the cap can reject an
+/// oversized payload before any base64 decoding is attempted.
+pub const MAX_MEDIA_BYTES: usize = 4 * 1024 * 1024;
+
 /// Cap on a caller-supplied token budget. A budget cannot force allocations
 /// by itself, but an absurd value would make the savings arithmetic
 /// meaningless, so adapters clamp to this ceiling instead of erroring.

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -39,6 +39,13 @@ pub const MAX_FRAGMENTS: usize = 1_024;
 /// oversized payload before any base64 decoding is attempted.
 pub const MAX_MEDIA_BYTES: usize = 4 * 1024 * 1024;
 
+/// Aggregate cap on ALL media payloads of one request (base64 length,
+/// summed). Without it, `MAX_FRAGMENTS` fragments each at [`MAX_MEDIA_BYTES`]
+/// would let a single request carry 4 GiB of media — far past the ~1 GiB
+/// worst case the text caps allow. 64 MiB comfortably fits a real
+/// screenshot-heavy session while bounding decode work.
+pub const MAX_TOTAL_MEDIA_BYTES: usize = 64 * 1024 * 1024;
+
 /// Cap on a caller-supplied token budget. A budget cannot force allocations
 /// by itself, but an absurd value would make the savings arithmetic
 /// meaningless, so adapters clamp to this ceiling instead of erroring.

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -28,6 +28,7 @@ fn fragment(content: &str) -> ContextFragment {
         kind: None,
         priority: None,
         metadata: None,
+        media: None,
     }
 }
 

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -1206,6 +1206,34 @@ fn test_identical_media_bytes_are_deduped_even_with_different_captions() {
     assert_eq!(out.decisions[1].action, ContextAction::Drop);
     assert_eq!(out.decisions[1].rule_id, "drop.duplicate");
     assert_eq!(out.decisions[1].risk, FidelityRisk::Low);
+    // And the reason is honest: the image survives, the differing caption
+    // does not — never a blanket "content survives" claim.
+    assert!(
+        out.decisions[1]
+            .reason
+            .contains("differing caption does not"),
+        "reason must not overclaim survival, got: {}",
+        out.decisions[1].reason
+    );
+}
+
+#[test]
+fn test_total_media_payload_over_the_aggregate_cap_is_rejected() {
+    // Given fragments whose individual payloads pass the per-fragment cap
+    // but whose SUM exceeds the aggregate request cap (64 MiB of base64)
+    let one_mib_b64 = "A".repeat(1024 * 1024);
+    let fragments: Vec<ContextFragment> = (0..65)
+        .map(|i| media_fragment(&format!("shot {i}"), &one_mib_b64))
+        .collect();
+    let err = ContextCompiler::new(CompilePolicy::default())
+        .compile(&request(fragments, 10_000))
+        .expect_err("65 MiB of aggregate media must be rejected");
+
+    // Then the rejection names the aggregate cap, before any decode work
+    assert!(
+        err.to_string().contains("total media payload"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -24,6 +24,7 @@ fn fragment(content: &str) -> ContextFragment {
         kind: None,
         priority: None,
         metadata: None,
+        media: None,
     }
 }
 
@@ -1055,4 +1056,219 @@ fn test_compile_wire_request_with_policy_pricing_yields_cost_insights() {
     );
     assert_eq!(out.insights.currency.as_deref(), Some("EUR"));
     assert_eq!(out.insights.pricing_version.as_deref(), Some("2026-07"));
+}
+
+// --- Media fragments (US-009 of EPIC-P-071, PR1: inline images) --------------
+
+use velesdb_memory::context::MediaRef;
+
+/// A synthetic, well-formed PNG signature + IHDR chunk declaring 64x48
+/// pixels — token cost `ceil(64*48/750) = 5`. No binary file is committed;
+/// this is the base64 of a hand-built 33-byte header (see the crate's
+/// `ImageTokenEstimator` unit tests for the byte-level fixture it mirrors).
+const PNG_64X48_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAYAAAAAAAAA";
+const PNG_64X48_COST: u64 = 5;
+
+/// A synthetic PNG declaring 1024x768 pixels — token cost
+/// `ceil(1024*768/750) = 1049`.
+const PNG_1024X768_B64: &str = "iVBORw0KGgoAAAANSUhEUgAABAAAAAMACAYAAAAAAAAA";
+const PNG_1024X768_COST: u64 = 1049;
+
+/// Build a fragment carrying an inline PNG media payload.
+fn media_fragment(caption: &str, bytes_b64: &str) -> ContextFragment {
+    ContextFragment {
+        media: Some(MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: bytes_b64.to_owned(),
+        }),
+        ..fragment(caption)
+    }
+}
+
+#[test]
+fn test_media_fragment_packs_atomically_and_is_preserved_when_budget_allows() {
+    // Given a media fragment with a caption, and a generous budget
+    let frag = media_fragment("a screenshot of the crash", PNG_64X48_B64);
+    let out = compile(&request(vec![frag], 10_000));
+
+    // Then it is preserved whole, under its own dedicated rule
+    let decision = &out.decisions[0];
+    assert_eq!(decision.action, ContextAction::Preserve);
+    assert_eq!(decision.rule_id, "media.atomic");
+    assert_eq!(decision.risk, FidelityRisk::Low);
+    assert!(decision.handle.is_none());
+    assert!(out.retrieval_handles.is_empty());
+    assert!(out.content.contains("a screenshot of the crash"));
+}
+
+#[test]
+fn test_media_fragment_with_blank_caption_is_preserved_but_contributes_no_visible_text() {
+    // Given a bare screenshot with no caption (the common case)
+    let frag = media_fragment("", PNG_1024X768_B64);
+    let out = compile(&request(vec![frag], 10_000));
+
+    // Then it is still preserved (the decision honestly reflects that the
+    // image survived the budget), but the assembled prompt text carries
+    // nothing for it — PR1 does not inject binary/image content into
+    // `content`, only accounts for its token cost (see the crate README).
+    assert_eq!(out.decisions[0].action, ContextAction::Preserve);
+    assert_eq!(out.content, "");
+    assert!(out.sections.is_empty());
+}
+
+#[test]
+fn test_media_fragment_insights_tokens_in_and_out_reflect_the_image_cost() {
+    // Given a single, blank-caption media fragment
+    let frag = media_fragment("", PNG_1024X768_B64);
+    let out = compile(&request(vec![frag], 10_000));
+
+    // Then the image's real token cost is what gets accounted, not a
+    // near-zero text-estimate of its (empty) caption
+    assert_eq!(out.insights.tokens_in, PNG_1024X768_COST);
+    assert_eq!(
+        out.insights.tokens_saved, 0,
+        "a fully preserved image must report zero tokens saved"
+    );
+}
+
+#[test]
+fn test_media_fragment_that_cannot_fit_the_budget_is_dropped_not_retrieved() {
+    // Given a media fragment far too large for the budget
+    let frag = media_fragment("a huge screenshot", PNG_1024X768_B64);
+    let out = compile(&request(vec![frag], 10));
+
+    // Then it is dropped with an explicit PR1-scope reason — never handed a
+    // ctx://source handle, since no binary retrieval store exists yet
+    let decision = &out.decisions[0];
+    assert_eq!(decision.action, ContextAction::Drop);
+    assert_eq!(decision.rule_id, "drop.media_unavailable");
+    assert_eq!(decision.risk, FidelityRisk::High);
+    assert!(decision.handle.is_none());
+    assert!(
+        decision.reason.contains("next PR"),
+        "the reason must be honest about the PR1 scope gap: {}",
+        decision.reason
+    );
+    assert!(out.retrieval_handles.is_empty());
+    assert_eq!(out.content, "");
+}
+
+#[test]
+fn test_media_fragment_pack_is_all_or_nothing_at_the_exact_budget_boundary() {
+    // Given the exact budget the image needs (its cost plus one joiner
+    // token) versus one token short of it
+    let joiner = HeuristicEstimator.estimate("\n\n");
+    let exact = request(
+        vec![media_fragment("", PNG_64X48_B64)],
+        PNG_64X48_COST + joiner,
+    );
+    let one_short = request(
+        vec![media_fragment("", PNG_64X48_B64)],
+        PNG_64X48_COST + joiner - 1,
+    );
+
+    // Then it packs fully right at the boundary, and not at all one token
+    // under it — atomic packing never yields a partial byte-range
+    assert_eq!(compile(&exact).decisions[0].action, ContextAction::Preserve);
+    assert_eq!(compile(&one_short).decisions[0].action, ContextAction::Drop);
+}
+
+#[test]
+fn test_dropped_media_fragment_attributes_its_full_cost_to_the_pr1_drop_rule() {
+    // Given a media fragment that cannot fit
+    let frag = media_fragment("", PNG_1024X768_B64);
+    let out = compile(&request(vec![frag], 10));
+
+    // Then its full precomputed cost is attributed to the rule that dropped
+    // it, exactly like every other savings-by-rule attribution
+    let decision = &out.decisions[0];
+    let saved = out
+        .insights
+        .tokens_saved_by_rule
+        .get(&decision.rule_id)
+        .copied()
+        .unwrap_or(0);
+    assert_eq!(saved, PNG_1024X768_COST);
+}
+
+#[test]
+fn test_identical_media_bytes_are_deduped_even_with_different_captions() {
+    // Given two fragments with byte-identical media but different captions
+    let fragments = vec![
+        media_fragment("shot A", PNG_64X48_B64),
+        media_fragment("shot B", PNG_64X48_B64),
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    // Then the first survives and the second is dropped as its duplicate —
+    // media identity is the raw bytes, never the caption text
+    assert_eq!(out.decisions[0].action, ContextAction::Preserve);
+    assert_eq!(out.decisions[1].action, ContextAction::Drop);
+    assert_eq!(out.decisions[1].rule_id, "drop.duplicate");
+    assert_eq!(out.decisions[1].risk, FidelityRisk::Low);
+}
+
+#[test]
+fn test_media_fragments_with_blank_captions_and_different_bytes_are_not_deduped() {
+    // Given two DISTINCT images that both happen to carry a blank caption —
+    // under plain text-content dedup these would collide ("" == ""); media
+    // identity must never fall back to comparing captions.
+    let fragments = vec![
+        media_fragment("", PNG_64X48_B64),
+        media_fragment("", PNG_1024X768_B64),
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    assert_eq!(out.decisions[0].action, ContextAction::Preserve);
+    assert_eq!(
+        out.decisions[1].action,
+        ContextAction::Preserve,
+        "distinct images with blank captions must never be falsely deduped"
+    );
+}
+
+#[test]
+fn test_media_fragment_never_scans_bytes_b64_for_text_classification_rules() {
+    // Given a media fragment whose base64 payload happens to embed
+    // substrings that would trigger text rules (a URL-shaped fragment, code
+    // fences) if it were ever treated as content
+    let frag = ContextFragment {
+        media: Some(MediaRef {
+            mime: "image/png".to_owned(),
+            // Deliberately not valid base64 semantics-wise for a real PNG,
+            // but well-formed base64 syntax (required by validation) that
+            // *contains* "http" and "```"-shaped runs if naively scanned as
+            // text — proving classification never reads `bytes_b64`.
+            bytes_b64: "aHR0cDovL2BgYA==".to_owned(),
+        }),
+        ..fragment("")
+    };
+    let out = compile(&request(vec![frag], 10_000));
+
+    // Then it still classifies as media.atomic, not preserve.url or
+    // preserve.code_fence
+    assert_eq!(out.decisions[0].rule_id, "media.atomic");
+}
+
+#[test]
+fn test_media_compilation_is_fully_deterministic() {
+    // Given a mixed corpus of media fragments: distinct, duplicated, and
+    // budget-exceeding
+    let fragments = vec![
+        media_fragment("first shot", PNG_64X48_B64),
+        media_fragment("", PNG_1024X768_B64),
+        media_fragment("first shot dup", PNG_64X48_B64),
+    ];
+    let req = request(fragments, 2_000);
+
+    // When compiling the same request twice
+    let first = compile(&req);
+    let second = compile(&req);
+
+    // Then the outputs are identical byte for byte
+    assert_eq!(
+        serde_json::to_string(&first).expect("serialize first"),
+        serde_json::to_string(&second).expect("serialize second"),
+        "media compilation must be fully deterministic, exactly like text compilation"
+    );
 }

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -22,6 +22,7 @@ fn fragment(content: &str) -> ContextFragment {
         kind: None,
         priority: None,
         metadata: None,
+        media: None,
     }
 }
 

--- a/crates/velesdb-memory/tests/context_property_bdd.rs
+++ b/crates/velesdb-memory/tests/context_property_bdd.rs
@@ -80,6 +80,7 @@ fn generated_fragment(rng: &mut Lcg, pool: &mut Vec<String>) -> ContextFragment 
         },
         priority: u8::try_from(rng.below(4)).ok(),
         metadata: None,
+        media: None,
     }
 }
 
@@ -226,6 +227,7 @@ fn test_compiler_keeps_critical_facts_a_naive_truncation_loses() {
             kind: None,
             priority: None,
             metadata: None,
+            media: None,
         })
         .collect();
     let constraints: Vec<String> = (0..5)
@@ -238,6 +240,7 @@ fn test_compiler_keeps_critical_facts_a_naive_truncation_loses() {
             kind: None,
             priority: None,
             metadata: None,
+            media: None,
         });
     }
 
@@ -328,6 +331,7 @@ fn test_adversarial_pathological_inputs_never_panic() {
                     kind: None,
                     priority: None,
                     metadata: None,
+                    media: None,
                 }],
                 project: None,
                 target_model: None,
@@ -352,6 +356,7 @@ fn test_adversarial_duplicate_avalanche_stays_linear_and_correct() {
             kind: None,
             priority: None,
             metadata: None,
+            media: None,
         })
         .collect();
     let out = ContextCompiler::new(CompilePolicy::default())


### PR DESCRIPTION
## Summary

PR1 of 3 for US-009 (multimodal/screenshot fragments), implementing the spike design as acted by Julien:

- **`ContextFragment.media: Option<MediaRef>`** (`mime` + `bytes_b64`) — `content` stays the text/caption. Wire-compatible via `#[serde(default)]`.
- **`MAX_MEDIA_BYTES` cap** (4 MiB base64, ≈3 MiB raw) checked at validation time, independent of the existing per-fragment text cap; malformed base64 is rejected with `INVALID_PARAMS` before any decode-dependent work.
- **Byte-identical dedup** on the *raw decoded* media bytes (never the caption text, never near-duplicated) — `dedup::find_duplicates` gained a media namespace so two screenshots sharing a blank caption never false-positive dedup.
- **Atomic packing**: a media fragment is always exactly one all-or-nothing piece (`pieces()`), mirroring the existing `Abstract` case — never handed to `chunk_text`, so an image can never be split mid-stream.
- **`ImageTokenEstimator`**: a dependency-free PNG (`IHDR`)/JPEG (`SOF0`/`SOF2`) header-dimension sniff, cost `ceil(width*height/750)` (Claude's published constant — one formula at launch, per-provider seam documented for later). Unsupported mime or an unreadable header falls back to the default text estimator over `bytes_b64` (safe over-count).
- **Classification**: a new `media.atomic` rule, checked *first*, unconditionally — a media fragment's classification never depends on its caption text, and no text rule (`is_code`, `has_url`, …) ever scans `bytes_b64`.
- **Honest externalization gap**: PR1 ships no binary retrieval store. A media fragment that cannot fit the budget is `drop`ped with an explicit reason (`drop.media_unavailable`) instead of a `ctx://source` handle that would never resolve — same treatment applied to a media duplicate whose kept twin also failed to pack.
- **Base64**: a minimal, dependency-free decoder (`context` feature keeps zero new dependencies) — `base64` is not in `velesdb-memory`'s dependency tree even transitively.

## RED → GREEN

TDD throughout: every new module/behavior started with a failing test (compile-error red for new APIs, assertion red for classify/dedup extensions) before the minimal implementation. Notable captured reds:
- `classify` media-rule tests failed against `"preserve.default"`/`"preserve.code_fence"`/`"cache.stable_prefix"` before `media.atomic` existed.
- `dedup::find_duplicates` tests failed to compile (2-arg call) before the `media_hashes` parameter was added.
- `budget::pack` precomputed-cost tests failed compiling before `Piece`/`PackItem.pieces: Vec<Piece>`.

## Gates (all green)

```
cargo fmt --all --check                                                          OK
cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic   OK
cargo clippy -p velesdb-node --lib -- -D warnings                                OK
RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context   OK
cargo test -p velesdb-memory                                                     255 lib + 141 integration tests, 0 failed
python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py  OK (post release-mode debug build, wire non-regression)
```

## Coverage (`cargo llvm-cov -p velesdb-memory --summary-only`) — new/touched files

| File | Line coverage |
|---|---|
| `context.rs` | 97.59% |
| `context/budget.rs` | 100.00% |
| `context/classify.rs` | 99.19% |
| `context/dedup.rs` | 100.00% |
| `context/estimator.rs` | 100.00% |
| `context/media.rs` | 100.00% |
| `context/model.rs` | 100.00% |

All ≥90% target met.

## Externalization decision (PR1 scope)

Per the acted design: a media fragment that fits the budget is `Preserve`d normally; one that doesn't is `Drop`ped with an explicit `"media externalization lands in the next PR"` reason rather than an `externalized_verdict`/`Retrieve` handle that would never resolve (no binary store exists yet). Same honesty applied one level deeper: a media duplicate whose kept twin also failed to pack gets no handle either (unlike the text-duplicate case, which still hands out an informational one).

## Deviations from the spike brief

None substantive. Two implementation choices made explicit and pinned by tests:
- `Analysis.tokens` / a packed media piece's precomputed cost = `image_tokens + estimator.estimate(caption)` (not image cost alone) — keeps `tokens_saved`/`tokens_saved_by_rule` honest when a caption is non-empty.
- `CompilationInsights.tokens_out` adds only the *image* portion on top of `estimator.estimate(content)` (which already picks up any non-empty caption text via the assembled content string) — avoids double-counting captions while still accounting for images, which are never textually present in `content`.

## Out of scope (PR2/PR3)

Externalized binary storage, screenshot expiry, and the Node/WASM/wire surface.

Do not merge — for review.