### PR TITLE
fix(ci): only trigger Docker Publish on workspace vX.Y.Z tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,11 @@ name: Docker Publish
 on:
   push:
     tags:
-      - "v*"
+      # v3.12.0-style workspace tags only. A bare "v*" also matches the
+      # velesdb-memory-vX.Y.Z tag series (it starts with a "v" too), which
+      # triggered this workflow with an empty semver tag list and failed
+      # every run since velesdb-memory-v0.8.0.
+      - "v[0-9]*"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

`Docker Publish` has failed on every `velesdb-memory-vX.Y.Z` tag since `v0.8.0` (found while shipping 0.9.2): the bare `v*` tag glob also matches that tag series — those tags start with a `v` too — so the workflow runs with a ref that `docker/metadata-action`'s semver patterns cannot parse, produces an empty Docker tag list, and dies at the manifest step with `can't push with no tags specified`.

The Docker image is versioned by the workspace (`v3.x`) tags only. Scope the trigger glob to `v[0-9]*` so memory tags no longer trigger a doomed run. `workflow_dispatch` stays available for manual publishes.