### PR TITLE
fix(memory): upgrade context source TTL slots instead of always skipping

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -38,6 +38,27 @@ fn now_nanos() -> u128 {
     }
 }
 
+/// Current Unix time in seconds — used only by
+/// [`MemoryService::should_upgrade_ttl`]'s extension-only comparison (the
+/// storage/expiry layer; the `compile` pipeline itself stays clock-free). On
+/// `wasm32-unknown-unknown` this is 0 (no clock, mirrors [`now_nanos`]); the
+/// wasm `MemoryStore` is in-memory only, so a stored durable expiry (a real
+/// epoch second count) never actually exists there for 0 to be compared
+/// against.
+fn now_unix_secs() -> u64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        0
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| elapsed.as_secs())
+            .unwrap_or(0)
+    }
+}
+
 use serde_json::{Map, Number, Value};
 
 use super::{positive_ttl, MemoryService, Metadata, HUB_FIELD};
@@ -80,6 +101,12 @@ const CTX_SOURCE_FIELD: &str = "_veles_ctx_source";
 /// one. Reserved like every other `_veles_ctx_*` key — a caller can neither
 /// set nor filter on it.
 const CTX_SOURCE_MEDIA_FIELD: &str = "_veles_ctx_source_media";
+/// The durable-TTL payload key set by [`super::positive_ttl`]-backed writes
+/// (`store_with_ttl`, via `store_fact`). Mirrors `velesdb_core::EXPIRES_AT_KEY`
+/// as a literal rather than an import: that re-export is `persistence`-gated,
+/// and this module (unlike `NativeStore`) must keep compiling under `context`
+/// alone (e.g. `velesdb-wasm`, which never enables `persistence`).
+const EXPIRES_AT_FIELD: &str = "_veles_expires_at";
 const CTX_WORKING_FIELD: &str = "_veles_ctx_working";
 const CTX_SESSION_FIELD: &str = "_veles_ctx_session";
 const CTX_TOKENS_IN_FIELD: &str = "_veles_ctx_tokens_in";
@@ -360,14 +387,29 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 continue;
             };
             let slot = source_id(hash);
-            // An occupied slot is never rewritten: without our marker it is a
-            // caller fact squatting the salt preimage (clobbering it would
-            // destroy user data); with the marker it already holds these
-            // exact bytes — sources are content-addressed — so re-embedding
-            // and re-storing would only burn work (quadratically, on an
-            // agent session whose context accumulates across turns).
-            if self.store.get(slot)?.is_some() {
+            // A slot never marked as ours is never rewritten: it is a caller
+            // fact squatting the salt preimage, and clobbering it would
+            // destroy user data. A slot already marked as ours holds these
+            // exact bytes — sources are content-addressed — so content and
+            // embedding never change; only durability can, and only upward
+            // (never-downgrade TTL upgrade, `should_store_source`) so a
+            // handle sold as permanent never silently expires just because
+            // an earlier compile first wrote it under a TTL.
+            if !self.should_store_source(slot, ttl_seconds)? {
                 continue;
+            }
+            // Upgrading to permanent needs the old point gone, not merely
+            // overwritten: velesdb-core's store path preserves every
+            // `_veles_*` key from a prior version of a re-stored id unless
+            // the new write explicitly sets it (semantic_memory.rs's
+            // `store_internal` carry-forward, so plain `remember` doesn't
+            // silently wipe learned state), and a permanent write has no
+            // expiry to explicitly set (`attach_expiry` is a no-op without
+            // one) — so without this delete, `_veles_expires_at` would
+            // survive the "upgrade" untouched. A TTL-to-TTL extension needs
+            // no delete: its new expiry always overwrites the old one.
+            if ttl_seconds.is_none() && self.store.get(slot)?.is_some() {
+                self.store.delete(slot)?;
             }
             let content = fragment.content.as_str();
             let mut extra: Vec<(&str, Value)> = vec![(CTX_SOURCE_FIELD, Value::Bool(true))];
@@ -399,6 +441,43 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             )?;
         }
         Ok(())
+    }
+
+    /// Whether [`Self::store_context_sources`] should (re-)write `slot` for
+    /// this compile's requested (already [`positive_ttl`]-normalized —
+    /// `None` means permanent) TTL.
+    ///
+    /// - Not marked as ours (absent, or a caller fact squatting the salt
+    ///   preimage): store only if the slot is genuinely empty.
+    /// - Marked as ours: never re-embed or change content (content-addressed);
+    ///   only [`Self::should_upgrade_ttl`] decides whether durability changes.
+    fn should_store_source(
+        &self,
+        slot: u64,
+        requested_ttl: Option<u64>,
+    ) -> Result<bool, MemoryError> {
+        match self.context_source_metadata(slot)? {
+            Some(existing) => Ok(Self::should_upgrade_ttl(&existing, requested_ttl)),
+            None => Ok(self.store.get(slot)?.is_none()),
+        }
+    }
+
+    /// Never-downgrade TTL upgrade rule for an already-stored source: permanent
+    /// once requested stays permanent, and a TTL only ever extends, never
+    /// shortens. The clock read here is fine — this is the storage/expiry
+    /// layer, not the clock-free `compile` pipeline.
+    fn should_upgrade_ttl(existing: &Metadata, requested_ttl: Option<u64>) -> bool {
+        let existing_expiry = existing.get(EXPIRES_AT_FIELD).and_then(Value::as_u64);
+        match (requested_ttl, existing_expiry) {
+            // Permanent requested, slot still carries a TTL: upgrade.
+            (None, Some(_)) => true,
+            // Already permanent, or a TTL requested against a permanent slot:
+            // never downgrade.
+            (None | Some(_), None) => false,
+            // Both carry a TTL: extend only if the new one outlives what
+            // remains — never shorten.
+            (Some(ttl), Some(existing_exp)) => now_unix_secs().saturating_add(ttl) > existing_exp,
+        }
     }
 
     /// A deterministic, non-degenerate embedding for a media source (US-009,
@@ -880,3 +959,7 @@ fn source_media(meta: &Metadata) -> Option<MediaRef> {
 fn working_id(project: &str, session: &str) -> u64 {
     stable_id(&format!("{WORKING_ID_SALT}{project}\u{1f}{session}"))
 }
+
+#[cfg(all(test, feature = "persistence"))]
+#[path = "memory_bridge_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -1,0 +1,277 @@
+//! Unit tests for the source writer's never-downgrade TTL upgrade rule and
+//! its squatter guard.
+//!
+//! These live here (rather than in the `tests/` integration suite) so the
+//! never-downgrade assertions can read the reserved `_veles_expires_at`
+//! metadata directly instead of sleeping past a real TTL and retrying
+//! retrieval: a sleep-based version of these tests was flaky under the full
+//! suite's parallel test load (a compile occasionally landed close enough to
+//! a 1-second TTL boundary that a 1.5s sleep wasn't reliably past it), and
+//! reading the metadata is both deterministic and faster. The squatter guard
+//! is a unit test for a second, independent reason: forging an unmarked
+//! occupied slot needs `self.store` (a private field) to write directly at
+//! the exact salted `source_id` the bridge would use — unreachable from an
+//! integration test, and unreachable through the public API too (a fact's id
+//! is `stable_id(fact)`, not caller-chosen, so colliding it with a specific
+//! `source_id` is an infeasible preimage search, not a realistic fixture).
+
+use super::*;
+use crate::context::model::CompilePolicy;
+use crate::embedder::HashEmbedder;
+
+const DIM: usize = 384;
+
+fn open_service() -> (tempfile::TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DIM)).expect("open memory store");
+    (dir, svc)
+}
+
+fn fragment(content: &str) -> ContextFragment {
+    ContextFragment {
+        id: None,
+        content: content.to_owned(),
+        kind: None,
+        priority: None,
+        metadata: None,
+        media: None,
+    }
+}
+
+fn request(content: &str, policy: CompilePolicy) -> CompileRequest {
+    CompileRequest {
+        query: "q".to_owned(),
+        fragments: vec![fragment(content)],
+        project: None,
+        target_model: None,
+        token_budget: 10_000,
+        memory_scope: None,
+        policy: Some(policy),
+    }
+}
+
+/// The slot a compiled source's handle resolves to.
+fn slot_of(handle: &str) -> u64 {
+    let hash = provenance::parse_handle(handle).expect("well-formed ctx://source handle");
+    source_id(hash)
+}
+
+#[test]
+fn test_permanent_compile_upgrades_ttl_slot_to_permanent() {
+    // Given a compile that stores the source under a short-lived TTL
+    let (_dir, svc) = open_service();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let content = "must be upgraded to permanent, not left to expire";
+
+    let ttl_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(60),
+            ..CompilePolicy::default()
+        },
+    );
+    let out = svc
+        .compile_context(&compiler, &ttl_req)
+        .expect("compile ttl");
+    let slot = slot_of(&out.sources[0].handle);
+    let meta = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("marked as a stored source");
+    assert!(
+        meta.contains_key(EXPIRES_AT_FIELD),
+        "sanity: the first compile must carry a TTL"
+    );
+
+    // When a later compile of the SAME content asks for permanent storage
+    let permanent_req = request(content, CompilePolicy::default());
+    svc.compile_context(&compiler, &permanent_req)
+        .expect("compile permanent");
+
+    // Then the slot's durable expiry must be gone — upgraded to permanent.
+    let meta_after = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("still marked as a stored source");
+    assert!(
+        !meta_after.contains_key(EXPIRES_AT_FIELD),
+        "a later permanent compile must upgrade an existing TTL slot to \
+         permanent, not leave it to expire silently: {meta_after:?}"
+    );
+}
+
+#[test]
+fn test_ttl_compile_never_downgrades_permanent_slot() {
+    // Given a compile that stores the source permanently
+    let (_dir, svc) = open_service();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let content = "must stay permanent even after a later short-TTL compile";
+
+    let permanent_req = request(content, CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &permanent_req)
+        .expect("compile permanent");
+    let slot = slot_of(&out.sources[0].handle);
+    let meta = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("marked as a stored source");
+    assert!(
+        !meta.contains_key(EXPIRES_AT_FIELD),
+        "sanity: the first compile must be permanent"
+    );
+
+    // When a later compile of the SAME content asks for a short TTL
+    let ttl_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(60),
+            ..CompilePolicy::default()
+        },
+    );
+    svc.compile_context(&compiler, &ttl_req)
+        .expect("compile ttl");
+
+    // Then the slot must still be permanent — never downgraded.
+    let meta_after = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("still marked as a stored source");
+    assert!(
+        !meta_after.contains_key(EXPIRES_AT_FIELD),
+        "a later TTL compile must never downgrade an existing permanent slot: {meta_after:?}"
+    );
+}
+
+#[test]
+fn test_ttl_extension_only_never_shrinks_a_longer_ttl() {
+    // Given a compile with a long TTL, then a later one with a shorter TTL
+    let (_dir, svc) = open_service();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let content = "extension-only never shrinks below the longer TTL";
+
+    let long_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(3600),
+            ..CompilePolicy::default()
+        },
+    );
+    let out = svc
+        .compile_context(&compiler, &long_req)
+        .expect("compile long ttl");
+    let slot = slot_of(&out.sources[0].handle);
+    let long_expiry = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("marked")
+        .get(EXPIRES_AT_FIELD)
+        .and_then(Value::as_u64)
+        .expect("the long-TTL compile must set an expiry");
+
+    // When a later compile of the SAME content requests a much shorter TTL
+    let short_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(60),
+            ..CompilePolicy::default()
+        },
+    );
+    svc.compile_context(&compiler, &short_req)
+        .expect("compile shorter ttl");
+
+    // Then the expiry must be unchanged — never shrunk.
+    let expiry_after = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("still marked")
+        .get(EXPIRES_AT_FIELD)
+        .and_then(Value::as_u64)
+        .expect("still carries an expiry");
+    assert_eq!(
+        expiry_after, long_expiry,
+        "a later shorter-TTL compile must never shrink an existing longer TTL"
+    );
+}
+
+#[test]
+fn test_ttl_extension_only_extends_a_shorter_ttl() {
+    // Given a compile with a short TTL, then a later one with a longer TTL
+    let (_dir, svc) = open_service();
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let content = "extension-only extends past a shorter original TTL";
+
+    let short_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(60),
+            ..CompilePolicy::default()
+        },
+    );
+    let out = svc
+        .compile_context(&compiler, &short_req)
+        .expect("compile shorter ttl");
+    let slot = slot_of(&out.sources[0].handle);
+    let short_expiry = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("marked")
+        .get(EXPIRES_AT_FIELD)
+        .and_then(Value::as_u64)
+        .expect("the short-TTL compile must set an expiry");
+
+    // When a later compile of the SAME content requests a much longer TTL
+    let long_req = request(
+        content,
+        CompilePolicy {
+            source_ttl_seconds: Some(3600),
+            ..CompilePolicy::default()
+        },
+    );
+    svc.compile_context(&compiler, &long_req)
+        .expect("compile longer ttl");
+
+    // Then the expiry must have moved further out — extended, not left as-is.
+    let expiry_after = svc
+        .context_source_metadata(slot)
+        .expect("meta lookup")
+        .expect("still marked")
+        .get(EXPIRES_AT_FIELD)
+        .and_then(Value::as_u64)
+        .expect("still carries an expiry");
+    assert!(
+        expiry_after > short_expiry,
+        "a later longer-TTL compile must extend an existing shorter TTL \
+         (before={short_expiry}, after={expiry_after})"
+    );
+}
+
+#[test]
+fn test_should_store_source_never_rewrites_an_unmarked_occupied_slot() {
+    // Given a slot occupied by a caller fact that carries none of the
+    // bridge's `_veles_ctx_source` marker (forged directly via the store —
+    // see module doc for why this can't be reached through `remember`)
+    let (_dir, svc) = open_service();
+
+    let probe = fragment("squatter probe content");
+    let slot = source_id(fragment_handle_hash(&probe));
+    let embedding = svc
+        .embedder
+        .embed("an unrelated caller fact")
+        .expect("embed");
+    svc.store
+        .store(slot, "an unrelated caller fact", &embedding)
+        .expect("forge an unmarked squatter at the exact slot");
+
+    // When the source writer is asked whether it should (re-)write that slot
+    let should_store = svc
+        .should_store_source(slot, None)
+        .expect("should_store_source must not error on a squatted slot");
+
+    // Then it must refuse — an unmarked occupied slot is a caller fact, and
+    // clobbering it would destroy user data.
+    assert!(
+        !should_store,
+        "an unmarked occupied slot must never be (re-)written by the source writer"
+    );
+}

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -506,6 +506,14 @@ fn test_source_ttl_zero_stores_permanently_like_remember() {
     assert_eq!(retrieved.content, "must stay retrievable");
 }
 
+// The never-downgrade TTL upgrade rule (permanent-upgrades-TTL,
+// TTL-never-downgrades-permanent, TTL-extension-only) is covered by unit
+// tests in `src/context/memory_bridge_tests.rs`, not here: those assertions
+// read the reserved `_veles_expires_at` metadata directly (unreachable from
+// this integration binary — reserved keys are always stripped from the
+// public API), which is also what keeps them from being a sleep-past-a-real-TTL
+// test, the flaky alternative under this suite's parallel test load.
+
 // --- Coverage round (2026-07-17): pricing trail, writer guard, provenance ----
 
 #[test]


### PR DESCRIPTION
## Summary

`store_context_sources` in `crates/velesdb-memory/src/context/memory_bridge.rs` skipped any occupied slot unconditionally. A context source first written under a TTL (e.g. `source_ttl_seconds: Some(60)`) never got promoted when a later compile of the same content requested permanent storage (`source_ttl_seconds: None`) — the `ctx://source/...` handle sold as permanent would silently expire once the original TTL ran out.

Fix: a never-downgrade upgrade rule decides whether an already-marked slot should be re-written:
- permanent requested against an existing TTL slot -> upgrade to permanent
- TTL requested against an existing permanent slot -> no-op (never downgrade)
- TTL requested against an existing TTL slot -> re-store only if the new expiry is later (extension only, never shrink)

Upgrading to permanent also deletes the point before re-storing: velesdb-core's store path (`semantic_memory.rs::store_internal`) carries forward every prior `_veles_*` key on a plain re-store (so a normal `remember` doesn't silently wipe learned state), which would otherwise leave the stale `_veles_expires_at` in place even after a "permanent" re-store.

## Test plan

- [x] `cargo test -p velesdb-memory` — 272 unit tests + all integration suites pass (run 3x to rule out flakiness)
- [x] `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context` — compiles without the `persistence` feature (wasm-compatible path)
- [x] `cargo clippy -p velesdb-memory --all-features -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo fmt -p velesdb-memory --check` — clean
- [x] `tests/golden/context/*.json` unchanged (`git status` confirms — no TTL involved in those fixtures)

New coverage:
- `src/context/memory_bridge_tests.rs` (new, in-crate unit tests): upgrade-to-permanent, never-downgrade-permanent, extension-only (both directions), and the squatter guard. These assert on the reserved `_veles_expires_at` metadata directly rather than sleeping past a real TTL — an earlier sleep-based version of these tests was flaky under the full suite's parallel test load.