### PR TITLE
feat(cli): add graph doctor subcommand for legacy phantom edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`velesdb-cli`**: new `graph doctor <collection> [--purge|--stub]`
+  subcommand to audit and repair legacy phantom edges -- edges present in
+  a graph collection's edge store whose `source` or `target` node has no
+  stored payload. These can only exist in a database created before the
+  #1442 referential-integrity fix; WAL/snapshot replay at `Collection::open`
+  intentionally never re-validates edges, since filtering them there could
+  silently drop data for legitimate edge-only graphs. `doctor` is
+  read-only by default (reports the phantom count with no mutation);
+  `--purge` removes phantom edges via the existing crash-durable
+  `remove_edge` path, `--stub` seeds a minimal `{}` payload for each
+  missing endpoint instead. Both flags are mutually exclusive and
+  idempotent. (#1469)
 - **`velesdb-memory` (Python)**: `MemoryService.feedback` is now exposed,
   closing the RL feedback loop from the Python binding. (#1452)
 

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -194,6 +194,8 @@ All graph REPL commands operate on graph collections via `.graph <subcommand>`:
 
 > **Naming note:** The REPL uses `.graph edges` while the CLI subcommand uses `graph get-edges`. Both do the same thing.
 
+> **CLI-only:** `graph doctor` (legacy phantom-edge audit/repair, see below) is a standalone CLI subcommand and has no REPL equivalent.
+
 ### Session Commands
 
 Session commands use the backslash prefix (dot prefix also accepted):
@@ -485,6 +487,15 @@ velesdb graph search ./data my_graph '[0.1, 0.2, 0.3]' --format json
 velesdb graph nodes ./data my_graph
 velesdb graph nodes ./data my_graph --page 2
 velesdb graph nodes ./data my_graph --format json
+
+# Audit legacy phantom edges (edge store entries whose source or target
+# node has no stored payload -- can only happen in a database created
+# before the #1442 add_edge referential-integrity fix). Read-only by
+# default; --purge and --stub are mutually exclusive and idempotent.
+velesdb graph doctor ./data my_graph                 # dry-run report
+velesdb graph doctor ./data my_graph --purge          # remove phantom edges
+velesdb graph doctor ./data my_graph --stub           # seed a {} payload for each missing endpoint
+velesdb graph doctor ./data my_graph --format json
 ```
 
 **`traverse` flags:**

--- a/crates/velesdb-cli/src/graph.rs
+++ b/crates/velesdb-cli/src/graph.rs
@@ -187,6 +187,34 @@ pub enum GraphAction {
         #[arg(short, long, default_value = "table")]
         format: String,
     },
+
+    /// Scan for legacy phantom edges (edge store entries whose source or
+    /// target node has no stored payload) and report or repair them.
+    ///
+    /// Read-only by default: reports the phantom edge count with no
+    /// mutation unless `--purge` or `--stub` is passed. These predate
+    /// #1442's referential-integrity check and can only exist in a
+    /// database that was created before that fix landed -- WAL replay at
+    /// `Collection::open` intentionally never re-validates edges, so
+    /// filtering them there would risk data loss for legitimate
+    /// edge-only graphs. `doctor` is the explicit, opt-in alternative.
+    Doctor {
+        /// Path to database directory
+        path: PathBuf,
+        /// Graph collection name
+        collection: String,
+        /// Remove phantom edges from the edge store (crash-durable via
+        /// the existing remove_edge/WAL-tombstone path)
+        #[arg(long, conflicts_with = "stub")]
+        purge: bool,
+        /// Seed a minimal `{}` payload for each missing endpoint instead
+        /// of removing the edge
+        #[arg(long, conflicts_with = "purge")]
+        stub: bool,
+        /// Output format (table, json)
+        #[arg(short, long, default_value = "table")]
+        format: String,
+    },
 }
 
 /// Handle graph subcommands with direct core calls.
@@ -277,9 +305,20 @@ pub fn handle(action: GraphAction) -> anyhow::Result<()> {
             page,
             format,
         } => graph_handlers::handle_graph_nodes(&path, &collection, page, &format),
+        GraphAction::Doctor {
+            path,
+            collection,
+            purge,
+            stub,
+            format,
+        } => graph_handlers::handle_graph_doctor(&path, &collection, purge, stub, &format),
     }
 }
 
 #[cfg(test)]
 #[path = "graph_bdd_tests.rs"]
 mod graph_bdd_tests;
+
+#[cfg(test)]
+#[path = "graph_doctor_tests.rs"]
+mod graph_doctor_tests;

--- a/crates/velesdb-cli/src/graph_doctor.rs
+++ b/crates/velesdb-cli/src/graph_doctor.rs
@@ -1,0 +1,239 @@
+//! Core logic for `velesdb-cli graph doctor`.
+//!
+//! Detects and (optionally) repairs legacy "phantom" edges: edges present
+//! in a graph collection's edge store whose `source` or `target` node has
+//! no stored payload. These can only exist via WAL/snapshot replay at
+//! `Collection::open` — `add_edge`/`add_edges_batch` reject such edges
+//! outright (#1442) — so `doctor` exists purely to audit/repair databases
+//! created before that validation landed. Replay itself is intentionally
+//! left unvalidated (see `docs/CONCURRENCY_MODEL.md`): filtering edges at
+//! open time would silently drop data for legitimate edge-only graphs.
+//!
+//! `doctor` is a separate, explicit, opt-in tool — never part of the
+//! replay path — and defaults to a read-only report (see #1469).
+
+use std::collections::{BTreeSet, HashMap};
+
+use colored::Colorize;
+use velesdb_core::GraphCollection;
+
+use crate::helpers;
+
+/// Number of phantom edges shown in the printed sample (table and JSON).
+const SAMPLE_SIZE: usize = 10;
+
+/// A single phantom edge: present in the edge store, missing one or both
+/// endpoint payloads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PhantomEdge {
+    pub edge_id: u64,
+    pub source: u64,
+    pub target: u64,
+    pub label: String,
+    pub missing_source: bool,
+    pub missing_target: bool,
+}
+
+/// Which repair action `doctor` should take, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DoctorMode {
+    /// Report-only: no mutation (the default).
+    Report,
+    /// Remove phantom edges from the edge store.
+    Purge,
+    /// Seed a minimal `{}` payload for each missing endpoint.
+    Stub,
+}
+
+impl DoctorMode {
+    fn label(self) -> &'static str {
+        match self {
+            DoctorMode::Report => "report",
+            DoctorMode::Purge => "purge",
+            DoctorMode::Stub => "stub",
+        }
+    }
+}
+
+/// Returns whether `node_id` has a stored payload, memoizing lookups so a
+/// high-degree node is only queried once per scan.
+fn node_has_payload(
+    col: &GraphCollection,
+    cache: &mut HashMap<u64, bool>,
+    node_id: u64,
+) -> anyhow::Result<bool> {
+    if let Some(&cached) = cache.get(&node_id) {
+        return Ok(cached);
+    }
+    let has = col
+        .get_node_payload(node_id)
+        .map_err(|e| anyhow::anyhow!("{e}"))?
+        .is_some();
+    cache.insert(node_id, has);
+    Ok(has)
+}
+
+/// Scans every edge in `col` and returns those whose source and/or target
+/// has no stored payload (legacy phantom edges).
+///
+/// # Errors
+///
+/// Returns an error if a node payload lookup fails.
+pub(crate) fn scan_phantom_edges(col: &GraphCollection) -> anyhow::Result<Vec<PhantomEdge>> {
+    let edges = col.get_edges(None);
+    let mut cache = HashMap::new();
+    let mut phantoms = Vec::new();
+    for edge in &edges {
+        let missing_source = !node_has_payload(col, &mut cache, edge.source())?;
+        let missing_target = !node_has_payload(col, &mut cache, edge.target())?;
+        if missing_source || missing_target {
+            phantoms.push(PhantomEdge {
+                edge_id: edge.id(),
+                source: edge.source(),
+                target: edge.target(),
+                label: edge.label().to_string(),
+                missing_source,
+                missing_target,
+            });
+        }
+    }
+    Ok(phantoms)
+}
+
+/// Removes every phantom edge from the edge store. Returns the number
+/// actually removed. Naturally idempotent: a re-scan after purging finds
+/// no phantoms, so a second call receives an empty slice.
+pub(crate) fn purge_phantom_edges(col: &GraphCollection, phantoms: &[PhantomEdge]) -> usize {
+    phantoms
+        .iter()
+        .filter(|p| col.remove_edge(p.edge_id))
+        .count()
+}
+
+/// Seeds a minimal `{}` payload for every node referenced as a missing
+/// endpoint. Returns the number of distinct nodes stubbed. Naturally
+/// idempotent: once a node has a payload it no longer appears as missing
+/// on a re-scan.
+///
+/// # Errors
+///
+/// Returns an error if writing a stub payload fails.
+pub(crate) fn stub_phantom_edges(
+    col: &GraphCollection,
+    phantoms: &[PhantomEdge],
+) -> anyhow::Result<usize> {
+    let mut missing_nodes: BTreeSet<u64> = BTreeSet::new();
+    for p in phantoms {
+        if p.missing_source {
+            missing_nodes.insert(p.source);
+        }
+        if p.missing_target {
+            missing_nodes.insert(p.target);
+        }
+    }
+    for &node_id in &missing_nodes {
+        col.upsert_node_payload(node_id, &serde_json::json!({}))
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }
+    Ok(missing_nodes.len())
+}
+
+fn phantom_to_json(p: &PhantomEdge) -> serde_json::Value {
+    serde_json::json!({
+        "edge_id": p.edge_id,
+        "source": p.source,
+        "target": p.target,
+        "label": p.label,
+        "missing_source": p.missing_source,
+        "missing_target": p.missing_target,
+    })
+}
+
+/// Prints the doctor report (phantom count, sample, action taken).
+///
+/// # Errors
+///
+/// Returns an error if JSON serialization fails.
+pub(crate) fn print_report(
+    collection: &str,
+    phantoms: &[PhantomEdge],
+    mode: DoctorMode,
+    fixed: usize,
+    format: &str,
+) -> anyhow::Result<()> {
+    if format == "json" {
+        let sample: Vec<_> = phantoms
+            .iter()
+            .take(SAMPLE_SIZE)
+            .map(phantom_to_json)
+            .collect();
+        helpers::print_json(&serde_json::json!({
+            "collection": collection,
+            "phantom_edge_count": phantoms.len(),
+            "mode": mode.label(),
+            "fixed": fixed,
+            "sample": sample,
+        }))?;
+    } else {
+        print_report_table(collection, phantoms, mode, fixed);
+    }
+    Ok(())
+}
+
+fn print_report_table(collection: &str, phantoms: &[PhantomEdge], mode: DoctorMode, fixed: usize) {
+    println!(
+        "\n{} '{}'\n",
+        "Graph Doctor".bold().underline(),
+        collection.green()
+    );
+    if phantoms.is_empty() {
+        println!("  {} No phantom edges found.\n", "✅".green());
+        return;
+    }
+    println!(
+        "  {} {} phantom edge(s) found (edge store references a node with no stored payload)\n",
+        "⚠️".yellow(),
+        phantoms.len().to_string().yellow()
+    );
+    for p in phantoms.iter().take(SAMPLE_SIZE) {
+        let missing = match (p.missing_source, p.missing_target) {
+            (true, true) => "source+target".to_string(),
+            (true, false) => format!("source={}", p.source),
+            (false, true) => format!("target={}", p.target),
+            (false, false) => String::new(),
+        };
+        println!(
+            "  {} {} --[{}]--> {}  missing={}",
+            format!("[{}]", p.edge_id).cyan(),
+            p.source,
+            p.label.green(),
+            p.target,
+            missing.red(),
+        );
+    }
+    if phantoms.len() > SAMPLE_SIZE {
+        println!("  ... and {} more", phantoms.len() - SAMPLE_SIZE);
+    }
+    match mode {
+        DoctorMode::Report => {
+            println!(
+                "\n  {} Dry-run: no changes made. Re-run with --purge or --stub to repair.\n",
+                "ℹ️".cyan()
+            );
+        }
+        DoctorMode::Purge => {
+            println!(
+                "\n  {} {} phantom edge(s) removed.\n",
+                "✅".green(),
+                fixed.to_string().green()
+            );
+        }
+        DoctorMode::Stub => {
+            println!(
+                "\n  {} {} missing node(s) stubbed with an empty payload.\n",
+                "✅".green(),
+                fixed.to_string().green()
+            );
+        }
+    }
+}

--- a/crates/velesdb-cli/src/graph_doctor_tests.rs
+++ b/crates/velesdb-cli/src/graph_doctor_tests.rs
@@ -1,0 +1,295 @@
+//! BDD tests for `velesdb-cli graph doctor` (GIVEN -> WHEN -> THEN).
+//!
+//! Legacy phantom edges -- present in the edge store but with a source or
+//! target that has no stored payload -- can only occur via WAL replay:
+//! `Collection::open` never re-validates edges loaded from a pre-existing
+//! WAL/snapshot (replay intentionally bypasses referential-integrity
+//! checks so a legitimate edge-only database created before the #1442 fix
+//! never silently loses data). See #1469 and `docs/CONCURRENCY_MODEL.md`.
+//!
+//! These tests simulate that scenario by writing a raw ADD entry directly
+//! to `edges.wal`, bypassing `add_edge`'s referential-integrity validation,
+//! then re-opening the collection so replay ingests it unchecked -- exactly
+//! as a pre-#1442 database would look on disk.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+use velesdb_core::collection::graph::GraphSchema;
+use velesdb_core::{Database, GraphCollection, GraphEdge};
+
+use crate::graph::GraphAction;
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+/// Create a fresh database + graph collection in a temp directory.
+fn setup_graph_db() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db_path = dir.path().join("test_db");
+    let db = Database::open(&db_path).expect("test: open database");
+    db.create_graph_collection("kg", GraphSchema::schemaless())
+        .expect("test: create graph collection");
+    drop(db);
+    (dir, db_path)
+}
+
+/// Open graph collection from path.
+fn open_graph(path: &PathBuf) -> GraphCollection {
+    let db = Database::open(path).expect("test: open database");
+    db.get_graph_collection("kg")
+        .expect("test: get graph collection")
+}
+
+/// WAL opcode for an Add entry. Mirrors `edge_wal.rs`'s private
+/// `WAL_OP_ADD`; the on-disk layout is documented as a stable contract in
+/// that module's doc comment (`[u32 body_len][u8 0x01][json(GraphEdge)]`).
+const WAL_OP_ADD: u8 = 0x01;
+
+/// Seeds a legacy phantom edge directly into `edges.wal`, bypassing
+/// `add_edge`'s referential-integrity validation (#1442). Simulates a
+/// pre-#1442 database on disk: the next `Collection::open` replays this
+/// entry unchecked, exactly like a real legacy WAL/snapshot would.
+fn seed_phantom_edge(db_path: &Path, id: u64, source: u64, target: u64, label: &str) {
+    let edge = GraphEdge::new(id, source, target, label).expect("test: valid edge shape");
+    let edge_bytes = serde_json::to_vec(&edge).expect("test: serialize edge");
+    let body_len = u32::try_from(edge_bytes.len() + 1).expect("test: body fits u32");
+    let wal_path = db_path.join("kg").join("edges.wal");
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&wal_path)
+        .expect("test: open edges.wal for append");
+    f.write_all(&body_len.to_le_bytes())
+        .expect("test: write len prefix");
+    f.write_all(&[WAL_OP_ADD]).expect("test: write op byte");
+    f.write_all(&edge_bytes).expect("test: write edge body");
+    f.sync_all().expect("test: fsync wal");
+}
+
+/// Runs `graph doctor` with the given flags against the "kg" collection.
+fn run_doctor(path: &Path, purge: bool, stub: bool) -> anyhow::Result<()> {
+    crate::graph::handle(GraphAction::Doctor {
+        path: path.to_path_buf(),
+        collection: "kg".to_string(),
+        purge,
+        stub,
+        format: "table".to_string(),
+    })
+}
+
+// =========================================================================
+// A. Nominal -- no phantoms
+// =========================================================================
+
+#[test]
+fn test_doctor_no_phantoms_reports_clean_and_mutates_nothing() {
+    // GIVEN: a graph with a single well-formed edge
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    for id in [1, 2] {
+        col.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("test: store payload");
+    }
+    col.add_edge(GraphEdge::new(1, 1, 2, "KNOWS").expect("test: valid edge"))
+        .expect("test: add edge");
+    col.flush().expect("test: flush");
+    drop(col);
+
+    // WHEN: doctor runs in default (report-only) mode
+    run_doctor(&path, false, false).expect("doctor report should succeed");
+
+    // THEN: nothing changed
+    let col = open_graph(&path);
+    assert_eq!(
+        col.edge_count(),
+        1,
+        "a clean graph must be left untouched by doctor"
+    );
+}
+
+// =========================================================================
+// B. Phantom detected, dry-run default
+// =========================================================================
+
+#[test]
+fn test_doctor_dry_run_detects_phantom_without_mutating() {
+    // GIVEN: node 1 has a payload, node 2 never does, and a legacy WAL
+    // entry links them with an edge that bypassed #1442 validation
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    col.upsert_node_payload(1, &serde_json::json!({}))
+        .expect("test: store payload");
+    col.flush().expect("test: flush");
+    drop(col);
+    seed_phantom_edge(&path, 99, 1, 2, "LEGACY");
+
+    // WHEN: doctor runs with no flags (dry-run report)
+    run_doctor(&path, false, false).expect("dry-run report should succeed");
+
+    // THEN: the phantom edge survives untouched and no stub was created
+    let col = open_graph(&path);
+    assert_eq!(
+        col.edge_count(),
+        1,
+        "dry-run must never remove the phantom edge"
+    );
+    assert!(
+        col.get_node_payload(2)
+            .expect("test: get payload")
+            .is_none(),
+        "dry-run must never create a stub payload"
+    );
+}
+
+// =========================================================================
+// C. --purge
+// =========================================================================
+
+#[test]
+fn test_doctor_purge_removes_phantom_edge_only() {
+    // GIVEN: one valid edge (1->2) plus one legacy phantom edge (2->4,
+    // node 4 has no payload)
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    for id in [1, 2, 3] {
+        col.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("test: store payload");
+    }
+    col.add_edge(GraphEdge::new(1, 1, 2, "VALID").expect("test: valid edge"))
+        .expect("test: add edge");
+    col.flush().expect("test: flush");
+    drop(col);
+    seed_phantom_edge(&path, 99, 2, 4, "LEGACY");
+
+    // WHEN: doctor runs with --purge
+    run_doctor(&path, true, false).expect("purge should succeed");
+
+    // THEN: only the phantom edge is gone; the valid edge survives
+    let col = open_graph(&path);
+    let edges = col.get_edges(None);
+    assert_eq!(edges.len(), 1, "only the phantom edge should be purged");
+    assert!(
+        edges.iter().any(|e| e.id() == 1),
+        "doctor must never touch a valid edge"
+    );
+    assert!(
+        !edges.iter().any(|e| e.id() == 99),
+        "the phantom edge must be removed"
+    );
+}
+
+#[test]
+fn test_doctor_purge_is_idempotent() {
+    // GIVEN: a single legacy phantom edge
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    col.upsert_node_payload(1, &serde_json::json!({}))
+        .expect("test: store payload");
+    col.flush().expect("test: flush");
+    drop(col);
+    seed_phantom_edge(&path, 99, 1, 2, "LEGACY");
+
+    // WHEN: purge runs twice
+    run_doctor(&path, true, false).expect("first purge should succeed");
+    let after_first = open_graph(&path).edge_count();
+    run_doctor(&path, true, false).expect("second purge should be a no-op");
+    let after_second = open_graph(&path).edge_count();
+
+    // THEN: the second run makes no further changes
+    assert_eq!(after_first, 0, "the phantom edge is removed on first purge");
+    assert_eq!(
+        after_second, 0,
+        "running purge twice must produce no further changes"
+    );
+}
+
+// =========================================================================
+// D. --stub
+// =========================================================================
+
+#[test]
+fn test_doctor_stub_seeds_empty_payload_for_missing_endpoint() {
+    // GIVEN: a legacy phantom edge whose target (node 2) has no payload
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    col.upsert_node_payload(1, &serde_json::json!({}))
+        .expect("test: store payload");
+    col.flush().expect("test: flush");
+    drop(col);
+    seed_phantom_edge(&path, 99, 1, 2, "LEGACY");
+
+    // WHEN: doctor runs with --stub
+    run_doctor(&path, false, true).expect("stub should succeed");
+
+    // THEN: the edge is kept, and node 2 now has a minimal `{}` payload
+    let col = open_graph(&path);
+    assert_eq!(col.edge_count(), 1, "stub must keep the edge");
+    assert_eq!(
+        col.get_node_payload(2).expect("test: get payload"),
+        Some(serde_json::json!({})),
+        "the missing endpoint must be stubbed with an empty payload"
+    );
+    assert!(
+        col.all_node_ids().contains(&2),
+        "the stubbed node must now be visible to all_node_ids/MATCH"
+    );
+}
+
+#[test]
+fn test_doctor_stub_is_idempotent() {
+    // GIVEN: a legacy phantom edge
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    col.upsert_node_payload(1, &serde_json::json!({}))
+        .expect("test: store payload");
+    col.flush().expect("test: flush");
+    drop(col);
+    seed_phantom_edge(&path, 99, 1, 2, "LEGACY");
+
+    // WHEN: stub runs twice
+    run_doctor(&path, false, true).expect("first stub should succeed");
+    run_doctor(&path, false, true).expect("second stub should be a no-op");
+
+    // THEN: the node payload is still just the stub, edge still present
+    let col = open_graph(&path);
+    assert_eq!(col.edge_count(), 1);
+    assert_eq!(
+        col.get_node_payload(2).expect("test: get payload"),
+        Some(serde_json::json!({})),
+        "running stub twice must produce no further changes"
+    );
+}
+
+// =========================================================================
+// E. Doctor never touches a valid edge (regression)
+// =========================================================================
+
+#[test]
+fn test_doctor_leaves_all_valid_edges_when_no_phantoms_exist_stub_mode() {
+    // GIVEN: a graph with only valid edges
+    let (_dir, path) = setup_graph_db();
+    let col = open_graph(&path);
+    for id in [1, 2, 3] {
+        col.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("test: store payload");
+    }
+    col.add_edge(GraphEdge::new(1, 1, 2, "A").expect("test: valid edge"))
+        .expect("test: add edge");
+    col.add_edge(GraphEdge::new(2, 2, 3, "B").expect("test: valid edge"))
+        .expect("test: add edge");
+    col.flush().expect("test: flush");
+    drop(col);
+
+    // WHEN: --stub runs on a graph with no phantoms
+    run_doctor(&path, false, true).expect("stub should succeed even with nothing to fix");
+
+    // THEN: both edges and both payloads are untouched
+    let col = open_graph(&path);
+    assert_eq!(col.edge_count(), 2);
+    assert_eq!(
+        col.get_node_payload(1).expect("test: get payload"),
+        Some(serde_json::json!({}))
+    );
+}

--- a/crates/velesdb-cli/src/graph_handlers.rs
+++ b/crates/velesdb-cli/src/graph_handlers.rs
@@ -10,6 +10,7 @@ use velesdb_core::GraphEdge;
 
 use crate::graph::{Direction, TraverseAlgo};
 use crate::graph_display;
+use crate::graph_doctor::{self, DoctorMode};
 use crate::helpers;
 
 /// Open a graph collection from a database path.
@@ -321,6 +322,49 @@ pub(crate) fn handle_graph_nodes(
         print_node_page_table(&node_page);
     }
     Ok(())
+}
+
+/// Scans a graph collection for legacy phantom edges and reports them, or
+/// repairs them when `--purge`/`--stub` is passed. Read-only by default.
+pub(crate) fn handle_graph_doctor(
+    path: &PathBuf,
+    collection: &str,
+    purge: bool,
+    stub: bool,
+    format: &str,
+) -> anyhow::Result<()> {
+    let col = open_graph(path, collection)?;
+    let phantoms = graph_doctor::scan_phantom_edges(&col)?;
+
+    let mode = if purge {
+        DoctorMode::Purge
+    } else if stub {
+        DoctorMode::Stub
+    } else {
+        DoctorMode::Report
+    };
+
+    let fixed = match mode {
+        DoctorMode::Purge => {
+            let n = graph_doctor::purge_phantom_edges(&col, &phantoms);
+            if n > 0 {
+                col.flush()
+                    .map_err(|e| anyhow::anyhow!("Flush failed: {e}"))?;
+            }
+            n
+        }
+        DoctorMode::Stub => {
+            let n = graph_doctor::stub_phantom_edges(&col, &phantoms)?;
+            if n > 0 {
+                col.flush()
+                    .map_err(|e| anyhow::anyhow!("Flush failed: {e}"))?;
+            }
+            n
+        }
+        DoctorMode::Report => 0,
+    };
+
+    graph_doctor::print_report(collection, &phantoms, mode, fixed, format)
 }
 
 /// Print paginated node data in table format.

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -21,6 +21,8 @@ mod graph;
 #[allow(clippy::pedantic)]
 mod graph_display;
 #[allow(clippy::pedantic)]
+mod graph_doctor;
+#[allow(clippy::pedantic)]
 mod graph_handlers;
 #[allow(clippy::pedantic)]
 mod handlers;

--- a/crates/velesdb-cli/tests/graph_commands_tests.rs
+++ b/crates/velesdb-cli/tests/graph_commands_tests.rs
@@ -767,3 +767,183 @@ fn test_graph_store_payload_invalid_json() {
         .failure()
         .stderr(predicate::str::contains("Invalid JSON"));
 }
+
+// =========================================================================
+// doctor — legacy phantom edges (#1469)
+// =========================================================================
+
+/// WAL opcode for an Add entry (`edge_wal.rs`'s private `WAL_OP_ADD`); the
+/// on-disk layout is documented as a stable contract in that module.
+const WAL_OP_ADD: u8 = 0x01;
+
+/// Seeds a legacy phantom edge directly into `<dir>/<collection>/edges.wal`,
+/// bypassing `add_edge`'s referential-integrity validation (#1442), so the
+/// next CLI invocation's `Collection::open` replays it unchecked -- exactly
+/// like a pre-#1442 database.
+fn seed_phantom_edge(
+    dir: &std::path::Path,
+    collection: &str,
+    id: u64,
+    source: u64,
+    target: u64,
+    label: &str,
+) {
+    use std::io::Write;
+    let edge = serde_json::json!({
+        "id": id, "source": source, "target": target,
+        "label": label, "properties": {}
+    });
+    let edge_bytes = serde_json::to_vec(&edge).unwrap();
+    let body_len = u32::try_from(edge_bytes.len() + 1).unwrap();
+    let wal_path = dir.join(collection).join("edges.wal");
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&wal_path)
+        .expect("open edges.wal for append");
+    f.write_all(&body_len.to_le_bytes()).unwrap();
+    f.write_all(&[WAL_OP_ADD]).unwrap();
+    f.write_all(&edge_bytes).unwrap();
+    f.sync_all().unwrap();
+}
+
+#[test]
+fn test_graph_help_lists_doctor_subcommand() {
+    cmd()
+        .args(["graph", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("doctor"));
+}
+
+#[test]
+fn test_graph_doctor_purge_and_stub_are_mutually_exclusive() {
+    let temp = tempfile::tempdir().unwrap();
+    create_graph_collection(temp.path(), "g");
+
+    cmd()
+        .args([
+            "graph",
+            "doctor",
+            temp.path().to_str().unwrap(),
+            "g",
+            "--purge",
+            "--stub",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
+}
+
+#[test]
+fn test_graph_doctor_clean_graph_reports_no_phantoms() {
+    let temp = tempfile::tempdir().unwrap();
+    create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    store_payload(temp.path(), "g", "2");
+    cmd()
+        .args([
+            "graph",
+            "add-edge",
+            temp.path().to_str().unwrap(),
+            "g",
+            "1",
+            "1",
+            "2",
+            "KNOWS",
+        ])
+        .assert()
+        .success();
+
+    cmd()
+        .args(["graph", "doctor", temp.path().to_str().unwrap(), "g"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No phantom edges found"));
+}
+
+#[test]
+fn test_graph_doctor_dry_run_reports_phantom_without_mutating() {
+    let temp = tempfile::tempdir().unwrap();
+    create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    seed_phantom_edge(temp.path(), "g", 99, 1, 2, "LEGACY");
+
+    cmd()
+        .args(["graph", "doctor", temp.path().to_str().unwrap(), "g"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 phantom edge"))
+        .stdout(predicate::str::contains("Dry-run"));
+
+    // The phantom edge must still be there after a dry-run.
+    cmd()
+        .args(["graph", "count", temp.path().to_str().unwrap(), "g"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Edges: 1"));
+}
+
+#[test]
+fn test_graph_doctor_purge_removes_phantom_edge() {
+    let temp = tempfile::tempdir().unwrap();
+    create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    seed_phantom_edge(temp.path(), "g", 99, 1, 2, "LEGACY");
+
+    cmd()
+        .args([
+            "graph",
+            "doctor",
+            temp.path().to_str().unwrap(),
+            "g",
+            "--purge",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 phantom edge(s) removed"));
+
+    cmd()
+        .args(["graph", "count", temp.path().to_str().unwrap(), "g"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Edges: 0"));
+}
+
+#[test]
+fn test_graph_doctor_stub_seeds_missing_endpoint_payload() {
+    let temp = tempfile::tempdir().unwrap();
+    create_graph_collection(temp.path(), "g");
+    store_payload(temp.path(), "g", "1");
+    seed_phantom_edge(temp.path(), "g", 99, 1, 2, "LEGACY");
+
+    cmd()
+        .args([
+            "graph",
+            "doctor",
+            temp.path().to_str().unwrap(),
+            "g",
+            "--stub",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("1 missing node(s) stubbed"));
+
+    // The edge is kept, and node 2 now resolves via get-payload.
+    cmd()
+        .args([
+            "graph",
+            "get-payload",
+            temp.path().to_str().unwrap(),
+            "g",
+            "2",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("{}"));
+    cmd()
+        .args(["graph", "count", temp.path().to_str().unwrap(), "g"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Edges: 1"));
+}

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -264,10 +264,11 @@ single-writer-per-collection model this section belongs under (see
 WAL/snapshot at `Collection::open` (replay) are trusted as-is and never
 re-validated — replay intentionally bypasses referential-integrity
 validation so legitimate edge-only databases created before the #1442 fix
-keep their data. A follow-up CLI tool to audit/repair such legacy phantom
-edges is tracked in issue
-[#1469](https://github.com/cyberlife-coder/VelesDB/issues/1469) (see also
-`guides/GRAPH_PATTERNS.md`).
+keep their data. `velesdb-cli graph doctor <collection>` audits/repairs
+such legacy phantom edges as an explicit, opt-in tool (read-only report by
+default, `--purge`/`--stub` to fix); see
+[#1469](https://github.com/cyberlife-coder/VelesDB/issues/1469) and
+`guides/GRAPH_PATTERNS.md`.
 
 ## RaBitQ Interior Mutability
 

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -65,9 +65,24 @@ for MATCH" above), then add the edge (#1442).
 > given a payload — those are loaded as-is on open (re-validating the
 > whole edge store at load time could turn a legitimate edge-only graph
 > into data loss) and stay invisible to `all_node_ids()`/MATCH until you
-> give the missing endpoint a payload yourself. A `velesdb-cli graph
-> doctor` subcommand to scan/purge/stub these is tracked in
+> give the missing endpoint a payload yourself. Use `velesdb-cli graph
+> doctor <collection>` to scan for these "phantom" edges — it is
+> read-only by default and only mutates the database when you pass
+> `--purge` (remove the phantom edges) or `--stub` (seed a minimal `{}`
+> payload for each missing endpoint). See the
+> [CLI reference](../../crates/velesdb-cli/README.md#graph) and
 > [issue #1469](https://github.com/cyberlife-coder/VelesDB/issues/1469).
+
+```bash
+# Report phantom edges without changing anything (dry-run, the default)
+velesdb graph doctor ./data knowledge
+
+# Remove phantom edges from the edge store
+velesdb graph doctor ./data knowledge --purge
+
+# Seed a minimal {} payload for each missing endpoint instead
+velesdb graph doctor ./data knowledge --stub
+```
 
 ```bash
 curl -X POST http://localhost:8080/collections/knowledge/graph/edges \


### PR DESCRIPTION
## Summary

- Adds `velesdb-cli graph doctor <collection> [--purge|--stub]` to audit and repair legacy "phantom" edges: edges present in a graph collection's edge store whose `source` or `target` node has no stored payload. These can only exist in a database created before the #1442 `add_edge` referential-integrity fix — WAL/snapshot replay at `Collection::open` intentionally never re-validates edges (filtering there could silently drop data for a legitimate edge-only graph).
- Read-only by default: reports the phantom edge count (with a sample) and makes no mutation.
- `--purge` removes phantom edges via the existing crash-durable `remove_edge`/WAL-tombstone path.
- `--stub` seeds a minimal `{}` payload for each missing endpoint instead of removing the edge.
- `--purge`/`--stub` are mutually exclusive (`conflicts_with`) and both idempotent (re-scanning after a fix finds no more phantoms).
- Doctor never touches a valid edge — only edges flagged as phantom by the scan are eligible for `--purge`/`--stub`.

## Test plan

- [x] `crates/velesdb-cli/src/graph_doctor_tests.rs` (new, in-process BDD tests): nominal/clean graph, dry-run detection without mutation, `--purge` removes only the phantom edge and is idempotent, `--stub` seeds the missing payload and is idempotent, doctor leaves valid edges untouched. Phantom edges are seeded by writing a raw `Add` entry directly into `edges.wal` (bypassing `add_edge`'s validation) to simulate a pre-#1442 database.
- [x] `crates/velesdb-cli/tests/graph_commands_tests.rs` (black-box CLI tests): `--help` lists `doctor`, `--purge --stub` rejected by clap, clean-graph report, dry-run report, `--purge`, `--stub`.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` (exact CI command)
- [x] `cargo test -p velesdb-cli` (full suite, 217+35+24+27+46+30+2+1 tests, all green)
- [x] Documented in `docs/guides/GRAPH_PATTERNS.md`, `docs/CONCURRENCY_MODEL.md`, `crates/velesdb-cli/README.md`, and `CHANGELOG.md`

Closes #1469