### PR TITLE
feat(python): expose MemoryService.feedback for the RL loop

### DIFF
--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -28,6 +28,8 @@ mem.why("why the aisle seat on Robert's flight?")   # walks booking â†’ reason â
 
 Full runnable demo: [`examples/agent_memory/why_across_sessions.py`](https://github.com/cyberlife-coder/VelesDB/blob/develop/examples/agent_memory/why_across_sessions.py). The same wedge ships for [Node](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) and as a local [MCP server](https://github.com/cyberlife-coder/VelesDB/tree/develop/crates/velesdb-memory).
 
+`mem.feedback(id, success)` closes the RL loop: reinforce or weaken a memory after use and `recall` re-ranks against the updated confidence.
+
 ## Context Compiler: token-budgeted, provenance-audited prompt context
 
 Your agent burns most of its tokens re-reading redundant context.

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2477,6 +2477,21 @@ class MemoryService:
         """
         ...
 
+    def feedback(self, id: int, success: bool) -> float:
+        """Reinforce (success=True) or weaken (False) a memory after use; returns the updated confidence [0,1].
+
+        Args:
+            id: The memory id that was used.
+            success: Whether the memory was useful.
+
+        Returns:
+            The updated confidence, in ``[0.0, 1.0]``.
+
+        Raises:
+            KeyError: If ``id`` does not exist.
+        """
+        ...
+
     def why(
         self,
         decision: str,

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -362,6 +362,19 @@ impl PyMemoryService {
         py.detach(|| self.svc.forget(id).map_err(to_py_err))
     }
 
+    /// Reinforce (`success=True`) or weaken (`False`) a memory after use,
+    /// closing the RL loop `recall` re-ranks against. Returns the updated
+    /// confidence in `[0.0, 1.0]`. Raises `KeyError` if `id` is not a live
+    /// fact — unlike `forget`, there is no confidence to report back.
+    fn feedback(&self, py: Python<'_>, id: u64, success: bool) -> PyResult<f64> {
+        py.detach(|| {
+            self.svc
+                .feedback(id, success)
+                .map(f64::from)
+                .map_err(to_py_err)
+        })
+    }
+
     /// Explain a decision: the best-matching memory plus its connected subgraph
     /// (multi-hop). Returns `{nodes, edges}` — the wedge a plain recall misses.
     ///

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -223,3 +223,20 @@ def test_oversized_fact_raises_value_error(mem):
     # Facts above the shared 1 MiB cap are rejected before any embedding work.
     with pytest.raises(ValueError):
         mem.remember("x" * (1024 * 1024 + 1))
+
+
+def test_feedback_success_increases_confidence_and_roundtrips(mem):
+    # remember -> feedback(id, True) returns a float, and repeated positive
+    # feedback moves confidence monotonically upward (the RL loop learning).
+    fid = mem.remember("we chose parking_lot to avoid lock poisoning")
+    first = mem.feedback(fid, True)
+    assert isinstance(first, float)
+    second = mem.feedback(fid, True)
+    assert second > first
+
+
+def test_feedback_unknown_id_raises_key_error(mem):
+    # Same taxonomy as forget: a missing memory id is a KeyError, not a
+    # silent no-op — feedback has no result to report if the fact is gone.
+    with pytest.raises(KeyError):
+        mem.feedback(999_999, True)


### PR DESCRIPTION
## Summary
- `MemoryService.feedback(id, success)` existed in Rust, the MCP server, and the Node binding, but not in Python — the RL reinforcement loop was unusable from Python.
- Adds the binding in `crates/velesdb-python/src/agent_memory_service.rs`, following the existing `forget()` pattern (`py.detach` + `to_py_err`), converting the Rust `f32` confidence to Python `float`.
- Adds the `.pyi` stub and a doc line in the Python README's MemoryService section.

## Test plan
- [x] TDD: new pytest `test_feedback_success_increases_confidence_and_roundtrips` / `test_feedback_unknown_id_raises_key_error` shown failing with `AttributeError` before the binding existed, passing after.
- [x] `pytest tests/ -q` (full binding suite): 514 passed, 23 skipped.
- [x] `cargo fmt -p velesdb-python --check`: clean.
- [x] `cargo clippy -p velesdb-python --lib`: no warnings.