### PR TITLE
test(node): guard bundled skills against drift from their sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,12 +580,15 @@ jobs:
 
       # Debug profile (dev = panic=unwind) is sufficient for the functional suite;
       # the release prebuild uses the [profile.release-node] panic=unwind override.
+      # `npm test` (not a hardcoded filename) so every __test__/*.spec.mjs file —
+      # including new ones like skills-sync.spec.mjs — is picked up automatically;
+      # see package.json's "test" script for the single source of truth on the glob.
       - name: Build napi addon + run Node tests
         working-directory: crates/velesdb-node
         run: |
           npm install --no-audit --no-fund
           npx napi build --platform
-          node --test __test__/index.spec.mjs
+          npm test
 
       # EPIC-P-071/A1 non-regression gate: "the facts survive compilation".
       # Reuses the napi addon just built above (no second Rust build) — this

--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -264,7 +264,11 @@ jobs:
         # load test. To close: run the smoke test under an emulator (QEMU for arm64,
         # or a native x86 mac runner) so every shipped .node is load-verified.
         if: ${{ !matrix.cross && matrix.target != 'x86_64-apple-darwin' }}
-        run: node --test __test__/
+        # `npm test` (package.json's __test__/*.spec.mjs glob) rather than a bare
+        # `node --test __test__/` directory argument: directory args stop being
+        # recursively discovered on recent Node majors (verified failing on Node
+        # 26 locally), and the glob also picks up new spec files automatically.
+        run: npm test
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/crates/velesdb-node/__test__/skills-sync.spec.mjs
+++ b/crates/velesdb-node/__test__/skills-sync.spec.mjs
@@ -1,0 +1,101 @@
+// Guards the skills bundled into the @wiscale/velesdb-memory-node npm package
+// (package.json "files": ["skills/"]) against silent drift from their
+// sources of truth elsewhere in the repo. There is no build step, symlink,
+// or CI check that keeps these copies in sync — they are committed,
+// hand-copied duplicates (velesdb-memory added in PR #1496) — so this test
+// is the only thing that notices when a source SKILL.md changes but the
+// bundled copy does not.
+//
+// Pure Node fs, no napi addon needed: `node --test __test__/skills-sync.spec.mjs`
+// runs standalone without `napi build` first.
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { join, relative } from 'node:path'
+
+// Resolved from import.meta.url (not cwd) so this test works regardless of
+// where `node --test` is invoked from (repo root, crates/velesdb-node/, CI
+// working-directory, etc.).
+const NODE_SKILLS_DIR = fileURLToPath(new URL('../skills', import.meta.url))
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url))
+
+/** Recursively list files under `dir`, returned as repo-relative-to-`dir` POSIX paths. */
+function listFiles(dir) {
+  const out = []
+  const walk = (current) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name)
+      if (entry.isDirectory()) {
+        walk(full)
+      } else if (entry.isFile()) {
+        out.push(relative(dir, full).split('\\').join('/'))
+      }
+    }
+  }
+  walk(dir)
+  return out.sort()
+}
+
+// (source dir, bundled copy dir) pairs. Add new bundled skills here.
+const PAIRS = [
+  {
+    name: 'velesdb-context-optimizer',
+    source: join(REPO_ROOT, 'skills', 'velesdb-context-optimizer'),
+    copy: join(NODE_SKILLS_DIR, 'velesdb-context-optimizer'),
+  },
+  {
+    name: 'velesdb-memory',
+    source: join(REPO_ROOT, 'crates', 'velesdb-memory', 'skill', 'velesdb-memory'),
+    copy: join(NODE_SKILLS_DIR, 'velesdb-memory'),
+  },
+]
+
+for (const { name, source, copy } of PAIRS) {
+  test(`bundled skill "${name}" stays byte-identical to its source`, () => {
+    assert.ok(
+      statSync(source, { throwIfNoEntry: false })?.isDirectory(),
+      `source dir missing: ${source}`,
+    )
+    assert.ok(
+      statSync(copy, { throwIfNoEntry: false })?.isDirectory(),
+      `bundled copy dir missing: ${copy}`,
+    )
+
+    const sourceFiles = listFiles(source)
+    const copyFiles = listFiles(copy)
+
+    const resync = `cp -r ${relative(REPO_ROOT, source)}/. ${relative(REPO_ROOT, copy)}/`
+
+    const onlyInSource = sourceFiles.filter((f) => !copyFiles.includes(f))
+    const onlyInCopy = copyFiles.filter((f) => !sourceFiles.includes(f))
+    assert.deepEqual(
+      onlyInSource,
+      [],
+      `file(s) present in source but missing from the bundled npm copy: ` +
+        `${onlyInSource.join(', ')}. Resync with: ${resync}`,
+    )
+    assert.deepEqual(
+      onlyInCopy,
+      [],
+      `file(s) present in the bundled npm copy but not in the source (stale/orphaned): ` +
+        `${onlyInCopy.join(', ')}. Resync with: ${resync}`,
+    )
+
+    const mismatched = []
+    for (const relPath of sourceFiles) {
+      const sourceContent = readFileSync(join(source, relPath))
+      const copyContent = readFileSync(join(copy, relPath))
+      if (!sourceContent.equals(copyContent)) {
+        mismatched.push(relPath)
+      }
+    }
+    assert.deepEqual(
+      mismatched,
+      [],
+      `bundled npm copy has drifted from its source for: ${mismatched.join(', ')}. ` +
+        `Resync with: ${resync}`,
+    )
+  })
+}


### PR DESCRIPTION
## Summary
- `crates/velesdb-node` bundles committed *copies* of two skills into the npm package (`files: ["skills/"]`):
  - `/skills/velesdb-context-optimizer` → `crates/velesdb-node/skills/velesdb-context-optimizer`
  - `/crates/velesdb-memory/skill/velesdb-memory` → `crates/velesdb-node/skills/velesdb-memory` (added in #1496)
- Nothing enforced that the copies stayed identical to their sources, so an edit to a source `SKILL.md` would drift silently — this was a finding left open from #1496.
- Adds `crates/velesdb-node/__test__/skills-sync.spec.mjs`: for each (source, copy) pair, recursively lists files on both sides and compares the file sets **and** byte-for-byte content. On mismatch the assertion message names the offending file(s) and gives the exact `cp -r` command to resync. Paths resolve from `import.meta.url`, so the test is robust to the runner's cwd. Pure `node:fs`, no napi addon required to run it standalone.
- `ci.yml`'s `node-binding-tests` job ran a hardcoded `node --test __test__/index.spec.mjs`, which would **not** have collected this (or any future) new spec file. Switched it to `npm test`, i.e. `package.json`'s own `__test__/*.spec.mjs` glob — single source of truth for which spec files run in CI.

## TDD proof (red → green)
1. Baseline: `node --test __test__/skills-sync.spec.mjs` → 2/2 pass (sources and copies already match).
2. Introduced a 1-byte drift by appending a stray character to `crates/velesdb-node/skills/velesdb-memory/SKILL.md`.
3. Re-ran → failure, actionable message:
   ```
   bundled npm copy has drifted from its source for: SKILL.md.
   Resync with: cp -r crates/velesdb-memory/skill/velesdb-memory/. crates/velesdb-node/skills/velesdb-memory/
   ```
4. `git checkout -- crates/velesdb-node/skills/velesdb-memory/SKILL.md` to restore.
5. Re-ran → 2/2 pass again.

## Test plan
- [x] `node --test __test__/skills-sync.spec.mjs` standalone (no napi build) — pass
- [x] Full gate after `npx napi build --platform`: `npm test` (`node --test __test__/*.spec.mjs`) — 28 pass, 1 skipped (Ollama-gated integration test, self-skips offline), 0 fail
- [x] RED proven: introduced then reverted a 1-byte drift, confirmed failing/passing output
- [ ] CI (`node-binding-tests` job in ci.yml) — will confirm on this PR

🤖 Not merged — for review only, per finding left open in #1496.