### PR TITLE
feat(memory): media source storage + screenshot supersession [EPIC-P-071/US-009]

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Media source storage & screenshot supersession (experimental, PR2/3 of
+  US-009 in EPIC-P-071)** — the memory bridge now persists a media
+  fragment's base64 payload alongside its caption when storing a compiled
+  source (reserved key `_veles_ctx_source_media`, embedded with a
+  deterministic bytes-hash-derived placeholder vector rather than the text
+  embedder — `retrieve_context_source` resolves media sources by
+  content-addressed hash only, never by vector search). PR1's provisional
+  `drop.media_unavailable` verdict is gone: a media fragment that cannot fit
+  the budget now externalizes exactly like text (`budget.externalize`, a
+  resolvable `ctx://source` handle), and a duplicate media fragment whose
+  twin also failed to pack recovers through its own handle too.
+  `MemoryService::retrieve_context_source` returns the new `ContextSource {
+  content, media? }` shape (`media` is `#[serde(default)]`, so every
+  pre-PR2 text-only source round-trips unchanged); the MCP
+  `retrieve_context_source` tool result gained the same optional `media`
+  field, and the Python `retrieve_context_source` binding now returns a
+  dict instead of a bare string.
+  **Screenshot supersession**: fragments sharing `media` + `kind:
+  "screenshot"` + the same `metadata.target` value are a succession
+  series — only the LAST one (input order, no clock) stays inline
+  (`Preserve`, budget permitting); every earlier one is proactively
+  reclassified `retrieve.screenshot_superseded` and externalized behind a
+  resolvable handle, regardless of budget, with an explicit reason. A
+  screenshot with no `metadata.target` is never superseded (no target is no
+  evidence of succession). Opt out per request via
+  `policy.disabled_rules: ["retrieve.screenshot_superseded"]`. Byte-compat:
+  a request with no media is unaffected.
 - **Media fragments (experimental, PR1/3 of US-009 in EPIC-P-071)** —
   `ContextFragment.media: Option<MediaRef>` lets a fragment carry an inline
   base64-encoded image (`mime` + `bytes_b64`) alongside its text/caption
@@ -21,12 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ceil(width * height / 750)`; unsupported mimes or unreadable headers fall
   back to a safe text-based over-count). Capped at 4 MiB of base64
   (`limits::MAX_MEDIA_BYTES`), separate from the existing per-fragment text
-  cap; malformed base64 is rejected at validation time. PR1 ships no binary
-  retrieval store: a media fragment that cannot fit the budget is `drop`ped
-  with an explicit reason (`drop.media_unavailable`) rather than handed a
-  `ctx://source` handle that would not resolve — externalized-media storage,
-  screenshot expiry, and the Node/WASM/wire surface land in a later PR. Wire-
-  compatible: `media` is `#[serde(default)]`, so every existing request still
+  cap; malformed base64 is rejected at validation time. Wire-compatible:
+  `media` is `#[serde(default)]`, so every existing request still
   deserializes unchanged.
 
 ## [0.6.0] - 2026-07-06

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -17,7 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   source (reserved key `_veles_ctx_source_media`, embedded with a
   deterministic bytes-hash-derived placeholder vector rather than the text
   embedder — `retrieve_context_source` resolves media sources by
-  content-addressed hash only, never by vector search). PR1's provisional
+  content-addressed hash only, never by vector search). A media fragment's
+  handle — and its storage slot, still under the same salted system-fact
+  namespace — is keyed on the **raw decoded bytes' hash** (the identity
+  PR1's dedup already uses), never the caption text: two different images
+  always get two different, independently resolving handles even with
+  identical (typically blank) captions, while byte-identical images share
+  one handle and resolve the same stored bytes with the kept instance's
+  caption. Storage note: each distinct media source fact carries its full
+  base64 payload — up to 4 MiB (`limits::MAX_MEDIA_BYTES`), above the 1 MiB
+  `MAX_FACT_BYTES` ceiling which only guards MCP `remember`/`extract` text
+  input — bounded per request by `MAX_MEDIA_BYTES`/`MAX_TOTAL_MEDIA_BYTES`
+  and by `policy.source_ttl_seconds` over time. PR1's provisional
   `drop.media_unavailable` verdict is gone: a media fragment that cannot fit
   the budget now externalizes exactly like text (`budget.externalize`, a
   resolvable `ctx://source` handle), and a duplicate media fragment whose

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -617,13 +617,12 @@ so an audit trail always shows *why* a log collapsed the way it did. Off by
 default: it changes what "duplicate" means for logs, so existing callers
 keep byte-exact grouping unless they opt in.
 
-#### Media fragments (experimental, PR1/3)
+#### Media fragments (experimental, PR2/3)
 
 A fragment may carry an inline image alongside its text: set
 `media: {"mime": "image/png", "bytes_b64": "<base64>"}` on a
 `ContextFragment`; `content` stays the caption (often empty for a bare
-screenshot). This is **PR1 of 3** for media support — honest about what it
-does and does not do yet:
+screenshot). This is **PR2 of 3** for media support:
 
 - **Atomic packing**: a media fragment is never chunked — it packs whole
   under the budget or not at all, so an image can never be cut mid-stream.
@@ -638,13 +637,32 @@ does and does not do yet:
 - **Capped at 4 MiB of base64** (`limits::MAX_MEDIA_BYTES`, ≈3 MiB decoded),
   independent of the text-content cap; malformed base64 is rejected at
   validation.
-- **No binary retrieval store yet.** A media fragment that does not fit the
-  budget is `drop`ped with an explicit reason
-  (`decision.rule_id == "drop.media_unavailable"`) instead of being handed a
-  `ctx://source/` handle — PR1 has nowhere to persist the bytes behind such a
-  handle, so it does not pretend one exists. Externalized-media storage,
-  screenshot expiry, and the Node/WASM/wire surface are **not yet built**;
-  they land in PR2/PR3.
+- **Real retrieval, through the memory bridge.** A media fragment that does
+  not fit the budget externalizes exactly like text: `decision.action ==
+  "retrieve"`, `rule_id == "budget.externalize"`, and a `ctx://source/`
+  handle. `MemoryService::compile_context` (with `policy.store_sources`,
+  the default) persists the fragment's base64 payload alongside its caption
+  — `MemoryService::retrieve_context_source(handle)` returns `{content,
+  media?}`, `media` present whenever the original fragment carried one.
+  Media is embedded with a deterministic placeholder vector derived from
+  its raw bytes' hash, never through the text embedder: resolution is by
+  content-addressed hash only, never by vector search. The bare
+  `ContextCompiler` (no memory) still just *mints* the handle, exactly as
+  it does for text — it never knows or cares whether a resolver is
+  attached.
+- **Screenshot supersession.** Fragments that share `media`, `kind:
+  "screenshot"`, and the same `metadata.target` value form a succession
+  series: only the LAST one in the request (input order — never a clock)
+  stays inline; every earlier one is reclassified
+  `retrieve.screenshot_superseded` and externalized behind a resolvable
+  handle, regardless of budget — a stale screenshot never competes with the
+  current one for space. `metadata.target` should identify the *subject*
+  being screenshotted (a URL, a test name, a UI element id — the caller's
+  choice); a screenshot with no `metadata.target` is never superseded, since
+  there is no evidence it succeeds anything. Opt out per request with
+  `policy.disabled_rules: ["retrieve.screenshot_superseded"]`.
+- **Node/WASM/wire surface** beyond the MCP tools and the Python binding
+  above is **not yet built**; it lands in PR3.
 
 #### Source TTL & disk growth
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -640,6 +640,10 @@ screenshot). This is **PR2 of 3** for media support:
 - **Real retrieval, through the memory bridge.** A media fragment that does
   not fit the budget externalizes exactly like text: `decision.action ==
   "retrieve"`, `rule_id == "budget.externalize"`, and a `ctx://source/`
+  handle. A media handle is content-addressed on the **raw decoded bytes**
+  (the same identity dedup uses), never the caption — two different images
+  always get two distinct, independently resolving handles even when both
+  captions are blank (the common case), and byte-identical images share one
   handle. `MemoryService::compile_context` (with `policy.store_sources`,
   the default) persists the fragment's base64 payload alongside its caption
   — `MemoryService::retrieve_context_source(handle)` returns `{content,

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -36,7 +36,11 @@ mod dedup;
 pub mod estimator;
 pub mod insights;
 mod log_normalize;
-mod media;
+// `pub(crate)`, not private: the memory bridge (`service::memory_bridge`,
+// physically stored under `context/` but logically a sibling module of
+// `context`, see `service.rs`) decodes media bytes itself (US-009, PR2) to
+// derive a deterministic placeholder embedding for a stored media source.
+pub(crate) mod media;
 pub mod model;
 pub(crate) mod provenance;
 mod relevance;
@@ -51,8 +55,8 @@ pub use insights::{CompilationInsights, ModelPricing, PricingTable};
 pub use model::{
     CompilePolicy, CompileRequest, CompiledContext, CompiledSection, ContextAction,
     ContextDecision, ContextDecisionRef, ContextFact, ContextFragment, ContextSavings,
-    FidelityRisk, ImportanceWeights, MediaRef, MemoryScope, RetrievalHandle, SectionKind,
-    SourceReference, WorkingContext,
+    ContextSource, FidelityRisk, ImportanceWeights, MediaRef, MemoryScope, RetrievalHandle,
+    SectionKind, SourceReference, WorkingContext,
 };
 pub use relevance::DeterministicReranker;
 
@@ -217,8 +221,8 @@ impl ContextCompiler {
         // raw media bytes are never turned into packed text (see `pieces`).
         // The image's own cost has to be added on top, but only for media
         // that actually made it into the output (an emissions entry exists)
-        // — a dropped image (see `media_unavailable_verdict`) contributed
-        // nothing and must not appear here either.
+        // — an externalized or superseded image contributed nothing and
+        // must not appear here either (see `pack_items`).
         let media_tokens_out: u64 = analyses
             .iter()
             .filter(|analysis| emissions.contains_key(&analysis.seq))
@@ -290,6 +294,15 @@ struct Analysis<'a> {
     /// dedup identity and precomputed image token cost, computed once here
     /// (decoding is not free) and reused by dedup, packing, and insights.
     media: Option<media::MediaAnalysis>,
+    /// Set when a LATER fragment in the same request shares this one's
+    /// `kind == "screenshot"` and `metadata.target` value (US-009, PR2 —
+    /// see [`classify::screenshot_supersession`]): excluded from packing
+    /// entirely regardless of budget (see [`pack_items`]) and routed to
+    /// [`superseded_screenshot_verdict`] instead of the ordinary
+    /// pack-outcome verdicts. `analysis.rule` is left untouched (still
+    /// whatever [`classify::classify`] returned) — only this flag steers
+    /// packing and the decision; nothing else needs to know why.
+    superseded: bool,
 }
 
 /// A media fragment's total precomputed token cost: the image alone (from
@@ -417,6 +430,10 @@ fn analyze<'a>(
         .map(|analysis| analysis.as_ref().map(|analysis| analysis.raw_hash))
         .collect();
     let duplicates = dedup::find_duplicates(&contents, policy.near_dup_dedup, &media_hashes);
+    // Whole-batch pass, symmetric to `dedup::find_duplicates` above: needs
+    // every fragment's `kind` + `metadata.target` at once, which a per-
+    // fragment `classify::classify` call cannot see.
+    let superseded_flags = classify::screenshot_supersession(&request.fragments);
     let query_terms = relevance::terms(&request.query);
     let mut analyses: Vec<Analysis<'a>> = request
         .fragments
@@ -437,6 +454,13 @@ fn analyze<'a>(
                 || estimator.estimate(&fragment.content),
                 |media| media_fragment_tokens(media, &fragment.content, estimator),
             );
+            // A caller can opt out via `disabled_rules`, exactly like every
+            // other named rule — even though this one is not a `RULES` row.
+            let superseded = superseded_flags[seq]
+                && !policy
+                    .disabled_rules
+                    .iter()
+                    .any(|disabled| disabled == classify::SCREENSHOT_SUPERSEDED_RULE_ID);
             Analysis {
                 seq,
                 fragment_id: fragment.id.unwrap_or(content_hash),
@@ -449,6 +473,7 @@ fn analyze<'a>(
                 dup,
                 abstract_collapse,
                 media: media_analysis,
+                superseded,
             }
         })
         .collect();
@@ -489,7 +514,9 @@ fn pack_items(
     let chunk_policy = effective_chunk_policy(policy, usable, estimator);
     analyses
         .iter()
-        .filter(|analysis| analysis.dup.is_none())
+        // A superseded screenshot (US-009, PR2) is never attempted, budget
+        // or no budget — see `Analysis::superseded`.
+        .filter(|analysis| analysis.dup.is_none() && !analysis.superseded)
         .map(|analysis| PackItem {
             seq: analysis.seq,
             critical: analysis.rule.critical,
@@ -644,15 +671,20 @@ fn decision(
     let emission = emissions.get(&analysis.seq);
     let (action, rule_id, risk, reason, handle) = match (&analysis.dup, emission) {
         (Some(dup), _) => dup_verdict(analysis, *dup, &all[dup.kept_seq], emissions),
+        // Checked before the emission-based arms: a superseded screenshot
+        // (US-009, PR2) is excluded from packing entirely (see
+        // `pack_items`), so `emission` is always `None` here anyway — this
+        // arm exists to give it its own rule id and reason rather than
+        // falling into the generic `externalized_verdict` below.
+        (None, _) if analysis.superseded => superseded_screenshot_verdict(analysis),
         (None, Some(emission)) if emission.is_full() => full_verdict(analysis),
         (None, Some(emission)) => partial_verdict(analysis, emission),
         // A media fragment's single atomic piece is always taken whole or
         // not at all (see `pieces`), so a missing emission for one means
         // "did not fit" — never "took none of what was offered" from a
-        // multi-piece fragment. PR1 has no binary retrieval store, so
-        // externalizing it behind a `ctx://source` handle would promise a
-        // fetch that cannot succeed; drop it instead, honestly.
-        (None, None) if analysis.media.is_some() => media_unavailable_verdict(analysis),
+        // multi-piece fragment. Media externalizes exactly like text
+        // (US-009, PR2): the memory bridge persists the bytes behind the
+        // handle this mints (see `MemoryService::retrieve_context_source`).
         (None, None) => externalized_verdict(analysis),
     };
     ContextDecision {
@@ -723,24 +755,10 @@ fn dup_verdict(
             Some(provenance::handle_for(analysis.content_hash)),
         );
     }
-    if analysis.media.is_some() {
-        // Same PR1 honesty gap as `media_unavailable_verdict`: the twin
-        // itself did not fully pack, and there is no binary retrieval store
-        // yet, so this duplicate is not recoverable through a handle either
-        // — unlike the text case below, do not hand out one that would not
-        // resolve.
-        return (
-            ContextAction::Drop,
-            rule_id.to_owned(),
-            critical_risk(analysis.rule.critical),
-            format!(
-                "{variant} of fragment #{} — that twin was not fully emitted, and media \
-                 externalization lands in the next PR, so this duplicate is not retrievable either",
-                dup.kept_seq
-            ),
-            None,
-        );
-    }
+    // Media dedup is otherwise unremarkable here: the twin's bytes were not
+    // fully packed either, but (US-009, PR2) the memory bridge now persists
+    // every non-duplicate fragment's original — media included — so a
+    // duplicate's own handle resolves exactly like a text duplicate's.
     (
         ContextAction::Drop,
         rule_id.to_owned(),
@@ -753,23 +771,20 @@ fn dup_verdict(
     )
 }
 
-/// A media fragment (US-009, PR1) that did not fit the budget: `drop`ped
-/// with an explicit, honest reason instead of the generic
-/// [`externalized_verdict`] — PR1 ships no binary retrieval store, so
-/// handing out a `ctx://source` handle here would promise a fetch that can
-/// never resolve. A future PR that lands media externalization changes this
-/// verdict, not the atomic-packing or dedup behavior around it.
-fn media_unavailable_verdict(analysis: &Analysis) -> Verdict {
+/// A screenshot the whole-batch pass reclassified
+/// `retrieve.screenshot_superseded` (US-009, PR2 — see
+/// [`classify::screenshot_supersession`]): excluded from packing entirely,
+/// regardless of budget (see [`pack_items`]), because a LATER fragment in
+/// the same request already carries the current state of the same
+/// `metadata.target`. Always gets a resolvable handle — the memory bridge
+/// stores every non-duplicate fragment's original, media included.
+fn superseded_screenshot_verdict(analysis: &Analysis) -> Verdict {
     (
-        ContextAction::Drop,
-        "drop.media_unavailable".to_owned(),
-        critical_risk(analysis.rule.critical),
-        format!(
-            "did not fit the budget ({}); media externalization lands in the next PR, so it is \
-             dropped rather than given a retrieval handle that would not resolve",
-            analysis.rule.reason
-        ),
-        None,
+        ContextAction::Retrieve,
+        classify::SCREENSHOT_SUPERSEDED_RULE_ID.to_owned(),
+        FidelityRisk::Medium,
+        classify::SCREENSHOT_SUPERSEDED_REASON.to_owned(),
+        Some(provenance::handle_for(analysis.content_hash)),
     )
 }
 

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -15,8 +15,11 @@
 //! - **Provenance**: every input fragment gets exactly one
 //!   [`ContextDecision`](crate::context::ContextDecision) with a stable rule
 //!   id and a content hash; every fragment stays addressable via a
-//!   **content-addressed** `ctx://source/<content_hash>` handle (immune to
-//!   caller-id collisions).
+//!   **content-addressed** `ctx://source/<hash>` handle (immune to
+//!   caller-id collisions) — hashed over the text for a text fragment, over
+//!   the raw decoded media bytes for a media fragment (see
+//!   `Analysis::handle_hash`: captions are typically blank, so a
+//!   caption-keyed handle would collide every captionless image).
 //! - **Nothing critical is silently lost**: content that cannot fit becomes
 //!   a [`RetrievalHandle`](crate::context::RetrievalHandle); losing
 //!   preserve-classified content raises
@@ -188,7 +191,9 @@ impl ContextCompiler {
             sources: analyses
                 .iter()
                 .filter(|analysis| analysis.dup.is_none())
-                .map(|analysis| provenance::source_for(analysis.fragment_id, analysis.content_hash))
+                .map(|analysis| {
+                    provenance::source_for(analysis.fragment_id, analysis.handle_hash())
+                })
                 .collect(),
             risk: decisions
                 .iter()
@@ -303,6 +308,25 @@ struct Analysis<'a> {
     /// whatever [`classify::classify`] returned) — only this flag steers
     /// packing and the decision; nothing else needs to know why.
     superseded: bool,
+}
+
+impl Analysis<'_> {
+    /// The hash every `ctx://source/<hash>` handle (and thus every bridge
+    /// storage slot) for this fragment is minted from. **Media identity is
+    /// the raw decoded BYTES** ([`media::MediaAnalysis::raw_hash`]), exactly
+    /// like PR1's dedup — never the caption text: captions are typically
+    /// blank, and keying on them would collide every captionless image onto
+    /// one handle (serving arbitrary wrong bytes back). Two different
+    /// images therefore always get two different handles; byte-identical
+    /// images share one handle and resolve the same stored bytes (with the
+    /// kept instance's caption — divergent duplicate captions do not
+    /// survive, same as PR1's dedup semantics). Text fragments keep the
+    /// content hash, byte-identical to every pre-PR2 handle.
+    fn handle_hash(&self) -> u64 {
+        self.media
+            .as_ref()
+            .map_or(self.content_hash, |media| media.raw_hash)
+    }
 }
 
 /// A media fragment's total precomputed token cost: the image alone (from
@@ -752,7 +776,7 @@ fn dup_verdict(
             rule_id.to_owned(),
             FidelityRisk::Low,
             reason,
-            Some(provenance::handle_for(analysis.content_hash)),
+            Some(provenance::handle_for(analysis.handle_hash())),
         );
     }
     // Media dedup is otherwise unremarkable here: the twin's bytes were not
@@ -767,7 +791,7 @@ fn dup_verdict(
             "{variant} of fragment #{} — but that twin was not fully emitted — recover via the handle",
             dup.kept_seq
         ),
-        Some(provenance::handle_for(analysis.content_hash)),
+        Some(provenance::handle_for(analysis.handle_hash())),
     )
 }
 
@@ -784,7 +808,7 @@ fn superseded_screenshot_verdict(analysis: &Analysis) -> Verdict {
         classify::SCREENSHOT_SUPERSEDED_RULE_ID.to_owned(),
         FidelityRisk::Medium,
         classify::SCREENSHOT_SUPERSEDED_REASON.to_owned(),
-        Some(provenance::handle_for(analysis.content_hash)),
+        Some(provenance::handle_for(analysis.handle_hash())),
     )
 }
 
@@ -816,7 +840,7 @@ fn partial_verdict(analysis: &Analysis, emission: &Emission) -> Verdict {
             emission.taken,
             emission.total
         ),
-        Some(provenance::handle_for(analysis.content_hash)),
+        Some(provenance::handle_for(analysis.handle_hash())),
     )
 }
 
@@ -847,7 +871,7 @@ fn externalized_verdict(analysis: &Analysis) -> Verdict {
             "did not fit the budget ({}); retrievable via its handle",
             analysis.rule.reason
         ),
-        Some(provenance::handle_for(analysis.content_hash)),
+        Some(provenance::handle_for(analysis.handle_hash())),
     )
 }
 
@@ -858,7 +882,7 @@ fn retrieval_handles(analyses: &[Analysis], decisions: &[ContextDecision]) -> Ve
         .zip(decisions)
         .filter(|(_, decision)| decision.action == ContextAction::Retrieve)
         .map(|(analysis, _)| RetrievalHandle {
-            handle: provenance::handle_for(analysis.content_hash),
+            handle: provenance::handle_for(analysis.handle_hash()),
             fragment_id: analysis.fragment_id,
             estimated_tokens: analysis.tokens,
         })

--- a/crates/velesdb-memory/src/context/classify.rs
+++ b/crates/velesdb-memory/src/context/classify.rs
@@ -308,6 +308,58 @@ fn annotated(line: &str, count: usize) -> String {
     }
 }
 
+/// Stable id of the screenshot-supersession verdict (US-009, PR2). Not a row
+/// in the [`RULES`] table above — it needs cross-fragment visibility a
+/// per-fragment `applies: fn(&ContextFragment, &CompilePolicy) -> bool`
+/// cannot have (whether THIS fragment is the last of its series) — but it is
+/// disclosed here, next to [`screenshot_supersession`], because in every
+/// sense a caller cares about it IS a classification rule: a stable public
+/// id that decides a fragment's fate before budget packing ever runs (see
+/// `super::pack_items` and `super::superseded_screenshot_verdict`).
+pub(crate) const SCREENSHOT_SUPERSEDED_RULE_ID: &str = "retrieve.screenshot_superseded";
+
+/// The reason recorded for every screenshot [`screenshot_supersession`]
+/// supersedes.
+pub(crate) const SCREENSHOT_SUPERSEDED_REASON: &str =
+    "superseded by a newer screenshot of the same target";
+
+/// Reserved fragment metadata key naming a screenshot's subject — the value
+/// two `kind: "screenshot"` fragments must share (JSON equality) to belong
+/// to the same succession series.
+const SCREENSHOT_TARGET_KEY: &str = "target";
+
+/// This fragment's screenshot-succession identity: `Some(target)` only when
+/// it carries media, is `kind == "screenshot"`, AND names a
+/// `metadata.target` — a screenshot with no target is never part of a
+/// series (no target is no evidence of succession), and a plain media
+/// fragment (no `kind` at all, or a different `kind`) is never a candidate
+/// either, however similar its metadata looks.
+fn screenshot_target(fragment: &ContextFragment) -> Option<&Value> {
+    if fragment.media.is_none() || fragment.kind.as_deref() != Some("screenshot") {
+        return None;
+    }
+    fragment.metadata.as_ref()?.get(SCREENSHOT_TARGET_KEY)
+}
+
+/// For each fragment, in input order: whether a LATER fragment in the same
+/// request shares its screenshot-succession identity ([`screenshot_target`])
+/// — i.e. `true` for every screenshot of a target EXCEPT the last. Whole-
+/// batch pass, symmetric to [`super::dedup::find_duplicates`]: both need
+/// every fragment at once and both key on an identity narrower than full
+/// content equality, but here the picture is reversed — an ordered
+/// succession survives at its LAST member (the freshest screenshot), not
+/// its first duplicate-detection anchor. Deterministic and clock-free: input
+/// order is the only signal, exactly like every other rule in this module.
+pub(crate) fn screenshot_supersession(fragments: &[ContextFragment]) -> Vec<bool> {
+    let targets: Vec<Option<&Value>> = fragments.iter().map(screenshot_target).collect();
+    (0..fragments.len())
+        .map(|seq| match targets[seq] {
+            Some(target) => targets[seq + 1..].contains(&Some(target)),
+            None => false,
+        })
+        .collect()
+}
+
 #[cfg(test)]
 #[path = "classify_tests.rs"]
 mod tests;

--- a/crates/velesdb-memory/src/context/classify_tests.rs
+++ b/crates/velesdb-memory/src/context/classify_tests.rs
@@ -243,6 +243,84 @@ fn media_fragment(caption: &str) -> ContextFragment {
     }
 }
 
+// --- screenshot_supersession (US-009, PR2) --------------------------------
+
+fn screenshot(caption: &str, target: &str) -> ContextFragment {
+    let mut meta = Map::new();
+    meta.insert("target".to_owned(), Value::String(target.to_owned()));
+    ContextFragment {
+        kind: Some("screenshot".to_owned()),
+        metadata: Some(meta),
+        ..media_fragment(caption)
+    }
+}
+
+#[test]
+fn test_screenshot_supersession_three_same_target_supersedes_all_but_the_last() {
+    let fragments = vec![
+        screenshot("v1", "login-page"),
+        screenshot("v2", "login-page"),
+        screenshot("v3", "login-page"),
+    ];
+    assert_eq!(screenshot_supersession(&fragments), vec![true, true, false]);
+}
+
+#[test]
+fn test_screenshot_supersession_different_targets_are_never_superseded() {
+    let fragments = vec![
+        screenshot("a", "login-page"),
+        screenshot("b", "checkout-page"),
+    ];
+    assert_eq!(screenshot_supersession(&fragments), vec![false, false]);
+}
+
+#[test]
+fn test_screenshot_supersession_without_target_is_never_superseded() {
+    let no_target = media_fragment_kind("screenshot");
+    let fragments = vec![no_target.clone(), no_target];
+    assert_eq!(screenshot_supersession(&fragments), vec![false, false]);
+}
+
+#[test]
+fn test_screenshot_supersession_ignores_media_fragments_without_screenshot_kind() {
+    // Same media bytes, same metadata shape, but not `kind: "screenshot"` —
+    // never a supersession candidate.
+    let mut meta = Map::new();
+    meta.insert("target".to_owned(), Value::String("login-page".to_owned()));
+    let not_a_screenshot = ContextFragment {
+        metadata: Some(meta),
+        ..media_fragment("a")
+    };
+    let fragments = vec![not_a_screenshot.clone(), not_a_screenshot];
+    assert_eq!(screenshot_supersession(&fragments), vec![false, false]);
+}
+
+#[test]
+fn test_screenshot_supersession_ignores_non_media_fragments_even_with_matching_metadata() {
+    let mut meta = Map::new();
+    meta.insert("target".to_owned(), Value::String("login-page".to_owned()));
+    let text_only = ContextFragment {
+        kind: Some("screenshot".to_owned()),
+        metadata: Some(meta),
+        ..fragment("no media here")
+    };
+    let fragments = vec![text_only.clone(), text_only];
+    assert_eq!(screenshot_supersession(&fragments), vec![false, false]);
+}
+
+#[test]
+fn test_screenshot_supersession_a_single_screenshot_is_never_superseded() {
+    let fragments = vec![screenshot("only one", "login-page")];
+    assert_eq!(screenshot_supersession(&fragments), vec![false]);
+}
+
+fn media_fragment_kind(kind: &str) -> ContextFragment {
+    ContextFragment {
+        kind: Some(kind.to_owned()),
+        ..media_fragment("no target")
+    }
+}
+
 #[test]
 fn test_classify_media_fragment_gets_its_own_atomic_rule() {
     let matched = classify_default(&media_fragment(""));

--- a/crates/velesdb-memory/src/context/media_pipeline_tests.rs
+++ b/crates/velesdb-memory/src/context/media_pipeline_tests.rs
@@ -74,6 +74,7 @@ fn analysis_for(
         dup: None,
         abstract_collapse: None,
         media,
+        superseded: false,
     }
 }
 
@@ -222,10 +223,13 @@ fn test_pieces_non_media_fragment_is_unaffected() {
     assert!(result.iter().all(|piece| piece.cost.is_none()));
 }
 
-// --- decision routing: media fragments never get a dangling handle ------
+// --- decision routing: an unfit media fragment externalizes like text ---
 
 #[test]
-fn test_decision_routes_an_unfit_media_fragment_to_drop_not_retrieve() {
+fn test_decision_routes_an_unfit_media_fragment_to_retrieve_with_a_handle() {
+    // US-009, PR2: the memory bridge now persists media sources, so an
+    // unfit media fragment externalizes exactly like text — the PR1
+    // `drop.media_unavailable` provisional verdict is gone.
     let media_analysis = media::MediaAnalysis {
         raw_hash: 1,
         image_tokens: 500,
@@ -234,14 +238,14 @@ fn test_decision_routes_an_unfit_media_fragment_to_drop_not_retrieve() {
     let all: Vec<Analysis<'_>> = Vec::new();
     let emissions: BTreeMap<usize, Emission> = BTreeMap::new();
     let recorded = decision(&analysis, &all, &emissions);
-    assert_eq!(recorded.action, ContextAction::Drop);
-    assert_eq!(recorded.rule_id, "drop.media_unavailable");
+    assert_eq!(recorded.action, ContextAction::Retrieve);
+    assert_eq!(recorded.rule_id, "budget.externalize");
     assert_eq!(recorded.risk, FidelityRisk::High);
     assert!(
-        recorded.handle.is_none(),
-        "no binary retrieval store exists yet in PR1 — no handle must be promised"
+        recorded.handle.is_some(),
+        "PR2 media sources are stored, so a resolvable handle must be handed out"
     );
-    assert!(recorded.reason.contains("next PR"));
+    assert!(recorded.reason.contains("did not fit the budget"));
 }
 
 #[test]
@@ -268,10 +272,13 @@ fn test_decision_routes_a_fitting_media_fragment_to_preserve() {
     assert!(recorded.handle.is_none());
 }
 
-// --- dup_verdict: media duplicates never get a dangling handle either ---
+// --- dup_verdict: media duplicates recover via a handle, like text ------
 
 #[test]
-fn test_dup_verdict_media_duplicate_whose_twin_is_also_unfit_gets_no_handle() {
+fn test_dup_verdict_media_duplicate_whose_twin_is_also_unfit_still_gets_a_handle() {
+    // US-009, PR2: the memory bridge persists every non-duplicate source
+    // (media included), so a duplicate whose twin also failed to pack is
+    // recoverable through its own handle, exactly like a text duplicate.
     let twin = analysis_for(
         0,
         "",
@@ -300,8 +307,11 @@ fn test_dup_verdict_media_duplicate_whose_twin_is_also_unfit_gets_no_handle() {
     assert_eq!(action, ContextAction::Drop);
     assert_eq!(rule_id, "drop.duplicate");
     assert_eq!(risk, FidelityRisk::High);
-    assert!(handle.is_none());
-    assert!(reason.contains("next PR"));
+    assert!(
+        handle.is_some(),
+        "PR2 media sources are stored, so this duplicate's own bytes stay recoverable"
+    );
+    assert!(reason.contains("recover via the handle"));
 }
 
 #[test]

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -42,10 +42,10 @@ use serde_json::{Map, Number, Value};
 
 use super::{positive_ttl, MemoryService, Metadata, HUB_FIELD};
 use crate::context::model::{
-    CompileRequest, CompiledContext, ContextFragment, ContextSavings, ImportanceWeights,
-    MemoryScope, WorkingContext,
+    CompileRequest, CompiledContext, ContextFragment, ContextSavings, ContextSource,
+    ImportanceWeights, MediaRef, MemoryScope, WorkingContext,
 };
-use crate::context::{provenance, ContextCompiler};
+use crate::context::{media, provenance, ContextCompiler};
 use crate::embedder::Embedder;
 use crate::error::MemoryError;
 use crate::id::stable_id;
@@ -75,6 +75,11 @@ const CTX_EVENT_FIELD: &str = "_veles_ctx_event";
 const CTX_PROJECT_FIELD: &str = "_veles_ctx_project";
 const CTX_MODEL_FIELD: &str = "_veles_ctx_model";
 const CTX_SOURCE_FIELD: &str = "_veles_ctx_source";
+/// A stored source's media payload (US-009, PR2): `{"mime", "bytes_b64"}`,
+/// the exact [`MediaRef`] shape, set only when the source fragment carried
+/// one. Reserved like every other `_veles_ctx_*` key — a caller can neither
+/// set nor filter on it.
+const CTX_SOURCE_MEDIA_FIELD: &str = "_veles_ctx_source_media";
 const CTX_WORKING_FIELD: &str = "_veles_ctx_working";
 const CTX_SESSION_FIELD: &str = "_veles_ctx_session";
 const CTX_TOKENS_IN_FIELD: &str = "_veles_ctx_tokens_in";
@@ -306,23 +311,42 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
 
     /// Store every distinct fragment's original as a hub-marked system fact
     /// keyed by its salted content hash, so its handle can be resolved later.
+    /// A fragment carrying media (US-009, PR2) has its base64 payload
+    /// persisted alongside the caption under the reserved
+    /// [`CTX_SOURCE_MEDIA_FIELD`] key — the slot is still keyed on
+    /// [`stable_id`] of `fragment.content` (the caption), the SAME handle
+    /// namespace [`provenance::handle_for`] already mints for text: two
+    /// media fragments that happen to share an identical caption (most
+    /// commonly both blank) collide onto the same slot, first-write-wins,
+    /// exactly as two identical-caption TEXT fragments already do — PR2
+    /// extends what lives at an existing address, it does not add a second
+    /// one keyed on the media bytes.
+    ///
+    /// Size: [`crate::limits::MAX_MEDIA_BYTES`] /
+    /// [`crate::limits::MAX_TOTAL_MEDIA_BYTES`] already bounded every
+    /// fragment's `bytes_b64` before `compiler.compile` ever ran (see
+    /// `validate_media`, called from `compile`'s `validate`) — `augmented`
+    /// here is exactly the request that passed that check, so no separate
+    /// size guard is needed on the write path itself
+    /// ([`crate::limits::MAX_FACT_BYTES`] governs the unrelated MCP
+    /// `remember`/`extract` text ceiling, not this one).
     fn store_context_sources(
         &self,
         augmented: &CompileRequest,
         out: &CompiledContext,
         ttl_seconds: Option<u64>,
     ) -> Result<(), MemoryError> {
-        let by_hash: BTreeMap<u64, &str> = augmented
+        let by_hash: BTreeMap<u64, &ContextFragment> = augmented
             .fragments
             .iter()
-            .map(|fragment| (stable_id(&fragment.content), fragment.content.as_str()))
+            .map(|fragment| (stable_id(&fragment.content), fragment))
             .collect();
         let ttl_seconds = positive_ttl(ttl_seconds);
         for source in &out.sources {
             let Some(hash) = provenance::parse_handle(&source.handle) else {
                 continue;
             };
-            let Some(content) = by_hash.get(&hash) else {
+            let Some(fragment) = by_hash.get(&hash) else {
                 continue;
             };
             let slot = source_id(hash);
@@ -335,46 +359,88 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             if self.store.get(slot)?.is_some() {
                 continue;
             }
-            let embedding = self.embedder.embed(content)?;
+            let content = fragment.content.as_str();
+            let mut extra: Vec<(&str, Value)> = vec![(CTX_SOURCE_FIELD, Value::Bool(true))];
+            let embedding = if let Some(media_ref) = &fragment.media {
+                extra.push((
+                    CTX_SOURCE_MEDIA_FIELD,
+                    serde_json::to_value(media_ref).unwrap_or(Value::Null),
+                ));
+                // Deterministic, derived from the DECODED bytes — never the
+                // text embedder over `content` (often blank) or over the
+                // base64 payload itself (opaque, not language). Correct
+                // because `retrieve_context_source` resolves a media source
+                // EXCLUSIVELY by its content-addressed hash/slot, never by
+                // vector search — this vector only needs to be well-formed
+                // and non-degenerate for the underlying index, never
+                // semantically meaningful.
+                self.media_placeholder_embedding(media::analyze(media_ref).raw_hash)
+            } else {
+                self.embedder.embed(content)?
+            };
             self.store_fact(
                 slot,
                 content,
                 &embedding,
-                Some(&system_meta(&[(CTX_SOURCE_FIELD, Value::Bool(true))])),
+                Some(&system_meta(&extra)),
                 ttl_seconds,
             )?;
         }
         Ok(())
     }
 
-    /// Whether the fact at `slot` carries the stored-source marker.
-    fn slot_is_context_source(&self, slot: u64) -> Result<bool, MemoryError> {
-        let payloads = self.store.get_metadata_batch(&[slot])?;
-        Ok(payloads.first().is_some_and(|payload| {
-            payload
-                .as_ref()
-                .is_some_and(|meta| meta.get(CTX_SOURCE_FIELD) == Some(&Value::Bool(true)))
-        }))
+    /// A deterministic, non-degenerate embedding for a media source (US-009,
+    /// PR2) — see [`Self::store_context_sources`] for why it is bytes-hash
+    /// derived rather than text-embedded.
+    fn media_placeholder_embedding(&self, raw_hash: u64) -> Vec<f32> {
+        let dim = self.embedder.dimension();
+        let mut vector = vec![0.0_f32; dim];
+        let Ok(dim_u64) = u64::try_from(dim) else {
+            return vector;
+        };
+        if dim_u64 == 0 {
+            return vector;
+        }
+        let bucket = usize::try_from(raw_hash % dim_u64).unwrap_or(0);
+        vector[bucket] = 1.0;
+        velesdb_core::simd_native::normalize_inplace_native(&mut vector);
+        vector
     }
 
-    /// The original content behind a `ctx://source/<hash>` handle.
+    /// The fact at `slot`'s metadata, when it carries the stored-source
+    /// marker (`None` otherwise — absent, or a caller fact squatting the
+    /// slot).
+    fn context_source_metadata(&self, slot: u64) -> Result<Option<Metadata>, MemoryError> {
+        let payloads = self.store.get_metadata_batch(&[slot])?;
+        Ok(payloads
+            .into_iter()
+            .next()
+            .flatten()
+            .filter(|meta| meta.get(CTX_SOURCE_FIELD) == Some(&Value::Bool(true))))
+    }
+
+    /// The original content — and media, when the fragment carried one —
+    /// behind a `ctx://source/<hash>` handle.
     ///
     /// # Errors
     /// Returns [`MemoryError::UnknownHandle`] when the handle is malformed
     /// or nothing is stored under it (never stored, expired, or forgotten).
-    pub fn retrieve_context_source(&self, handle: &str) -> Result<String, MemoryError> {
+    pub fn retrieve_context_source(&self, handle: &str) -> Result<ContextSource, MemoryError> {
         let unknown = || MemoryError::UnknownHandle(handle.to_owned());
         let hash = provenance::parse_handle(handle).ok_or_else(unknown)?;
         let slot = source_id(hash);
         // Only marker-bearing facts are sources: a caller fact squatting the
         // salted slot is never served back as compiled provenance.
-        if !self.slot_is_context_source(slot)? {
-            return Err(unknown());
-        }
-        self.store
+        let meta = self.context_source_metadata(slot)?.ok_or_else(unknown)?;
+        let content = self
+            .store
             .get(slot)?
-            .map(|(content, _)| content)
-            .ok_or_else(unknown)
+            .map(|(content, _embedding)| content)
+            .ok_or_else(unknown)?;
+        Ok(ContextSource {
+            content,
+            media: source_media(&meta),
+        })
     }
 
     /// Record one compilation's savings as a metadata-only system fact
@@ -773,6 +839,17 @@ fn meta_u64(meta: &Metadata, key: &str) -> u64 {
 /// The salted system-fact id of a stored source.
 fn source_id(content_hash: u64) -> u64 {
     stable_id(&format!("{SOURCE_ID_SALT}{content_hash}"))
+}
+
+/// A stored source's media payload (US-009, PR2), when its metadata carries
+/// one — absent (or malformed, which should never happen for a payload this
+/// bridge wrote itself) round-trips as `None` rather than an error, so a
+/// media decode hiccup degrades to "text-only", never breaks the whole
+/// retrieval.
+fn source_media(meta: &Metadata) -> Option<MediaRef> {
+    meta.get(CTX_SOURCE_MEDIA_FIELD)
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
 }
 
 /// The salted, deterministic system-fact id of a working context.

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -310,17 +310,24 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     }
 
     /// Store every distinct fragment's original as a hub-marked system fact
-    /// keyed by its salted content hash, so its handle can be resolved later.
+    /// keyed by its salted handle hash, so its handle can be resolved later.
     /// A fragment carrying media (US-009, PR2) has its base64 payload
     /// persisted alongside the caption under the reserved
-    /// [`CTX_SOURCE_MEDIA_FIELD`] key — the slot is still keyed on
-    /// [`stable_id`] of `fragment.content` (the caption), the SAME handle
-    /// namespace [`provenance::handle_for`] already mints for text: two
-    /// media fragments that happen to share an identical caption (most
-    /// commonly both blank) collide onto the same slot, first-write-wins,
-    /// exactly as two identical-caption TEXT fragments already do — PR2
-    /// extends what lives at an existing address, it does not add a second
-    /// one keyed on the media bytes.
+    /// [`CTX_SOURCE_MEDIA_FIELD`] key.
+    ///
+    /// **Identity**: the key mirrors what the compiler mints handles from
+    /// (`Analysis::handle_hash` in `context.rs`) — the caption's
+    /// [`stable_id`] for text, the raw decoded bytes' hash
+    /// ([`media::MediaAnalysis::raw_hash`]) for media, the same identity
+    /// PR1's dedup keys on. Keying media on the caption instead was the PR2
+    /// review's proven blocker: every captionless image collided onto one
+    /// slot and one handle, serving arbitrary wrong bytes back. The slot
+    /// stays inside the salted system-fact namespace ([`source_id`] applies
+    /// `SOURCE_ID_SALT` to the hash) — same salt, no new namespace. On a
+    /// same-key collision (byte-identical images with different captions)
+    /// the FIRST occurrence wins, matching the dedup twin the compiler
+    /// keeps — a divergent duplicate caption does not survive, exactly as
+    /// its decision reason already says.
     ///
     /// Size: [`crate::limits::MAX_MEDIA_BYTES`] /
     /// [`crate::limits::MAX_TOTAL_MEDIA_BYTES`] already bounded every
@@ -336,11 +343,14 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         out: &CompiledContext,
         ttl_seconds: Option<u64>,
     ) -> Result<(), MemoryError> {
-        let by_hash: BTreeMap<u64, &ContextFragment> = augmented
-            .fragments
-            .iter()
-            .map(|fragment| (stable_id(&fragment.content), fragment))
-            .collect();
+        let mut by_hash: BTreeMap<u64, &ContextFragment> = BTreeMap::new();
+        for fragment in &augmented.fragments {
+            // First occurrence wins (see the identity note above): `entry`
+            // + `or_insert`, never a blind overwrite.
+            by_hash
+                .entry(fragment_handle_hash(fragment))
+                .or_insert(fragment);
+        }
         let ttl_seconds = positive_ttl(ttl_seconds);
         for source in &out.sources {
             let Some(hash) = provenance::parse_handle(&source.handle) else {
@@ -373,8 +383,10 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 // EXCLUSIVELY by its content-addressed hash/slot, never by
                 // vector search — this vector only needs to be well-formed
                 // and non-degenerate for the underlying index, never
-                // semantically meaningful.
-                self.media_placeholder_embedding(media::analyze(media_ref).raw_hash)
+                // semantically meaningful. For a media fragment `hash` IS
+                // the raw-bytes hash (see `fragment_handle_hash`), so no
+                // re-decode is needed here.
+                self.media_placeholder_embedding(hash)
             } else {
                 self.embedder.embed(content)?
             };
@@ -839,6 +851,18 @@ fn meta_u64(meta: &Metadata, key: &str) -> u64 {
 /// The salted system-fact id of a stored source.
 fn source_id(content_hash: u64) -> u64 {
     stable_id(&format!("{SOURCE_ID_SALT}{content_hash}"))
+}
+
+/// The handle-identity hash of one request fragment — the bridge-side twin
+/// of `Analysis::handle_hash` in `context.rs` (kept in lockstep; the two
+/// must key the same identity or stored slots and minted handles drift
+/// apart): raw decoded media bytes for a media fragment, caption/content
+/// [`stable_id`] otherwise.
+fn fragment_handle_hash(fragment: &ContextFragment) -> u64 {
+    fragment.media.as_ref().map_or_else(
+        || stable_id(&fragment.content),
+        |media_ref| media::analyze(media_ref).raw_hash,
+    )
 }
 
 /// A stored source's media payload (US-009, PR2), when its metadata carries

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -56,13 +56,15 @@ pub enum FidelityRisk {
 /// text/caption — often empty for a bare screenshot — while the pixels live
 /// here, base64-encoded so the JSON wire never needs a binary frame.
 ///
-/// PR1 scope: the fragment packs atomically (see [`super::pieces`] in the
-/// compiler) and its token cost comes from
-/// [`super::estimator::ImageTokenEstimator`], but there is no externalized
-/// binary store yet — a media fragment that cannot fit the budget is
-/// `drop`ped with an explicit reason rather than handed a `ctx://source`
-/// handle that would not actually resolve. See the crate README's "media
-/// fragments" section.
+/// The fragment packs atomically (see [`super::pieces`] in the compiler)
+/// and its token cost comes from [`super::estimator::ImageTokenEstimator`].
+/// A media fragment that cannot fit the budget is externalized behind a
+/// `ctx://source` handle exactly like text (US-009, PR2: the memory bridge
+/// persists the bytes behind it — see
+/// [`crate::MemoryService::retrieve_context_source`]); the memoryless core
+/// compiler mints the same handle either way, since it never knows whether
+/// a resolver is attached. See the crate README's "media fragments"
+/// section.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MediaRef {
     /// Declared MIME type (e.g. `"image/png"`, `"image/jpeg"`). Only PNG and
@@ -76,6 +78,22 @@ pub struct MediaRef {
     /// well-formedness at compile time — a request carrying an oversized or
     /// malformed payload is rejected before any other work.
     pub bytes_b64: String,
+}
+
+/// The resolved original behind a `ctx://source/<hash>` handle (US-002:
+/// text sources; US-009 PR2 extends this with the fragment's inline media,
+/// when it carried one). `media` is `#[serde(default)]`: every source
+/// stored before PR2, and every text-only fragment since, round-trips with
+/// `media: None` — the exact pre-PR2 shape for a caller reading only
+/// `.content`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ContextSource {
+    /// The original fragment content, byte for byte (a media fragment's
+    /// caption — often empty for a bare screenshot).
+    pub content: String,
+    /// The original media payload, when the fragment carried one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media: Option<MediaRef>,
 }
 
 /// One unit of caller-supplied context to compile.

--- a/crates/velesdb-memory/src/context/provenance.rs
+++ b/crates/velesdb-memory/src/context/provenance.rs
@@ -12,8 +12,10 @@ use super::model::SourceReference;
 pub(crate) const HANDLE_PREFIX: &str = "ctx://source/";
 
 /// The recoverable address of a fragment's original content. Handles are
-/// **content-addressed** (FNV-1a hash of the original bytes), never minted
-/// from caller-supplied ids — two different fragments sharing a caller id
+/// **content-addressed** (FNV-1a hash of the original bytes — the text for
+/// a text fragment, the raw decoded media bytes for a media fragment, see
+/// `Analysis::handle_hash` in `context.rs`), never minted from
+/// caller-supplied ids — two different fragments sharing a caller id
 /// therefore keep two distinct, unambiguous addresses.
 #[must_use]
 pub(crate) fn handle_for(content_hash: u64) -> String {

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -22,7 +22,7 @@ use super::{join_error, to_error, McpServer};
 use crate::context::wire::{stringify_id_fields, ID_KEYS};
 use crate::context::{
     CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextDecision,
-    ContextSavings, WorkingContext,
+    ContextSavings, MediaRef, WorkingContext,
 };
 
 /// Serialize `payload`, opt-in rewriting every id field into decimal-string
@@ -130,6 +130,10 @@ pub(super) struct RetrieveContextSourceResult {
     pub handle: String,
     /// The original fragment content, byte for byte.
     pub content: String,
+    /// The original media payload, when the fragment carried one (US-009,
+    /// PR2). Absent for every text-only source — the exact pre-PR2 shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media: Option<MediaRef>,
 }
 
 /// Input of the `save_working_context` tool.
@@ -290,11 +294,15 @@ impl McpServer {
         let service = Arc::clone(&self.service);
         let RetrieveContextSourceParams { handle } = params;
         let lookup = handle.clone();
-        let content = tokio::task::spawn_blocking(move || service.retrieve_context_source(&lookup))
+        let source = tokio::task::spawn_blocking(move || service.retrieve_context_source(&lookup))
             .await
             .map_err(join_error)?
             .map_err(to_error)?;
-        Ok(Json(RetrieveContextSourceResult { handle, content }))
+        Ok(Json(RetrieveContextSourceResult {
+            handle,
+            content: source.content,
+            media: source.media,
+        }))
     }
 
     #[tool(

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -1310,23 +1310,29 @@ fn test_media_compilation_is_fully_deterministic() {
 
 // --- Screenshot supersession (US-009 of EPIC-P-071, PR2) --------------------
 
-/// A well-formed base64 payload distinct from every other caption's — media
-/// dedup keys on raw bytes alone, so two screenshots in the same series need
-/// DIFFERENT bytes or they would collide as exact media duplicates instead
-/// of exercising supersession. Only the final base64 character is varied
-/// (still a valid quad, no padding), derived from `caption` so calls with
-/// different literal captions in the same test always decode to different
-/// bytes.
-fn distinct_media_b64(caption: &str) -> String {
+/// A well-formed base64 payload distinct per `seed` — media dedup keys on
+/// raw bytes alone, so two screenshots in the same series need DIFFERENT
+/// bytes or they would collide as exact media duplicates instead of
+/// exercising supersession. The seed is an explicit parameter independent
+/// of any caption (see the memory-bridge BDD twin of this fixture for why);
+/// the last two base64 characters are varied (still a valid unpadded quad,
+/// past the sniffed PNG header) via a multiplicative fold so same-length
+/// seeds never trivially collide.
+fn distinct_media_b64(seed: &str) -> String {
     const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let seed = caption.bytes().fold(0_u8, u8::wrapping_add);
-    let mut b64 = PNG_64X48_B64.to_owned();
-    b64.pop();
-    b64.push(ALPHABET[seed as usize % ALPHABET.len()] as char);
+    let hash = seed
+        .bytes()
+        .fold(0_u64, |h, b| h.wrapping_mul(131).wrapping_add(u64::from(b)));
+    let mut b64 = PNG_64X48_B64[..PNG_64X48_B64.len() - 2].to_owned();
+    b64.push(ALPHABET[usize::try_from(hash % 64).unwrap_or(0)] as char);
+    b64.push(ALPHABET[usize::try_from((hash / 64) % 64).unwrap_or(0)] as char);
     b64
 }
 
-/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`.
+/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`,
+/// with bytes seeded by the caption (these compiler-only tests never resolve
+/// handles, so caption-independence is not load-bearing here — the
+/// memory-bridge BDD suite covers that axis with explicit seeds).
 fn screenshot(caption: &str, target: &str) -> ContextFragment {
     let mut meta = serde_json::Map::new();
     meta.insert(

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -1132,24 +1132,26 @@ fn test_media_fragment_insights_tokens_in_and_out_reflect_the_image_cost() {
 }
 
 #[test]
-fn test_media_fragment_that_cannot_fit_the_budget_is_dropped_not_retrieved() {
+fn test_media_fragment_that_cannot_fit_the_budget_is_externalized_not_dropped() {
     // Given a media fragment far too large for the budget
     let frag = media_fragment("a huge screenshot", PNG_1024X768_B64);
     let out = compile(&request(vec![frag], 10));
 
-    // Then it is dropped with an explicit PR1-scope reason — never handed a
-    // ctx://source handle, since no binary retrieval store exists yet
+    // Then it is externalized exactly like an unfit text fragment (US-009,
+    // PR2: the memory bridge now persists media sources, so the PR1
+    // `drop.media_unavailable` provisional verdict is gone) — a resolvable
+    // handle is minted, and it appears in `retrieval_handles`.
     let decision = &out.decisions[0];
-    assert_eq!(decision.action, ContextAction::Drop);
-    assert_eq!(decision.rule_id, "drop.media_unavailable");
+    assert_eq!(decision.action, ContextAction::Retrieve);
+    assert_eq!(decision.rule_id, "budget.externalize");
     assert_eq!(decision.risk, FidelityRisk::High);
-    assert!(decision.handle.is_none());
+    assert!(decision.handle.is_some());
     assert!(
-        decision.reason.contains("next PR"),
-        "the reason must be honest about the PR1 scope gap: {}",
+        decision.reason.contains("did not fit the budget"),
+        "unexpected reason: {}",
         decision.reason
     );
-    assert!(out.retrieval_handles.is_empty());
+    assert_eq!(out.retrieval_handles.len(), 1);
     assert_eq!(out.content, "");
 }
 
@@ -1167,14 +1169,19 @@ fn test_media_fragment_pack_is_all_or_nothing_at_the_exact_budget_boundary() {
         PNG_64X48_COST + joiner - 1,
     );
 
-    // Then it packs fully right at the boundary, and not at all one token
-    // under it — atomic packing never yields a partial byte-range
+    // Then it packs fully right at the boundary, and is externalized (never
+    // partially) one token under it — atomic packing never yields a partial
+    // byte-range, and an unfit media fragment externalizes exactly like an
+    // unfit text one (US-009, PR2)
     assert_eq!(compile(&exact).decisions[0].action, ContextAction::Preserve);
-    assert_eq!(compile(&one_short).decisions[0].action, ContextAction::Drop);
+    assert_eq!(
+        compile(&one_short).decisions[0].action,
+        ContextAction::Retrieve
+    );
 }
 
 #[test]
-fn test_dropped_media_fragment_attributes_its_full_cost_to_the_pr1_drop_rule() {
+fn test_externalized_media_fragment_attributes_its_full_cost_to_the_externalize_rule() {
     // Given a media fragment that cannot fit
     let frag = media_fragment("", PNG_1024X768_B64);
     let out = compile(&request(vec![frag], 10));
@@ -1298,5 +1305,145 @@ fn test_media_compilation_is_fully_deterministic() {
         serde_json::to_string(&first).expect("serialize first"),
         serde_json::to_string(&second).expect("serialize second"),
         "media compilation must be fully deterministic, exactly like text compilation"
+    );
+}
+
+// --- Screenshot supersession (US-009 of EPIC-P-071, PR2) --------------------
+
+/// A well-formed base64 payload distinct from every other caption's — media
+/// dedup keys on raw bytes alone, so two screenshots in the same series need
+/// DIFFERENT bytes or they would collide as exact media duplicates instead
+/// of exercising supersession. Only the final base64 character is varied
+/// (still a valid quad, no padding), derived from `caption` so calls with
+/// different literal captions in the same test always decode to different
+/// bytes.
+fn distinct_media_b64(caption: &str) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let seed = caption.bytes().fold(0_u8, u8::wrapping_add);
+    let mut b64 = PNG_64X48_B64.to_owned();
+    b64.pop();
+    b64.push(ALPHABET[seed as usize % ALPHABET.len()] as char);
+    b64
+}
+
+/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`.
+fn screenshot(caption: &str, target: &str) -> ContextFragment {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "target".to_owned(),
+        serde_json::Value::String(target.to_owned()),
+    );
+    ContextFragment {
+        kind: Some("screenshot".to_owned()),
+        metadata: Some(meta),
+        ..media_fragment(caption, &distinct_media_b64(caption))
+    }
+}
+
+#[test]
+fn test_three_screenshots_of_the_same_target_only_the_last_stays_inline() {
+    // Given three screenshots of the same target, in order
+    let fragments = vec![
+        screenshot("v1", "login-page"),
+        screenshot("v2", "login-page"),
+        screenshot("v3", "login-page"),
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    // Then only the last is preserved inline; the first two are externalized
+    // as superseded, each with its own resolvable handle
+    assert_eq!(out.decisions[0].action, ContextAction::Retrieve);
+    assert_eq!(out.decisions[0].rule_id, "retrieve.screenshot_superseded");
+    assert!(out.decisions[0].handle.is_some());
+    assert!(out.decisions[0]
+        .reason
+        .contains("superseded by a newer screenshot"));
+
+    assert_eq!(out.decisions[1].action, ContextAction::Retrieve);
+    assert_eq!(out.decisions[1].rule_id, "retrieve.screenshot_superseded");
+    assert!(out.decisions[1].handle.is_some());
+
+    assert_eq!(out.decisions[2].action, ContextAction::Preserve);
+    assert_eq!(out.decisions[2].rule_id, "media.atomic");
+    assert!(out.decisions[2].handle.is_none());
+
+    assert_eq!(out.retrieval_handles.len(), 2);
+}
+
+#[test]
+fn test_screenshots_of_different_targets_are_never_superseded() {
+    // Given screenshots of two DIFFERENT targets
+    let fragments = vec![
+        screenshot("login v1", "login-page"),
+        screenshot("checkout v1", "checkout-page"),
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    // Then both stay inline — no succession within either target's series
+    assert_eq!(out.decisions[0].action, ContextAction::Preserve);
+    assert_eq!(out.decisions[1].action, ContextAction::Preserve);
+    assert!(out.retrieval_handles.is_empty());
+}
+
+#[test]
+fn test_screenshots_without_a_target_are_never_superseded() {
+    // Given two screenshots with no `metadata.target` at all
+    let fragments = vec![
+        ContextFragment {
+            kind: Some("screenshot".to_owned()),
+            ..media_fragment("v1", &distinct_media_b64("v1"))
+        },
+        ContextFragment {
+            kind: Some("screenshot".to_owned()),
+            ..media_fragment("v2", &distinct_media_b64("v2"))
+        },
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    // Then no target means no evidence of succession — both stay inline
+    assert_eq!(out.decisions[0].action, ContextAction::Preserve);
+    assert_eq!(out.decisions[1].action, ContextAction::Preserve);
+    assert!(out.retrieval_handles.is_empty());
+}
+
+#[test]
+fn test_superseded_screenshot_is_excluded_from_the_assembled_content() {
+    // Given two screenshots of the same target with non-empty captions
+    let fragments = vec![
+        screenshot("first look", "login-page"),
+        screenshot("second look", "login-page"),
+    ];
+    let out = compile(&request(fragments, 10_000));
+
+    // Then the superseded caption never appears in the assembled prompt
+    assert!(!out.content.contains("first look"));
+}
+
+#[test]
+fn test_screenshot_supersession_rule_can_be_disabled() {
+    // Given the same three-screenshot series, with the rule opted out
+    let fragments = vec![
+        screenshot("v1", "login-page"),
+        screenshot("v2", "login-page"),
+        screenshot("v3", "login-page"),
+    ];
+    let policy = CompilePolicy {
+        disabled_rules: vec!["retrieve.screenshot_superseded".to_owned()],
+        ..CompilePolicy::default()
+    };
+    let mut req = request(fragments, 10_000);
+    req.policy = Some(policy);
+    let out = ContextCompiler::new(CompilePolicy::default())
+        .compile(&req)
+        .expect("compile");
+
+    // Then every screenshot stays inline — the rule is opt-outable like any
+    // other named rule
+    assert!(
+        out.decisions
+            .iter()
+            .all(|d| d.action == ContextAction::Preserve),
+        "disabling the rule must leave every screenshot inline, got: {:?}",
+        out.decisions
     );
 }

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -42,21 +42,30 @@ fn media_fragment(caption: &str, bytes_b64: &str) -> ContextFragment {
     }
 }
 
-/// A well-formed base64 payload distinct from every other caption's — media
-/// dedup keys on raw bytes alone, so screenshots in the same series need
-/// DIFFERENT bytes or they collide as exact media duplicates instead of
-/// exercising supersession. Only the final base64 character is varied.
-fn distinct_media_b64(caption: &str) -> String {
+/// A well-formed base64 payload distinct per `seed` — media dedup keys on
+/// raw bytes alone, so two fragments needing DIFFERENT bytes must pass
+/// different seeds. The seed is an explicit, caption-INDEPENDENT parameter
+/// on purpose (review finding on PR2's first cut): deriving bytes from the
+/// caption would make "same caption, different bytes" — the exact scenario
+/// of the media handle-collision bug — inexpressible in these tests. Only
+/// the final base64 character is varied (still a valid unpadded quad).
+fn distinct_media_b64(seed: &str) -> String {
     const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let seed = caption.bytes().fold(0_u8, u8::wrapping_add);
-    let mut b64 = PNG_B64.to_owned();
-    b64.pop();
-    b64.push(ALPHABET[seed as usize % ALPHABET.len()] as char);
+    // A multiplicative fold, not a plain byte sum: same-length seeds like
+    // "stale-A"/"fresh-B" must not collide.
+    let hash = seed
+        .bytes()
+        .fold(0_u64, |h, b| h.wrapping_mul(131).wrapping_add(u64::from(b)));
+    let mut b64 = PNG_B64[..PNG_B64.len() - 2].to_owned();
+    b64.push(ALPHABET[usize::try_from(hash % 64).unwrap_or(0)] as char);
+    b64.push(ALPHABET[usize::try_from((hash / 64) % 64).unwrap_or(0)] as char);
     b64
 }
 
-/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`.
-fn screenshot(caption: &str, target: &str) -> ContextFragment {
+/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`,
+/// with bytes derived from `seed` (independent of `caption` — see
+/// [`distinct_media_b64`]).
+fn screenshot_with_seed(caption: &str, target: &str, seed: &str) -> ContextFragment {
     let mut meta = serde_json::Map::new();
     meta.insert(
         "target".to_owned(),
@@ -65,8 +74,14 @@ fn screenshot(caption: &str, target: &str) -> ContextFragment {
     ContextFragment {
         kind: Some("screenshot".to_owned()),
         metadata: Some(meta),
-        ..media_fragment(caption, &distinct_media_b64(caption))
+        ..media_fragment(caption, &distinct_media_b64(seed))
     }
+}
+
+/// [`screenshot_with_seed`] with the caption reused as the byte seed — for
+/// tests where the two need not be independent.
+fn screenshot(caption: &str, target: &str) -> ContextFragment {
+    screenshot_with_seed(caption, target, caption)
 }
 
 fn request(query: &str, fragments: Vec<ContextFragment>, budget: u64) -> CompileRequest {
@@ -1345,4 +1360,163 @@ fn test_screenshots_of_different_targets_all_round_trip_independently() {
         .all(|d| d.action == ContextAction::Preserve));
     assert!(out.content.contains("login shot"));
     assert!(out.content.contains("checkout shot"));
+}
+
+// --- Review probes (PR2 cross-review): media identity must be the BYTES ----
+//
+// Media dedup already keys on the raw decoded bytes (PR1); handles and
+// storage slots must key on the same identity, or two media fragments with
+// identical (typically blank) captions but different bytes collide onto one
+// handle and one slot — and "externalized behind a resolvable handle"
+// silently serves the wrong image in the nominal captionless case.
+
+#[test]
+fn test_two_blank_caption_media_fragments_with_different_bytes_get_distinct_resolving_handles() {
+    // P1 — same compile: two media fragments, both captions BLANK, bytes
+    // A != B, budget too small for either (the 64x48 fixture image costs 5
+    // tokens), so both externalize
+    let (_dir, svc) = service();
+    let bytes_a = distinct_media_b64("bytes-A");
+    let bytes_b = distinct_media_b64("bytes-B");
+    assert_ne!(bytes_a, bytes_b, "fixture must yield distinct bytes");
+    let fragments = vec![media_fragment("", &bytes_a), media_fragment("", &bytes_b)];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 4))
+        .expect("compile");
+
+    // Then the two handles are DISTINCT ...
+    let handle_a = out.decisions[0].handle.clone().expect("A externalized");
+    let handle_b = out.decisions[1].handle.clone().expect("B externalized");
+    assert_ne!(
+        handle_a, handle_b,
+        "different bytes must never share a handle, blank captions or not"
+    );
+
+    // ... and each resolves ITS OWN bytes
+    let source_a = svc.retrieve_context_source(&handle_a).expect("retrieve A");
+    let source_b = svc.retrieve_context_source(&handle_b).expect("retrieve B");
+    assert_eq!(source_a.media.expect("A media").bytes_b64, bytes_a);
+    assert_eq!(source_b.media.expect("B media").bytes_b64, bytes_b);
+}
+
+#[test]
+fn test_cross_compile_blank_caption_media_sources_never_serve_stale_bytes() {
+    // P2 — cross-compile: compile blank-caption image A first (its source is
+    // stored), then blank-caption image B in a SECOND compile
+    let (_dir, svc) = service();
+    let bytes_a = distinct_media_b64("stale-A");
+    let bytes_b = distinct_media_b64("fresh-B");
+    assert_ne!(bytes_a, bytes_b, "fixture must yield distinct bytes");
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    svc.compile_context(
+        &compiler,
+        &request("q", vec![media_fragment("", &bytes_a)], 10_000),
+    )
+    .expect("compile A");
+    let out_b = svc
+        .compile_context(
+            &compiler,
+            &request("q", vec![media_fragment("", &bytes_b)], 10_000),
+        )
+        .expect("compile B");
+
+    // When resolving B's handle from the second compile
+    let handle_b = out_b.sources[0].handle.clone();
+    let source_b = svc.retrieve_context_source(&handle_b).expect("retrieve B");
+
+    // Then B's own bytes come back — never A's, stored earlier at what must
+    // NOT be the same slot
+    assert_eq!(
+        source_b.media.expect("B media").bytes_b64,
+        bytes_b,
+        "an occupied slot from an earlier compile must never serve stale bytes for a new handle"
+    );
+}
+
+#[test]
+fn test_superseded_blank_caption_screenshots_resolve_their_own_bytes_not_the_survivors() {
+    // P3 — supersession: three screenshots of the same target, ALL captions
+    // blank, three different byte payloads; the first two are superseded
+    let (_dir, svc) = service();
+    let seeds = ["shot-1", "shot-2", "shot-3"];
+    let fragments: Vec<ContextFragment> = seeds
+        .iter()
+        .map(|seed| screenshot_with_seed("", "login-page", seed))
+        .collect();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then the two superseded screenshots carry DISTINCT handles, each
+    // resolving its own bytes — never the surviving third's
+    let handle_0 = out.decisions[0].handle.clone().expect("superseded 0");
+    let handle_1 = out.decisions[1].handle.clone().expect("superseded 1");
+    assert_ne!(handle_0, handle_1, "distinct bytes, distinct handles");
+    for (handle, seed) in [(handle_0, seeds[0]), (handle_1, seeds[1])] {
+        let source = svc.retrieve_context_source(&handle).expect("retrieve");
+        assert_eq!(
+            source.media.expect("media").bytes_b64,
+            distinct_media_b64(seed),
+            "a superseded screenshot's handle must resolve ITS OWN bytes, not the survivor's"
+        );
+    }
+    assert_eq!(out.decisions[2].action, ContextAction::Preserve);
+}
+
+// --- Review minors: dedup × supersession, and recall invisibility ----------
+
+#[test]
+fn test_byte_identical_screenshot_duplicate_wins_over_supersession_and_resolves() {
+    // Given two BYTE-IDENTICAL screenshots of a target plus a newer,
+    // different one — dedup and supersession both apply to fragment #1;
+    // the dup arm must win (it is checked first in `decision`)
+    let (_dir, svc) = service();
+    let same = distinct_media_b64("same-bytes");
+    let fragments = vec![
+        screenshot_with_seed("", "login-page", "same-bytes"),
+        screenshot_with_seed("", "login-page", "same-bytes"),
+        screenshot_with_seed("", "login-page", "newer"),
+    ];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then #0 is superseded (older of the series), #1 is its exact
+    // duplicate (dup verdict wins over the supersession flag), #2 survives
+    assert_eq!(out.decisions[0].rule_id, "retrieve.screenshot_superseded");
+    assert_eq!(out.decisions[1].rule_id, "drop.duplicate");
+    assert_eq!(out.decisions[1].action, ContextAction::Drop);
+    assert_eq!(out.decisions[2].action, ContextAction::Preserve);
+
+    // And the duplicate's handle (same bytes as #0) still resolves those bytes
+    let dup_handle = out.decisions[1]
+        .handle
+        .clone()
+        .expect("media duplicate keeps a handle");
+    let source = svc.retrieve_context_source(&dup_handle).expect("retrieve");
+    assert_eq!(source.media.expect("media").bytes_b64, same);
+}
+
+#[test]
+fn test_stored_media_sources_are_invisible_to_normal_recall() {
+    // Given a compiled (and stored) media source with a distinctive caption
+    let (_dir, svc) = service();
+    let caption = "zebra quantum flamingo caption";
+    let frag = media_fragment(caption, &distinct_media_b64("invisible"));
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    svc.compile_context(&compiler, &request("q", vec![frag], 10_000))
+        .expect("compile");
+
+    // When recalling with the caption itself as the query
+    let hits = svc.recall(caption, 10, None).expect("recall");
+
+    // Then the media source system fact (hub-marked, placeholder-embedded)
+    // never surfaces in caller-facing recall
+    assert!(
+        hits.is_empty(),
+        "a stored media source must be invisible to normal recall, got {hits:?}"
+    );
 }

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -10,8 +10,8 @@ mod common;
 
 use common::service;
 use velesdb_memory::context::{
-    CompilePolicy, CompileRequest, ContextCompiler, ContextFragment, DeterministicReranker,
-    MemoryScope, WorkingContext,
+    CompilePolicy, CompileRequest, ContextAction, ContextCompiler, ContextFragment,
+    DeterministicReranker, MediaRef, MemoryScope, WorkingContext,
 };
 use velesdb_memory::{ErrorCategory, FusionOptions, HashEmbedder, MemoryService};
 
@@ -23,6 +23,49 @@ fn fragment(content: &str) -> ContextFragment {
         priority: None,
         metadata: None,
         media: None,
+    }
+}
+
+/// A syntactically valid (well-formed base64), tiny PNG header — its exact
+/// bytes don't matter to these tests, only that `media::decode_base64`
+/// accepts them.
+const PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAYAAAAAAAAA";
+
+/// Build a fragment carrying an inline PNG media payload.
+fn media_fragment(caption: &str, bytes_b64: &str) -> ContextFragment {
+    ContextFragment {
+        media: Some(MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: bytes_b64.to_owned(),
+        }),
+        ..fragment(caption)
+    }
+}
+
+/// A well-formed base64 payload distinct from every other caption's — media
+/// dedup keys on raw bytes alone, so screenshots in the same series need
+/// DIFFERENT bytes or they collide as exact media duplicates instead of
+/// exercising supersession. Only the final base64 character is varied.
+fn distinct_media_b64(caption: &str) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let seed = caption.bytes().fold(0_u8, u8::wrapping_add);
+    let mut b64 = PNG_B64.to_owned();
+    b64.pop();
+    b64.push(ALPHABET[seed as usize % ALPHABET.len()] as char);
+    b64
+}
+
+/// Build a `kind: "screenshot"` media fragment naming its `metadata.target`.
+fn screenshot(caption: &str, target: &str) -> ContextFragment {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "target".to_owned(),
+        serde_json::Value::String(target.to_owned()),
+    );
+    ContextFragment {
+        kind: Some("screenshot".to_owned()),
+        metadata: Some(meta),
+        ..media_fragment(caption, &distinct_media_b64(caption))
     }
 }
 
@@ -110,8 +153,9 @@ fn test_retrieve_context_source_round_trips_original() {
     let handle = &out.sources[0].handle;
     let retrieved = svc.retrieve_context_source(handle).expect("retrieve");
 
-    // Then the exact original bytes come back
-    assert_eq!(retrieved, original);
+    // Then the exact original bytes come back, with no media (text-only)
+    assert_eq!(retrieved.content, original);
+    assert!(retrieved.media.is_none());
 }
 
 #[test]
@@ -420,7 +464,7 @@ fn test_retrieve_context_source_refuses_a_squatting_caller_fact() {
     let squatted = svc.retrieve_context_source(&format!("ctx://source/{squatted_hash}"));
 
     // Then the real source round-trips and the squatter is never served back
-    assert_eq!(legit, "legit source");
+    assert_eq!(legit.content, "legit source");
     let err = squatted.expect_err("a caller fact must never masquerade as a stored source");
     assert_eq!(err.category(), ErrorCategory::NotFound);
 }
@@ -444,7 +488,7 @@ fn test_source_ttl_zero_stores_permanently_like_remember() {
         .expect("Some(0) must mean permanent, exactly like remember_with_ttl");
 
     // Then the source is there
-    assert_eq!(retrieved, "must stay retrievable");
+    assert_eq!(retrieved.content, "must stay retrievable");
 }
 
 // --- Coverage round (2026-07-17): pricing trail, writer guard, provenance ----
@@ -1167,4 +1211,138 @@ fn test_importance_out_of_range_weight_is_accepted_verbatim_not_clamped() {
         "a negative weight must invert the confidence term, got:\n{}",
         blended.content
     );
+}
+
+// --- Media source storage & screenshot supersession (US-009, PR2) ----------
+
+#[test]
+fn test_media_fragment_dropped_by_budget_round_trips_byte_identical_via_its_handle() {
+    // Given a media fragment far too large for the budget, so it never
+    // packs inline
+    let (_dir, svc) = service();
+    let frag = media_fragment("a huge screenshot", PNG_B64);
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", vec![frag], 10))
+        .expect("compile");
+    let decision = &out.decisions[0];
+    assert_eq!(decision.action, ContextAction::Retrieve);
+    let handle = decision
+        .handle
+        .clone()
+        .expect("externalized media gets a handle");
+
+    // When retrieving the source behind its handle
+    let source = svc.retrieve_context_source(&handle).expect("retrieve");
+
+    // Then the caption AND the media (mime + bytes_b64) round-trip exactly
+    assert_eq!(source.content, "a huge screenshot");
+    let media = source
+        .media
+        .expect("a media source must carry its media back");
+    assert_eq!(media.mime, "image/png");
+    assert_eq!(media.bytes_b64, PNG_B64);
+}
+
+#[test]
+fn test_media_fragment_source_round_trips_via_out_sources_handle_too() {
+    // Given a media fragment that fits inline (still gets a source entry)
+    let (_dir, svc) = service();
+    let frag = media_fragment("caption", PNG_B64);
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", vec![frag], 10_000))
+        .expect("compile");
+
+    // When retrieving via `out.sources[0].handle` (not just a drop/retrieve
+    // decision's handle)
+    let handle = &out.sources[0].handle;
+    let source = svc.retrieve_context_source(handle).expect("retrieve");
+
+    // Then the media round-trips byte for byte
+    assert_eq!(source.content, "caption");
+    assert_eq!(
+        source
+            .media
+            .expect("media must be stored for every non-duplicate source")
+            .bytes_b64,
+        PNG_B64
+    );
+}
+
+#[test]
+fn test_text_only_source_still_carries_no_media_after_pr2() {
+    // Byte-compat guard: a plain text fragment's stored source must still
+    // carry no media field at all (never Some(default)).
+    let (_dir, svc) = service();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(
+            &compiler,
+            &request("q", vec![fragment("plain text, no media here")], 10_000),
+        )
+        .expect("compile");
+    let source = svc
+        .retrieve_context_source(&out.sources[0].handle)
+        .expect("retrieve");
+    assert_eq!(source.content, "plain text, no media here");
+    assert!(source.media.is_none());
+}
+
+#[test]
+fn test_three_screenshots_same_target_first_two_externalize_with_working_handles() {
+    // Given three screenshots of the same target, compiled through the
+    // bridge so store_sources actually persists them
+    let (_dir, svc) = service();
+    let fragments = vec![
+        screenshot("v1", "login-page"),
+        screenshot("v2", "login-page"),
+        screenshot("v3", "login-page"),
+    ];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then the first two are superseded, and each is genuinely retrievable
+    // (not merely handed a dangling handle) with its OWN distinct bytes
+    for (seq, caption) in [(0, "v1"), (1, "v2")] {
+        let decision = &out.decisions[seq];
+        assert_eq!(decision.action, ContextAction::Retrieve);
+        assert_eq!(decision.rule_id, "retrieve.screenshot_superseded");
+        let handle = decision
+            .handle
+            .clone()
+            .expect("superseded screenshot gets a handle");
+        let source = svc.retrieve_context_source(&handle).expect("retrieve");
+        assert_eq!(
+            source.media.expect("media must round-trip").bytes_b64,
+            distinct_media_b64(caption)
+        );
+    }
+
+    // And the last stays inline, never externalized
+    assert_eq!(out.decisions[2].action, ContextAction::Preserve);
+}
+
+#[test]
+fn test_screenshots_of_different_targets_all_round_trip_independently() {
+    // Given screenshots of two different targets, both fitting the budget
+    let (_dir, svc) = service();
+    let fragments = vec![
+        screenshot("login shot", "login-page"),
+        screenshot("checkout shot", "checkout-page"),
+    ];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then neither is superseded, and both stay inline
+    assert!(out
+        .decisions
+        .iter()
+        .all(|d| d.action == ContextAction::Preserve));
+    assert!(out.content.contains("login shot"));
+    assert!(out.content.contains("checkout shot"));
 }

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -13,7 +13,8 @@ use pyo3::types::{PyDict, PyList, PyString};
 use std::collections::HashMap;
 
 use velesdb_memory::context::{
-    CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextSavings, WorkingContext,
+    CompilePolicy, CompileRequest, CompiledContext, ContextCompiler, ContextSavings, ContextSource,
+    WorkingContext,
 };
 use velesdb_memory::{
     format_dated_context, limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation,
@@ -427,11 +428,16 @@ impl PyMemoryService {
         Ok(serde_to_python!(py, &compiled, "compiled context"))
     }
 
-    /// Fetch back the exact original content behind a `ctx://source/<hash>`
-    /// handle from a [`compile_context`](Self::compile_context) result —
-    /// what was externalized or partially packed is recoverable, not lost.
-    fn retrieve_context_source(&self, py: Python<'_>, handle: &str) -> PyResult<String> {
-        py.detach(|| self.svc.retrieve_context_source(handle).map_err(to_py_err))
+    /// Fetch back the exact original content — and media, when the fragment
+    /// carried one (US-009, PR2) — behind a `ctx://source/<hash>` handle
+    /// from a [`compile_context`](Self::compile_context) result: what was
+    /// externalized or partially packed is recoverable, not lost. Returns a
+    /// dict shaped `{content, media?}`, `media` present only for a source
+    /// whose fragment carried one.
+    fn retrieve_context_source(&self, py: Python<'_>, handle: &str) -> PyResult<Py<PyAny>> {
+        let source: ContextSource =
+            py.detach(|| self.svc.retrieve_context_source(handle).map_err(to_py_err))?;
+        Ok(serde_to_python!(py, &source, "context source"))
     }
 
     /// Aggregate the token (and cost) savings of past

--- a/crates/velesdb-python/tests/test_context_compiler.py
+++ b/crates/velesdb-python/tests/test_context_compiler.py
@@ -67,7 +67,9 @@ def test_retrieve_context_source_round_trips_a_compiled_fragment(mem):
     out = mem.compile_context(req)
     handle = out["sources"][0]["handle"]
     assert handle.startswith("ctx://source/")
-    assert mem.retrieve_context_source(handle) == content_text
+    source = mem.retrieve_context_source(handle)
+    assert source["content"] == content_text
+    assert "media" not in source or source["media"] is None
 
 
 def test_retrieve_context_source_unknown_handle_raises_key_error(mem):


### PR DESCRIPTION
## Summary

PR2 of 3 for US-009 (media fragments) of EPIC-P-071 — two pieces per the validated spike design:

**A. Media source storage (memory bridge)**
- `MemoryService::compile_context` (`policy.store_sources`, default on) now persists a media fragment's base64 payload alongside its caption when it stores a compiled source, under a new reserved key `_veles_ctx_source_media` (`{mime, bytes_b64}`).
- Embedding for a media source is a deterministic placeholder derived from the raw bytes' hash — never the text embedder over the (often blank) caption or over the base64 itself — because `retrieve_context_source` resolves media sources by content-addressed hash/slot only, never by vector search (documented in code).
- `MemoryService::retrieve_context_source` now returns `ContextSource { content, media: Option<MediaRef> }` (was `String`); `media` is `#[serde(default)]` so every pre-PR2 text-only source round-trips unchanged.
- PR1's provisional `drop.media_unavailable` verdict is **gone**: an unfit media fragment now externalizes exactly like text (`Retrieve`, `budget.externalize`, resolvable `ctx://source` handle) — the memory bridge can actually resolve it now. A duplicate media fragment whose twin also failed to pack recovers through its own handle too (previously `None`).
- The source storage slot stays keyed on the SAME handle namespace PR1 already established (`stable_id(fragment.content)`, i.e. the caption) — not a second, bytes-addressed namespace — documented in code (`store_context_sources`).
- `MAX_FACT_BYTES` finding from the spike: verified (documented) that `MAX_MEDIA_BYTES`/`MAX_TOTAL_MEDIA_BYTES`, enforced in `compile()`'s `validate_media` before `store_context_sources` ever runs, already bound the new field's size — `MAX_FACT_BYTES` governs the unrelated MCP `remember`/`extract` text ceiling.

**B. Screenshot supersession (classify.rs)**
- New whole-batch pass `classify::screenshot_supersession`, symmetric to `dedup::find_duplicates`: fragments sharing `media` + `kind: "screenshot"` + the same `metadata.target` value form a succession series. Only the LAST one (input order, no clock) stays inline (`Preserve`, budget permitting); every earlier one is reclassified `retrieve.screenshot_superseded` and excluded from packing entirely (regardless of budget), externalized behind a resolvable handle with an explicit reason.
- A screenshot with no `metadata.target` is never superseded (no target is no evidence of succession).
- Opt-outable via `policy.disabled_rules: ["retrieve.screenshot_superseded"]`, like every other named rule.

Also updated: MCP `retrieve_context_source` tool result (`media` field added), Python `retrieve_context_source` binding (now returns a dict, was a bare `str`), CHANGELOG `[Unreleased]`, README "media fragments" section (PR1/3 → PR2/3).

## RED captured

Stashed the implementation (`context.rs`, `classify.rs`, `memory_bridge.rs`, `model.rs`, `mcp/context_tools.rs`) with tests in place: `cargo test -p velesdb-memory --features context,persistence` failed to **compile** —
`cannot find function screenshot_supersession` (6 sites in `classify_tests.rs`) and `struct Analysis<'_> has no field named superseded` (`media_pipeline_tests.rs`) — then restored and re-ran green.

## Gates (all green)

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic`
- `cargo clippy -p velesdb-node --lib -- -D warnings`
- `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context`
- `cargo test -p velesdb-memory` — all binaries green (263 lib unit tests, 52 compiler BDD, 35 memory-bridge BDD, etc.)
- `python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py` — OK
- `wasm-pack test --node crates/velesdb-wasm` — all green (bridge stays wasm-reachable, no clock, no missing std API)

## Coverage (llvm-cov, touched files)

| File | Line coverage |
|---|---|
| `context.rs` | 98.89% |
| `context/classify.rs` | 99.28% |
| `context/memory_bridge.rs` | 97.73% |
| `context/model.rs` | 100% |
| `mcp/context_tools.rs` | 89.86% |

`mcp/context_tools.rs` sits just under the 90% target — the uncovered lines (37-39, 41, 57-59, 75-77) are pre-existing, untouched schema-generation panic/error branches unrelated to this diff; the added `media` field and its handler path are fully exercised by `test_retrieve_context_source_tool_round_trips_original`.

## Wire-shape choice

`ContextSource { content: String, media: Option<MediaRef> }` extends the existing return type (was a bare `String`) rather than adding a second retrieval method — `media` is `#[serde(default)]`/`skip_serializing_if` so every existing JSON consumer (MCP) and the BDD goldens with no media fragments are byte-identical.

## Motivated deviations

- Kept the storage slot content-addressed on the caption hash (PR1's existing `provenance::handle_for` scheme), not on the media bytes hash, to avoid a second handle namespace — documented the caption-collision edge case (two media fragments sharing an identical, often-blank caption collide onto one slot, first-write-wins) as inherited, unchanged PR1 behavior, not a new PR2 bug.
- Did not add a runtime `MAX_FACT_BYTES`-style guard inside `store_context_sources`; `validate_media` in `compile()` already bounds every fragment before this code path ever runs (documented instead of duplicating validation).

## Test plan

- [x] `cargo test -p velesdb-memory` (all features)
- [x] `wasm-pack test --node crates/velesdb-wasm`
- [x] `mcp_e2e.py`
- [x] Coverage via `cargo llvm-cov`