### PR TITLE
fix(memory): re-anchor media dedup on the freshest non-superseded copy

### DIFF
--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -453,11 +453,19 @@ fn analyze<'a>(
         .iter()
         .map(|analysis| analysis.as_ref().map(|analysis| analysis.raw_hash))
         .collect();
-    let duplicates = dedup::find_duplicates(&contents, policy.near_dup_dedup, &media_hashes);
-    // Whole-batch pass, symmetric to `dedup::find_duplicates` above: needs
+    // Whole-batch pass, symmetric to `dedup::find_duplicates` below: needs
     // every fragment's `kind` + `metadata.target` at once, which a per-
-    // fragment `classify::classify` call cannot see.
+    // fragment `classify::classify` call cannot see. Computed *before*
+    // dedup so the media namespace can re-anchor off a superseded fragment
+    // (see `dedup::find_duplicates`'s doc) instead of anchoring dedup on a
+    // screenshot that supersession has already excluded from packing.
     let superseded_flags = classify::screenshot_supersession(&request.fragments);
+    let duplicates = dedup::find_duplicates(
+        &contents,
+        policy.near_dup_dedup,
+        &media_hashes,
+        &superseded_flags,
+    );
     let query_terms = relevance::terms(&request.query);
     let mut analyses: Vec<Analysis<'a>> = request
         .fragments

--- a/crates/velesdb-memory/src/context/dedup.rs
+++ b/crates/velesdb-memory/src/context/dedup.rs
@@ -18,6 +18,15 @@
 //! can never be mistaken for — or mistakenly anchor — a plain-text
 //! fragment's dedup chain, even when both have identical (often empty)
 //! content strings.
+//!
+//! **Media re-anchoring** (US-009, PR3): the media namespace anchors on the
+//! *first* occurrence by default, same as text — except when that anchor is
+//! itself superseded (see [`super::classify::screenshot_supersession`]) and a
+//! later, byte-identical occurrence is not. Anchoring on a superseded fragment
+//! would make every byte-identical twin "dup of a fragment excluded from
+//! packing," which drops the whole image chain from the compiled output.
+//! Re-anchoring on the later, non-superseded occurrence guarantees the
+//! freshest surviving copy is exactly the one every duplicate resolves to.
 
 use std::collections::BTreeMap;
 
@@ -49,57 +58,94 @@ pub(crate) struct Duplicate {
 /// (its identity — see the module doc), `None` for an ordinary text
 /// fragment; it must be the same length as `contents` (one entry per
 /// fragment, same input order).
+///
+/// `media_superseded[i]` is `true` when fragment `i` was flagged by
+/// [`super::classify::screenshot_supersession`] (ignored for a `None` media
+/// hash); it drives the re-anchoring described in the module doc and must
+/// also be the same length as `contents`.
 pub(crate) fn find_duplicates(
     contents: &[&str],
     near: bool,
     media_hashes: &[Option<u64>],
+    media_superseded: &[bool],
 ) -> Vec<Option<Duplicate>> {
     let mut exact_seen: BTreeMap<u64, usize> = BTreeMap::new();
     let mut near_seen: BTreeMap<u64, usize> = BTreeMap::new();
-    let mut media_seen: BTreeMap<u64, usize> = BTreeMap::new();
-    contents
-        .iter()
-        .zip(media_hashes)
-        .enumerate()
-        .map(|(seq, (content, media_hash))| {
-            if let Some(&hash) = media_hash.as_ref() {
-                // Media's own namespace: Exact-only, never reads or writes
-                // the text-content tables below (see the module doc).
-                let verdict = media_seen.get(&hash).map(|&kept_seq| Duplicate {
-                    kind: DupKind::Exact,
-                    kept_seq,
-                });
-                media_seen.entry(hash).or_insert(seq);
-                return verdict;
-            }
-            let exact_hash = stable_id(content);
-            // Skip the normalize+hash pass entirely when near-dup detection
-            // is off — the value would never be read.
-            let near_hash = near.then(|| stable_id(&normalize(content)));
-            let verdict = check(exact_hash, near_hash, &exact_seen, &near_seen);
-            // Anchor differently per hash: `near_seen` must always chain to
-            // the true root (only the root's bytes are ever emitted, so
-            // that is the only fragment whose survival matters), but
-            // `exact_seen` must anchor at THIS fragment whenever it is only
-            // a *near* match of its twin — its own bytes differ from the
-            // root's, so a later byte-identical copy is exact-duplicating
-            // *this* fragment, not the root it merely resembles. Chaining an
-            // exact match to the root there would let downstream code
-            // assume the copy's exact bytes survive whenever the root is
-            // emitted verbatim, which is false whenever root and twin
-            // differ (exactly why they were only a near match).
-            let near_root = verdict.map_or(seq, |dup| dup.kept_seq);
-            let exact_anchor = match verdict {
-                Some(dup) if dup.kind == DupKind::Exact => dup.kept_seq,
-                _ => seq,
-            };
-            exact_seen.entry(exact_hash).or_insert(exact_anchor);
-            if let Some(near_hash) = near_hash {
-                near_seen.entry(near_hash).or_insert(near_root);
-            }
-            verdict
-        })
-        .collect()
+    // Media anchor per raw hash, paired with whether that anchor fragment is
+    // itself superseded — see "Media re-anchoring" in the module doc.
+    let mut media_seen: BTreeMap<u64, (usize, bool)> = BTreeMap::new();
+    let mut results: Vec<Option<Duplicate>> = Vec::with_capacity(contents.len());
+    for (seq, (content, media_hash)) in contents.iter().zip(media_hashes).enumerate() {
+        if let Some(&hash) = media_hash.as_ref() {
+            // Media's own namespace: Exact-only, never reads or writes
+            // the text-content tables below (see the module doc).
+            let current_superseded = media_superseded.get(seq).copied().unwrap_or(false);
+            let verdict =
+                media_verdict(&mut media_seen, &mut results, hash, seq, current_superseded);
+            results.push(verdict);
+            continue;
+        }
+        let exact_hash = stable_id(content);
+        // Skip the normalize+hash pass entirely when near-dup detection
+        // is off — the value would never be read.
+        let near_hash = near.then(|| stable_id(&normalize(content)));
+        let verdict = check(exact_hash, near_hash, &exact_seen, &near_seen);
+        // Anchor differently per hash: `near_seen` must always chain to
+        // the true root (only the root's bytes are ever emitted, so
+        // that is the only fragment whose survival matters), but
+        // `exact_seen` must anchor at THIS fragment whenever it is only
+        // a *near* match of its twin — its own bytes differ from the
+        // root's, so a later byte-identical copy is exact-duplicating
+        // *this* fragment, not the root it merely resembles. Chaining an
+        // exact match to the root there would let downstream code
+        // assume the copy's exact bytes survive whenever the root is
+        // emitted verbatim, which is false whenever root and twin
+        // differ (exactly why they were only a near match).
+        let near_root = verdict.map_or(seq, |dup| dup.kept_seq);
+        let exact_anchor = match verdict {
+            Some(dup) if dup.kind == DupKind::Exact => dup.kept_seq,
+            _ => seq,
+        };
+        exact_seen.entry(exact_hash).or_insert(exact_anchor);
+        if let Some(near_hash) = near_hash {
+            near_seen.entry(near_hash).or_insert(near_root);
+        }
+        results.push(verdict);
+    }
+    results
+}
+
+/// Classify one media fragment against the media namespace's current anchor
+/// for `hash`, re-anchoring on `seq` when the existing anchor is superseded
+/// and `seq` is not (see "Media re-anchoring" in the module doc). When a
+/// re-anchor happens, the stale anchor's own `results` entry — already
+/// pushed as `None` when it was first seen — is rewritten in place to point
+/// at the new anchor.
+fn media_verdict(
+    media_seen: &mut BTreeMap<u64, (usize, bool)>,
+    results: &mut [Option<Duplicate>],
+    hash: u64,
+    seq: usize,
+    current_superseded: bool,
+) -> Option<Duplicate> {
+    match media_seen.get(&hash) {
+        Some(&(anchor_seq, anchor_superseded)) if anchor_superseded && !current_superseded => {
+            results[anchor_seq] = Some(Duplicate {
+                kind: DupKind::Exact,
+                kept_seq: seq,
+            });
+            media_seen.insert(hash, (seq, current_superseded));
+            None
+        }
+        Some(&(anchor_seq, _)) => Some(Duplicate {
+            kind: DupKind::Exact,
+            kept_seq: anchor_seq,
+        }),
+        None => {
+            media_seen.insert(hash, (seq, current_superseded));
+            None
+        }
+    }
 }
 
 /// Classify one content (by its precomputed hashes) against what was seen.

--- a/crates/velesdb-memory/src/context/dedup_tests.rs
+++ b/crates/velesdb-memory/src/context/dedup_tests.rs
@@ -8,9 +8,20 @@ fn no_media(len: usize) -> Vec<Option<u64>> {
     vec![None; len]
 }
 
+/// No fragment is supersession-flagged — the shape every test that isn't
+/// specifically exercising media re-anchoring (US-009, PR3) wants.
+fn not_superseded(len: usize) -> Vec<bool> {
+    vec![false; len]
+}
+
 #[test]
 fn test_find_duplicates_exact_marks_second_occurrence() {
-    let verdicts = find_duplicates(&["a fact", "other", "a fact"], true, &no_media(3));
+    let verdicts = find_duplicates(
+        &["a fact", "other", "a fact"],
+        true,
+        &no_media(3),
+        &not_superseded(3),
+    );
     assert!(verdicts[0].is_none());
     assert!(verdicts[1].is_none());
     let dup = verdicts[2].expect("third entry duplicates the first");
@@ -24,6 +35,7 @@ fn test_find_duplicates_near_matches_case_and_spacing() {
         &["The Server restarts.", "the  server   restarts."],
         true,
         &no_media(2),
+        &not_superseded(2),
     );
     let dup = verdicts[1].expect("second entry near-duplicates the first");
     assert_eq!(dup.kind, DupKind::Near);
@@ -36,19 +48,25 @@ fn test_find_duplicates_near_detection_can_be_disabled() {
         &["The Server restarts.", "the  server   restarts."],
         false,
         &no_media(2),
+        &not_superseded(2),
     );
     assert!(verdicts[1].is_none(), "near detection was disabled");
 }
 
 #[test]
 fn test_find_duplicates_exact_still_found_when_near_disabled() {
-    let verdicts = find_duplicates(&["same", "same"], false, &no_media(2));
+    let verdicts = find_duplicates(&["same", "same"], false, &no_media(2), &not_superseded(2));
     assert_eq!(verdicts[1].expect("exact duplicate").kind, DupKind::Exact);
 }
 
 #[test]
 fn test_find_duplicates_distinct_contents_are_all_kept() {
-    let verdicts = find_duplicates(&["alpha", "beta", "gamma"], true, &no_media(3));
+    let verdicts = find_duplicates(
+        &["alpha", "beta", "gamma"],
+        true,
+        &no_media(3),
+        &not_superseded(3),
+    );
     assert!(verdicts.iter().all(Option::is_none));
 }
 
@@ -65,6 +83,7 @@ fn test_find_duplicates_exact_copy_of_a_near_duplicate_reports_exact() {
         &["Hello World", "hello  world", "hello  world"],
         true,
         &no_media(3),
+        &not_superseded(3),
     );
     let dup = verdicts[2].expect("third entry duplicates the second");
     assert_eq!(
@@ -88,13 +107,14 @@ fn test_find_duplicates_near_dup_still_anchors_the_near_chain_at_the_root() {
         &["Hello World", "hello  world", "hello  world", "HELLO WORLD"],
         true,
         &no_media(4),
+        &not_superseded(4),
     );
     assert_eq!(verdicts[3].expect("near dup").kept_seq, 0);
 }
 
 #[test]
 fn test_find_duplicates_chain_points_to_first_occurrence() {
-    let verdicts = find_duplicates(&["x", "x", "x"], true, &no_media(3));
+    let verdicts = find_duplicates(&["x", "x", "x"], true, &no_media(3), &not_superseded(3));
     assert_eq!(verdicts[1].expect("dup").kept_seq, 0);
     assert_eq!(verdicts[2].expect("dup").kept_seq, 0);
 }
@@ -105,7 +125,7 @@ fn test_find_duplicates_chain_points_to_first_occurrence() {
 #[test]
 fn test_find_duplicates_media_with_identical_raw_hash_is_exact_duplicate() {
     let media = vec![Some(42_u64), Some(42_u64)];
-    let verdicts = find_duplicates(&["", ""], true, &media);
+    let verdicts = find_duplicates(&["", ""], true, &media, &not_superseded(2));
     let dup = verdicts[1].expect("same raw hash duplicates the first");
     assert_eq!(dup.kind, DupKind::Exact);
     assert_eq!(dup.kept_seq, 0);
@@ -114,7 +134,12 @@ fn test_find_duplicates_media_with_identical_raw_hash_is_exact_duplicate() {
 #[test]
 fn test_find_duplicates_media_with_different_raw_hash_is_not_a_duplicate() {
     let media = vec![Some(1_u64), Some(2_u64)];
-    let verdicts = find_duplicates(&["same caption", "same caption"], true, &media);
+    let verdicts = find_duplicates(
+        &["same caption", "same caption"],
+        true,
+        &media,
+        &not_superseded(2),
+    );
     assert!(
         verdicts[1].is_none(),
         "different images must never dedup on caption text alone"
@@ -127,7 +152,7 @@ fn test_find_duplicates_media_fragments_with_blank_captions_never_false_positive
     // for a bare screenshot: under plain text-content dedup these would be
     // an exact match ("" == ""); media identity must ignore that entirely.
     let media = vec![Some(111_u64), Some(222_u64)];
-    let verdicts = find_duplicates(&["", ""], true, &media);
+    let verdicts = find_duplicates(&["", ""], true, &media, &not_superseded(2));
     assert!(verdicts[1].is_none());
 }
 
@@ -137,7 +162,12 @@ fn test_find_duplicates_media_never_marked_near_duplicate() {
     // resolve as Exact-or-none for media — DupKind::Near never appears when
     // a media hash is present.
     let media = vec![Some(7_u64), Some(7_u64)];
-    let verdicts = find_duplicates(&["Hello World", "hello  world"], true, &media);
+    let verdicts = find_duplicates(
+        &["Hello World", "hello  world"],
+        true,
+        &media,
+        &not_superseded(2),
+    );
     assert_eq!(verdicts[1].expect("dup").kind, DupKind::Exact);
 }
 
@@ -148,7 +178,7 @@ fn test_find_duplicates_media_fragment_does_not_pollute_text_dedup_of_others() {
     // with empty content must NOT be marked a duplicate of the media
     // fragment merely because both "contents" are blank.
     let media = vec![Some(999_u64), None];
-    let verdicts = find_duplicates(&["", ""], true, &media);
+    let verdicts = find_duplicates(&["", ""], true, &media, &not_superseded(2));
     assert!(
         verdicts[1].is_none(),
         "a plain-text empty fragment must not dedup against a media fragment's blank caption"
@@ -161,14 +191,14 @@ fn test_find_duplicates_media_and_text_dedup_use_independent_namespaces() {
     // happens to be "shared" but with a distinct raw hash — must not dedup
     // against #0 via the text namespace.
     let media = vec![None, Some(1_u64)];
-    let verdicts = find_duplicates(&["shared", "shared"], true, &media);
+    let verdicts = find_duplicates(&["shared", "shared"], true, &media, &not_superseded(2));
     assert!(verdicts[1].is_none());
 }
 
 #[test]
 fn test_find_duplicates_media_chain_points_to_first_occurrence() {
     let media = vec![Some(5_u64), Some(5_u64), Some(5_u64)];
-    let verdicts = find_duplicates(&["", "", ""], true, &media);
+    let verdicts = find_duplicates(&["", "", ""], true, &media, &not_superseded(3));
     assert_eq!(verdicts[1].expect("dup").kept_seq, 0);
     assert_eq!(verdicts[2].expect("dup").kept_seq, 0);
 }

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -1501,6 +1501,78 @@ fn test_byte_identical_screenshot_duplicate_wins_over_supersession_and_resolves(
 }
 
 #[test]
+fn test_two_identical_screenshots_same_target_emits_latest() {
+    // Given two BYTE-IDENTICAL screenshots of the same target — dedup
+    // (anchored on #0, the first occurrence) and supersession (which keeps
+    // only the LAST occurrence, #1) disagree on which one survives. Without
+    // re-anchoring, #0 is superseded (dropped) and #1 is "just a duplicate
+    // of #0" (also dropped) — the image vanishes from the compiled output
+    // entirely, contradicting US-009's "the freshest copy stays inline".
+    let (_dir, svc) = service();
+    let fragments = vec![
+        screenshot("dup shot", "login-page"),
+        screenshot("dup shot", "login-page"),
+    ];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then the image survives, exactly once, through the LATEST occurrence
+    assert_eq!(
+        out.content.matches("dup shot").count(),
+        1,
+        "the image must appear exactly once in the compiled content"
+    );
+    assert_eq!(out.decisions[0].action, ContextAction::Drop);
+    assert_eq!(out.decisions[0].rule_id, "drop.duplicate");
+    assert!(
+        out.decisions[0]
+            .reason
+            .contains("of fragment #1"),
+        "the stale fragment #0 must be recorded as a duplicate of the LATEST occurrence (#1), got: {}",
+        out.decisions[0].reason
+    );
+    assert_eq!(out.decisions[1].action, ContextAction::Preserve);
+
+    // And dropping the stale twin never registers as a High-fidelity-risk
+    // loss — the content it carried fully survives through #1
+    assert_ne!(
+        out.risk,
+        velesdb_memory::context::FidelityRisk::High,
+        "the surviving twin carries the same bytes, so risk must not reach High"
+    );
+}
+
+#[test]
+fn test_three_identical_screenshots_reanchors_on_last() {
+    // Given three BYTE-IDENTICAL screenshots of the same target — the media
+    // dedup namespace must chain #0 and #1 as duplicates of the final
+    // survivor (#2), never anchor on a superseded fragment.
+    let (_dir, svc) = service();
+    let fragments = vec![
+        screenshot("dup shot", "login-page"),
+        screenshot("dup shot", "login-page"),
+        screenshot("dup shot", "login-page"),
+    ];
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request("q", fragments, 10_000))
+        .expect("compile");
+
+    // Then the image survives exactly once, and only the last fragment
+    // stays inline
+    assert_eq!(
+        out.content.matches("dup shot").count(),
+        1,
+        "the image must appear exactly once in the compiled content"
+    );
+    assert_eq!(out.decisions[0].action, ContextAction::Drop);
+    assert_eq!(out.decisions[1].action, ContextAction::Drop);
+    assert_eq!(out.decisions[2].action, ContextAction::Preserve);
+}
+
+#[test]
 fn test_stored_media_sources_are_invisible_to_normal_recall() {
     // Given a compiled (and stored) media source with a distinctive caption
     let (_dir, svc) = service();


### PR DESCRIPTION
## Summary

Byte-identical screenshots of the same supersession target could vanish from compiled context entirely. `dedup::find_duplicates` anchored the media namespace on the FIRST occurrence, while `classify::screenshot_supersession` keeps only the LAST occurrence per target. With two byte-identical screenshots `[A(t), A(t)]`: #0 was flagged superseded, and #1 was "just a duplicate of #0" — the packing filter (`dup.is_none() && !superseded`) excludes both, so the image disappears entirely and risk climbs to High. This violates the US-009 contract that the freshest copy stays inline.

## Fix

- `analyze()` now computes `screenshot_supersession` *before* calling `find_duplicates`, and passes the flags in.
- The media namespace in `dedup::find_duplicates` re-anchors: when the current anchor for a raw hash is itself superseded and the new occurrence is not, the stale anchor is rewritten to `Duplicate { kind: Exact, kept_seq: <new anchor> }` and the new occurrence becomes the anchor. The existing `decision()` "dup before superseded" precedence then does the rest — the stale copy exits as a duplicate, the fresh one gets emitted.
- Text-namespace dedup is untouched.

## Test plan

- [x] New test `test_two_identical_screenshots_same_target_emits_latest`: `[A(t), A(t)]` — image appears once, #0 recorded as `drop.duplicate` of #1, risk never reaches High. Confirmed RED (image count 0) before the fix, GREEN after.
- [x] New test `test_three_identical_screenshots_reanchors_on_last`: `[A, A, A]` same target — only #2 stays inline, confirmed RED before / GREEN after.
- [x] Existing regression `test_byte_identical_screenshot_duplicate_wins_over_supersession_and_resolves` (`[A, A, B-newer]`) still green, unmodified.
- [x] `cargo test -p velesdb-memory` — 267+ tests, 0 failed.
- [x] `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context` — clean.
- [x] `cargo clippy -p velesdb-memory --all-features -- -D warnings -D clippy::pedantic` — clean.
- [x] `cargo fmt -p velesdb-memory --check` — clean.
- [x] Golden fixtures (`compile_basic.json`, `compile_importance_zero.json`) unchanged.