### PR TITLE
fix(server): gate metrics handlers consistently under no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # Closes the --no-default-features matrix gap from #1472: nothing in CI
+      # previously checked the workspace with every crate's own default
+      # features disabled, so cross-crate feature-unification mismatches
+      # (e.g. a cfg-gated call site in one crate vs. the feature state its
+      # dependency actually ends up unified to) went undetected.
+      - name: Check --no-default-features (workspace matrix gap, #1472)
+        run: cargo check --workspace --no-default-features
+
       - name: Run Clippy (strict)
         run: |
           cargo clippy --workspace --all-targets --features persistence,gpu,update-check \

--- a/crates/velesdb-server/Cargo.toml
+++ b/crates/velesdb-server/Cargo.toml
@@ -21,7 +21,7 @@ name = "velesdb-server"
 path = "src/main.rs"
 
 [dependencies]
-velesdb-core = { workspace = true, default-features = false, features = ["openapi"] }
+velesdb-core = { workspace = true, default-features = false, features = ["openapi", "persistence"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -58,6 +58,12 @@ gpu = ["velesdb-core/gpu"]
 internal-bench = ["velesdb-core/internal-bench"]
 loom = ["velesdb-core/loom"]
 openapi = ["velesdb-core/openapi"]
+## `velesdb-core/persistence` is already forced on unconditionally via the
+## `[dependencies]` entry above (like `openapi`), because velesdb-server's own
+## code uses persistence-gated core APIs (index management, admin
+## diagnostics, graph handlers, etc.) without matching cfg gates throughout.
+## This feature is kept as a no-op alias for backward compatibility with
+## existing `--features persistence` invocations (see #1472).
 persistence = ["velesdb-core/persistence"]
 ## Serves GET /metrics (Prometheus exposition format). Default since 1.19:
 ## released binaries and the Docker image expose operational metrics.

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -200,7 +200,6 @@ fn apply_advanced_with_rollback(
     };
     if let Err(phase_two_err) = coll.apply_advanced_config(
         advanced.pq_rescore_oversampling,
-        #[cfg(feature = "persistence")]
         advanced.deferred_indexing,
         advanced.async_index_builder,
     ) {
@@ -251,23 +250,16 @@ fn log_rollback_invariant(
 #[derive(Default)]
 struct AdvancedCreateOverrides {
     pq_rescore_oversampling: Option<Option<u32>>,
-    #[cfg(feature = "persistence")]
     deferred_indexing: Option<Option<velesdb_core::collection::streaming::DeferredIndexerConfig>>,
     async_index_builder:
         Option<Option<velesdb_core::collection::streaming::AsyncIndexBuilderConfig>>,
 }
 
 impl AdvancedCreateOverrides {
-    #[cfg(feature = "persistence")]
     fn has_any(&self) -> bool {
         self.pq_rescore_oversampling.is_some()
             || self.deferred_indexing.is_some()
             || self.async_index_builder.is_some()
-    }
-
-    #[cfg(not(feature = "persistence"))]
-    fn has_any(&self) -> bool {
-        self.pq_rescore_oversampling.is_some() || self.async_index_builder.is_some()
     }
 }
 
@@ -283,7 +275,6 @@ fn parse_advanced_config(
         ..Default::default()
     };
 
-    #[cfg(feature = "persistence")]
     if let Some(ref value) = req.deferred_indexing {
         let parsed: velesdb_core::collection::streaming::DeferredIndexerConfig =
             serde_json::from_value(value.clone()).map_err(|e| {

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -82,7 +82,12 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
 // ============================================================================
 // OpenAPI Documentation
 
-/// VelesDB API Documentation
+/// VelesDB API Documentation (paths that exist regardless of build features).
+///
+/// The `/metrics` path lives in [`MetricsApiDoc`] because `utoipa`'s `paths(...)`
+/// list is a fixed macro argument list — individual entries can't carry a
+/// `#[cfg(...)]`, so a handler gated behind the `prometheus` feature can't be
+/// listed here unconditionally without breaking `--no-default-features` builds.
 #[derive(OpenApi)]
 #[openapi(
     info(
@@ -174,7 +179,6 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         handlers::points::relations::unrelate_points,
         handlers::points::relations::get_point_relations,
         handlers::points::relations::set_point_ttl,
-        handlers::metrics::prometheus_metrics
     ),
     components(
         schemas(
@@ -257,7 +261,30 @@ pub use handlers::metrics::{health_metrics, prometheus_metrics};
         )
     )
 )]
+struct ApiDocBase;
+
+/// OpenAPI doc fragment for the `/metrics` endpoint, only compiled when the
+/// `prometheus` feature is enabled (see [`ApiDocBase`] for why this is split out).
+#[cfg(feature = "prometheus")]
+#[derive(OpenApi)]
+#[openapi(paths(handlers::metrics::prometheus_metrics))]
+struct MetricsApiDoc;
+
+/// Public entry point for the full OpenAPI document. Merges in the
+/// `prometheus`-gated `/metrics` path when that feature is enabled.
 pub struct ApiDoc;
+
+impl ApiDoc {
+    pub fn openapi() -> utoipa::openapi::OpenApi {
+        #[allow(unused_mut)]
+        let mut doc = ApiDocBase::openapi();
+        #[cfg(feature = "prometheus")]
+        {
+            doc = doc.merge_from(MetricsApiDoc::openapi());
+        }
+        doc
+    }
+}
 
 // ============================================================================
 // Application State

--- a/crates/velesdb-server/src/lib.rs
+++ b/crates/velesdb-server/src/lib.rs
@@ -313,7 +313,6 @@ pub struct AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use utoipa::OpenApi;
 
     #[test]
     fn test_openapi_spec_generation() {

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -13,8 +13,6 @@ use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[cfg(feature = "swagger-ui")]
-use utoipa::OpenApi;
-#[cfg(feature = "swagger-ui")]
 use utoipa_swagger_ui::SwaggerUi;
 use velesdb_core::Database;
 #[cfg(feature = "swagger-ui")]


### PR DESCRIPTION
## Summary

Closes #1472. `cargo check --no-default-features` on a clean develop checkout broke `velesdb-server` with:

```
error[E0433]: failed to resolve: could not find `metrics` in `handlers`
  --> crates/velesdb-server/src/lib.rs:86:10
error[E0061]: this method takes 3 arguments but 2 arguments were supplied
  --> crates/velesdb-server/src/handlers/collections.rs:201:38
```

**Root cause 1 (E0433):** the `#[derive(OpenApi)]` `paths(...)` list in `lib.rs` referenced `handlers::metrics::prometheus_metrics` unconditionally, but that module is `#[cfg(feature = "prometheus")]`-gated. utoipa's `paths(...)` argument list can't carry a per-item `#[cfg(...)]` (verified against utoipa-gen's parser), so the reference can't live inside the always-compiled derive. Fix: split the derive into `ApiDocBase` (paths that always exist) plus a `prometheus`-gated `MetricsApiDoc`, merged by a small `ApiDoc::openapi()` wrapper (`merge_from`) so every existing `ApiDoc::openapi()` call site — main.rs and ~12 tests — is untouched.

**Root cause 2 (E0061):** the call site in `collections.rs` gated the `deferred_indexing` argument behind velesdb-server's *own* `persistence` Cargo feature, mirroring how velesdb-core gates the parameter behind *its* `persistence` feature. In a full-workspace `--no-default-features` build, Cargo's feature unification still turns velesdb-core's `persistence` on (several sibling crates — velesdb-cli, velesdb-python, velesdb-migrate, velesdb-mobile, tauri-plugin-velesdb — depend on velesdb-core without `default-features = false`), while velesdb-server's local `persistence` feature stays off, so the call site omits an argument the linked velesdb-core actually requires.

Separately, isolating `cargo check -p velesdb-server --no-default-features` showed velesdb-server's own code already uses persistence-gated core APIs pervasively (admin diagnostics, index management, graph handlers, query explain) *without* matching cfg gates — so `persistence` was never a functional optional feature for this crate. Made that explicit instead of patching around it: velesdb-core's `persistence` feature is now forced on unconditionally in velesdb-server's Cargo.toml dependency entry (same pattern already used for `openapi`), and the now-redundant cfg gates in `collections.rs` were removed. The crate-level `persistence` Cargo feature is kept as a no-op alias for anyone with existing `--features persistence` invocations.

- Added a `cargo check --workspace --no-default-features` step to the existing `lint` job to close this matrix gap in CI.

## Verification

- `cargo check --no-default-features` (workspace root, exact issue repro) — pass
- `cargo check --workspace --no-default-features` — pass
- `cargo check -p velesdb-server --no-default-features` (isolated) — pass (previously ~62 unrelated pre-existing errors also disappeared as a side effect)
- `cargo check -p velesdb-server --no-default-features --features <f>` for every velesdb-server feature (`bench-sift1m`, `gpu`, `internal-bench`, `loom`, `openapi`, `persistence`, `prometheus`, `update-check`, `swagger-ui`, `test-fault-injection`) — all pass
- `cargo test -p velesdb-server` — green
- `cargo fmt --all -- --check` and `cargo clippy -p velesdb-server -- -D warnings` (default and `--no-default-features`) — clean
- `.github/workflows/ci.yml` parses (validated with Ruby's YAML lib)

## Test plan

- [ ] CI green on this PR, including the new `cargo check --workspace --no-default-features` step
- [ ] Confirm no OpenAPI doc drift (`openapi-drift` job) — verified locally with `--test-threads=1` matching CI exactly, no diff produced