### PR TITLE
fix(mcp): orphaned-server self-exit + actionable lock error (#1448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`velesdb-memory`**: hardened the MCP server against a leaked client
+  process (#1448). The server itself was already healthy (it exits cleanly
+  on stdin EOF), but a client that leaks its child process — observed in
+  practice with a headless `claude -p` run — never closes stdin, so the
+  server correctly kept serving forever and held the store's single-writer
+  lock, making every later session fail with an opaque `Storage
+  (DatabaseLocked)` / "Failed to connect". Two defensive fixes: (1) the
+  server now detects a dead parent (`std::os::unix::process::parent_id()`
+  polled every ~2s, Unix-only, no new dependency) and self-exits, releasing
+  the lock, even when stdin is artificially held open; (2) a `DatabaseLocked`
+  at startup now retries briefly (3 × 500ms, covering a normal
+  close/reopen handover) and, if the store is still locked, prints an
+  actionable message on stderr naming the fix (`pkill velesdb-memory` or
+  set `VELESDB_MEMORY_PATH` elsewhere) instead of a bare error dump — and
+  exits non-zero so client health-checks can detect the failure. Net
+  effect: one leaked client can no longer brick every later session, and
+  when a store really is locked, the user is told what to do about it.
+
 ### Added — deterministic context compiler (EPIC-P-070; ships as `velesdb-memory` 0.8.0 / `velesdb-node` 0.8.0 via the `velesdb-memory-v0.8.0` tag)
 
 - **`velesdb-memory`**: new default `context` feature — a deterministic

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -16,6 +16,15 @@ use velesdb_memory::mcp::McpServer;
 use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Captured FIRST — before the (possibly seconds-long) embedder probe and
+    // store open — so a client that exits during our own startup still
+    // reparents us AFTER the baseline, and the watchdog sees the change. A
+    // baseline taken later would read the already-reparented pid and go
+    // permanently inert (review finding on #1449).
+    #[cfg(unix)]
+    let original_parent = std::os::unix::process::parent_id();
+    #[cfg(not(unix))]
+    let original_parent = 0_u32;
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
 
     // All synchronous setup (env probing, blocking HTTP to Ollama, disk open)
@@ -26,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = apply_default_ttl(build_server(service)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
-        spawn_orphan_watchdog();
+        spawn_orphan_watchdog(original_parent);
         let running = server
             .serve((tokio::io::stdin(), tokio::io::stdout()))
             .await?;
@@ -67,10 +76,9 @@ const ORPHAN_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_sec
 /// and therefore unlocks — unconditionally on process exit, confirmed by
 /// the investigation on #1448 ("released by the kernel even on SIGKILL").
 #[cfg(unix)]
-fn spawn_orphan_watchdog() {
+fn spawn_orphan_watchdog(original_parent: u32) {
     use std::os::unix::process::parent_id;
 
-    let original_parent = parent_id();
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(ORPHAN_CHECK_INTERVAL).await;
@@ -91,7 +99,7 @@ fn spawn_orphan_watchdog() {
 /// parent this cheaply, so this hardening is Unix-only for now — behavior on
 /// Windows is unchanged (still relies on the stdin-EOF path).
 #[cfg(not(unix))]
-fn spawn_orphan_watchdog() {}
+fn spawn_orphan_watchdog(_original_parent: u32) {}
 
 /// Attempts before giving up on a locked store and printing the actionable
 /// error. Three short tries (with [`LOCK_RETRY_DELAY`] between them) is

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -9,9 +9,11 @@
 //! `remember_extracted` tool (auto text → fact↔topic graph). Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
 
+use std::time::Duration;
+
 use rmcp::ServiceExt;
 use velesdb_memory::mcp::McpServer;
-use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
@@ -20,16 +22,134 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // runs here, before the async runtime starts, so we never block a tokio
     // worker thread on a synchronous operation.
     let embedder = build_embedder()?;
-    let service = MemoryService::open(&store_path, embedder)?;
+    let service = open_store_with_actionable_lock_error(&store_path, embedder)?;
     let server = apply_default_ttl(build_server(service)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
+        spawn_orphan_watchdog();
         let running = server
             .serve((tokio::io::stdin(), tokio::io::stdout()))
             .await?;
         running.waiting().await?;
         Ok::<(), Box<dyn std::error::Error>>(())
     })
+}
+
+/// How often the orphan watchdog re-checks its parent pid. The MCP stdio
+/// transport only observes disconnects via stdin EOF, which a client that
+/// leaks its child process (the #1448 scenario) never delivers — so this is
+/// the *only* signal that would otherwise catch that leak. 2s keeps the
+/// worst-case self-exit latency low (a handful of polls) without burning
+/// meaningful CPU on an idle server.
+#[cfg(unix)]
+const ORPHAN_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Detect a dead parent and self-exit, releasing the store's `flock` even
+/// when stdin is artificially kept open (a leaked child process, #1448).
+///
+/// A normal MCP stdio client closes the child's stdin on disconnect, which
+/// the existing EOF path already handles. But a client that merely forgets
+/// to reap/close its child (observed in practice: a headless `claude -p`
+/// run left its server running) never closes that pipe — the server then
+/// legitimately keeps serving forever, holding the single-writer store lock
+/// and making every later session fail `Storage(DatabaseLocked)`.
+///
+/// This has no other shutdown trigger to lean on, so it polls: capture the
+/// parent pid at startup, and if it ever changes, the parent is gone (Unix
+/// re-parents orphans to init/launchd, pid 1 or the user's launchd pid —
+/// never the original parent), so exit. `std::os::unix::process::parent_id`
+/// is pure `std`, avoiding a new dependency (e.g. `libc::getppid`) for a
+/// single syscall.
+///
+/// Process exit (even via `std::process::exit`, which skips destructors)
+/// still releases the store's `flock`: that lock is a kernel-held resource
+/// tied to the process's open file descriptors, which the kernel closes —
+/// and therefore unlocks — unconditionally on process exit, confirmed by
+/// the investigation on #1448 ("released by the kernel even on SIGKILL").
+#[cfg(unix)]
+fn spawn_orphan_watchdog() {
+    use std::os::unix::process::parent_id;
+
+    let original_parent = parent_id();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(ORPHAN_CHECK_INTERVAL).await;
+            let current_parent = parent_id();
+            if current_parent != original_parent {
+                eprintln!(
+                    "[velesdb-memory] parent process (pid {original_parent}) is gone \
+                     (now reparented under pid {current_parent}) — exiting to release \
+                     the store lock rather than leak a zombie session (#1448)"
+                );
+                std::process::exit(0);
+            }
+        }
+    });
+}
+
+/// Windows has no equivalent of `parent_id()` re-parenting to detect a dead
+/// parent this cheaply, so this hardening is Unix-only for now — behavior on
+/// Windows is unchanged (still relies on the stdin-EOF path).
+#[cfg(not(unix))]
+fn spawn_orphan_watchdog() {}
+
+/// Attempts before giving up on a locked store and printing the actionable
+/// error. Three short tries (with [`LOCK_RETRY_DELAY`] between them) is
+/// enough to ride out the handover between one session's process exiting
+/// and the next one starting — the case the retry is *for* — without making
+/// a genuinely-stuck lock (the leaked-process scenario from #1448) hang
+/// startup for long.
+const LOCK_RETRY_ATTEMPTS: u32 = 3;
+
+/// Delay between retries of an already-locked store. See
+/// [`LOCK_RETRY_ATTEMPTS`] for the reasoning on the total budget.
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+/// Open the native store at `store_path`, retrying briefly through a
+/// `DatabaseLocked` error before giving up with actionable stderr guidance.
+///
+/// Bypasses [`MemoryService::open`] in favor of [`NativeStore::open`] +
+/// [`MemoryService::with_store`] because the retry only needs
+/// `embedder.dimension()` (a plain `usize`, trivially reusable across
+/// attempts) — not the embedder itself — so `embedder` can move into the
+/// service exactly once, on the attempt that finally succeeds, with no
+/// `Clone` bound required on `E`.
+///
+/// # Errors
+/// Returns any [`MemoryError`] other than `DatabaseLocked` unchanged (e.g. a
+/// dimension mismatch against an existing store). On a `DatabaseLocked` that
+/// outlives every retry, prints the actionable message and exits the process
+/// with a non-zero status instead of returning — that message, not a
+/// generic `Result` bubble-up, is the point: a bare
+/// `Storage(DatabaseLocked(..))` debug dump gives a user nothing to act on
+/// (#1448).
+fn open_store_with_actionable_lock_error(
+    store_path: &str,
+    embedder: DynEmbedder,
+) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
+    use velesdb_memory::MemoryError;
+
+    let dimension = embedder.dimension();
+    let mut last_locked_path: Option<String> = None;
+    for attempt in 0..LOCK_RETRY_ATTEMPTS {
+        match NativeStore::open(store_path, dimension) {
+            Ok(store) => return Ok(MemoryService::with_store(store, embedder)),
+            Err(MemoryError::Storage(velesdb_core::Error::DatabaseLocked(locked_path))) => {
+                last_locked_path = Some(locked_path);
+                if attempt + 1 < LOCK_RETRY_ATTEMPTS {
+                    std::thread::sleep(LOCK_RETRY_DELAY);
+                }
+            }
+            Err(other) => return Err(other.into()),
+        }
+    }
+
+    let locked_path = last_locked_path.unwrap_or_else(|| store_path.to_owned());
+    eprintln!(
+        "[velesdb-memory] another velesdb-memory process holds {locked_path} — \
+         kill it (pkill velesdb-memory) or point VELESDB_MEMORY_PATH elsewhere"
+    );
+    std::process::exit(1);
 }
 
 /// Default store location when `VELESDB_MEMORY_PATH` is unset: `~/.velesdb-memory`

--- a/crates/velesdb-memory/tests/mcp_lifecycle.rs
+++ b/crates/velesdb-memory/tests/mcp_lifecycle.rs
@@ -17,7 +17,7 @@
 //! actually released by successfully `initialize`-ing a second process on
 //! the same store path.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStdout, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -196,4 +196,234 @@ fn store_lock_is_released_after_stdin_eof_so_a_second_session_can_connect() {
         let _ = second.kill();
         let _ = second.wait();
     }
+}
+
+/// Read everything available on `reader` until EOF (or `timeout` elapses,
+/// whichever first) on a helper thread. Used to drain a dead process's
+/// stderr — by the time this is called the process is already believed
+/// gone, so `read_to_string` should hit EOF almost immediately; the timeout
+/// is only a backstop against a stuck assumption.
+fn drain_with_timeout<R: Read + Send + 'static>(mut reader: R, timeout: Duration) -> String {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = reader.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx.recv_timeout(timeout).unwrap_or_default()
+}
+
+/// Upper bound the orphan test is willing to wait for the store lock to be
+/// released. The watchdog is specified to poll on a ~2s cadence and the
+/// intermediate process adds another ~1s grace period before it exits, so
+/// in isolation this is already several polls of headroom over the
+/// "≤ ~6s" self-exit target. Generous on top of that for the full suite
+/// running several real `velesdb-memory` process spawns concurrently
+/// (parallel `cargo test` threads), where OS scheduling/process-spawn
+/// latency — not the watchdog logic itself — can dominate.
+const ORPHAN_LOCK_RELEASE_TIMEOUT: Duration = Duration::from_secs(25);
+
+/// Per-attempt bound for a single lock-release probe's `initialize`
+/// round trip. Generous (matching [`SHUTDOWN_TIMEOUT`]) for the same
+/// concurrent-process-spawn reason as [`ORPHAN_LOCK_RELEASE_TIMEOUT`]: a
+/// tight per-probe timeout under a loaded test run flags "this probe was
+/// slow to spawn" as "the lock is still held", which is a false signal —
+/// the outer deadline is what actually bounds the regression check.
+const PROBE_HANDSHAKE_TIMEOUT: Duration = SHUTDOWN_TIMEOUT;
+
+#[test]
+fn server_self_exits_when_orphaned_even_with_stdin_held_open() {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let sync_dir = tempfile::tempdir().expect("create sync dir for handoff fifo");
+    let fifo_path = sync_dir.path().join("orphan-handoff");
+    let server_bin = env!("CARGO_BIN_EXE_velesdb-memory");
+
+    let mkfifo_status = Command::new("mkfifo")
+        .arg(&fifo_path)
+        .status()
+        .expect("failed to run mkfifo");
+    assert!(
+        mkfifo_status.success(),
+        "mkfifo failed to create handoff fifo"
+    );
+
+    // Intermediate process: forks a subshell that `exec`s straight into the
+    // real server binary — preserving the subshell's pid across the exec —
+    // then blocks reading the handoff fifo before exiting. The server never
+    // called `wait()` on anyone, and the outer shell never waits on it
+    // either, so once the outer shell is gone the subshell (now the server)
+    // reparents to init/launchd (an orphan).
+    //
+    // The fifo handoff (instead of a fixed `sleep`) is load-bearing, not
+    // padding: OS reparenting can complete *faster than the freshly-exec'd
+    // server binary finishes loading*, especially under a loaded test run
+    // (several real process spawns competing for CPU/IO across parallel
+    // `cargo test` threads). A wall-clock `sleep` can lose that race — the
+    // server would then capture its "original" parent pid via `parent_id()`
+    // only *after* it was already reparented, permanently defeating the
+    // watchdog's change-detection (nothing to ever compare against). Blocking
+    // the intermediate on the fifo until this test has proven — via a
+    // completed `initialize` round trip — that the server is fully up
+    // (necessarily past the point where `spawn_orphan_watchdog` captured its
+    // real parent) makes the ordering deterministic instead of timing-based.
+    //
+    // `3<&0` duplicates the original stdin onto fd 3 *before* backgrounding:
+    // POSIX/bash redirect an asynchronous (`&`) command's own fd 0 to
+    // `/dev/null` when job control is off (always true for a non-interactive
+    // `sh -c`), unless that command explicitly redirects fd 0 itself — which
+    // `0<&3` inside the subshell does, re-attaching the real pipe. Without
+    // this dance the exec'd server would see immediate stdin EOF from
+    // `/dev/null` and exit via the already-covered EOF path instead of ever
+    // becoming a live orphan.
+    let mut child = Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            r#"exec 3<&0; (exec "{server_bin}" 0<&3 3<&-) & read -r _line < "{fifo}"; exit 0"#,
+            fifo = fifo_path.display()
+        ))
+        .env("VELESDB_MEMORY_PATH", store_dir.path())
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn intermediate shell");
+
+    // Prove the (soon-to-be-orphaned) server actually came up before we
+    // start asserting anything about its shutdown.
+    complete_initialize_handshake(&mut child);
+
+    // Unblock the intermediate's `read` now that the server has proven
+    // (by answering `initialize`) that it already captured its real parent
+    // pid — this is the deterministic handoff described above.
+    std::fs::write(&fifo_path, b"go\n").expect("signal intermediate to exit via fifo");
+
+    // Keep the write end of the stdin pipe open for the rest of the test —
+    // this is the crucial plumbing detail: if this handle is dropped, the
+    // server observes stdin EOF and exits via the *already-covered* path
+    // (`server_exits_when_stdin_reaches_eof` above), which would make this
+    // test pass for the wrong reason. Held open here, the server can only
+    // exit because it detected its parent died, not because of EOF.
+    let stdin_guard = child.stdin.take().expect("stdin must stay piped open");
+
+    // Grab stderr now so we can inspect the orphan-shutdown log line once
+    // the process is confirmed gone.
+    let stderr = child.stderr.take().expect("stderr must be piped");
+
+    // The regression signal: poll for the store lock being released by
+    // trying to `initialize` a brand-new server on the same store path.
+    // Today the orphaned server never notices its parent is gone (stdin is
+    // still open, so it has no other shutdown trigger) and keeps holding
+    // the `flock`, so every probe below fails/times out until the overall
+    // deadline — reproducing the exact "next session can't connect"
+    // symptom from #1448.
+    let deadline = Instant::now() + ORPHAN_LOCK_RELEASE_TIMEOUT;
+    let mut released = false;
+    while Instant::now() < deadline {
+        let mut probe = spawn_server(store_dir.path());
+        let mut probe_stdin = probe.stdin.take().expect("probe stdin must be piped");
+        let probe_stdout = probe.stdout.take().expect("probe stdout must be piped");
+        let reader = BufReader::new(probe_stdout);
+
+        let wrote = writeln!(probe_stdin, "{}", initialize_request(1)).is_ok()
+            && probe_stdin.flush().is_ok();
+
+        if wrote {
+            if let Some(line) = read_line_with_timeout(reader, PROBE_HANDSHAKE_TIMEOUT) {
+                if line.contains("\"protocolVersion\"") {
+                    released = true;
+                }
+            }
+        }
+
+        drop(probe_stdin);
+        let _ = probe.kill();
+        let _ = probe.wait();
+
+        if released {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    // Now that the lock is (supposedly) free, the orphaned server must
+    // actually be gone — drop the stdin guard and drain whatever it logged.
+    drop(stdin_guard);
+    let stderr_text = drain_with_timeout(stderr, Duration::from_secs(2));
+
+    assert!(
+        released,
+        "store lock was never released within {ORPHAN_LOCK_RELEASE_TIMEOUT:?} of the \
+         server being orphaned with stdin still held open — the server does not \
+         detect that its parent died and self-exit (#1448)"
+    );
+    assert!(
+        stderr_text.to_lowercase().contains("parent"),
+        "expected the orphaned server to log a clear parent-death shutdown \
+         message on stderr, got: {stderr_text:?}"
+    );
+}
+
+/// Regression this catches (#1448): a second `velesdb-memory` process opened
+/// against a store another live process already holds must fail fast with
+/// *actionable* guidance on stderr — not just the bare `Storage(DatabaseLocked
+/// (..))` debug dump Rust's default `Result`-returning-`main` prints, which
+/// gave users nothing to act on beyond an opaque "Failed to connect" in their
+/// MCP client. It must also still exit non-zero (client health-checks depend
+/// on that to report failure at all).
+#[test]
+fn database_locked_at_startup_prints_actionable_guidance_and_exits_nonzero() {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+
+    // First server: opened and kept alive for the whole test — it
+    // legitimately holds the store's single-writer flock throughout, playing
+    // the role of the leaked/still-running process from #1448.
+    let mut holder = spawn_server(store_dir.path());
+    complete_initialize_handshake(&mut holder);
+
+    // Second process on the same store path, while the first is still up.
+    let mut contender = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env("VELESDB_MEMORY_PATH", store_dir.path())
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn contending velesdb-memory process");
+
+    let stderr = contender
+        .stderr
+        .take()
+        .expect("contender stderr must be piped");
+    // The contender fails during synchronous startup, before it ever reads
+    // the MCP transport — stdin/stdout are irrelevant to that failure, so
+    // just let them close.
+    drop(contender.stdin.take());
+    drop(contender.stdout.take());
+
+    let status = wait_for_exit(&mut contender, Duration::from_secs(5)).unwrap_or_else(|| {
+        let _ = contender.kill();
+        let _ = contender.wait();
+        panic!(
+            "a process opening an already-locked store did not exit within 5s \
+             (#1448) — startup must fail fast (bounded retry), not hang"
+        );
+    });
+    assert!(
+        !status.success(),
+        "a process opening an already-locked store must exit non-zero so \
+         client health-checks can detect the failure, got: {status:?}"
+    );
+
+    let stderr_text = drain_with_timeout(stderr, Duration::from_secs(2));
+    let lower = stderr_text.to_lowercase();
+    assert!(
+        lower.contains("velesdb_memory_path") && lower.contains("pkill"),
+        "expected an actionable lock-contention message on stderr (naming \
+         VELESDB_MEMORY_PATH as the escape hatch and pkill as the fix), \
+         got: {stderr_text:?}"
+    );
+
+    let _ = holder.kill();
+    let _ = holder.wait();
 }


### PR DESCRIPTION
## Summary

Closes #1448 as *defensive hardening* per the issue's own diagnosis-correction
comment: the server was already healthy (clean exit on stdin EOF, `flock`
released by the kernel even on SIGKILL). The real risk is client-side — a
leaked child process (observed in practice: a headless `claude -p` run left
its server running, stdin never closed) that legitimately keeps the server
serving forever, holding the store's single-writer lock and breaking every
later session with an opaque `Storage(DatabaseLocked)` / "Failed to connect".

Two defensive fixes, both **std-only** (no new dependency):

1. **Orphan self-exit** — `spawn_orphan_watchdog()` in
   `crates/velesdb-memory/src/main.rs` captures `std::os::unix::process::parent_id()`
   at startup and polls it every ~2s from a tokio task. When it changes (Unix
   reparents orphans to init/launchd), the server logs why on stderr and
   self-exits — releasing the `flock` even when a leaked client keeps stdin
   artificially open. `#[cfg(unix)]`; Windows behavior is unchanged
   (documented, no equivalent cheap reparent-detection).
2. **Actionable lock error** — `open_store_with_actionable_lock_error()`
   retries a `DatabaseLocked` open briefly (3 × 500ms, covering a normal
   session-handover race) and, if still locked, prints a concrete stderr
   message (`pkill velesdb-memory` or repoint `VELESDB_MEMORY_PATH`) and
   exits non-zero — instead of the bare `Storage(DatabaseLocked(..))` debug
   dump a user can't act on.

CHANGELOG `[Unreleased]/Fixed` entry added.

## Test plan

Both fixes are TDD'd against the *real* binary in
`crates/velesdb-memory/tests/mcp_lifecycle.rs` (the existing EOF-lifecycle
tests are untouched and still green):

- `server_self_exits_when_orphaned_even_with_stdin_held_open` — spawns an
  intermediate shell that `exec`s into the server (preserving its pid) with
  stdin duplicated onto fd 3 (POSIX/bash redirect an async job's fd 0 to
  `/dev/null` otherwise), completes a real `initialize` handshake to prove
  the server captured its true parent pid, then hands off via a FIFO
  (deterministic — a fixed `sleep` lost the reparent-vs-startup race
  intermittently under load) before the intermediate exits, orphaning the
  server *with stdin still open*. Asserts the store lock is eventually
  released (a second `initialize` on the same path succeeds) and that
  stderr names the parent-death reason.
  - Captured red: without the watchdog, the probe loop timed out at 25s
    every time — "store lock was never released ... the server does not
    detect that its parent died and self-exit (#1448)".
- `database_locked_at_startup_prints_actionable_guidance_and_exits_nonzero`
  — keeps a first server alive holding the lock, starts a second process on
  the same store path, asserts it exits non-zero and stderr mentions both
  `VELESDB_MEMORY_PATH` and `pkill`.
  - Captured red: `got: "Error: Storage(DatabaseLocked(\"...\"))\n"` — the
    bare debug dump, no actionable guidance.

### Gates (all green, exit codes checked explicitly)

```
cargo fmt --all --check                                                    FMT=0
cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic   CLIPPY=0
cargo test -p velesdb-memory                                               TEST=0  (451 passed)
cargo build --release -p velesdb-memory && python3 .../mcp_e2e.py          E2E=0
RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features \
  --features context                                                       CHECK=0
```

### Notes / deviations

- The orphan test's first design used a fixed `sleep 1` before the
  intermediate process exited. Under concurrent test load this intermittently
  lost the race against the freshly-exec'd server binary's startup time,
  making the watchdog's baseline-pid capture happen *after* it was already
  reparented (permanently defeating change-detection) — a real flake, not a
  timing-tolerance issue. Replaced with a FIFO handoff: the intermediate
  blocks until this test proves (via a completed `initialize` round trip)
  that the server is definitely past the point where it captured its real
  parent pid. 8/8 consecutive full-suite runs green after the fix (was
  failing ~40% of concurrent runs before).
- Retry budget for the lock error is 3 attempts × 500ms as specified in the
  issue (covers a normal close/reopen handover without meaningfully slowing
  down a clean start).

Not merging — leaving for review.