### PR TITLE
fix(memory): strip uint64 format from remember tool input schema

### DIFF
--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -25,6 +25,7 @@ use crate::service::Metadata;
 
 /// Parameters for the `remember` tool.
 #[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RememberParams {
     /// The fact to store in memory.
     pub(super) fact: String,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix`-type change → targets **`develop`**.

> Note: the branch is named `claude/hopeful-einstein-692grw` (session-designated name) rather than a `fix/*` prefix. The change itself is a bug fix targeting `develop`.

## Description

`RememberParams` in `crates/velesdb-memory/src/mcp/dto.rs` was the **only** MCP params struct in that file missing the `#[schemars(transform = crate::schema::strip_int_formats)]` attribute. Every sibling — `RecallParams`, `RecallWhereParams`, `RecallFusedParams`, `RelateParams`, `ForgetParams`, `FeedbackParams`, `WhyParams` — already carries it.

Because the transform was absent, the `remember` tool advertised a non-standard `"format": "uint64"` keyword on its `ttl_seconds` field. Strict MCP clients log this as `"unknown format uint64 ignored"` — harmless, but noisy and inconsistent with every other tool's schema.

The fix is a single-line attribute addition above `pub(super) struct RememberParams`.

This is pre-existing and independent of the `id_str` / float-lossy-client work (issue #1468).

Fixes # (no tracked issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — `cargo test -p velesdb-memory` passes (all suites green).
- [x] Manual testing — drove `tools/list` over stdio JSON-RPC against the built `./target/debug/velesdb-memory` binary (with `VELESDB_MEMORY_PATH` set) and inspected the `remember` tool's `inputSchema`:
  - **Before:** `properties.ttl_seconds` contained `"format": "uint64"`.
  - **After:** the `format` keyword is gone; `ttl_seconds` is `{"type": ["integer","null"], "minimum": 0, ...}`.

**Test Configuration:**
- OS: Linux
- Rust version: stable (edition 2021)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

One-line change; no `unsafe`, no high-risk paths touched.


https://claude.ai/code/session_011Rr44czne7pN4HGSgnTBcc
