### PR TITLE
feat(integrations): Claude Code & Codex agent hooks for continuous memory

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -97,6 +97,15 @@ Each connector persists into the same kind of `./data` directory, but use
 one framework per collection — payload schemas differ across connectors
 (see the table above).
 
+## Agent hooks (Claude Code, Codex)
+
+[`agent-hooks/`](agent-hooks) is a different kind of integration: not a
+vector-store connector, but the wiring that makes a coding agent actually
+*use* `velesdb-memory` continuously (load context on session start, save it
+before stopping/compacting) instead of only on request. See
+[`agent-hooks/README.md`](agent-hooks/README.md) for the mono-process
+constraint that shapes its design and the install steps.
+
 ## Reporting issues
 
 Please file framework-specific issues against the corresponding sub-directory

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -1,0 +1,114 @@
+# Agent hooks — continuous velesdb-memory usage
+
+Wiring the `velesdb-memory` MCP server into an agent (see
+[`crates/velesdb-memory/README.md`](../../crates/velesdb-memory/README.md))
+gives it the *tools*. It does not make the agent actually call
+`load_working_context` at the start of every session or
+`save_working_context` before every one ends — that only happens if the
+agent remembers to, which it won't reliably do on its own. This directory
+closes that gap for [Claude Code](claude-code/) (real, tested hooks) and
+[Codex CLI](codex/) (a documented instruction-file convention, since Codex
+has no equivalent hook mechanism yet).
+
+## Install (Claude Code, one project)
+
+```bash
+mkdir -p .claude/hooks/velesdb-memory
+cp /path/to/velesdb/integrations/agent-hooks/claude-code/hooks/*.sh .claude/hooks/velesdb-memory/
+cp -r /path/to/velesdb/integrations/agent-hooks/claude-code/hooks/lib .claude/hooks/velesdb-memory/
+chmod +x .claude/hooks/velesdb-memory/*.sh
+```
+
+Then merge [`claude-code/settings-snippet.json`](claude-code/settings-snippet.json)
+into your project's `.claude/settings.json` (or `~/.claude/settings.json`
+for a global install) under its `"hooks"` key. Finally, drop a
+`.velesdb-hooks.json` at your project root (format below). Requires `bash`
+and `jq` on PATH — the hooks refuse to run without `jq` rather than
+silently emitting malformed JSON.
+
+## The structural constraint that shapes this whole design
+
+**velesdb-memory's store is mono-process, guarded by an flock.** While a
+Claude Code session is running, *its own* `velesdb-memory` MCP server
+process holds that lock for the whole session. A hook is a plain shell
+command Claude Code shells out to — if that hook script tried to open the
+same store itself (a second `velesdb-memory` invocation, or any direct
+file access), it would block on, or fail to acquire, a lock already held
+by the session's own server process. Two processes cannot both hold the
+lock; a hook that tries becomes a second process.
+
+So hooks in this directory **never touch the store**. They drive the
+*model*, not the store: each hook reads its JSON payload from stdin and
+prints a JSON instruction that tells the model — which already holds an
+MCP connection to the one server allowed to touch the store — to call a
+specific tool itself. The lock is never contended because there is only
+ever one process (the session's own MCP server) that ever opens the
+store.
+
+This is why, for example, the `SessionStart` hook cannot pre-load context
+and hand it to the model directly (that would require opening the store
+from the hook) — it can only tell the model to call
+`load_working_context` itself.
+
+## The three hooks
+
+| Event | What it does | Mechanism |
+|---|---|---|
+| `SessionStart` | Fires on every session start (new, resume, clear, or post-compact). Emits `additionalContext` telling the model to call `load_working_context(project, session)` as its first action if it hasn't already. | `hookSpecificOutput.additionalContext` — supported by `SessionStart`. |
+| `Stop` | Fires when Claude is about to stop responding. The **first** `Stop` per session is blocked with a reason telling the model to call `save_working_context(project, session)` with the distilled state before stopping; every later `Stop` in the same session passes through untouched. | `{"decision":"block","reason":"..."}`, gated by a sentinel file in `$TMPDIR` (or `/tmp`) keyed by the payload's `session_id`, so the reminder fires once, not on every turn. |
+| `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `save_working_context` first (compaction can lose detail the model hasn't distilled yet); later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
+
+**Design note — why `PreCompact` blocks instead of using
+`additionalContext`:** the original plan for this feature assumed
+`PreCompact` could carry `additionalContext` like `SessionStart`/`Stop`.
+Checking the actual hook output schema shows it cannot —
+`PreCompact`'s output only supports the top-level `decision` + `reason`
+pair (no `hookSpecificOutput` wrapper at all for this event). Blocking
+once per session with `reason` is the only channel that reaches the
+model, so that's what's implemented; blocking *every* `PreCompact` was
+rejected as unsafe (auto-compaction can retrigger repeatedly on a long
+session, and refusing it every time risks the transcript never
+compacting).
+
+## `.velesdb-hooks.json` config format
+
+Place at your project root (the hooks walk up from the payload's `cwd`
+looking for it, up to 20 directories):
+
+```json
+{
+  "project": "my-project",
+  "session": "rolling"
+}
+```
+
+- `project` — a stable label for this codebase/product. Defaults to
+  `basename(cwd)` if the file or field is missing.
+- `session` — a stable slot id, not a fresh id per run. Defaults to
+  `"rolling"`. Using a stable id (rather than each hook's own
+  `session_id`) is deliberate: it makes `load_working_context` /
+  `save_working_context` accumulate one continuously-updated state across
+  every Claude Code session on this project, instead of fragmenting into
+  one throwaway slot per session that nothing else ever reads back.
+
+Both fields are optional — with no config file at all, the hooks still
+work (defaulting `project` to the directory name and `session` to
+`"rolling"`), just with a less deliberately-chosen `project` label.
+
+## Testing
+
+```bash
+bash test/hooks.test.sh
+```
+
+Simulates the stdin payloads Claude Code sends for each event and asserts
+the exact JSON each script prints back (including the block-once/pass-
+after behavior of `Stop` and `PreCompact`). Run it after touching any
+script in `claude-code/hooks/`.
+
+## Roadmap note (V2b)
+
+`PreCompact` currently only nudges the model to save by hand before
+compaction. Once `compile_transcript` ships (tracked separately), this
+hook can compile the transcript directly instead of relying on the model
+to distill it under time pressure right as compaction is about to run.

--- a/integrations/agent-hooks/claude-code/hooks/lib/common.sh
+++ b/integrations/agent-hooks/claude-code/hooks/lib/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared helpers for the VelesDB agent-hooks scripts.
+# Sourced by session-start.sh, stop.sh, pre-compact.sh — not meant to be run directly.
+
+# require_jq: fail loudly (not silently) if jq is missing, since every hook
+# builds its JSON output through jq to get escaping right.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "velesdb agent-hooks: 'jq' is required but was not found on PATH." >&2
+    exit 1
+  fi
+}
+
+# resolve_config CWD
+# Walks up from CWD looking for a .velesdb-hooks.json file (project root
+# convention). Sets PROJECT and SESSION globals. Falls back to
+# project=basename(cwd) and session="rolling" when no config file is found
+# or a field is missing — so the hooks work with zero setup, but a project
+# can pin stable identifiers via the config file.
+resolve_config() {
+  local start_dir="$1"
+  local dir="$start_dir"
+  local config=""
+  local depth=0
+
+  while [ "$depth" -lt 20 ]; do
+    if [ -f "$dir/.velesdb-hooks.json" ]; then
+      config="$dir/.velesdb-hooks.json"
+      break
+    fi
+    if [ "$dir" = "/" ] || [ -z "$dir" ]; then
+      break
+    fi
+    dir="$(dirname "$dir")"
+    depth=$((depth + 1))
+  done
+
+  PROJECT=""
+  SESSION=""
+  if [ -n "$config" ] && jq -e . "$config" >/dev/null 2>&1; then
+    PROJECT="$(jq -r '.project // empty' "$config")"
+    SESSION="$(jq -r '.session // empty' "$config")"
+  fi
+
+  if [ -z "$PROJECT" ]; then
+    PROJECT="$(basename "$start_dir")"
+  fi
+  if [ -z "$SESSION" ]; then
+    SESSION="rolling"
+  fi
+}
+
+# read_stdin_payload: read the hook's JSON payload from stdin exactly once.
+read_stdin_payload() {
+  cat
+}
+
+# sentinel_path KIND SESSION_ID: path to the once-per-session marker file
+# used by the Stop and PreCompact hooks to fire their reminder exactly once.
+# Uses $TMPDIR (falling back to /tmp) rather than a hardcoded path so it
+# works unmodified on macOS and Linux, and namespaces under
+# velesdb-agent-hooks/ to avoid colliding with unrelated temp files.
+sentinel_path() {
+  local kind="$1"
+  local session_id="$2"
+  local dir="${TMPDIR:-/tmp}/velesdb-agent-hooks"
+  mkdir -p "$dir"
+  printf '%s/%s-%s.marker' "$dir" "$kind" "$session_id"
+}

--- a/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
+++ b/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# PreCompact hook: remind the model to save its working context before
+# transcript compaction discards detail.
+#
+# IMPORTANT deviation from a naive "additionalContext" design: PreCompact's
+# output schema does NOT support hookSpecificOutput/additionalContext (only
+# SessionStart and Stop do) — the only channel that reaches the model is
+# `decision:"block"` + `reason`, which also blocks the compaction attempt.
+# So this hook blocks the FIRST PreCompact per session (the model reads
+# `reason`, saves, and Claude Code will naturally re-attempt compaction),
+# then passes every later PreCompact through untouched via the same
+# sentinel-file pattern as stop.sh. Blocking every single PreCompact would
+# be unsafe (auto-compaction can fire repeatedly as a long session grows;
+# refusing it every time risks the transcript never compacting).
+#
+# TODO(V2b): once compile_transcript ships, this hook can compile the
+# transcript directly instead of only nudging the model to save by hand.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+if [ -z "$session_id" ]; then
+  session_id="unknown-session"
+fi
+
+resolve_config "$cwd"
+
+sentinel="$(sentinel_path "precompact" "$session_id")"
+
+if [ -f "$sentinel" ]; then
+  echo '{}'
+  exit 0
+fi
+
+: > "$sentinel"
+
+reason="Before compaction: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") via velesdb-memory with the distilled state so nothing is lost, then retry — compaction will proceed on the next attempt."
+
+jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/integrations/agent-hooks/claude-code/hooks/session-start.sh
+++ b/integrations/agent-hooks/claude-code/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SessionStart hook: tell the model to resume its rolling working context.
+#
+# Why a hook and not a second velesdb-memory process: the store is
+# mono-process (flock). The MCP server already running inside this Claude
+# Code session holds the lock, so this script cannot open the store itself —
+# it can only steer the model to call the *session's own* MCP tool. See
+# integrations/agent-hooks/README.md for the full constraint writeup.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+
+resolve_config "$cwd"
+
+context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally."
+
+jq -n --arg ctx "$context" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/integrations/agent-hooks/claude-code/hooks/session-start.sh
+++ b/integrations/agent-hooks/claude-code/hooks/session-start.sh
@@ -23,7 +23,7 @@ fi
 
 resolve_config "$cwd"
 
-context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally."
+context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally. Reinforcement loop: whenever a memory surfaced by recall/recall_fused (or pulled into compile_context — its decision carries the memory_id) actually helps you, call feedback(id, true) with the id_str string; if it misled you, feedback(id, false). This is what makes ranking improve with use — skipping it keeps confidence flat."
 
 jq -n --arg ctx "$context" \
   '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/integrations/agent-hooks/claude-code/hooks/stop.sh
+++ b/integrations/agent-hooks/claude-code/hooks/stop.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Stop hook: remind the model, once per session, to save its working context
+# before finishing. Blocks the first Stop with decision:block + reason (the
+# model reads `reason` and acts on it); every later Stop in the same session
+# passes through untouched, guarded by a sentinel file keyed on session_id
+# (Claude Code does not hand hooks a "have I already blocked once" flag, so
+# the hook tracks it itself — see lib/common.sh sentinel_path).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+if [ -z "$session_id" ]; then
+  session_id="unknown-session"
+fi
+
+resolve_config "$cwd"
+
+sentinel="$(sentinel_path "stop" "$session_id")"
+
+if [ -f "$sentinel" ]; then
+  # Already reminded this session — let Claude stop normally.
+  echo '{}'
+  exit 0
+fi
+
+: > "$sentinel"
+
+reason="Before finishing: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") via velesdb-memory with the distilled state (goal, key decisions, verified facts, pending actions), then stop."
+
+jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/integrations/agent-hooks/claude-code/settings-snippet.json
+++ b/integrations/agent-hooks/claude-code/settings-snippet.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/velesdb-memory/session-start.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/velesdb-memory/stop.sh\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/velesdb-memory/pre-compact.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/agent-hooks/codex/README.md
+++ b/integrations/agent-hooks/codex/README.md
@@ -1,0 +1,76 @@
+# Codex CLI — continuous velesdb-memory usage
+
+Codex CLI (as of this writing) has no shell-hook lifecycle equivalent to
+Claude Code's `SessionStart` / `Stop` / `PreCompact` — there is no
+documented mechanism to run a command when a Codex session starts, stops,
+or is about to compact its transcript. So there is nothing here to
+automate at the harness level (unlike `../claude-code/`, which has a
+tested `test/hooks.test.sh`).
+
+What Codex *does* support is `AGENTS.md`: an instructions file it reads
+automatically from the project root. That gives us a soft equivalent —
+the model is told the same load → work → save loop the Claude Code hooks
+enforce mechanically, but here it's the model following written
+instructions rather than a script driving it. It is strictly weaker (no
+guarantee it fires, no once-per-session sentinel) — treat it as
+best-effort until Codex ships real lifecycle hooks.
+
+## 1. Wire the velesdb-memory MCP server
+
+`~/.codex/config.toml` (or the project-local equivalent). Use an absolute
+path — `~` is not expanded in this file:
+
+```toml
+[mcp_servers.velesdb-memory]
+command = "/home/you/.cargo/bin/velesdb-memory"
+args = []
+env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
+```
+
+Adjust `command` to wherever `cargo install velesdb-memory` (or your local
+`target/release/velesdb-memory` build) actually put the binary — Codex
+spawns it directly, without a shell, so `~` and `$HOME` are not expanded
+here.
+
+## 2. Add the load → work → save loop to AGENTS.md
+
+Append a section like this to the project's `AGENTS.md` (create the file
+if it doesn't exist yet):
+
+```markdown
+## Continuous memory (velesdb-memory)
+
+This project has a velesdb-memory MCP server configured. Use it every
+session, not just when asked:
+
+- **At the start of a session**, before doing anything else, call
+  `load_working_context(project="<project>", session="<session>")` to
+  resume the prior distilled state (goal, decisions, verified facts,
+  pending actions). A null result means nothing was saved yet — proceed
+  normally.
+- **Whenever the working state changes meaningfully**, and always
+  **before ending a session**, call
+  `save_working_context(project="<project>", session="<session>")` with
+  the distilled state. Saving again under the same project + session
+  replaces the previous save (idempotent upsert).
+
+Use a stable `session` id (e.g. `"rolling"`) rather than a fresh id per
+run, so state actually accumulates across sessions instead of fragmenting.
+Pick `project` to match the repository/product, not the individual task.
+```
+
+Replace `<project>` / `<session>` with your actual values, or better,
+keep them as literal placeholders and tell the model once (in the same
+AGENTS.md section, or in your first message) what they are for this repo.
+
+## Why this is thinner than the Claude Code integration
+
+The Claude Code hooks in `../claude-code/` are mechanically enforced: a
+real process runs on `SessionStart`/`Stop`/`PreCompact`, reads the JSON
+payload, and returns a JSON decision the harness acts on — verified by
+`../test/hooks.test.sh`. Nothing here is enforced the same way: it is
+prose in a file Codex happens to load, and the model can forget to act on
+it. If/when Codex ships an equivalent lifecycle-hook mechanism, this
+directory should grow real scripts mirroring `../claude-code/hooks/`,
+and the "soft hook via AGENTS.md" section above should be trimmed down to
+a fallback note.

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Test harness for the Claude Code agent hooks (session-start.sh, stop.sh,
+# pre-compact.sh). Simulates the stdin JSON payloads Claude Code sends for
+# each event and asserts the exact JSON shape each script prints back.
+#
+# Run: bash test/hooks.test.sh   (exit 0 = all good, exit 1 = a check failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_DIR="$ROOT/claude-code/hooks"
+
+FAILED=0
+
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1"; FAILED=1; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to run this test harness" >&2
+  exit 1
+fi
+
+TMP_TEST_DIR="$(mktemp -d)"
+# shellcheck disable=SC2329 # invoked indirectly via `trap ... EXIT` below
+cleanup() { rm -rf "$TMP_TEST_DIR"; }
+trap cleanup EXIT
+
+# Isolate the sentinel-file mechanism from the real /tmp so repeated runs
+# never see stale sentinels from a previous run or a real session.
+export TMPDIR="$TMP_TEST_DIR/tmp"
+mkdir -p "$TMPDIR"
+
+PROJECT_DIR="$TMP_TEST_DIR/project"
+mkdir -p "$PROJECT_DIR"
+cat > "$PROJECT_DIR/.velesdb-hooks.json" <<'EOF'
+{"project": "test-project", "session": "rolling"}
+EOF
+
+SESSION_ID="test-session-$$"
+
+# ---------------------------------------------------------------------------
+# SessionStart
+# ---------------------------------------------------------------------------
+session_start_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "SessionStart", source: "startup"}')"
+
+session_start_out="$(printf '%s' "$session_start_payload" | bash "$HOOKS_DIR/session-start.sh")"
+
+if printf '%s' "$session_start_out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null; then
+  pass "SessionStart: hookSpecificOutput.hookEventName is SessionStart"
+else
+  fail "SessionStart: hookSpecificOutput.hookEventName is SessionStart"
+fi
+
+if printf '%s' "$session_start_out" | jq -e '.hookSpecificOutput.additionalContext | contains("load_working_context")' >/dev/null; then
+  pass "SessionStart: additionalContext mentions load_working_context"
+else
+  fail "SessionStart: additionalContext mentions load_working_context"
+fi
+
+if printf '%s' "$session_start_out" | jq -e '.hookSpecificOutput.additionalContext | contains("test-project")' >/dev/null; then
+  pass "SessionStart: additionalContext uses project from .velesdb-hooks.json"
+else
+  fail "SessionStart: additionalContext uses project from .velesdb-hooks.json"
+fi
+
+# ---------------------------------------------------------------------------
+# Stop — first call blocks, second call (same session_id) passes
+# ---------------------------------------------------------------------------
+stop_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "Stop", last_assistant_message: "done"}')"
+
+stop_out_1="$(printf '%s' "$stop_payload" | bash "$HOOKS_DIR/stop.sh")"
+
+if printf '%s' "$stop_out_1" | jq -e '.decision == "block"' >/dev/null; then
+  pass "Stop: first call blocks (decision == block)"
+else
+  fail "Stop: first call blocks (decision == block)"
+fi
+
+if printf '%s' "$stop_out_1" | jq -e '.reason | contains("save_working_context")' >/dev/null; then
+  pass "Stop: reason mentions save_working_context"
+else
+  fail "Stop: reason mentions save_working_context"
+fi
+
+stop_out_2="$(printf '%s' "$stop_payload" | bash "$HOOKS_DIR/stop.sh")"
+
+if printf '%s' "$stop_out_2" | jq -e '.decision == null' >/dev/null; then
+  pass "Stop: second call in same session does not block"
+else
+  fail "Stop: second call in same session does not block"
+fi
+
+# A different session_id must get its own reminder (sentinel is per-session).
+other_stop_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg sid "${SESSION_ID}-other" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "Stop", last_assistant_message: "done"}')"
+other_stop_out="$(printf '%s' "$other_stop_payload" | bash "$HOOKS_DIR/stop.sh")"
+
+if printf '%s' "$other_stop_out" | jq -e '.decision == "block"' >/dev/null; then
+  pass "Stop: a different session_id gets its own first-call block"
+else
+  fail "Stop: a different session_id gets its own first-call block"
+fi
+
+# ---------------------------------------------------------------------------
+# PreCompact — first call blocks, second call (same session_id) passes
+# ---------------------------------------------------------------------------
+pre_compact_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "PreCompact", trigger: "auto"}')"
+
+pre_compact_out_1="$(printf '%s' "$pre_compact_payload" | bash "$HOOKS_DIR/pre-compact.sh")"
+
+if printf '%s' "$pre_compact_out_1" | jq -e '.decision == "block"' >/dev/null; then
+  pass "PreCompact: first call blocks (decision == block)"
+else
+  fail "PreCompact: first call blocks (decision == block)"
+fi
+
+if printf '%s' "$pre_compact_out_1" | jq -e '.reason | contains("save_working_context")' >/dev/null; then
+  pass "PreCompact: reason mentions save_working_context"
+else
+  fail "PreCompact: reason mentions save_working_context"
+fi
+
+if printf '%s' "$pre_compact_out_1" | jq -e 'has("hookSpecificOutput") | not' >/dev/null; then
+  pass "PreCompact: no hookSpecificOutput wrapper (unsupported for this event)"
+else
+  fail "PreCompact: no hookSpecificOutput wrapper (unsupported for this event)"
+fi
+
+pre_compact_out_2="$(printf '%s' "$pre_compact_payload" | bash "$HOOKS_DIR/pre-compact.sh")"
+
+if printf '%s' "$pre_compact_out_2" | jq -e '. == {}' >/dev/null; then
+  pass "PreCompact: second call in same session passes through ({})"
+else
+  fail "PreCompact: second call in same session passes through ({})"
+fi
+
+# ---------------------------------------------------------------------------
+# Defaults when no .velesdb-hooks.json is present
+# ---------------------------------------------------------------------------
+NO_CONFIG_DIR="$TMP_TEST_DIR/no-config-project"
+mkdir -p "$NO_CONFIG_DIR"
+no_config_sid="test-session-nocfg-$$"
+
+no_config_payload="$(jq -n --arg cwd "$NO_CONFIG_DIR" --arg sid "$no_config_sid" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "SessionStart", source: "startup"}')"
+
+no_config_out="$(printf '%s' "$no_config_payload" | bash "$HOOKS_DIR/session-start.sh")"
+
+if printf '%s' "$no_config_out" | jq -e '.hookSpecificOutput.additionalContext | contains("no-config-project")' >/dev/null; then
+  pass "SessionStart: defaults project to basename(cwd) with no config file"
+else
+  fail "SessionStart: defaults project to basename(cwd) with no config file"
+fi
+
+if printf '%s' "$no_config_out" | jq -e '.hookSpecificOutput.additionalContext | contains("rolling")' >/dev/null; then
+  pass "SessionStart: defaults session to \"rolling\" with no config file"
+else
+  fail "SessionStart: defaults session to \"rolling\" with no config file"
+fi
+
+# ---------------------------------------------------------------------------
+# No hardcoded absolute user paths in the scripts (everything must come from
+# the stdin payload or the .velesdb-hooks.json config).
+# ---------------------------------------------------------------------------
+if grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >/dev/null 2>&1; then
+  fail "no hardcoded user home paths in hook scripts"
+  grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >&2 || true
+else
+  pass "no hardcoded user home paths in hook scripts"
+fi
+
+# ---------------------------------------------------------------------------
+# Static analysis via shellcheck, if available (gate says: note if not
+# installed, don't fail the suite over its absence)
+# ---------------------------------------------------------------------------
+if command -v shellcheck >/dev/null 2>&1; then
+  if find "$HOOKS_DIR" -name '*.sh' -print0 | xargs -0 shellcheck; then
+    pass "shellcheck: hook scripts are clean"
+  else
+    fail "shellcheck: hook scripts are clean"
+  fi
+else
+  echo "note - shellcheck not installed, skipping static analysis check"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "FAILURES DETECTED"
+  exit 1
+fi
+
+echo "All hook tests passed."
+exit 0


### PR DESCRIPTION
## Summary
- Adds `integrations/agent-hooks/`: real Claude Code hooks (`SessionStart`, `Stop`, `PreCompact`) that drive continuous `velesdb-memory` usage (load on start, save before stopping/compacting) without an agent having to remember to call the tools itself.
- **Structural constraint (documented in `agent-hooks/README.md`):** the velesdb-memory store is mono-process (flock). A hook script cannot open a second `velesdb-memory` process while the session's own MCP server holds the lock, so the hooks never touch the store — they emit JSON that steers the *model* to call `load_working_context` / `save_working_context` itself, through the one MCP connection already open in that session.
- `Stop` and `PreCompact` block exactly once per session (a sentinel file keyed on the payload's `session_id`, since Claude Code doesn't hand hooks an "already blocked" flag) with a `reason` nudging `save_working_context`; every later call in the same session passes through untouched.
- **Deviation from the original plan, called out explicitly:** `PreCompact`'s actual output schema does not support `additionalContext`/`hookSpecificOutput` (verified against the current hooks docs) — only top-level `decision`/`reason`. The hook uses `decision:"block"` + `reason` instead, blocking only the first `PreCompact` per session (blocking every one would be unsafe on a long session with repeated auto-compaction).
- `codex/README.md`: Codex CLI has no equivalent lifecycle-hook mechanism today, so its integration is an `mcp_servers` config.toml block (absolute path, no `~`) plus an `AGENTS.md` section instructing the same load → work → save loop by hand — documented as strictly weaker (no enforcement, no sentinel) until Codex ships real hooks.
- `test/hooks.test.sh`: simulates the stdin JSON payload for each event and asserts the exact JSON each script returns, including config-file resolution (`.velesdb-hooks.json`, walked up from `cwd`), default fallback (`project=basename(cwd)`, `session="rolling"`) when no config is present, per-session-id isolation, and the block-once/pass-after behavior for `Stop`/`PreCompact`.

## Test plan
- [x] `bash test/hooks.test.sh` — 15/15 checks pass, `EXIT=0`
- [x] `jq` parses every JSON output produced by the three hooks and the `settings-snippet.json`
- [x] `shellcheck -x` clean on all scripts (`lib/common.sh`, `session-start.sh`, `stop.sh`, `pre-compact.sh`, `test/hooks.test.sh`)
- [x] `grep` confirms no hardcoded absolute user paths in the scripts (only in docs, as literal placeholder examples matching `crates/velesdb-memory/README.md`'s existing convention)