### PR TITLE
fix(mcp): memory-tool ids survive float-lossy clients (id_str echo + string inputs)

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Memory-tool ids now survive float-lossy JSON clients (issue #1468).**
+  `remember`, `recall`/`recall_where`/`recall_fused`, `relate`, `forget`,
+  `feedback`, `remember_extracted`, and `why` return `u64` ids as plain JSON
+  numbers, which a client whose JSON layer round-trips numbers through an
+  IEEE-754 `f64` (JS `number`, Claude Code included) silently rounds once the
+  id exceeds 2^53 — the rounded id is then rejected by `relate`/`forget`/
+  `feedback` with "memory does not exist", reported from real dogfooding.
+  Every MCP response now also carries a decimal-string twin of each id
+  (`id_str` on `remember`/`recall*`/`forget`/`feedback`/`why`'s nodes,
+  `edge_id_str` on `relate`, `ids_str` on `remember_extracted`,
+  `from_str`/`to_str` on `why`'s edges) — purely additive, the numeric field
+  is unchanged so 0.9.x callers are unaffected. `relate`'s `from`/`to`,
+  `forget`/`feedback`'s `id`, and `remember`'s `links[].target` also accept
+  that decimal-string form on input (in addition to a plain number), with the
+  advertised tool schemas updated to match, so a client can safely resubmit
+  an `id_str` it received. **Wire-only, no Rust API change**: the string
+  twins live entirely in the MCP DTO layer (`mcp::dto`); the public domain
+  types (`Recollection`, `MemoryNode`, `MemoryEdge`, `Explanation`) are
+  unchanged, so library consumers of the crate (bindings, crates.io users)
+  see no breakage — the only `model` change is that `Link::target`
+  *deserialization* additionally tolerates a decimal string, which is
+  strictly widening. (#1468)
+
 ## [0.9.1] — 2026-07-19
 
 ### Security

--- a/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
+++ b/crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
@@ -81,6 +81,34 @@ assert explain["rule_id"] in {"drop.duplicate", "preserve.default"}, explain
 savings = srv.call("context_savings", {"project": "veles"})
 assert savings["events"] == 1 and savings["tokens_saved"] > 0, savings
 
+# --- memory tools: id_str round-trip closes #1468 (float-lossy JSON ids) ----
+# A float-lossy JSON client (JS `number`, Claude Code included) rounds a u64
+# id above 2^53 on the way out of a response and resubmits the rounded value
+# on the way in, so relate/forget/feedback fail with "memory does not exist".
+# The fix: every id also comes back as a decimal-string `..._str` twin, and
+# every id parameter accepts that string form. Proven here over the REAL
+# stdio JSON-RPC transport — relate is driven with the `id_str` STRINGS, not
+# the numeric `id` field, exactly as a fixed client must.
+mem_a = srv.call("remember", {"fact": "we chose parking_lot to avoid lock poisoning"})
+mem_b = srv.call("remember", {"fact": "PR #42 swaps the mutex"})
+assert mem_a["id_str"] == str(mem_a["id"]), mem_a
+assert mem_b["id_str"] == str(mem_b["id"]), mem_b
+
+rel = srv.call("relate", {"from": mem_a["id_str"], "to": mem_b["id_str"], "relation": "decided_in"})
+assert rel["edge_id_str"] == str(rel["edge_id"]), rel
+
+why_mem = srv.call("why", {"decision": "parking_lot poisoning", "max_hops": 1})
+node_ids = {n["id"] for n in why_mem["nodes"]}
+assert mem_a["id"] in node_ids and mem_b["id"] in node_ids, why_mem
+edge = next(e for e in why_mem["edges"] if e["relation"] == "decided_in")
+assert edge["from_str"] == mem_a["id_str"] and edge["to_str"] == mem_b["id_str"], edge
+
+fb = srv.call("feedback", {"id": mem_a["id_str"], "success": True})
+assert fb["id_str"] == mem_a["id_str"], fb
+
+forgotten = srv.call("forget", {"id": mem_b["id_str"]})
+assert forgotten["found"] and forgotten["id_str"] == mem_b["id_str"], forgotten
+
 # --- media fragment: compile with an image -> externalize -> retrieve byte-identical (US-009, PR3) ---
 # A real, independently-decodable 1x1 transparent PNG (IHDR + IDAT + IEND) --
 # fixed bytes, never derived from the fragment's caption.
@@ -127,4 +155,5 @@ srv2.terminate()
 print("MCP E2E OK — 6 tools exercised over real stdio: list, compile (dedup+insights+handles), "
       "retrieve round-trip (text AND a real PNG media fragment, byte-identical base64), explain, "
       "savings, error taxonomy, and save/load_working_context round-tripping ACROSS two separate "
-      "server processes")
+      "server processes; plus remember/relate/why/feedback/forget driven by id_str STRINGS "
+      "end to end over the real JSON-RPC transport (issue #1468)")

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -52,6 +52,12 @@ well is a *loop you run throughout a task*, not a one-shot lookup.
    labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
    `fixes`, `concerns`. This is the differentiator's fuel — build the graph
    incrementally, don't batch it up "later" (later never comes).
+   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
+   too): every id in a response also comes back as a decimal-string `id_str`
+   twin specifically because a raw JSON-number id can exceed 2^53 and get
+   rounded by a float-lossy client on the way back in, silently pointing
+   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
+   the numeric `id`.
 
 4. **Explain with `why`, not `recall`.** When asked to justify a value, a config,
    or a design choice, use `why`: recall alone finds text that *looks* similar;
@@ -59,10 +65,12 @@ well is a *loop you run throughout a task*, not a one-shot lookup.
    with the code but is the actual reason.
 
 5. **Reinforce after use (`feedback`).** After you act on a recalled memory, tell
-   the memory whether it helped: `feedback(id, success=true)` if it was useful,
-   `success=false` if it was noise. Recall re-ranks by this learned confidence, so
-   over time useful facts rise and noise sinks — the memory improves without any
-   retraining. Give feedback on the memory you actually used, not on everything.
+   the memory whether it helped: `feedback(id_str, success=true)` if it was useful,
+   `success=false` if it was noise — pass the recalled memory's `id_str`, not its
+   numeric `id` (see the `id_str` note above). Recall re-ranks by this learned
+   confidence, so over time useful facts rise and noise sinks — the memory
+   improves without any retraining. Give feedback on the memory you actually
+   used, not on everything.
 
 ## Concrete scenarios
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -7,12 +7,14 @@
 use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
+use rmcp::handler::server::tool::schema_for_input;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::{ErrorCode, Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{ErrorCode, Implementation, JsonObject, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
+use schemars::JsonSchema;
 
 use crate::limits::{DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
-use crate::model::{Explanation, FusionOptions};
+use crate::model::FusionOptions;
 use crate::service::MemoryService;
 
 /// Default number of memories returned by `recall`.
@@ -26,9 +28,10 @@ use crate::extract::DynExtractor;
 
 // --- Tool parameter / result DTOs ------------------------------------------
 //
-// The request envelopes and small id-results live in their own module so this
-// file stays focused on the server and tool wiring; output shapes reuse the
-// domain types from `crate::model` directly (no duplicate wire/domain struct).
+// The request envelopes, small id-results, and the id-echoing wire wrappers
+// (`RecollectionDto`, `ExplanationDto` — the `id_str` twins of issue #1468)
+// live in their own module so this file stays focused on the server and tool
+// wiring; the domain types in `crate::model` are unchanged.
 /// The context compiler's six tools — a second `#[tool_router]` block whose
 /// router is combined with the main one below, extending the ONE server.
 #[cfg(feature = "context")]
@@ -36,10 +39,31 @@ mod context_tools;
 
 mod dto;
 use dto::{
-    FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, RecallFusedParams,
+    ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, RecallFusedParams,
     RecallFusedResult, RecallParams, RecallResult, RecallWhereParams, RelateParams, RelateResult,
     RememberExtractedParams, RememberExtractedResult, RememberParams, RememberResult, WhyParams,
 };
+
+/// Advertised-schema counterpart of [`crate::model::deserialize_id`]: `keys`
+/// (e.g. `["from", "to"]`) widen from `integer` to `["integer", "string"]` so
+/// a client generating requests from the schema can discover the
+/// decimal-string form (issue #1468). Scoped per tool — each takes a
+/// different set of id-named parameters (`relate`'s `from`/`to`,
+/// `forget`/`feedback`'s `id`, `remember`'s nested `links[].target`) — unlike
+/// the context compiler's `wire_safe_input_schema` (single hardcoded `"id"`
+/// key, `context`-feature-gated). Both reuse the same underlying
+/// [`crate::schema::widen_id_properties`] tree walk.
+fn id_wire_input_schema<T: JsonSchema + std::any::Any>(keys: &[&str]) -> Arc<JsonObject> {
+    let schema = schema_for_input::<Parameters<T>>().unwrap_or_else(|e| {
+        panic!(
+            "Invalid input schema for {}: {e}",
+            std::any::type_name::<T>()
+        )
+    });
+    let mut map = (*schema).clone();
+    crate::schema::widen_id_properties(&mut map, keys);
+    Arc::new(map)
+}
 
 // --- The server ------------------------------------------------------------
 
@@ -103,7 +127,8 @@ impl McpServer {
 
     #[tool(
         name = "remember",
-        description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering — metadata is capped at 64 KiB serialized. Set `ttl_seconds` to make the fact expire after a delay (a durable TTL that survives restarts); omit it for a permanent memory. Returns the fact's stable id."
+        description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering — metadata is capped at 64 KiB serialized. Set `ttl_seconds` to make the fact expire after a delay (a durable TTL that survives restarts); omit it for a permanent memory. Returns the fact's stable id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+        input_schema = id_wire_input_schema::<RememberParams>(&["target"])
     )]
     async fn remember(
         &self,
@@ -130,12 +155,15 @@ impl McpServer {
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(RememberResult { id }))
+        Ok(Json(RememberResult {
+            id,
+            id_str: id.to_string(),
+        }))
     }
 
     #[tool(
         name = "recall",
-        description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}."
+        description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients."
     )]
     async fn recall(
         &self,
@@ -152,7 +180,7 @@ impl McpServer {
                 .await
                 .map_err(join_error)?
                 .map_err(to_error)?;
-        Ok(Json(RecallResult { memories }))
+        Ok(Json(RecallResult::new(memories)))
     }
 
     #[tool(
@@ -174,7 +202,7 @@ impl McpServer {
                 .await
                 .map_err(join_error)?
                 .map_err(to_error)?;
-        Ok(Json(RecallResult { memories }))
+        Ok(Json(RecallResult::new(memories)))
     }
 
     #[tool(
@@ -217,16 +245,13 @@ impl McpServer {
             .map_err(to_error)?;
             (hits, None, None)
         };
-        Ok(Json(RecallFusedResult {
-            memories,
-            dated_context,
-            now,
-        }))
+        Ok(Json(RecallFusedResult::new(memories, dated_context, now)))
     }
 
     #[tool(
         name = "feedback",
-        description = "Reinforce a recalled memory with an outcome: `success=true` if the fact was useful, `false` if it was noise. This durably updates the fact's learned confidence, which `recall` uses to re-rank future results — over repeated feedback, useful facts drift up and noise drifts down, so the memory improves with use without retraining the model. Returns the fact's new confidence in [0,1]."
+        description = "Reinforce a recalled memory with an outcome: `success=true` if the fact was useful, `false` if it was noise. This durably updates the fact's learned confidence, which `recall` uses to re-rank future results — over repeated feedback, useful facts drift up and noise drifts down, so the memory improves with use without retraining the model. Returns the fact's new confidence in [0,1].",
+        input_schema = id_wire_input_schema::<FeedbackParams>(&["id"])
     )]
     async fn feedback(
         &self,
@@ -238,12 +263,17 @@ impl McpServer {
             .await
             .map_err(join_error)?
             .map_err(to_error)?;
-        Ok(Json(FeedbackResult { id, confidence }))
+        Ok(Json(FeedbackResult {
+            id,
+            id_str: id.to_string(),
+            confidence,
+        }))
     }
 
     #[tool(
         name = "relate",
-        description = "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Direction matters: traversal follows OUTGOING edges only, so point `from` at the memory you will later ask `why` about and `to` at its evidence (decision → cause, fact → source) — an edge pointing INTO a memory is invisible to `why(that memory)`. Idempotent per (from, relation, to). Returns the new edge id."
+        description = "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Direction matters: traversal follows OUTGOING edges only, so point `from` at the memory you will later ask `why` about and `to` at its evidence (decision → cause, fact → source) — an edge pointing INTO a memory is invisible to `why(that memory)`. Idempotent per (from, relation, to). Returns the new edge id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+        input_schema = id_wire_input_schema::<RelateParams>(&["from", "to"])
     )]
     async fn relate(
         &self,
@@ -255,12 +285,16 @@ impl McpServer {
             .await
             .map_err(join_error)?
             .map_err(to_error)?;
-        Ok(Json(RelateResult { edge_id }))
+        Ok(Json(RelateResult {
+            edge_id,
+            edge_id_str: edge_id.to_string(),
+        }))
     }
 
     #[tool(
         name = "forget",
-        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the requested id plus `found`: `true` if a memory actually existed and was deleted, `false` if nothing was stored under that id (a stale id or a typo) — a no-op, not an error, but distinguishable from a real deletion."
+        description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the requested id plus `found`: `true` if a memory actually existed and was deleted, `false` if nothing was stored under that id (a stale id or a typo) — a no-op, not an error, but distinguishable from a real deletion.",
+        input_schema = id_wire_input_schema::<ForgetParams>(&["id"])
     )]
     async fn forget(
         &self,
@@ -272,7 +306,11 @@ impl McpServer {
             .await
             .map_err(join_error)?
             .map_err(to_error)?;
-        Ok(Json(ForgetResult { id, found }))
+        Ok(Json(ForgetResult {
+            id,
+            id_str: id.to_string(),
+            found,
+        }))
     }
 
     #[tool(
@@ -282,7 +320,7 @@ impl McpServer {
     async fn why(
         &self,
         Parameters(params): Parameters<WhyParams>,
-    ) -> Result<Json<Explanation>, ErrorData> {
+    ) -> Result<Json<ExplanationDto>, ErrorData> {
         let max_hops = params
             .max_hops
             .unwrap_or(DEFAULT_WHY_HOPS)
@@ -296,7 +334,7 @@ impl McpServer {
                 .await
                 .map_err(join_error)?
                 .map_err(to_error)?;
-        Ok(Json(explanation))
+        Ok(Json(ExplanationDto::from(explanation)))
     }
 
     #[tool(
@@ -333,7 +371,8 @@ impl McpServer {
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(RememberExtractedResult { ids }))
+        let ids_str = ids.iter().map(u64::to_string).collect();
+        Ok(Json(RememberExtractedResult { ids, ids_str }))
     }
 }
 

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -1,15 +1,26 @@
 //! Tool parameter / result DTOs for the MCP transport.
 //!
-//! Output shapes reuse the domain types from [`crate::model`] / [`crate::service`]
-//! directly (they derive `Serialize` + `JsonSchema`), so there is no duplicate
-//! wire/domain struct. Only request envelopes and small id-results live here,
-//! split out of [`super`] (`mcp.rs`) so that file stays focused on the server
-//! and tool wiring.
+//! Request envelopes, small id-results, and the id-echoing wire wrappers live
+//! here, split out of [`super`] (`mcp.rs`) so that file stays focused on the
+//! server and tool wiring.
+//!
+//! The `..._str` id twins ([`RecollectionDto::id_str`] and friends) are a
+//! **wire concern of this MCP layer only** (issue #1468: a u64 id above 2^53
+//! is rounded by float-lossy JSON clients): the domain types in
+//! [`crate::model`] stay untouched — no extra field, no changed constructor —
+//! so the crate's public Rust API is unchanged and library consumers
+//! (bindings, crates.io users) see no breakage. Where a tool used to
+//! serialize a domain type directly ([`Recollection`], [`Explanation`]), a
+//! thin `Dto` wrapper here adds the string twins at the serialization
+//! boundary via `From`.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
-use crate::model::{ColumnFilter, Link, Recollection};
+use crate::model::{
+    deserialize_id, ColumnFilter, Explanation, Link, MemoryEdge, MemoryNode, Recollection,
+};
 use crate::service::Metadata;
 
 /// Parameters for the `remember` tool.
@@ -37,6 +48,11 @@ pub(super) struct RememberParams {
 pub(super) struct RememberResult {
     /// Stable id assigned to the remembered fact.
     pub(super) id: u64,
+    /// Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/
+    /// `feedback`, never `id` itself: a u64 above 2^53 loses precision
+    /// through a float-lossy JSON client (issue #1468). Additive: `id` is
+    /// unchanged, so 0.9.x callers are unaffected.
+    pub(super) id_str: String,
 }
 
 /// Parameters for the `recall` tool.
@@ -52,11 +68,56 @@ pub(super) struct RecallParams {
     pub(super) filter: Option<Metadata>,
 }
 
+/// Wire shape of one recalled memory: [`Recollection`] plus the `id_str`
+/// twin (issue #1468). Built via `From<Recollection>` at the serialization
+/// boundary so the domain type itself stays untouched.
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct RecollectionDto {
+    /// Stable id of the memory.
+    pub(super) id: u64,
+    /// Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/
+    /// `feedback`, never `id` itself: a u64 above 2^53 loses precision
+    /// through a float-lossy JSON client (issue #1468). Additive: `id` is
+    /// unchanged and stays present for 0.9.x callers.
+    pub(super) id_str: String,
+    /// Similarity score (higher is closer).
+    pub(super) score: f32,
+    /// Stored fact content.
+    pub(super) content: String,
+    /// Caller-supplied structured metadata stored with the fact, reserved
+    /// system keys excluded — the exact field [`Recollection::metadata`]
+    /// carries, forwarded unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) metadata: Option<Map<String, Value>>,
+}
+
+impl From<Recollection> for RecollectionDto {
+    fn from(memory: Recollection) -> Self {
+        Self {
+            id: memory.id,
+            id_str: memory.id.to_string(),
+            score: memory.score,
+            content: memory.content,
+            metadata: memory.metadata,
+        }
+    }
+}
+
 /// Result of the `recall` tool.
 #[derive(Serialize, JsonSchema)]
 pub(super) struct RecallResult {
     /// Recalled memories, most similar first.
-    pub(super) memories: Vec<Recollection>,
+    pub(super) memories: Vec<RecollectionDto>,
+}
+
+impl RecallResult {
+    /// Wrap recalled domain memories into their wire shape.
+    pub(super) fn new(memories: Vec<Recollection>) -> Self {
+        Self {
+            memories: memories.into_iter().map(RecollectionDto::from).collect(),
+        }
+    }
 }
 
 /// Parameters for the `recall_where` tool.
@@ -108,7 +169,7 @@ pub(super) struct RecallFusedParams {
 #[derive(Serialize, JsonSchema)]
 pub(super) struct RecallFusedResult {
     /// Recalled memories, most relevant first.
-    pub(super) memories: Vec<Recollection>,
+    pub(super) memories: Vec<RecollectionDto>,
     /// Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]
     /// content` per line, oldest first, undated facts last). Present only when
     /// `date_field` was set.
@@ -120,13 +181,35 @@ pub(super) struct RecallFusedResult {
     pub(super) now: Option<String>,
 }
 
+impl RecallFusedResult {
+    /// Wrap fused-recall domain memories into their wire shape.
+    pub(super) fn new(
+        memories: Vec<Recollection>,
+        dated_context: Option<String>,
+        now: Option<String>,
+    ) -> Self {
+        Self {
+            memories: memories.into_iter().map(RecollectionDto::from).collect(),
+            dated_context,
+            now,
+        }
+    }
+}
+
 /// Parameters for the `relate` tool.
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RelateParams {
-    /// Source memory id — the link points FROM here (as returned by `remember`/`recall`).
+    /// Source memory id — the link points FROM here (as returned by
+    /// `remember`/`recall`). Accepts a JSON number or a decimal string:
+    /// always relay a previous response's `id_str` here — a plain JSON
+    /// number above 2^53 loses precision on a float-lossy client (issue
+    /// #1468).
+    #[serde(deserialize_with = "deserialize_id")]
     pub(super) from: u64,
-    /// Target memory id — the link points TO here (as returned by `remember`/`recall`).
+    /// Target memory id — the link points TO here (as returned by
+    /// `remember`/`recall`). Same string-or-number contract as `from`.
+    #[serde(deserialize_with = "deserialize_id")]
     pub(super) to: u64,
     /// Directional relationship label, read as `from` <relation> `to`.
     /// Examples: `caused_by`, `depends_on`, `authored_by`, `supersedes`.
@@ -139,13 +222,19 @@ pub(super) struct RelateParams {
 pub(super) struct RelateResult {
     /// Id of the created edge.
     pub(super) edge_id: u64,
+    /// Decimal-string twin of `edge_id` (issue #1468) — see
+    /// [`RememberResult::id_str`].
+    pub(super) edge_id_str: String,
 }
 
 /// Parameters for the `forget` tool.
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct ForgetParams {
-    /// Id of the memory to permanently delete (as returned by `remember` or `recall`).
+    /// Id of the memory to permanently delete (as returned by `remember` or
+    /// `recall`). Accepts a JSON number or a decimal string — relay `id_str`
+    /// to avoid float-precision loss above 2^53 (issue #1468).
+    #[serde(deserialize_with = "deserialize_id")]
     pub(super) id: u64,
 }
 
@@ -155,6 +244,9 @@ pub(super) struct ForgetParams {
 pub(super) struct ForgetResult {
     /// Id that was requested for deletion.
     pub(super) id: u64,
+    /// Decimal-string twin of `id` (issue #1468) — see
+    /// [`RememberResult::id_str`].
+    pub(super) id_str: String,
     /// Whether a memory actually existed under `id` and was deleted.
     /// `false` means nothing was stored there — a stale id or a typo, not a
     /// second successful deletion — so a caller can tell the two apart.
@@ -165,7 +257,11 @@ pub(super) struct ForgetResult {
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct FeedbackParams {
-    /// Id of the recalled memory to reinforce (as returned by `recall`/`remember`).
+    /// Id of the recalled memory to reinforce (as returned by
+    /// `recall`/`remember`). Accepts a JSON number or a decimal string —
+    /// relay `id_str` to avoid float-precision loss above 2^53 (issue
+    /// #1468).
+    #[serde(deserialize_with = "deserialize_id")]
     pub(super) id: u64,
     /// `true` if the memory was useful (reinforce it), `false` if it was noise
     /// (weaken it).
@@ -178,6 +274,9 @@ pub(super) struct FeedbackParams {
 pub(super) struct FeedbackResult {
     /// Id of the reinforced memory.
     pub(super) id: u64,
+    /// Decimal-string twin of `id` (issue #1468) — see
+    /// [`RememberResult::id_str`].
+    pub(super) id_str: String,
     /// The memory's new learned confidence in `[0.0, 1.0]` after this feedback.
     pub(super) confidence: f32,
 }
@@ -195,6 +294,91 @@ pub(super) struct WhyParams {
     pub(super) filter: Option<Metadata>,
 }
 
+/// Wire shape of one node in a `why` subgraph: [`MemoryNode`] plus the
+/// `id_str` twin (issue #1468).
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct MemoryNodeDto {
+    /// Stable id of the memory.
+    pub(super) id: u64,
+    /// Decimal-string twin of `id` (issue #1468) — see
+    /// [`RecollectionDto::id_str`].
+    pub(super) id_str: String,
+    /// Stored fact content.
+    pub(super) content: String,
+    /// Distance in hops from the seed memory (the seed is hop `0`).
+    pub(super) hop: usize,
+}
+
+impl From<MemoryNode> for MemoryNodeDto {
+    fn from(node: MemoryNode) -> Self {
+        Self {
+            id: node.id,
+            id_str: node.id.to_string(),
+            content: node.content,
+            hop: node.hop,
+        }
+    }
+}
+
+/// Wire shape of one edge in a `why` subgraph: [`MemoryEdge`] plus the
+/// `from_str`/`to_str` twins (issue #1468).
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct MemoryEdgeDto {
+    /// Source memory id.
+    pub(super) from: u64,
+    /// Decimal-string twin of `from` (issue #1468) — see
+    /// [`RecollectionDto::id_str`].
+    pub(super) from_str: String,
+    /// Target memory id.
+    pub(super) to: u64,
+    /// Decimal-string twin of `to` (issue #1468) — see
+    /// [`RecollectionDto::id_str`].
+    pub(super) to_str: String,
+    /// Relationship label.
+    pub(super) relation: String,
+}
+
+impl From<MemoryEdge> for MemoryEdgeDto {
+    fn from(edge: MemoryEdge) -> Self {
+        Self {
+            from: edge.from,
+            from_str: edge.from.to_string(),
+            to: edge.to,
+            to_str: edge.to.to_string(),
+            relation: edge.relation,
+        }
+    }
+}
+
+/// Result of the `why` tool: the wire shape of [`Explanation`], with the
+/// decimal-string id twins on every node and edge (issue #1468).
+#[derive(Serialize, JsonSchema)]
+pub(super) struct ExplanationDto {
+    /// Memories in the subgraph, seed first.
+    pub(super) nodes: Vec<MemoryNodeDto>,
+    /// Typed edges connecting the nodes.
+    pub(super) edges: Vec<MemoryEdgeDto>,
+}
+
+impl From<Explanation> for ExplanationDto {
+    fn from(explanation: Explanation) -> Self {
+        Self {
+            nodes: explanation
+                .nodes
+                .into_iter()
+                .map(MemoryNodeDto::from)
+                .collect(),
+            edges: explanation
+                .edges
+                .into_iter()
+                .map(MemoryEdgeDto::from)
+                .collect(),
+        }
+    }
+}
+
 /// Parameters for the `remember_extracted` tool.
 #[derive(Deserialize, JsonSchema)]
 pub(super) struct RememberExtractedParams {
@@ -210,4 +394,7 @@ pub(super) struct RememberExtractedParams {
 pub(super) struct RememberExtractedResult {
     /// Stable ids of the stored facts, in extraction order.
     pub(super) ids: Vec<u64>,
+    /// Decimal-string twins of `ids`, same order (issue #1468) — see
+    /// [`RememberResult::id_str`].
+    pub(super) ids_str: Vec<String>,
 }

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -833,3 +833,244 @@ async fn remember_extracted_without_backend_returns_internal_error() {
         .expect_err("extraction with no backend must error");
     assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
 }
+
+// --- u64-id wire compatibility (issue #1468) --------------------------------
+//
+// Float-lossy JSON clients (JS `number`, Claude Code included) round a u64
+// id above 2^53 on the way OUT of a response, then resubmit the rounded
+// value on the way IN to relate/forget/feedback — which fails with "memory
+// does not exist" against a real (large) id. The fix is additive: every id a
+// memory tool returns also comes back as a decimal-string `..._str` twin, and
+// every id a memory tool accepts tolerates that string form. Proven at the
+// serde boundary (`serde_json::from_value`), not by constructing the Rust
+// struct directly, since the latter sidesteps JSON entirely and would not
+// have caught the bug.
+
+#[test]
+fn relate_params_accept_string_or_number_ids_on_the_wire() {
+    let numeric: RelateParams =
+        serde_json::from_value(serde_json::json!({"from": 1, "to": 2, "relation": "r"}))
+            .expect("numeric ids must still deserialize (0.9.x compat)");
+    assert_eq!((numeric.from, numeric.to), (1, 2));
+
+    let stringy: RelateParams =
+        serde_json::from_value(serde_json::json!({"from": "1", "to": "2", "relation": "r"}))
+            .expect("decimal-string ids must deserialize");
+    assert_eq!((stringy.from, stringy.to), (1, 2));
+}
+
+#[test]
+fn forget_and_feedback_params_accept_string_ids_on_the_wire() {
+    let forget: ForgetParams = serde_json::from_value(serde_json::json!({"id": "42"}))
+        .expect("forget id must accept a decimal string");
+    assert_eq!(forget.id, 42);
+
+    let feedback: FeedbackParams =
+        serde_json::from_value(serde_json::json!({"id": "42", "success": true}))
+            .expect("feedback id must accept a decimal string");
+    assert_eq!(feedback.id, 42);
+}
+
+#[test]
+fn remember_link_target_accepts_a_string_id_on_the_wire() {
+    let link: Link = serde_json::from_value(serde_json::json!({"target": "7", "relation": "r"}))
+        .expect("Link::target must accept a decimal string");
+    assert_eq!(link.target, 7);
+}
+
+#[tokio::test]
+async fn remember_recall_relate_forget_feedback_responses_echo_an_id_str_twin() {
+    let (_dir, srv) = server();
+    let Json(remembered) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember");
+    assert_eq!(remembered.id_str, remembered.id.to_string());
+
+    let Json(recalled) = srv
+        .recall(Parameters(RecallParams {
+            query: "parking_lot poisoning".to_owned(),
+            limit: None,
+            filter: None,
+        }))
+        .await
+        .expect("recall");
+    let hit = recalled
+        .memories
+        .iter()
+        .find(|m| m.id == remembered.id)
+        .expect("recalled memory present");
+    assert_eq!(hit.id_str, hit.id.to_string());
+
+    let Json(pr) = srv
+        .remember(Parameters(RememberParams {
+            fact: "PR #42 swaps the mutex".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember pr");
+    let Json(relate_res) = srv
+        .relate(Parameters(RelateParams {
+            from: remembered.id,
+            to: pr.id,
+            relation: "decided_in".to_owned(),
+        }))
+        .await
+        .expect("relate");
+    assert_eq!(relate_res.edge_id_str, relate_res.edge_id.to_string());
+
+    let Json(feedback_res) = srv
+        .feedback(Parameters(FeedbackParams {
+            id: remembered.id,
+            success: true,
+        }))
+        .await
+        .expect("feedback");
+    assert_eq!(feedback_res.id_str, feedback_res.id.to_string());
+
+    let Json(forget_res) = srv
+        .forget(Parameters(ForgetParams { id: pr.id }))
+        .await
+        .expect("forget");
+    assert_eq!(forget_res.id_str, forget_res.id.to_string());
+}
+
+#[tokio::test]
+async fn why_response_echoes_id_str_and_from_to_str_on_nodes_and_edges() {
+    let (_dir, srv) = server();
+    let Json(decision) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember decision");
+    let Json(pr) = srv
+        .remember(Parameters(RememberParams {
+            fact: "PR #42 swaps the mutex".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember pr");
+    srv.relate(Parameters(RelateParams {
+        from: decision.id,
+        to: pr.id,
+        relation: "decided_in".to_owned(),
+    }))
+    .await
+    .expect("relate");
+
+    let Json(why) = srv
+        .why(Parameters(WhyParams {
+            decision: DECISION.to_owned(),
+            max_hops: Some(1),
+            filter: None,
+        }))
+        .await
+        .expect("why");
+    assert!(!why.nodes.is_empty() && !why.edges.is_empty());
+    for node in &why.nodes {
+        assert_eq!(node.id_str, node.id.to_string());
+    }
+    for edge in &why.edges {
+        assert_eq!(edge.from_str, edge.from.to_string());
+        assert_eq!(edge.to_str, edge.to.to_string());
+    }
+}
+
+#[tokio::test]
+async fn remember_extracted_response_echoes_ids_str() {
+    use crate::extract::{ExtractError, ExtractedFact, Extractor};
+    struct Stub;
+    impl Extractor for Stub {
+        fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+            Ok(vec![ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_owned(),
+                entities: vec!["rust".to_owned()],
+            }])
+        }
+    }
+    let (_dir, srv) = server();
+    let srv = srv.with_extractor(Arc::new(Stub) as DynExtractor);
+    let Json(res) = srv
+        .remember_extracted(Parameters(RememberExtractedParams {
+            text: "Alice works in Rust.".to_owned(),
+            metadata: None,
+        }))
+        .await
+        .expect("remember_extracted");
+    assert_eq!(res.ids_str.len(), res.ids.len());
+    for (id, id_str) in res.ids.iter().zip(res.ids_str.iter()) {
+        assert_eq!(*id_str, id.to_string());
+    }
+}
+
+/// The round-trip that closes #1468. Simulates the reported failure two
+/// ways: (1) a wrong numeric id — the client-side rounding stand-in — is
+/// rejected by `relate` exactly like the maintainer's dogfooding report
+/// ("memory does not exist"); (2) relaying the exact `id_str` decimal-string
+/// twins instead (deserialized straight off raw JSON, not the Rust struct)
+/// succeeds, and `why` finds the resulting edge — proving the fix actually
+/// closes the loop end to end, not just at the DTO level.
+#[tokio::test]
+async fn relate_by_wrong_numeric_id_fails_but_id_str_round_trip_succeeds() {
+    let (_dir, srv) = server();
+    let Json(decision) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember decision");
+    let Json(pr) = srv
+        .remember(Parameters(RememberParams {
+            fact: "PR #42 swaps the mutex".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember pr");
+
+    // Stand-in for a float-lossy client rounding the id on the way out and
+    // back in: the perturbed id was never stored, so relate must reject it.
+    let wrong_from = decision.id + 1_000_003;
+    let err = srv
+        .relate(Parameters(RelateParams {
+            from: wrong_from,
+            to: pr.id,
+            relation: "decided_in".to_owned(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("a rounded/wrong id must not silently resolve to the real memory");
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+
+    // The fix: relay the exact `id_str` twins as JSON strings, off the wire.
+    let params: RelateParams = serde_json::from_value(serde_json::json!({
+        "from": decision.id_str,
+        "to": pr.id_str,
+        "relation": "decided_in",
+    }))
+    .expect("id_str values must deserialize as RelateParams");
+    srv.relate(Parameters(params))
+        .await
+        .expect("relate via id_str must succeed");
+
+    let (ids, edges) = why_one_hop(&srv).await;
+    assert!(ids.contains(&decision.id) && ids.contains(&pr.id));
+    assert_eq!(edges, 1);
+}

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -10,11 +10,46 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+/// Serde `deserialize_with` for a required `u64` id field: accepts a JSON
+/// number or a decimal string (issue #1468). Sibling of
+/// [`crate::context::wire::deserialize_optional_id`] (that one is
+/// `Option`-shaped and lives behind the `context` feature) — this one is
+/// deliberately feature-independent because [`Link`] is compiled whenever
+/// `model` is, regardless of `context`. Reused by `crate::mcp::dto`'s
+/// `relate`/`forget`/`feedback` id parameters so the accepted-forms rule
+/// lives in exactly one place. Input-side only and purely widening — the
+/// serialized (output) shape of every domain type is unchanged.
+///
+/// # Errors
+/// Returns a deserialize error naming the offending value if it is neither a
+/// `u64` number nor a decimal-`u64` string.
+pub(crate) fn deserialize_id<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    let expected = "expected a u64 number or a decimal u64 string";
+    match Value::deserialize(deserializer)? {
+        Value::Number(number) => number
+            .as_u64()
+            .ok_or_else(|| Error::custom(format!("invalid id {number} ({expected})"))),
+        Value::String(text) => text
+            .parse()
+            .map_err(|_| Error::custom(format!("invalid id '{text}' ({expected})"))),
+        other => Err(Error::custom(format!("invalid id {other} ({expected})"))),
+    }
+}
+
 /// A typed link from a freshly remembered fact to an existing memory.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub struct Link {
-    /// Id of the memory being linked to.
+    /// Id of the memory being linked to. Accepts a JSON number or a decimal
+    /// string — ids can exceed 2^53, where float-lossy JSON clients (JS
+    /// `number`) round a plain integer, so a caller relaying an `id_str`
+    /// value straight from a previous response must be able to resubmit it
+    /// as-is (see issue #1468).
+    #[serde(deserialize_with = "deserialize_id")]
     pub target: u64,
     /// Relationship label (e.g. `"decided_in"`, `"references"`, `"depends_on"`).
     pub relation: String,


### PR DESCRIPTION
## Summary

- Closes #1468. Memory-tool ids (`remember`/`recall`/`recall_where`/`recall_fused`/`relate`/`forget`/`feedback`/`remember_extracted`/`why`) are `u64`, which a JSON client that round-trips numbers through an `f64` (JS `number`, Claude Code included) silently rounds once the id exceeds 2^53 — the rounded id is then rejected by `relate`/`forget`/`feedback` with "memory does not exist", exactly as reported from real dogfooding.
- **Wire-only, no Rust API change.** The `..._str` id twins live entirely in the MCP DTO layer (`src/mcp/dto.rs`): thin `RecollectionDto` / `ExplanationDto` (nodes/edges) wrappers built `From` the domain types at the serialization boundary. The public domain types (`Recollection`, `MemoryNode`, `MemoryEdge`, `Explanation`) and every construction site are **byte-for-byte unchanged** vs `develop` — a crates.io library consumer sees zero breakage, so this ships as a patch release, not 0.10.0.
- Every MCP response now also carries a decimal-string twin of each id — `id_str` (`remember`, `recall*`'s memories, `forget`, `feedback`, `why`'s nodes), `edge_id_str` (`relate`), `ids_str` (`remember_extracted`), `from_str`/`to_str` (`why`'s edges) — purely additive: the numeric field is unchanged, so 0.9.x MCP callers are unaffected.
- `relate`'s `from`/`to`, `forget`/`feedback`'s `id`, and `remember`'s `links[].target` now also accept the decimal-string form on input (in addition to a plain number). The only `model.rs` change is input-side and strictly widening: a shared `deserialize_id` helper + `deserialize_with` on `Link::target`. Advertised tool input schemas widened to `["integer", "string"]` (reusing the context compiler's `widen_id_properties` tree walk — same established pattern as `CompilePolicy::ids_as_strings`).
- `remember`/`recall`/`relate` tool descriptions gained a one-line note pointing callers at `id_str`; the `velesdb-memory` skill (SKILL.md) now tells the agent to relay `id_str`, not `id`, into `relate`/`feedback`/`forget`.

## Scope confirmed

- **Entries already accepting string-or-number**: none — every memory-tool id parameter (`relate.from/to`, `forget.id`, `feedback.id`, `remember.links[].target`) was a bare `u64` before this PR; all four are fixed here.
- **Domain model intact**: `git diff origin/develop -- crates/velesdb-memory/src/model.rs` shows ONLY the `deserialize_id` helper and the `Link::target` `deserialize_with` (input-side). `fused_recall.rs`, `storage.rs`, `service.rs`, and all domain test fixtures are untouched.
- **WASM verdict**: not affected, zero changes. `velesdb-wasm`'s own JS-facing DTOs (`RecollectionOut`, `MemoryNodeOut`, `MemoryEdgeOut`) already represent every id as a `String` end to end — confirmed by reading `memory_service.rs`, and `cargo check -p velesdb-wasm` passes with `memory_store.rs` unmodified.
- **Node/Python bindings**: untouched, `cargo check -p velesdb-node -p velesdb-python` green — Node already stringifies ids at its boundary, Python keeps native ints.

## Test plan

- [x] TDD red shown first: the new tests in `crates/velesdb-memory/src/mcp/server_tests.rs` fail against the pre-fix code (missing `id_str`/`edge_id_str`/`ids_str`/`from_str`/`to_str` response fields; `RelateParams` rejecting string ids at the serde boundary).
- [x] `relate_by_wrong_numeric_id_fails_but_id_str_round_trip_succeeds` — the round-trip closing #1468: a wrong numeric id is rejected, then relaying the exact `id_str` decimal strings (deserialized off raw JSON, not the Rust struct) succeeds and `why` finds the edge.
- [x] `cargo test -p velesdb-memory` — all green (280 lib tests + integration suites)
- [x] `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context` — green (confirms the id-parsing helper is feature-independent of `mcp`)
- [x] `cargo clippy -p velesdb-memory --all-features -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo fmt -p velesdb-memory --check` — clean
- [x] `cargo build --release -p velesdb-memory` + `mcp_e2e.py` (extended with a `remember`→`id_str`→`relate`→`why`→`feedback`→`forget` case driven by `id_str` STRINGS over the real stdio JSON-RPC transport) — passes
- [x] `cargo check -p velesdb-wasm -p velesdb-node -p velesdb-python` — all green, no source changes in any binding

## Note

Filed a separate, unrelated pre-existing quirk spotted in passing (not part of this fix): `remember`'s `ttl_seconds` field leaks a non-standard `"format": "uint64"` in its advertised schema because `RememberParams` was already missing the `strip_int_formats` transform every sibling params struct has — left out of scope here.