### PR TITLE
test(examples): CI gate — ground-truth facts survive compilation in both arms [EPIC-P-071]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,18 @@ jobs:
           npx napi build --platform
           node --test __test__/index.spec.mjs
 
+      # EPIC-P-071/A1 non-regression gate: "the facts survive compilation".
+      # Reuses the napi addon just built above (no second Rust build) — this
+      # job is the cheapest place to run it: the "Tests" job never sets up
+      # Node or builds the addon, so branching there would pay for a full
+      # extra napi build for one offline, network-free JS test file.
+      # gpt-tokenizer is installed here (not committed) per
+      # examples/real-session-benchmark/README.md's prereqs.
+      - name: Real-session benchmark — facts-survive gate (offline, no network)
+        run: |
+          npm install --no-save --no-audit --no-fund --prefix crates/velesdb-node gpt-tokenizer
+          node --test examples/real-session-benchmark/test/facts-survive.test.mjs
+
   # ===========================================================================
   # Coverage (main seulement)
   # ===========================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,15 @@ account).
 
 ### Fixed
 
+- **Benchmark online mode**: the CLI runner now uses the CLI-enforced
+  `--output-format stream-json` pairing (parsing the final NDJSON `result`
+  event) — the previous `json` output form was rejected by the CLI at the
+  first real call; and the online summary now prints per-arm BILLED dollars
+  (`total_cost_usd` summed per session) plus cache-field totals, because on
+  a caching runner the context lives in cache_creation/cache_read, not
+  `input_tokens` (measured: input_tokens≈2 on every turn of both arms).
+  [EPIC-P-071]
+
 - **The context compiler no longer aborts on `wasm32-unknown-unknown`** when
   recording savings events: `SystemTime::now()` (unsupported in wasm `std`,
   panics) is only reached on native targets now; wasm events carry a 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Claude Code CLI's headless mode (`BENCH_RUNNER=cli`, no key — the user's
   own authenticated account; wire shapes verified by a real calibration
   call). [EPIC-P-071]
+- **CI gate — ground-truth facts survive compilation** (EPIC-P-071/A1):
+  `examples/real-session-benchmark/test/facts-survive.test.mjs` turns the
+  benchmark's per-turn fact checklists (`corpus/questions.mjs`) into an
+  executable non-regression check: for every turn of the base session, in
+  BOTH the lossless and the window-8000 compiled arms, every ground-truth
+  fact must be present in what that arm would actually send to the model —
+  inline, or PROVEN recoverable by really resolving its `ctx://source/`
+  handle via `retrieveContextSource` (never assumed from a listed handle).
+  Runs offline, no network, in CI's `Node Binding Tests` job (reuses the
+  napi addon already built there). [EPIC-P-071]
 
 R1 `Collection`-internals train: resolves and **closes the god-object EPIC
 ([#1384](https://github.com/cyberlife-coder/VelesDB/issues/1384))**. The

--- a/crates/velesdb-memory/tests/mcp_lifecycle.rs
+++ b/crates/velesdb-memory/tests/mcp_lifecycle.rs
@@ -1,0 +1,191 @@
+//! MCP server process lifecycle (#1448).
+//!
+//! Regression this catches: the `velesdb-memory` binary must exit — and
+//! release its single-writer store lock — when its stdio transport reaches
+//! EOF, exactly as any well-behaved MCP stdio server does when its client
+//! disconnects. Before the fix, closing stdin left the process running
+//! forever (`running.waiting()` never resolved because nothing observed
+//! the transport's EOF), so every disconnect (a `claude mcp list`
+//! health-check, a closed Claude Code session) leaked a zombie that kept
+//! holding the store lock — and the *next* session's `initialize` failed
+//! with `Storage(DatabaseLocked)`, surfaced to the user as an opaque
+//! "Failed to connect".
+//!
+//! Spawns the real binary (`env!("CARGO_BIN_EXE_velesdb-memory")`), talks
+//! one `initialize` over stdin/stdout, closes stdin, and asserts the
+//! process exits within a bounded timeout — then proves the lock was
+//! actually released by successfully `initialize`-ing a second process on
+//! the same store path.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Upper bound the test is willing to wait for a clean shutdown. The MCP
+/// stdio lifecycle is local-process and near-instantaneous, so 5s is already
+/// generous headroom over any plausible tokio/runtime teardown cost.
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Read one line from `reader` on a helper thread and wait for it at most
+/// `timeout`. `BufRead::read_line` has no built-in deadline, and if the
+/// process under test is the one hanging (exactly what #1448 is about), a
+/// direct blocking read would hang this test — and the whole suite — right
+/// along with it. Returns `None` on timeout, leaving the helper thread
+/// (and its now-orphaned read) to be cleaned up when the child is killed
+/// and its pipe closed.
+fn read_line_with_timeout(mut reader: BufReader<ChildStdout>, timeout: Duration) -> Option<String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let result = reader.read_line(&mut line).map(|n| (n, line));
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(Ok((0, _))) => None, // EOF before any line arrived
+        Ok(Ok((_, line))) => Some(line),
+        Ok(Err(_)) | Err(_) => None,
+    }
+}
+
+fn initialize_request(id: u64) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":{id},"method":"initialize","params":{{"protocolVersion":"2024-11-05","capabilities":{{}},"clientInfo":{{"name":"mcp_lifecycle_test","version":"0"}}}}}}"#
+    )
+}
+
+/// Spawn the server binary against `store_path`, pointed at a scratch store
+/// so this test never touches the user's real `~/.velesdb-memory`.
+fn spawn_server(store_path: &std::path::Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env("VELESDB_MEMORY_PATH", store_path)
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn velesdb-memory binary")
+}
+
+/// Send one `initialize` request and block until the matching JSON-RPC
+/// response line comes back on stdout — the request/response round trip
+/// that proves the server is actually up before we exercise shutdown.
+fn complete_initialize_handshake(child: &mut Child) {
+    let mut stdin = child.stdin.take().expect("child stdin must be piped");
+    let stdout = child.stdout.take().expect("child stdout must be piped");
+    let reader = BufReader::new(stdout);
+
+    writeln!(stdin, "{}", initialize_request(1)).expect("write initialize to child stdin");
+    stdin.flush().expect("flush initialize request");
+
+    let response = read_line_with_timeout(reader, SHUTDOWN_TIMEOUT)
+        .unwrap_or_else(|| panic!("no initialize response within {SHUTDOWN_TIMEOUT:?}"));
+    assert!(
+        response.contains("\"protocolVersion\""),
+        "expected an initialize response, got: {response}"
+    );
+
+    // Put stdin back so the caller controls exactly when EOF happens; the
+    // stdout reader (and its handshake-reading thread) is dropped — we
+    // don't need any more output for this test.
+    child.stdin = Some(stdin);
+}
+
+/// Poll `Child::try_wait` until the process exits or `timeout` elapses.
+/// Returns the exit status, or `None` on timeout (process still alive).
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn server_exits_when_stdin_reaches_eof() {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let mut child = spawn_server(store_dir.path());
+
+    complete_initialize_handshake(&mut child);
+
+    // Close stdin: this is exactly what happens when an MCP client
+    // disconnects (a health-check like `claude mcp list`, or a closed
+    // Claude Code session) — the transport must observe EOF and shut down.
+    drop(child.stdin.take());
+
+    let status = wait_for_exit(&mut child, SHUTDOWN_TIMEOUT);
+
+    if status.is_none() {
+        // Don't leak the hung process into the rest of the test run.
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    let status = status.unwrap_or_else(|| {
+        panic!(
+            "server did not exit within {SHUTDOWN_TIMEOUT:?} of stdin EOF — \
+             it is not observing transport closure (#1448)"
+        )
+    });
+    assert!(
+        status.success(),
+        "server exited non-zero on stdin EOF: {status:?}"
+    );
+}
+
+#[test]
+fn store_lock_is_released_after_stdin_eof_so_a_second_session_can_connect() {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+
+    let mut first = spawn_server(store_dir.path());
+    complete_initialize_handshake(&mut first);
+    drop(first.stdin.take());
+    let first_status = wait_for_exit(&mut first, SHUTDOWN_TIMEOUT);
+    if first_status.is_none() {
+        let _ = first.kill();
+        let _ = first.wait();
+    }
+    assert!(
+        first_status.is_some(),
+        "first server did not exit within {SHUTDOWN_TIMEOUT:?} of stdin EOF (#1448); \
+         a second session on the same store cannot be expected to connect"
+    );
+
+    // The regression this second half catches: even if the first process
+    // eventually exits, a still-held OS-level lock (released too late, or
+    // never, by a lingering background task) would make this second
+    // `initialize` hang or fail with `Storage(DatabaseLocked)` — exactly the
+    // "opaque Failed to connect" symptom reported in #1448.
+    let mut second = spawn_server(store_dir.path());
+    let mut stdin = second.stdin.take().expect("second child stdin must be piped");
+    let stdout = second.stdout.take().expect("second child stdout must be piped");
+    let reader = BufReader::new(stdout);
+
+    writeln!(stdin, "{}", initialize_request(1)).expect("write initialize to second child");
+    stdin.flush().expect("flush initialize request to second child");
+
+    let response = read_line_with_timeout(reader, SHUTDOWN_TIMEOUT).unwrap_or_else(|| {
+        let _ = second.kill();
+        let _ = second.wait();
+        panic!(
+            "second server on the same store did not answer initialize within \
+             {SHUTDOWN_TIMEOUT:?} — the store lock from the first (EOF-closed) \
+             session was not released (#1448)"
+        );
+    });
+    assert!(
+        response.contains("\"protocolVersion\""),
+        "expected an initialize response from the second session, got: {response}"
+    );
+
+    drop(stdin);
+    let second_status = wait_for_exit(&mut second, SHUTDOWN_TIMEOUT);
+    if second_status.is_none() {
+        let _ = second.kill();
+        let _ = second.wait();
+    }
+}

--- a/crates/velesdb-memory/tests/mcp_lifecycle.rs
+++ b/crates/velesdb-memory/tests/mcp_lifecycle.rs
@@ -42,7 +42,7 @@ fn read_line_with_timeout(mut reader: BufReader<ChildStdout>, timeout: Duration)
     });
     match rx.recv_timeout(timeout) {
         // 0 bytes = EOF before any line arrived; read/recv errors read the same.
-        Ok(Ok((0, _))) | Ok(Err(_)) | Err(_) => None,
+        Ok(Ok((0, _)) | Err(_)) | Err(_) => None,
         Ok(Ok((_, line))) => Some(line),
     }
 }

--- a/crates/velesdb-memory/tests/mcp_lifecycle.rs
+++ b/crates/velesdb-memory/tests/mcp_lifecycle.rs
@@ -41,9 +41,9 @@ fn read_line_with_timeout(mut reader: BufReader<ChildStdout>, timeout: Duration)
         let _ = tx.send(result);
     });
     match rx.recv_timeout(timeout) {
-        Ok(Ok((0, _))) => None, // EOF before any line arrived
+        // 0 bytes = EOF before any line arrived; read/recv errors read the same.
+        Ok(Ok((0, _))) | Ok(Err(_)) | Err(_) => None,
         Ok(Ok((_, line))) => Some(line),
-        Ok(Err(_)) | Err(_) => None,
     }
 }
 
@@ -161,12 +161,20 @@ fn store_lock_is_released_after_stdin_eof_so_a_second_session_can_connect() {
     // `initialize` hang or fail with `Storage(DatabaseLocked)` — exactly the
     // "opaque Failed to connect" symptom reported in #1448.
     let mut second = spawn_server(store_dir.path());
-    let mut stdin = second.stdin.take().expect("second child stdin must be piped");
-    let stdout = second.stdout.take().expect("second child stdout must be piped");
+    let mut stdin = second
+        .stdin
+        .take()
+        .expect("second child stdin must be piped");
+    let stdout = second
+        .stdout
+        .take()
+        .expect("second child stdout must be piped");
     let reader = BufReader::new(stdout);
 
     writeln!(stdin, "{}", initialize_request(1)).expect("write initialize to second child");
-    stdin.flush().expect("flush initialize request to second child");
+    stdin
+        .flush()
+        .expect("flush initialize request to second child");
 
     let response = read_line_with_timeout(reader, SHUTDOWN_TIMEOUT).unwrap_or_else(|| {
         let _ = second.kill();

--- a/examples/real-session-benchmark/README.md
+++ b/examples/real-session-benchmark/README.md
@@ -254,6 +254,11 @@ pins the deterministic grader's case/whitespace-insensitivity.
 is byte-for-byte reproducible from its committed generator, and pins the
 byte-level relationships each US-009 mechanism needs (distinct bytes for
 supersession, identical bytes for dedup, per series).
+`test/facts-survive.test.mjs` proves, for every turn and both compiled arms
+(lossless and window-8000), that every ground-truth fact from
+`corpus/questions.mjs` survives compilation — inline or via a handle that
+`retrieveContextSource` actually resolves — **this promise is CI-enforced**
+(runs offline, no network, in the `Node Binding Tests` CI job).
 
 ## Corpus (`corpus/*.mjs`)
 

--- a/examples/real-session-benchmark/lib/claude-cli.mjs
+++ b/examples/real-session-benchmark/lib/claude-cli.mjs
@@ -67,10 +67,15 @@ export async function runCliTurn(turn, opts = {}) {
     '-p',
     '--model',
     MODEL,
+    // stream-json input REQUIRES stream-json output (CLI-enforced, caught
+    // live at the first calibration turn of the billed campaign): we parse
+    // the final NDJSON `result` event, which carries the same usage /
+    // total_cost_usd fields as --output-format json.
     '--output-format',
-    'json',
+    'stream-json',
     '--input-format',
     'stream-json',
+    '--verbose',
     '--tools',
     '',
     '--system-prompt',
@@ -104,7 +109,24 @@ export async function runCliTurn(turn, opts = {}) {
     child.stdin.end()
   })
 
-  const json = JSON.parse(stdout)
+  // stream-json output is NDJSON: one JSON event per line, the final
+  // `type: "result"` event carries usage and total_cost_usd.
+  let json = null
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const evt = JSON.parse(trimmed)
+      if (evt && evt.type === 'result') json = evt
+    } catch {
+      // non-JSON noise on stdout: ignore (defensive)
+    }
+  }
+  if (!json) {
+    throw new Error(
+      `claude CLI produced no result event in stream-json output (got ${stdout.length} bytes)`,
+    )
+  }
   const usage = json.usage ?? {}
   if (!('input_tokens' in usage) && !warnedMissingUsage) {
     warnedMissingUsage = true

--- a/examples/real-session-benchmark/lib/claude-cli.mjs
+++ b/examples/real-session-benchmark/lib/claude-cli.mjs
@@ -82,6 +82,7 @@ export async function runCliTurn(turn, opts = {}) {
     systemPrompt,
   ]
 
+  let stderrText = ''
   const stdout = await new Promise((resolve, reject) => {
     const child = spawn(claudeBin, args, { stdio: ['pipe', 'pipe', 'pipe'] })
     let out = ''
@@ -94,7 +95,10 @@ export async function runCliTurn(turn, opts = {}) {
       opts.timeoutMs ?? 120000,
     )
     child.stdout.on('data', (d) => (out += d))
-    child.stderr.on('data', (d) => (err += d))
+    child.stderr.on('data', (d) => {
+      err += d
+      stderrText = err
+    })
     child.on('error', (e) => {
       clearTimeout(timer)
       reject(e)
@@ -124,7 +128,7 @@ export async function runCliTurn(turn, opts = {}) {
   }
   if (!json) {
     throw new Error(
-      `claude CLI produced no result event in stream-json output (got ${stdout.length} bytes)`,
+      `claude CLI produced no result event in stream-json output (got ${stdout.length} bytes; stderr: ${stderrText.slice(0, 2000)})`,
     )
   }
   const usage = json.usage ?? {}

--- a/examples/real-session-benchmark/online.mjs
+++ b/examples/real-session-benchmark/online.mjs
@@ -170,6 +170,59 @@ async function main() {
   const rawRuns = await runArm(rawTurns, 'RAW (bras A)')
   const compiledRuns = await runArm(compiledTurns, 'COMPILED (bras B)')
 
+  // Per-arm BILLED DOLLARS and cache-field totals. On a caching runner (the
+  // CLI, and any real harness) the context lives in cache_creation /
+  // cache_read, NOT input_tokens — the first campaign measured
+  // input_tokens=2 on every turn of both arms, which reads as "0% saved"
+  // while the actual billing difference (raw arm re-creates cache every
+  // turn; the compiled arm's byte-stable output cache-HITS) was invisible.
+  // total_cost_usd, when the runner provides it, is the ground truth.
+  function armMoney(runs) {
+    let cost = 0
+    let costSamples = 0
+    let cacheCreate = 0
+    let cacheRead = 0
+    let input = 0
+    for (const samples of runs) {
+      for (const sVal of samples) {
+        if (typeof sVal.total_cost_usd === 'number') {
+          cost += sVal.total_cost_usd
+          costSamples++
+        }
+        cacheCreate += sVal.cache_creation_input_tokens
+        cacheRead += sVal.cache_read_input_tokens
+        input += sVal.input_tokens
+      }
+    }
+    const runsCount = runs[0]?.length ?? 1
+    return {
+      meanCostPerSession: costSamples > 0 ? cost / runsCount : null,
+      costSamples,
+      cacheCreatePerSession: cacheCreate / runsCount,
+      cacheReadPerSession: cacheRead / runsCount,
+      inputPerSession: input / runsCount,
+    }
+  }
+  const rawMoney = armMoney(rawRuns)
+  const compiledMoney = armMoney(compiledRuns)
+  console.log('')
+  console.log('--- session totals: BILLED DOLLARS + cache fields (per session, mean over runs) ---')
+  for (const [label, m] of [
+    ['raw     ', rawMoney],
+    ['compiled', compiledMoney],
+  ]) {
+    console.log(
+      `  ${label}: total_cost_usd=${m.meanCostPerSession === null ? 'n/a (runner reports no cost)' : '$' + m.meanCostPerSession.toFixed(4)}` +
+        ` | input=${m.inputPerSession.toFixed(0)} cache_creation=${m.cacheCreatePerSession.toFixed(0)} cache_read=${m.cacheReadPerSession.toFixed(0)} tokens`,
+    )
+  }
+  if (rawMoney.meanCostPerSession !== null && compiledMoney.meanCostPerSession !== null && rawMoney.meanCostPerSession > 0) {
+    const saved = (1 - compiledMoney.meanCostPerSession / rawMoney.meanCostPerSession) * 100
+    console.log(
+      `  BILLED savings: ${saved.toFixed(1)}% per session in real dollars (includes the constant harness overhead in both arms — the content-only gap is wider)`,
+    )
+  }
+
   console.log('')
   console.log('--- session totals: TOKENS (billed usage.input_tokens, mean over N runs per turn) + QUALITY (deterministic grader) ---')
   let totalRawMean = 0

--- a/examples/real-session-benchmark/test/facts-survive.test.mjs
+++ b/examples/real-session-benchmark/test/facts-survive.test.mjs
@@ -179,3 +179,18 @@ test(
     assert.equal(failures.length, 0, `${failures.length} fact(s) lost in the WINDOW-8000 arm:\n${formatFailureReport(failures)}`)
   },
 )
+
+test('facts survive even under a destructive 1-token budget — via recoverable handles (pins the checker resolve path)', async () => {
+  // Regression caught: if retrieveContextSource stops resolving externalized
+  // sources (or the checker stops re-verifying facts in resolved content),
+  // this test fails — the committed corpus never exercises that branch
+  // (all 22 facts land inline at the real budgets), so without this test
+  // the checker's recovery path would be dead code in CI.
+  const { failures, turnReports } = await checkFactsSurviveArm({
+    budget: 1,
+    label: 'destructive-budget',
+  })
+  assert.deepStrictEqual(failures, [], 'every fact must still be inline or genuinely recoverable')
+  const recovered = turnReports.filter((r) => r.status === 'recoverable').length
+  assert.ok(recovered >= 1, `expected at least one fact through the recoverable path, got ${recovered}`)
+})

--- a/examples/real-session-benchmark/test/facts-survive.test.mjs
+++ b/examples/real-session-benchmark/test/facts-survive.test.mjs
@@ -1,0 +1,181 @@
+// CI non-regression gate (EPIC-P-071, axis A1): "the facts survive
+// compilation". Every ground-truth fact checklist in corpus/questions.mjs
+// was written to be answerable from the corpus AT THE TURN the question is
+// asked (fixture-independence rule — see that file's header). This test
+// turns that checklist from documentation into an executable promise: for
+// EVERY turn of the base 14-turn session and EVERY compiled arm (lossless
+// budget and window-8000), every fact must actually be present in what that
+// arm would send to the model at that turn — either inline in `content`, or
+// behind a `ctx://source/` handle that `retrieveContextSource` genuinely
+// resolves back to text containing the fact. A handle merely being LISTED
+// is not proof of recoverability; this test always calls
+// retrieveContextSource and re-checks the fact in the resolved text before
+// counting it as survived — a fact behind a handle that fails to resolve
+// (or resolves to content missing the fact) is a hard failure, identical to
+// a fact that is simply gone.
+//
+// What regression this catches: any change to the compiler, the dedup/
+// supersession rules, or the budget-externalization path that silently
+// drops a piece of unique information a real agent would need to answer a
+// question about that turn — the kind of regression the token-savings
+// numbers in README.md cannot catch by themselves, because a compiler that
+// deletes content instead of externalizing it also "saves tokens".
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { SYSTEM, TURN_EVENTS } from '../corpus/session.mjs'
+import { TURN_QUESTIONS } from '../corpus/questions.mjs'
+import { loadNodeAddon } from '../lib/compile-node.mjs'
+import { QUERY, LOSSLESS_BUDGET } from '../lib/ab-session.mjs'
+
+const { MemoryService } = loadNodeAddon()
+
+// Same normalization as lib/grade.mjs's deterministic grader (lowercase,
+// whitespace-collapsed substring presence) — checking "is this fact present
+// in this text" with the exact same rule the ONLINE-mode grader would apply
+// to a model's answer, so this gate and the online quality grader agree on
+// what "the fact is there" means.
+function normalize(s) {
+  return String(s).toLowerCase().replace(/\s+/g, ' ').trim()
+}
+function contains(haystack, fact) {
+  return normalize(haystack).includes(normalize(fact))
+}
+
+/**
+ * Runs the base session through compileContext turn by turn at `budget`
+ * and proves, for every (turn, ground-truth fact) pair, that the fact
+ * survives the compiled arm — inline, or PROVEN recoverable by actually
+ * resolving a retrieval handle. Never assumes recoverability from a listed
+ * handle alone.
+ *
+ * @param {{budget: number, label: string, fragmentFilter?: (f: object) => boolean}} opts
+ *   `fragmentFilter` is NOT part of the committed gate (always undefined
+ *   there — every accumulated fragment is sent, matching the offline
+ *   benchmark's non-memory arms exactly). It exists only so a local,
+ *   real-policy destructive run (e.g. excluding every media fragment) can
+ *   prove this checker actually fails when a fact-bearing fragment never
+ *   reaches compileContext at all — see the "red" proof in the PR body.
+ * @returns {Promise<{turnReports: object[], failures: object[]}>}
+ *   failures is empty iff every fact from every turn survives this arm.
+ */
+export async function checkFactsSurviveArm({ budget, label, fragmentFilter = null }) {
+  const dir = mkdtempSync(join(tmpdir(), `veles-facts-survive-${label}-`))
+  const mem = MemoryService.open(dir, 'hash')
+  const accumulated = [SYSTEM]
+  const turnReports = []
+  const failures = []
+
+  try {
+    for (let turn = 0; turn < TURN_EVENTS.length; turn++) {
+      accumulated.push(...TURN_EVENTS[turn])
+      const armBFragments = fragmentFilter ? accumulated.filter(fragmentFilter) : accumulated
+
+      const request = {
+        query: QUERY,
+        token_budget: budget,
+        fragments: armBFragments,
+        policy: { normalize_log_timestamps: true },
+      }
+      const out = await mem.compileContext(request)
+      // Reproducibility guard (same convention as lib/ab-session.mjs): a
+      // nondeterministic compiler would make a single pass/fail verdict
+      // meaningless, since a later resolve could see different content.
+      const again = await mem.compileContext(request)
+      assert.equal(
+        out.content,
+        again.content,
+        `[${label}] turn ${turn + 1}: compileContext must be deterministic (byte-identical across two calls with the same input)`,
+      )
+
+      const sourceByFragmentId = new Map(out.sources.map((s) => [s.fragment_id, s.handle]))
+      const { facts } = TURN_QUESTIONS[turn]
+
+      for (const fact of facts) {
+        const report = { turn: turn + 1, arm: label, fact, status: null, detail: null }
+
+        if (contains(out.content, fact)) {
+          report.status = 'inline'
+          turnReports.push(report)
+          continue
+        }
+
+        // Not inline: find every fragment ACTUALLY SENT to this arm whose
+        // ORIGINAL content carries this fact, and PROVE at least one is
+        // recoverable by resolving its handle for real. A fragment excluded
+        // by fragmentFilter never reaches compileContext, so it has no
+        // decision/source/handle here — correctly unrecoverable.
+        let recoveredVia = null
+        const candidates = []
+        for (let i = 0; i < armBFragments.length; i++) {
+          const f = armBFragments[i]
+          if (!contains(f.content, fact)) continue
+          const d = out.decisions[i]
+          const handle = d ? sourceByFragmentId.get(d.fragment_id) : undefined
+          candidates.push({
+            fragmentIndex: i,
+            rule_id: d?.rule_id ?? null,
+            action: d?.action ?? null,
+            handle: handle ?? null,
+            snippet: f.content.slice(0, 80).replace(/\n/g, ' '),
+          })
+          if (!handle || recoveredVia) continue
+          const resolved = await mem.retrieveContextSource(handle)
+          if (contains(resolved.content ?? '', fact)) {
+            recoveredVia = { fragmentIndex: i, handle, rule_id: d.rule_id, action: d.action }
+          }
+        }
+
+        if (recoveredVia) {
+          report.status = 'recoverable'
+          report.detail = recoveredVia
+          turnReports.push(report)
+        } else {
+          report.status = 'LOST'
+          report.detail = { candidates }
+          turnReports.push(report)
+          failures.push(report)
+        }
+      }
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  return { turnReports, failures }
+}
+
+function formatFailureReport(failures) {
+  return failures
+    .map((f) => {
+      const cand = f.detail?.candidates ?? []
+      const candLines = cand.length
+        ? cand
+            .map((c) => `      fragment[${c.fragmentIndex}] rule_id=${c.rule_id} action=${c.action} handle=${c.handle} :: "${c.snippet}"`)
+            .join('\n')
+        : '      (no accumulated fragment contains this fact at all — corpus/questions.mjs fixture is out of sync with corpus/session.mjs)'
+      return `  turn ${f.turn} [${f.arm}] fact ${JSON.stringify(f.fact)} — NEITHER inline NOR recoverable via any handle:\n${candLines}`
+    })
+    .join('\n')
+}
+
+test(
+  'LOSSLESS arm (non-constraining budget): every ground-truth fact from every turn survives compileContext, inline or via a handle that actually resolves — ' +
+    'catches a compiler regression that silently discards unique information (e.g. a dedup/supersession rule over-matching, or a handle that stops resolving) even when nothing forces it to',
+  async () => {
+    const { failures } = await checkFactsSurviveArm({ budget: LOSSLESS_BUDGET, label: 'lossless' })
+    assert.equal(failures.length, 0, `${failures.length} fact(s) lost in the LOSSLESS arm:\n${formatFailureReport(failures)}`)
+  },
+)
+
+test(
+  'WINDOW-8000 arm: every ground-truth fact from every turn survives compileContext, inline or via a handle that actually resolves — ' +
+    'catches a regression where budget.externalize mints a retrieval handle for unique content that does not actually resolve back to it (a dangling promise of recoverability), or where truncation drops a fact with no handle at all',
+  async () => {
+    const { failures } = await checkFactsSurviveArm({ budget: 8000, label: 'window-8000' })
+    assert.equal(failures.length, 0, `${failures.length} fact(s) lost in the WINDOW-8000 arm:\n${formatFailureReport(failures)}`)
+  },
+)

--- a/examples/real-session-benchmark/test/online-mock.test.mjs
+++ b/examples/real-session-benchmark/test/online-mock.test.mjs
@@ -6,8 +6,10 @@
 //     field-mapping and response-text extraction.
 //   - the cli runner is pointed at a fake `claude` executable (a tiny Node
 //     script on a scratch PATH) that ASSERTS the argv flags it receives
-//     (review fix A5: removing --tools ""/--model/--output-format json/
-//     --input-format stream-json from claude-cli.mjs now FAILS these tests)
+//     (review fix A5: removing --tools ""/--model/--output-format
+//     stream-json/--input-format stream-json/--verbose from claude-cli.mjs
+//     now FAILS these tests; output MUST be stream-json — the CLI rejects
+//     json output with stream-json input, caught live at calibration)
 //     and validates the stdin NDJSON envelope before printing a fixed JSON
 //     result — proves argv construction, stdin write, and usage parsing.
 //
@@ -123,8 +125,9 @@ function requireFlagPair(flag, expected) {
 }
 if (!args.includes('-p')) { process.stderr.write('missing -p'); process.exit(1) }
 requireFlagPair('--model', 'claude-sonnet-5')
-requireFlagPair('--output-format', 'json')
+requireFlagPair('--output-format', 'stream-json') // CLI-enforced pairing with stream-json input
 requireFlagPair('--input-format', 'stream-json')
+if (!args.includes('--verbose')) { process.stderr.write('missing --verbose (required for stream-json output in print mode)'); process.exit(1) }
 requireFlagPair('--tools', '')          // empty string = disable all built-in tools
 requireFlagPair('--system-prompt')      // present, any value
 let input = ''
@@ -138,7 +141,11 @@ process.stdin.on('end', () => {
     process.stderr.write('malformed stdin envelope: ' + line)
     process.exit(1)
   }
-  process.stdout.write(JSON.stringify(${JSON.stringify(fixedJson)}))
+  // stream-json output = NDJSON events; the runner reads the final
+  // type:"result" event. Emit a leading non-result event too, so the
+  // parser's event filtering is exercised, not just trivially satisfied.
+  process.stdout.write(JSON.stringify({ type: 'system', subtype: 'init' }) + '\\n')
+  process.stdout.write(JSON.stringify(Object.assign({ type: 'result' }, ${JSON.stringify(fixedJson)})) + '\\n')
   process.exit(0)
 })
 `


### PR DESCRIPTION
## Summary

- Adds `examples/real-session-benchmark/test/facts-survive.test.mjs`: turns the benchmark's per-turn ground-truth fact checklists (`corpus/questions.mjs`) into an executable non-regression gate. For every turn of the base 14-turn session, in **both** compiled arms (lossless budget and window-8000), every fact must actually be present in what that arm would send to the model at that turn — either inline in `content`, or **proven** recoverable by really resolving its `ctx://source/` handle through `retrieveContextSource` (never assumed from a listed handle). A fact that is neither inline nor recoverable is a hard failure, with a report naming the turn, the arm, the missing fact, and every candidate fragment/decision that touched it.
- Wires the new test into CI's **`Node Binding Tests`** job (see "CI job choice" below).
- Docs: one line in the benchmark README ("this promise is CI-enforced") + a CHANGELOG [Unreleased] entry.
- **Also carries** `ecf7ca1c` (committed directly to this branch by the orchestrator while this PR was in flight): a real fix to the ONLINE-mode CLI runner — the `claude` CLI enforces `--output-format stream-json` when `--input-format stream-json` is set, so `lib/claude-cli.mjs` now requests `stream-json` output, parses the NDJSON `result` event, and passes `--verbose` (required for stream-json output in print mode); `test/online-mock.test.mjs`'s fake binary was updated to assert the new flags and emit an NDJSON envelope. Verified against a real calibration call (input 2 / output 4 / cache_creation 7939 tokens / cost $0.048). Unrelated to the A1 gate itself but ships in the same diff.

## What regression each key test catches

- `LOSSLESS arm` test: catches a compiler regression that silently discards unique information (e.g. a dedup/supersession rule over-matching, or a handle that stops resolving) even when the budget is non-constraining and nothing should force content out.
- `WINDOW-8000 arm` test: catches a regression where `budget.externalize` mints a retrieval handle for unique content that does not actually resolve back to it (a dangling promise of recoverability), or where truncation drops a fact with no handle at all.
- Both tests also assert `compileContext` is byte-identical across two calls per turn (same convention as `lib/ab-session.mjs`) — a nondeterministic compiler would make a single pass/fail verdict meaningless.

## Honest finding from writing this gate

With the **current** corpus + question pairing, every one of the 22 ground-truth facts across 14 turns lands **inline** in both arms — the "recoverable via handle" branch is implemented and correct (verified manually: at a destructive budget the same 22 facts shift from `inline` to `recoverable`, still 0 lost) but is not exercised by the committed gate's real run, because each question is asked right when its fact is first introduced, before any dedup/supersession/externalization has a chance to touch that specific fragment. The test's report distinguishes `inline` from `recoverable` per the mission's honesty requirement, so this is visible rather than hidden, and the recoverable path is exercised in production runs (window-enforcement mode over the full session, per README's attribution numbers) even if not by this specific checklist-vs-corpus pairing.

## Proof of authentic red (local only, not committed)

Budget alone cannot produce a genuine loss with this compiler: it always mints a `ctx://source/` handle for every fragment regardless of budget (verified down to `token_budget: 1`; `token_budget: 0` is rejected by the compiler as invalid input). So the destructive proof uses a real, already-existing parameter shape (`fragmentFilter`, the same mechanism `lib/ab-session.mjs` already uses for the memory-enabled arm) — restricting arm B's own `compileContext` input to media-only fragments, a stand-in for a real regression class (a future context-filtering change that accidentally excludes text fragments). This is the same exported `checkFactsSurviveArm()` the committed test uses, called locally with a destructive `fragmentFilter`, not a stub:

```
AssertionError [ERR_ASSERTION]: 16 fact(s) lost:
  turn 2 [DESTRUCTIVE-media-only] fact "round-half-to-even" — NEITHER inline NOR recoverable
  turn 2 [DESTRUCTIVE-media-only] fact "INC-2024-118" — NEITHER inline NOR recoverable
  turn 3 [DESTRUCTIVE-media-only] fact "discountRatio" — NEITHER inline NOR recoverable
  turn 4 [DESTRUCTIVE-media-only] fact "preDiscountSubtotal" — NEITHER inline NOR recoverable
  turn 5 [DESTRUCTIVE-media-only] fact "48213" — NEITHER inline NOR recoverable
  turn 5 [DESTRUCTIVE-media-only] fact "bd97d3cd" — NEITHER inline NOR recoverable
  turn 6 [DESTRUCTIVE-media-only] fact "computeCheckoutTotal" — NEITHER inline NOR recoverable
  turn 6 [DESTRUCTIVE-media-only] fact "runningTotal" — NEITHER inline NOR recoverable
  turn 7 [DESTRUCTIVE-media-only] fact "runningTotal" — NEITHER inline NOR recoverable
  turn 8 [DESTRUCTIVE-media-only] fact "4.4" — NEITHER inline NOR recoverable
  turn 8 [DESTRUCTIVE-media-only] fact "P1" — NEITHER inline NOR recoverable
  turn 9 [DESTRUCTIVE-media-only] fact "0%" — NEITHER inline NOR recoverable
  turn 11 [DESTRUCTIVE-media-only] fact "preDiscountSubtotal" — NEITHER inline NOR recoverable
  turn 12 [DESTRUCTIVE-media-only] fact "discountApplied" — NEITHER inline NOR recoverable
  turn 12 [DESTRUCTIVE-media-only] fact "discountRatio" — NEITHER inline NOR recoverable
  turn 14 [DESTRUCTIVE-media-only] fact "AC3" — NEITHER inline NOR recoverable

16 !== 0
```

The committed test runs with the real budgets only (`LOSSLESS_BUDGET`, `8000`) — 0 failures, `fragmentFilter` defaults to `null` (unused by the committed gate; the parameter exists solely so this local demo doesn't have to stub any code).

## CI job choice (motivated)

Two candidates per the mission brief: the `Tests` job's "MCP server e2e (stdio)" step, and the `Node Binding Tests` job.

- **`Tests` job**: pure Rust — no Node setup, no napi addon build anywhere in it. Branching the gate there would mean paying for a Node setup *and* a full napi addon cross-build (`npx napi build --platform`) from scratch, purely to run one offline JS test file.
- **`Node Binding Tests` job**: already sets up Node 20, builds the napi addon (`npx napi build --platform`), and runs `node --test __test__/index.spec.mjs` — exactly the addon `lib/compile-node.mjs` loads. The gate's own cost here is `npm install --no-save gpt-tokenizer` (per the benchmark's README prereqs) plus one `node --test` invocation (~1.4s locally for both new tests).

Chose `Node Binding Tests` — the addon build is already paid for, so this is close to marginal cost.

## Test plan

- [x] `node --test 'examples/real-session-benchmark/test/*.test.mjs'` — 16/16 pass (includes the 2 new tests + the pre-existing 14).
- [x] Ran twice independently — same pass/fail outcome both times (determinism).
- [x] `.github/workflows/ci.yml` validated with `ruby -ryaml -e "YAML.load_file(...)"` after editing.
- [x] `docs/openapi.json` / `docs/openapi.yaml` untouched (checked via `git checkout --` no-op before commit).
- [x] Local red proof captured above with a real destructive `fragmentFilter`, not a stub.
- [ ] CI run on this PR (not yet observed — will show the new step in `Node Binding Tests`).