### PR TITLE
chore(release): velesdb-memory 0.9.2 prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "criterion",
  "rmcp",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-07-20
+
 ### Added
 
 - **Agentic quick wins for the MCP surface.** `get_info().instructions` now

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,17 +17,19 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
-> **Release 0.9.1** — hotfix cycle over the 0.9.0 context compiler: a
-> permanent `ctx://source/` handle no longer expires silently, byte-identical
-> screenshot duplicates no longer both drop from compiled context, metadata
-> is now size-capped (64 KiB) and the working context load path verifies its
-> system marker; published to the registries by the `velesdb-memory-v0.9.1`
+> **Release 0.9.2** — agent-ergonomics cycle over the 0.9.1 memory server:
+> ids now survive float-lossy JSON clients end-to-end (`id_str` decimal-string
+> twins on every id-bearing response, string ids accepted on input, surrounding
+> whitespace tolerated), `get_info` documents all three tool families, new
+> `list_working_contexts` and `suggest_budget` tools, `compile_context` gains
+> `warnings[]` and `policy.slim_response`; published to the registries by the
+> `velesdb-memory-v0.9.2`
 > tag, so the links below may briefly lag right after merge. `velesdb-memory`
 > ships on [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.9.1**
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.9.2**
 > and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**
 > (memory API only — the context compiler is merged on `develop` but **the
 > published 3.12.0 wheel predates it**; it ships with the next PyPI release,

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.9.1"
+version = "0.9.2"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release prep for the `velesdb-memory-v0.9.2` tag, mirroring the 0.9.1 prep (#1463):

- `velesdb-memory` + `velesdb-node` Cargo.toml → 0.9.2
- npm `package.json` + `package-lock.json` → 0.9.2
- `server.json` (`.version` + `packages[0].version`) → 0.9.2
- `Cargo.lock` entries regenerated via `cargo check` (no global update)
- README release banner rewritten for 0.9.2 (agent-ergonomics highlights: `id_str` twins + string-id inputs + whitespace tolerance, `get_info` covering all tool families, `list_working_contexts`, `suggest_budget`, `compile_context` `warnings[]`/`slim_response`)
- CHANGELOG stamped `[0.9.2] — 2026-07-20`

Release content since 0.9.1: #1471, #1476, #1478, #1479, #1490 (+ repo-level #1474 README, #1475 hooks, #1489 promise-contract guard).