### PR TITLE
docs(marketing): guard 2026-07-19 economics claims in promise contract

### DIFF
--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-07-10",
+  "last_updated": "2026-07-19",
   "claims": [
     {
       "id": "root_readme_hnsw_latency_microseconds",
@@ -170,6 +170,46 @@
       "validation_command": "grep -cE \"^  /\" docs/openapi.yaml  # 54 paths (61 operations counting per-verb)",
       "source": "docs/openapi.yaml on this branch: 54 paths / 61 operations, including the relations + TTL endpoints and GET /metrics. Corroborated by crates/velesdb-server/src/routes.rs (54 .route() registrations). Endpoint count convention = OpenAPI paths.",
       "last_updated": "2026-07-10"
+    },
+    {
+      "id": "readme_economics_cropped_dollars_saved",
+      "file": "README.md",
+      "must_contain": "**10.9 %**",
+      "validation_command": "grep -qF '10.9 %' README.md && grep -qF '10.9%' examples/real-session-benchmark/README.md",
+      "source": "examples/real-session-benchmark/README.md:405 (billed campaign 2026-07-19, 19-turn cropped-screenshot session, cli runner: $0.4442 -> $0.3960 = 10.9% $ saved; raw logs examples/real-session-benchmark/results/2026-07-19-vibe-cli/) — consistency check only, no live billed re-run.",
+      "last_updated": "2026-07-19"
+    },
+    {
+      "id": "readme_economics_retina_dollars_and_tokens_saved",
+      "file": "README.md",
+      "must_contain": "**21.9 %**",
+      "validation_command": "grep -qF '21.9 %' README.md && grep -qF '21.9%' examples/real-session-benchmark/README.md && grep -qF '17.6%' examples/real-session-benchmark/README.md",
+      "source": "examples/real-session-benchmark/README.md:406 (billed campaign 2026-07-19, 19-turn real-Retina-screenshot session, cli runner: $0.5693 -> $0.4444 = 21.9% $ saved, 17.6% tokens saved; raw logs examples/real-session-benchmark/results/2026-07-19-day-scale/) — consistency check only, no live billed re-run.",
+      "last_updated": "2026-07-19"
+    },
+    {
+      "id": "readme_economics_day_scale_dollars_saved",
+      "file": "README.md",
+      "must_contain": "**14.7 %**",
+      "validation_command": "grep -qF '14.7 %' README.md && grep -qF '14.7%' examples/real-session-benchmark/README.md",
+      "source": "examples/real-session-benchmark/README.md:407 (billed campaign 2026-07-19, 36-turn day-scale session, cli runner: $1.8613 -> $1.5876 = 14.7% $ saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-long36-cli.log) — consistency check only, no live billed re-run.",
+      "last_updated": "2026-07-19"
+    },
+    {
+      "id": "readme_economics_api_input_tokens_saved",
+      "file": "README.md",
+      "must_contain": "**15.1 %**",
+      "validation_command": "grep -qF '15.1 %' README.md && grep -qF '15.1%' examples/real-session-benchmark/README.md",
+      "source": "examples/real-session-benchmark/README.md:408 (billed campaign 2026-07-19, 19-turn session via direct Messages API runner: input_tokens 15.1% saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-api.log) — consistency check only, no live billed re-run.",
+      "last_updated": "2026-07-19"
+    },
+    {
+      "id": "readme_economics_context_savings_corpus",
+      "file": "README.md",
+      "must_contain": "**82.5 %**",
+      "validation_command": "grep -qF '82.5 %' README.md && grep -qF '82.5% saved' crates/velesdb-memory/examples/context_savings/README.md && grep -qF '26533 raw -> 4647 compiled' crates/velesdb-memory/examples/context_savings/README.md",
+      "source": "crates/velesdb-memory/examples/context_savings/README.md:58 (committed 12-turn agent-session corpus, real cl100k BPE: 26533 raw -> 4647 compiled tokens = 82.5% saved) — consistency check only, no live re-run.",
+      "last_updated": "2026-07-19"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `docs/reference/promise-contract.json` (the CI-enforced marketing-claims registry) covered performance claims only and had not been touched since 2026-07-10.
- The economics claims added to README.md on 2026-07-19 (billed $ savings, token savings — README.md lines ~68-79 and ~272-279) were correctly sourced in prose but had no automated guard against silent drift.
- Adds 5 registry entries, one per economics figure, each pinning the exact substring in README.md and cross-checking it against the committed source that produced it:
  - `readme_economics_cropped_dollars_saved` — 10.9 % $ (19-turn, cropped screenshots) vs `examples/real-session-benchmark/README.md:405`
  - `readme_economics_retina_dollars_and_tokens_saved` — 21.9 % $ / 17.6 % tokens (19-turn, Retina) vs `:406`
  - `readme_economics_day_scale_dollars_saved` — 14.7 % $ (36-turn day-scale) vs `:407`
  - `readme_economics_api_input_tokens_saved` — 15.1 % input tokens (direct Messages API) vs `:408`
  - `readme_economics_context_savings_corpus` — 82.5 % tokens (12-turn corpus, 26533→4647) vs `crates/velesdb-memory/examples/context_savings/README.md:58`
- Each `validation_command` is a deterministic `grep` consistency check between README.md and the committed source file — no live billed campaign is re-run, matching how every other entry in this registry works (the CI script only enforces `must_contain` presence in `file`; `validation_command` documents the reproducible check).
- Bumped the registry's top-level `last_updated` to 2026-07-19 to match the newest entries.

## Test plan
- [x] `python3 -c "import json; json.load(open('docs/reference/promise-contract.json'))"` — valid JSON
- [x] `python3 scripts/check-promise-contract.py` — `Promise contract check passed (27 claims; 3 capacity-mode docs clean).` exit 0
- [x] Ran each new `validation_command` manually — all 5 PASS
- [x] No Rust code reads `promise-contract.json` (grepped the workspace), so no `cargo test` scope is affected