### PR TITLE
fix(ci): add the matrix target to the pinned toolchain in the mcpb release workflow

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -72,6 +72,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # rust-toolchain.toml pins the build to its own toolchain, which rustup
+      # auto-installs WITHOUT the cross-compilation target added above (the
+      # action only adds it to `stable`). Add it to the pinned toolchain too,
+      # or every non-native matrix entry fails with E0463 "can't find crate
+      # for `std`" — which is exactly what shelved the 0.8.0–0.9.1 bundles.
+      - name: Add target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
       - name: Install aarch64 linux cross linker
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |


### PR DESCRIPTION
## Summary

The mcpb release workflow (`release-mcpb.yml`) has failed on every tag since `velesdb-memory-v0.8.0` (last success: `v0.7.0`, July 12): the two non-native matrix entries (`x86_64-apple-darwin` on the arm64 macOS runner, `aarch64-unknown-linux-gnu` on the x86_64 Linux runner) die with `E0463: can't find crate for std`.

**Root cause**: `rust-toolchain.toml` pins the build to its own toolchain. The `dtolnay/rust-toolchain@stable` step's `targets` input installs the cross target on **stable**, but cargo resolves the **pinned** toolchain via the directory override — which rustup auto-installs *without* that target.

**Consequence (found by a fresh-eyes onboarding audit)**: no `.mcpb` bundles attached for 0.8.0–0.9.1 and the official MCP registry entry (`io.github.cyberlife-coder/velesdb-memory`) is stale, while the crate README promises registry-aware installs.

## Fix
An explicit `rustup target add ${{ matrix.target }}` after checkout — applied to whatever toolchain the directory override actually selects. Native entries are unaffected (no-op).

The upcoming `velesdb-memory-v0.9.2` tag will re-run this workflow and refresh bundles + registry in one pass.