### PR TITLE
docs+fix(memory): onboarding polish — skill install paths, npm bundle, --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ On the committed 12-turn agent-session corpus the compiler measures **[82.5 % re
 
 | Surface | Context-compiler tools today |
 |---|---|
-| **MCP server** ([`velesdb-memory`](crates/velesdb-memory)) + **Rust** | Full set: `compile_context`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context`, `explain_compilation` — MCP covers any other client |
-| **Node** ([`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node)) | `compileContext`, `retrieveContextSource`, `save/loadWorkingContext`, `feedback` — not yet `context_savings` or `explain_compilation` |
-| **Python** (`pip install velesdb`) | Same set as Node plus `context_savings` merged on `develop`, but the published PyPI wheel predates it — until the next release, Python agents reach the compiler through the MCP server |
-| **WASM / TypeScript SDK** | `compileContext` alone, in-memory |
+| **MCP server** ([`velesdb-memory`](crates/velesdb-memory)) + **Rust** | Full set: `compile_context`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context`, `list_working_contexts`, `explain_compilation` — MCP covers any other client |
+| **Node** ([`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node)) | `compileContext`, `retrieveContextSource`, `save/loadWorkingContext`, `feedback` — not yet `context_savings`, `explain_compilation`, or `list_working_contexts` |
+| **Python** (`pip install velesdb`) | Same set as Node plus `context_savings` merged on `develop`, but the published PyPI wheel predates it — until the next release, Python agents reach the compiler through the MCP server; `list_working_contexts` is also not yet bound |
+| **WASM / TypeScript SDK** | `compileContext` alone, in-memory — no working-context persistence (`save`/`load`/`list_working_contexts`) on this surface |
 
 **Install both bundled skills without cloning the repo** — every
 [GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -22,6 +22,17 @@ not just look-alike text), it **connects** facts (a typed graph you build as you
 work), and it **learns** which memories are worth surfacing (`feedback`). Using it
 well is a *loop you run throughout a task*, not a one-shot lookup.
 
+## Installation
+
+Install: `cp -r crates/velesdb-memory/skill/velesdb-memory ~/.claude/skills/`
+(repo clone). No repo clone? Every
+[GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)
+attaches `velesdb-skills.tar.gz` (both bundled skills, one folder per skill):
+`curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz | tar -xz -C ~/.claude/skills/`.
+The npm package bundles it too, at
+`node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory`.
+Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+
 ## The loop (run it every task)
 
 1. **Recall before you act.** At the start of a task, retrieve what's already

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -8,6 +8,8 @@
 //! `--features extract`, set `VELESDB_MEMORY_EXTRACTOR=ollama` to enable the
 //! `remember_extracted` tool (auto text → fact↔topic graph). Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
+//! Run with `--version` (or `-V`) to print the binary's version and exit,
+//! without opening the store.
 
 use std::time::Duration;
 
@@ -16,6 +18,18 @@ use velesdb_memory::mcp::McpServer;
 use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Handled before anything else touches the filesystem or the embedder:
+    // `--version`/`-V` must work even when the store path is unwritable or
+    // absent (e.g. a fresh dev running it once to sanity-check the install),
+    // so it short-circuits ahead of the store open below.
+    if std::env::args()
+        .nth(1)
+        .is_some_and(|arg| arg == "--version" || arg == "-V")
+    {
+        println!("velesdb-memory {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     // Captured FIRST — before the (possibly seconds-long) embedder probe and
     // store open — so a client that exits during our own startup still
     // reparents us AFTER the baseline, and the watchdog sees the change. A

--- a/crates/velesdb-memory/tests/cli_flags.rs
+++ b/crates/velesdb-memory/tests/cli_flags.rs
@@ -1,0 +1,92 @@
+//! CLI flag handling for the `velesdb-memory` binary (onboarding audit P2-3).
+//!
+//! Regression this catches: the binary previously had no CLI flags at all —
+//! `velesdb-memory --version` (a first thing any new dev tries) silently
+//! ignored the argument and tried to open the MCP stdio store instead,
+//! which either hangs waiting on stdin or fails opening the default store
+//! path. `--version` / `-V` must short-circuit BEFORE the store is opened:
+//! print `velesdb-memory <CARGO_PKG_VERSION>` to stdout and exit 0, with no
+//! store side effects.
+//!
+//! Spawns the real binary (`env!("CARGO_BIN_EXE_velesdb-memory")`) exactly
+//! like `tests/mcp_lifecycle.rs` does, rather than calling an internal
+//! function, so the test proves the actual argv-parsing entry point works.
+
+use std::process::Command;
+use std::time::Duration;
+
+/// Upper bound the test is willing to wait for `--version` to print and
+/// exit. This path never opens the store or touches stdio transport, so it
+/// should return near-instantly; 5s is generous headroom over any plausible
+/// process-startup cost.
+const VERSION_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn run_with_arg(arg: &str) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .arg(arg)
+        // A store path that does not exist and is never created: proves
+        // --version exits before any store-opening attempt would fail on
+        // this bogus path.
+        .env(
+            "VELESDB_MEMORY_PATH",
+            "/nonexistent/path/that/must/never/be/opened",
+        )
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn velesdb-memory binary");
+
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().expect("failed to poll child status") {
+            let output = child
+                .wait_with_output()
+                .expect("failed to collect child output after exit");
+            return std::process::Output { status, ..output };
+        }
+        if start.elapsed() > VERSION_TIMEOUT {
+            let _ = child.kill();
+            panic!("velesdb-memory {arg} did not exit within {VERSION_TIMEOUT:?} (still trying to open the store?)");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn test_version_flag_long_prints_version_and_exits_zero() {
+    let output = run_with_arg("--version");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout was not valid UTF-8");
+    let expected = format!("velesdb-memory {}\n", env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        stdout, expected,
+        "expected stdout to be exactly {expected:?}, got {stdout:?}"
+    );
+}
+
+#[test]
+fn test_version_flag_short_prints_version_and_exits_zero() {
+    let output = run_with_arg("-V");
+
+    assert!(
+        output.status.success(),
+        "expected exit code 0, got {:?}; stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout was not valid UTF-8");
+    let expected = format!("velesdb-memory {}\n", env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        stdout, expected,
+        "expected stdout to be exactly {expected:?}, got {stdout:?}"
+    );
+}

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -58,6 +58,17 @@ cross the boundary as **decimal strings** (a JS `number` loses precision above
 2^53). Errors are `Error`s whose message is prefixed with a stable code:
 `[INVALID_INPUT]`, `[NOT_FOUND]`, or `[INTERNAL]`.
 
+Wiring the API gives your agent the *methods*; it doesn't tell it *when* to use
+them — the bundled
+[`velesdb-memory` skill](./skills/velesdb-memory/SKILL.md) teaches the loop
+(recall before acting → remember decisions with metadata **and** links →
+`relate` facts as relationships appear → `why` to explain → `feedback` to
+reinforce). Install it the same way as the context-optimizer skill below:
+
+```bash
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory ~/.claude/skills/
+```
+
 ### Auto-extraction (`rememberExtracted`)
 
 ```js

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: velesdb-memory
+description: >
+  Use durable, explainable, self-improving memory across a coding session via the
+  velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
+  (remember/recall/recall_fused/relate/why/feedback/forget) are available and the
+  work would benefit from remembering decisions, recalling prior context, or
+  answering "why did we do X". Use it at the START of a task (recall what's known),
+  when a decision or durable fact emerges (remember + relate it), when asked why
+  something is the way it is (why), and after using a recalled memory (feedback).
+  Especially relevant for: multi-session projects, architecture/config decisions,
+  incident postmortems, "why is this value/setting like this", onboarding to an
+  unfamiliar codebase, and any place a fact learned now must survive to a later
+  session. Do NOT use for transient chatter, secrets, or one-off scratch notes.
+---
+
+# velesdb-memory — the agent memory flow
+
+velesdb-memory gives you **durable local memory** with three properties no plain
+vector store has: it **explains** its recalls (`why` returns the evidence trail,
+not just look-alike text), it **connects** facts (a typed graph you build as you
+work), and it **learns** which memories are worth surfacing (`feedback`). Using it
+well is a *loop you run throughout a task*, not a one-shot lookup.
+
+## Installation
+
+Install: `cp -r crates/velesdb-memory/skill/velesdb-memory ~/.claude/skills/`
+(repo clone). No repo clone? Every
+[GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)
+attaches `velesdb-skills.tar.gz` (both bundled skills, one folder per skill):
+`curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz | tar -xz -C ~/.claude/skills/`.
+The npm package bundles it too, at
+`node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory`.
+Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
+
+## The loop (run it every task)
+
+1. **Recall before you act.** At the start of a task, retrieve what's already
+   known before doing anything else.
+   - `recall(query)` for semantic look-up of facts.
+   - `recall_fused(query)` when the answer may depend on a *connected* fact the
+     query doesn't name directly (multi-hop) — it also walks the graph.
+   - `why(question)` when the user asks *why* something is the way it is: it
+     returns the seed fact **plus the subgraph that explains it**.
+   - If recall returns nothing useful, say so and proceed — don't invent memory.
+
+2. **Remember durable facts and decisions — with metadata AND links.** When a
+   decision is made or a durable fact is established, store it. Two things make it
+   valuable later, so never skip them:
+   - **metadata** (the `ColumnStore` facet): `{ "type": "decision"|"fact"|"incident",
+     "area": "payments", "project": "acme", "date": 20260711, "status": "active" }`
+     — this is what lets you filter/scope recall later. **Store dates and other
+     comparable values NUMERICALLY** (`20260711`, not `"2026-07-11"`):
+     `recall_where`'s range/comparison filters (`lt`/`le`/`gt`/`ge`) are
+     type-strict with no coercion (issue #1473) — a numeric filter value never
+     matches a string-stored one, silently returning nothing, no error. Plain
+     equality filters on `recall`/`recall_fused` are unaffected either way.
+   - **links** (the graph facet): connect the new fact to the artifacts it concerns
+     — the PR, the ticket, the file, the prior decision it supersedes. **The graph
+     is what makes `why` work.** A fact with no edges is invisible to `why`.
+
+3. **Connect facts as relationships appear (`relate`).** Whenever a new fact
+   relates to an existing memory, create a typed, directional edge. **Direction
+   rule**: `why` walks *outgoing* edges only — always point `from` at the thing
+   you will later ask about and `to` at its evidence (decision → cause,
+   fact → source). An edge pointing *into* a memory is invisible to
+   `why(that memory)`. Good relation
+   labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
+   `fixes`, `concerns`. This is the differentiator's fuel — build the graph
+   incrementally, don't batch it up "later" (later never comes).
+   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
+   too): every id in a response also comes back as a decimal-string `id_str`
+   twin specifically because a raw JSON-number id can exceed 2^53 and get
+   rounded by a float-lossy client on the way back in, silently pointing
+   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
+   the numeric `id`.
+   **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
+   JSON string) back into a JSON number before it reaches the server, which
+   defeats `id_str` and reintroduces the precision loss it exists to avoid. If
+   that happens, prefix the id with `+` (e.g. `"+12732540571541475285"`) — not
+   a valid JSON number, so the harness leaves it as a string, and the id
+   parser accepts the leading `+`. Surrounding whitespace in an id string is
+   also tolerated (trimmed before parsing).
+
+4. **Explain with `why`, not `recall`.** When asked to justify a value, a config,
+   or a design choice, use `why`: recall alone finds text that *looks* similar;
+   `why` follows the links to the decision/incident/ticket that shares **no words**
+   with the code but is the actual reason.
+
+5. **Reinforce after use (`feedback`).** After you act on a recalled memory, tell
+   the memory whether it helped: `feedback(id_str, success=true)` if it was useful,
+   `success=false` if it was noise — pass the recalled memory's `id_str`, not its
+   numeric `id` (see the `id_str` note above). Recall re-ranks by this learned
+   confidence, so over time useful facts rise and noise sinks — the memory
+   improves without any retraining. Give feedback on the memory you actually
+   used, not on everything.
+
+## Concrete scenarios
+
+**Incident → decision → later "why?"** — the flagship case.
+An incident postmortem finds the payment provider's 30 s timeout let a stalled
+request pile up and take down checkout. The team drops it to 8 s.
+- `remember("Payment provider timeout set to 8s", metadata={type:"decision",
+  area:"payments", date:"2026-07-11"})` → returns id `D`.
+- `remember("Incident 2026-07-10: 30s payment timeout stalled checkout under load",
+  metadata={type:"incident", area:"payments"})` → id `I`.
+- `relate(D, I, "caused_by")` and `relate(D, <config-PR fact>, "decided_in")`.
+- Six weeks later a new dev asks *"why is the payment timeout only 8 seconds?"* The
+  config file just says `timeout = 8`. `why("why is the payment timeout 8s")`
+  surfaces the **incident** — the real reason — through the graph, which a vector
+  search over the code would never find.
+
+**Onboarding to an unfamiliar codebase.**
+You learn that `orders.status` is driven by a state machine, not free-form text.
+`remember("orders.status is a strict state machine: created→paid→shipped→closed",
+metadata={type:"fact", area:"orders"})` and `relate` it to the ADR and the module.
+Next session, `recall("orders status")` restores that context instantly.
+
+**Cross-session continuity.**
+At the start of each session on a project, `recall("open decisions <project>")` and
+`recall_fused("current architecture <project>")` to rebuild context before touching
+code — memory that survived the process restart is exactly the point.
+
+## Anti-patterns
+
+- **Storing everything.** Remember decisions and durable facts, not transient
+  conversation, not secrets/tokens, not scratch output.
+- **Facts with no edges.** An unlinked fact can be recalled but never *explained*.
+  If it relates to something, `relate` it.
+- **Recall-and-forget.** Not giving `feedback` leaves the memory unable to learn —
+  a quick `feedback` on the memory you used is what makes tomorrow's recall better.
+- **Trusting recall quality blindly with the default embedder.** See below.
+
+## Setup notes (know your embedder)
+
+Recall quality depends entirely on the embedding backend the server was built and
+launched with:
+
+- **`hash` (default in the prebuilt binary): lexical, NOT semantic.** It matches on
+  shared words, so recall of paraphrases is weak. Good enough to demo the *graph*
+  (`why` still works — it follows links, not similarity), but for real semantic
+  recall configure a semantic embedder.
+- **`ollama`:** real on-device semantic recall. Requires a build with
+  `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
+  `VELESDB_MEMORY_EMBEDDER=ollama`.
+
+Set a stable store location with `VELESDB_MEMORY_PATH` (e.g. `~/.velesdb-memory`) so
+memory persists in one place across sessions. Optionally set
+`VELESDB_MEMORY_DEFAULT_TTL` (seconds) to auto-expire facts you only want short-term.
+
+The store never leaves the machine — memory is local by design.

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -2,6 +2,20 @@
 
 *Stable since v1.9.1*
 
+> **Two different paths, same underlying engine.** If you followed the root
+> README's `why()` / MCP / skills narrative here, this guide is the *other*
+> one: a low-level, language-native API (`AgentMemory` with explicit
+> `semantic` / `episodic` / `procedural` stores) for embedding directly into
+> Python or Rust code you control. There is no `why()` graph walk, no MCP
+> tool surface, and no bundled agent skill on this path — for that, see the
+> **[velesdb-memory MCP server](../../crates/velesdb-memory/README.md)**
+> (`remember`/`recall`/`relate`/`why`/`feedback`, plus the deterministic
+> context compiler) and its bundled
+> [`velesdb-memory` skill](../../crates/velesdb-memory/skill/velesdb-memory/SKILL.md)
+> that teaches an agent when to use it. Pick this guide when you want direct
+> control over embeddings and storage from your own code; pick the MCP server
+> when you want an agent (Claude Code, Cursor, etc.) to manage memory itself.
+
 Complete guide for using VelesDB's Agent Memory SDK. Covers the three memory subsystems (semantic, episodic, procedural), embedding generation, TTL configuration, snapshots, and production best practices.
 
 ---

--- a/docs/quickstart/timing-results.md
+++ b/docs/quickstart/timing-results.md
@@ -4,6 +4,16 @@
 
 **Goal**: prove with reproducible measurements that a developer arriving on a clean Linux machine reaches their first vector search result in well under five minutes, regardless of which language stack they pick (Python, Rust, TypeScript, or REST against the server binary).
 
+> **Frozen reference run — 2026-05-01, `velesdb-core@1.14.2` / `velesdb-server@1.14.2`.**
+> The numbers below are a point-in-time measurement, not a live dashboard. The
+> `scripts/dx-timing/scenario_*.sh` harness has since been re-pinned to a
+> newer release (currently `3.12.0`) so it keeps installing cleanly, but these
+> timings were not re-collected against that version — treat them as
+> directionally representative of the onboarding-path *shape* (which step
+> dominates, relative ordering of the four scenarios), not as current
+> absolute numbers. Re-run `bash scripts/dx-timing/run_all.sh` for fresh,
+> version-accurate timings.
+
 ## TL;DR
 
 | Scenario | Median | Range | Status vs. 300 s SLO |


### PR DESCRIPTION
## Summary

Fixes the P1/P2 findings from the onboarding audit (P0 — the `.mcpb` release workflow — is handled separately and untouched here).

- **P1-1** — `crates/velesdb-memory/skill/velesdb-memory/SKILL.md` had no Installation section, while `skills/velesdb-context-optimizer/SKILL.md` had one. Added a symmetric section (repo-clone `cp`, the `velesdb-skills.tar.gz` GitHub Release tarball, the npm bundle).
- **P1-2** — `crates/velesdb-node/package.json`'s `files: ["skills/"]` only ever shipped `velesdb-context-optimizer`; `crates/velesdb-node/skills/` had no `velesdb-memory` folder. Copied it in (same "committed copy" pattern already used for `velesdb-context-optimizer`) and documented the install path in `crates/velesdb-node/README.md`. No existing test/CI guard checks bundled-skill staleness, so none was extended (verified none exists).
- **P1-3** — `docs/guides/AGENT_MEMORY.md`, linked as "Full guide" from the root README's Agent Memory SDK section, is a low-level Python/Rust API doc with no link back to the MCP/`why()`/skills narrative the reader arrives from. Added a short transition paragraph up top pointing to `crates/velesdb-memory/README.md`.
- **P2-1** — `docs/quickstart/timing-results.md`'s methodology table cited `velesdb-core@1.14.2` / `velesdb-server@1.14.2`, but `scripts/dx-timing/scenario_rust.sh` / `scenario_server.sh` now pin `3.12.0`. Rewriting the cited numbers against `3.12.0` without re-running the harness would misrepresent unmeasured data as measured, so the doc now states plainly it's a frozen reference run dated 2026-05-01, with the scripts since re-pinned but not re-measured.
- **P2-2** — Root README's context-compiler parity table (~L283-288) was missing `list_working_contexts`. Verified per surface: MCP has it; Node and Python bind `save`/`loadWorkingContext` but not `list`; WASM/TypeScript SDK has none of the working-context tools (in-memory only). Table updated accordingly.
- **P2-3** — `velesdb-memory` binary had no CLI flags at all; `--version`/`-V` now short-circuits before the store opens, printing `velesdb-memory <CARGO_PKG_VERSION>` and exiting 0. TDD: `crates/velesdb-memory/tests/cli_flags.rs` spawns the real binary (same pattern as `tests/mcp_lifecycle.rs`) against a deliberately unwritable/nonexistent store path — RED confirmed before the fix (exit 1, tried to open the bogus path), GREEN after.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p velesdb-memory --all-features -- -D warnings`
- [x] `cargo test -p velesdb-memory` (all 303+ tests, including the new `cli_flags` RED→GREEN pair)
- [x] `npm --prefix crates/velesdb-node run build` (napi build) + `node --test __test__/index.spec.mjs` (26/26 passing) — replays the CI "Node Binding Tests" job since `crates/velesdb-node` was touched
- [x] Pre-commit hooks passed on every commit (fmt/clippy/workspace tests)