### PR TITLE
fix(mcp): tolerate surrounding whitespace in string memory ids

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -27,6 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Memory-tool id strings now tolerate surrounding whitespace.** Follow-up
+  to issue #1468/#1471: some MCP harnesses (Claude Code included) coerce any
+  all-digit scalar back into a JSON number even when the client sends a
+  string, which defeats the `id_str` string-id workaround and reintroduces
+  precision loss above 2^53. A caller working around this by padding the id
+  with whitespace (e.g. `" 12732540571541475285"`) was rejected by the
+  string-or-number id parser used by `relate`/`forget`/`feedback` (and
+  `Link.target`) with "expected a u64 number or a decimal u64 string" — the
+  id string is now trimmed before parsing. The `+`-prefixed workaround
+  (`"+12732540571541475285"`, already accepted since `u64::from_str` allows a
+  leading `+`) keeps working unchanged.
+
 - **`recall_where`'s type-strict comparisons are now documented (issue
   #1473).** Behavior is unchanged (no runtime coercion added): a numeric
   filter value never matched a string-stored metadata value, and vice

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -63,6 +63,13 @@ well is a *loop you run throughout a task*, not a one-shot lookup.
    rounded by a float-lossy client on the way back in, silently pointing
    `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
    the numeric `id`.
+   **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
+   JSON string) back into a JSON number before it reaches the server, which
+   defeats `id_str` and reintroduces the precision loss it exists to avoid. If
+   that happens, prefix the id with `+` (e.g. `"+12732540571541475285"`) — not
+   a valid JSON number, so the harness leaves it as a string, and the id
+   parser accepts the leading `+`. Surrounding whitespace in an id string is
+   also tolerated (trimmed before parsing).
 
 4. **Explain with `why`, not `recall`.** When asked to justify a value, a config,
    or a design choice, use `why`: recall alone finds text that *looks* similar;

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -34,6 +34,7 @@ where
             .as_u64()
             .ok_or_else(|| Error::custom(format!("invalid id {number} ({expected})"))),
         Value::String(text) => text
+            .trim()
             .parse()
             .map_err(|_| Error::custom(format!("invalid id '{text}' ({expected})"))),
         other => Err(Error::custom(format!("invalid id {other} ({expected})"))),
@@ -243,3 +244,7 @@ pub struct Explanation {
     /// Typed edges connecting the nodes.
     pub edges: Vec<MemoryEdge>,
 }
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/model_tests.rs
+++ b/crates/velesdb-memory/src/model_tests.rs
@@ -1,0 +1,62 @@
+//! Tests for [`deserialize_id`](super::deserialize_id).
+//!
+//! Exercised through [`Link`], the simplest type whose `target` field uses
+//! `#[serde(deserialize_with = "deserialize_id")]` — `mcp/dto.rs`'s
+//! `relate`/`forget`/`feedback` params reuse the exact same function, so a
+//! fix proven here covers those call sites too.
+
+use super::Link;
+use serde_json::json;
+
+#[test]
+fn deserialize_id_leading_whitespace_string_parses() {
+    // Some MCP harnesses (observed with Claude Code, 2026-07-20) coerce any
+    // all-digit scalar to a JSON number, losing precision above 2^53. A
+    // client working around this by prefixing whitespace keeps the value a
+    // JSON string, but the id must still parse.
+    let link: Link = serde_json::from_value(json!({
+        "target": " 123",
+        "relation": "r",
+    }))
+    .expect("leading whitespace around a decimal id must be tolerated");
+
+    assert_eq!(link.target, 123);
+}
+
+#[test]
+fn deserialize_id_trailing_whitespace_string_parses() {
+    let link: Link = serde_json::from_value(json!({
+        "target": "123 ",
+        "relation": "r",
+    }))
+    .expect("trailing whitespace around a decimal id must be tolerated");
+
+    assert_eq!(link.target, 123);
+}
+
+#[test]
+fn deserialize_id_whitespace_padded_max_u64_parses() {
+    let link: Link = serde_json::from_value(json!({
+        "target": " 18446744073709551615 ",
+        "relation": "r",
+    }))
+    .expect("whitespace-padded u64::MAX must be tolerated");
+
+    assert_eq!(link.target, u64::MAX);
+}
+
+#[test]
+fn deserialize_id_plus_prefixed_string_parses() {
+    // Non-regression: the documented workaround for the whitespace problem
+    // above. A '+'-prefixed decimal string is not a JSON number, so a
+    // digit-coercing harness leaves it as a string — and `u64::from_str`
+    // already accepts the leading '+', so this must keep working
+    // independently of the trim fix.
+    let link: Link = serde_json::from_value(json!({
+        "target": "+123",
+        "relation": "r",
+    }))
+    .expect("a '+'-prefixed decimal id must keep working");
+
+    assert_eq!(link.target, 123);
+}


### PR DESCRIPTION
## Summary

Follow-up to #1468/#1471. Some MCP harnesses (Claude Code included) coerce any all-digit scalar back into a JSON number even when the client sends a string, which defeats the `id_str` workaround and reintroduces f64 precision loss above 2^53. A client can keep the value a string by padding it (whitespace or a `+` prefix), but the string-or-number id parser rejected whitespace-padded ids with "expected a u64 number or a decimal u64 string".

Found while dogfooding the typed-links workflow on 2026-07-20: `relate` calls failed from Claude Code until the `+`-prefix workaround was applied.

## Changes
- `deserialize_id` now trims the string before parsing (covers `relate`/`forget`/`feedback` params and `Link.target` — all reuse the same deserializer).
- 4 tests in a separate `model_tests.rs`: leading/trailing whitespace, whitespace-padded `u64::MAX`, and a non-regression test for the `+`-prefixed workaround.
- CHANGELOG entry + SKILL.md documents the harness caveat and both workarounds.

## Validation
- `cargo fmt --all -- --check` EXIT=0
- `cargo test -p velesdb-memory deserialize_id` — 4 passed
- `cargo clippy -p velesdb-memory --all-features -- -D warnings` EXIT=0
- Repo pre-commit hook (fmt+clippy+tests strict) passed on commit