### PR TITLE
feat(memory): media fragments across MCP schemas, Node retrieve, WASM, TS [EPIC-P-071/US-009]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,15 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo test --workspace --features persistence,gpu,update-check \
+          cargo test --workspace --features persistence,gpu,update-check
+
+      # Real-stdio MCP end-to-end (6 tools + text/media retrieve round-trip).
+      # The debug binary is already built by the workspace test compile above;
+      # cargo build is a cache no-op that guarantees it exists.
+      - name: MCP server e2e (stdio)
+        run: |
+          cargo build -p velesdb-memory
+          python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py \
             --exclude velesdb-python --exclude velesdb-node \
             -- --test-threads=1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,11 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo test --workspace --features persistence,gpu,update-check
+          cargo test --workspace --features persistence,gpu,update-check \
+            --exclude velesdb-python --exclude velesdb-node \
+            -- --test-threads=1
+        env:
+          RUST_TEST_THREADS: 1
 
       # Real-stdio MCP end-to-end (6 tools + text/media retrieve round-trip).
       # The debug binary is already built by the workspace test compile above;
@@ -285,11 +289,7 @@ jobs:
       - name: MCP server e2e (stdio)
         run: |
           cargo build -p velesdb-memory
-          python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py \
-            --exclude velesdb-python --exclude velesdb-node \
-            -- --test-threads=1
-        env:
-          RUST_TEST_THREADS: 1
+          python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
 
   # ===========================================================================
   # Security Audit (parallèle - outils pré-compilés)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the `velesdb-memory` and `velesdb-context-optimizer` agent skills, one
   folder per skill at the archive root) — `curl -L … | tar -xz -C
   ~/.claude/skills/` installs both without cloning the repo. [EPIC-P-071]
+- **Media fragments now wired on every surface** (US-009, PR3 of 3 —
+  PR1/PR2 shipped the compiler-side atomic packing, dedup, cost, screenshot
+  supersession, and the MCP/Python bindings): the MCP `compile_context` /
+  `retrieve_context_source` advertised JSON schemas now carry
+  `fragments[].media` and the optional `media` on the retrieve result
+  (pinned by structural schema tests, not just accepted-on-input); the Node
+  binding (`@wiscale/velesdb-memory-node`) gains
+  `retrieveContextSource(handle)` (`{handle, content, media?}`, same shape
+  as the MCP tool) alongside `compileContext`'s existing media passthrough;
+  WASM's `compileContext` compiles, dedups, and prices media fragments
+  correctly on the in-memory `WasmStore` (`retrieveContextSource` is not
+  yet exposed there — a deliberately separate follow-up, not required to
+  prove media fragments compile on wasm); the TypeScript SDK's
+  `CompileContextFragment` type gains `media?: {mime, bytes_b64}`. The
+  `velesdb-context-optimizer` skill documents when to route a screenshot
+  through `media` and how `metadata.target` drives supersession.
+  [EPIC-P-071/US-009]
 
 R1 `Collection`-internals train: resolves and **closes the god-object EPIC
 ([#1384](https://github.com/cyberlife-coder/VelesDB/issues/1384))**. The

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Media source storage & screenshot supersession (experimental, PR2/3 of
+- **Media source storage & screenshot supersession (complete as of PR3: MCP schemas, Node retrieve, WASM compile, TS types of
   US-009 in EPIC-P-071)** — the memory bridge now persists a media
   fragment's base64 payload alongside its caption when storing a compiled
   source (reserved key `_veles_ctx_source_media`, embedded with a

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -617,12 +617,12 @@ so an audit trail always shows *why* a log collapsed the way it did. Off by
 default: it changes what "duplicate" means for logs, so existing callers
 keep byte-exact grouping unless they opt in.
 
-#### Media fragments (experimental, PR2/3)
+#### Media fragments
 
 A fragment may carry an inline image alongside its text: set
 `media: {"mime": "image/png", "bytes_b64": "<base64>"}` on a
 `ContextFragment`; `content` stays the caption (often empty for a bare
-screenshot). This is **PR2 of 3** for media support:
+screenshot).
 
 - **Atomic packing**: a media fragment is never chunked — it packs whole
   under the budget or not at all, so an image can never be cut mid-stream.
@@ -665,8 +665,31 @@ screenshot). This is **PR2 of 3** for media support:
   choice); a screenshot with no `metadata.target` is never superseded, since
   there is no evidence it succeeds anything. Opt out per request with
   `policy.disabled_rules: ["retrieve.screenshot_superseded"]`.
-- **Node/WASM/wire surface** beyond the MCP tools and the Python binding
-  above is **not yet built**; it lands in PR3.
+- **Every surface carries media**: the MCP tools (`compile_context` /
+  `retrieve_context_source`, schemas included — `fragments[].media` and the
+  optional `media` on the retrieve result are both advertised, not just
+  accepted), the Python binding, the Node binding (`compileContext` /
+  `retrieveContextSource`, same `{handle, content, media?}` shape as the MCP
+  tool — see the [Node README](../velesdb-node/README.md#media-fragments-retrievecontextsource)),
+  and WASM's `compileContext` (media fragments compile, dedup, and cost
+  correctly on the in-memory `WasmStore`; `retrieveContextSource` is not yet
+  exposed on the WASM binding, so resolving a media handle back to bytes
+  *within* a wasm session is Node/Python/MCP-only for now).
+
+Minimal end-to-end example, over the MCP tools (the exact calls
+`examples/context_savings/real_measures/mcp_e2e.py` makes against a real
+`velesdb-memory` server over stdio):
+
+```python
+handle_req = {"query": "a screenshot of the failing build", "token_budget": 1,
+              "fragments": [{"content": "the failing build, before the fix",
+                             "media": {"mime": "image/png", "bytes_b64": png_b64}}]}
+out = server.call("compile_context", handle_req)
+handle = out["retrieval_handles"][0]["handle"]      # too big for budget=1, externalized
+
+source = server.call("retrieve_context_source", {"handle": handle})
+assert source["media"]["bytes_b64"] == png_b64      # byte-identical round trip
+```
 
 #### Source TTL & disk growth
 

--- a/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
+++ b/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
@@ -81,6 +81,22 @@ assert explain["rule_id"] in {"drop.duplicate", "preserve.default"}, explain
 savings = srv.call("context_savings", {"project": "veles"})
 assert savings["events"] == 1 and savings["tokens_saved"] > 0, savings
 
+# --- media fragment: compile with an image -> externalize -> retrieve byte-identical (US-009, PR3) ---
+# A real, independently-decodable 1x1 transparent PNG (IHDR + IDAT + IEND) --
+# fixed bytes, never derived from the fragment's caption.
+PNG_1X1_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+media_req = {"query": "a screenshot of the failing build", "token_budget": 1, "project": "veles",
+             "fragments": [{"content": "the failing build, before the fix",
+                            "media": {"mime": "image/png", "bytes_b64": PNG_1X1_B64}}]}
+media_out = srv.call("compile_context", media_req)
+assert len(media_out["retrieval_handles"]) >= 1, f"the oversized image must externalize: {media_out}"
+media_handle = media_out["retrieval_handles"][0]["handle"]
+assert media_handle.startswith("ctx://source/")
+
+media_src = srv.call("retrieve_context_source", {"handle": media_handle})
+assert media_src["media"]["mime"] == "image/png", media_src
+assert media_src["media"]["bytes_b64"] == PNG_1X1_B64, "base64 payload must round-trip byte-identical"
+
 err = srv.call("compile_context", {"query": "x", "token_budget": 0, "fragments": [{"content": "y"}]})
 assert "__error__" in err and err["__error__"]["code"] == -32602, err
 
@@ -109,5 +125,6 @@ assert resumed["pending_actions"] == working["pending_actions"], resumed
 srv2.terminate()
 
 print("MCP E2E OK — 6 tools exercised over real stdio: list, compile (dedup+insights+handles), "
-      "retrieve round-trip, explain, savings, error taxonomy, and save/load_working_context "
-      "round-tripping ACROSS two separate server processes")
+      "retrieve round-trip (text AND a real PNG media fragment, byte-identical base64), explain, "
+      "savings, error taxonomy, and save/load_working_context round-tripping ACROSS two separate "
+      "server processes")

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -555,6 +555,173 @@ async fn test_retrieve_context_source_tool_round_trips_original() {
     assert_eq!(retrieved.handle, handle);
 }
 
+// --- media fragments through the MCP tools (US-009, PR3) -------------------
+//
+// PR2 already pins media round-tripping at the `MemoryService` level
+// (`tests/context_memory_bdd.rs`); these cover the MCP tool WRAPPER
+// specifically — `compile_context`/`retrieve_context_source` serialize
+// through `to_wire_value`/`Json<RetrieveContextSourceResult>` on a separate
+// path from the bare service call, and nothing exercised that path with a
+// real media payload before this PR.
+
+/// A syntactically valid (well-formed base64), tiny PNG header — fixed,
+/// independent bytes (never derived from a caption or any other property
+/// under test — see the incident this rule prevents in PR2's dedup tests).
+const PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAEAAAAAwCAYAAAAAAAAA";
+
+fn media_fragment(caption: &str) -> ContextFragment {
+    ContextFragment {
+        media: Some(crate::context::MediaRef {
+            mime: "image/png".to_owned(),
+            bytes_b64: PNG_B64.to_owned(),
+        }),
+        ..fragment(caption)
+    }
+}
+
+/// Regression this attrapes: the MCP `retrieve_context_source` tool builds
+/// its own `RetrieveContextSourceResult` envelope (handle, content, media)
+/// rather than returning the service's `ContextSource` directly — a field
+/// rename or a dropped `media: source.media` in that wrapper would silently
+/// lose the picture for every MCP client while the underlying
+/// `MemoryService` test suite kept passing.
+#[tokio::test]
+async fn test_retrieve_context_source_tool_round_trips_media_byte_identical() {
+    // Given a media fragment too large for the budget, so it externalizes
+    let (_dir, srv) = server();
+    let req = request("a screenshot", vec![media_fragment("a screenshot")], 1);
+    let Json(value) = srv
+        .compile_context(Parameters(req))
+        .await
+        .expect("compile_context");
+    let out = compiled_context_of(value);
+    let handle = out
+        .retrieval_handles
+        .first()
+        .expect("the oversized media fragment must externalize")
+        .handle
+        .clone();
+
+    // When retrieving through the tool
+    let Json(retrieved) = srv
+        .retrieve_context_source(Parameters(RetrieveContextSourceParams {
+            handle: handle.clone(),
+        }))
+        .await
+        .expect("retrieve_context_source");
+
+    // Then the media round-trips byte for byte through the MCP wrapper
+    let media = retrieved
+        .media
+        .expect("a media source must carry its media back through the MCP tool");
+    assert_eq!(media.mime, "image/png");
+    assert_eq!(media.bytes_b64, PNG_B64);
+}
+
+/// Regression this attrapes: a text-only source picking up a spurious
+/// `media` field through the MCP wrapper (e.g. a `Some(default)` instead of
+/// `None`) would be invisible to every other test here, which only ever
+/// compiles text fragments and checks `.content`.
+#[tokio::test]
+async fn test_retrieve_context_source_tool_text_only_carries_no_media() {
+    let (_dir, srv) = server();
+    let req = request("plain", vec![fragment("no picture here")], 10_000);
+    let Json(value) = srv
+        .compile_context(Parameters(req))
+        .await
+        .expect("compile_context");
+    let out = compiled_context_of(value);
+    let handle = out.sources[0].handle.clone();
+
+    let Json(retrieved) = srv
+        .retrieve_context_source(Parameters(RetrieveContextSourceParams { handle }))
+        .await
+        .expect("retrieve_context_source");
+
+    assert!(retrieved.media.is_none());
+}
+
+// --- MCP schema advertises the media fragment shape (US-009, PR3) ----------
+//
+// `schemars` derives the schema straight from `MediaRef`/`ContextFragment`/
+// `RetrieveContextSourceResult`, so nothing here is hand-authored — these
+// tests pin the schema the server ACTUALLY publishes (not just "it should
+// compile"), the same structural-test pattern the wave-5 id-widening tests
+// use above (`test_compile_context_output_schema_advertises_string_ids`).
+// Regression this attrapes: an MCP client generates requests/validates
+// responses from the advertised JSON Schema alone — if a future refactor
+// moved `media` behind a `#[serde(skip)]`, a renamed field, or a schemars
+// attribute that hides it from `$defs`, a client would never learn the
+// fragment/source can carry media at all, even though the Rust type still
+// round-trips it — these tests fail on that class of regression while every
+// behavioral test above still passes (they talk to the Rust struct, not the
+// advertised JSON).
+
+#[test]
+fn test_compile_context_input_schema_advertises_fragment_media_field() {
+    let tool = McpServer::compile_context_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+
+    let media_property = &schema["$defs"]["ContextFragment"]["properties"]["media"];
+    assert!(
+        !media_property.is_null(),
+        "fragments[].media must be advertised on compile_context's input schema"
+    );
+    // Resolve the (possibly $ref'd) MediaRef schema and check its shape.
+    let media_schema = if let Some(reference) = media_property.get("$ref") {
+        let reference = reference
+            .as_str()
+            .expect("$ref is a string")
+            .trim_start_matches("#/$defs/");
+        &schema["$defs"][reference]
+    } else if let Some(one_of) = media_property
+        .get("anyOf")
+        .or_else(|| media_property.get("oneOf"))
+    {
+        // Optional fields sometimes wrap the ref in anyOf: [{$ref}, {type: null}]
+        one_of
+            .as_array()
+            .and_then(|variants| variants.iter().find(|v| v.get("$ref").is_some()))
+            .and_then(|v| v.get("$ref"))
+            .and_then(serde_json::Value::as_str)
+            .map(|r| r.trim_start_matches("#/$defs/"))
+            .map_or(media_property, |name| &schema["$defs"][name])
+    } else {
+        media_property
+    };
+    for expected in ["mime", "bytes_b64"] {
+        assert!(
+            !media_schema["properties"][expected].is_null(),
+            "MediaRef must advertise '{expected}'; media schema was {media_schema}"
+        );
+    }
+}
+
+#[test]
+fn test_retrieve_context_source_output_schema_advertises_optional_media_field() {
+    let tool = McpServer::retrieve_context_source_tool_attr();
+    let schema = serde_json::to_value(
+        tool.output_schema
+            .expect("retrieve_context_source declares an output schema"),
+    )
+    .expect("schema serializes");
+
+    let media_property = &schema["properties"]["media"];
+    assert!(
+        !media_property.is_null(),
+        "retrieve_context_source's output schema must advertise 'media'; schema was {schema}"
+    );
+    // Required stays scoped to handle/content: media is optional (US-009 PR2
+    // kept every pre-PR2 text-only response byte-identical).
+    let required = schema["required"]
+        .as_array()
+        .expect("output schema declares required properties");
+    assert!(
+        !required.contains(&serde_json::json!("media")),
+        "media must stay optional on the advertised schema, got required: {required:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_compile_context_tool_zero_budget_is_invalid_params() {
     let (_dir, srv) = server();

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -106,6 +106,37 @@ it into your agent's skills directory:
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
 ```
 
+#### Media fragments (`retrieveContextSource`)
+
+A fragment may carry an inline screenshot alongside its caption — set
+`media: {mime, bytes_b64}` on a fragment:
+
+```js
+const out = await mem.compileContext({
+  query: 'a screenshot of the failing build',
+  token_budget: 4000,
+  fragments: [
+    { content: 'the failing build, before the fix', media: { mime: 'image/png', bytes_b64: pngB64 } },
+  ],
+})
+```
+
+The image packs atomically (never chunked) and costs tokens from its actual
+pixels, not its base64 text — see the crate README's "Media fragments"
+section for the full model. `out.sources[i].handle` is a pointer only
+(`fragment_id` + `handle`); fetch the image itself back — inline or
+externalized by budget, it makes no difference — with `retrieveContextSource`:
+
+```js
+const source = await mem.retrieveContextSource(out.sources[0].handle)
+source.content   // the caption, byte for byte
+source.media     // { mime, bytes_b64 } when the fragment carried one, else undefined
+```
+
+Same JSON shape as the MCP `retrieve_context_source` tool
+(`{handle, content, media?}`); an unknown or expired handle rejects with
+`NOT_FOUND`.
+
 ## Need the full engine?
 
 This addon is the **memory wedge**: `remember` / `recall` / `relate` /

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -34,6 +34,7 @@ test('surface allowlist — exactly the supported methods, no engine leak', () =
     'relate',
     'remember',
     'rememberExtracted',
+    'retrieveContextSource',
     'saveWorkingContext',
     'why',
   ])
@@ -312,6 +313,104 @@ test('compileContext malformed request rejects with INVALID_INPUT', async () => 
   const { store, cleanup } = freshStore()
   try {
     await assert.rejects(store.compileContext({ fragments: 'not-an-array' }), /INVALID_INPUT/)
+  } finally {
+    cleanup()
+  }
+})
+
+// --- media fragments (US-009, PR3) ------------------------------------------
+// A real, independently-decodable 1x1 transparent PNG (IHDR + IDAT + IEND) —
+// fixed bytes, never derived from any caption or property under test (per
+// the fixture-independence rule: PR2's real incident was test bytes derived
+// from the caption, which masked a corruption).
+const PNG_1X1_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+
+test('compileContext with a media fragment: atomic preserve decision, handle resolves the image', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const out = await store.compileContext({
+      query: 'a screenshot of the failing build',
+      fragments: [
+        {
+          content: 'the failing build, before the fix',
+          media: { mime: 'image/png', bytes_b64: PNG_1X1_B64 },
+        },
+      ],
+      token_budget: 10000,
+    })
+    // Media fragments pack whole-or-nothing (rule_id "media.atomic"); with a
+    // generous budget the image fits inline and the decision preserves it.
+    assert.equal(out.decisions.length, 1)
+    assert.equal(out.decisions[0].rule_id, 'media.atomic')
+    assert.equal(out.decisions[0].action, 'preserve')
+    assert.equal(typeof out.decisions[0].fragment_id, 'string', 'media fragment ids stay strings too')
+    // `compile_context`'s own `sources` entries are pointers only
+    // (fragment_id + handle) — the image itself is fetched back through
+    // retrieveContextSource, exercised by the tests below.
+    assert.equal(out.sources.length, 1)
+    assert.ok(out.sources[0].handle.startsWith('ctx://source/'))
+  } finally {
+    cleanup()
+  }
+})
+
+test('retrieveContextSource resolves a text-only source with no media field', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    const out = await store.compileContext({
+      query: 'a plain fact',
+      fragments: [{ content: 'never restart the primary node during a rebalance' }],
+      token_budget: 10000,
+    })
+    const handle = out.sources[0].handle
+
+    const resolved = await store.retrieveContextSource(handle)
+    assert.equal(resolved.handle, handle)
+    assert.equal(resolved.content, 'never restart the primary node during a rebalance')
+    assert.equal(resolved.media, undefined, 'a text-only source must not carry a media field')
+  } finally {
+    cleanup()
+  }
+})
+
+test('retrieveContextSource round-trips a media source byte-identical, even when externalized by budget', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    // A budget far too small for the image forces it behind a retrieval
+    // handle — this is the path a caller actually needs retrieveContextSource
+    // for (an inline media fragment is already in `content`, nothing to fetch).
+    const out = await store.compileContext({
+      query: 'a screenshot',
+      fragments: [
+        {
+          content: 'a screenshot',
+          media: { mime: 'image/png', bytes_b64: PNG_1X1_B64 },
+        },
+      ],
+      token_budget: 1,
+    })
+    assert.ok(out.retrievalHandles.length >= 1, 'the oversized media fragment must externalize')
+    const handle = out.retrievalHandles[0].handle
+
+    const resolved = await store.retrieveContextSource(handle)
+    assert.equal(resolved.handle, handle)
+    assert.ok(resolved.media, 'the resolved source must carry its media back')
+    assert.equal(resolved.media.mime, 'image/png')
+    assert.equal(
+      resolved.media.bytes_b64,
+      PNG_1X1_B64,
+      'the base64 payload must be byte-identical after the store round-trip',
+    )
+  } finally {
+    cleanup()
+  }
+})
+
+test('retrieveContextSource unknown handle rejects with NOT_FOUND', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await assert.rejects(store.retrieveContextSource('ctx://source/999999'), /NOT_FOUND/)
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -368,7 +368,7 @@ test('retrieveContextSource resolves a text-only source with no media field', as
     const resolved = await store.retrieveContextSource(handle)
     assert.equal(resolved.handle, handle)
     assert.equal(resolved.content, 'never restart the primary node during a rebalance')
-    assert.equal(resolved.media, undefined, 'a text-only source must not carry a media field')
+    assert.strictEqual(resolved.media, undefined, 'a text-only source must not carry a media field')
   } finally {
     cleanup()
   }
@@ -402,6 +402,20 @@ test('retrieveContextSource round-trips a media source byte-identical, even when
       PNG_1X1_B64,
       'the base64 payload must be byte-identical after the store round-trip',
     )
+  } finally {
+    cleanup()
+  }
+})
+
+test('retrieveContextSource malformed handles reject with NOT_FOUND, never crash', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    // Regression caught: a handle that is not ctx://source/<u64> at all must
+    // fail through the same NOT_FOUND taxonomy as an unknown-but-well-formed
+    // one — never an INTERNAL error or a crash.
+    for (const bad of ['garbage', 'ctx://source/zzzz', '']) {
+      await assert.rejects(store.retrieveContextSource(bad), /NOT_FOUND/, `handle: ${JSON.stringify(bad)}`)
+    }
   } finally {
     cleanup()
   }

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -133,6 +133,52 @@ Compression keeps one prompt small; `save_working_context` /
 {"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
 ```
 
+## Screenshots and images
+
+A fragment may carry an inline image alongside its caption:
+`media: {"mime": "image/png", "bytes_b64": "<base64>"}` on a fragment passed
+to `compile_context`. Route a screenshot into a fragment's `media` field
+instead of describing it in prose — the compiler prices it from the actual
+pixels (`ceil(width * height / 750)` for PNG/JPEG, a published per-image token
+constant), not from a text description that either under- or over-states its
+cost.
+
+- **Set `metadata.target`** to whatever the screenshot is *of* (a URL, a test
+  name, a UI element id) whenever you take repeated screenshots of the same
+  subject over a session (e.g. re-checking the same failing page after each
+  fix attempt). Fragments that share `media`, `kind: "screenshot"`, and the
+  same `metadata.target` form a succession series: only the LAST one (input
+  order in the request — never a clock) stays inline, every earlier one is
+  externalized behind a `ctx://source/` handle regardless of budget. Skipping
+  `metadata.target` means every screenshot competes for space on equal
+  footing with everything else — fine for one-off images, wasteful for a
+  before/after/after-again sequence of the same page.
+- **Pixel cost adds up fast.** A handful of full-resolution screenshots can
+  consume more budget than a page of text; prefer cropping to the relevant
+  region before attaching it, and lean on `metadata.target` supersession so
+  only the current state of a repeatedly-screenshotted subject stays inline.
+- **Fetching a media source back** is `retrieve_context_source` — like any
+  other handle, but the result carries `media: {mime, bytes_b64}` alongside
+  `content` (the caption) whenever the original fragment carried one.
+
+```json
+{"tool": "compile_context", "arguments": {
+  "query": "why is the deploy page still red",
+  "token_budget": 4000,
+  "fragments": [
+    {"content": "before the fix", "kind": "screenshot",
+     "metadata": {"target": "deploy-status-page"},
+     "media": {"mime": "image/png", "bytes_b64": "<base64>"}},
+    {"content": "after the fix", "kind": "screenshot",
+     "metadata": {"target": "deploy-status-page"},
+     "media": {"mime": "image/png", "bytes_b64": "<base64>"}}
+  ]
+}}
+```
+
+Here only "after the fix" stays inline; "before the fix" is retrievable on
+demand, not silently dropped.
+
 ## When NOT to compress
 
 - **Small contexts.** Below a few hundred tokens the joiner/section overhead

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -118,6 +118,28 @@ pub fn parse_fragment_id_strings(request: &mut Value) -> napi::Result<()> {
     velesdb_memory::context::wire::parse_fragment_id_strings(request).map_err(invalid_input)
 }
 
+/// Marshal a resolved `ctx://source/<hash>` lookup into the binding's
+/// `{handle, content, media?}` wire shape (US-009, PR3) — the same envelope
+/// the MCP `retrieve_context_source` tool returns, built here since
+/// [`velesdb_memory::context::ContextSource`] itself carries no `handle`
+/// (the caller already has it; the service only resolves content + media).
+pub fn to_retrieve_source_js(
+    handle: &str,
+    source: &velesdb_memory::context::ContextSource,
+) -> napi::Result<Value> {
+    let internal =
+        |what: &str| napi::Error::from_reason(format!("[INTERNAL] context source: {what}"));
+    let Value::Object(fields) =
+        serde_json::to_value(source).map_err(|err| internal(&format!("serialize: {err}")))?
+    else {
+        return Err(internal("not an object"));
+    };
+    let mut map = serde_json::Map::new();
+    map.insert("handle".to_owned(), Value::String(handle.to_owned()));
+    map.extend(fields);
+    Ok(Value::Object(map))
+}
+
 /// Marshal a compiled context into its JS shape: serialize to the wire JSON,
 /// stringify every id field, then lift the top-level fields into the typed
 /// [`CompiledContextJs`] envelope. Pure conversion — no compile logic.

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -337,6 +337,26 @@ impl MemoryStore {
         }))
     }
 
+    /// Fetch back the exact original content — and media, when the fragment
+    /// carried one (US-009, PR3) — behind a `ctx://source/<hash>` handle
+    /// from a [`Self::compile_context`] result: what was externalized or
+    /// partially packed is recoverable, not lost. Same JSON shape as the MCP
+    /// `retrieve_context_source` tool: `{handle, content, media?}`, `media`
+    /// present only for a source whose fragment carried one. Pure
+    /// delegation to [`velesdb_memory`]'s bridge — zero logic in the
+    /// binding.
+    #[napi(
+        js_name = "retrieveContextSource",
+        ts_return_type = "Promise<{ handle: string; content: string; media?: { mime: string; bytes_b64: string } }>"
+    )]
+    pub fn retrieve_context_source(&self, handle: String) -> AsyncTask<Job<JsonOut>> {
+        let svc = Arc::clone(&self.inner);
+        AsyncTask::new(Job::new(move || {
+            let source = svc.retrieve_context_source(&handle).map_err(to_napi_err)?;
+            convert::to_retrieve_source_js(&handle, &source).map(JsonOut)
+        }))
+    }
+
     /// Persist the agent's distilled working state under `project` +
     /// `session` (idempotent upsert: saving again replaces the previous
     /// state), for inter-session resumption. Same JSON shape as the MCP

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -188,3 +188,96 @@ fn compile_context_memory_scope_pulls_stored_memories() {
         "the scoped memory must be pulled into the compiled context, got: {content}"
     );
 }
+
+// --- media fragments (US-009, PR3) ------------------------------------------
+//
+// `WasmMemoryService::compile_context` takes the request as a plain JS
+// object and returns the wire JSON as-is (`serde_wasm_bindgen`, no field
+// remapping), so `fragments[].media` already crosses the boundary via the
+// same passthrough `compile_context_round_trips_with_string_ids` pins for
+// ids — nothing wasm-specific needed to be built for a fragment to CARRY
+// media across. What was never exercised is that the media-aware rules
+// (`media.atomic`, dedup, cost) actually run correctly on `WasmStore`
+// (a different `MemoryStore` impl than the native one every other media
+// test in this workspace runs against).
+//
+// `retrieve_context_source` is not exposed on `WasmMemoryService` at all
+// (checked against `src/memory_service.rs` before writing this test) — so
+// resolving a media handle back to its bytes within a wasm session is not
+// covered here; that lands whenever wasm gets a `retrieveContextSource`
+// binding of its own (mirroring the Node one added in this same PR). Adding
+// that binding is out of scope for this PR: it is a new, independently
+// reviewable surface, not required to prove media fragments compile
+// correctly on `WasmStore`.
+
+/// A real, independently-decodable 1x1 transparent PNG (IHDR + IDAT + IEND),
+/// fixed bytes never derived from the fragment's caption or any other
+/// property under test.
+const PNG_1X1_B64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+/// Regression this attrapes: `WasmStore`'s `MemoryStore` impl diverges from
+/// the native file-backed one (different metadata batch/get paths) — a
+/// media-specific bug there (e.g. the atomic-packing rule never matching, or
+/// the media source never getting a handle) would show up only on wasm,
+/// never in the native `context_memory_bdd` suite.
+#[wasm_bindgen_test]
+fn compile_context_with_media_fragment_decides_atomic_preserve_and_mints_a_handle() {
+    let svc = WasmMemoryService::new(16);
+    let request = js_sys::JSON::parse(&format!(
+        r#"{{
+            "query": "a screenshot of the failing build",
+            "token_budget": 4000,
+            "fragments": [
+                {{"content": "the failing build, before the fix",
+                  "media": {{"mime": "image/png", "bytes_b64": "{PNG_1X1_B64}"}}}}
+            ]
+        }}"#
+    ))
+    .unwrap();
+
+    let compiled = svc.compile_context(request).unwrap();
+    let decisions = js_sys::Reflect::get(&compiled, &"decisions".into()).unwrap();
+    let first = js_sys::Reflect::get(&decisions, &0.into()).unwrap();
+    let rule_id = js_sys::Reflect::get(&first, &"rule_id".into()).unwrap();
+    assert_eq!(
+        rule_id.as_string().as_deref(),
+        Some("media.atomic"),
+        "the media fragment must be decided by the atomic-packing rule"
+    );
+    let action = js_sys::Reflect::get(&first, &"action".into()).unwrap();
+    assert_eq!(action.as_string().as_deref(), Some("preserve"));
+
+    let sources = js_sys::Reflect::get(&compiled, &"sources".into()).unwrap();
+    let source = js_sys::Reflect::get(&sources, &0.into()).unwrap();
+    let handle = js_sys::Reflect::get(&source, &"handle".into())
+        .unwrap()
+        .as_string()
+        .expect("the media fragment gets an addressable ctx://source/ handle");
+    assert!(handle.starts_with("ctx://source/"));
+}
+
+/// Byte-determinism of media fragments across the wasm boundary — the same
+/// media-carrying request compiles to the exact same bytes twice, extending
+/// `compile_context_is_deterministic` (text-only) to a fragment whose
+/// classification depends on the decoded image (dimensions, token cost).
+/// Regression this attrapes: a non-deterministic path in the image
+/// estimator or the media dedup hash (e.g. an uninitialized buffer, a
+/// HashMap iteration order leak) would flap this test across runs while a
+/// single-compile assertion could not tell determinism from luck.
+#[wasm_bindgen_test]
+fn compile_context_with_media_fragment_is_deterministic() {
+    let svc = WasmMemoryService::new(16);
+    let request = || {
+        js_sys::JSON::parse(&format!(
+            r#"{{"query": "q", "token_budget": 4000,
+                "fragments": [{{"content": "same caption",
+                  "media": {{"mime": "image/png", "bytes_b64": "{PNG_1X1_B64}"}}}}]}}"#
+        ))
+        .unwrap()
+    };
+    let a = svc.compile_context(request()).unwrap();
+    let b = svc.compile_context(request()).unwrap();
+    let stringify = |v: &JsValue| js_sys::JSON::stringify(v).unwrap().as_string().unwrap();
+    assert_eq!(stringify(&a), stringify(&b), "same media input, same bytes");
+}

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-> The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) is available in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md); this WASM SDK does not expose it yet.
+> The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md) (which additionally exposes `retrieveContextSource` for externalized-source retrieval).
 
 **v3.12.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -39,16 +39,40 @@ export interface MemoryRecollection {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * An inline media payload on a {@link CompileContextFragment} (US-009).
+ * `content` on the fragment stays the caption — often empty for a bare
+ * screenshot — while the pixels live here, base64-encoded. The fragment
+ * packs atomically (never chunked) and its token cost comes from the
+ * image itself (dimensions sniffed from the PNG/JPEG header), not its
+ * base64 text.
+ */
+export interface CompileContextMedia {
+  /** Declared MIME type, e.g. `"image/png"` or `"image/jpeg"`. */
+  mime: string;
+  /** The raw media bytes, base64-encoded (standard alphabet, padded). */
+  bytes_b64: string;
+}
+
 /** One input fragment of {@link MemoryService.compileContext}. */
 export interface CompileContextFragment {
   /** Optional caller id as a decimal string (content-derived when absent). */
   id?: string;
-  /** The fragment text. */
+  /** The fragment text (the caption, when {@link media} is set). */
   content: string;
-  /** Classification hint (`"code"`, `"log"`, …). */
+  /** Classification hint (`"code"`, `"log"`, `"screenshot"`, …). */
   kind?: string;
   /** Fragment flags, e.g. `{ verbatim: true }` or `{ cache: true }`. */
   metadata?: Record<string, unknown>;
+  /**
+   * Inline media payload (US-009). `undefined` keeps every pre-existing
+   * request wire-compatible. Fetch it back later — inline or externalized
+   * by budget, it makes no difference — through `retrieve_context_source`
+   * over the underlying `compileContext` handle (not yet exposed on this
+   * WASM-backed SDK client; see the Node binding's `retrieveContextSource`
+   * for the same shape).
+   */
+  media?: CompileContextMedia;
 }
 
 /**

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryService } from '../src/memory';
+import type { CompileContextFragment } from '../src/memory';
 import { ConnectionError, NotFoundError, ValidationError } from '../src/types';
 
 // Captures the most recently constructed mock instance so a test can
@@ -231,6 +232,33 @@ describe('MemoryService', () => {
       expect(compiled.content).toBe('compiled');
       const decisions = compiled.decisions as Array<{ fragment_id: string }>;
       expect(decisions[0].fragment_id).toBe('18446744073709551615');
+    });
+
+    it('compileContext() passes a media fragment through untouched (US-009)', async () => {
+      // Regression this attrapes: a future refactor of compileContext() that
+      // reconstructs the request object field-by-field (instead of a plain
+      // passthrough) would silently drop an unlisted key like `media` —
+      // this fails the moment that happens, without needing a real wasm
+      // build to observe it.
+      const request = {
+        query: 'a screenshot of the failing build',
+        token_budget: 4000,
+        fragments: [
+          {
+            content: 'the failing build, before the fix',
+            kind: 'screenshot',
+            metadata: { target: 'deploy-status-page' },
+            media: { mime: 'image/png', bytes_b64: 'aGVsbG8=' },
+          },
+        ],
+      };
+      await memory.compileContext(request);
+      expect(lastMockInstance!.compileContext).toHaveBeenCalledWith(request);
+      // Type-level check: CompileContextFragment must accept `media` without
+      // a cast — this line fails to *compile* (not just run) if the field is
+      // ever removed from the interface.
+      const fragment: CompileContextFragment = request.fragments[0];
+      expect(fragment.media?.bytes_b64).toBe('aGVsbG8=');
     });
 
     it('why() returns the explanation subgraph', async () => {

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -133,6 +133,52 @@ Compression keeps one prompt small; `save_working_context` /
 {"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
 ```
 
+## Screenshots and images
+
+A fragment may carry an inline image alongside its caption:
+`media: {"mime": "image/png", "bytes_b64": "<base64>"}` on a fragment passed
+to `compile_context`. Route a screenshot into a fragment's `media` field
+instead of describing it in prose — the compiler prices it from the actual
+pixels (`ceil(width * height / 750)` for PNG/JPEG, a published per-image token
+constant), not from a text description that either under- or over-states its
+cost.
+
+- **Set `metadata.target`** to whatever the screenshot is *of* (a URL, a test
+  name, a UI element id) whenever you take repeated screenshots of the same
+  subject over a session (e.g. re-checking the same failing page after each
+  fix attempt). Fragments that share `media`, `kind: "screenshot"`, and the
+  same `metadata.target` form a succession series: only the LAST one (input
+  order in the request — never a clock) stays inline, every earlier one is
+  externalized behind a `ctx://source/` handle regardless of budget. Skipping
+  `metadata.target` means every screenshot competes for space on equal
+  footing with everything else — fine for one-off images, wasteful for a
+  before/after/after-again sequence of the same page.
+- **Pixel cost adds up fast.** A handful of full-resolution screenshots can
+  consume more budget than a page of text; prefer cropping to the relevant
+  region before attaching it, and lean on `metadata.target` supersession so
+  only the current state of a repeatedly-screenshotted subject stays inline.
+- **Fetching a media source back** is `retrieve_context_source` — like any
+  other handle, but the result carries `media: {mime, bytes_b64}` alongside
+  `content` (the caption) whenever the original fragment carried one.
+
+```json
+{"tool": "compile_context", "arguments": {
+  "query": "why is the deploy page still red",
+  "token_budget": 4000,
+  "fragments": [
+    {"content": "before the fix", "kind": "screenshot",
+     "metadata": {"target": "deploy-status-page"},
+     "media": {"mime": "image/png", "bytes_b64": "<base64>"}},
+    {"content": "after the fix", "kind": "screenshot",
+     "metadata": {"target": "deploy-status-page"},
+     "media": {"mime": "image/png", "bytes_b64": "<base64>"}}
+  ]
+}}
+```
+
+Here only "after the fix" stays inline; "before the fix" is retrievable on
+demand, not silently dropped.
+
 ## When NOT to compress
 
 - **Small contexts.** Below a few hundred tokens the joiner/section overhead


### PR DESCRIPTION
## Summary

PR3 (final) of US-009 (media fragments), EPIC-P-071. PR1 shipped atomic
packing/dedup/cost in the compiler; PR2 shipped memory-backed retrieval,
screenshot supersession, and the MCP/Python bindings. This PR wires the
remaining surfaces: MCP schema proof, Node `retrieveContextSource`, WASM
coverage, and the TypeScript SDK type.

## What changed, and the regression each key test catches

- **MCP structural schema tests** (`context_tools_tests.rs`):
  `test_compile_context_input_schema_advertises_fragment_media_field` and
  `test_retrieve_context_source_output_schema_advertises_optional_media_field`
  parse the schema the server *actually publishes* (not the Rust type) —
  catches a future `#[serde(skip)]`/rename/schemars attribute that would
  hide `media` from a schema-validating MCP client while the Rust struct
  still round-trips it fine.
- **MCP behavioral tests**: `test_retrieve_context_source_tool_round_trips_media_byte_identical`
  exercises the MCP tool *wrapper* specifically (its own
  `RetrieveContextSourceResult` envelope, built separately from the
  service's `ContextSource`) — catches a dropped `media: source.media` in
  that wrapper, which PR2's `MemoryService`-level BDD suite cannot see.
  `test_retrieve_context_source_tool_text_only_carries_no_media` catches
  the inverse: a spurious `media` field leaking onto a text-only source.
- **Node**: new `retrieveContextSource(handle)` (mirrors the Python
  binding's `{handle, content, media?}` shape). The integration test with a
  real PNG fixture caught a real bug while writing it — `compile_context`'s
  `sources[]` are pointers only (`fragment_id` + `handle`), never `media`
  directly (that's `SourceReference`, not `ContextSource`); the test was
  fixed to resolve through `retrieveContextSource` like the Rust BDD suite
  already does. It also caught that `CompiledContextJs`'s
  `retrieval_handles` field crosses as `retrievalHandles` (napi's automatic
  camelCasing of top-level struct fields) — an easy point to get wrong
  from the wire-shape docs alone, now pinned.
- **WASM**: `compile_context_with_media_fragment_decides_atomic_preserve_and_mints_a_handle`
  catches a `media.atomic`-rule or handle-minting regression specific to
  `WasmStore` (a different `MemoryStore` impl than native — nothing
  wasm-specific exercised media before this PR).
  `compile_context_with_media_fragment_is_deterministic` catches
  non-determinism in the image estimator or media dedup hash that a
  single-compile assertion couldn't tell from luck. `retrieveContextSource`
  is **not** added to the WASM binding here — checked against
  `memory_service.rs` before writing tests; scoped out as a separate,
  independently reviewable follow-up and documented as a gap in the crate
  README, per "decide the minimal coherent thing, don't inflate scope."
- **TypeScript SDK**: `CompileContextFragment.media` type; the vitest test
  fails to *compile* if the field is ever removed, and fails at *runtime*
  if `compileContext()` is ever refactored into a field-by-field
  reconstruction that drops unlisted keys.
- **`velesdb-context-optimizer` skill**: new "Screenshots and images"
  section (routing, `metadata.target` supersession, pixel cost) — synced
  byte-identical across both copies (top-level `skills/` and the npm
  package's bundled copy).
- **`mcp_e2e.py`**: extended with a real media case against a live stdio
  server — compile a PNG image, externalize by budget, retrieve, assert
  byte-identical base64.

## Note on TDD framing

Per the task's own instructions, item 1 (MCP schemas) was expected to
already be correctly wired by PR1/PR2's `JsonSchema` derives — confirmed:
every new MCP-level test went green on first run, no red-then-green cycle,
because there was no missing production code to make them pass. These are
verification/pinning tests (real regression coverage of the advertised
schema, not novel behavior), not TDD-red tests. Every other surface (Node
`retrieveContextSource`, the two WASM tests, the TS type) followed real
red -> green: the method/type did not exist, the test failed by absence,
then the minimal code was added.

## Gates (all green, run locally)

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic`
- [x] `cargo clippy -p velesdb-node --lib -- -D warnings`
- [x] `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context`
- [x] `cargo test -p velesdb-memory` (267 lib tests + all integration suites, all green; 25/25 MCP tool tests including the new ones)
- [x] `python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py` (release build, real stdio server)
- [x] `cd crates/velesdb-node && npm run build && node --test __test__/index.spec.mjs` (24/24 green)
- [x] `wasm-pack test --node crates/velesdb-wasm` (all suites green, including 8/8 in `memory_wedge_web.rs`)
- [x] `cd sdks/typescript && npm test` (897/897 green) + `tsc --noEmit` clean
- [x] CHANGELOG `[Unreleased]` entry added

## Deliberate scope decisions (documented, not silent)

- WASM `retrieveContextSource` is out of scope for this PR (see above).
- Node `contextSavings` was checked and does not exist on the Node surface
  at all (predates this PR) — nothing to verify for non-regression there.

Do not merge — for review.