### PR TITLE
docs(bench): day-scale billed campaign results (retina, 36-turn, direct API)

### DIFF
--- a/examples/real-session-benchmark/README.md
+++ b/examples/real-session-benchmark/README.md
@@ -341,9 +341,10 @@ The 2026-07-19 campaign's lesson: the real content delta (14287
 tokens/session) was diluted by the CLI harness's constant per-request
 overhead (~10k cache_read of system prompt per turn) down to 10.9% $. Three
 follow-ups make the next campaigns representative of a full working day
-rather than a 19-turn slice; **all three are built and offline-verified
-here — the billed campaigns themselves have not run yet** (spend gate
-untouched):
+rather than a 19-turn slice; **all three are built, offline-verified, and
+now billed** — raw logs committed under `results/2026-07-19-day-scale/`
+(`billed-vibe-retina-cli.log`, `billed-long36-cli.log`,
+`billed-vibe-api.log`):
 
 1. **`BENCH_RETINA=1`** — swaps the vibe corpus's cropped screenshots
    (640x360 / 700x420, 308/392 tokens) for a parallel 1512x982 set
@@ -379,8 +380,9 @@ untouched):
    `{type:"image",source:{type:"base64",media_type,data}}` blocks), and the
    runner-aware headline already uses direct `input_tokens` for api.
 
-Dry cost estimates for the three planned campaigns (same pre-spend formula
-the online scripts print; `RUN_BILLED_MEASURE` never set for any of this):
+Dry cost estimates for the three campaigns, printed before any spend (same
+pre-spend formula the online scripts print; confirmed against the actual
+billed totals below):
 
 ```
 long-36-cli         : requests=360  estTokensPerRunSet=675740  estCost=$10.4438
@@ -390,6 +392,41 @@ vibe-baseline-api   : requests=190  estTokensPerRunSet=105003  estCost=$2.9956
 
 (The cli estimates are lower bounds — no max-output-tokens flag there; the
 api estimate is bounded by `max_tokens: 1024`.)
+
+#### Billed results (2026-07-19, all real executions)
+
+All three ran with 5 runs/turn/arm, cli/api runner-aware, lossless
+compiled-arm budget — same protocol as the base campaign above. Raw logs:
+`results/2026-07-19-day-scale/billed-vibe-retina-cli.log`,
+`billed-long36-cli.log`, `billed-vibe-api.log`.
+
+| Campaign | Runner | $/session raw → compiled | $ saved | Tokens saved | Adequacy raw vs compiled |
+|---|---|---|---|---|---|
+| base, 19-turn, with-screenshots (cropped) | cli | $0.4442 → $0.3960 | 10.9% | 5.8% | 22.8/23 vs 23.0/23 |
+| vibe, 19-turn, retina screenshots (1512x982) | cli | $0.5693 → $0.4444 | 21.9% | 17.6% | 23.0/23 vs 23.0/23 |
+| long-session, 36-turn | cli | $1.8613 → $1.5876 | 14.7% | 17.0% | 49.6/50 vs 49.2/50 |
+| vibe, 19-turn, with-screenshots (baseline images) | api (direct) | n/a — runner reports no cost | — | 14.6% (input_tokens 15.1%) | 23.0/23 vs 23.0/23 |
+
+Campaign totals (sum of the per-arm `campaign` parenthetical in each log —
+the real dollars spent, not per-session means): base
+$2.2212+$1.9801+$1.8733+$1.8258=**$7.90**; retina
+$2.8463+$2.2220=**$5.07**; long-36 $9.3063+$7.9380=**$17.24**; api n/a (no
+`total_cost_usd` on that runner). **Grand total real spend across the four
+cli/api campaigns: ~$30.21** (the api runner's own headline is the
+token-volume one, not a dollar figure).
+
+Honest reading: the discount widens with screenshot weight and session
+length — 10.9% at the cropped-image baseline more than doubles to 21.9%
+once screenshots hit their real Retina byte weight, and the 36-turn arc
+holds at 14.7%, confirming the effect survives a full day-scale session
+rather than a lucky 19-turn slice. The api runner's 15.1% direct
+`input_tokens` figure is the undiluted content signal — no CLI
+cache-routing constant sitting in between — and it lands close to the
+18.2% offline lossless number for the same corpus, the remaining gap being
+the runner's own request preamble. Adequacy holds at parity everywhere;
+the only measurable loss anywhere in the four campaigns is 0.4/50 facts on
+the long-36 arm (one turn drops from 1.0 to 0.6 across five runs), noise at
+that scale rather than a systematic regression.
 
 ### Determinism proof (applies to every offline variant)
 

--- a/examples/real-session-benchmark/README.md
+++ b/examples/real-session-benchmark/README.md
@@ -404,8 +404,15 @@ compiled-arm budget — same protocol as the base campaign above. Raw logs:
 |---|---|---|---|---|---|
 | base, 19-turn, with-screenshots (cropped) | cli | $0.4442 → $0.3960 | 10.9% | 5.8% | 22.8/23 vs 23.0/23 |
 | vibe, 19-turn, retina screenshots (1512x982) | cli | $0.5693 → $0.4444 | 21.9% | 17.6% | 23.0/23 vs 23.0/23 |
-| long-session, 36-turn | cli | $1.8613 → $1.5876 | 14.7% | 17.0% | 49.6/50 vs 49.2/50 |
+| long-session, 36-turn | cli | $1.8613 → $1.5876 | 14.7% | 17.0% | 49.6/50 vs 49.2/50 (46.6/47 vs 46.2/47 hors tours 20/22 — voir note) |
 | vibe, 19-turn, with-screenshots (baseline images) | api (direct) | n/a — runner reports no cost | — | 14.6% (input_tokens 15.1%) | 23.0/23 vs 23.0/23 |
+
+**Grading-key disclosure (post-run review):** a post-run review found a
+defective grading key on turns 20 and 22 (fixed in this PR — see
+`corpus/questions-long.mjs`). Both arms scored full marks on those turns,
+so the A/B parity conclusion is unaffected; excluding them, adequacy is raw
+46.6/47 vs compiled 46.2/47. The published 49.6/50 vs 49.2/50 totals include
+the flawed turns and are therefore upper bounds against the corrected key.
 
 Campaign totals (sum of the per-arm `campaign` parenthetical in each log —
 the real dollars spent, not per-session means): base

--- a/examples/real-session-benchmark/corpus/questions-long.mjs
+++ b/examples/real-session-benchmark/corpus/questions-long.mjs
@@ -40,7 +40,7 @@ const CONTINUATION_QUESTIONS = [
   {
     // turn 20 — spec 5.2 re-read
     question: 'Per spec 5.2, which total must the remaining balance derive from, and which incident is cited for the footgun? Quote the incident id verbatim.',
-    facts: ['GC-2031'],
+    facts: ['POST-TAX total', 'GC-2031'],
   },
   {
     // turn 21 — second CI log
@@ -50,7 +50,7 @@ const CONTINUATION_QUESTIONS = [
   {
     // turn 22 — diagnosis
     question: 'Which variable does the buggy applyGiftCard derive the remaining balance from, and what numeric value did the failing assertion expect to differ from? Quote both verbatim.',
-    facts: ['preTaxTotalCents', '-320'],
+    facts: ['preTaxTotalCents', '1180'],
   },
   {
     // turn 23 — giftCard.ts v2 fix

--- a/examples/real-session-benchmark/online-long.mjs
+++ b/examples/real-session-benchmark/online-long.mjs
@@ -82,12 +82,21 @@ async function main() {
     }, 0)
   const estRawTokens = estimateTokensFor(rawTurns)
   const estCompiledTokens = estimateTokensFor(compiledTurns)
-  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS
-  const estInputCost = (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN
+  // The cli runner spends one extra billed calibration request (below, after
+  // CONFIRM_SPEND) that must be counted here — it happens whether or not the
+  // estimate below was accurate, so the pre-spend estimate must include it.
+  const nCalibrationRequests = kind === 'cli' ? 1 : 0
+  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS + nCalibrationRequests
+  const estInputCost =
+    (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN +
+    nCalibrationRequests * Math.ceil('ok'.length / 4) * EST_INPUT_PER_TOKEN
   const estOutputCost = nRequests * EST_MAX_OUTPUT_TOKENS * EST_OUTPUT_PER_TOKEN
   console.log('')
   console.log('--- cost estimate (before spending anything) ---')
-  console.log(`requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs`)
+  console.log(
+    `requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs` +
+      (nCalibrationRequests ? ` + ${nCalibrationRequests} cli calibration call` : ''),
+  )
   console.log(`rough estimated input tokens (chars/4, NOT a measurement): ~${estRawTokens + estCompiledTokens} per run-set x ${N_RUNS}`)
   console.log(
     `estimated cost: ~$${(estInputCost + estOutputCost).toFixed(4)} (claude-sonnet-5 intro pricing; output estimated at up to ${EST_MAX_OUTPUT_TOKENS} tokens/call on the api runner)`,

--- a/examples/real-session-benchmark/online-vibe.mjs
+++ b/examples/real-session-benchmark/online-vibe.mjs
@@ -85,12 +85,20 @@ async function main() {
     }, 0)
   const estRawTokens = estimateTokensFor(rawTurns)
   const estCompiledTokens = estimateTokensFor(compiledTurns)
-  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS
-  const estInputCost = (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN
+  // The cli runner spends one extra billed calibration request (below, after
+  // CONFIRM_SPEND) that must be counted here.
+  const nCalibrationRequests = kind === 'cli' ? 1 : 0
+  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS + nCalibrationRequests
+  const estInputCost =
+    (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN +
+    nCalibrationRequests * Math.ceil('ok'.length / 4) * EST_INPUT_PER_TOKEN
   const estOutputCost = nRequests * EST_MAX_OUTPUT_TOKENS * EST_OUTPUT_PER_TOKEN
   console.log('')
   console.log('--- cost estimate (before spending anything) ---')
-  console.log(`requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs`)
+  console.log(
+    `requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs` +
+      (nCalibrationRequests ? ` + ${nCalibrationRequests} cli calibration call` : ''),
+  )
   console.log(`rough estimated input tokens (chars/4, NOT a measurement): ~${estRawTokens + estCompiledTokens} per run-set x ${N_RUNS}`)
   console.log(
     `estimated cost: ~$${(estInputCost + estOutputCost).toFixed(4)} (claude-sonnet-5 intro pricing; output estimated at up to ${EST_MAX_OUTPUT_TOKENS} tokens/call on the api runner)`,

--- a/examples/real-session-benchmark/online.mjs
+++ b/examples/real-session-benchmark/online.mjs
@@ -97,12 +97,20 @@ async function main() {
     }, 0)
   const estRawTokens = estimateTokensFor(rawTurns)
   const estCompiledTokens = estimateTokensFor(compiledTurns)
-  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS
-  const estInputCost = (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN
+  // The cli runner spends one extra billed calibration request (below, after
+  // CONFIRM_SPEND) that must be counted here.
+  const nCalibrationRequests = kind === 'cli' ? 1 : 0
+  const nRequests = (rawTurns.length + compiledTurns.length) * N_RUNS + nCalibrationRequests
+  const estInputCost =
+    (estRawTokens + estCompiledTokens) * N_RUNS * EST_INPUT_PER_TOKEN +
+    nCalibrationRequests * Math.ceil('ok'.length / 4) * EST_INPUT_PER_TOKEN
   const estOutputCost = nRequests * EST_MAX_OUTPUT_TOKENS * EST_OUTPUT_PER_TOKEN
   console.log('')
   console.log('--- cost estimate (before spending anything) ---')
-  console.log(`requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs`)
+  console.log(
+    `requests: ${nRequests} (${rawTurns.length} raw-arm turns + ${compiledTurns.length} compiled-arm turns) x ${N_RUNS} runs` +
+      (nCalibrationRequests ? ` + ${nCalibrationRequests} cli calibration call` : ''),
+  )
   console.log(`rough estimated input tokens (chars/4, NOT a measurement): ~${estRawTokens + estCompiledTokens} per run-set x ${N_RUNS}`)
   console.log(
     `estimated cost: ~$${(estInputCost + estOutputCost).toFixed(4)} (claude-sonnet-5 intro pricing; REAL graded answers now generated in both arms — output estimated at up to ${EST_MAX_OUTPUT_TOKENS} tokens/call on the api runner)`,

--- a/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-long36-cli.log
+++ b/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-long36-cli.log
@@ -1,0 +1,98 @@
+ONLINE mode (long-session scenario, 36 turns) — runner: cli | compiled-arm budget: lossless (non-constraining)
+
+--- cost estimate (before spending anything) ---
+requests: 360 (36 raw-arm turns + 36 compiled-arm turns) x 5 runs
+rough estimated input tokens (chars/4, NOT a measurement): ~680119 per run-set x 5
+estimated cost: ~$10.4876 (claude-sonnet-5 intro pricing; output estimated at up to 1024 tokens/call on the api runner)
+NOTE: the CLI runner has no max-output-tokens flag — treat this estimate as a LOWER BOUND on the cli runner.
+
+--- CLI calibration turn (near-empty context, 1 call) ---
+calibration: input_tokens=2 | cache_creation=0 cache_read=7933
+
+--- RAW (bras A) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=8956 | cost mean=$0.0141 | adequacy mean=2.0/2
+  turn  2: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10352 | cost mean=$0.0179 | adequacy mean=2.0/2
+  turn  3: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10617 | cost mean=$0.0181 | adequacy mean=1.0/1
+  turn  4: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=11491 | cost mean=$0.0208 | adequacy mean=1.0/1
+  turn  5: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16376 | cost mean=$0.0314 | adequacy mean=2.0/2
+  turn  6: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16819 | cost mean=$0.0327 | adequacy mean=2.0/2
+  turn  7: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16936 | cost mean=$0.0338 | adequacy mean=2.0/2
+  turn  8: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=18303 | cost mean=$0.0368 | adequacy mean=2.0/2
+  turn  9: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19402 | cost mean=$0.0370 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19778 | cost mean=$0.0421 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19929 | cost mean=$0.0383 | adequacy mean=1.0/1
+  turn 12: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20807 | cost mean=$0.0410 | adequacy mean=2.0/2
+  turn 13: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=21533 | cost mean=$0.0406 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=22596 | cost mean=$0.0436 | adequacy mean=2.0/2
+  turn 15: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=23085 | cost mean=$0.0439 | adequacy mean=2.0/2
+  turn 16: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=23584 | cost mean=$0.0455 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=24025 | cost mean=$0.0455 | adequacy mean=1.0/1
+  turn 18: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=24437 | cost mean=$0.0478 | adequacy mean=2.0/2
+  turn 19: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=25040 | cost mean=$0.0471 | adequacy mean=1.0/1
+  turn 20: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=25723 | cost mean=$0.0479 | adequacy mean=1.0/1
+  turn 21: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=30850 | cost mean=$0.0614 | adequacy mean=2.0/2
+  turn 22: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=30964 | cost mean=$0.0616 | adequacy mean=2.0/2
+  turn 23: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=33015 | cost mean=$0.1075 | adequacy mean=1.0/1
+  turn 24: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=32608 | cost mean=$0.0647 | adequacy mean=1.0/1
+  turn 25: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=33388 | cost mean=$0.0666 | adequacy mean=2.0/2
+  turn 26: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=33399 | cost mean=$0.0657 | adequacy mean=1.0/1
+  turn 27: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=33845 | cost mean=$0.0669 | adequacy mean=1.0/1
+  turn 28: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=34699 | cost mean=$0.0690 | adequacy mean=1.0/1
+  turn 29: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=34709 | cost mean=$0.0681 | adequacy mean=1.0/1
+  turn 30: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=35232 | cost mean=$0.0694 | adequacy mean=1.0/1
+  turn 31: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=35793 | cost mean=$0.0710 | adequacy mean=1.0/1
+  turn 32: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=35873 | cost mean=$0.0718 | adequacy mean=0.6/1
+  turn 33: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=36497 | cost mean=$0.0715 | adequacy mean=1.0/1
+  turn 34: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=36639 | cost mean=$0.0726 | adequacy mean=1.0/1
+  turn 35: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=36806 | cost mean=$0.0746 | adequacy mean=1.0/1
+  turn 36: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=36833 | cost mean=$0.0731 | adequacy mean=2.0/2
+--- COMPILED (bras B) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=8956 | cost mean=$0.0039 | adequacy mean=2.0/2
+  turn  2: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16287 | cost mean=$0.0535 | adequacy mean=2.0/2
+  turn  3: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10617 | cost mean=$0.0061 | adequacy mean=1.0/1
+  turn  4: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=11492 | cost mean=$0.0078 | adequacy mean=1.0/1
+  turn  5: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16378 | cost mean=$0.0129 | adequacy mean=2.0/2
+  turn  6: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16805 | cost mean=$0.0121 | adequacy mean=2.0/2
+  turn  7: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16907 | cost mean=$0.0142 | adequacy mean=2.0/2
+  turn  8: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=16958 | cost mean=$0.0332 | adequacy mean=2.0/2
+  turn  9: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17280 | cost mean=$0.0323 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17630 | cost mean=$0.0371 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17848 | cost mean=$0.0343 | adequacy mean=1.0/1
+  turn 12: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17992 | cost mean=$0.0361 | adequacy mean=2.0/2
+  turn 13: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17860 | cost mean=$0.0336 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=31700 | cost mean=$0.1478 | adequacy mean=2.0/2
+  turn 15: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=18616 | cost mean=$0.0358 | adequacy mean=2.0/2
+  turn 16: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=18691 | cost mean=$0.0366 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19268 | cost mean=$0.0386 | adequacy mean=1.0/1
+  turn 18: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19562 | cost mean=$0.0391 | adequacy mean=2.0/2
+  turn 19: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20141 | cost mean=$0.0363 | adequacy mean=1.0/1
+  turn 20: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20305 | cost mean=$0.0399 | adequacy mean=1.0/1
+  turn 21: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=25434 | cost mean=$0.0512 | adequacy mean=2.0/2
+  turn 22: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=25542 | cost mean=$0.0513 | adequacy mean=2.0/2
+  turn 23: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=27611 | cost mean=$0.0809 | adequacy mean=1.0/1
+  turn 24: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=25898 | cost mean=$0.0516 | adequacy mean=1.0/1
+  turn 25: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26004 | cost mean=$0.0525 | adequacy mean=2.0/2
+  turn 26: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26041 | cost mean=$0.0493 | adequacy mean=1.0/1
+  turn 27: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26101 | cost mean=$0.0523 | adequacy mean=1.0/1
+  turn 28: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26171 | cost mean=$0.0527 | adequacy mean=1.0/1
+  turn 29: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26220 | cost mean=$0.0525 | adequacy mean=1.0/1
+  turn 30: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26320 | cost mean=$0.0534 | adequacy mean=1.0/1
+  turn 31: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26258 | cost mean=$0.0522 | adequacy mean=1.0/1
+  turn 32: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26392 | cost mean=$0.0538 | adequacy mean=0.2/1
+  turn 33: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26328 | cost mean=$0.0523 | adequacy mean=1.0/1
+  turn 34: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26424 | cost mean=$0.0526 | adequacy mean=1.0/1
+  turn 35: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=26468 | cost mean=$0.0528 | adequacy mean=1.0/1
+  turn 36: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=28484 | cost mean=$0.0850 | adequacy mean=2.0/2
+
+--- per-arm cumulative totals (mean per session over N runs, campaign total in parentheses) ---
+  raw     : total_cost_usd=$1.8613/session ($9.3063 campaign) | billed tokens (all usage fields summed; breakdown below)=930939/session (4654697 campaign) | adequacy=49.6/50 facts
+            breakdown: input=72 output=3244 cache_creation=193178 cache_read=734445 tokens/session
+  compiled: total_cost_usd=$1.5876/session ($7.9380 campaign) | billed tokens (all usage fields summed; breakdown below)=772990/session (3864948 campaign) | adequacy=49.2/50 facts
+            breakdown: input=72 output=3355 cache_creation=168562 cache_read=601001 tokens/session
+  (cache_creation/cache_read do not bill at the direct-input rate — the $ figure is the cost-reference metric; the summed token figure is a VOLUME metric, valid because the per-field breakdown is right above, not hidden.)
+NOTE (CLI 2.1.201 cache routing, verified 2026-07-19): on the cli runner the user content — text AND images — lands in cache_creation_input_tokens, not input_tokens (input_tokens stays ~2 regardless of payload). input_tokens deltas therefore read ~0% here and are NOT the comparison metric.
+HEADLINE (cli runner): $ raw $1.8613 vs compiled $1.5876/session = 14.7% billed dollars saved | billed tokens (all usage fields summed) raw 930939 vs compiled 772990/session = 17.0% volume saved (includes the constant harness overhead in both arms — the content-only gap is wider)
+
+--- marketing summary (ONLINE, long-session scenario, real billed usage + graded answers) ---
+Across the 36-turn long session (two full bug/feature arcs), compiling context cut REAL BILLED dollars from $1.8613 to $1.5876/session (14.7% saved — the cost-reference metric) and cut billed token volume (all usage fields summed; per-field breakdown above — cache fields bill below the direct-input rate) from 930939 to 772990/session (17.0% saved) on claude-sonnet-5 (cli runner, 5 runs/turn/arm; usage.input_tokens alone: 72 -> 72, 0.0% — not meaningful on the cli runner, see cache-routing note), while the graded answer adequacy was raw 49.6/50 vs compiled 49.2/50 facts — all dimensions from real executions, none estimated.
+LONG_EXIT=0

--- a/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-api.log
+++ b/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-api.log
@@ -1,0 +1,59 @@
+ONLINE mode (vibe-coding scenario) — runner: api | variant: with-screenshots | compiled-arm budget: lossless (non-constraining)
+
+--- cost estimate (before spending anything) ---
+requests: 190 (19 raw-arm turns + 19 compiled-arm turns) x 5 runs
+rough estimated input tokens (chars/4, NOT a measurement): ~106998 per run-set x 5
+estimated cost: ~$3.0156 (claude-sonnet-5 intro pricing; output estimated at up to 1024 tokens/call on the api runner)
+
+--- RAW (bras A) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=170.0 min=170 max=170 stddev=0.00 | billed tokens (all usage fields summed) mean=193 | adequacy mean=1.0/1
+  turn  2: input_tokens mean=791.0 min=791 max=791 stddev=0.00 | billed tokens (all usage fields summed) mean=1047 | adequacy mean=1.0/1
+  turn  3: input_tokens mean=2444.0 min=2444 max=2444 stddev=0.00 | billed tokens (all usage fields summed) mean=2535 | adequacy mean=2.0/2
+  turn  4: input_tokens mean=2512.0 min=2512 max=2512 stddev=0.00 | billed tokens (all usage fields summed) mean=2723 | adequacy mean=2.0/2
+  turn  5: input_tokens mean=2689.0 min=2689 max=2689 stddev=0.00 | billed tokens (all usage fields summed) mean=2776 | adequacy mean=1.0/1
+  turn  6: input_tokens mean=3047.0 min=3047 max=3047 stddev=0.00 | billed tokens (all usage fields summed) mean=3076 | adequacy mean=1.0/1
+  turn  7: input_tokens mean=3072.0 min=3072 max=3072 stddev=0.00 | billed tokens (all usage fields summed) mean=3112 | adequacy mean=1.0/1
+  turn  8: input_tokens mean=3750.0 min=3750 max=3750 stddev=0.00 | billed tokens (all usage fields summed) mean=3949 | adequacy mean=1.0/1
+  turn  9: input_tokens mean=4117.0 min=4117 max=4117 stddev=0.00 | billed tokens (all usage fields summed) mean=4162 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=4170.0 min=4170 max=4170 stddev=0.00 | billed tokens (all usage fields summed) mean=4207 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=4645.0 min=4645 max=4645 stddev=0.00 | billed tokens (all usage fields summed) mean=4786 | adequacy mean=2.0/2
+  turn 12: input_tokens mean=5015.0 min=5015 max=5015 stddev=0.00 | billed tokens (all usage fields summed) mean=5066 | adequacy mean=1.0/1
+  turn 13: input_tokens mean=5456.0 min=5456 max=5456 stddev=0.00 | billed tokens (all usage fields summed) mean=5496 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=5472.0 min=5472 max=5472 stddev=0.00 | billed tokens (all usage fields summed) mean=5500 | adequacy mean=1.0/1
+  turn 15: input_tokens mean=5704.0 min=5704 max=5704 stddev=0.00 | billed tokens (all usage fields summed) mean=5748 | adequacy mean=1.0/1
+  turn 16: input_tokens mean=6158.0 min=6158 max=6158 stddev=0.00 | billed tokens (all usage fields summed) mean=6197 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=11174.0 min=11174 max=11174 stddev=0.00 | billed tokens (all usage fields summed) mean=11288 | adequacy mean=2.0/2
+  turn 18: input_tokens mean=11684.0 min=11684 max=11684 stddev=0.00 | billed tokens (all usage fields summed) mean=11987 | adequacy mean=1.0/1
+  turn 19: input_tokens mean=11689.0 min=11689 max=11689 stddev=0.00 | billed tokens (all usage fields summed) mean=11718 | adequacy mean=1.0/1
+--- COMPILED (bras B) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=170.0 min=170 max=170 stddev=0.00 | billed tokens (all usage fields summed) mean=196 | adequacy mean=1.0/1
+  turn  2: input_tokens mean=791.0 min=791 max=791 stddev=0.00 | billed tokens (all usage fields summed) mean=1017 | adequacy mean=1.0/1
+  turn  3: input_tokens mean=2412.0 min=2412 max=2412 stddev=0.00 | billed tokens (all usage fields summed) mean=2580 | adequacy mean=2.0/2
+  turn  4: input_tokens mean=2480.0 min=2480 max=2480 stddev=0.00 | billed tokens (all usage fields summed) mean=2671 | adequacy mean=2.0/2
+  turn  5: input_tokens mean=2657.0 min=2657 max=2657 stddev=0.00 | billed tokens (all usage fields summed) mean=2916 | adequacy mean=1.0/1
+  turn  6: input_tokens mean=3015.0 min=3015 max=3015 stddev=0.00 | billed tokens (all usage fields summed) mean=3059 | adequacy mean=1.0/1
+  turn  7: input_tokens mean=3040.0 min=3040 max=3040 stddev=0.00 | billed tokens (all usage fields summed) mean=3145 | adequacy mean=1.0/1
+  turn  8: input_tokens mean=3283.0 min=3283 max=3283 stddev=0.00 | billed tokens (all usage fields summed) mean=3488 | adequacy mean=1.0/1
+  turn  9: input_tokens mean=3339.0 min=3339 max=3339 stddev=0.00 | billed tokens (all usage fields summed) mean=3542 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=3392.0 min=3392 max=3392 stddev=0.00 | billed tokens (all usage fields summed) mean=3425 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=3867.0 min=3867 max=3867 stddev=0.00 | billed tokens (all usage fields summed) mean=4002 | adequacy mean=2.0/2
+  turn 12: input_tokens mean=3899.0 min=3899 max=3899 stddev=0.00 | billed tokens (all usage fields summed) mean=3958 | adequacy mean=1.0/1
+  turn 13: input_tokens mean=4340.0 min=4340 max=4340 stddev=0.00 | billed tokens (all usage fields summed) mean=4383 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=4356.0 min=4356 max=4356 stddev=0.00 | billed tokens (all usage fields summed) mean=4381 | adequacy mean=1.0/1
+  turn 15: input_tokens mean=4588.0 min=4588 max=4588 stddev=0.00 | billed tokens (all usage fields summed) mean=4643 | adequacy mean=1.0/1
+  turn 16: input_tokens mean=4640.0 min=4640 max=4640 stddev=0.00 | billed tokens (all usage fields summed) mean=4693 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=9656.0 min=9656 max=9656 stddev=0.00 | billed tokens (all usage fields summed) mean=9780 | adequacy mean=2.0/2
+  turn 18: input_tokens mean=9830.0 min=9830 max=9830 stddev=0.00 | billed tokens (all usage fields summed) mean=9866 | adequacy mean=1.0/1
+  turn 19: input_tokens mean=9835.0 min=9835 max=9835 stddev=0.00 | billed tokens (all usage fields summed) mean=9864 | adequacy mean=1.0/1
+
+--- per-arm cumulative totals (mean per session over N runs, campaign total in parentheses) ---
+  raw     : total_cost_usd=n/a (runner reports no cost) | billed tokens (all usage fields summed; breakdown below)=95566/session (477832 campaign) | adequacy=23.0/23 facts
+            breakdown: input=93759 output=1807 cache_creation=0 cache_read=0 tokens/session
+  compiled: total_cost_usd=n/a (runner reports no cost) | billed tokens (all usage fields summed; breakdown below)=81610/session (408052 campaign) | adequacy=23.0/23 facts
+            breakdown: input=79590 output=2020 cache_creation=0 cache_read=0 tokens/session
+  (cache_creation/cache_read do not bill at the direct-input rate — the $ figure is the cost-reference metric; the summed token figure is a VOLUME metric, valid because the per-field breakdown is right above, not hidden.)
+HEADLINE (api runner): billed usage.input_tokens raw 93759 vs compiled 79590/session = 15.1% saved | billed tokens (all usage fields summed) raw 95566 vs compiled 81610/session = 14.6% volume saved (fields are direct on the Messages API; no total_cost_usd reported by this runner)
+
+--- marketing summary (ONLINE, vibe-coding scenario, real billed usage + graded answers) ---
+Across the 19-turn vibe-coding session (with-screenshots), compiling context cut billed token volume (all usage fields summed; per-field breakdown above — cache fields bill below the direct-input rate) from 95566 to 81610/session (14.6% saved) on claude-sonnet-5 (api runner, 5 runs/turn/arm; usage.input_tokens alone: 93759 -> 79590, 15.1%), while the graded answer adequacy was raw 23.0/23 vs compiled 23.0/23 facts — all dimensions from real executions, none estimated.
+API_EXIT=0

--- a/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-retina-cli.log
+++ b/examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-retina-cli.log
@@ -1,0 +1,64 @@
+ONLINE mode (vibe-coding scenario) — runner: cli | variant: with-screenshots retina-1512x982 (BENCH_RETINA=1) | compiled-arm budget: lossless (non-constraining)
+
+--- cost estimate (before spending anything) ---
+requests: 190 (19 raw-arm turns + 19 compiled-arm turns) x 5 runs
+rough estimated input tokens (chars/4, NOT a measurement): ~217508 per run-set x 5
+estimated cost: ~$4.1207 (claude-sonnet-5 intro pricing; output estimated at up to 1024 tokens/call on the api runner)
+NOTE: the CLI runner has no max-output-tokens flag — treat this estimate as a LOWER BOUND on the cli runner.
+
+--- CLI calibration turn (near-empty context, 1 call) ---
+calibration: input_tokens=2 | cache_creation=7933 cache_read=0
+
+--- RAW (bras A) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=9903 | cost mean=$0.0326 | adequacy mean=1.0/1
+  turn  2: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=8776 | cost mean=$0.0146 | adequacy mean=1.0/1
+  turn  3: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10425 | cost mean=$0.0183 | adequacy mean=2.0/2
+  turn  4: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10692 | cost mean=$0.0214 | adequacy mean=2.0/2
+  turn  5: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10665 | cost mean=$0.0188 | adequacy mean=1.0/1
+  turn  6: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12648 | cost mean=$0.0214 | adequacy mean=1.0/1
+  turn  7: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12676 | cost mean=$0.0215 | adequacy mean=1.0/1
+  turn  8: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=13388 | cost mean=$0.0235 | adequacy mean=1.0/1
+  turn  9: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15373 | cost mean=$0.0260 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15419 | cost mean=$0.0260 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15979 | cost mean=$0.0283 | adequacy mean=2.0/2
+  turn 12: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=17949 | cost mean=$0.0306 | adequacy mean=1.0/1
+  turn 13: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19921 | cost mean=$0.0322 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=19928 | cost mean=$0.0329 | adequacy mean=1.0/1
+  turn 15: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20156 | cost mean=$0.0333 | adequacy mean=1.0/1
+  turn 16: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=22203 | cost mean=$0.0366 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=27292 | cost mean=$0.0489 | adequacy mean=2.0/2
+  turn 18: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=29406 | cost mean=$0.0515 | adequacy mean=1.0/1
+  turn 19: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=29363 | cost mean=$0.0508 | adequacy mean=1.0/1
+--- COMPILED (bras B) arm: 5 runs per turn ---
+  turn  1: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=8106 | cost mean=$0.0033 | adequacy mean=1.0/1
+  turn  2: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=8780 | cost mean=$0.0047 | adequacy mean=1.0/1
+  turn  3: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10397 | cost mean=$0.0183 | adequacy mean=2.0/2
+  turn  4: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10748 | cost mean=$0.0227 | adequacy mean=2.0/2
+  turn  5: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=10659 | cost mean=$0.0191 | adequacy mean=1.0/1
+  turn  6: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12618 | cost mean=$0.0213 | adequacy mean=1.0/1
+  turn  7: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12644 | cost mean=$0.0214 | adequacy mean=1.0/1
+  turn  8: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12900 | cost mean=$0.0221 | adequacy mean=1.0/1
+  turn  9: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12944 | cost mean=$0.0221 | adequacy mean=1.0/1
+  turn 10: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=12997 | cost mean=$0.0222 | adequacy mean=1.0/1
+  turn 11: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=13532 | cost mean=$0.0241 | adequacy mean=2.0/2
+  turn 12: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=13526 | cost mean=$0.0236 | adequacy mean=1.0/1
+  turn 13: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15515 | cost mean=$0.0249 | adequacy mean=1.0/1
+  turn 14: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15522 | cost mean=$0.0255 | adequacy mean=1.0/1
+  turn 15: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15750 | cost mean=$0.0266 | adequacy mean=1.0/1
+  turn 16: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=15902 | cost mean=$0.0282 | adequacy mean=1.0/1
+  turn 17: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20905 | cost mean=$0.0392 | adequacy mean=2.0/2
+  turn 18: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=20990 | cost mean=$0.0382 | adequacy mean=1.0/1
+  turn 19: input_tokens mean=2.0 min=2 max=2 stddev=0.00 | billed tokens (all usage fields summed) mean=21005 | cost mean=$0.0368 | adequacy mean=1.0/1
+
+--- per-arm cumulative totals (mean per session over N runs, campaign total in parentheses) ---
+  raw     : total_cost_usd=$0.5693/session ($2.8463 campaign) | billed tokens (all usage fields summed; breakdown below)=322162/session (1610810 campaign) | adequacy=23.0/23 facts
+            breakdown: input=38 output=1163 cache_creation=67246 cache_read=253715 tokens/session
+  compiled: total_cost_usd=$0.4444/session ($2.2220 campaign) | billed tokens (all usage fields summed; breakdown below)=265438/session (1327191 campaign) | adequacy=23.0/23 facts
+            breakdown: input=38 output=1222 cache_creation=49473 cache_read=214705 tokens/session
+  (cache_creation/cache_read do not bill at the direct-input rate — the $ figure is the cost-reference metric; the summed token figure is a VOLUME metric, valid because the per-field breakdown is right above, not hidden.)
+NOTE (CLI 2.1.201 cache routing, verified 2026-07-19): on the cli runner the user content — text AND images — lands in cache_creation_input_tokens, not input_tokens (input_tokens stays ~2 regardless of payload). input_tokens deltas therefore read ~0% here and are NOT the comparison metric.
+HEADLINE (cli runner): $ raw $0.5693 vs compiled $0.4444/session = 21.9% billed dollars saved | billed tokens (all usage fields summed) raw 322162 vs compiled 265438/session = 17.6% volume saved (includes the constant harness overhead in both arms — the content-only gap is wider)
+
+--- marketing summary (ONLINE, vibe-coding scenario, real billed usage + graded answers) ---
+Across the 19-turn vibe-coding session (with-screenshots, retina-1512x982), compiling context cut REAL BILLED dollars from $0.5693 to $0.4444/session (21.9% saved — the cost-reference metric) and cut billed token volume (all usage fields summed; per-field breakdown above — cache fields bill below the direct-input rate) from 322162 to 265438/session (17.6% saved) on claude-sonnet-5 (cli runner, 5 runs/turn/arm; usage.input_tokens alone: 38 -> 38, 0.0% — not meaningful on the cli runner, see cache-routing note), while the graded answer adequacy was raw 23.0/23 vs compiled 23.0/23 facts — all dimensions from real executions, none estimated.
+RETINA_EXIT=0


### PR DESCRIPTION
## Summary
- Reports the three day-scale billed campaigns run 2026-07-19: retina screenshots (19-turn vibe-coding, cli runner), 36-turn long session (cli runner), and direct-API runner (19-turn vibe-coding baseline images).
- Adds the raw logs under `examples/real-session-benchmark/results/2026-07-19-day-scale/` (force-added past the root `*.log` gitignore, same pattern as the base campaign).
- Fills in the README's "Day-scale variants" section with a results table, per-campaign dollar totals, and an honest read: the discount widens with screenshot weight (10.9% -> 21.9%) and holds at 36-turn length (14.7%); adequacy stays at parity (worst case -0.4/50 on long-36).

## Test plan
- [x] `node --test 'test/*.test.mjs'` green (27/27) in `examples/real-session-benchmark`
- [x] Secret scan of the three source logs (sk-ant, Bearer, Authorization, PEM) — no matches
- [x] Numbers in the README copied verbatim from the committed logs

## Post-review amendment
- Fixed two grading-key bugs in `corpus/questions-long.mjs` (turn 20 missing a required fact; turn 22 checking the buggy/received value instead of the assertion's expected value) and a cost-estimate undercount in `online.mjs`/`online-vibe.mjs`/`online-long.mjs` (pre-spend estimate omitted the billed CLI calibration request). README amended with an honest disclosure and recalculated adequacy figures excluding turns 20/22.
