### PR TITLE
fix(graph): reject add_edge to non-existent nodes (#1442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   supersession target could both drop from compiled context instead of one
   surviving. Media dedup now re-anchors onto the freshest non-superseded
   occurrence. (#1453)
+- **`velesdb-core` / `velesdb-server`**: `add_edge` and `add_edges_batch`
+  now reject an edge whose `source` or `target` node has no stored payload
+  (#1442), instead of silently accepting it. Previously, on schemaless
+  graph collections (the default), an edge could reference a node ID that
+  was never explicitly created — the edge was stored, but the node stayed
+  invisible to `GET /graph/nodes`, `all_node_ids()`, and `MATCH`, since all
+  three resolve their node set from the payload store, not the edge store.
+  The REST layer now returns `404 NodeNotFound` (`VELES-022`) for such an
+  edge, matching the existing strict-schema behavior and the
+  `velesdb-memory` wedge's `relate()`, which already required both
+  endpoints to exist. **Migration note:** code that called `addEdge`/
+  `INSERT EDGE` without first creating the endpoint nodes (via a point
+  upsert or `PUT /graph/nodes/{id}/payload`) must now create them first —
+  see `docs/guides/GRAPH_PATTERNS.md`.
+
 - **`velesdb-memory`**: hardened the MCP server against a leaked client
   process (#1448). The server itself was already healthy (it exits cleanly
   on stdin EOF), but a client that leaks its child process — observed in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it now stubs each edge endpoint before inserting, and a batch-level
   validation failure degrades to per-edge accounting instead of aborting
   the whole migration.
+- **`velesdb-core`**: closed a race left by the #1442 fix above —
+  `add_edge`/`add_edges_batch` used to release the payload-store guard
+  right after checking that both endpoints exist, then separately acquire
+  the edge-WAL lock to write the edge. A concurrent `delete()` of an
+  endpoint could land in that window and still leave a "phantom" edge
+  (present in the edge store, invisible to `all_node_ids()`/MATCH). Both
+  entry points now hold the payload-store read guard from the check
+  through the end of the write, so a racing `delete()` blocks until the
+  edge is durable instead of running ahead; see the "Collection-level lock
+  order" section of `docs/CONCURRENCY_MODEL.md` for the full mechanism.
+  Also fixed: `velesdb-migrate`'s FK-relations node-seeding marked a node
+  as seeded even when its stub upsert failed, permanently skipping any
+  retry for that node later in the same relation — it now only marks a
+  node seeded on a successful upsert. **Known, accepted limitation**:
+  edges loaded from a pre-existing WAL/snapshot (replay) are not
+  re-validated, so a database created before the original #1442 fix may
+  still contain legacy phantom edges; tracked in
+  [#1469](https://github.com/cyberlife-coder/VelesDB/issues/1469) (a
+  `velesdb-cli graph doctor` audit/repair subcommand). The
+  strict-vs-schemaless error-type divergence (`SchemaValidation` vs.
+  `NodeNotFound`) noted above remains deliberate; unifying it is tracked
+  for the next major version in
+  [#1470](https://github.com/cyberlife-coder/VelesDB/issues/1470).
 
 - **`velesdb-memory`**: hardened the MCP server against a leaked client
   process (#1448). The server itself was already healthy (it exits cleanly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   endpoints to exist. **Migration note:** code that called `addEdge`/
   `INSERT EDGE` without first creating the endpoint nodes (via a point
   upsert or `PUT /graph/nodes/{id}/payload`) must now create them first —
-  see `docs/guides/GRAPH_PATTERNS.md`.
+  see `docs/guides/GRAPH_PATTERNS.md`. Follow-on fixes found in review:
+  `POST /collections/{name}/relations` (the point-relations REST endpoint)
+  previously mapped this same error to a generic `500`; it now returns
+  `404`/`VELES-022` like every other graph endpoint. `velesdb-memory`'s
+  `relate()` previously downgraded the identical concurrent-delete race to
+  a generic internal error instead of its documented `NotFound` contract;
+  fixed. `velesdb-migrate`'s FK-relations phase writes into a fresh,
+  edge-only graph collection that never otherwise gets node payloads —
+  it now stubs each edge endpoint before inserting, and a batch-level
+  validation failure degrades to per-edge accounting instead of aborting
+  the whole migration.
 
 - **`velesdb-memory`**: hardened the MCP server against a leaked client
   process (#1448). The server itself was already healthy (it exits cleanly

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -116,8 +116,7 @@ pub async fn add_edge<R: Runtime>(
                 &request.label,
                 request.properties,
             )?;
-            coll.add_edge(edge)
-                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            coll.add_edge(edge)?;
             Ok(())
         })
         .map_err(CommandError::from)
@@ -140,9 +139,7 @@ pub async fn add_edges_batch<R: Runtime>(
                 .into_iter()
                 .map(|e| build_edge(e.id, e.source, e.target, &e.label, e.properties))
                 .collect::<std::result::Result<Vec<_>, _>>()?;
-            let added = coll
-                .add_edges_batch(edges)
-                .map_err(|e| Error::InvalidConfig(e.to_string()))?;
+            let added = coll.add_edges_batch(edges)?;
             Ok(u64::try_from(added).unwrap_or(u64::MAX))
         })
         .map_err(CommandError::from)

--- a/crates/tauri-plugin-velesdb/tests/command_handlers.rs
+++ b/crates/tauri-plugin-velesdb/tests/command_handlers.rs
@@ -767,6 +767,19 @@ fn graph_create_add_edges_traverse_degree() {
     .expect("create_graph_collection");
     assert_eq!(info.storage_mode, "graph");
 
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store nodes 10, 20, 30 before creating the edges below.
+    st(&app)
+        .with_db(|db| {
+            let coll = db.get_graph_collection("kg").expect("kg collection");
+            for node_id in [10, 20, 30] {
+                coll.upsert_node_payload(node_id, &serde_json::json!({}))
+                    .expect("store node payload");
+            }
+            Ok(())
+        })
+        .expect("seed graph nodes");
+
     // Add a single edge with properties.
     run(add_edge(
         handle(&app),

--- a/crates/velesdb-cli/src/graph_bdd_tests.rs
+++ b/crates/velesdb-cli/src/graph_bdd_tests.rs
@@ -52,6 +52,12 @@ fn open_graph(path: &PathBuf) -> GraphCollection {
 /// Populate a graph with test edges: 1→2→3→4, 2→5.
 fn populate_edges(path: &PathBuf) {
     let col = open_graph(path);
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store all 5 nodes referenced by the edges below first.
+    for id in [1, 2, 3, 4, 5] {
+        col.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("test: store node payload");
+    }
     for (id, src, tgt, lbl) in [
         (100, 1, 2, "KNOWS"),
         (101, 2, 3, "KNOWS"),
@@ -125,6 +131,16 @@ fn test_remove_edge_then_readd_same_id() {
         edge_id: 100,
     })
     .expect("remove should succeed");
+
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store nodes 10 and 20 before the re-add below.
+    let col = open_graph(&path);
+    col.upsert_node_payload(10, &serde_json::json!({}))
+        .expect("test: store node 10");
+    col.upsert_node_payload(20, &serde_json::json!({}))
+        .expect("test: store node 20");
+    col.flush().expect("test: flush");
+    drop(col);
 
     crate::graph::handle(GraphAction::AddEdge {
         path: path.clone(),

--- a/crates/velesdb-cli/src/repl_collection_cmds_tests.rs
+++ b/crates/velesdb-cli/src/repl_collection_cmds_tests.rs
@@ -53,9 +53,12 @@ fn graph_db(name: &str) -> (Database, TempDir) {
     db.create_graph_collection(name, GraphSchema::schemaless())
         .unwrap();
     let col = db.get_graph_collection(name).unwrap();
-    col.add_edge(GraphEdge::new(1, 10, 11, "LINKS").unwrap())
-        .unwrap();
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store both nodes before creating the edge.
     col.upsert_node_payload(10, &serde_json::json!({"name": "n10"}))
+        .unwrap();
+    col.upsert_node_payload(11, &serde_json::json!({})).unwrap();
+    col.add_edge(GraphEdge::new(1, 10, 11, "LINKS").unwrap())
         .unwrap();
     col.flush().unwrap();
     (db, dir)

--- a/crates/velesdb-cli/src/repl_graph_bdd_tests.rs
+++ b/crates/velesdb-cli/src/repl_graph_bdd_tests.rs
@@ -27,6 +27,12 @@ fn populate(db: &Database) {
     let col = db
         .get_graph_collection("kg")
         .expect("test: get graph collection");
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store all 5 nodes referenced by the edges below first.
+    for id in [1, 2, 3, 4, 5] {
+        col.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("test: store node payload");
+    }
     for (id, src, tgt, lbl) in [
         (100, 1, 2, "KNOWS"),
         (101, 2, 3, "KNOWS"),
@@ -417,8 +423,14 @@ fn test_repl_nodes_nonexistent_collection_returns_error() {
 
 #[test]
 fn test_repl_add_edge_creates_edge() {
-    // GIVEN: an empty graph
+    // GIVEN: an empty graph with the edge's endpoint nodes already created
+    // (add_edge requires both endpoints to have a stored node payload, #1442)
     let (_dir, db) = setup_db();
+    let col = graph_col(&db);
+    col.upsert_node_payload(10, &serde_json::json!({}))
+        .expect("test: store node 10");
+    col.upsert_node_payload(20, &serde_json::json!({}))
+        .expect("test: store node 20");
 
     // WHEN: .graph add-edge kg 1 10 20 KNOWS
     let parts: Vec<&str> = vec![".graph", "add-edge", "kg", "1", "10", "20", "KNOWS"];

--- a/crates/velesdb-cli/tests/e2e_complete.rs
+++ b/crates/velesdb-cli/tests/e2e_complete.rs
@@ -178,25 +178,29 @@ mod graph_commands {
             .success();
     }
 
+    /// `add-edge` requires both endpoints to have a stored node payload
+    /// (#1442) — call this for each endpoint before creating an edge.
+    fn store_payload(temp: &TempDir, collection: &str, node_id: &str) {
+        cli()
+            .args([
+                "graph",
+                "store-payload",
+                temp.path().to_str().unwrap(),
+                collection,
+                node_id,
+                "{}",
+            ])
+            .assert()
+            .success();
+    }
+
     #[test]
     fn test_graph_traverse_bfs() {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
 
-        // add-edge requires both endpoints to have a stored node payload
-        // (#1442) — store nodes 10 and 20 before creating the edge.
         for node_id in ["10", "20"] {
-            cli()
-                .args([
-                    "graph",
-                    "store-payload",
-                    temp.path().to_str().unwrap(),
-                    "g",
-                    node_id,
-                    "{}",
-                ])
-                .assert()
-                .success();
+            store_payload(&temp, "g", node_id);
         }
 
         // Add an edge so traversal has something to find
@@ -236,20 +240,8 @@ mod graph_commands {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
 
-        // add-edge requires both endpoints to have a stored node payload
-        // (#1442) — store nodes 10 and 20 before creating the edge.
         for node_id in ["10", "20"] {
-            cli()
-                .args([
-                    "graph",
-                    "store-payload",
-                    temp.path().to_str().unwrap(),
-                    "g",
-                    node_id,
-                    "{}",
-                ])
-                .assert()
-                .success();
+            store_payload(&temp, "g", node_id);
         }
 
         cli()
@@ -301,20 +293,8 @@ mod graph_commands {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
 
-        // add-edge requires both endpoints to have a stored node payload
-        // (#1442) — store nodes 100 and 200 before creating the edge.
         for node_id in ["100", "200"] {
-            cli()
-                .args([
-                    "graph",
-                    "store-payload",
-                    temp.path().to_str().unwrap(),
-                    "g",
-                    node_id,
-                    "{}",
-                ])
-                .assert()
-                .success();
+            store_payload(&temp, "g", node_id);
         }
 
         cli()

--- a/crates/velesdb-cli/tests/e2e_complete.rs
+++ b/crates/velesdb-cli/tests/e2e_complete.rs
@@ -183,6 +183,22 @@ mod graph_commands {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
 
+        // add-edge requires both endpoints to have a stored node payload
+        // (#1442) — store nodes 10 and 20 before creating the edge.
+        for node_id in ["10", "20"] {
+            cli()
+                .args([
+                    "graph",
+                    "store-payload",
+                    temp.path().to_str().unwrap(),
+                    "g",
+                    node_id,
+                    "{}",
+                ])
+                .assert()
+                .success();
+        }
+
         // Add an edge so traversal has something to find
         cli()
             .args([
@@ -219,6 +235,22 @@ mod graph_commands {
     fn test_graph_traverse_dfs() {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
+
+        // add-edge requires both endpoints to have a stored node payload
+        // (#1442) — store nodes 10 and 20 before creating the edge.
+        for node_id in ["10", "20"] {
+            cli()
+                .args([
+                    "graph",
+                    "store-payload",
+                    temp.path().to_str().unwrap(),
+                    "g",
+                    node_id,
+                    "{}",
+                ])
+                .assert()
+                .success();
+        }
 
         cli()
             .args([
@@ -268,6 +300,22 @@ mod graph_commands {
     fn test_graph_add_edge() {
         let temp = temp_db_dir();
         create_graph(&temp, "g");
+
+        // add-edge requires both endpoints to have a stored node payload
+        // (#1442) — store nodes 100 and 200 before creating the edge.
+        for node_id in ["100", "200"] {
+            cli()
+                .args([
+                    "graph",
+                    "store-payload",
+                    temp.path().to_str().unwrap(),
+                    "g",
+                    node_id,
+                    "{}",
+                ])
+                .assert()
+                .success();
+        }
 
         cli()
             .args([

--- a/crates/velesdb-cli/tests/graph_commands_tests.rs
+++ b/crates/velesdb-cli/tests/graph_commands_tests.rs
@@ -18,6 +18,23 @@ fn create_graph_collection(dir: &std::path::Path, name: &str) {
         .success();
 }
 
+/// Helper: store an empty payload on a graph node via CLI. `add-edge`
+/// requires both endpoints to have a stored node payload (#1442), so tests
+/// that add edges must create the endpoint nodes first.
+fn store_payload(dir: &std::path::Path, name: &str, node_id: &str) {
+    cmd()
+        .args([
+            "graph",
+            "store-payload",
+            dir.to_str().unwrap(),
+            name,
+            node_id,
+            "{}",
+        ])
+        .assert()
+        .success();
+}
+
 // =========================================================================
 // Help / subcommand listing
 // =========================================================================
@@ -45,6 +62,8 @@ fn test_graph_help_lists_all_subcommands() {
 fn test_graph_add_edge_success() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "kg");
+    store_payload(temp.path(), "kg", "100");
+    store_payload(temp.path(), "kg", "200");
 
     cmd()
         .args([
@@ -125,6 +144,9 @@ fn test_graph_get_edges_empty() {
 fn test_graph_get_edges_after_add() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["10", "20", "30"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     // Add two edges
     cmd()
@@ -168,6 +190,9 @@ fn test_graph_get_edges_after_add() {
 fn test_graph_get_edges_filter_by_label() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["10", "20", "30"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     cmd()
         .args([
@@ -215,6 +240,8 @@ fn test_graph_get_edges_filter_by_label() {
 fn test_graph_get_edges_json_format() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "10");
+    store_payload(temp.path(), "g", "20");
 
     cmd()
         .args([
@@ -284,6 +311,9 @@ fn test_graph_degree_zero_for_isolated_node() {
 fn test_graph_degree_after_edges() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["10", "20", "30"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     // 10 -> 20 and 10 -> 30
     cmd()
@@ -353,6 +383,9 @@ fn test_graph_traverse_bfs_empty() {
 fn test_graph_traverse_bfs_finds_reachable_nodes() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["1", "2", "3"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     // Chain: 1 -> 2 -> 3
     cmd()
@@ -403,6 +436,8 @@ fn test_graph_traverse_bfs_finds_reachable_nodes() {
 fn test_graph_traverse_dfs() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    store_payload(temp.path(), "g", "2");
 
     cmd()
         .args([
@@ -438,6 +473,8 @@ fn test_graph_traverse_dfs() {
 fn test_graph_traverse_json_format() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    store_payload(temp.path(), "g", "2");
 
     cmd()
         .args([
@@ -478,6 +515,9 @@ fn test_graph_traverse_json_format() {
 fn test_graph_traverse_with_rel_types() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["1", "2", "3"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     // 1 --KNOWS--> 2, 1 --FOLLOWS--> 3
     cmd()
@@ -531,6 +571,8 @@ fn test_graph_traverse_with_rel_types() {
 fn test_graph_neighbors_outgoing() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "10");
+    store_payload(temp.path(), "g", "20");
 
     cmd()
         .args([
@@ -565,6 +607,8 @@ fn test_graph_neighbors_outgoing() {
 fn test_graph_neighbors_incoming() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "10");
+    store_payload(temp.path(), "g", "20");
 
     cmd()
         .args([
@@ -600,6 +644,9 @@ fn test_graph_neighbors_incoming() {
 fn test_graph_neighbors_both() {
     let temp = tempfile::tempdir().unwrap();
     create_graph_collection(temp.path(), "g");
+    for node_id in ["10", "20", "30"] {
+        store_payload(temp.path(), "g", node_id);
+    }
 
     // 10 -> 20 and 30 -> 20
     cmd()

--- a/crates/velesdb-cli/tests/phase3_commands_tests.rs
+++ b/crates/velesdb-cli/tests/phase3_commands_tests.rs
@@ -915,12 +915,14 @@ fn setup_graph_collection(name: &str) -> (std::path::PathBuf, tempfile::TempDir)
     db.create_graph_collection(name, velesdb_core::GraphSchema::schemaless())
         .unwrap();
     let col = db.get_graph_collection(name).unwrap();
-    let edge = velesdb_core::GraphEdge::new(1, 10, 20, "KNOWS").unwrap();
-    col.add_edge(edge).unwrap();
+    // add_edge requires both endpoints to have a stored node payload
+    // (#1442) — store both nodes before creating the edge.
     col.upsert_node_payload(10, &serde_json::json!({"name": "Alice"}))
         .unwrap();
     col.upsert_node_payload(20, &serde_json::json!({"name": "Bob"}))
         .unwrap();
+    let edge = velesdb_core::GraphEdge::new(1, 10, 20, "KNOWS").unwrap();
+    col.add_edge(edge).unwrap();
     drop(db);
     (db_path, temp_dir)
 }

--- a/crates/velesdb-cli/tests/repl_e2e_tests.rs
+++ b/crates/velesdb-cli/tests/repl_e2e_tests.rs
@@ -68,13 +68,20 @@ fn setup_graph(name: &str) -> (std::path::PathBuf, TempDir) {
         .unwrap();
     let col = db.get_graph_collection(name).unwrap();
     for i in 1u64..=3 {
-        let edge = GraphEdge::new(i, i * 10, i * 10 + 1, "LINKS").unwrap();
-        col.add_edge(edge).unwrap();
+        // add_edge requires both endpoints to have a stored node payload
+        // (#1442) — store both nodes before creating the edge.
         col.upsert_node_payload(
             i * 10,
             &serde_json::json!({"name": format!("node_{}", i * 10)}),
         )
         .unwrap();
+        col.upsert_node_payload(
+            i * 10 + 1,
+            &serde_json::json!({"name": format!("node_{}", i * 10 + 1)}),
+        )
+        .unwrap();
+        let edge = GraphEdge::new(i, i * 10, i * 10 + 1, "LINKS").unwrap();
+        col.add_edge(edge).unwrap();
     }
     col.flush().unwrap();
     drop(db);

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -414,6 +414,15 @@ pub(super) fn add_relation_edge(
             Ok(()) => return Ok(edge_id),
             // Lost the residual allocation race — try the next id.
             Err(crate::error::Error::EdgeExists(_)) => {}
+            // The endpoint was deleted between `ensure_live` and this write
+            // (the same check-then-add race `verify_relation_endpoints`
+            // compensates for after a successful write) — surface the same
+            // `NotFound` contract, not a generic `CollectionError`/Internal.
+            Err(crate::error::Error::NodeNotFound(id)) => {
+                return Err(AgentMemoryError::NotFound(format!(
+                    "a relation endpoint ({id}) was deleted concurrently"
+                )))
+            }
             Err(e) => return Err(AgentMemoryError::CollectionError(e.to_string())),
         }
     }

--- a/crates/velesdb-core/src/cache/plan_cache_tests.rs
+++ b/crates/velesdb-core/src/cache/plan_cache_tests.rs
@@ -621,11 +621,13 @@ fn test_plan_invalidation_on_graph_mutation() {
     let coll = db.get_vector_collection("cache_graph").unwrap();
 
     // Seed with one vector point so the query returns results and the
-    // planner can produce a stable plan to cache.
+    // planner can produce a stable plan to cache. Payload must be non-None
+    // for add_edge's endpoint-existence check below (#1442): a None payload
+    // is filtered out before it reaches payload_storage.
     coll.upsert(vec![crate::Point {
         id: 1,
         vector: vec![1.0, 0.0, 0.0, 0.0],
-        payload: None,
+        payload: Some(serde_json::json!({})),
         sparse_vectors: None,
     }])
     .unwrap();
@@ -645,6 +647,14 @@ fn test_plan_invalidation_on_graph_mutation() {
     );
 
     // Graph mutation: add_edge bumps write_generation, invalidating the cached plan.
+    // Edge target (id=2) must exist first (#1442).
+    coll.upsert(vec![crate::Point {
+        id: 2,
+        vector: vec![0.0, 1.0, 0.0, 0.0],
+        payload: Some(serde_json::json!({})),
+        sparse_vectors: None,
+    }])
+    .unwrap();
     let edge = crate::GraphEdge::new(1, 1, 2, "KNOWS").expect("edge should be valid");
     coll.add_edge(edge).unwrap();
 

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -292,7 +292,12 @@ impl Collection {
     ///
     /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
     /// (strict mode: missing endpoint, no `_labels`, or an edge-type
-    /// constraint violation).
+    /// constraint violation). This divergence is deliberate and documented,
+    /// not an oversight: `SchemaValidation` is part of the strict-schema
+    /// contract already published, so folding the missing-endpoint case
+    /// into `NodeNotFound` there would be a breaking change. Tracked for
+    /// the next major version in
+    /// <https://github.com/cyberlife-coder/VelesDB/issues/1470>.
     fn validate_edge_referential_integrity(
         payload: &LogPayloadStorage,
         schema: Option<&GraphSchema>,

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -202,14 +202,20 @@ impl Collection {
     /// [`Self::endpoint_node_type`], this does not require a `_labels`
     /// field — plain (untyped) node payloads are enough.
     ///
+    /// Same check-then-write race as the strict-schema path
+    /// ([`Self::endpoint_node_type`]): the payload-store lock is released
+    /// before the edge is written, so a concurrent `delete()` of an
+    /// endpoint between this check and the write can still land a
+    /// dangling edge. Pre-existing characteristic of this validate-then-
+    /// mutate pattern, not introduced by this check.
+    ///
     /// # Errors
     ///
     /// Returns `Error::NodeNotFound` if `source` or `target` has no stored
     /// payload.
     fn validate_edge_endpoints_exist(&self, edge: &GraphEdge) -> Result<()> {
-        let storage = self.storage.payload_storage.read();
         for node_id in [edge.source(), edge.target()] {
-            if storage.retrieve(node_id)?.is_none() {
+            if self.get_node_payload(node_id)?.is_none() {
                 return Err(Error::NodeNotFound(node_id));
             }
         }

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -10,7 +10,7 @@ use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::index::VectorIndex;
 use crate::point::{Point, SearchResult};
-use crate::storage::{PayloadStorage, VectorStorage};
+use crate::storage::{LogPayloadStorage, PayloadStorage, VectorStorage};
 
 use super::graph_property_index_wiring::extract_labels;
 use super::graph_traversal_helpers::{
@@ -45,9 +45,18 @@ impl Collection {
     /// collection.add_edge(edge)?;
     /// ```
     pub fn add_edge(&self, edge: GraphEdge) -> Result<()> {
-        // Reject before any mutation so a violation leaves no partial write
-        // and does not bump write_generation.
-        self.validate_edge_referential_integrity(&edge)?;
+        // Position 1, hoisted before the payload guard below (position 3) so
+        // the acquisition order is never 3 → 1 (see LOCK ORDERING in
+        // collection/types.rs).
+        let schema = self.non_schemaless_graph_schema();
+
+        // Position 3, held from the referential-integrity check through the
+        // end of the write below — see `validate_edge_endpoints_exist`'s
+        // "Concurrency guarantee" doc for the race this closes. Reject
+        // before any mutation so a violation leaves no partial write and
+        // does not bump write_generation.
+        let payload_guard = self.storage.payload_storage.read();
+        Self::validate_edge_referential_integrity(&payload_guard, schema.as_ref(), &edge)?;
 
         let edge_id = edge.id();
         let rel_type = edge.label().to_string();
@@ -63,7 +72,8 @@ impl Collection {
         // The WAL lock spans append + apply so the WAL order always equals
         // the store-apply order (replay must resolve id collisions exactly
         // like live execution) and concurrent appends can never interleave
-        // a multi-write entry.
+        // a multi-write entry. Position 3b — acquired here while STILL
+        // holding `payload_guard` (position 3): see `GraphStore::edge_wal_lock`.
         let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         crate::collection::graph::edge_wal::wal_append_add(
@@ -81,6 +91,9 @@ impl Collection {
         self.generations
             .write_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        // `payload_guard` is dropped here (end of scope), AFTER the edge is
+        // fully durable — see the concurrency guarantee this enforces.
         Ok(())
     }
 
@@ -105,16 +118,24 @@ impl Collection {
             return Ok(0);
         }
 
-        // Validate the ENTIRE batch before any mutation (WAL append or store
-        // write), so a single violating edge fails the whole batch with no
-        // partial write and no orphaned WAL entry.
+        // Position 1, hoisted before the payload guard (see add_edge).
+        let schema = self.non_schemaless_graph_schema();
+
+        // Position 3, held for validating the ENTIRE batch through the end
+        // of the apply below — with the guard held for the whole batch, "an
+        // endpoint disappears mid-batch" is impossible by construction (see
+        // `validate_edge_endpoints_exist`'s concurrency guarantee), so no
+        // rollback is needed. A single violating edge still fails the whole
+        // batch with no partial write and no orphaned WAL entry.
+        let payload_guard = self.storage.payload_storage.read();
         for edge in &edges {
-            self.validate_edge_referential_integrity(edge)?;
+            Self::validate_edge_referential_integrity(&payload_guard, schema.as_ref(), edge)?;
         }
 
         // Unconditional WAL (see add_edge): writing edges implies wanting
         // them back after a restart, whatever the collection type. The WAL
-        // lock spans append + apply (see add_edge).
+        // lock spans append + apply (see add_edge). Position 3b, acquired
+        // while STILL holding `payload_guard` (position 3).
         let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         crate::collection::graph::edge_wal::wal_append_add_batch(
@@ -196,26 +217,55 @@ impl Collection {
         Ok(())
     }
 
+    /// Returns the collection's graph schema, but only when it declares a
+    /// non-schemaless mode (`None` otherwise, including "no schema at all").
+    ///
+    /// Reads `config` — lock order position **1**. Callers MUST call this
+    /// BEFORE acquiring `payload_storage` (position 3): resolving the
+    /// schema after the payload guard would invert the documented
+    /// acquisition order to 3 → 1 (see LOCK ORDERING in
+    /// `collection/types.rs`).
+    fn non_schemaless_graph_schema(&self) -> Option<GraphSchema> {
+        match self.storage.config.read().graph_schema.clone() {
+            Some(s) if !s.is_schemaless() => Some(s),
+            _ => None,
+        }
+    }
+
     /// Enforces that both edge endpoints have a stored node payload
     /// (schemaless-mode existence check — see
     /// [`Self::validate_edge_referential_integrity`]). Unlike
     /// [`Self::endpoint_node_type`], this does not require a `_labels`
     /// field — plain (untyped) node payloads are enough.
     ///
-    /// Same check-then-write race as the strict-schema path
-    /// ([`Self::endpoint_node_type`]): the payload-store lock is released
-    /// before the edge is written, so a concurrent `delete()` of an
-    /// endpoint between this check and the write can still land a
-    /// dangling edge. Pre-existing characteristic of this validate-then-
-    /// mutate pattern, not introduced by this check.
+    /// Takes the already-acquired payload-store guard by reference instead
+    /// of re-locking — see the "Concurrency guarantee" section below for
+    /// why a fresh lock acquisition here would be both redundant and unsafe.
+    ///
+    /// # Concurrency guarantee
+    ///
+    /// `add_edge`/`add_edges_batch` hold `payload_storage`'s READ guard from
+    /// this check through the end of the edge write (WAL append + edge-store
+    /// apply). `delete()`'s node-removal path acquires `payload_storage`'s
+    /// WRITE guard before it can remove a payload, so it blocks until that
+    /// read guard is released — by which point the edge is already durable,
+    /// and `delete()`'s own edge cascade (`cascade_delete_node_edges`) will
+    /// see and remove it. This closes the race the previous version of this
+    /// check left open (drop the read guard, THEN write the edge — a
+    /// concurrent delete could interleave in between and land a dangling
+    /// edge). Passing the guard down also avoids a second, nested
+    /// `payload_storage.read()` call from inside the outer guard's scope:
+    /// parking_lot's `RwLock` is not safely re-entrant once a writer is
+    /// queued, so a nested read acquired on the same thread while a writer
+    /// waits would deadlock.
     ///
     /// # Errors
     ///
     /// Returns `Error::NodeNotFound` if `source` or `target` has no stored
     /// payload.
-    fn validate_edge_endpoints_exist(&self, edge: &GraphEdge) -> Result<()> {
+    fn validate_edge_endpoints_exist(payload: &LogPayloadStorage, edge: &GraphEdge) -> Result<()> {
         for node_id in [edge.source(), edge.target()] {
-            if self.get_node_payload(node_id)?.is_none() {
+            if payload.retrieve(node_id)?.is_none() {
                 return Err(Error::NodeNotFound(node_id));
             }
         }
@@ -232,37 +282,49 @@ impl Collection {
     /// In strict mode it additionally verifies that the edge type /
     /// endpoint types satisfy the declared schema.
     ///
+    /// `payload` is the caller's already-acquired `payload_storage` read
+    /// guard (see [`Self::validate_edge_endpoints_exist`]'s concurrency
+    /// guarantee) and `schema` is the caller's [`Self::non_schemaless_graph_schema`]
+    /// result — both resolved by the caller so this function never acquires
+    /// a lock itself.
+    ///
     /// # Errors
     ///
     /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
     /// (strict mode: missing endpoint, no `_labels`, or an edge-type
     /// constraint violation).
-    fn validate_edge_referential_integrity(&self, edge: &GraphEdge) -> Result<()> {
-        let schema = match self.storage.config.read().graph_schema.clone() {
-            Some(s) if !s.is_schemaless() => s,
-            _ => return self.validate_edge_endpoints_exist(edge),
+    fn validate_edge_referential_integrity(
+        payload: &LogPayloadStorage,
+        schema: Option<&GraphSchema>,
+        edge: &GraphEdge,
+    ) -> Result<()> {
+        let Some(schema) = schema else {
+            return Self::validate_edge_endpoints_exist(payload, edge);
         };
 
-        let from_type = self.endpoint_node_type(edge.source())?;
-        let to_type = self.endpoint_node_type(edge.target())?;
+        let from_type = Self::endpoint_node_type(payload, edge.source())?;
+        let to_type = Self::endpoint_node_type(payload, edge.target())?;
         schema.validate_edge_type(edge.label(), &from_type, &to_type)
     }
 
     /// Resolves the node type (first `_labels` entry) for a graph node,
     /// requiring the node to exist and carry a label (strict-mode helper).
     ///
+    /// Takes the already-acquired payload-store guard by reference — see
+    /// [`Self::validate_edge_endpoints_exist`]'s concurrency guarantee.
+    ///
     /// # Errors
     ///
     /// Returns `Error::SchemaValidation` if the node has no stored payload
     /// (referential integrity violation) or the payload declares no `_labels`.
-    fn endpoint_node_type(&self, node_id: u64) -> Result<String> {
-        let payload = self.storage.payload_storage.read().retrieve(node_id)?;
-        let Some(payload) = payload else {
+    fn endpoint_node_type(payload: &LogPayloadStorage, node_id: u64) -> Result<String> {
+        let stored = payload.retrieve(node_id)?;
+        let Some(stored) = stored else {
             return Err(Error::SchemaValidation(format!(
                 "edge references non-existent node {node_id}"
             )));
         };
-        extract_labels(&payload)
+        extract_labels(&stored)
             .into_iter()
             .next()
             .ok_or_else(|| Error::SchemaValidation(format!("node {node_id} has no '_labels' type")))

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -30,6 +30,11 @@ impl Collection {
     /// # Errors
     ///
     /// Returns `Error::EdgeExists` if an edge with the same ID already exists.
+    /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
+    /// (strict schema) if `source` or `target` has no stored node payload —
+    /// an edge to a node that was never created would otherwise be invisible
+    /// to `all_node_ids()` and MATCH (issue #1442), since both derive their
+    /// node set from the payload store, not the edge store.
     ///
     /// # Example
     ///
@@ -40,9 +45,8 @@ impl Collection {
     /// collection.add_edge(edge)?;
     /// ```
     pub fn add_edge(&self, edge: GraphEdge) -> Result<()> {
-        // Strict-schema referential integrity: reject before any mutation so a
-        // violation leaves no partial write and does not bump write_generation.
-        // Schemaless collections (the default) short-circuit at zero added cost.
+        // Reject before any mutation so a violation leaves no partial write
+        // and does not bump write_generation.
         self.validate_edge_referential_integrity(&edge)?;
 
         let edge_id = edge.id();
@@ -93,16 +97,17 @@ impl Collection {
     /// # Errors
     ///
     /// Returns an error if WAL logging fails (fail-closed: the in-memory
-    /// store is not mutated when the WAL append fails).
+    /// store is not mutated when the WAL append fails). Returns
+    /// `Error::NodeNotFound` if any edge's `source` or `target` has no
+    /// stored node payload (see [`Self::add_edge`]).
     pub fn add_edges_batch(&self, edges: Vec<GraphEdge>) -> Result<usize> {
         if edges.is_empty() {
             return Ok(0);
         }
 
-        // Strict-schema referential integrity: validate the ENTIRE batch before
-        // any mutation (WAL append or store write), so a single violating edge
-        // fails the whole batch with no partial write and no orphaned WAL entry.
-        // Schemaless collections (the default) short-circuit at zero added cost.
+        // Validate the ENTIRE batch before any mutation (WAL append or store
+        // write), so a single violating edge fails the whole batch with no
+        // partial write and no orphaned WAL entry.
         for edge in &edges {
             self.validate_edge_referential_integrity(edge)?;
         }
@@ -191,20 +196,45 @@ impl Collection {
         Ok(())
     }
 
-    /// Enforces strict-schema referential integrity for an edge write.
-    ///
-    /// In schemaless mode (the default), this is a no-op and returns
-    /// immediately. In strict mode it verifies that both endpoint nodes exist
-    /// and that the edge type / endpoint types satisfy the declared schema.
+    /// Enforces that both edge endpoints have a stored node payload
+    /// (schemaless-mode existence check — see
+    /// [`Self::validate_edge_referential_integrity`]). Unlike
+    /// [`Self::endpoint_node_type`], this does not require a `_labels`
+    /// field — plain (untyped) node payloads are enough.
     ///
     /// # Errors
     ///
-    /// Returns `Error::SchemaValidation` if an endpoint node is missing, has no
-    /// `_labels`, or the edge violates the schema's edge-type constraints.
+    /// Returns `Error::NodeNotFound` if `source` or `target` has no stored
+    /// payload.
+    fn validate_edge_endpoints_exist(&self, edge: &GraphEdge) -> Result<()> {
+        let storage = self.storage.payload_storage.read();
+        for node_id in [edge.source(), edge.target()] {
+            if storage.retrieve(node_id)?.is_none() {
+                return Err(Error::NodeNotFound(node_id));
+            }
+        }
+        Ok(())
+    }
+
+    /// Enforces referential integrity for an edge write.
+    ///
+    /// In schemaless mode (the default), only endpoint existence is checked
+    /// (`Error::NodeNotFound`) — an edge to a node that was never created
+    /// would otherwise be accepted into the edge store while staying
+    /// invisible to `all_node_ids()` and MATCH, which both resolve their
+    /// node set from the payload store rather than the edge store (#1442).
+    /// In strict mode it additionally verifies that the edge type /
+    /// endpoint types satisfy the declared schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
+    /// (strict mode: missing endpoint, no `_labels`, or an edge-type
+    /// constraint violation).
     fn validate_edge_referential_integrity(&self, edge: &GraphEdge) -> Result<()> {
         let schema = match self.storage.config.read().graph_schema.clone() {
             Some(s) if !s.is_schemaless() => s,
-            _ => return Ok(()),
+            _ => return self.validate_edge_endpoints_exist(edge),
         };
 
         let from_type = self.endpoint_node_type(edge.source())?;

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -20,6 +20,17 @@ mod tests {
         GraphEdge::new(id, source, target, label).expect("edge should be valid")
     }
 
+    /// Test helper: stores empty payloads for both edge endpoints, then adds
+    /// the edge. Schemaless `add_edge` requires endpoints to already exist
+    /// (#1442), so tests that only care about edge/traversal mechanics use
+    /// this instead of spelling out `store_node_payload` per endpoint.
+    fn add_edge_with_nodes(collection: &Collection, edge: GraphEdge) -> crate::error::Result<()> {
+        for node_id in [edge.source(), edge.target()] {
+            collection.store_node_payload(node_id, &serde_json::json!({}))?;
+        }
+        collection.add_edge(edge)
+    }
+
     // =========================================================================
     // Edge CRUD
     // =========================================================================
@@ -28,7 +39,7 @@ mod tests {
     fn test_add_edge_success() {
         let (collection, _temp) = create_test_collection();
         let edge = make_edge(1, 100, 200, "KNOWS");
-        assert!(collection.add_edge(edge).is_ok());
+        assert!(add_edge_with_nodes(&collection, edge).is_ok());
         assert_eq!(
             collection.edge_count(),
             1,
@@ -39,10 +50,9 @@ mod tests {
     #[test]
     fn test_add_duplicate_edge_fails() {
         let (collection, _temp) = create_test_collection();
-        collection
-            .add_edge(make_edge(1, 100, 200, "KNOWS"))
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"))
             .unwrap();
-        let result = collection.add_edge(make_edge(1, 100, 200, "KNOWS"));
+        let result = add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"));
         assert!(result.is_err(), "duplicate edge ID should return error");
     }
 
@@ -55,15 +65,15 @@ mod tests {
     #[test]
     fn test_edge_count_after_adding() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 2, 3, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 2, 3, "KNOWS")).unwrap();
         assert_eq!(collection.edge_count(), 2);
     }
 
     #[test]
     fn test_remove_edge_existing() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
         assert!(collection.remove_edge(1), "should return true when removed");
         assert_eq!(collection.edge_count(), 0);
     }
@@ -90,8 +100,8 @@ mod tests {
     #[test]
     fn test_get_all_edges_returns_all() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 2, 3, "LIKES")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 2, 3, "LIKES")).unwrap();
         let edges = collection.get_all_edges();
         assert_eq!(edges.len(), 2);
     }
@@ -99,9 +109,9 @@ mod tests {
     #[test]
     fn test_get_edges_by_label_matching() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 1, 3, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(3, 1, 4, "LIKES")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 1, 3, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 1, 4, "LIKES")).unwrap();
 
         let knows = collection.get_edges_by_label("KNOWS");
         assert_eq!(knows.len(), 2);
@@ -111,7 +121,7 @@ mod tests {
     #[test]
     fn test_get_edges_by_label_no_match() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
         let result = collection.get_edges_by_label("NONEXISTENT");
         assert!(result.is_empty());
     }
@@ -119,9 +129,9 @@ mod tests {
     #[test]
     fn test_get_outgoing_edges() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 10, 20, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 10, 30, "LIKES")).unwrap();
-        collection.add_edge(make_edge(3, 20, 30, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 10, 20, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 10, 30, "LIKES")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 20, 30, "KNOWS")).unwrap();
 
         let outgoing = collection.get_outgoing_edges(10);
         assert_eq!(outgoing.len(), 2);
@@ -137,9 +147,9 @@ mod tests {
     #[test]
     fn test_get_incoming_edges() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 10, 30, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 20, 30, "LIKES")).unwrap();
-        collection.add_edge(make_edge(3, 10, 20, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 10, 30, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 20, 30, "LIKES")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 10, 20, "KNOWS")).unwrap();
 
         let incoming = collection.get_incoming_edges(30);
         assert_eq!(incoming.len(), 2);
@@ -167,8 +177,8 @@ mod tests {
     #[test]
     fn test_get_node_degree_out_only() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 1, 3, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 1, 3, "KNOWS")).unwrap();
         let (in_deg, out_deg) = collection.get_node_degree(1);
         assert_eq!(in_deg, 0);
         assert_eq!(out_deg, 2);
@@ -177,8 +187,8 @@ mod tests {
     #[test]
     fn test_get_node_degree_in_only() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 2, 5, "KNOWS")).unwrap();
-        collection.add_edge(make_edge(2, 3, 5, "LIKES")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 2, 5, "KNOWS")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 3, 5, "LIKES")).unwrap();
         let (in_deg, out_deg) = collection.get_node_degree(5);
         assert_eq!(in_deg, 2);
         assert_eq!(out_deg, 0);
@@ -187,9 +197,9 @@ mod tests {
     #[test]
     fn test_get_node_degree_both() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 10, 20, "A")).unwrap();
-        collection.add_edge(make_edge(2, 30, 20, "B")).unwrap();
-        collection.add_edge(make_edge(3, 20, 40, "C")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 10, 20, "A")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 30, 20, "B")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 20, 40, "C")).unwrap();
         let (in_deg, out_deg) = collection.get_node_degree(20);
         assert_eq!(in_deg, 2);
         assert_eq!(out_deg, 1);
@@ -201,9 +211,9 @@ mod tests {
 
     fn build_chain(collection: &Collection) {
         // 1 -> 2 -> 3 -> 4
-        collection.add_edge(make_edge(1, 1, 2, "NEXT")).unwrap();
-        collection.add_edge(make_edge(2, 2, 3, "NEXT")).unwrap();
-        collection.add_edge(make_edge(3, 3, 4, "NEXT")).unwrap();
+        add_edge_with_nodes(collection, make_edge(1, 1, 2, "NEXT")).unwrap();
+        add_edge_with_nodes(collection, make_edge(2, 2, 3, "NEXT")).unwrap();
+        add_edge_with_nodes(collection, make_edge(3, 3, 4, "NEXT")).unwrap();
     }
 
     #[test]
@@ -229,8 +239,8 @@ mod tests {
     #[test]
     fn test_traverse_bfs_label_filter() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "NEXT")).unwrap();
-        collection.add_edge(make_edge(2, 1, 3, "OTHER")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 1, 3, "OTHER")).unwrap();
 
         let results = collection.traverse_bfs(1, 3, Some(&["NEXT"]), 100).unwrap();
         assert_eq!(results.len(), 1);
@@ -263,9 +273,9 @@ mod tests {
     fn test_traverse_bfs_no_cycles() {
         let (collection, _temp) = create_test_collection();
         // Cycle: 1 -> 2 -> 3 -> 1
-        collection.add_edge(make_edge(1, 1, 2, "A")).unwrap();
-        collection.add_edge(make_edge(2, 2, 3, "A")).unwrap();
-        collection.add_edge(make_edge(3, 3, 1, "A")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "A")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 2, 3, "A")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 3, 1, "A")).unwrap();
 
         let results = collection.traverse_bfs(1, 10, None, 100).unwrap();
         // Should visit 2 and 3, but not revisit 1
@@ -297,8 +307,8 @@ mod tests {
     #[test]
     fn test_traverse_dfs_label_filter() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "NEXT")).unwrap();
-        collection.add_edge(make_edge(2, 1, 3, "OTHER")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 1, 3, "OTHER")).unwrap();
 
         let results = collection.traverse_dfs(1, 3, Some(&["NEXT"]), 100).unwrap();
         assert_eq!(results.len(), 1);
@@ -376,8 +386,8 @@ mod tests {
     #[test]
     fn test_traverse_dfs_config_rel_filter() {
         let (collection, _temp) = create_test_collection();
-        collection.add_edge(make_edge(1, 1, 2, "NEXT")).unwrap();
-        collection.add_edge(make_edge(2, 1, 3, "OTHER")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 1, 3, "OTHER")).unwrap();
 
         let config = TraversalConfig {
             max_depth: 2,
@@ -519,10 +529,10 @@ mod tests {
     fn test_traverse_bfs_parallel_multiple_starts() {
         let (collection, _temp) = create_test_collection();
         // Two separate chains: 1->2->3 and 10->20->30
-        collection.add_edge(make_edge(1, 1, 2, "NEXT")).unwrap();
-        collection.add_edge(make_edge(2, 2, 3, "NEXT")).unwrap();
-        collection.add_edge(make_edge(10, 10, 20, "NEXT")).unwrap();
-        collection.add_edge(make_edge(20, 20, 30, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 1, 2, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 2, 3, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(10, 10, 20, "NEXT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(20, 20, 30, "NEXT")).unwrap();
 
         let config = TraversalConfig {
             max_depth: 2,
@@ -629,8 +639,7 @@ mod tests {
         collection
             .store_node_payload(200, &serde_json::json!({"name": "B"}))
             .unwrap();
-        collection
-            .add_edge(make_edge(1, 100, 200, "KNOWS"))
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"))
             .unwrap();
         assert_eq!(collection.edge_count(), 1);
 
@@ -657,11 +666,11 @@ mod tests {
         // A -> B and C -> B; deleting B must remove BOTH edges (outgoing from
         // others into B, i.e. incoming on the deleted node).
         let (collection, _temp) = create_graph_test_collection();
-        collection.add_edge(make_edge(1, 100, 200, "OUT")).unwrap();
-        collection.add_edge(make_edge(2, 300, 200, "IN")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "OUT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 300, 200, "IN")).unwrap();
         // Also an outgoing edge from B so we cover both directions on the
         // deleted node itself.
-        collection.add_edge(make_edge(3, 200, 400, "OUT")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(3, 200, 400, "OUT")).unwrap();
         assert_eq!(collection.edge_count(), 3);
 
         collection.delete(&[200]).unwrap();
@@ -680,8 +689,8 @@ mod tests {
     #[test]
     fn test_delete_node_does_not_touch_unrelated_edges() {
         let (collection, _temp) = create_graph_test_collection();
-        collection.add_edge(make_edge(1, 100, 200, "A")).unwrap();
-        collection.add_edge(make_edge(2, 300, 400, "B")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "A")).unwrap();
+        add_edge_with_nodes(&collection, make_edge(2, 300, 400, "B")).unwrap();
 
         collection.delete(&[100]).unwrap();
 
@@ -701,9 +710,7 @@ mod tests {
         for src in 0..n {
             for step in 1..=fanout {
                 let dst = (src + step) % n;
-                collection
-                    .add_edge(make_edge(edge_id, src, dst, "E"))
-                    .unwrap();
+                add_edge_with_nodes(collection, make_edge(edge_id, src, dst, "E")).unwrap();
                 edge_id += 1;
             }
         }
@@ -752,12 +759,17 @@ mod tests {
         use rustc_hash::{FxHashMap, FxHashSet};
 
         let (collection, _temp) = create_graph_test_collection();
-        // Hub node 0 with 5_000 distinct out-edges.
+        // Hub node 0 with 5_000 distinct out-edges. Bulk-create all endpoint
+        // payloads in one upsert (single fsync) rather than fanout individual
+        // store_node_payload calls (one WAL fsync each — a real hotspot at
+        // this scale, see test_dfs_hub_stays_bounded_and_terminates).
         let fanout = 5_000u64;
+        let nodes: Vec<crate::point::Point> = (0..=fanout)
+            .map(|id| crate::point::Point::metadata_only(id, serde_json::json!({})))
+            .collect();
+        collection.upsert(nodes).expect("bulk-create nodes");
         for t in 1..=fanout {
-            collection
-                .add_edge(make_edge(t, 0, t, "E"))
-                .expect("add edge");
+            collection.add_edge(make_edge(t, 0, t, "E")).expect("add edge");
         }
 
         let rel_filter: FxHashSet<&str> = FxHashSet::default();
@@ -800,11 +812,15 @@ mod tests {
         // no depth-2 node, so with min_depth=2 the result is empty even though
         // the hub queues thousands of neighbors at push time.
         let (collection, _temp) = create_graph_test_collection();
+        // Bulk-create endpoint payloads in one upsert (see
+        // test_expand_dfs_neighbors_bounds_push_growth for why).
         let fanout = 20_000u64;
+        let nodes: Vec<crate::point::Point> = (0..=fanout)
+            .map(|id| crate::point::Point::metadata_only(id, serde_json::json!({})))
+            .collect();
+        collection.upsert(nodes).expect("bulk-create nodes");
         for t in 1..=fanout {
-            collection
-                .add_edge(make_edge(t, 0, t, "E"))
-                .expect("add edge");
+            collection.add_edge(make_edge(t, 0, t, "E")).expect("add edge");
         }
 
         let config = TraversalConfig {
@@ -929,13 +945,31 @@ mod tests {
     }
 
     #[test]
-    fn test_schemaless_mode_allows_dangling_edge() {
-        // Regression guard: default schemaless path is unchanged — no endpoint
-        // payloads, arbitrary edge label, still accepted.
+    fn test_schemaless_mode_rejects_dangling_edge() {
+        // Regression guard (#1442): endpoint existence is required regardless
+        // of schema strictness — a dangling edge would otherwise be invisible
+        // to all_node_ids()/MATCH, which both resolve nodes from the payload
+        // store rather than the edge store.
+        let (collection, _temp) = create_graph_test_collection();
+        let err = collection
+            .add_edge(make_edge(1, 100, 200, "ANY_REL"))
+            .expect_err("schemaless collection must reject edges to non-existent nodes");
+        assert!(matches!(err, crate::error::Error::NodeNotFound(100)));
+        assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
+    }
+
+    #[test]
+    fn test_schemaless_mode_allows_edge_between_existing_nodes() {
         let (collection, _temp) = create_graph_test_collection();
         collection
+            .store_node_payload(100, &serde_json::json!({}))
+            .expect("store node 100");
+        collection
+            .store_node_payload(200, &serde_json::json!({}))
+            .expect("store node 200");
+        collection
             .add_edge(make_edge(1, 100, 200, "ANY_REL"))
-            .expect("schemaless collection must accept dangling edges");
+            .expect("edge between existing nodes must be accepted");
         assert_eq!(collection.edge_count(), 1);
     }
 
@@ -985,15 +1019,38 @@ mod tests {
     }
 
     #[test]
-    fn test_schemaless_batch_allows_dangling_edges() {
-        // Regression guard: schemaless batch path unchanged.
+    fn test_schemaless_batch_rejects_dangling_edges() {
+        // Regression guard (#1442): batch endpoint existence is required
+        // regardless of schema strictness (see test_schemaless_mode_rejects_dangling_edge).
         let (collection, _temp) = create_graph_test_collection();
+        let err = collection
+            .add_edges_batch(vec![
+                make_edge(1, 100, 200, "ANY_REL"),
+                make_edge(2, 300, 400, "OTHER_REL"),
+            ])
+            .expect_err("schemaless batch must reject edges to non-existent nodes");
+        assert!(matches!(err, crate::error::Error::NodeNotFound(100)));
+        assert_eq!(
+            collection.edge_count(),
+            0,
+            "a violating edge must fail the whole batch with no partial write"
+        );
+    }
+
+    #[test]
+    fn test_schemaless_batch_allows_edges_between_existing_nodes() {
+        let (collection, _temp) = create_graph_test_collection();
+        for id in [100, 200, 300, 400] {
+            collection
+                .store_node_payload(id, &serde_json::json!({}))
+                .expect("store node");
+        }
         let added = collection
             .add_edges_batch(vec![
                 make_edge(1, 100, 200, "ANY_REL"),
                 make_edge(2, 300, 400, "OTHER_REL"),
             ])
-            .expect("schemaless collection must accept dangling edges in batch");
+            .expect("batch between existing nodes must be accepted");
         assert_eq!(added, 2);
         assert_eq!(collection.edge_count(), 2);
     }

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -704,11 +704,21 @@ mod tests {
     /// Builds a dense, highly-connected cyclic graph: every node points to the
     /// next `fanout` nodes (mod `n`), creating many cycles and a large frontier.
     fn build_dense_cyclic_graph(collection: &Collection, n: u64, fanout: u64) {
+        // Bulk-create all n node payloads in one upsert (single fsync)
+        // rather than re-storing each node's payload on every edge that
+        // touches it (up to `fanout` redundant WAL fsyncs per node).
+        let nodes: Vec<crate::point::Point> = (0..n)
+            .map(|id| crate::point::Point::metadata_only(id, serde_json::json!({})))
+            .collect();
+        collection.upsert(nodes).expect("bulk-create nodes");
+
         let mut edge_id = 1u64;
         for src in 0..n {
             for step in 1..=fanout {
                 let dst = (src + step) % n;
-                add_edge_with_nodes(collection, make_edge(edge_id, src, dst, "E")).unwrap();
+                collection
+                    .add_edge(make_edge(edge_id, src, dst, "E"))
+                    .unwrap();
                 edge_id += 1;
             }
         }
@@ -956,6 +966,35 @@ mod tests {
         let err = collection
             .add_edge(make_edge(1, 100, 200, "ANY_REL"))
             .expect_err("schemaless collection must reject edges to non-existent nodes");
+        assert!(matches!(err, crate::error::Error::NodeNotFound(100)));
+        assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
+    }
+
+    #[test]
+    fn test_schemaless_mode_rejects_edge_with_only_source_existing() {
+        // Regression guard (#1442): validate_edge_endpoints_exist checks
+        // BOTH endpoints — a partially-satisfied edge (only source stored)
+        // must still be rejected, naming the missing target.
+        let (collection, _temp) = create_graph_test_collection();
+        collection
+            .store_node_payload(100, &serde_json::json!({}))
+            .expect("store source node");
+        let err = collection
+            .add_edge(make_edge(1, 100, 200, "ANY_REL"))
+            .expect_err("edge with a missing target must be rejected");
+        assert!(matches!(err, crate::error::Error::NodeNotFound(200)));
+        assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
+    }
+
+    #[test]
+    fn test_schemaless_mode_rejects_edge_with_only_target_existing() {
+        let (collection, _temp) = create_graph_test_collection();
+        collection
+            .store_node_payload(200, &serde_json::json!({}))
+            .expect("store target node");
+        let err = collection
+            .add_edge(make_edge(1, 100, 200, "ANY_REL"))
+            .expect_err("edge with a missing source must be rejected");
         assert!(matches!(err, crate::error::Error::NodeNotFound(100)));
         assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
     }

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -1189,4 +1189,145 @@ mod tests {
             "failed write must leave no payload behind"
         );
     }
+
+    // =========================================================================
+    // Race regression (#1442 re-fix): a concurrent delete() of an edge
+    // endpoint must never leave a phantom edge (edge present in the store,
+    // endpoint payload gone). Deterministic interleaving: the test thread
+    // holds `edge_wal_lock` itself so the writer (add_edge/add_edges_batch)
+    // parks on it; post-fix the writer still holds `payload_storage`'s read
+    // guard while parked there, so a racing delete() must block instead of
+    // running ahead.
+    // =========================================================================
+
+    /// Runs one race iteration. `write` performs the edge write (via
+    /// `add_edge` or `add_edges_batch`) on a fresh collection seeded with
+    /// `source`/`target` payloads. Returns `(delete_raced_ahead, is_phantom)`:
+    /// pre-fix, `delete()` is not blocked by the writer (raced ahead = true)
+    /// and can produce a phantom edge; post-fix `delete()` must block on
+    /// `payload_storage` until the writer finishes.
+    fn race_write_vs_delete_iteration(
+        iteration: u64,
+        edge_id: u64,
+        write: impl FnOnce(&Collection, GraphEdge) -> crate::error::Result<()> + Send + 'static,
+    ) -> (bool, bool) {
+        let (collection, _temp) = create_graph_test_collection();
+        let source = iteration * 10 + 1;
+        let target = iteration * 10 + 2;
+        collection
+            .store_node_payload(source, &serde_json::json!({}))
+            .expect("seed source");
+        collection
+            .store_node_payload(target, &serde_json::json!({}))
+            .expect("seed target");
+        let collection = std::sync::Arc::new(collection);
+
+        // Hold the WAL lock from the test thread so the writer parks on it
+        // right after (post-fix) or well after releasing payload_storage
+        // (pre-fix).
+        let wal_guard = collection.graph.edge_wal_lock.lock();
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel::<()>();
+        let c1 = std::sync::Arc::clone(&collection);
+        let edge = make_edge(edge_id, source, target, "REL");
+        let t1 = std::thread::spawn(move || {
+            started_tx.send(()).ok();
+            write(&c1, edge)
+        });
+        started_rx.recv().expect("writer thread should start");
+        std::thread::sleep(std::time::Duration::from_millis(30));
+
+        let c2 = std::sync::Arc::clone(&collection);
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let t2 = std::thread::spawn(move || {
+            let _ = c2.delete(&[source]);
+            done_tx.send(()).ok();
+        });
+        let delete_raced_ahead = done_rx
+            .recv_timeout(std::time::Duration::from_millis(300))
+            .is_ok();
+
+        drop(wal_guard);
+        t1.join().expect("writer thread must not panic").ok();
+        t2.join().expect("delete thread must not panic");
+
+        let edge_exists = collection.edge_exists(edge_id);
+        let payload_present = collection
+            .get_node_payload(source)
+            .expect("retrieve must not error")
+            .is_some();
+        (delete_raced_ahead, edge_exists && !payload_present)
+    }
+
+    #[test]
+    fn add_edge_concurrent_delete_never_leaves_phantom_edge() {
+        for i in 0..10 {
+            let (delete_raced_ahead, is_phantom) =
+                race_write_vs_delete_iteration(i, i, |c, edge| c.add_edge(edge));
+            assert!(
+                !delete_raced_ahead,
+                "iteration {i}: delete() must block on payload_storage while \
+                 add_edge holds its read guard through the WAL pause"
+            );
+            assert!(
+                !is_phantom,
+                "iteration {i}: phantom edge — edge exists but endpoint payload is gone"
+            );
+        }
+    }
+
+    #[test]
+    fn add_edges_batch_concurrent_delete_never_leaves_phantom_edge() {
+        for i in 0..10 {
+            let (delete_raced_ahead, is_phantom) = race_write_vs_delete_iteration(i, i, |c, edge| {
+                c.add_edges_batch(vec![edge]).map(|_| ())
+            });
+            assert!(
+                !delete_raced_ahead,
+                "iteration {i}: delete() must block on payload_storage while \
+                 add_edges_batch holds its read guard through the WAL pause"
+            );
+            assert!(
+                !is_phantom,
+                "iteration {i}: phantom edge — edge exists but endpoint payload is gone"
+            );
+        }
+    }
+
+    #[test]
+    fn stress_add_edge_concurrent_delete_never_leaves_phantom_edge() {
+        // Probabilistic filet (pattern: edge_concurrent_tests.rs) — no forced
+        // rendezvous, just many yield_now-interleaved iterations to catch the
+        // race by chance in addition to the deterministic tests above.
+        for i in 0..2_000u64 {
+            let (collection, _temp) = create_graph_test_collection();
+            let source = i * 10 + 1;
+            let target = i * 10 + 2;
+            collection
+                .store_node_payload(source, &serde_json::json!({}))
+                .expect("seed source");
+            collection
+                .store_node_payload(target, &serde_json::json!({}))
+                .expect("seed target");
+            let collection = std::sync::Arc::new(collection);
+
+            let c1 = std::sync::Arc::clone(&collection);
+            let edge = make_edge(i, source, target, "REL");
+            let h1 = std::thread::spawn(move || {
+                std::thread::yield_now();
+                let _ = c1.add_edge(edge);
+            });
+            let c2 = std::sync::Arc::clone(&collection);
+            let h2 = std::thread::spawn(move || {
+                std::thread::yield_now();
+                let _ = c2.delete(&[source]);
+            });
+            h1.join().expect("add_edge thread must not panic");
+            h2.join().expect("delete thread must not panic");
+
+            let is_phantom =
+                collection.edge_exists(i) && collection.get_node_payload(source).unwrap().is_none();
+            assert!(!is_phantom, "iteration {i}: phantom edge under stress");
+        }
+    }
 }

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -1263,7 +1263,7 @@ mod tests {
     fn add_edge_concurrent_delete_never_leaves_phantom_edge() {
         for i in 0..10 {
             let (delete_raced_ahead, is_phantom) =
-                race_write_vs_delete_iteration(i, i, |c, edge| c.add_edge(edge));
+                race_write_vs_delete_iteration(i, i, Collection::add_edge);
             assert!(
                 !delete_raced_ahead,
                 "iteration {i}: delete() must block on payload_storage while \
@@ -1279,9 +1279,10 @@ mod tests {
     #[test]
     fn add_edges_batch_concurrent_delete_never_leaves_phantom_edge() {
         for i in 0..10 {
-            let (delete_raced_ahead, is_phantom) = race_write_vs_delete_iteration(i, i, |c, edge| {
-                c.add_edges_batch(vec![edge]).map(|_| ())
-            });
+            let (delete_raced_ahead, is_phantom) =
+                race_write_vs_delete_iteration(i, i, |c, edge| {
+                    c.add_edges_batch(vec![edge]).map(|_| ())
+                });
             assert!(
                 !delete_raced_ahead,
                 "iteration {i}: delete() must block on payload_storage while \

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -50,8 +50,7 @@ mod tests {
     #[test]
     fn test_add_duplicate_edge_fails() {
         let (collection, _temp) = create_test_collection();
-        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"))
-            .unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS")).unwrap();
         let result = add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"));
         assert!(result.is_err(), "duplicate edge ID should return error");
     }
@@ -639,8 +638,7 @@ mod tests {
         collection
             .store_node_payload(200, &serde_json::json!({"name": "B"}))
             .unwrap();
-        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS"))
-            .unwrap();
+        add_edge_with_nodes(&collection, make_edge(1, 100, 200, "KNOWS")).unwrap();
         assert_eq!(collection.edge_count(), 1);
 
         collection.delete(&[100]).unwrap();
@@ -769,7 +767,9 @@ mod tests {
             .collect();
         collection.upsert(nodes).expect("bulk-create nodes");
         for t in 1..=fanout {
-            collection.add_edge(make_edge(t, 0, t, "E")).expect("add edge");
+            collection
+                .add_edge(make_edge(t, 0, t, "E"))
+                .expect("add edge");
         }
 
         let rel_filter: FxHashSet<&str> = FxHashSet::default();
@@ -820,7 +820,9 @@ mod tests {
             .collect();
         collection.upsert(nodes).expect("bulk-create nodes");
         for t in 1..=fanout {
-            collection.add_edge(make_edge(t, 0, t, "E")).expect("add edge");
+            collection
+                .add_edge(make_edge(t, 0, t, "E"))
+                .expect("add edge");
         }
 
         let config = TraversalConfig {

--- a/crates/velesdb-core/src/collection/core/graph_edge_wal_recovery_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_edge_wal_recovery_tests.rs
@@ -37,13 +37,16 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [356, 200, 300] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
+            coll.store_node_payload(100, &serde_json::json!({"name": "A"}))
+                .unwrap();
             // Same-shard edge (source 100, target 356 → both shard 100).
             coll.add_edge(make_edge(1, 100, 356, "KNOWS")).unwrap();
             // Cross-shard edge (source 100 → shard 100, target 200 → shard 200).
             coll.add_edge(make_edge(2, 100, 200, "KNOWS")).unwrap();
             coll.add_edge(make_edge(3, 200, 300, "FOLLOWS")).unwrap();
-            coll.store_node_payload(100, &serde_json::json!({"name": "A"}))
-                .unwrap();
             // DROP without flush → edge_store.bin is never written (crash sim).
         }
 
@@ -66,6 +69,9 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [1, 2, 3, 4] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
             coll.add_edge(make_edge(1, 1, 2, "KNOWS")).unwrap();
             coll.add_edge(make_edge(2, 2, 3, "KNOWS")).unwrap();
             coll.add_edge(make_edge(3, 3, 4, "KNOWS")).unwrap();
@@ -86,6 +92,9 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [60, 70, 80, 90] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
             coll.store_node_payload(50, &serde_json::json!({"n": "N"}))
                 .unwrap();
             coll.add_edge(make_edge(1, 50, 60, "E")).unwrap();
@@ -110,6 +119,11 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            let nodes: Vec<crate::point::Point> = (0..50)
+                .flat_map(|i| [i, i + 1000])
+                .map(|id| crate::point::Point::metadata_only(id, serde_json::json!({})))
+                .collect();
+            coll.upsert(nodes).unwrap();
             let edges: Vec<GraphEdge> = (0..50)
                 .map(|i| make_edge(i, i, i + 1000, "BATCH"))
                 .collect();
@@ -129,6 +143,9 @@ mod tests {
         let wal = path.join("edges.wal");
 
         let coll = create_graph(path.clone());
+        for id in [1, 2, 3, 4] {
+            coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+        }
         coll.add_edge(make_edge(1, 1, 2, "A")).unwrap();
         coll.add_edge(make_edge(2, 2, 3, "A")).unwrap();
         assert!(wal.metadata().unwrap().len() > 0, "WAL has entries");
@@ -158,6 +175,9 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [1, 2] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
             coll.add_edge(make_edge(1, 1, 2, "L")).unwrap();
             coll.flush_full().unwrap();
         }
@@ -178,6 +198,9 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [1, 2] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
             coll.add_edge(make_edge(1, 1, 2, "T")).unwrap();
         }
         // Append a truncated partial entry: a length prefix declaring 32
@@ -200,6 +223,9 @@ mod tests {
 
         {
             let coll = create_graph(path.clone());
+            for id in [1, 2] {
+                coll.store_node_payload(id, &serde_json::json!({})).unwrap();
+            }
             let mut props = HashMap::new();
             props.insert("weight".to_string(), serde_json::json!(42));
             let edge = make_edge(1, 1, 2, "WEIGHTED").with_properties(props);

--- a/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_tests.rs
@@ -395,9 +395,9 @@ fn test_open_without_edge_store_bin_recovers_gracefully() {
     let col_path = temp_dir.path().join("graph_col");
 
     // 1. Create a graph collection, flush to persist config.json, then drop.
-    //    Schemaless: this test exercises edge_store.bin recovery, not strict
-    //    referential-integrity enforcement (which would reject this dangling
-    //    edge with no endpoint node payloads).
+    //    Schemaless: this test exercises edge_store.bin recovery, not
+    //    referential-integrity enforcement, so endpoint nodes are created
+    //    explicitly first (add_edge now requires them to exist, #1442).
     {
         let schema = GraphSchema::schemaless();
         let collection = Collection::create_graph_collection(
@@ -409,6 +409,11 @@ fn test_open_without_edge_store_bin_recovers_gracefully() {
         )
         .expect("graph collection should be created");
 
+        for id in [100, 200] {
+            collection
+                .store_node_payload(id, &serde_json::json!({}))
+                .expect("store node payload should succeed");
+        }
         let edge = GraphEdge::new(1, 100, 200, "KNOWS").expect("valid edge");
         collection.add_edge(edge).expect("add edge should succeed");
 
@@ -440,6 +445,11 @@ fn test_open_without_edge_store_bin_recovers_gracefully() {
     );
 
     // 5. Graph operations must work on the recovered collection.
+    for id in [1, 2] {
+        reopened
+            .store_node_payload(id, &serde_json::json!({}))
+            .expect("store node payload should succeed");
+    }
     let edge_a = GraphEdge::new(10, 1, 2, "LIKES").expect("valid edge");
     reopened
         .add_edge(edge_a)

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -494,6 +494,9 @@ mod tests {
         let (_dir, col) = make_test_collection(None);
 
         assert_eq!(col.edge_count(), 0);
+        for id in [10, 20, 30] {
+            col.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
 
         let edge1 = crate::collection::graph::GraphEdge::new(1, 10, 20, "knows").unwrap();
         col.add_edge(edge1).unwrap();
@@ -509,6 +512,9 @@ mod tests {
         let (_dir, col) = make_test_collection(None);
 
         // Build chain: 1->2->3
+        for id in [1, 2, 3] {
+            col.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
         col.add_edge(GraphEdge::new(1, 1, 2, "NEXT").unwrap())
             .unwrap();
         col.add_edge(GraphEdge::new(2, 2, 3, "NEXT").unwrap())
@@ -579,6 +585,9 @@ mod tests {
     fn test_has_edge_and_remove_edge() {
         let (_dir, col) = make_test_collection(None);
         assert!(!col.has_edge(7), "unknown edge id is absent");
+        for id in [10, 20] {
+            col.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
 
         col.add_edge(GraphEdge::new(7, 10, 20, "KNOWS").unwrap())
             .unwrap();
@@ -606,6 +615,9 @@ mod tests {
     #[test]
     fn test_get_edges_filtered_by_label() {
         let (_dir, col) = make_test_collection(None);
+        for id in [10, 20, 30, 40] {
+            col.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
         col.add_edge(GraphEdge::new(1, 10, 20, "KNOWS").unwrap())
             .unwrap();
         col.add_edge(GraphEdge::new(2, 20, 30, "LIKES").unwrap())
@@ -624,6 +636,9 @@ mod tests {
     #[test]
     fn test_node_degree_and_directional_edges() {
         let (_dir, col) = make_test_collection(None);
+        for id in [10, 20, 30, 40] {
+            col.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
         col.add_edge(GraphEdge::new(1, 10, 20, "NEXT").unwrap())
             .unwrap();
         col.add_edge(GraphEdge::new(2, 30, 20, "NEXT").unwrap())
@@ -688,6 +703,7 @@ mod tests {
         let (_dir, col) = make_test_collection(None);
         col.upsert_node_payload(1, &serde_json::json!({"k": 1}))
             .unwrap();
+        col.upsert_node_payload(2, &serde_json::json!({})).unwrap();
         col.add_edge(GraphEdge::new(1, 1, 2, "NEXT").unwrap())
             .unwrap();
         col.flush().expect("fast-path flush succeeds");
@@ -709,6 +725,7 @@ mod tests {
             .unwrap();
             col.upsert_node_payload(1, &serde_json::json!({"name": "A"}))
                 .unwrap();
+            col.upsert_node_payload(2, &serde_json::json!({})).unwrap();
             col.add_edge(GraphEdge::new(5, 1, 2, "NEXT").unwrap())
                 .unwrap();
             col.flush_full().unwrap();

--- a/crates/velesdb-core/src/collection/tests.rs
+++ b/crates/velesdb-core/src/collection/tests.rs
@@ -1428,6 +1428,11 @@ fn test_traverse_bfs_config_respects_min_depth() {
     )
     .unwrap();
 
+    for id in [1, 2, 3] {
+        collection
+            .store_node_payload(id, &serde_json::json!({}))
+            .unwrap();
+    }
     collection
         .add_edge(crate::collection::graph::GraphEdge::new(100, 1, 2, "KNOWS").unwrap())
         .unwrap();
@@ -1456,6 +1461,11 @@ fn test_legacy_traverse_paths_use_edge_ids() {
     )
     .unwrap();
 
+    for id in [1, 2, 3] {
+        collection
+            .store_node_payload(id, &serde_json::json!({}))
+            .unwrap();
+    }
     collection
         .add_edge(crate::collection::graph::GraphEdge::new(100, 1, 2, "KNOWS").unwrap())
         .unwrap();

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -189,6 +189,8 @@ impl Default for RuntimeLimits {
 //   1b. payload_mirror   (held while acquiring 2 and 3 during the lazy build)
 //   2. vector_storage
 //   3. payload_storage
+//   3b. edge_wal_lock    (see below — sometimes nested inside 3, sometimes
+//                          acquired alone)
 //   4. sq8_cache / binary_cache / pq_cache  (any order among themselves)
 //   5. pq_quantizer → pq_training_buffer
 //   6. secondary_indexes
@@ -198,6 +200,19 @@ impl Default for RuntimeLimits {
 //  10. delta_buffer
 //  11. deferred_indexer / async_index_builder (internal locks)
 //  12. stats_io_mutex                         (disk I/O only, no other lock held)
+//
+// `edge_wal_lock` (3b) has two call patterns, both consistent with 3 → 3b:
+//   - `add_edge`/`add_edges_batch` (collection/core/graph_api.rs) acquire it
+//     WHILE STILL HOLDING `payload_storage`'s read guard (see those
+//     functions' rustdoc for the concurrency guarantee this gives —
+//     `docs/CONCURRENCY_MODEL.md`'s "Collection-level lock order" section
+//     has the full narrative).
+//   - `remove_edge` and the delete-cascade path
+//     (collection/core/crud_read_delete.rs) acquire it ALONE, with no other
+//     collection lock held (the delete path has already dropped its
+//     `payload_storage` write guard by the time it reaches the cascade).
+// Neither path ever acquires `payload_storage` while already holding
+// `edge_wal_lock` — the order stays acyclic.
 
 /// Vector + payload storage, quantization caches and the columnar mirror.
 ///
@@ -338,9 +353,14 @@ pub(crate) struct GraphStore {
     /// like live execution) and concurrent appends cannot interleave one
     /// entry's bytes.
     ///
-    /// Lock order position: **7c** — acquired with no other collection lock
-    /// held; the edge store's internal `edge_ids → shards` chain is acquired
-    /// while holding it.
+    /// Lock order position: **3b**. `add_edge`/`add_edges_batch` acquire it
+    /// while still holding `payload_storage`'s (3) read guard, so a
+    /// concurrent `delete()` of an endpoint — which needs `payload_storage`'s
+    /// WRITE guard — blocks until the edge write finishes (see those
+    /// functions' rustdoc in `collection/core/graph_api.rs`). `remove_edge`
+    /// and the delete-cascade path acquire it alone, with no other
+    /// collection lock held. The edge store's internal `edge_ids → shards`
+    /// chain is acquired while holding it in both cases.
     pub(super) edge_wal_lock: Arc<Mutex<()>>,
 }
 

--- a/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
@@ -12,6 +12,7 @@ use tempfile::TempDir;
 
 use crate::collection::graph::{GraphEdge, TraversalConfig};
 use crate::distance::DistanceMetric;
+use crate::point::Point;
 use crate::quantization::StorageMode;
 use crate::VectorCollection;
 
@@ -27,6 +28,11 @@ fn create_test_vc() -> (VectorCollection, TempDir) {
 #[test]
 fn test_traverse_bfs_reaches_edges_added_via_shared_edge_store() {
     let (coll, _dir) = create_test_vc();
+
+    for id in [1u64, 2, 3] {
+        coll.upsert(vec![Point::new(id, vec![0.0; 4], Some(serde_json::json!({})))])
+            .unwrap();
+    }
 
     // Same path REST `/relations` and the memory wedge use: `add_edge`
     // delegates to the shared `Collection` edge store.
@@ -50,6 +56,11 @@ fn test_traverse_bfs_reaches_edges_added_via_shared_edge_store() {
 #[test]
 fn test_traverse_bfs_respects_max_depth_on_vector_collection() {
     let (coll, _dir) = create_test_vc();
+
+    for id in [1u64, 2, 3] {
+        coll.upsert(vec![Point::new(id, vec![0.0; 4], Some(serde_json::json!({})))])
+            .unwrap();
+    }
 
     coll.add_edge(GraphEdge::new(1, 1, 2, "KNOWS").unwrap())
         .unwrap();

--- a/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/traverse_tests.rs
@@ -30,8 +30,12 @@ fn test_traverse_bfs_reaches_edges_added_via_shared_edge_store() {
     let (coll, _dir) = create_test_vc();
 
     for id in [1u64, 2, 3] {
-        coll.upsert(vec![Point::new(id, vec![0.0; 4], Some(serde_json::json!({})))])
-            .unwrap();
+        coll.upsert(vec![Point::new(
+            id,
+            vec![0.0; 4],
+            Some(serde_json::json!({})),
+        )])
+        .unwrap();
     }
 
     // Same path REST `/relations` and the memory wedge use: `add_edge`
@@ -58,8 +62,12 @@ fn test_traverse_bfs_respects_max_depth_on_vector_collection() {
     let (coll, _dir) = create_test_vc();
 
     for id in [1u64, 2, 3] {
-        coll.upsert(vec![Point::new(id, vec![0.0; 4], Some(serde_json::json!({})))])
-            .unwrap();
+        coll.upsert(vec![Point::new(
+            id,
+            vec![0.0; 4],
+            Some(serde_json::json!({})),
+        )])
+        .unwrap();
     }
 
     coll.add_edge(GraphEdge::new(1, 1, 2, "KNOWS").unwrap())

--- a/crates/velesdb-core/src/database/ddl_executor_tests.rs
+++ b/crates/velesdb-core/src/database/ddl_executor_tests.rs
@@ -304,6 +304,12 @@ fn test_insert_edge_into_graph() {
     });
     execute_ddl(&db, create).expect("create graph");
 
+    let gc = db.get_graph_collection("edges_g").expect("get graph");
+    for id in [100, 200] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
+
     let dml = DmlStatement::InsertEdge(InsertEdgeStatement {
         collection: "edges_g".to_string(),
         edge_id: Some(42),
@@ -339,6 +345,12 @@ fn test_insert_edge_with_properties() {
         }),
     });
     execute_ddl(&db, create).expect("create graph");
+
+    let gc = db.get_graph_collection("props_g").expect("get graph");
+    for id in [1, 2] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
 
     let dml = DmlStatement::InsertEdge(InsertEdgeStatement {
         collection: "props_g".to_string(),
@@ -449,6 +461,10 @@ fn test_delete_edge() {
 
     // Insert two edges.
     let gc = db.get_graph_collection("del_edge_g").expect("get");
+    for id in [10, 20, 30] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
     gc.add_edge(crate::GraphEdge::new(1, 10, 20, "A").expect("edge"))
         .expect("add 1");
     gc.add_edge(crate::GraphEdge::new(2, 20, 30, "B").expect("edge"))
@@ -585,6 +601,12 @@ fn test_insert_edge_auto_generates_id_when_none() {
         }),
     });
     execute_ddl(&db, create).expect("create graph");
+
+    let gc = db.get_graph_collection("autoid_g").expect("get");
+    for id in [1, 2] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
 
     let dml = DmlStatement::InsertEdge(InsertEdgeStatement {
         collection: "autoid_g".to_string(),
@@ -798,6 +820,12 @@ fn test_default_observer_allows_dml_mutations() {
     });
     execute_ddl(&db, create).expect("create graph");
 
+    let gc = db.get_graph_collection("dml_graph").expect("get");
+    for id in [10, 20] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
+
     // INSERT EDGE should succeed.
     let dml = DmlStatement::InsertEdge(InsertEdgeStatement {
         collection: "dml_graph".to_string(),
@@ -997,6 +1025,10 @@ fn test_select_edges_and_swaps_for_selectivity() {
     execute_ddl(&db, create).expect("create graph");
 
     let gc = db.get_graph_collection("sel_and_g").expect("get");
+    for id in [10, 20, 30, 40, 50] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
     gc.add_edge(crate::GraphEdge::new(1, 10, 20, "KNOWS").expect("edge"))
         .expect("add 1");
     gc.add_edge(crate::GraphEdge::new(2, 10, 30, "LIKES").expect("edge"))

--- a/crates/velesdb-core/tests/bdd/admin_operations.rs
+++ b/crates/velesdb-core/tests/bdd/admin_operations.rs
@@ -442,7 +442,14 @@ fn test_truncate_graph_edges_only_no_node_payloads() {
     )
     .expect("create");
 
-    // Insert edges without explicit node payloads (nodes exist as edge endpoints).
+    // Edge endpoints must exist before an edge can reference them (#1442).
+    for id in [100, 200] {
+        execute_sql(
+            &db,
+            &format!("INSERT NODE INTO edges_only (id = {id}, payload = '{{}}')"),
+        )
+        .expect("node");
+    }
     execute_sql(
         &db,
         "INSERT EDGE INTO edges_only (id = 1, source = 100, target = 200, label = 'REF')",

--- a/crates/velesdb-core/tests/bdd/ddl_lifecycle.rs
+++ b/crates/velesdb-core/tests/bdd/ddl_lifecycle.rs
@@ -587,7 +587,14 @@ fn test_graph_collection_without_embeddings() {
     );
     assert!(gc.schema().is_schemaless());
 
-    // Insert edge via SQL with explicit ID
+    // Insert edge via SQL with explicit ID (endpoints must exist first, #1442)
+    for id in [10, 20] {
+        execute_sql(
+            &db,
+            &format!("INSERT NODE INTO pure_graph (id = {id}, payload = '{{}}');"),
+        )
+        .expect("test: INSERT NODE should succeed");
+    }
     execute_sql(
         &db,
         "INSERT EDGE INTO pure_graph (id = 1, source = 10, target = 20, label = 'LINKED');",
@@ -614,6 +621,13 @@ fn test_insert_edge_with_properties_round_trip() {
     )
     .expect("test: CREATE graph");
 
+    for id in [1, 2] {
+        execute_sql(
+            &db,
+            &format!("INSERT NODE INTO props_kg (id = {id}, payload = '{{}}');"),
+        )
+        .expect("test: INSERT NODE should succeed");
+    }
     execute_sql(
         &db,
         "INSERT EDGE INTO props_kg (id = 1, source = 1, target = 2, label = 'FRIEND') WITH PROPERTIES (since = 2020, weight = 0.85);",
@@ -655,6 +669,15 @@ fn test_multiple_edges_selective_delete() {
         "CREATE GRAPH COLLECTION multi_edge (dimension = 4, metric = 'cosine') SCHEMALESS;",
     )
     .expect("test: CREATE graph");
+
+    // Endpoints must exist before edges can reference them (#1442).
+    for id in [1, 2, 3] {
+        execute_sql(
+            &db,
+            &format!("INSERT NODE INTO multi_edge (id = {id}, payload = '{{}}');"),
+        )
+        .expect("test: INSERT NODE should succeed");
+    }
 
     // Insert 3 edges with explicit IDs
     execute_sql(

--- a/crates/velesdb-core/tests/bdd/graph_queries.rs
+++ b/crates/velesdb-core/tests/bdd/graph_queries.rs
@@ -18,6 +18,10 @@ fn setup_graph_collection(db: &velesdb_core::Database) {
 }
 
 fn populate_graph_edges(db: &velesdb_core::Database) {
+    for id in [1, 2, 3] {
+        execute_sql(db, &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"))
+            .expect("test: INSERT NODE should succeed");
+    }
     execute_sql(
         db,
         "INSERT EDGE INTO kg (source = 1, target = 2, label = 'KNOWS');",

--- a/crates/velesdb-core/tests/bdd/graph_queries.rs
+++ b/crates/velesdb-core/tests/bdd/graph_queries.rs
@@ -19,8 +19,11 @@ fn setup_graph_collection(db: &velesdb_core::Database) {
 
 fn populate_graph_edges(db: &velesdb_core::Database) {
     for id in [1, 2, 3] {
-        execute_sql(db, &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"))
-            .expect("test: INSERT NODE should succeed");
+        execute_sql(
+            db,
+            &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"),
+        )
+        .expect("test: INSERT NODE should succeed");
     }
     execute_sql(
         db,

--- a/crates/velesdb-core/tests/bdd/regression.rs
+++ b/crates/velesdb-core/tests/bdd/regression.rs
@@ -356,8 +356,11 @@ fn test_regression_select_edges_returns_inserted_edges() {
     .expect("create");
 
     for id in [1, 2] {
-        execute_sql(&db, &format!("INSERT NODE INTO g (id = {id}, payload = '{{}}')"))
-            .expect("insert node");
+        execute_sql(
+            &db,
+            &format!("INSERT NODE INTO g (id = {id}, payload = '{{}}')"),
+        )
+        .expect("insert node");
     }
 
     execute_sql(

--- a/crates/velesdb-core/tests/bdd/regression.rs
+++ b/crates/velesdb-core/tests/bdd/regression.rs
@@ -355,6 +355,11 @@ fn test_regression_select_edges_returns_inserted_edges() {
     )
     .expect("create");
 
+    for id in [1, 2] {
+        execute_sql(&db, &format!("INSERT NODE INTO g (id = {id}, payload = '{{}}')"))
+            .expect("insert node");
+    }
+
     execute_sql(
         &db,
         "INSERT EDGE INTO g (source = 1, target = 2, label = 'KNOWS')",

--- a/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
@@ -64,8 +64,11 @@ fn setup_graph(db: &Database) {
     )
     .expect("test: create graph");
     for id in [1, 2] {
-        execute_sql(db, &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"))
-            .expect("test: insert node");
+        execute_sql(
+            db,
+            &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"),
+        )
+        .expect("test: insert node");
     }
     execute_sql(
         db,

--- a/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
+++ b/crates/velesdb-core/tests/bdd/velesql_reject_conformance.rs
@@ -63,6 +63,10 @@ fn setup_graph(db: &Database) {
         "CREATE GRAPH COLLECTION kg (dimension = 4, metric = 'cosine') SCHEMALESS;",
     )
     .expect("test: create graph");
+    for id in [1, 2] {
+        execute_sql(db, &format!("INSERT NODE INTO kg (id = {id}, payload = '{{}}');"))
+            .expect("test: insert node");
+    }
     execute_sql(
         db,
         "INSERT EDGE INTO kg (id = 10, source = 1, target = 2, label = 'KNOWS');",

--- a/crates/velesdb-core/tests/loom_tests.rs
+++ b/crates/velesdb-core/tests/loom_tests.rs
@@ -273,3 +273,110 @@ fn test_loom_parallel_insert_no_contention() {
         assert_eq!(store.get_outgoing(2).len(), 1);
     });
 }
+
+// ============================================================================
+// Test 6: add_edge / delete phantom-edge race closure (#1442 re-fix)
+// ============================================================================
+//
+// Models the fix in `collection/core/graph_api.rs`: `add_edge` holds the
+// payload-store READ guard from the endpoint-existence check through the
+// edge-store write (the WAL mutex is acquired WHILE that read guard is
+// still held). `delete()` needs the payload-store WRITE guard to remove a
+// node, so it cannot interleave between the check and the write anymore.
+//
+// The real path is loom-incompatible (the WAL append fsyncs to disk, and
+// loom cannot model syscalls) — same limitation already documented for the
+// rest of this file, hence a simplified model of just the lock
+// interleaving, which is exactly what the fix changes.
+mod loom_payload_guard {
+    use loom::sync::{Mutex, RwLock};
+    use std::collections::HashSet;
+
+    /// Simplified graph: `payload` mirrors `payload_storage`, `wal` mirrors
+    /// `edge_wal_lock`, `edges` mirrors the edge store.
+    pub struct FixedGraph {
+        payload: RwLock<HashSet<u64>>,
+        wal: Mutex<()>,
+        edges: RwLock<HashSet<(u64, u64)>>,
+    }
+
+    impl FixedGraph {
+        pub fn new() -> Self {
+            Self {
+                payload: RwLock::new(HashSet::new()),
+                wal: Mutex::new(()),
+                edges: RwLock::new(HashSet::new()),
+            }
+        }
+
+        pub fn seed(&self, node: u64) {
+            self.payload.write().unwrap().insert(node);
+        }
+
+        /// Mirrors the fixed `add_edge`: the payload read guard spans the
+        /// WAL-mutex acquisition and the edge-store write.
+        pub fn add_edge(&self, source: u64, target: u64) -> bool {
+            let payload = self.payload.read().unwrap();
+            if !payload.contains(&source) || !payload.contains(&target) {
+                return false;
+            }
+            let _wal = self.wal.lock().unwrap();
+            self.edges.write().unwrap().insert((source, target));
+            true
+        }
+
+        /// Mirrors `delete()`: the payload write guard is dropped BEFORE
+        /// the WAL mutex is taken for the edge cascade (same as
+        /// `crud_read_delete.rs`'s `cascade_delete_node_edges`).
+        pub fn delete(&self, node: u64) {
+            self.payload.write().unwrap().remove(&node);
+            let _wal = self.wal.lock().unwrap();
+            self.edges
+                .write()
+                .unwrap()
+                .retain(|(s, t)| *s != node && *t != node);
+        }
+
+        pub fn has_phantom_edge(&self, node: u64) -> bool {
+            let payload_gone = !self.payload.read().unwrap().contains(&node);
+            let edge_remains = self
+                .edges
+                .read()
+                .unwrap()
+                .iter()
+                .any(|(s, t)| *s == node || *t == node);
+            payload_gone && edge_remains
+        }
+    }
+}
+
+use loom_payload_guard::FixedGraph;
+
+#[test]
+fn loom_payload_guard_excludes_delete_during_edge_write() {
+    loom::model(|| {
+        let graph = Arc::new(FixedGraph::new());
+        graph.seed(1);
+        graph.seed(2);
+
+        let g1 = Arc::clone(&graph);
+        let t1 = thread::spawn(move || {
+            g1.add_edge(1, 2);
+        });
+
+        let g2 = Arc::clone(&graph);
+        let t2 = thread::spawn(move || {
+            g2.delete(1);
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        // Whichever order the two threads actually ran in, the fixed lock
+        // nesting must never leave an edge whose endpoint payload is gone.
+        assert!(
+            !graph.has_phantom_edge(1),
+            "fixed lock order must never leave a phantom edge"
+        );
+    });
+}

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -278,7 +278,9 @@ fn seed_edge_endpoints<F, E>(
                 Ok(()) => {
                     seeded_nodes.insert(id);
                 }
-                Err(e) => warn!("Failed to seed graph node {id}: {e}; will retry on next occurrence"),
+                Err(e) => {
+                    warn!("Failed to seed graph node {id}: {e}; will retry on next occurrence")
+                }
             }
         }
     }

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -256,6 +256,11 @@ fn attach_weight(
 /// specific id). `seeded_nodes` is shared across the whole relation so a node
 /// referenced by many edges (e.g. a popular FK target) is not re-written on
 /// every recurrence.
+///
+/// A node is only marked seeded on a successful upsert. A failed upsert logs
+/// a warning and leaves the id out of `seeded_nodes`, so the next edge
+/// referencing the same node retries the upsert instead of silently skipping
+/// it forever (upserts are idempotent, so a retry is always safe).
 fn seed_edge_endpoints<F, E>(
     edges: &[velesdb_core::GraphEdge],
     seeded_nodes: &mut std::collections::HashSet<u64>,
@@ -266,10 +271,14 @@ fn seed_edge_endpoints<F, E>(
 {
     for edge in edges {
         for id in [edge.source(), edge.target()] {
-            if seeded_nodes.insert(id) {
-                if let Err(e) = upsert(id) {
-                    warn!("Failed to seed graph node {id}: {e}");
+            if seeded_nodes.contains(&id) {
+                continue;
+            }
+            match upsert(id) {
+                Ok(()) => {
+                    seeded_nodes.insert(id);
                 }
+                Err(e) => warn!("Failed to seed graph node {id}: {e}; will retry on next occurrence"),
             }
         }
     }

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -161,15 +161,9 @@ impl<'a> GraphMigrationPhase<'a> {
             }
 
             if !edges.is_empty() {
-                for edge in &edges {
-                    for id in [edge.source(), edge.target()] {
-                        if seeded_nodes.insert(id) {
-                            if let Err(e) = gc.upsert_node_payload(id, &serde_json::json!({})) {
-                                warn!("Failed to seed graph node {id}: {e}");
-                            }
-                        }
-                    }
-                }
+                seed_edge_endpoints(&edges, &mut seeded_nodes, |id| {
+                    gc.upsert_node_payload(id, &serde_json::json!({}))
+                });
 
                 let total = edges.len() as u64;
                 match gc.add_edges_batch(edges.clone()) {
@@ -252,6 +246,33 @@ fn attach_weight(
         "weight".to_string(),
         serde_json::json!(weight),
     )]))
+}
+
+/// Seeds a stub node payload for each not-yet-seeded edge endpoint.
+///
+/// Extracted from `migrate_relation_edges` so the seed/retry bookkeeping is
+/// unit-testable with an injectable `upsert` closure (real usage passes
+/// `GraphCollection::upsert_node_payload`; tests can simulate a failure for a
+/// specific id). `seeded_nodes` is shared across the whole relation so a node
+/// referenced by many edges (e.g. a popular FK target) is not re-written on
+/// every recurrence.
+fn seed_edge_endpoints<F, E>(
+    edges: &[velesdb_core::GraphEdge],
+    seeded_nodes: &mut std::collections::HashSet<u64>,
+    mut upsert: F,
+) where
+    F: FnMut(u64) -> std::result::Result<(), E>,
+    E: std::fmt::Display,
+{
+    for edge in edges {
+        for id in [edge.source(), edge.target()] {
+            if seeded_nodes.insert(id) {
+                if let Err(e) = upsert(id) {
+                    warn!("Failed to seed graph node {id}: {e}");
+                }
+            }
+        }
+    }
 }
 
 fn value_to_id_str(value: &serde_json::Value) -> Option<String> {
@@ -433,5 +454,51 @@ mod tests {
         // THEN: the non-numeric value is ignored, no weight property attached
         assert!(edge.property("weight").is_none());
         assert!(edge.properties().is_empty());
+    }
+
+    #[test]
+    fn seed_retries_failed_node_on_next_occurrence() {
+        // Regression guard: a node whose stub-seed upsert fails must NOT be
+        // marked as seeded, so a later edge referencing the same node id
+        // retries the upsert instead of silently skipping it forever (which
+        // would leave that node's edges permanently rejected by #1442's
+        // add_edges_batch validation, since the endpoint was never actually
+        // stored).
+        let attempts = std::cell::RefCell::new(Vec::new());
+        let mut seeded = std::collections::HashSet::new();
+
+        let edge1 = velesdb_core::GraphEdge::new(1, 100, 200, "REL").expect("valid edge");
+        let edge2 = velesdb_core::GraphEdge::new(2, 100, 300, "REL").expect("valid edge");
+
+        // First occurrence of node 100: its upsert fails.
+        seed_edge_endpoints(std::slice::from_ref(&edge1), &mut seeded, |id| {
+            attempts.borrow_mut().push(id);
+            if id == 100 {
+                Err("simulated storage failure")
+            } else {
+                Ok(())
+            }
+        });
+        assert!(
+            !seeded.contains(&100),
+            "a failed upsert must not mark the node as seeded"
+        );
+        assert!(seeded.contains(&200), "the succeeding endpoint is seeded");
+
+        // Second occurrence of node 100 (via edge2): must retry since it was
+        // never marked seeded.
+        seed_edge_endpoints(std::slice::from_ref(&edge2), &mut seeded, |id| {
+            attempts.borrow_mut().push(id);
+            Ok::<(), &str>(())
+        });
+        assert!(
+            seeded.contains(&100),
+            "node 100 must be seeded after a successful retry"
+        );
+        assert_eq!(
+            *attempts.borrow(),
+            vec![100, 200, 100, 300],
+            "node 100's upsert must be attempted again on its next occurrence"
+        );
     }
 }

--- a/crates/velesdb-migrate/src/pipeline_graph.rs
+++ b/crates/velesdb-migrate/src/pipeline_graph.rs
@@ -126,6 +126,14 @@ impl<'a> GraphMigrationPhase<'a> {
         let mut created = 0u64;
         let mut failed = 0u64;
         let mut offset = None;
+        // add_edges_batch now requires every edge endpoint to have a stored
+        // node payload (#1442). This graph collection is a fresh, edge-only
+        // index — the real point data lives in the vector destination
+        // collection — so every endpoint needs a minimal stub payload
+        // seeded here. Tracks ids already stubbed across the whole
+        // relation so a node referenced by many edges (e.g. a popular FK
+        // target) is not re-written on every recurrence.
+        let mut seeded_nodes: std::collections::HashSet<u64> = std::collections::HashSet::new();
 
         loop {
             let batch = self
@@ -153,12 +161,40 @@ impl<'a> GraphMigrationPhase<'a> {
             }
 
             if !edges.is_empty() {
+                for edge in &edges {
+                    for id in [edge.source(), edge.target()] {
+                        if seeded_nodes.insert(id) {
+                            if let Err(e) = gc.upsert_node_payload(id, &serde_json::json!({})) {
+                                warn!("Failed to seed graph node {id}: {e}");
+                            }
+                        }
+                    }
+                }
+
                 let total = edges.len() as u64;
-                let inserted = gc.add_edges_batch(edges).map_err(|e| {
-                    Error::DestinationConnection(format!("Edge batch insert failed: {e}"))
-                })? as u64;
-                created += inserted;
-                failed += total.saturating_sub(inserted);
+                match gc.add_edges_batch(edges.clone()) {
+                    Ok(inserted) => {
+                        created += inserted as u64;
+                        failed += total.saturating_sub(inserted as u64);
+                    }
+                    Err(e) => {
+                        // add_edges_batch validates the whole batch before any
+                        // write, so one genuinely bad edge (e.g. node-seeding
+                        // above failed for one id) fails the entire batch.
+                        // Fall back to per-edge inserts so that degrades to a
+                        // counted failure instead of aborting the migration.
+                        warn!("Edge batch insert failed ({e}); retrying edges individually");
+                        for edge in edges {
+                            match gc.add_edge(edge) {
+                                Ok(()) => created += 1,
+                                Err(e) => {
+                                    failed += 1;
+                                    debug!("Edge insert failed: {e}");
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             if !batch.has_more {

--- a/crates/velesdb-migrate/tests/pipeline_e2e.rs
+++ b/crates/velesdb-migrate/tests/pipeline_e2e.rs
@@ -190,6 +190,61 @@ async fn test_pipeline_csv_e2e_persists_and_reads_back() {
     );
 }
 
+/// Regression (#1442): `add_edges_batch` now requires every edge endpoint to
+/// have a stored node payload. The graph-relations migration phase writes
+/// edges into a fresh, edge-only `GraphCollection` that never otherwise gets
+/// node payloads — without stubbing endpoints first, every edge would now be
+/// rejected. This proves the migration still completes and produces a
+/// traversable, node-visible graph (not silently empty or hard-aborted).
+#[tokio::test]
+async fn test_pipeline_json_e2e_graph_relations_survive_node_requirement() {
+    let source = TempDir::new().expect("source dir");
+    let destination = TempDir::new().expect("destination dir");
+    let mut file = NamedTempFile::new_in(source.path()).expect("json source file");
+    write_json_source(
+        &mut file,
+        &[
+            serde_json::json!({"id": 1, "vector": [1.0, 0.0], "author_id": 2}),
+            serde_json::json!({"id": 2, "vector": [0.0, 1.0], "author_id": 1}),
+        ],
+    );
+
+    let mut config = json_config(file.path(), destination.path(), "rel_docs");
+    config.destination.graph_collection = Some("rel_docs_graph".to_string());
+    config.relations = vec![velesdb_migrate::config::RelationConfig {
+        from_column: "author_id".to_string(),
+        to_table: "rel_docs".to_string(),
+        to_column: "id".to_string(),
+        edge_label: "AUTHORED_BY".to_string(),
+        weight_column: None,
+    }];
+
+    let mut pipeline = Pipeline::new(config).expect("pipeline");
+    let stats = pipeline.run().await.expect("pipeline run");
+
+    assert_eq!(stats.loaded, 2, "both points load");
+    assert_eq!(stats.relations_processed, 1);
+    assert_eq!(
+        stats.edges_created, 2,
+        "both edges succeed via node stubbing"
+    );
+    assert_eq!(stats.edges_failed, 0);
+
+    let db = Database::open(destination.path()).expect("open database");
+    let gc = db
+        .get_graph_collection("rel_docs_graph")
+        .expect("graph collection exists");
+    assert_eq!(gc.edge_count(), 2);
+
+    // The original bug (#1442): edge endpoints must be visible via
+    // all_node_ids(), not just present in the edge store.
+    let node_ids = gc.all_node_ids();
+    assert!(node_ids.contains(&1), "node 1 must be visible");
+    assert!(node_ids.contains(&2), "node 2 must be visible");
+    assert_eq!(gc.get_outgoing(1).len(), 1);
+    assert_eq!(gc.get_outgoing(2).len(), 1);
+}
+
 #[tokio::test]
 async fn test_pipeline_dry_run_does_not_create_collection() {
     let source = TempDir::new().expect("source dir");

--- a/crates/velesdb-python/tests/test_database_gil.py
+++ b/crates/velesdb-python/tests/test_database_gil.py
@@ -118,7 +118,10 @@ def test_get_graph_collection_roundtrip(temp_db) -> None:
 def test_graph_collection_edge_aliases_and_payload(temp_db) -> None:
     """Documented graph alternatives work on persistent graph collections."""
     gc = temp_db.create_graph_collection("gil_graph_aliases")
+    # add_edge requires both endpoints to have a stored node payload
+    # (#1442) — store node 20 in addition to node 10.
     gc.upsert_node_payload(10, {"name": "Alice"})
+    gc.upsert_node_payload(20, {})
     gc.add_edge({"id": 1, "source": 10, "target": 20, "label": "KNOWS"})
 
     assert gc.get_outgoing_edges(10) == gc.get_outgoing(10)

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -149,7 +149,7 @@ pub async fn get_edges(
     responses(
         (status = 201, description = "Edge added successfully"),
         (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 404, description = "Collection not found, or source/target node has no stored payload (VELES-022 NodeNotFound)", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "graph"
@@ -219,7 +219,7 @@ fn build_edge(request: AddEdgeRequest) -> Result<GraphEdge, (StatusCode, Json<Er
     responses(
         (status = 201, description = "Edges added successfully", body = AddEdgesBatchResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 404, description = "Collection not found, or a source/target node has no stored payload (VELES-022 NodeNotFound) — the whole batch is rejected", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "graph"

--- a/crates/velesdb-server/src/handlers/graph/mod.rs
+++ b/crates/velesdb-server/src/handlers/graph/mod.rs
@@ -52,6 +52,10 @@ mod tests {
         // Graph: 1 --KNOWS--> 2 --KNOWS--> 3 --KNOWS--> 4
         //                     |
         //                     +--WROTE--> 5
+        for id in [1, 2, 3, 4, 5] {
+            coll.upsert_node_payload(id, &serde_json::json!({}))
+                .unwrap();
+        }
         for (id, src, tgt, lbl) in [
             (100, 1, 2, "KNOWS"),
             (101, 2, 3, "KNOWS"),
@@ -66,6 +70,9 @@ mod tests {
     #[test]
     fn test_graph_collection_add_and_get_edges() {
         let (coll, _dir) = make_graph();
+        for id in [100, 200] {
+            coll.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+        }
         coll.add_edge(GraphEdge::new(1, 100, 200, "KNOWS").unwrap())
             .unwrap();
         let edges = coll.get_edges(Some("KNOWS"));
@@ -211,35 +218,20 @@ mod tests {
 
     #[test]
     fn test_all_node_ids() {
+        // `all_node_ids` delegates to `inner.all_ids()`, which enumerates
+        // payload-stored IDs. Since add_edge now requires both endpoints to
+        // have a stored payload before the edge is accepted (#1442), every
+        // node reachable via add_test_edges is necessarily already visible
+        // here — this asserts that invariant end-to-end rather than the
+        // pre-payload/post-payload distinction from before the fix.
         let (coll, _dir) = make_graph();
         add_test_edges(&coll);
 
-        // Precondition: `all_node_ids` delegates to
-        // `inner.all_ids()` which enumerates payload-stored IDs
-        // only — nodes referenced purely by edges do not appear
-        // in the result. Before any payload is written, the
-        // method must therefore return an empty set even though
-        // `add_test_edges` populated the edge store with nodes
-        // 1..5. The previous version of this test computed and
-        // discarded the pre-payload result (`let _ids = ...`);
-        // asserting the empty invariant turns that scaffold into
-        // a real guard against regressions in the payload-vs-edge
-        // distinction.
-        let pre_payload_ids = coll.all_node_ids();
-        assert!(
-            pre_payload_ids.is_empty(),
-            "all_node_ids must be empty before any payload is stored, got {:?}",
-            pre_payload_ids
-        );
-
-        // Store payloads for nodes 1 and 2 so they become visible
-        // to `all_node_ids`.
-        coll.upsert_node_payload(1, &serde_json::json!({})).unwrap();
-        coll.upsert_node_payload(2, &serde_json::json!({})).unwrap();
         let ids = coll.all_node_ids();
-        assert!(ids.contains(&1));
-        assert!(ids.contains(&2));
-        assert_eq!(ids.len(), 2);
+        for id in [1, 2, 3, 4, 5] {
+            assert!(ids.contains(&id), "node {id} should be visible");
+        }
+        assert_eq!(ids.len(), 5);
     }
 
     #[test]

--- a/crates/velesdb-server/src/handlers/graph/mod.rs
+++ b/crates/velesdb-server/src/handlers/graph/mod.rs
@@ -71,7 +71,8 @@ mod tests {
     fn test_graph_collection_add_and_get_edges() {
         let (coll, _dir) = make_graph();
         for id in [100, 200] {
-            coll.upsert_node_payload(id, &serde_json::json!({})).unwrap();
+            coll.upsert_node_payload(id, &serde_json::json!({}))
+                .unwrap();
         }
         coll.add_edge(GraphEdge::new(1, 100, 200, "KNOWS").unwrap())
             .unwrap();

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -21,7 +21,7 @@ use velesdb_core::point::Point;
 use crate::types::ErrorResponse;
 use crate::AppState;
 
-use super::super::helpers::{error_response, get_collection_or_404};
+use super::super::helpers::{auto_core_error_response, error_response, get_collection_or_404};
 
 use velesdb_core::EXPIRES_AT_KEY;
 
@@ -106,7 +106,7 @@ pub struct SetTtlRequest {
     responses(
         (status = 201, description = "Relation created", body = RelateResponse),
         (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 404, description = "Collection not found", body = ErrorResponse),
+        (status = 404, description = "Collection not found, or source/target point has no stored payload (VELES-022 NodeNotFound)", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "graph"
@@ -174,12 +174,10 @@ fn insert_edge_with_retry(
             Err(velesdb_core::Error::EdgeExists(_)) => {
                 next_id = next_id.saturating_add(1);
             }
-            Err(e) => {
-                return Err(error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("failed to create relation: {e}"),
-                ))
-            }
+            // Route through the shared error→status mapping (e.g.
+            // NodeNotFound -> 404, not a generic 500) instead of collapsing
+            // every non-EdgeExists error into Internal Server Error.
+            Err(e) => return Err(auto_core_error_response(&e)),
         }
     }
     Err(error_response(

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -7,7 +7,9 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state};
+use common::{
+    create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state,
+};
 use futures::stream;
 use serde_json::{json, Value};
 use tempfile::TempDir;

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -7,7 +7,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_graph_collection, create_test_app, create_test_app_with_state};
+use common::{create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state};
 use futures::stream;
 use serde_json::{json, Value};
 use tempfile::TempDir;
@@ -1940,6 +1940,8 @@ async fn test_graph_add_edge() {
 
     // Graph collections must be explicitly created since F-05 (Sprint 1).
     create_graph_collection(&app, "test").await;
+    create_graph_node(&app, "test", 100).await;
+    create_graph_node(&app, "test", 200).await;
 
     // Add edge
     let response = app
@@ -1972,6 +1974,9 @@ async fn test_graph_add_edges_batch() {
     let app = create_test_app(&temp_dir);
 
     create_graph_collection(&app, "test").await;
+    for id in [100, 200, 300] {
+        create_graph_node(&app, "test", id).await;
+    }
 
     // Insert three edges in one batched request.
     let response = app
@@ -2080,6 +2085,9 @@ async fn test_graph_get_edges_by_label() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "test").await;
+    for id in [100, 200, 300] {
+        create_graph_node(&app, "test", id).await;
+    }
 
     // Add edges
     let response = app
@@ -2174,6 +2182,9 @@ async fn test_graph_traverse_bfs() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "graph_test").await;
+    for id in [1, 2, 3, 4] {
+        create_graph_node(&app, "graph_test", id).await;
+    }
 
     // Build a graph: 1 -> 2 -> 3 -> 4
     for (id, src, tgt) in [(1, 1, 2), (2, 2, 3), (3, 3, 4)] {
@@ -2242,6 +2253,9 @@ async fn test_graph_traverse_dfs() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "dfs_test").await;
+    for id in [1, 2, 3] {
+        create_graph_node(&app, "dfs_test", id).await;
+    }
 
     // Build graph
     for (id, src, tgt) in [(1, 1, 2), (2, 2, 3)] {
@@ -2305,6 +2319,9 @@ async fn test_graph_traverse_with_rel_type_filter() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "filter_test").await;
+    for id in [1, 2, 3] {
+        create_graph_node(&app, "filter_test", id).await;
+    }
 
     // Build graph with mixed edge types: 1 -KNOWS-> 2 -WROTE-> 3
     let edges = [(1, 1, 2, "KNOWS"), (2, 2, 3, "WROTE")];
@@ -2400,6 +2417,9 @@ async fn test_graph_node_degree() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "degree_test").await;
+    for id in [1, 2, 3, 4] {
+        create_graph_node(&app, "degree_test", id).await;
+    }
 
     // Build graph: 1 -> 2, 3 -> 2, 2 -> 4
     // Node 2 has in_degree=2, out_degree=1
@@ -4072,6 +4092,8 @@ async fn test_graph_endpoint_works_after_explicit_creation() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "explicit").await;
+    create_graph_node(&app, "explicit", 100).await;
+    create_graph_node(&app, "explicit", 200).await;
 
     let response = app
         .oneshot(
@@ -5070,4 +5092,100 @@ async fn test_graph_endpoint_on_vector_collection_returns_409() {
         .expect("Graph edge request failed");
 
     assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+/// Regression (#1442): `POST /graph/edges` referencing a node that was
+/// never created must be rejected with 404, not silently accepted — the
+/// prior behavior left the node invisible to `graph-nodes`/MATCH.
+#[tokio::test]
+async fn test_graph_add_edge_rejects_nonexistent_endpoint() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "dangling").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/dangling/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "id": 1,
+                        "source": 1,
+                        "target": 2,
+                        "label": "KNOWS"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// Regression (#1442): once endpoints are created explicitly, the edge is
+/// accepted and both endpoints are visible through `graph-nodes`.
+#[tokio::test]
+async fn test_graph_nodes_endpoint_lists_edge_endpoints() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+    create_graph_collection(&app, "visible").await;
+    create_graph_node(&app, "visible", 1).await;
+    create_graph_node(&app, "visible", 2).await;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/visible/graph/edges")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "id": 1,
+                        "source": 1,
+                        "target": 2,
+                        "label": "KNOWS"
+                    })
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/collections/visible/graph/nodes")
+                .body(Body::empty())
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    let node_ids: Vec<u64> = json["node_ids"]
+        .as_array()
+        .expect("node_ids should be an array")
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .expect("node id should be a string (precision-safe u64)")
+                .parse()
+                .expect("node id should parse as u64")
+        })
+        .collect();
+
+    assert_eq!(json["count"], 2);
+    assert!(node_ids.contains(&1));
+    assert!(node_ids.contains(&2));
 }

--- a/crates/velesdb-server/tests/api_integration.rs
+++ b/crates/velesdb-server/tests/api_integration.rs
@@ -5191,3 +5191,127 @@ async fn test_graph_nodes_endpoint_lists_edge_endpoints() {
     assert!(node_ids.contains(&1));
     assert!(node_ids.contains(&2));
 }
+
+/// Regression (#1442): `POST /collections/{name}/relations` referencing a
+/// point that doesn't exist must return 404 with the VELES-022 code, not a
+/// generic 500 — `insert_edge_with_retry`'s catch-all error arm previously
+/// mapped every non-`EdgeExists` error to `INTERNAL_SERVER_ERROR`.
+#[tokio::test]
+async fn test_relate_points_rejects_nonexistent_target_with_404() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"name": "rel_test", "dimension": 4, "metric": "cosine"}).to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rel_test/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"points": [{"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {}}]})
+                        .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rel_test/relations")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"source": 1, "target": 999, "rel_type": "KNOWS"}).to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).expect("Invalid JSON");
+    assert_eq!(json["code"], "VELES-022");
+}
+
+/// Happy path: `POST /relations` between two existing points succeeds and
+/// is retrievable via `GET /points/{id}/relations`.
+#[tokio::test]
+async fn test_relate_points_between_existing_points_succeeds() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let app = create_test_app(&temp_dir);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"name": "rel_ok", "dimension": 4, "metric": "cosine"}).to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rel_ok/points")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"points": [
+                        {"id": 1, "vector": [1.0, 0.0, 0.0, 0.0], "payload": {}},
+                        {"id": 2, "vector": [0.0, 1.0, 0.0, 0.0], "payload": {}}
+                    ]})
+                    .to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections/rel_ok/relations")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({"source": 1, "target": 2, "rel_type": "KNOWS"}).to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -252,11 +252,11 @@ pub async fn create_graph_node(app: &Router, collection: &str, node_id: u64) {
         .oneshot(
             Request::builder()
                 .method("PUT")
-                .uri(format!("/collections/{collection}/graph/nodes/{node_id}/payload"))
-                .header("Content-Type", "application/json")
-                .body(Body::from(
-                    serde_json::json!({ "payload": {} }).to_string(),
+                .uri(format!(
+                    "/collections/{collection}/graph/nodes/{node_id}/payload"
                 ))
+                .header("Content-Type", "application/json")
+                .body(Body::from(serde_json::json!({ "payload": {} }).to_string()))
                 .expect("test: build create graph node request"),
         )
         .await

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -17,9 +17,9 @@ use velesdb_server::{
     explain, get_collection, get_collection_config, get_edges, get_node_degree, get_node_payload,
     get_point, health_check, hybrid_search, list_collections, list_nodes, match_query,
     multi_query_search, multi_query_search_ids, query, readiness_check, rebuild_index,
-    reorder_for_locality, scroll_points, search, search_ids, set_point_ttl, stream_insert,
-    stream_upsert_points, text_search, traverse_graph, upsert_node_payload, upsert_points,
-    upsert_points_raw, vacuum_collection, AppState, OnboardingMetrics,
+    relate_points, reorder_for_locality, scroll_points, search, search_ids, set_point_ttl,
+    stream_insert, stream_upsert_points, text_search, traverse_graph, upsert_node_payload,
+    upsert_points, upsert_points_raw, vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -92,6 +92,7 @@ fn graph_and_maintenance_routes() -> Router<Arc<AppState>> {
             "/collections/{name}/graph/nodes/{node_id}/payload",
             get(get_node_payload).put(upsert_node_payload),
         )
+        .route("/collections/{name}/relations", post(relate_points))
         // Maintenance + bulk endpoints (PR #648)
         .route(
             "/collections/{name}/points/delete",

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -14,12 +14,12 @@ use velesdb_server::{
     auth::{auth_middleware, AuthState},
     batch_search, bulk_delete_points, collection_diagnostics, collection_sanity,
     compact_collection, create_collection, delete_collection, delete_point, enable_streaming,
-    explain, get_collection, get_collection_config, get_edges, get_node_degree, get_point,
-    health_check, hybrid_search, list_collections, match_query, multi_query_search,
-    multi_query_search_ids, query, readiness_check, rebuild_index, reorder_for_locality,
-    scroll_points, search, search_ids, set_point_ttl, stream_insert, stream_upsert_points,
-    text_search, traverse_graph, upsert_points, upsert_points_raw, vacuum_collection, AppState,
-    OnboardingMetrics,
+    explain, get_collection, get_collection_config, get_edges, get_node_degree, get_node_payload,
+    get_point, health_check, hybrid_search, list_collections, list_nodes, match_query,
+    multi_query_search, multi_query_search_ids, query, readiness_check, rebuild_index,
+    reorder_for_locality, scroll_points, search, search_ids, set_point_ttl, stream_insert,
+    stream_upsert_points, text_search, traverse_graph, upsert_node_payload, upsert_points,
+    upsert_points_raw, vacuum_collection, AppState, OnboardingMetrics,
 };
 
 fn base_routes() -> Router<Arc<AppState>> {
@@ -86,6 +86,11 @@ fn graph_and_maintenance_routes() -> Router<Arc<AppState>> {
         .route(
             "/collections/{name}/graph/nodes/{node_id}/degree",
             get(get_node_degree),
+        )
+        .route("/collections/{name}/graph/nodes", get(list_nodes))
+        .route(
+            "/collections/{name}/graph/nodes/{node_id}/payload",
+            get(get_node_payload).put(upsert_node_payload),
         )
         // Maintenance + bulk endpoints (PR #648)
         .route(
@@ -229,5 +234,37 @@ pub async fn create_graph_collection(app: &Router, name: &str) {
         response.status(),
         axum::http::StatusCode::CREATED,
         "test: failed to create graph collection '{name}'"
+    );
+}
+
+/// Creates a graph node via `PUT /collections/{name}/graph/nodes/{id}/payload`.
+///
+/// `add_edge`/`add_edges_batch` reject edges whose endpoints have no stored
+/// node payload (`Error::NodeNotFound`, issue #1442), so tests exercising
+/// edges must create their endpoint nodes first.
+pub async fn create_graph_node(app: &Router, collection: &str, node_id: u64) {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/collections/{collection}/graph/nodes/{node_id}/payload"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "payload": {} }).to_string(),
+                ))
+                .expect("test: build create graph node request"),
+        )
+        .await
+        .expect("test: create graph node request failed");
+
+    assert_eq!(
+        response.status(),
+        axum::http::StatusCode::NO_CONTENT,
+        "test: failed to create graph node {node_id} in '{collection}'"
     );
 }

--- a/crates/velesdb-server/tests/coverage_handlers.rs
+++ b/crates/velesdb-server/tests/coverage_handlers.rs
@@ -20,7 +20,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_graph_collection, create_test_app, create_test_app_with_state};
+use common::{create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -303,6 +303,8 @@ async fn test_add_edge_null_properties_ok() {
     let temp_dir = TempDir::new().expect("temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "edge_null_props").await;
+    create_graph_node(&app, "edge_null_props", 10).await;
+    create_graph_node(&app, "edge_null_props", 20).await;
 
     let resp = post(
         &app,

--- a/crates/velesdb-server/tests/coverage_handlers.rs
+++ b/crates/velesdb-server/tests/coverage_handlers.rs
@@ -20,7 +20,9 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state};
+use common::{
+    create_graph_collection, create_graph_node, create_test_app, create_test_app_with_state,
+};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tower::ServiceExt;

--- a/crates/velesdb-server/tests/match_error_codes_tests.rs
+++ b/crates/velesdb-server/tests/match_error_codes_tests.rs
@@ -9,7 +9,7 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
-use common::{create_graph_collection, create_test_app};
+use common::{create_graph_collection, create_graph_node, create_test_app};
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -135,6 +135,8 @@ async fn test_duplicate_edge_returns_veles_019() {
     let temp_dir = TempDir::new().expect("temp dir");
     let app = create_test_app(&temp_dir);
     create_graph_collection(&app, "social").await;
+    create_graph_node(&app, "social", 10).await;
+    create_graph_node(&app, "social", 20).await;
 
     let edge = json!({
         "id": 1,

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -205,6 +205,70 @@ The snapshot invalidation / debounced rebuild (see below) runs **after** the
 `edge_ids` write lock is released, never while holding it, to avoid deadlocking
 against the downstream rebuild lock acquisition.
 
+### Collection-level lock order
+
+Separate from the HNSW `LockRank` total ordering above, `Collection`'s own
+fields (`config`, `vector_storage`, `payload_storage`, the quantization
+caches, `edge_wal_lock`, the property/range/label indexes, ...) follow a
+documentation-enforced ascending order recorded as a plain comment block at
+the top of `crates/velesdb-core/src/collection/types.rs` (`=== LOCK
+ORDERING ===`). It is not backed by a typed `LockRank`-style assertion —
+this section only narrates one addition to it: position **3b**,
+`edge_wal_lock`, sitting right after `payload_storage` (3).
+
+`edge_wal_lock` has two acquisition patterns:
+
+- `add_edge`/`add_edges_batch` (`collection/core/graph_api.rs`) hold
+  `payload_storage`'s **read** guard from the endpoint referential-integrity
+  check through the end of the edge write, and acquire `edge_wal_lock`
+  **while that read guard is still held** — so the acquisition order for
+  this path is `payload_storage(3) → edge_wal_lock(3b)`.
+- `remove_edge` and the delete-cascade path
+  (`collection/core/crud_read_delete.rs`'s `cascade_delete_node_edges`)
+  acquire `edge_wal_lock` **alone**, with no other collection lock held —
+  the delete path has already released its `payload_storage` write guard by
+  the time it reaches the cascade.
+
+This closes a race left open by the original #1442 fix: `add_edge` used to
+release `payload_storage`'s read guard immediately after checking that both
+endpoints exist, then separately acquire `edge_wal_lock` to write the edge.
+A concurrent `delete()` of an endpoint could land in that window — its own
+write guard acquisition would not contend with anything, since the reader
+had already let go — and finish removing the node (and, if the edge
+happened to already exist, cascading its removal) before `add_edge` ever
+wrote it. The result was a "phantom" edge: present in the edge store,
+invisible to `all_node_ids()`/`MATCH`, since both resolve nodes from the
+payload store.
+
+Holding `payload_storage`(3) across `edge_wal_lock`(3b) fixes this: a
+concurrent `delete()` needs `payload_storage`'s **write** guard, which
+cannot be acquired while `add_edge` holds the read guard, so the delete
+blocks until the edge is fully durable (WAL + edge-store apply). By the
+time the delete proceeds, the edge already exists, so its own cascade sees
+and removes it — no phantom, no compensation logic, no rollback. The same
+guard is held once for the whole batch in `add_edges_batch`, so "an
+endpoint disappears mid-batch" is impossible by construction.
+
+The order stays acyclic: neither `remove_edge` nor the delete cascade ever
+acquires `payload_storage` while holding `edge_wal_lock`, so there is no
+path back from 3b to 3.
+
+**Residual latency**: writers to `payload_storage` (upserts, deletes) can
+now stall behind an in-flight edge write for up to one `fsync` (the edge
+WAL append) — typically 0.05–5 ms on an SSD, consistent with the
+single-writer-per-collection model this section belongs under (see
+[`guides/WRITE_CONCURRENCY.md`](guides/WRITE_CONCURRENCY.md#edge-writes-and-payload-contention)).
+
+**Known limitation (accepted)**: this only protects edges written through
+`Collection::add_edge`/`add_edges_batch`. Edges loaded from a pre-existing
+WAL/snapshot at `Collection::open` (replay) are trusted as-is and never
+re-validated — replay intentionally bypasses referential-integrity
+validation so legitimate edge-only databases created before the #1442 fix
+keep their data. A follow-up CLI tool to audit/repair such legacy phantom
+edges is tracked in issue
+[#1469](https://github.com/cyberlife-coder/VelesDB/issues/1469) (see also
+`guides/GRAPH_PATTERNS.md`).
+
 ## RaBitQ Interior Mutability
 
 ### Lock Layout

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2573,6 +2573,12 @@ INSERT EDGE INTO kg (id = 20, source = 2, target = 3, label = 'KNOWS')
 
 WITH PROPERTIES accepts key-value pairs (strings, integers, or floats).
 
+> `source` and `target` must already exist as nodes (created via
+> `INSERT NODE` or a point upsert) before `INSERT EDGE` — an edge to a
+> node that was never created is rejected with `NodeNotFound` (#1442),
+> since `SELECT NODES` / MATCH resolve nodes from the payload store, not
+> the edge store.
+
 ### DELETE EDGE (v3.3+)
 
 Remove an edge by its ID from a graph collection.

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -59,6 +59,16 @@ created (`404 NodeNotFound` over REST, `Error::NodeNotFound` in Rust). This is
 enforced, not just recommended: create the points first (see "Setting Up Data
 for MATCH" above), then add the edge (#1442).
 
+> **Legacy databases**: this enforcement only applies to edges written
+> through `add_edge`/`add_edges_batch`. A database created before this
+> validation existed may already contain edges whose endpoint was never
+> given a payload — those are loaded as-is on open (re-validating the
+> whole edge store at load time could turn a legitimate edge-only graph
+> into data loss) and stay invisible to `all_node_ids()`/MATCH until you
+> give the missing endpoint a payload yourself. A `velesdb-cli graph
+> doctor` subcommand to scan/purge/stub these is tracked in
+> [issue #1469](https://github.com/cyberlife-coder/VelesDB/issues/1469).
+
 ```bash
 curl -X POST http://localhost:8080/collections/knowledge/graph/edges \
   -H "Content-Type: application/json" \

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -53,6 +53,12 @@ A point can have multiple labels: `"_labels": ["Document", "Published", "Reviewe
 
 Edges must exist in the collection's edge store before MATCH can traverse them.
 
+**Both endpoints must already have a stored payload before you call `add_edge`** —
+`add_edge`/`add_edges_batch` reject an edge whose `source` or `target` was never
+created (`404 NodeNotFound` over REST, `Error::NodeNotFound` in Rust). This is
+enforced, not just recommended: create the points first (see "Setting Up Data
+for MATCH" above), then add the edge (#1442).
+
 ```bash
 curl -X POST http://localhost:8080/collections/knowledge/graph/edges \
   -H "Content-Type: application/json" \

--- a/docs/guides/WRITE_CONCURRENCY.md
+++ b/docs/guides/WRITE_CONCURRENCY.md
@@ -81,6 +81,28 @@ The ceiling you hit with the Community model is:
   `docs_tenant_1`, `docs_tenant_2`, ... into separate collections, each
   gets its own writer lock and they run in parallel.
 
+### Edge writes and payload contention
+
+`add_edge`/`add_edges_batch` hold the `payload_storage` read guard for the
+entire edge write (referential-integrity check through the WAL append and
+edge-store apply — see
+[`../CONCURRENCY_MODEL.md`](../CONCURRENCY_MODEL.md#collection-level-lock-order)),
+closing a race that could otherwise leave a dangling edge after a
+concurrent node delete. The practical effect: a payload writer (`upsert`,
+`delete`) racing an in-flight edge write can stall for up to one `fsync` of
+the edge WAL — typically 0.05-5 ms on an SSD, the same per-write fsync cost
+that already existed for edges. This is consistent with the single-writer
+model above, not a new bottleneck class.
+
+If you migrate or seed graphs with many edges per endpoint node, prefer
+`add_edges_batch` with batches of **up to ~10k edges**: the payload guard
+is held once per batch rather than once per edge, so batching amortizes
+this stall the same way it amortizes the WAL fsync itself. Very large
+batches (well beyond 10k) hold the payload read guard longer per batch,
+which increases the worst-case stall for a concurrent payload writer
+without adding throughput — 10k is a reasonable upper bound before that
+trade-off stops paying for itself.
+
 ---
 
 ## Best practices for Community scale

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -622,7 +622,7 @@
             }
           },
           "404": {
-            "description": "Collection not found",
+            "description": "Collection not found, or source/target node has no stored payload (VELES-022 NodeNotFound)",
             "content": {
               "application/json": {
                 "schema": {
@@ -693,7 +693,7 @@
             }
           },
           "404": {
-            "description": "Collection not found",
+            "description": "Collection not found, or a source/target node has no stored payload (VELES-022 NodeNotFound) — the whole batch is rejected",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2349,7 +2349,7 @@
             }
           },
           "404": {
-            "description": "Collection not found",
+            "description": "Collection not found, or source/target point has no stored payload (VELES-022 NodeNotFound)",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -392,7 +392,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
-          description: Collection not found
+          description: Collection not found, or source/target node has no stored payload (VELES-022 NodeNotFound)
           content:
             application/json:
               schema:
@@ -435,7 +435,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
-          description: Collection not found
+          description: Collection not found, or a source/target node has no stored payload (VELES-022 NodeNotFound) — the whole batch is rejected
           content:
             application/json:
               schema:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1550,7 +1550,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
-          description: Collection not found
+          description: Collection not found, or source/target point has no stored payload (VELES-022 NodeNotFound)
           content:
             application/json:
               schema:

--- a/integrations/langchain/tests/test_graph_retriever_native.py
+++ b/integrations/langchain/tests/test_graph_retriever_native.py
@@ -162,6 +162,13 @@ class TestBug5SeedExpansion:
                 f"Graph collection '{graph_collection_name}' not found. "
                 "The test must create it explicitly before populating."
             )
+        # add_edge requires both endpoints to have a stored node payload
+        # (#1442) — the graph collection here is separate from the vector
+        # store's document collection, so seed nodes are never otherwise
+        # created in it.
+        for seed_id in seed_ids:
+            graph.add_node(seed_id, payload={})
+
         # Add edges: seed[0] → seed[1], seed[1] → seed[0]
         if len(seed_ids) >= 2:
             graph.add_edge({


### PR DESCRIPTION
Supersedes #1457, recreated on a branch matching this repo's Git Flow naming policy (`fix/*`) so the governance check passes. Same original commits, plus a re-fix pass (see below) after adversarial review found a residual race.

## Description

Fixes #1442 — nodes created implicitly via `addEdge`/`INSERT EDGE` were invisible to `graph-nodes`/MATCH on schemaless graph collections (the SDK default). Root cause: `Collection::add_edge`/`add_edges_batch` never validated that an edge's `source`/`target` had a stored payload unless the collection used a *strict* graph schema — silently accepting edges to node IDs that were never created. `GET /graph/nodes`, `all_node_ids()`, and `MATCH` all resolve their node set from the payload store, not the edge store, so those "phantom" edges were permanently invisible outside direct edge queries.

The fix makes `add_edge`/`add_edges_batch` reject (not silently accept, not auto-create) an edge to a missing endpoint with `Error::NodeNotFound` (`VELES-022`, REST `404`), matching what strict-schema collections and the `velesdb-memory` wedge already did. An earlier adversarial review (6 finder passes) found four additional real bugs beyond the original scope — REST `relations` 500, `velesdb-memory`'s `relate()` race downgrade, `velesdb-migrate`'s FK-relations breakage, `tauri-plugin-velesdb`'s error collapsing — all fixed in the original commit set (`4038ead8`, `51d7377e`, `101338dd`, `7d7bd3ab`).

## Re-fix: two additional bugs closed in this pass

A second adversarial review of the fix itself found two more issues, both closed here with TDD (red tests committed before the fix):

### 1. Concurrent-delete phantom-edge race (core)

`add_edge`/`add_edges_batch` validated endpoint existence under `payload_storage.read()`, then **released that guard** before writing the edge (WAL append + edge-store apply). A concurrent `delete()` of an endpoint could land in that window and still leave a "phantom" edge — present in the edge store, invisible to `all_node_ids()`/MATCH, since both resolve nodes from the payload store.

**Fix**: both entry points now hold `payload_storage`'s read guard from the referential-integrity check through the end of the write; `delete()` needs the **write** guard to remove a payload, so it blocks until the edge is fully durable, at which point `delete()`'s own edge cascade sees and removes it. No compensation logic, no rollback — for the batch path the same guard covers the whole batch, so "an endpoint disappears mid-batch" is impossible by construction. Full mechanism documented as an additive "Collection-level lock order" section in `docs/CONCURRENCY_MODEL.md` (position **3b** for `edge_wal_lock`, nested inside `payload_storage`(3) for this path — the frozen `LockRank` table above it is untouched).

Validator signatures (`validate_edge_endpoints_exist`, `validate_edge_referential_integrity`, `endpoint_node_type`) now take the caller's already-acquired `&LogPayloadStorage` instead of re-locking internally — re-locking from inside the outer guard's scope would risk a self-deadlock once a writer is queued on the same `parking_lot` `RwLock`.

**Residual cost**: payload writers can stall behind an in-flight edge write for up to one `fsync` (typically 0.05-5 ms on SSD) — the same per-edge fsync cost that already existed. Documented in `docs/guides/WRITE_CONCURRENCY.md` with a batch-size recommendation (≤10k edges).

### 2. Migrate seed-retry bug (velesdb-migrate)

`velesdb-migrate`'s FK-relations seeding phase marked a node id as "seeded" (`seeded_nodes.insert(id)`) **before** checking whether its stub `upsert_node_payload` call actually succeeded. A failed upsert permanently skipped any retry for that node later in the same relation, silently orphaning every edge referencing it. Now only marks a node seeded on `Ok`; a failure logs a warning and leaves the id retryable (upserts are idempotent, so a retry is always safe).

## Red tests (TDD, archived)

```
test collection::core::graph_api_tests::tests::add_edge_concurrent_delete_never_leaves_phantom_edge ...
thread '...' panicked at crates/velesdb-core/src/collection/core/graph_api_tests.rs:1267:13:
iteration 0: delete() must block on payload_storage while add_edge holds its read guard through the WAL pause
FAILED
test collection::core::graph_api_tests::tests::add_edges_batch_concurrent_delete_never_leaves_phantom_edge ...
thread '...' panicked at crates/velesdb-core/src/collection/core/graph_api_tests.rs:1285:13:
iteration 0: delete() must block on payload_storage while add_edges_batch holds its read guard through the WAL pause
FAILED
test collection::core::graph_api_tests::tests::stress_add_edge_concurrent_delete_never_leaves_phantom_edge ...
thread '...' panicked at crates/velesdb-core/src/collection/core/graph_api_tests.rs:1330:13:
iteration 25: phantom edge under stress
FAILED
```

```
test pipeline_graph::tests::seed_retries_failed_node_on_next_occurrence ...
thread '...' panicked at crates/velesdb-migrate/src/pipeline_graph.rs:482:9:
a failed upsert must not mark the node as seeded
FAILED
```

All four green after the corresponding fix commit.

## Review points addressed

- **Race closed by holding the guard, not compensating.** A compensating approach (write the edge, then check-and-undo if the endpoint vanished) was considered and rejected: it leaves a crash window where the ADD is fsynced but a crash hits before the compensating REMOVE, and WAL replay bypasses referential-integrity validation by design (see "Known limitation" below) — so a crash-interrupted compensation would recreate the phantom permanently on the next open. Holding the guard closes the window instead of racing to patch it after the fact, and needs no rollback path.
- **Seed-retry**: fixed as described above; covered by an injectable-upsert unit test since simulating a real storage failure end-to-end isn't practical.

## Known, accepted limitations (tracked)

- Edges loaded from a pre-existing WAL/snapshot at `Collection::open` (replay) are trusted as-is and never re-validated — replay intentionally bypasses referential-integrity validation, since a database predating the original #1442 fix may legitimately be edge-only. A database created before that fix may still contain legacy phantom edges. Tracked in #1469 (`velesdb-cli graph doctor <collection> [--purge|--stub]`).
- The strict-vs-schemaless error-type divergence (`SchemaValidation` vs. `NodeNotFound`) from the original fix remains deliberate (changing it now would be breaking). Tracked for the next major version in #1470.

## Gates (all local, this pass)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | pass |
| `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` | pass |
| `cargo clippy -p velesdb-node --lib` | pass |
| `cargo test -p velesdb-core --features persistence -- --test-threads=1` | pass — 5287 passed, 0 failed |
| `cargo test -p velesdb-migrate` | pass — 33 passed, 0 failed |
| `cargo test -p velesdb-server` | pass — 0 failed |
| `cargo check --no-default-features` | **fails identically on unmodified `origin/develop`** (pre-existing `velesdb-server` breakage unrelated to this PR's files — verified in a separate baseline worktree) |
| `wasm-pack test --node crates/velesdb-wasm` | pass — 29 passed, 0 failed |
| `RUSTFLAGS="--cfg loom" cargo +nightly test --features loom,persistence -p velesdb-core --test loom_tests` | pass — 5 passed, including the new `loom_payload_guard_excludes_delete_during_edge_write` model |
| grep: no `get_node_payload`/nested `payload_storage.read()` call under an already-held guard | clean |
| grep: no `payload_storage` acquisition while holding `edge_wal_lock` | clean |
| grep: no AI attribution in any commit on this branch | clean |

Follow-up issues: #1469, #1470.
