### PR TITLE
feat(memory): add compile_transcript MCP tool (V2b-2)

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Path-referenced context fragments.** A `compile_context`/
+  `explain_compilation` fragment may set `path` (an absolute filesystem
+  path) instead of inline `content` to ingest a file by reference — exactly
+  one of `path`, `content`, or `media` per fragment. Opt-in via
+  `VELESDB_MEMORY_INGEST_ROOTS` (a `PATH`-list of allowlisted directories,
+  parsed fail-fast at startup); the resolved file must be a plain UTF-8
+  text file under 1 MiB, and the resolved content flows through the same
+  pipeline as an inline fragment (dedup, classification, budget packing,
+  `ctx://source/` handles).
+- **`compile_transcript` MCP tool.** A one-call shortcut over
+  `compile_context` for a raw agent-session transcript: deterministically
+  segments it into turns (plain marker-based —
+  `System:`/`User:`/`Human:`/`Assistant:`/`AI:`/`Tool:`/`### User`/
+  `### Assistant` — or JSONL, one line per turn) and, within each plain
+  turn, into fenced-code/log-run/body sub-segments (fenced code stays
+  atomic; runs of 8+ log-like lines collapse the same way
+  `abstract.log_dedup` would), then compiles the result exactly like
+  `compile_context`. Accepts `transcript` (inline) or `path` (reusing the
+  ingest allowlist, capped at a wider 8 MiB since the transcript is
+  segmented into sub-1-MiB pieces immediately after being read). Returns
+  the compiled context plus a `segmentation` audit report (detected
+  format, one entry per segment with turn/role/kind/byte range/
+  `fragment_id`, and how many segments normalization merged).
+
 ## [0.9.2] — 2026-07-20
 
 ### Added

--- a/crates/velesdb-memory/benches/context_compiler_benchmark.rs
+++ b/crates/velesdb-memory/benches/context_compiler_benchmark.rs
@@ -40,6 +40,7 @@ fn paragraph(seed: usize) -> String {
 fn plain_fragments(n: usize) -> Vec<ContextFragment> {
     (0..n)
         .map(|i| ContextFragment {
+            path: None,
             id: None,
             content: paragraph(i),
             kind: None,
@@ -57,6 +58,7 @@ fn duplicate_heavy_fragments(n: usize) -> Vec<ContextFragment> {
         .map(|i| {
             let source = if i % 3 == 0 { i } else { i - (i % 3) };
             ContextFragment {
+                path: None,
                 id: None,
                 content: paragraph(source),
                 kind: None,
@@ -137,6 +139,7 @@ fn bench_oversized_fragment(c: &mut Criterion) {
     for &budget in &[2_000_u64, 1_000_000] {
         let req = request(
             vec![ContextFragment {
+                path: None,
                 id: None,
                 content: huge.clone(),
                 kind: None,

--- a/crates/velesdb-memory/examples/context_savings/main.rs
+++ b/crates/velesdb-memory/examples/context_savings/main.rs
@@ -101,6 +101,7 @@ fn to_fragments(fixtures: &[Fixture]) -> Vec<ContextFragment> {
     fixtures
         .iter()
         .map(|fixture| ContextFragment {
+            path: None,
             id: None,
             content: fixture.content.clone(),
             kind: fixture.kind.map(str::to_owned),

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -37,6 +37,14 @@ pub mod chunk;
 mod classify;
 mod dedup;
 pub mod estimator;
+/// Adapter-side I/O pre-pass for `path`-referenced context fragments
+/// (V2b-1): resolves `ContextFragment::path` into `content` under a strict,
+/// short-circuiting security pipeline, BEFORE the request reaches the pure
+/// compiler core. Not compiled for `wasm32` — there is no local filesystem
+/// to read from a WASM host; see [`crate::error::MemoryError::IngestDisabled`]
+/// for what a `path` fragment does there instead.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod ingest;
 pub mod insights;
 mod log_normalize;
 // `pub(crate)`, not private: the memory bridge (`service::memory_bridge`,
@@ -57,6 +65,8 @@ pub mod wire;
 
 pub use chunk::{chunk_text, ChunkBoundary, ChunkPolicy, TextChunk};
 pub use estimator::{DynTokenEstimator, HeuristicEstimator, TokenEstimator};
+#[cfg(not(target_arch = "wasm32"))]
+pub use ingest::IngestRoots;
 pub use insights::{CompilationInsights, ModelPricing, PricingTable};
 pub use model::{
     CompilePolicy, CompileRequest, CompiledContext, CompiledSection, ContextAction,
@@ -101,6 +111,7 @@ pub fn fragment_id(content: &str) -> u64 {
 ///         fragments: vec![ContextFragment {
 ///             id: None,
 ///             content: "The deploy pipeline is green.".to_owned(),
+///             path: None,
 ///             kind: None,
 ///             priority: None,
 ///             metadata: None,
@@ -387,6 +398,15 @@ impl Emission {
 /// Reject requests over the [`crate::limits`] caps and compute the usable
 /// budget (`clamped budget − reserve`).
 fn validate(request: &CompileRequest, policy: &CompilePolicy) -> Result<u64, MemoryError> {
+    // The pure core never resolves `path` (V2b-1): that is an adapter-side
+    // I/O pre-pass (`context::ingest::resolve_fragments`) that clears the
+    // field on success. A `path` still set here means either no adapter ran
+    // (e.g. a binding with no ingest support, such as the WASM build) or
+    // ingestion is disabled — both report the same explicit error rather
+    // than silently compiling an empty-content fragment.
+    if request.fragments.iter().any(|f| f.path.is_some()) {
+        return Err(MemoryError::IngestDisabled);
+    }
     if request.fragments.len() > limits::MAX_FRAGMENTS {
         return Err(MemoryError::ContextOverLimit(format!(
             "{} fragments exceed the cap of {}",

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -58,6 +58,12 @@ pub mod model;
 pub mod model_windows;
 pub(crate) mod provenance;
 mod relevance;
+/// Deterministic transcript segmentation for the `compile_transcript` MCP
+/// tool (V2b-2): splits a raw agent-session transcript into turns and, within
+/// each turn, into code/log/body sub-segments — pure, zero-regex, zero-clock,
+/// so the same transcript + policy always segments byte-identically. See
+/// [`segment::segment_transcript`].
+pub mod segment;
 /// The id wire contract (decimal-string `u64`) shared by every JS-facing
 /// binding of these types — one source of truth for [`wire::ID_KEYS`]
 /// instead of a Node/WASM copy each.
@@ -77,6 +83,10 @@ pub use model::{
 };
 pub use model_windows::{model_window, suggest_token_budget, SuggestedBudget};
 pub use relevance::DeterministicReranker;
+pub use segment::{
+    segment_transcript, SegmentFormat, SegmentKind, SegmentationOutcome, SegmentationPolicy,
+    TranscriptSegment,
+};
 
 use std::collections::BTreeMap;
 

--- a/crates/velesdb-memory/src/context/chunk.rs
+++ b/crates/velesdb-memory/src/context/chunk.rs
@@ -109,7 +109,13 @@ fn units(text: &str, boundary: ChunkBoundary) -> Vec<Unit> {
 }
 
 /// A top-level slice of the text: either a whole fenced block or plain text.
-enum Segment {
+///
+/// `pub(crate)` (V2b-2): [`super::segment::segment_transcript`] reuses this
+/// same fence/plain partition to carve atomic code segments out of a
+/// transcript turn before running its own log-run detection over the
+/// remaining plain spans — one fence-detection implementation, never a
+/// second regex-free scanner copy-pasted for the transcript segmenter.
+pub(crate) enum Segment {
     /// A triple-backtick-fenced block, atomic.
     Fence(core::ops::Range<usize>),
     /// Plain text between fences.
@@ -118,7 +124,9 @@ enum Segment {
 
 /// Walk the text line by line, separating triple-backtick-fenced blocks (atomic) from the
 /// plain text around them. An unclosed fence runs to the end of the text.
-fn fence_segments(text: &str) -> Vec<Segment> {
+///
+/// `pub(crate)`, see [`Segment`]'s doc for why.
+pub(crate) fn fence_segments(text: &str) -> Vec<Segment> {
     let mut segments = Vec::new();
     let mut cursor = 0_usize;
     let mut fence_start: Option<usize> = None;

--- a/crates/velesdb-memory/src/context/classify_tests.rs
+++ b/crates/velesdb-memory/src/context/classify_tests.rs
@@ -9,6 +9,7 @@ fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
         id: None,
         content: content.to_owned(),
+        path: None,
         kind: None,
         priority: None,
         metadata: None,

--- a/crates/velesdb-memory/src/context/ingest.rs
+++ b/crates/velesdb-memory/src/context/ingest.rs
@@ -1,0 +1,276 @@
+//! Adapter-side I/O pre-pass for `path`-referenced context fragments
+//! (V2b-1, see the crate's `PLAN.md`).
+//!
+//! [`resolve_fragments`] turns every [`ContextFragment::path`] into ordinary
+//! `content` — read from disk under a strict, short-circuiting security
+//! pipeline — BEFORE the request reaches [`super::ContextCompiler`], which
+//! never performs I/O itself (mirrors the [`super::media`] pre-pass: decode
+//! once at the boundary, keep the pipeline core pure). Called from the MCP
+//! adapter (`crate::mcp::context_tools`) ahead of `compile_context` and
+//! `explain_compilation`; a `path` fragment that reaches the compiler
+//! unresolved is rejected with [`MemoryError::IngestDisabled`] (see
+//! `context::validate`) rather than silently compiling empty content.
+//!
+//! # Security model
+//!
+//! Path ingestion is opt-in and allowlisted: nothing is readable unless
+//! [`IngestRoots::parse`] was given at least one root
+//! (`VELESDB_MEMORY_INGEST_ROOTS`, platform `PATH`-list syntax). Every
+//! `path` fragment then runs this ordered, short-circuiting pipeline:
+//!
+//! 1. Shape: a fragment may set exactly one of `path`, non-empty `content`,
+//!    or `media` — checked first, independent of whether ingestion is even
+//!    enabled (a malformed request is a malformed request regardless of
+//!    server configuration).
+//! 2. At least one configured root, else [`MemoryError::IngestDisabled`].
+//! 3. The number of `path` fragments in the request is bounded
+//!    ([`crate::limits::MAX_INGEST_FILES`]).
+//! 4. The path must be absolute — an MCP server's working directory is not
+//!    something a caller can rely on.
+//! 5. [`std::fs::canonicalize`] resolves *every* symlink in one call.
+//! 6. The canonical path is checked against the canonical roots
+//!    **component-wise** (never a string prefix, which a sibling directory
+//!    name like `/root-evil` next to `/root` would defeat). On failure the
+//!    error cites the path the caller ASKED for, never the resolved
+//!    target — the target itself can be sensitive (e.g. that a symlink
+//!    escapes to a specific system path).
+//! 7. `fs::metadata` must report a plain file, within
+//!    [`crate::limits::MAX_INGEST_FILE_BYTES`] and the request's running
+//!    [`crate::limits::MAX_TOTAL_INGEST_BYTES`] — checked BEFORE any read.
+//! 8. `fs::read`, a re-check of the length actually read, then
+//!    `String::from_utf8`; non-UTF-8 content is rejected (never lossily
+//!    decoded), with a short hint when the leading bytes look like a known
+//!    image format.
+//!
+//! Symlinks are allowed as long as their canonical target lands under a
+//! root — no special-casing needed, step 5 already resolves them. TOCTOU
+//! (a file changing between steps 7 and 8, or after) is an accepted,
+//! documented non-goal: this is a local, single-user server, and the
+//! deterministic contract is on the bytes actually read, not on the file as
+//! it exists at any other instant.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::context::model::ContextFragment;
+use crate::error::MemoryError;
+use crate::limits::{MAX_INGEST_FILES, MAX_INGEST_FILE_BYTES, MAX_TOTAL_INGEST_BYTES};
+
+/// A parsed, canonicalized allowlist of filesystem roots a `path` fragment
+/// may resolve under. The only way to construct one is [`Self::parse`] —
+/// there is no "allow everything" escape hatch.
+#[derive(Debug, Clone, Default)]
+pub struct IngestRoots {
+    roots: Vec<PathBuf>,
+}
+
+impl IngestRoots {
+    /// Parse `VELESDB_MEMORY_INGEST_ROOTS`'s value: a platform `PATH`-list
+    /// (`:`-separated on Unix, `;`-separated on Windows, via
+    /// [`std::env::split_paths`]) of directories, each canonicalized
+    /// immediately. Fails fast — a root that does not exist or is not a
+    /// directory is a startup configuration error, not something to
+    /// discover later on a caller's first `path` fragment. An empty or
+    /// unset value parses to an empty (disabled) allowlist, not an error.
+    ///
+    /// # Errors
+    /// A human-readable message naming the offending entry.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        let mut roots = Vec::new();
+        for raw in std::env::split_paths(value) {
+            if raw.as_os_str().is_empty() {
+                continue;
+            }
+            let canonical = fs::canonicalize(&raw).map_err(|err| {
+                format!(
+                    "VELESDB_MEMORY_INGEST_ROOTS entry '{}' could not be resolved: {err}",
+                    raw.display()
+                )
+            })?;
+            if !canonical.is_dir() {
+                return Err(format!(
+                    "VELESDB_MEMORY_INGEST_ROOTS entry '{}' is not a directory",
+                    raw.display()
+                ));
+            }
+            roots.push(canonical);
+        }
+        Ok(Self { roots })
+    }
+
+    /// Whether path ingestion is enabled at all (at least one root
+    /// configured). `false` short-circuits every `path` fragment with
+    /// [`MemoryError::IngestDisabled`] before any filesystem access.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        !self.roots.is_empty()
+    }
+
+    /// Whether the already-canonical `candidate` sits under one of the
+    /// roots, checked path-COMPONENT-wise via [`Path::starts_with`] — never
+    /// a string prefix, which would wrongly accept a sibling directory that
+    /// merely shares a prefix (`/root-evil` under a root of `/root`).
+    fn contains(&self, candidate: &Path) -> bool {
+        self.roots.iter().any(|root| candidate.starts_with(root))
+    }
+}
+
+/// Resolve every `path`-carrying fragment of `fragments` into `content`, in
+/// place, in one pre-pass — see the module docs for the full ordered
+/// pipeline. A no-op (and roots-independent) when no fragment carries a
+/// `path`. The first fragment to fail short-circuits the whole request:
+/// never a partial resolution, so a caller never has to guess which
+/// fragments actually got read.
+///
+/// # Errors
+/// [`MemoryError::IngestPath`] for a malformed request shape or an
+/// unreadable/non-UTF-8 path, [`MemoryError::IngestDisabled`] when no root
+/// is configured, [`MemoryError::IngestOutsideRoots`] when a path (after
+/// resolving symlinks) escapes every root, and [`MemoryError::ContextOverLimit`]
+/// for the file-count and byte caps.
+pub fn resolve_fragments(
+    fragments: &mut [ContextFragment],
+    roots: Option<&IngestRoots>,
+) -> Result<(), MemoryError> {
+    // Step 1 (shape): exactly one of `path`, non-empty `content`, `media` —
+    // checked for every fragment up front, independent of whether
+    // ingestion is enabled at all.
+    for fragment in fragments.iter() {
+        if fragment.path.is_some() && (!fragment.content.is_empty() || fragment.media.is_some()) {
+            return Err(MemoryError::IngestPath(
+                "a fragment may set `path`, or `content`, or `media` — never more than one"
+                    .to_owned(),
+            ));
+        }
+    }
+
+    let indices: Vec<usize> = fragments
+        .iter()
+        .enumerate()
+        .filter(|(_, fragment)| fragment.path.is_some())
+        .map(|(index, _)| index)
+        .collect();
+    if indices.is_empty() {
+        return Ok(());
+    }
+
+    // Step 2: ingestion must be enabled at all.
+    let Some(roots) = roots.filter(|roots| roots.is_enabled()) else {
+        return Err(MemoryError::IngestDisabled);
+    };
+
+    // Step 3: bound the number of files one request may reference.
+    if indices.len() > MAX_INGEST_FILES {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "request references {} files via `path`, exceeding the cap of {MAX_INGEST_FILES}",
+            indices.len()
+        )));
+    }
+
+    let mut total_bytes: usize = 0;
+    for index in indices {
+        let requested = fragments[index]
+            .path
+            .clone()
+            .expect("index was filtered on path.is_some() above");
+        let content = resolve_one(&requested, roots, &mut total_bytes)?;
+        fragments[index].content = content;
+        fragments[index].path = None;
+    }
+    Ok(())
+}
+
+/// Resolve a single `path` fragment's content — steps 4 through 8 of the
+/// module-level pipeline, each short-circuiting on failure. `total_bytes`
+/// accumulates across the whole request (the caller threads the same
+/// counter through every call) so the aggregate cap
+/// ([`MAX_TOTAL_INGEST_BYTES`]) is enforced across files, not just within
+/// one.
+fn resolve_one(
+    requested: &str,
+    roots: &IngestRoots,
+    total_bytes: &mut usize,
+) -> Result<String, MemoryError> {
+    // Step 4: relative paths are refused outright.
+    let requested_path = Path::new(requested);
+    if requested_path.is_relative() {
+        return Err(MemoryError::IngestPath(format!(
+            "path '{requested}' is relative; only absolute paths are accepted"
+        )));
+    }
+
+    // Step 5: canonicalize resolves every symlink in one call, so the
+    // prefix check in step 6 can never be fooled by an intermediate one.
+    let canonical = fs::canonicalize(requested_path).map_err(|err| {
+        MemoryError::IngestPath(format!("cannot resolve path '{requested}': {err}"))
+    })?;
+
+    // Step 6: prefix check by path components against the canonical roots.
+    // Cites `requested`, never `canonical` — see the module docs.
+    if !roots.contains(&canonical) {
+        return Err(MemoryError::IngestOutsideRoots(requested.to_owned()));
+    }
+
+    // Step 7: metadata checks BEFORE any read.
+    let file_metadata = fs::metadata(&canonical)
+        .map_err(|err| MemoryError::IngestPath(format!("cannot stat path '{requested}': {err}")))?;
+    if !file_metadata.is_file() {
+        return Err(MemoryError::IngestPath(format!(
+            "path '{requested}' is not a regular file"
+        )));
+    }
+    let declared_len = usize::try_from(file_metadata.len()).unwrap_or(usize::MAX);
+    if declared_len > MAX_INGEST_FILE_BYTES {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "file '{requested}' is {declared_len} bytes, exceeding the cap of \
+             {MAX_INGEST_FILE_BYTES} bytes"
+        )));
+    }
+    let running_total = total_bytes.saturating_add(declared_len);
+    if running_total > MAX_TOTAL_INGEST_BYTES {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "ingesting '{requested}' would bring the request total to {running_total} bytes, \
+             exceeding the cap of {MAX_TOTAL_INGEST_BYTES} bytes"
+        )));
+    }
+
+    // Step 8: read, re-check the length actually read (the file may have
+    // changed since `metadata` — documented TOCTOU non-goal, but a race
+    // that would silently blow the byte cap is still caught), then decode.
+    let bytes = fs::read(&canonical)
+        .map_err(|err| MemoryError::IngestPath(format!("cannot read path '{requested}': {err}")))?;
+    if bytes.len() > MAX_INGEST_FILE_BYTES {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "file '{requested}' grew to {} bytes while being read, exceeding the cap of \
+             {MAX_INGEST_FILE_BYTES} bytes",
+            bytes.len()
+        )));
+    }
+    *total_bytes = total_bytes.saturating_add(bytes.len());
+
+    String::from_utf8(bytes).map_err(|err| {
+        let hint = magic_bytes_hint(err.as_bytes());
+        MemoryError::IngestPath(format!("path '{requested}' is not valid UTF-8{hint}"))
+    })
+}
+
+/// A short, actionable suffix appended to the non-UTF-8 error when the
+/// file's leading bytes match a recognized image format's magic number —
+/// steering a caller who ingested a screenshot by mistake toward
+/// [`super::model::MediaRef`] instead of leaving them to guess why a
+/// `path` fragment failed. Recognizes exactly PNG and JPEG (the two
+/// formats [`super::estimator::ImageTokenEstimator`] special-cases);
+/// unrecognized binary content gets no hint, never a wrong guess.
+fn magic_bytes_hint(bytes: &[u8]) -> &'static str {
+    const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    const JPEG_MAGIC: [u8; 3] = [0xFF, 0xD8, 0xFF];
+    if bytes.starts_with(&PNG_MAGIC) || bytes.starts_with(&JPEG_MAGIC) {
+        " (looks like an image — use a media fragment instead of `path`)"
+    } else {
+        ""
+    }
+}
+
+#[cfg(test)]
+#[path = "ingest_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/context/ingest.rs
+++ b/crates/velesdb-memory/src/context/ingest.rs
@@ -171,13 +171,14 @@ pub fn resolve_fragments(
 
     let mut total_bytes: usize = 0;
     for index in indices {
-        let requested = fragments[index]
-            .path
-            .clone()
-            .expect("index was filtered on path.is_some() above");
+        // Indices were filtered on `path.is_some()` above; `take` both fetches
+        // the path and clears it without a panicking unwrap. On error the whole
+        // request is rejected, so the cleared field is never observed.
+        let Some(requested) = fragments[index].path.take() else {
+            continue;
+        };
         let content = resolve_one(&requested, roots, &mut total_bytes, MAX_INGEST_FILE_BYTES)?;
         fragments[index].content = content;
-        fragments[index].path = None;
     }
     Ok(())
 }

--- a/crates/velesdb-memory/src/context/ingest.rs
+++ b/crates/velesdb-memory/src/context/ingest.rs
@@ -54,7 +54,9 @@ use std::path::{Path, PathBuf};
 
 use crate::context::model::ContextFragment;
 use crate::error::MemoryError;
-use crate::limits::{MAX_INGEST_FILES, MAX_INGEST_FILE_BYTES, MAX_TOTAL_INGEST_BYTES};
+use crate::limits::{
+    MAX_INGEST_FILES, MAX_INGEST_FILE_BYTES, MAX_TOTAL_INGEST_BYTES, MAX_TRANSCRIPT_BYTES,
+};
 
 /// A parsed, canonicalized allowlist of filesystem roots a `path` fragment
 /// may resolve under. The only way to construct one is [`Self::parse`] —
@@ -173,11 +175,39 @@ pub fn resolve_fragments(
             .path
             .clone()
             .expect("index was filtered on path.is_some() above");
-        let content = resolve_one(&requested, roots, &mut total_bytes)?;
+        let content = resolve_one(&requested, roots, &mut total_bytes, MAX_INGEST_FILE_BYTES)?;
         fragments[index].content = content;
         fragments[index].path = None;
     }
     Ok(())
+}
+
+/// Resolve a `compile_transcript` transcript's `path` field (V2b-2): the same
+/// ordered security pipeline as [`resolve_fragments`]'s `path` handling
+/// (steps 4 through 8 below), but with [`MAX_TRANSCRIPT_BYTES`] in place of
+/// [`MAX_INGEST_FILE_BYTES`] — a transcript is the one caller-facing shape
+/// allowed to read past the ordinary 1 MiB fragment ceiling, because
+/// [`super::segment::segment_transcript`] segments it into sub-1-MiB pieces
+/// immediately after this read, never compiling it as one oversized
+/// fragment. `roots` must already be checked enabled by the caller (the MCP
+/// adapter mirrors [`resolve_fragments`]'s step 2 before calling this).
+///
+/// # Errors
+/// [`MemoryError::IngestPath`] for a relative path, an unreadable path, a
+/// non-plain-file, or non-UTF-8 content; [`MemoryError::IngestOutsideRoots`]
+/// when the canonicalized path escapes every root; [`MemoryError::ContextOverLimit`]
+/// when the file exceeds [`MAX_TRANSCRIPT_BYTES`].
+///
+/// `pub`, not `pub(crate)` — like [`resolve_fragments`], part of the public
+/// `context::ingest` surface (the `mcp` adapter is its first caller, but the
+/// module itself only requires `context`; a build with `context` and no
+/// `mcp` would otherwise flag this crate-internal-only function dead code).
+pub fn resolve_transcript_path(
+    requested: &str,
+    roots: &IngestRoots,
+) -> Result<String, MemoryError> {
+    let mut total_bytes: usize = 0;
+    resolve_one(requested, roots, &mut total_bytes, MAX_TRANSCRIPT_BYTES)
 }
 
 /// Resolve a single `path` fragment's content — steps 4 through 8 of the
@@ -185,11 +215,16 @@ pub fn resolve_fragments(
 /// accumulates across the whole request (the caller threads the same
 /// counter through every call) so the aggregate cap
 /// ([`MAX_TOTAL_INGEST_BYTES`]) is enforced across files, not just within
-/// one.
+/// one. `file_cap` is the per-file ceiling: [`MAX_INGEST_FILE_BYTES`] for an
+/// ordinary `path` fragment, [`MAX_TRANSCRIPT_BYTES`] for
+/// [`resolve_transcript_path`] (V2b-2) — parameterized rather than a second
+/// copy of this function, so the ordered pipeline (steps 4-8) can never drift
+/// between the two callers.
 fn resolve_one(
     requested: &str,
     roots: &IngestRoots,
     total_bytes: &mut usize,
+    file_cap: usize,
 ) -> Result<String, MemoryError> {
     // Step 4: relative paths are refused outright.
     let requested_path = Path::new(requested);
@@ -220,10 +255,9 @@ fn resolve_one(
         )));
     }
     let declared_len = usize::try_from(file_metadata.len()).unwrap_or(usize::MAX);
-    if declared_len > MAX_INGEST_FILE_BYTES {
+    if declared_len > file_cap {
         return Err(MemoryError::ContextOverLimit(format!(
-            "file '{requested}' is {declared_len} bytes, exceeding the cap of \
-             {MAX_INGEST_FILE_BYTES} bytes"
+            "file '{requested}' is {declared_len} bytes, exceeding the cap of {file_cap} bytes"
         )));
     }
     let running_total = total_bytes.saturating_add(declared_len);
@@ -239,10 +273,10 @@ fn resolve_one(
     // that would silently blow the byte cap is still caught), then decode.
     let bytes = fs::read(&canonical)
         .map_err(|err| MemoryError::IngestPath(format!("cannot read path '{requested}': {err}")))?;
-    if bytes.len() > MAX_INGEST_FILE_BYTES {
+    if bytes.len() > file_cap {
         return Err(MemoryError::ContextOverLimit(format!(
             "file '{requested}' grew to {} bytes while being read, exceeding the cap of \
-             {MAX_INGEST_FILE_BYTES} bytes",
+             {file_cap} bytes",
             bytes.len()
         )));
     }

--- a/crates/velesdb-memory/src/context/ingest_tests.rs
+++ b/crates/velesdb-memory/src/context/ingest_tests.rs
@@ -1,0 +1,286 @@
+//! TDD suite for [`super::resolve_fragments`] and [`super::IngestRoots`]
+//! (V2b-1): the security pipeline, its short-circuit ordering, and the
+//! round trip of a resolved `path` fragment through the compiler and the
+//! memory bridge's `ctx://source` handle.
+
+use std::fs;
+use std::path::Path;
+
+use super::{resolve_one, IngestRoots};
+use crate::context::model::{CompilePolicy, CompileRequest, ContextFragment};
+use crate::context::ContextCompiler;
+use crate::embedder::HashEmbedder;
+use crate::error::MemoryError;
+use crate::limits::{MAX_INGEST_FILES, MAX_INGEST_FILE_BYTES, MAX_TOTAL_INGEST_BYTES};
+use crate::service::MemoryService;
+
+const DIM: usize = 384;
+
+fn path_fragment(path: &str) -> ContextFragment {
+    ContextFragment {
+        id: None,
+        content: String::new(),
+        path: Some(path.to_owned()),
+        kind: None,
+        priority: None,
+        metadata: None,
+        media: None,
+    }
+}
+
+/// An [`IngestRoots`] allowlisting exactly `dir`.
+fn roots_for(dir: &Path) -> IngestRoots {
+    let value = std::env::join_paths([dir.as_os_str()])
+        .expect("a single absolute path always joins")
+        .to_string_lossy()
+        .into_owned();
+    IngestRoots::parse(&value).expect("tempdir is a valid, existing directory")
+}
+
+#[test]
+fn ingest_disabled_without_roots() {
+    let mut fragments = vec![path_fragment("/does/not/matter.txt")];
+    let err = super::resolve_fragments(&mut fragments, None).expect_err("no roots configured");
+    assert!(matches!(err, MemoryError::IngestDisabled), "{err:?}");
+}
+
+#[test]
+fn ingest_rejects_relative_path() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let roots = roots_for(dir.path());
+    let mut fragments = vec![path_fragment("relative/path.txt")];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots)).expect_err("relative path");
+    match err {
+        MemoryError::IngestPath(msg) => assert!(msg.contains("relative"), "{msg}"),
+        other => panic!("expected IngestPath, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_path_outside_roots() {
+    let allowed = tempfile::TempDir::new().expect("tempdir");
+    let outside = tempfile::TempDir::new().expect("tempdir");
+    let target = outside.path().join("secret.txt");
+    fs::write(&target, "top secret").expect("write");
+
+    let roots = roots_for(allowed.path());
+    let requested = target.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err =
+        super::resolve_fragments(&mut fragments, Some(&roots)).expect_err("outside every root");
+    match err {
+        MemoryError::IngestOutsideRoots(path) => assert_eq!(path, requested),
+        other => panic!("expected IngestOutsideRoots, got {other:?}"),
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn ingest_follows_symlink_inside_roots() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let real = dir.path().join("real.txt");
+    fs::write(&real, "hello from the real file").expect("write");
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+    let roots = roots_for(dir.path());
+    let requested = link.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    super::resolve_fragments(&mut fragments, Some(&roots)).expect("symlink stays inside roots");
+    assert_eq!(fragments[0].content, "hello from the real file");
+    assert!(fragments[0].path.is_none());
+}
+
+#[test]
+#[cfg(unix)]
+fn ingest_rejects_symlink_escaping_roots() {
+    let allowed = tempfile::TempDir::new().expect("tempdir");
+    let outside = tempfile::TempDir::new().expect("tempdir");
+    let target = outside.path().join("secret.txt");
+    fs::write(&target, "top secret").expect("write");
+    let link = allowed.path().join("escape.txt");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    let roots = roots_for(allowed.path());
+    let requested = link.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots))
+        .expect_err("symlink escapes the root");
+    match err {
+        MemoryError::IngestOutsideRoots(path) => assert_eq!(path, requested),
+        other => panic!("expected IngestOutsideRoots, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_directory() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let sub = dir.path().join("subdir");
+    fs::create_dir(&sub).expect("mkdir");
+
+    let roots = roots_for(dir.path());
+    let requested = sub.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots)).expect_err("a directory");
+    match err {
+        MemoryError::IngestPath(msg) => assert!(msg.contains("not a regular file"), "{msg}"),
+        other => panic!("expected IngestPath, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_oversized_file() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let file = dir.path().join("big.txt");
+    fs::write(&file, vec![b'a'; MAX_INGEST_FILE_BYTES + 1]).expect("write");
+
+    let roots = roots_for(dir.path());
+    let requested = file.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots)).expect_err("oversized file");
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains(&MAX_INGEST_FILE_BYTES.to_string()), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_non_utf8_with_binary_hint() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let file = dir.path().join("image.png");
+    let mut bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    bytes.extend_from_slice(&[0xFF, 0xFE, 0x00, 0x01]);
+    fs::write(&file, &bytes).expect("write");
+
+    let roots = roots_for(dir.path());
+    let requested = file.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots)).expect_err("non-utf8");
+    match err {
+        MemoryError::IngestPath(msg) => {
+            assert!(msg.contains("not valid UTF-8"), "{msg}");
+            assert!(msg.contains("media fragment"), "{msg}");
+        }
+        other => panic!("expected IngestPath, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_rejects_path_plus_content() {
+    // No roots configured at all — the shape rule fires first, regardless
+    // of whether ingestion is even enabled.
+    let mut fragment = path_fragment("/tmp/whatever.txt");
+    fragment.content = "already have content".to_owned();
+    let mut fragments = vec![fragment];
+    let err = super::resolve_fragments(&mut fragments, None).expect_err("path + content");
+    match err {
+        MemoryError::IngestPath(msg) => assert!(msg.contains("never more than one"), "{msg}"),
+        other => panic!("expected IngestPath, got {other:?}"),
+    }
+}
+
+#[test]
+fn ingest_caps_file_count_and_total_bytes() {
+    // File-count cap: MAX_INGEST_FILES + 1 fragments, none of which need to
+    // resolve to a real file — the count check runs before any filesystem
+    // access.
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let roots = roots_for(dir.path());
+    let mut fragments: Vec<ContextFragment> = (0..=MAX_INGEST_FILES)
+        .map(|i| path_fragment(&format!("/nonexistent/{i}.txt")))
+        .collect();
+    let err = super::resolve_fragments(&mut fragments, Some(&roots))
+        .expect_err("too many path fragments");
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains(&MAX_INGEST_FILES.to_string()), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+
+    // Aggregate byte cap: white-box call into `resolve_one` with a
+    // `total_bytes` accumulator already near the ceiling — with
+    // MAX_INGEST_FILES * MAX_INGEST_FILE_BYTES == MAX_TOTAL_INGEST_BYTES,
+    // the aggregate cap can never be exceeded by real max-sized files
+    // without first tripping the count cap above, so this is the only way
+    // to exercise it directly without writing tens of megabytes to disk.
+    let file = dir.path().join("small.txt");
+    fs::write(&file, b"just a little bit of content").expect("write");
+    let requested = file.to_string_lossy().into_owned();
+    let mut total_bytes = MAX_TOTAL_INGEST_BYTES - 10;
+    let err = resolve_one(&requested, &roots, &mut total_bytes)
+        .expect_err("pushes the running total over the aggregate cap");
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains(&MAX_TOTAL_INGEST_BYTES.to_string()), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn path_fragment_compiles_and_round_trips_source_handle() {
+    let store_dir = tempfile::TempDir::new().expect("tempdir");
+    let service =
+        MemoryService::open(store_dir.path(), HashEmbedder::new(DIM)).expect("open memory store");
+
+    let source_dir = tempfile::TempDir::new().expect("tempdir");
+    let file = source_dir.path().join("notes.txt");
+    fs::write(&file, "the deploy pipeline is green").expect("write");
+
+    let roots = roots_for(source_dir.path());
+    let requested = file.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    super::resolve_fragments(&mut fragments, Some(&roots)).expect("resolves cleanly");
+
+    let request = CompileRequest {
+        query: "deploy status".to_owned(),
+        fragments,
+        project: None,
+        target_model: None,
+        token_budget: 10_000,
+        memory_scope: None,
+        policy: Some(CompilePolicy::default()),
+    };
+    let compiled = service
+        .compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
+        .expect("compiles like any other fragment");
+    assert!(compiled.content.contains("the deploy pipeline is green"));
+
+    let source = compiled
+        .sources
+        .first()
+        .expect("the resolved fragment has exactly one source");
+    let resolved = service
+        .retrieve_context_source(&source.handle)
+        .expect("the source round-trips");
+    assert_eq!(resolved.content, "the deploy pipeline is green");
+}
+
+#[test]
+#[cfg(unix)]
+fn outside_roots_error_never_echoes_resolved_target() {
+    let allowed = tempfile::TempDir::new().expect("tempdir");
+    let outside = tempfile::TempDir::new().expect("tempdir");
+    let target = outside.path().join("only-visible-if-leaked.txt");
+    fs::write(&target, "top secret").expect("write");
+    let link = allowed.path().join("escape.txt");
+    std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+    let roots = roots_for(allowed.path());
+    let requested = link.to_string_lossy().into_owned();
+    let mut fragments = vec![path_fragment(&requested)];
+    let err = super::resolve_fragments(&mut fragments, Some(&roots))
+        .expect_err("symlink escapes the root");
+    let message = err.to_string();
+    assert!(
+        message.contains(&requested),
+        "error should cite the requested path: {message}"
+    );
+    assert!(
+        !message.contains("only-visible-if-leaked"),
+        "error must never echo the resolved target: {message}"
+    );
+}

--- a/crates/velesdb-memory/src/context/ingest_tests.rs
+++ b/crates/velesdb-memory/src/context/ingest_tests.rs
@@ -210,7 +210,7 @@ fn ingest_caps_file_count_and_total_bytes() {
     fs::write(&file, b"just a little bit of content").expect("write");
     let requested = file.to_string_lossy().into_owned();
     let mut total_bytes = MAX_TOTAL_INGEST_BYTES - 10;
-    let err = resolve_one(&requested, &roots, &mut total_bytes)
+    let err = resolve_one(&requested, &roots, &mut total_bytes, MAX_INGEST_FILE_BYTES)
         .expect_err("pushes the running total over the aggregate cap");
     match err {
         MemoryError::ContextOverLimit(msg) => {

--- a/crates/velesdb-memory/src/context/media_pipeline_tests.rs
+++ b/crates/velesdb-memory/src/context/media_pipeline_tests.rs
@@ -31,6 +31,7 @@ fn plain_fragment(content: &str) -> ContextFragment {
     ContextFragment {
         id: None,
         content: content.to_owned(),
+        path: None,
         kind: None,
         priority: None,
         metadata: None,

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -832,6 +832,7 @@ impl MemoryCandidate {
             fragment: ContextFragment {
                 id: None,
                 content: self.content,
+                path: None,
                 kind: Some("memory".to_owned()),
                 priority: None,
                 metadata: None,

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -31,6 +31,7 @@ fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
         id: None,
         content: content.to_owned(),
+        path: None,
         kind: None,
         priority: None,
         metadata: None,

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -112,8 +112,29 @@ pub struct ContextFragment {
         deserialize_with = "super::wire::deserialize_optional_id"
     )]
     pub id: Option<u64>,
-    /// The fragment text.
+    /// The fragment text. `#[serde(default)]` (V2b-1): a `path` fragment
+    /// carries no `content` on the wire — the adapter resolves `path` into
+    /// `content` in a pre-pass before the pure compiler core ever sees the
+    /// request, so this stays the only field the core reads.
+    #[serde(default)]
     pub content: String,
+    /// Read this file's content from disk in place of an inline `content`
+    /// (V2b-1 path ingestion): exactly one of `path`, non-empty `content`,
+    /// or `media` is accepted — a fragment carrying `path` together with
+    /// `content` or `media` is rejected. Requires the server to be started
+    /// with `VELESDB_MEMORY_INGEST_ROOTS` set (a colon/semicolon-separated
+    /// allowlist of directories, platform `PATH`-list syntax); otherwise
+    /// every `path` fragment fails with an explicit "ingestion disabled"
+    /// error. The path must be absolute and resolve (after following
+    /// symlinks) to a plain file under one of the configured roots, no
+    /// larger than [`crate::limits::MAX_INGEST_FILE_BYTES`] and valid UTF-8.
+    /// The **pure compiler core never reads this field** — resolution is an
+    /// adapter-side I/O pre-pass (see the crate's `context::ingest`
+    /// module); a `path` fragment that reaches [`super::ContextCompiler`]
+    /// unresolved is rejected with
+    /// [`crate::error::MemoryError::IngestDisabled`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
     /// Free-form kind hint (`"code"`, `"log"`, `"prose"`, …) — classification
     /// works without it, but honors it when present.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -288,30 +288,57 @@ struct JsonlLine {
     content: String,
 }
 
-/// Parse every line of `text` as one JSONL turn. `Err` names the first
-/// (1-based) offending line — the first failure short-circuits, so a caller
-/// forcing `jsonl` on a bad transcript gets an actionable pointer instead of
-/// a generic "not jsonl".
+/// Parse every non-blank line of `text` as one JSONL turn. A wholly empty
+/// line (`""` once the trailing `\r`/`\n` is stripped) never fails parsing
+/// and never opens a turn of its own — its bytes fold into the PRECEDING
+/// piece's range (or, for a leading blank run with no preceding piece yet,
+/// are deferred and prepended onto the first real turn once one arrives) so
+/// the byte ranges keep partitioning `text` exactly. Without this, a
+/// perfectly valid JSONL transcript that merely uses a blank line as a
+/// separator would fail to parse and (in [`SegmentFormat::Auto`]) silently
+/// fall back to a single roleless `plain` turn.
+///
+/// `Err` names the first (1-based) offending LINE — not turn — number: the
+/// first failure short-circuits, so a caller forcing `jsonl` on a bad
+/// transcript gets an actionable pointer instead of a generic "not jsonl".
 fn jsonl_pieces(text: &str) -> Result<Vec<RawPiece>, String> {
-    let mut pieces = Vec::new();
+    let mut pieces: Vec<RawPiece> = Vec::new();
+    let mut pending_prefix_start: Option<usize> = None;
+    let mut turn = 0_usize;
     let mut cursor = 0_usize;
-    for (turn, line) in text.split_inclusive('\n').enumerate() {
+    for (line_index, line) in text.split_inclusive('\n').enumerate() {
         let start = cursor;
         cursor += line.len();
         let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            if let Some(last) = pieces.last_mut() {
+                last.range.end = cursor;
+            } else {
+                pending_prefix_start.get_or_insert(start);
+            }
+            continue;
+        }
         let parsed: JsonlLine = serde_json::from_str(trimmed).map_err(|err| {
             format!(
                 "jsonl line {}: not a valid {{role, content}} object: {err}",
-                turn + 1
+                line_index + 1
             )
         })?;
+        let piece_start = pending_prefix_start.take().unwrap_or(start);
         pieces.push(RawPiece {
             kind: SegmentKind::Body,
-            range: start..cursor,
+            range: piece_start..cursor,
             turn,
             role: Some(parsed.role),
             content_override: Some(parsed.content),
         });
+        turn += 1;
+    }
+    if pieces.is_empty() {
+        // Every line (if any at all) was blank — nothing real to call
+        // jsonl; Auto mode falls back to plain, a forced jsonl request gets
+        // an honest error instead of a silently empty result.
+        return Err("no non-blank jsonl line found".to_owned());
     }
     Ok(pieces)
 }
@@ -505,14 +532,11 @@ fn reject_oversized_fences(pieces: &[RawPiece]) -> Result<(), MemoryError> {
     Ok(())
 }
 
-/// Re-split every `body` piece over [`MAX_FRAGMENT_BYTES`] with
-/// [`chunk_text`] — the same re-chunker `compile_context` itself uses for an
-/// oversized fragment. A `jsonl` piece's decoded `content_override` has no
-/// byte-aligned mapping back to the raw (JSON-escaped) source line, so its
-/// re-split children all keep the ORIGINAL line's full byte range — a
-/// documented, deliberately narrow trade-off: the byte-range-covers-the-
-/// transcript property holds at the turn level regardless, and a single
-/// JSONL line's `content` exceeding 1 MiB is an extreme edge case.
+/// Re-split every `body` or `log` piece over [`MAX_FRAGMENT_BYTES`] — see
+/// [`resplit_body`] and [`resplit_log`] for the two (deliberately different)
+/// strategies. A `code` piece is never touched here: it is atomic by
+/// construction (a fence is never cut, see [`super::chunk`]) and already
+/// rejected outright by [`reject_oversized_fences`] when oversized.
 fn resplit_oversized_bodies(text: &str, pieces: Vec<RawPiece>) -> Vec<RawPiece> {
     let chunk_policy = ChunkPolicy {
         max_chunk_bytes: MAX_FRAGMENT_BYTES,
@@ -526,9 +550,22 @@ fn resplit_oversized_bodies(text: &str, pieces: Vec<RawPiece>) -> Vec<RawPiece> 
 }
 
 fn resplit_one(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<RawPiece> {
-    if piece.kind != SegmentKind::Body {
-        return vec![piece];
+    match piece.kind {
+        SegmentKind::Body => resplit_body(text, piece, chunk_policy),
+        SegmentKind::Log => resplit_log(text, piece),
+        SegmentKind::Code => vec![piece],
     }
+}
+
+/// Re-split a `body` piece over [`MAX_FRAGMENT_BYTES`] with [`chunk_text`] —
+/// the same re-chunker `compile_context` itself uses for an oversized
+/// fragment. A `jsonl` piece's decoded `content_override` has no
+/// byte-aligned mapping back to the raw (JSON-escaped) source line, so its
+/// re-split children all keep the ORIGINAL line's full byte range — a
+/// documented, deliberately narrow trade-off: the byte-range-covers-the-
+/// transcript property holds at the turn level regardless, and a single
+/// JSONL line's `content` exceeding 1 MiB is an extreme edge case.
+fn resplit_body(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<RawPiece> {
     let effective_len = piece
         .content_override
         .as_ref()
@@ -561,12 +598,93 @@ fn resplit_one(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<R
     }
 }
 
+/// Re-split a `log` piece over [`MAX_FRAGMENT_BYTES`] on LINE boundaries —
+/// never mid-line, so each resulting sub-run stays meaningful to
+/// `abstract.log_dedup` (which classifies and dedups per fragment, not
+/// across a cut line). Unlike [`resplit_body`], never [`chunk_text`]
+/// directly: paragraph-boundary chunking has no notion of "line", and would
+/// happily cut a log line in half. A `log` piece never carries a
+/// `content_override` (only `jsonl` pieces do, and `jsonl` never produces
+/// `log` — see the module docs), so this always reads straight from `text`.
+///
+/// Lines are packed greedily into chunks of at most [`MAX_FRAGMENT_BYTES`];
+/// a single line that alone exceeds the cap (extreme edge case — one log
+/// line over 1 MiB) is hard-split at char boundaries as a last resort, the
+/// same fallback [`super::chunk::chunk_text`] uses for an oversized atomic
+/// unit.
+fn resplit_log(text: &str, piece: RawPiece) -> Vec<RawPiece> {
+    if piece.range.len() <= MAX_FRAGMENT_BYTES {
+        return vec![piece];
+    }
+    let hard_split_policy = ChunkPolicy {
+        max_chunk_bytes: MAX_FRAGMENT_BYTES,
+        overlap_bytes: 0,
+        boundary: ChunkBoundary::Fixed,
+    };
+    let mut result = Vec::new();
+    let mut chunk_start = piece.range.start;
+    let mut cursor = piece.range.start;
+    for line in text[piece.range.clone()].split_inclusive('\n') {
+        let line_start = cursor;
+        let line_end = line_start + line.len();
+        cursor = line_end;
+
+        if line_end - line_start > MAX_FRAGMENT_BYTES {
+            // The line itself is oversized: seal whatever came before it,
+            // hard-split the line alone, then resume after it.
+            if chunk_start < line_start {
+                result.push(log_piece(&piece, chunk_start..line_start));
+            }
+            for hard in chunk_text(&text[line_start..line_end], &hard_split_policy) {
+                result.push(log_piece(
+                    &piece,
+                    (line_start + hard.byte_range.start)..(line_start + hard.byte_range.end),
+                ));
+            }
+            chunk_start = line_end;
+            continue;
+        }
+
+        if line_end - chunk_start > MAX_FRAGMENT_BYTES {
+            // Adding this line would overflow the open chunk: seal it
+            // first — `chunk_start..line_start` is guaranteed non-empty
+            // here (a lone line never exceeds the cap in this branch).
+            result.push(log_piece(&piece, chunk_start..line_start));
+            chunk_start = line_start;
+        }
+    }
+    if chunk_start < piece.range.end {
+        result.push(log_piece(&piece, chunk_start..piece.range.end));
+    }
+    result
+}
+
+/// A `log`-kind [`RawPiece`] over `range`, inheriting `source`'s turn/role —
+/// the shared constructor [`resplit_log`]'s two push sites use.
+fn log_piece(source: &RawPiece, range: Range<usize>) -> RawPiece {
+    RawPiece {
+        kind: SegmentKind::Log,
+        range,
+        turn: source.turn,
+        role: source.role.clone(),
+        content_override: None,
+    }
+}
+
 /// Merge adjacent pieces of the SAME turn and kind when either side is under
 /// `min_bytes` — see the module docs' step 4. A `jsonl` piece never merges
 /// with another (each holds its own unique `turn`, since `jsonl` is
 /// one-line-one-turn by construction), nor does any piece carrying a
 /// `content_override` (merging would require re-deriving a combined decoded
 /// string, which is not meaningful once JSON escaping is involved).
+///
+/// **Never merges past [`MAX_FRAGMENT_BYTES`]** — a piece that survived
+/// [`resplit_body`]/[`resplit_log`] is only guaranteed to be AT MOST the
+/// cap, so blindly recombining it with even a tiny neighbor can push the
+/// result back over (a ~1 MiB chunk plus a few trailing bytes, or two
+/// adjacent fences each individually under the cap). Merging is an
+/// optimization (fewer, more useful fragments), never allowed to violate the
+/// one invariant every other normalization step exists to uphold.
 fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
     let mut merged: Vec<RawPiece> = Vec::new();
     for piece in pieces {
@@ -576,6 +694,7 @@ fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
                 && last.content_override.is_none()
                 && piece.content_override.is_none()
                 && last.range.end == piece.range.start
+                && last.range.len() + piece.range.len() <= MAX_FRAGMENT_BYTES
                 && (last.range.len() < min_bytes || piece.range.len() < min_bytes)
         });
         if mergeable {

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -1,0 +1,643 @@
+//! Deterministic transcript segmentation for the `compile_transcript` MCP
+//! tool (V2b-2, see the crate's `PLAN.md`, section V2b).
+//!
+//! [`segment_transcript`] turns a raw agent-session transcript — plain text
+//! with role markers, or JSONL — into an ordered list of
+//! [`TranscriptSegment`]s, each wrapping an ordinary [`super::ContextFragment`]
+//! plus the audit metadata (`turn`, `role`, `kind`, byte range) the
+//! `compile_transcript` tool reports alongside the compiled context. The
+//! resulting fragments feed the existing, unmodified [`super::ContextCompiler`]
+//! pipeline — this module only decides *how to cut the transcript up*, never
+//! what to keep or drop.
+//!
+//! **Zero regex, zero clock, single linear scan per stage** — same
+//! determinism contract as [`super::chunk`]: the same transcript + the same
+//! [`SegmentationPolicy`] always segment byte-identically (see
+//! `segmentation_twice_is_byte_identical` in the test suite).
+//!
+//! # Pipeline
+//!
+//! 1. **Format detection** ([`detect_and_segment`]): `jsonl` when every
+//!    non-empty line parses as a `{role, content}` JSON object, `plain`
+//!    otherwise. A caller-forced format that does not parse is a hard error —
+//!    never a silent fallback to the other format.
+//! 2. **Turns**: `jsonl` — one line, one turn, `role` taken directly from the
+//!    parsed JSON. `plain` — a CLOSED table of markers (`"System:"`,
+//!    `"User:"`, `"Human:"`, `"Assistant:"`, `"AI:"`, `"Tool:"`,
+//!    `"### User"`, `"### Assistant"`), first match at the start of a line
+//!    opens a new turn; a transcript with no marker at all is one turn with
+//!    `role: None`.
+//! 3. **Sub-segmentation** (`plain` turns only — a `jsonl` turn's `content` is
+//!    a JSON-decoded string, not a byte-aligned slice of the transcript, so
+//!    it is never re-scanned; the underlying `content.contains("```")` /
+//!    value-density rules in [`super::classify`] still see it, unaffected):
+//!    fenced code blocks ([`super::chunk::fence_segments`]) become atomic
+//!    `code` segments; runs of at least 8 consecutive log-like lines (a
+//!    volatile timestamp/pid prefix — [`super::log_normalize::mask_volatile_prefix`]
+//!    — or a raw-text repeat) become `log` segments; everything else is
+//!    `body`.
+//! 4. **Normalization**: an unsplittable fence over
+//!    [`crate::limits::MAX_FRAGMENT_BYTES`] is a hard error (never silently
+//!    truncated); an oversized `body` segment is re-split with
+//!    [`super::chunk_text`]; segments under
+//!    [`SegmentationPolicy::min_segment_bytes`] merge into an adjacent
+//!    segment of the *same turn and kind*; more than
+//!    [`crate::limits::MAX_FRAGMENTS`] segments after merging is a hard,
+//!    actionable error ("raise `min_segment_bytes`") — never a silent drop.
+//!
+//! Every error surfaces as [`crate::error::MemoryError::ContextOverLimit`] or
+//! [`crate::error::MemoryError::IngestDisabled`]/[`crate::error::MemoryError::IngestOutsideRoots`]/
+//! [`crate::error::MemoryError::IngestPath`] (the last three only for a
+//! `path`-sourced transcript, via [`super::ingest::resolve_transcript_path`])
+//! — the same `INVALID_PARAMS`-category taxonomy `compile_context` already
+//! uses, deliberately not a new variant for this PR.
+
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+use super::chunk::{self, chunk_text, ChunkBoundary, ChunkPolicy};
+use super::log_normalize::mask_volatile_prefix;
+use super::model::ContextFragment;
+use crate::error::MemoryError;
+use crate::limits::{MAX_FRAGMENTS, MAX_FRAGMENT_BYTES, MAX_TRANSCRIPT_BYTES};
+
+/// A contiguous run of at least this many candidate log lines becomes a
+/// `log` segment (see the module docs' step 3). Chosen high enough that an
+/// ordinary short warning burst stays `body` (nothing to abstract), low
+/// enough that a real log dump — which `abstract.log_dedup` exists to
+/// collapse — is reliably recognized.
+const MIN_LOG_RUN_LINES: usize = 8;
+
+/// Which transcript format to assume, or detect automatically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SegmentFormat {
+    /// Detect `jsonl` vs `plain` from the transcript itself (the default).
+    Auto,
+    /// Force plain-text, marker-based turn splitting — a transcript that
+    /// happens to also be valid JSONL is still segmented as plain text.
+    Plain,
+    /// Force one-line-one-turn JSONL parsing — a line that does not parse as
+    /// a `{role, content}` object is a hard error, never a silent fallback.
+    Jsonl,
+}
+
+/// What kind of content a sub-segment carries — decides whether it was cut
+/// out as an atomic fence, a detected log run, or ordinary prose/dialogue
+/// left for [`super::classify`]'s rule table to judge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SegmentKind {
+    /// Ordinary text — [`ContextFragment::kind`] stays `None`, so the
+    /// existing classification rules (code fence, URL, negative constraint,
+    /// value density, …) decide its fate exactly as for `compile_context`.
+    Body,
+    /// A triple-backtick-fenced block, cut out atomically by
+    /// [`super::chunk::fence_segments`]. Tagged `kind = "code"` so
+    /// [`super::classify::classify`]'s `preserve.code_fence` rule matches
+    /// even for a fence whose content does not itself literally contain
+    /// `` ``` `` (defense in depth; it usually does).
+    Code,
+    /// A run of at least [`MIN_LOG_RUN_LINES`] log-like lines. Tagged
+    /// `kind = "log"` so `abstract.log_dedup` can consider it for
+    /// repeated-line collapsing exactly like a caller-declared `kind: "log"`
+    /// fragment in `compile_context`.
+    Log,
+}
+
+impl SegmentKind {
+    /// The [`ContextFragment::kind`] hint this segment kind maps to —
+    /// `None` for `body` (let the rule table decide unconstrained).
+    fn fragment_kind(self) -> Option<&'static str> {
+        match self {
+            Self::Body => None,
+            Self::Code => Some("code"),
+            Self::Log => Some("log"),
+        }
+    }
+}
+
+/// Tuning knobs for [`segment_transcript`]. `Default` is the recommended
+/// profile.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub struct SegmentationPolicy {
+    /// Which format to assume (see [`SegmentFormat`]). Default [`SegmentFormat::Auto`].
+    pub format: SegmentFormat,
+    /// Segments under this many bytes merge into an adjacent segment of the
+    /// same turn and kind (see the module docs' step 4). Default `256`.
+    pub min_segment_bytes: usize,
+    /// When `true` (the default) and [`SegmentationPolicy::format`]
+    /// determines the FIRST turn's role is `"system"` (case-insensitive),
+    /// every segment of that turn is marked `metadata.cache = true` — the
+    /// same signal `compile_context`'s `cache.stable_prefix` rule reads, so
+    /// a system prompt turn becomes the compiled output's stable,
+    /// cache-friendly prefix without the caller hand-annotating it.
+    pub cache_system_turn: bool,
+}
+
+impl Default for SegmentationPolicy {
+    fn default() -> Self {
+        Self {
+            format: SegmentFormat::Auto,
+            min_segment_bytes: 256,
+            cache_system_turn: true,
+        }
+    }
+}
+
+/// One segmented piece of the transcript: an ordinary [`ContextFragment`]
+/// (ready to feed [`super::ContextCompiler`]) plus the audit metadata the
+/// `compile_transcript` tool reports in its `segmentation.segments` list.
+#[derive(Debug, Clone)]
+pub struct TranscriptSegment {
+    /// The fragment this segment produces — feed it straight into a
+    /// [`super::CompileRequest::fragments`] list.
+    pub fragment: ContextFragment,
+    /// Which turn (0-based, transcript order) this segment belongs to.
+    pub turn: usize,
+    /// The turn's role, when one was determined (a marker match in `plain`
+    /// mode, or the parsed `role` field in `jsonl` mode). `None` for a
+    /// `plain` transcript with no matching marker at all.
+    pub role: Option<String>,
+    /// What kind of content this segment carries.
+    pub kind: SegmentKind,
+    /// Start byte offset (inclusive) of this segment in the ORIGINAL
+    /// transcript text.
+    pub byte_start: usize,
+    /// End byte offset (exclusive) of this segment in the ORIGINAL
+    /// transcript text.
+    pub byte_end: usize,
+}
+
+/// The full result of [`segment_transcript`]: the detected format, the
+/// segments, and how much normalization merging did.
+#[derive(Debug, Clone)]
+pub struct SegmentationOutcome {
+    /// `jsonl` or `plain` — never [`SegmentFormat::Auto`], which only ever
+    /// names a caller's REQUEST, not a detected outcome.
+    pub format_detected: SegmentFormat,
+    /// The final segments, in transcript order.
+    pub segments: Vec<TranscriptSegment>,
+    /// How many segments the [`SegmentationPolicy::min_segment_bytes`] merge
+    /// step eliminated (`pieces_before_merge - segments.len()`).
+    pub merged_segments: usize,
+}
+
+/// Segment `text` under `policy` — see the module docs for the full
+/// pipeline. Pure: no I/O, no clock, no randomness; the same `text` +
+/// `policy` always produce byte-identical output.
+///
+/// # Errors
+/// [`MemoryError::ContextOverLimit`] when `text` exceeds
+/// [`MAX_TRANSCRIPT_BYTES`], when [`SegmentFormat::Jsonl`] is forced but a
+/// line does not parse as a `{role, content}` object, when an unsplittable
+/// fence exceeds [`MAX_FRAGMENT_BYTES`], or when the segment count after
+/// merging still exceeds [`MAX_FRAGMENTS`].
+pub fn segment_transcript(
+    text: &str,
+    policy: &SegmentationPolicy,
+) -> Result<SegmentationOutcome, MemoryError> {
+    if text.len() > MAX_TRANSCRIPT_BYTES {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "transcript of {} bytes exceeds the cap of {MAX_TRANSCRIPT_BYTES} bytes",
+            text.len()
+        )));
+    }
+
+    let (format_detected, pieces) = detect_and_segment(text, policy.format)?;
+    reject_oversized_fences(&pieces)?;
+    let pieces = resplit_oversized_bodies(text, pieces);
+    let pieces_before_merge = pieces.len();
+    let merged = merge_tiny(pieces, policy.min_segment_bytes);
+    if merged.len() > MAX_FRAGMENTS {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "transcript segmented into {} fragments, exceeding the cap of {MAX_FRAGMENTS} — \
+             raise segmentation.min_segment_bytes to merge more small segments",
+            merged.len()
+        )));
+    }
+    let merged_segments = pieces_before_merge - merged.len();
+    let segments = merged
+        .into_iter()
+        .map(|piece| build_segment(text, piece, policy))
+        .collect();
+    Ok(SegmentationOutcome {
+        format_detected,
+        segments,
+        merged_segments,
+    })
+}
+
+// --- Raw (pre-normalization) pieces -----------------------------------------
+
+/// A sub-segment before normalization: still tied to the ORIGINAL text's byte
+/// range, except `content_override` — set only for a `jsonl` turn (and its
+/// re-split children), whose fragment content is a JSON-decoded string with
+/// no byte-aligned slice of the raw transcript (JSON escaping means the
+/// decoded text is not a substring of the source bytes). When set, `range`
+/// still names the raw JSON line's span (needed so the segmentation-wide
+/// byte ranges keep partitioning the transcript), but the fragment's
+/// `content` comes from `content_override`, never `text[range]`.
+struct RawPiece {
+    kind: SegmentKind,
+    range: Range<usize>,
+    turn: usize,
+    role: Option<String>,
+    content_override: Option<String>,
+}
+
+/// Detect the format and produce the initial (pre-normalization) pieces in
+/// one pass — for `jsonl` this avoids parsing every line twice (once to
+/// detect, once to build).
+fn detect_and_segment(
+    text: &str,
+    requested: SegmentFormat,
+) -> Result<(SegmentFormat, Vec<RawPiece>), MemoryError> {
+    match requested {
+        SegmentFormat::Plain => Ok((SegmentFormat::Plain, plain_pieces(text))),
+        SegmentFormat::Jsonl => {
+            let pieces = jsonl_pieces(text).map_err(MemoryError::ContextOverLimit)?;
+            Ok((SegmentFormat::Jsonl, pieces))
+        }
+        SegmentFormat::Auto => {
+            if !text.is_empty() {
+                if let Ok(pieces) = jsonl_pieces(text) {
+                    return Ok((SegmentFormat::Jsonl, pieces));
+                }
+            }
+            Ok((SegmentFormat::Plain, plain_pieces(text)))
+        }
+    }
+}
+
+// --- JSONL -------------------------------------------------------------------
+
+/// One JSONL line's required shape. Both fields are mandatory: a line
+/// missing either — or not a JSON object at all — fails to parse, which
+/// [`detect_and_segment`] treats as "not jsonl" in [`SegmentFormat::Auto`]
+/// and as a hard error under a forced [`SegmentFormat::Jsonl`].
+#[derive(Deserialize)]
+struct JsonlLine {
+    role: String,
+    content: String,
+}
+
+/// Parse every line of `text` as one JSONL turn. `Err` names the first
+/// (1-based) offending line — the first failure short-circuits, so a caller
+/// forcing `jsonl` on a bad transcript gets an actionable pointer instead of
+/// a generic "not jsonl".
+fn jsonl_pieces(text: &str) -> Result<Vec<RawPiece>, String> {
+    let mut pieces = Vec::new();
+    let mut cursor = 0_usize;
+    for (turn, line) in text.split_inclusive('\n').enumerate() {
+        let start = cursor;
+        cursor += line.len();
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        let parsed: JsonlLine = serde_json::from_str(trimmed).map_err(|err| {
+            format!(
+                "jsonl line {}: not a valid {{role, content}} object: {err}",
+                turn + 1
+            )
+        })?;
+        pieces.push(RawPiece {
+            kind: SegmentKind::Body,
+            range: start..cursor,
+            turn,
+            role: Some(parsed.role),
+            content_override: Some(parsed.content),
+        });
+    }
+    Ok(pieces)
+}
+
+// --- Plain ---------------------------------------------------------------
+
+/// The CLOSED table of plain-text turn markers, checked in order — the first
+/// one a line starts with wins. Never a caller-supplied pattern, so turn
+/// detection stays deterministic and predictable (a "User:" cited in prose
+/// is a known, accepted false positive — see the crate README).
+const PLAIN_MARKERS: &[&str] = &[
+    "System:",
+    "User:",
+    "Human:",
+    "Assistant:",
+    "AI:",
+    "Tool:",
+    "### User",
+    "### Assistant",
+];
+
+/// The first [`PLAIN_MARKERS`] entry `line` starts with, if any.
+fn match_marker(line: &str) -> Option<&'static str> {
+    PLAIN_MARKERS
+        .iter()
+        .find(|marker| line.starts_with(*marker))
+        .copied()
+}
+
+/// A marker's role label: `"### User"` → `"User"`, `"System:"` → `"System"`.
+fn marker_role(marker: &str) -> String {
+    marker
+        .strip_prefix("### ")
+        .unwrap_or(marker)
+        .trim_end_matches(':')
+        .to_owned()
+}
+
+/// Split `text` into plain-format turns: `(byte_range, role)`, in order,
+/// partitioning `text` exactly. No marker anywhere in `text` yields exactly
+/// one turn covering the whole text with `role: None`.
+fn plain_turns(text: &str) -> Vec<(Range<usize>, Option<String>)> {
+    let mut turns = Vec::new();
+    let mut turn_start = 0_usize;
+    let mut pending_role: Option<String> = None;
+    let mut cursor = 0_usize;
+    for line in text.split_inclusive('\n') {
+        let line_start = cursor;
+        if let Some(marker) = match_marker(line) {
+            if line_start > turn_start {
+                turns.push((turn_start..line_start, pending_role.take()));
+            }
+            pending_role = Some(marker_role(marker));
+            turn_start = line_start;
+        }
+        cursor += line.len();
+    }
+    turns.push((turn_start..text.len(), pending_role));
+    turns
+}
+
+/// Build the initial pieces for a `plain` transcript: turns, then within
+/// each turn's slice, fences (atomic `code`) and log runs (`log`), the rest
+/// `body` — see the module docs' step 3.
+fn plain_pieces(text: &str) -> Vec<RawPiece> {
+    let mut pieces = Vec::new();
+    for (turn, (range, role)) in plain_turns(text).into_iter().enumerate() {
+        if range.is_empty() {
+            continue;
+        }
+        for segment in chunk::fence_segments(&text[range.clone()]) {
+            match segment {
+                chunk::Segment::Fence(relative) => pieces.push(RawPiece {
+                    kind: SegmentKind::Code,
+                    range: (range.start + relative.start)..(range.start + relative.end),
+                    turn,
+                    role: role.clone(),
+                    content_override: None,
+                }),
+                chunk::Segment::Plain(relative) => {
+                    let absolute = (range.start + relative.start)..(range.start + relative.end);
+                    for (kind, sub_range) in log_split(text, absolute) {
+                        pieces.push(RawPiece {
+                            kind,
+                            range: sub_range,
+                            turn,
+                            role: role.clone(),
+                            content_override: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+    pieces
+}
+
+/// Split `range` of `text` into alternating `body`/`log` pieces: a maximal
+/// run of at least [`MIN_LOG_RUN_LINES`] consecutive "log-candidate" lines
+/// (a volatile timestamp/pid prefix, or a line that repeats elsewhere in
+/// `range`) becomes one `log` piece; every other line stays `body`,
+/// contiguous runs of it merged into one piece. Single linear scan.
+fn log_split(text: &str, range: Range<usize>) -> Vec<(SegmentKind, Range<usize>)> {
+    if range.is_empty() {
+        return Vec::new();
+    }
+    let slice = &text[range.clone()];
+    let mut lines: Vec<(Range<usize>, &str)> = Vec::new();
+    let mut cursor = range.start;
+    for line in slice.split_inclusive('\n') {
+        let end = cursor + line.len();
+        lines.push((cursor..end, line));
+        cursor = end;
+    }
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let trimmed: Vec<&str> = lines
+        .iter()
+        .map(|(_, line)| line.trim_end_matches(['\r', '\n']))
+        .collect();
+    let mut repeat_counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for line in &trimmed {
+        *repeat_counts.entry(line).or_insert(0) += 1;
+    }
+    let candidate: Vec<bool> = trimmed
+        .iter()
+        .map(|line| {
+            !line.is_empty() && (mask_volatile_prefix(line).is_some() || repeat_counts[line] > 1)
+        })
+        .collect();
+
+    let mut pieces = Vec::new();
+    let mut body_start: Option<usize> = None;
+    let mut index = 0_usize;
+    while index < lines.len() {
+        if candidate[index] {
+            let run_start = index;
+            while index < lines.len() && candidate[index] {
+                index += 1;
+            }
+            if index - run_start >= MIN_LOG_RUN_LINES {
+                if let Some(start) = body_start.take() {
+                    pieces.push((
+                        SegmentKind::Body,
+                        lines[start].0.start..lines[run_start - 1].0.end,
+                    ));
+                }
+                pieces.push((
+                    SegmentKind::Log,
+                    lines[run_start].0.start..lines[index - 1].0.end,
+                ));
+            } else if body_start.is_none() {
+                body_start = Some(run_start);
+            }
+        } else {
+            if body_start.is_none() {
+                body_start = Some(index);
+            }
+            index += 1;
+        }
+    }
+    if let Some(start) = body_start {
+        pieces.push((
+            SegmentKind::Body,
+            lines[start].0.start..lines[lines.len() - 1].0.end,
+        ));
+    }
+    pieces
+}
+
+// --- Normalization -----------------------------------------------------------
+
+/// Reject an unsplittable fence over [`MAX_FRAGMENT_BYTES`] — a fence is
+/// always atomic (never cut, see [`super::chunk`]), so an oversized one
+/// cannot be brought under the cap the way a `body` piece can.
+///
+/// # Errors
+/// [`MemoryError::ContextOverLimit`] naming the first oversized fence found.
+fn reject_oversized_fences(pieces: &[RawPiece]) -> Result<(), MemoryError> {
+    if let Some(piece) = pieces
+        .iter()
+        .find(|piece| piece.kind == SegmentKind::Code && piece.range.len() > MAX_FRAGMENT_BYTES)
+    {
+        return Err(MemoryError::ContextOverLimit(format!(
+            "an unsplittable fenced code block of {} bytes exceeds the cap of {MAX_FRAGMENT_BYTES} bytes",
+            piece.range.len()
+        )));
+    }
+    Ok(())
+}
+
+/// Re-split every `body` piece over [`MAX_FRAGMENT_BYTES`] with
+/// [`chunk_text`] — the same re-chunker `compile_context` itself uses for an
+/// oversized fragment. A `jsonl` piece's decoded `content_override` has no
+/// byte-aligned mapping back to the raw (JSON-escaped) source line, so its
+/// re-split children all keep the ORIGINAL line's full byte range — a
+/// documented, deliberately narrow trade-off: the byte-range-covers-the-
+/// transcript property holds at the turn level regardless, and a single
+/// JSONL line's `content` exceeding 1 MiB is an extreme edge case.
+fn resplit_oversized_bodies(text: &str, pieces: Vec<RawPiece>) -> Vec<RawPiece> {
+    let chunk_policy = ChunkPolicy {
+        max_chunk_bytes: MAX_FRAGMENT_BYTES,
+        overlap_bytes: 0,
+        boundary: ChunkBoundary::Paragraph,
+    };
+    pieces
+        .into_iter()
+        .flat_map(|piece| resplit_one(text, piece, &chunk_policy))
+        .collect()
+}
+
+fn resplit_one(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<RawPiece> {
+    if piece.kind != SegmentKind::Body {
+        return vec![piece];
+    }
+    let effective_len = piece
+        .content_override
+        .as_ref()
+        .map_or(piece.range.len(), String::len);
+    if effective_len <= MAX_FRAGMENT_BYTES {
+        return vec![piece];
+    }
+    match &piece.content_override {
+        Some(content) => chunk_text(content, chunk_policy)
+            .into_iter()
+            .map(|chunk| RawPiece {
+                kind: SegmentKind::Body,
+                range: piece.range.clone(),
+                turn: piece.turn,
+                role: piece.role.clone(),
+                content_override: Some(chunk.text),
+            })
+            .collect(),
+        None => chunk_text(&text[piece.range.clone()], chunk_policy)
+            .into_iter()
+            .map(|chunk| RawPiece {
+                kind: SegmentKind::Body,
+                range: (piece.range.start + chunk.byte_range.start)
+                    ..(piece.range.start + chunk.byte_range.end),
+                turn: piece.turn,
+                role: piece.role.clone(),
+                content_override: None,
+            })
+            .collect(),
+    }
+}
+
+/// Merge adjacent pieces of the SAME turn and kind when either side is under
+/// `min_bytes` — see the module docs' step 4. A `jsonl` piece never merges
+/// with another (each holds its own unique `turn`, since `jsonl` is
+/// one-line-one-turn by construction), nor does any piece carrying a
+/// `content_override` (merging would require re-deriving a combined decoded
+/// string, which is not meaningful once JSON escaping is involved).
+fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
+    let mut merged: Vec<RawPiece> = Vec::new();
+    for piece in pieces {
+        let mergeable = merged.last().is_some_and(|last: &RawPiece| {
+            last.turn == piece.turn
+                && last.kind == piece.kind
+                && last.content_override.is_none()
+                && piece.content_override.is_none()
+                && last.range.end == piece.range.start
+                && (last.range.len() < min_bytes || piece.range.len() < min_bytes)
+        });
+        if mergeable {
+            // Safe: `mergeable` only true when `merged` is non-empty.
+            merged
+                .last_mut()
+                .expect("checked non-empty above")
+                .range
+                .end = piece.range.end;
+        } else {
+            merged.push(piece);
+        }
+    }
+    merged
+}
+
+// --- Assembly ------------------------------------------------------------
+
+/// Build the final [`TranscriptSegment`] for one normalized piece:
+/// `metadata = {role, turn}`, plus `cache: true` when
+/// [`SegmentationPolicy::cache_system_turn`] applies (turn 0, role
+/// case-insensitively `"system"`).
+fn build_segment(text: &str, piece: RawPiece, policy: &SegmentationPolicy) -> TranscriptSegment {
+    let content = piece
+        .content_override
+        .clone()
+        .unwrap_or_else(|| text[piece.range.clone()].to_owned());
+
+    let mut metadata = Map::new();
+    metadata.insert(
+        "role".to_owned(),
+        piece.role.clone().map_or(Value::Null, Value::String),
+    );
+    metadata.insert("turn".to_owned(), Value::Number(piece.turn.into()));
+    let is_first_turn_system = piece.turn == 0
+        && piece
+            .role
+            .as_deref()
+            .is_some_and(|role| role.eq_ignore_ascii_case("system"));
+    if policy.cache_system_turn && is_first_turn_system {
+        metadata.insert("cache".to_owned(), Value::Bool(true));
+    }
+
+    let fragment = ContextFragment {
+        id: None,
+        content,
+        path: None,
+        kind: piece.kind.fragment_kind().map(str::to_owned),
+        priority: None,
+        metadata: Some(metadata),
+        media: None,
+    };
+    TranscriptSegment {
+        fragment,
+        turn: piece.turn,
+        role: piece.role,
+        kind: piece.kind,
+        byte_start: piece.range.start,
+        byte_end: piece.range.end,
+    }
+}
+
+#[cfg(test)]
+#[path = "segment_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/context/segment_tests.rs
+++ b/crates/velesdb-memory/src/context/segment_tests.rs
@@ -1,0 +1,327 @@
+//! TDD suite for [`super::segment_transcript`] (V2b-2): format detection,
+//! turn splitting, fence/log/body sub-segmentation, and normalization
+//! (merge/re-split/caps).
+
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+use super::{segment_transcript, SegmentFormat, SegmentKind, SegmentationPolicy};
+use crate::error::MemoryError;
+use crate::limits::{MAX_FRAGMENTS, MAX_FRAGMENT_BYTES};
+
+fn policy() -> SegmentationPolicy {
+    SegmentationPolicy::default()
+}
+
+#[test]
+fn plain_text_without_markers_is_single_body_segment() {
+    // Given plain prose with no role marker anywhere
+    let text = "The deploy pipeline is green.\nNothing else to report.";
+
+    // When segmenting with the default (auto) policy
+    let outcome = segment_transcript(text, &policy()).expect("segments");
+
+    // Then it detects plain format and yields exactly one body segment
+    // covering the whole text, with a null role
+    assert_eq!(outcome.format_detected, SegmentFormat::Plain);
+    assert_eq!(outcome.segments.len(), 1);
+    let segment = &outcome.segments[0];
+    assert_eq!(segment.kind, SegmentKind::Body);
+    assert_eq!(segment.role, None);
+    assert_eq!(segment.turn, 0);
+    assert_eq!(segment.fragment.content, text);
+    assert_eq!(segment.byte_start, 0);
+    assert_eq!(segment.byte_end, text.len());
+}
+
+#[test]
+fn user_assistant_markers_split_turns() {
+    // Given a two-turn plain transcript
+    let text = "User: what is the deploy status?\nAssistant: it is green.\n";
+
+    // When segmenting
+    let outcome = segment_transcript(text, &policy()).expect("segments");
+
+    // Then it splits into two turns with the expected roles, in order,
+    // partitioning the transcript
+    assert_eq!(outcome.format_detected, SegmentFormat::Plain);
+    let roles: Vec<Option<String>> = outcome.segments.iter().map(|s| s.role.clone()).collect();
+    assert_eq!(
+        roles,
+        vec![Some("User".to_owned()), Some("Assistant".to_owned())]
+    );
+    assert_eq!(outcome.segments[0].turn, 0);
+    assert_eq!(outcome.segments[1].turn, 1);
+    assert!(outcome.segments[0].fragment.content.starts_with("User:"));
+    assert!(outcome.segments[1]
+        .fragment
+        .content
+        .starts_with("Assistant:"));
+}
+
+#[test]
+fn jsonl_roles_detected_and_forced_format_errors_on_bad_line() {
+    // Given a well-formed JSONL transcript
+    let good =
+        "{\"role\":\"system\",\"content\":\"be terse\"}\n{\"role\":\"user\",\"content\":\"hi\"}\n";
+
+    // When segmenting with format forced to jsonl
+    let mut jsonl_policy = policy();
+    jsonl_policy.format = SegmentFormat::Jsonl;
+    let outcome = segment_transcript(good, &jsonl_policy).expect("valid jsonl segments");
+
+    // Then roles come straight from the parsed JSON, one turn per line
+    assert_eq!(outcome.format_detected, SegmentFormat::Jsonl);
+    assert_eq!(outcome.segments.len(), 2);
+    assert_eq!(outcome.segments[0].role, Some("system".to_owned()));
+    assert_eq!(outcome.segments[0].fragment.content, "be terse");
+    assert_eq!(outcome.segments[1].role, Some("user".to_owned()));
+    assert_eq!(outcome.segments[1].fragment.content, "hi");
+
+    // Given a transcript with one bad line
+    let bad = "{\"role\":\"system\",\"content\":\"be terse\"}\nnot json at all\n";
+
+    // When forcing jsonl on it
+    let err = segment_transcript(bad, &jsonl_policy).expect_err("bad line must error");
+
+    // Then it is a hard, actionable error — never a silent fallback to plain
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains("line 2"), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn code_fence_becomes_atomic_code_segment() {
+    // Given a turn with a fenced code block
+    let text = "User: run this\n```rust\nfn main() {}\n```\nUser: thanks\n";
+
+    // When segmenting
+    let outcome = segment_transcript(text, &policy()).expect("segments");
+
+    // Then the fence is its own segment, tagged kind = code
+    let code_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Code)
+        .collect();
+    assert_eq!(code_segments.len(), 1);
+    assert_eq!(code_segments[0].fragment.kind.as_deref(), Some("code"));
+    assert!(code_segments[0].fragment.content.contains("fn main()"));
+}
+
+#[test]
+fn log_run_with_volatile_prefixes_becomes_log_segment() {
+    // Given 8 consecutive lines with distinct ISO timestamps (volatile
+    // prefix), all otherwise identical
+    let mut text = String::from("User: what happened?\n");
+    for i in 0..8 {
+        writeln!(text, "2026-07-18T10:00:0{i}Z request handled")
+            .expect("write to String never fails");
+    }
+
+    // When segmenting
+    let outcome = segment_transcript(&text, &policy()).expect("segments");
+
+    // Then the run becomes one log segment
+    let log_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Log)
+        .collect();
+    assert_eq!(log_segments.len(), 1, "{outcome:?}");
+    assert_eq!(log_segments[0].fragment.kind.as_deref(), Some("log"));
+}
+
+#[test]
+fn repeated_lines_run_becomes_log_segment() {
+    // Given 8 consecutive identical lines with no timestamp at all
+    let mut text = String::from("User: watch this\n");
+    for _ in 0..8 {
+        text.push_str("connection retry failed\n");
+    }
+
+    // When segmenting
+    let outcome = segment_transcript(&text, &policy()).expect("segments");
+
+    // Then the repeated-line run still becomes one log segment
+    let log_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Log)
+        .collect();
+    assert_eq!(log_segments.len(), 1, "{outcome:?}");
+}
+
+#[test]
+fn system_turn_gets_cache_metadata() {
+    // Given a transcript opening with a system turn
+    let text = "System: be terse.\nUser: hello\n";
+
+    // When segmenting with cache_system_turn on (the default)
+    let outcome = segment_transcript(text, &policy()).expect("segments");
+
+    // Then the system turn's segment(s) carry metadata.cache = true, and no
+    // other turn does
+    let system_segment = outcome
+        .segments
+        .iter()
+        .find(|s| s.turn == 0)
+        .expect("first turn segment");
+    let metadata = system_segment.fragment.metadata.as_ref().expect("metadata");
+    assert_eq!(metadata.get("cache"), Some(&Value::Bool(true)));
+
+    let other_segment = outcome
+        .segments
+        .iter()
+        .find(|s| s.turn == 1)
+        .expect("second turn segment");
+    let other_metadata = other_segment.fragment.metadata.as_ref().expect("metadata");
+    assert_eq!(other_metadata.get("cache"), None);
+}
+
+#[test]
+fn tiny_segments_merge_within_turn_same_kind() {
+    // Given a single turn with two tiny, byte-adjacent fenced code blocks
+    // (no plain text between them) — two distinct `code` pieces of the same
+    // turn, each well under min_segment_bytes
+    let text = "User: two blocks\n```\na\n```\n```\nb\n```\n";
+
+    // When segmenting with a generous min_segment_bytes
+    let mut merge_policy = policy();
+    merge_policy.min_segment_bytes = 4096;
+    let outcome = segment_transcript(text, &merge_policy).expect("segments");
+
+    // Then the two adjacent code segments collapse into one, and the
+    // outcome reports the merge — the preceding body segment (a different
+    // kind) stays separate
+    let code_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Code)
+        .collect();
+    assert_eq!(code_segments.len(), 1, "{outcome:?}");
+    assert!(code_segments[0].fragment.content.contains('a'));
+    assert!(code_segments[0].fragment.content.contains('b'));
+    assert!(outcome.merged_segments > 0);
+}
+
+#[test]
+fn segmentation_twice_is_byte_identical() {
+    // Given a mixed transcript (markers, a fence, a log run)
+    let mut text =
+        String::from("System: be terse\nUser: run it\n```rust\nfn f() {}\n```\nAssistant: watch\n");
+    for i in 0..8 {
+        writeln!(text, "2026-07-18T10:00:0{i}Z tick").expect("write to String never fails");
+    }
+
+    // When segmenting it twice
+    let first = segment_transcript(&text, &policy()).expect("first segmentation");
+    let second = segment_transcript(&text, &policy()).expect("second segmentation");
+
+    // Then every field of every segment matches exactly
+    assert_eq!(first.segments.len(), second.segments.len());
+    for (a, b) in first.segments.iter().zip(second.segments.iter()) {
+        assert_eq!(a.turn, b.turn);
+        assert_eq!(a.role, b.role);
+        assert_eq!(a.kind, b.kind);
+        assert_eq!(a.byte_start, b.byte_start);
+        assert_eq!(a.byte_end, b.byte_end);
+        assert_eq!(a.fragment.content, b.fragment.content);
+    }
+    assert_eq!(first.format_detected, second.format_detected);
+    assert_eq!(first.merged_segments, second.merged_segments);
+}
+
+#[test]
+fn segment_ranges_cover_transcript_exactly() {
+    // Given a mixed transcript (markers, a fence, a log run, tiny bits)
+    let mut text =
+        String::from("System: be terse\nUser: run it\n```rust\nfn f() {}\n```\nAssistant: watch\n");
+    for i in 0..8 {
+        writeln!(text, "2026-07-18T10:00:0{i}Z tick").expect("write to String never fails");
+    }
+
+    // When segmenting
+    let outcome = segment_transcript(&text, &policy()).expect("segments");
+
+    // Then the segments' byte ranges, sorted, partition [0, text.len())
+    // exactly — no gaps, no overlaps
+    let mut ranges: Vec<(usize, usize)> = outcome
+        .segments
+        .iter()
+        .map(|s| (s.byte_start, s.byte_end))
+        .collect();
+    ranges.sort_unstable();
+    let mut cursor = 0_usize;
+    for (start, end) in ranges {
+        assert_eq!(start, cursor, "gap or overlap at byte {cursor}");
+        cursor = end;
+    }
+    assert_eq!(cursor, text.len());
+}
+
+#[test]
+fn over_max_fragments_errors_with_actionable_message() {
+    // Given a transcript whose plain markers alone produce more turns (and
+    // thus segments) than MAX_FRAGMENTS allows, even with the default merge
+    // threshold too small to fold them together across different turns
+    let mut text = String::new();
+    for i in 0..=MAX_FRAGMENTS {
+        writeln!(text, "User: turn {i}").expect("write to String never fails");
+    }
+    let mut tight_policy = policy();
+    tight_policy.min_segment_bytes = 0; // never merge — every turn stays its own segment
+
+    // When segmenting
+    let err = segment_transcript(&text, &tight_policy).expect_err("over the fragment cap");
+
+    // Then it is an actionable error naming the remedy
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains("min_segment_bytes"), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn oversized_fence_errors() {
+    // Given a single fenced code block bigger than MAX_FRAGMENT_BYTES
+    let mut text = String::from("```\n");
+    text.push_str(&"a".repeat(MAX_FRAGMENT_BYTES + 1));
+    text.push_str("\n```\n");
+
+    // When segmenting
+    let err = segment_transcript(&text, &policy()).expect_err("oversized fence");
+
+    // Then it is a hard error, never a silent truncation
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains("fenced"), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}
+
+#[test]
+fn transcript_over_cap_rejected() {
+    use crate::limits::MAX_TRANSCRIPT_BYTES;
+
+    // Given a transcript bigger than MAX_TRANSCRIPT_BYTES
+    let text = "a".repeat(MAX_TRANSCRIPT_BYTES + 1);
+
+    // When segmenting
+    let err = segment_transcript(&text, &policy()).expect_err("over the transcript cap");
+
+    // Then it is rejected before any segmentation work
+    match err {
+        MemoryError::ContextOverLimit(msg) => {
+            assert!(msg.contains(&MAX_TRANSCRIPT_BYTES.to_string()), "{msg}");
+        }
+        other => panic!("expected ContextOverLimit, got {other:?}"),
+    }
+}

--- a/crates/velesdb-memory/src/context/segment_tests.rs
+++ b/crates/velesdb-memory/src/context/segment_tests.rs
@@ -325,3 +325,150 @@ fn transcript_over_cap_rejected() {
         other => panic!("expected ContextOverLimit, got {other:?}"),
     }
 }
+
+// --- Adversarial-review fixes (post-PR #1500) -------------------------------
+
+#[test]
+fn oversized_log_run_is_resplit_not_left_over_the_cap() {
+    // Given ONE contiguous log run whose lines are individually tiny but
+    // together exceed MAX_FRAGMENT_BYTES (B1 repro: ~1 MiB+ of timestamped
+    // lines) — reject_oversized_fences only ever looked at `code` pieces
+    // and resplit_oversized_bodies only ever looked at `body` pieces, so a
+    // `log` piece this large used to sail through unresplit and unrejected,
+    // only to blow up later at compile() time with a confusing "a fragment
+    // of N bytes" error the caller never directly supplied.
+    let mut text = String::from("User: watch this\n");
+    let line_count = (MAX_FRAGMENT_BYTES / 30) + 100;
+    for i in 0..line_count {
+        writeln!(text, "2026-07-18T10:00:00Z tick {i}").expect("write to String never fails");
+    }
+    assert!(
+        text.len() > MAX_FRAGMENT_BYTES,
+        "test setup must exceed the cap"
+    );
+
+    // When segmenting
+    let outcome = segment_transcript(&text, &policy()).expect("must segment, never error");
+
+    // Then the run is resplit into several `log` segments, none over the
+    // cap, and the byte ranges still partition the transcript exactly
+    let log_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Log)
+        .collect();
+    assert!(log_segments.len() > 1, "{outcome:?}");
+    for segment in &log_segments {
+        assert!(
+            segment.fragment.content.len() <= MAX_FRAGMENT_BYTES,
+            "log segment of {} bytes exceeds the cap of {MAX_FRAGMENT_BYTES} bytes",
+            segment.fragment.content.len()
+        );
+    }
+    let mut ranges: Vec<(usize, usize)> = outcome
+        .segments
+        .iter()
+        .map(|s| (s.byte_start, s.byte_end))
+        .collect();
+    ranges.sort_unstable();
+    let mut cursor = 0_usize;
+    for (start, end) in ranges {
+        assert_eq!(start, cursor, "gap or overlap at byte {cursor}");
+        cursor = end;
+    }
+    assert_eq!(cursor, text.len());
+}
+
+#[test]
+fn merge_never_recombines_a_resplit_body_over_the_fragment_cap() {
+    // Given a body whose paragraph split leaves one chunk near the cap and
+    // a tiny trailing remainder (M1 repro: ~1 MiB body + a tail under
+    // min_segment_bytes) — merge_tiny used to merge purely on "one side is
+    // small", with no check that the COMBINED size stays under the cap.
+    let big_paragraph = "a".repeat(MAX_FRAGMENT_BYTES - 5);
+    let text = format!("User: {big_paragraph}\n\ntiny tail\n");
+
+    // When segmenting with the default (small) min_segment_bytes, which
+    // would otherwise want to merge the tiny tail into its same-turn,
+    // same-kind neighbor
+    let outcome = segment_transcript(&text, &policy()).expect("segments");
+
+    // Then no resulting body segment exceeds the cap
+    let body_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Body)
+        .collect();
+    assert!(body_segments.len() >= 2, "{outcome:?}");
+    for segment in &body_segments {
+        assert!(
+            segment.fragment.content.len() <= MAX_FRAGMENT_BYTES,
+            "body segment of {} bytes exceeds the cap of {MAX_FRAGMENT_BYTES} bytes",
+            segment.fragment.content.len()
+        );
+    }
+}
+
+#[test]
+fn merge_never_recombines_adjacent_fences_over_the_fragment_cap() {
+    // Given two adjacent code fences whose combined size exceeds
+    // MAX_FRAGMENT_BYTES even though each one alone is under the cap (M1's
+    // second repro shape)
+    let near_cap_body = "b".repeat(MAX_FRAGMENT_BYTES - 14);
+    let text = format!("User: two blocks\n```\na\n```\n```\n{near_cap_body}\n```\n");
+
+    // When segmenting with the default (small) min_segment_bytes
+    let outcome = segment_transcript(&text, &policy()).expect("segments");
+
+    // Then the two fences never merge into one oversized fragment
+    let code_segments: Vec<_> = outcome
+        .segments
+        .iter()
+        .filter(|s| s.kind == SegmentKind::Code)
+        .collect();
+    assert_eq!(code_segments.len(), 2, "{outcome:?}");
+    for segment in &code_segments {
+        assert!(
+            segment.fragment.content.len() <= MAX_FRAGMENT_BYTES,
+            "code segment of {} bytes exceeds the cap of {MAX_FRAGMENT_BYTES} bytes",
+            segment.fragment.content.len()
+        );
+    }
+}
+
+#[test]
+fn jsonl_tolerates_a_blank_line_between_turns() {
+    // Given a JSONL transcript with a blank line between two real turns —
+    // jsonl_pieces used to fail to parse the blank line as `{role,
+    // content}`, and detect_and_segment's Auto branch swallowed that
+    // error, silently falling back to a single roleless plain turn for an
+    // otherwise perfectly valid JSONL transcript.
+    let text = "{\"role\":\"system\",\"content\":\"be terse\"}\n\n{\"role\":\"user\",\"content\":\"hi\"}\n";
+
+    // When segmenting with auto-detection (the default)
+    let outcome = segment_transcript(text, &policy()).expect("segments");
+
+    // Then it is still recognized as jsonl, with two correctly-numbered
+    // turns and roles taken straight from the JSON
+    assert_eq!(outcome.format_detected, SegmentFormat::Jsonl, "{outcome:?}");
+    assert_eq!(outcome.segments.len(), 2, "{outcome:?}");
+    assert_eq!(outcome.segments[0].turn, 0);
+    assert_eq!(outcome.segments[0].role, Some("system".to_owned()));
+    assert_eq!(outcome.segments[1].turn, 1);
+    assert_eq!(outcome.segments[1].role, Some("user".to_owned()));
+
+    // And the byte ranges still partition the transcript exactly — the
+    // blank line's bytes must land somewhere, never vanish
+    let mut ranges: Vec<(usize, usize)> = outcome
+        .segments
+        .iter()
+        .map(|s| (s.byte_start, s.byte_end))
+        .collect();
+    ranges.sort_unstable();
+    let mut cursor = 0_usize;
+    for (start, end) in ranges {
+        assert_eq!(start, cursor, "gap or overlap at byte {cursor}");
+        cursor = end;
+    }
+    assert_eq!(cursor, text.len());
+}

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -119,6 +119,41 @@ pub enum MemoryError {
     #[error("working context codec error: {0}")]
     WorkingContextCodec(String),
 
+    /// A context fragment carried a `path` (V2b-1 path ingestion) but no
+    /// filesystem root is configured (`VELESDB_MEMORY_INGEST_ROOTS` unset or
+    /// empty) — the tool is always advertised, but ingestion itself is
+    /// opt-in. Also the fallback the pure compiler core reports when a
+    /// `path` fragment reaches it unresolved (e.g. a binding that has no
+    /// ingest adapter, such as the WASM build): [`crate::context`] never
+    /// performs I/O itself, so an un-cleared `path` field always means the
+    /// adapter that should have resolved or rejected it was skipped.
+    #[cfg(feature = "context")]
+    #[error(
+        "path ingestion is disabled: set VELESDB_MEMORY_INGEST_ROOTS to enable the `path` field"
+    )]
+    IngestDisabled,
+
+    /// A `path`-referenced fragment resolved (after following symlinks) to a
+    /// location outside every configured ingest root. Carries the
+    /// caller-supplied `path` VERBATIM, never the canonicalized target — the
+    /// resolved location may be filesystem structure the caller has no
+    /// business learning about (e.g. that a symlink escapes).
+    #[cfg(feature = "context")]
+    #[error("path '{0}' is outside the configured ingest roots")]
+    IngestOutsideRoots(String),
+
+    /// A `path`-referenced fragment could not be read for any reason other
+    /// than escaping the ingest roots: a relative path (an MCP server's
+    /// working directory is unpredictable, so only absolute paths are
+    /// accepted), a path that does not exist or is not a plain file
+    /// (directories are rejected), a `path` fragment combined with
+    /// non-empty `content` or a `media` payload (exactly one of `path`,
+    /// `content`, `media` is accepted), or a file whose bytes are not valid
+    /// UTF-8.
+    #[cfg(feature = "context")]
+    #[error("cannot ingest path: {0}")]
+    IngestPath(String),
+
     /// A `remember` link failed after the fact was stored AND the
     /// compensating rollback delete also failed — unlike every other error
     /// from `remember`, the fact **remains stored**. Both errors are
@@ -154,6 +189,10 @@ impl MemoryError {
             | Self::MetadataTooLarge { .. } => ErrorCategory::InvalidInput,
             #[cfg(feature = "context")]
             Self::ContextBudget { .. } | Self::ContextOverLimit(_) => ErrorCategory::InvalidInput,
+            #[cfg(feature = "context")]
+            Self::IngestDisabled | Self::IngestOutsideRoots(_) | Self::IngestPath(_) => {
+                ErrorCategory::InvalidInput
+            }
             #[cfg(feature = "context")]
             Self::UnknownHandle(_) => ErrorCategory::NotFound,
             #[cfg(feature = "context")]

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -67,6 +67,28 @@ pub const MAX_MEDIA_BYTES: usize = 4 * 1024 * 1024;
 /// screenshot-heavy session while bounding decode work.
 pub const MAX_TOTAL_MEDIA_BYTES: usize = 64 * 1024 * 1024;
 
+/// Maximum accepted size of a single file read through a `path`-referenced
+/// context fragment (V2b-1 path ingestion) — 1 MiB, the same ceiling as
+/// [`MAX_FRAGMENT_BYTES`]: an ingested file becomes an ordinary fragment's
+/// `content`, so it must not exceed what a fragment is allowed to carry.
+/// Checked from `fs::metadata` BEFORE the file is read, and re-checked after
+/// (`fs::read` can race a concurrent write) — never clamped, always refused,
+/// so a truncated read can never silently masquerade as the whole file.
+pub const MAX_INGEST_FILE_BYTES: usize = 1_048_576;
+
+/// Maximum number of `path`-referenced fragments accepted in one compile
+/// request — bounds the filesystem work (and open-file churn) a single call
+/// can demand, symmetric to [`MAX_FRAGMENTS`] for inline fragments.
+pub const MAX_INGEST_FILES: usize = 64;
+
+/// Aggregate cap on the bytes read across every `path`-referenced fragment of
+/// one request (64 MiB) — symmetric to [`MAX_TOTAL_MEDIA_BYTES`]. Without it,
+/// [`MAX_INGEST_FILES`] fragments each at [`MAX_INGEST_FILE_BYTES`] would
+/// still admit 64 MiB (the two caps happen to coincide at these values), but
+/// this cap is checked independently and first — a future change to either
+/// per-item constant must not silently loosen the aggregate ceiling.
+pub const MAX_TOTAL_INGEST_BYTES: usize = 64 * 1024 * 1024;
+
 /// Cap on a caller-supplied token budget. A budget cannot force allocations
 /// by itself, but an absurd value would make the savings arithmetic
 /// meaningless, so adapters clamp to this ceiling instead of erroring.

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -89,6 +89,14 @@ pub const MAX_INGEST_FILES: usize = 64;
 /// per-item constant must not silently loosen the aggregate ceiling.
 pub const MAX_TOTAL_INGEST_BYTES: usize = 64 * 1024 * 1024;
 
+/// Maximum accepted size of a `compile_transcript` transcript (V2b-2), inline
+/// or `path`-referenced — 8 MiB. The ONE caller-facing shape allowed to read
+/// past the ordinary [`MAX_INGEST_FILE_BYTES`]/[`MAX_FRAGMENT_BYTES`] 1 MiB
+/// ceiling: a transcript is segmented into sub-1-MiB pieces immediately after
+/// being read (see `context::segment`), so it is never itself compiled as one
+/// oversized fragment — only the raw pre-segmentation read gets the wider cap.
+pub const MAX_TRANSCRIPT_BYTES: usize = 8 * 1024 * 1024;
+
 /// Cap on a caller-supplied token budget. A budget cannot force allocations
 /// by itself, but an absurd value would make the savings arithmetic
 /// meaningless, so adapters clamp to this ceiling instead of erroring.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -8,6 +8,9 @@
 //! `--features extract`, set `VELESDB_MEMORY_EXTRACTOR=ollama` to enable the
 //! `remember_extracted` tool (auto text → fact↔topic graph). Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
+//! Set `VELESDB_MEMORY_INGEST_ROOTS` (a `PATH`-list of directories) to let
+//! `compile_context`/`explain_compilation` fragments reference a file by
+//! `path` instead of inline `content`; unset disables that field entirely.
 //! Run with `--version` (or `-V`) to print the binary's version and exit,
 //! without opening the store.
 
@@ -46,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // worker thread on a synchronous operation.
     let embedder = build_embedder()?;
     let service = open_store_with_actionable_lock_error(&store_path, embedder)?;
-    let server = apply_default_ttl(build_server(service)?)?;
+    let server = apply_ingest_roots(apply_default_ttl(build_server(service)?)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
         spawn_orphan_watchdog(original_parent);
@@ -207,6 +210,33 @@ fn apply_default_ttl(server: McpServer) -> Result<McpServer, Box<dyn std::error:
         }
         Err(_) => Ok(server),
     }
+}
+
+/// Apply `VELESDB_MEMORY_INGEST_ROOTS` (V2b-1) — a platform `PATH`-list of
+/// directories a `path`-referenced context fragment may read from — enabling
+/// the `compile_context`/`explain_compilation` `path` field. Unset or empty
+/// leaves path ingestion disabled (every `path` fragment then fails with an
+/// explicit error, not a silent no-op). Parsed here, at startup, so a
+/// misconfigured root (missing directory, broken symlink) fails fast instead
+/// of surfacing on a caller's first `path` fragment.
+#[cfg(feature = "context")]
+fn apply_ingest_roots(server: McpServer) -> Result<McpServer, Box<dyn std::error::Error>> {
+    match std::env::var("VELESDB_MEMORY_INGEST_ROOTS") {
+        Ok(raw) if !raw.trim().is_empty() => {
+            let roots = velesdb_memory::context::IngestRoots::parse(&raw)?;
+            Ok(server.with_ingest_roots(roots))
+        }
+        _ => Ok(server),
+    }
+}
+
+/// Without the `context` feature there is no `IngestRoots` type (or `path`
+/// field) to configure. The `Result` return mirrors the `context` arm's
+/// signature so the caller is identical for both builds.
+#[cfg(not(feature = "context"))]
+#[allow(clippy::unnecessary_wraps)]
+fn apply_ingest_roots(server: McpServer) -> Result<McpServer, Box<dyn std::error::Error>> {
+    Ok(server)
 }
 
 /// Build the MCP server, attaching an extraction backend from

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -79,6 +79,12 @@ pub struct McpServer {
     /// specify their own `ttl_seconds`. `None` (the default) stores permanently.
     /// Set from `VELESDB_MEMORY_DEFAULT_TTL` by the binary.
     default_ttl: Option<u64>,
+    /// Allowlisted filesystem roots for `path`-referenced context fragments
+    /// (V2b-1). `None` (the default) disables path ingestion entirely — every
+    /// `path` fragment fails with an explicit error. Set from
+    /// `VELESDB_MEMORY_INGEST_ROOTS` by the binary via [`Self::with_ingest_roots`].
+    #[cfg(all(feature = "context", not(target_arch = "wasm32")))]
+    ingest_roots: Option<crate::context::IngestRoots>,
     tool_router: ToolRouter<McpServer>,
 }
 
@@ -91,6 +97,8 @@ impl McpServer {
             service: Arc::new(service),
             extractor: None,
             default_ttl: None,
+            #[cfg(all(feature = "context", not(target_arch = "wasm32")))]
+            ingest_roots: None,
             tool_router: Self::combined_router(),
         }
     }
@@ -122,6 +130,18 @@ impl McpServer {
     #[must_use]
     pub fn with_default_ttl(mut self, ttl_seconds: u64) -> Self {
         self.default_ttl = (ttl_seconds > 0).then_some(ttl_seconds);
+        self
+    }
+
+    /// Enable path ingestion (V2b-1): `compile_context` and
+    /// `explain_compilation` fragments carrying `path` are resolved against
+    /// this allowlist before compilation. Without this (the default), every
+    /// `path` fragment fails with an explicit "ingestion disabled" error —
+    /// same pattern as [`Self::with_extractor`].
+    #[cfg(all(feature = "context", not(target_arch = "wasm32")))]
+    #[must_use]
+    pub fn with_ingest_roots(mut self, roots: crate::context::IngestRoots) -> Self {
+        self.ingest_roots = Some(roots);
         self
     }
 
@@ -385,7 +405,7 @@ impl McpServer {
 /// "context")]` variant since the context-compiler tools only exist in that
 /// build.
 #[cfg(feature = "context")]
-const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, recall, recall_fused, recall_where, relate, forget, feedback, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); (2) the deterministic context compiler — compile_context, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. Nothing ever leaves the machine.";
+const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, recall, recall_fused, recall_where, relate, forget, feedback, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); (2) the deterministic context compiler — compile_context, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories. Nothing ever leaves the machine.";
 
 #[cfg(not(feature = "context"))]
 const SERVER_INSTRUCTIONS: &str = "Local-first memory for AI agents: remember facts, recall them \

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -22,7 +22,7 @@ use super::{join_error, to_error, McpServer};
 use crate::context::wire::{stringify_id_fields, ID_KEYS};
 use crate::context::{
     suggest_token_budget, CompilePolicy, CompileRequest, CompiledContext, ContextCompiler,
-    ContextDecision, ContextSavings, MediaRef, SuggestedBudget, WorkingContext,
+    ContextDecision, ContextFragment, ContextSavings, MediaRef, SuggestedBudget, WorkingContext,
     WorkingContextSession,
 };
 
@@ -223,16 +223,44 @@ pub(super) struct SuggestBudgetParams {
 
 #[tool_router(router = context_tool_router, vis = "pub(super)")]
 impl McpServer {
+    /// Resolve every `path`-carrying fragment of `fragments` against this
+    /// server's configured ingest roots (V2b-1), turning `path` into
+    /// ordinary `content` in place before the request reaches the compiler
+    /// — the adapter-side pre-pass `context::ingest` describes. A no-op
+    /// when no fragment carries a `path`. Shared by `compile_context` and
+    /// `explain_compilation`, the only two tools that accept a `path`
+    /// fragment.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_ingest(&self, fragments: &mut [ContextFragment]) -> Result<(), ErrorData> {
+        crate::context::ingest::resolve_fragments(fragments, self.ingest_roots.as_ref())
+            .map_err(to_error)
+    }
+
+    /// This crate never targets `wasm32` with the `mcp` feature on (the
+    /// server pulls in `rmcp`/`tokio`), so this arm exists only to keep the
+    /// call site uniform if that ever changes — a `path` fragment simply
+    /// reports the same "ingestion disabled" error the pure compiler core
+    /// would (see `context::validate`), since there is no adapter here to
+    /// resolve it.
+    #[cfg(target_arch = "wasm32")]
+    fn resolve_ingest(&self, fragments: &mut [ContextFragment]) -> Result<(), ErrorData> {
+        if fragments.iter().any(|f| f.path.is_some()) {
+            return Err(to_error(crate::error::MemoryError::IngestDisabled));
+        }
+        Ok(())
+    }
+
     #[tool(
         name = "compile_context",
-        description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Each fragment's own `metadata` is capped at 64 KiB serialized. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, token-savings insights, and `warnings` — a mechanical shortlist of externalized fragments relevant enough to the query that they are worth a second look, so checking `decisions` by hand is only needed when `warnings` is non-empty and still ambiguous. `policy.slim_response` (default false) empties `sections`/`decisions` from the response — keep it off when you need the audit trail, or re-compile without it later (compilation is deterministic). `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
+        description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Each fragment's own `metadata` is capped at 64 KiB serialized. A fragment may set `path` (an absolute filesystem path) instead of inline `content` to ingest a file by reference — exactly one of `path`, `content`, or `media` per fragment; requires the server to be started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories, and the resolved file must be plain UTF-8 text under 1 MiB. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, token-savings insights, and `warnings` — a mechanical shortlist of externalized fragments relevant enough to the query that they are worth a second look, so checking `decisions` by hand is only needed when `warnings` is non-empty and still ambiguous. `policy.slim_response` (default false) empties `sections`/`decisions` from the response — keep it off when you need the audit trail, or re-compile without it later (compilation is deterministic). `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
         input_schema = wire_safe_input_schema::<CompileRequest>(),
         output_schema = wire_safe_output_schema::<CompiledContext>()
     )]
     async fn compile_context(
         &self,
-        Parameters(request): Parameters<CompileRequest>,
+        Parameters(mut request): Parameters<CompileRequest>,
     ) -> Result<Json<Value>, ErrorData> {
+        self.resolve_ingest(&mut request.fragments)?;
         let ids_as_strings = request.policy.as_ref().is_some_and(|p| p.ids_as_strings);
         let service = Arc::clone(&self.service);
         let compiled = tokio::task::spawn_blocking(move || {
@@ -263,7 +291,7 @@ impl McpServer {
 
     #[tool(
         name = "explain_compilation",
-        description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
+        description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was; a `path` fragment is likewise re-read from disk, so the decision reflects the file's CURRENT content, not necessarily what the original compile_context call saw. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
         input_schema = wire_safe_input_schema::<ExplainCompilationParams>(),
         output_schema = wire_safe_output_schema::<ContextDecision>()
     )]
@@ -273,10 +301,11 @@ impl McpServer {
     ) -> Result<Json<Value>, ErrorData> {
         let service = Arc::clone(&self.service);
         let ExplainCompilationParams {
-            request,
+            mut request,
             fragment_id,
             fragment_index,
         } = params;
+        self.resolve_ingest(&mut request.fragments)?;
         if let Some(index) = fragment_index {
             let fragment_count = request.fragments.len();
             if index >= fragment_count {

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -407,16 +407,30 @@ impl McpServer {
             segmentation,
         } = params;
         let transcript_text = match (transcript, path) {
-            (Some(text), None) if !text.is_empty() => text,
+            (Some(text), None) => text,
             (None, Some(path)) => self.resolve_transcript_path(&path)?,
             _ => {
                 return Err(ErrorData::new(
                     ErrorCode::INVALID_PARAMS,
-                    "exactly one of `transcript` (non-empty) or `path` must be set".to_owned(),
+                    "exactly one of `transcript` or `path` must be set".to_owned(),
                     None,
                 ));
             }
         };
+        // Checked AFTER resolving `path` (not folded into the match guard
+        // above) so an inline empty string and a `path` that resolves to an
+        // empty file are rejected identically — the ingest pipeline itself
+        // happily reads a zero-byte file, so this is the one place that
+        // catches "nothing to compile" regardless of source.
+        if transcript_text.is_empty() {
+            return Err(ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                "the transcript is empty — `transcript` must be non-empty text, or `path` must \
+                 point to a non-empty file"
+                    .to_owned(),
+                None,
+            ));
+        }
         let segmentation_policy = segmentation.unwrap_or_default();
         let outcome =
             segment_transcript(&transcript_text, &segmentation_policy).map_err(to_error)?;

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -21,8 +21,9 @@ use serde_json::Value;
 use super::{join_error, to_error, McpServer};
 use crate::context::wire::{stringify_id_fields, ID_KEYS};
 use crate::context::{
-    suggest_token_budget, CompilePolicy, CompileRequest, CompiledContext, ContextCompiler,
-    ContextDecision, ContextFragment, ContextSavings, MediaRef, SuggestedBudget, WorkingContext,
+    fragment_id, segment_transcript, suggest_token_budget, CompilePolicy, CompileRequest,
+    CompiledContext, ContextCompiler, ContextDecision, ContextFragment, ContextSavings, MediaRef,
+    SegmentFormat, SegmentKind, SegmentationPolicy, SuggestedBudget, WorkingContext,
     WorkingContextSession,
 };
 
@@ -208,6 +209,96 @@ pub(super) struct ListWorkingContextsResult {
     pub sessions: Vec<WorkingContextSession>,
 }
 
+/// Input of the `compile_transcript` tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct CompileTranscriptParams {
+    /// What the agent is working on — drives relevance scoring, exactly like
+    /// `compile_context`'s `query`.
+    pub query: String,
+    /// The raw transcript text (plain, marker-based, or JSONL). Exactly one
+    /// of `transcript` or `path` must be set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transcript: Option<String>,
+    /// Read the transcript from this absolute filesystem path instead of
+    /// inline `transcript` — the same `VELESDB_MEMORY_INGEST_ROOTS`
+    /// allowlist and security pipeline as a `compile_context` fragment's
+    /// `path` (V2b-1), except capped at
+    /// [`crate::limits::MAX_TRANSCRIPT_BYTES`] (8 MiB) instead of the
+    /// ordinary 1 MiB fragment ceiling — the transcript is segmented into
+    /// sub-1-MiB pieces immediately after this read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Hard token ceiling for the assembled content, same as
+    /// `compile_context`'s `token_budget`.
+    pub token_budget: u64,
+    /// Project facet, recorded in provenance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    /// Target model name, for cost insights.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_model: Option<String>,
+    /// Per-request compile policy override, same as `compile_context`'s
+    /// `policy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy: Option<CompilePolicy>,
+    /// Tuning knobs for the transcript segmentation step itself (format,
+    /// merge threshold, system-turn caching). `None` uses
+    /// [`SegmentationPolicy::default`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segmentation: Option<SegmentationPolicy>,
+}
+
+/// One entry of [`SegmentationReport::segments`] — the audit trail of how
+/// `compile_transcript` cut the transcript up, independent of what
+/// `compile_context` then did with the resulting fragments.
+#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct SegmentInfo {
+    /// Position of this segment in `segmentation.segments`, in transcript
+    /// order.
+    pub index: usize,
+    /// Which turn (0-based) this segment belongs to.
+    pub turn: usize,
+    /// The turn's role, when one was determined. `null` for a `plain`
+    /// transcript with no matching marker at all.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// `"body"`, `"code"`, or `"log"`.
+    pub kind: SegmentKind,
+    /// Start byte offset (inclusive) in the original transcript.
+    pub byte_start: usize,
+    /// End byte offset (exclusive) in the original transcript.
+    pub byte_end: usize,
+    /// The id this segment's fragment carries into `context.decisions` —
+    /// content-addressed, same formula as every other `compile_context`
+    /// fragment with no caller-supplied `id`.
+    pub fragment_id: u64,
+}
+
+/// The segmentation audit trail returned alongside `context`.
+#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+pub(super) struct SegmentationReport {
+    /// `"plain"` or `"jsonl"` — the format actually used, never `"auto"`
+    /// even when the request asked for it.
+    pub format_detected: SegmentFormat,
+    /// Every segment, in transcript order.
+    pub segments: Vec<SegmentInfo>,
+    /// How many segments [`SegmentationPolicy::min_segment_bytes`] merging
+    /// eliminated.
+    pub merged_segments: usize,
+}
+
+/// Output of the `compile_transcript` tool.
+#[derive(Debug, serde::Serialize, serde::Deserialize, JsonSchema)]
+pub(super) struct CompileTranscriptResult {
+    /// The compiled context — byte-compatible with `compile_context`'s
+    /// output.
+    pub context: CompiledContext,
+    /// How the transcript was cut into fragments before compilation.
+    pub segmentation: SegmentationReport,
+}
+
 /// Input of the `suggest_budget` tool.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(super) struct SuggestBudgetParams {
@@ -250,6 +341,29 @@ impl McpServer {
         Ok(())
     }
 
+    /// Resolve a `compile_transcript` `path` field against this server's
+    /// configured ingest roots (V2b-2) — the same security pipeline as
+    /// [`Self::resolve_ingest`], but through
+    /// [`crate::context::ingest::resolve_transcript_path`] so the byte cap
+    /// is [`crate::limits::MAX_TRANSCRIPT_BYTES`], not the ordinary 1 MiB
+    /// fragment ceiling.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_transcript_path(&self, path: &str) -> Result<String, ErrorData> {
+        let roots = self
+            .ingest_roots
+            .as_ref()
+            .filter(|roots| roots.is_enabled())
+            .ok_or_else(|| to_error(crate::error::MemoryError::IngestDisabled))?;
+        crate::context::ingest::resolve_transcript_path(path, roots).map_err(to_error)
+    }
+
+    /// `mcp` never targets `wasm32` (see [`Self::resolve_ingest`]'s wasm
+    /// arm) — kept for call-site uniformity.
+    #[cfg(target_arch = "wasm32")]
+    fn resolve_transcript_path(&self, _path: &str) -> Result<String, ErrorData> {
+        Err(to_error(crate::error::MemoryError::IngestDisabled))
+    }
+
     #[tool(
         name = "compile_context",
         description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Each fragment's own `metadata` is capped at 64 KiB serialized. A fragment may set `path` (an absolute filesystem path) instead of inline `content` to ingest a file by reference — exactly one of `path`, `content`, or `media` per fragment; requires the server to be started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories, and the resolved file must be plain UTF-8 text under 1 MiB. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, token-savings insights, and `warnings` — a mechanical shortlist of externalized fragments relevant enough to the query that they are worth a second look, so checking `decisions` by hand is only needed when `warnings` is non-empty and still ambiguous. `policy.slim_response` (default false) empties `sections`/`decisions` from the response — keep it off when you need the audit trail, or re-compile without it later (compilation is deterministic). `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
@@ -270,6 +384,87 @@ impl McpServer {
         .map_err(join_error)?
         .map_err(to_error)?;
         Ok(Json(to_wire_value(&compiled, ids_as_strings)?))
+    }
+
+    #[tool(
+        name = "compile_transcript",
+        description = "One-call shortcut over compile_context for a raw agent-session transcript: deterministically segments it into turns (plain marker-based — System:/User:/Human:/Assistant:/AI:/Tool:/### User/### Assistant — or JSONL, one line per turn) and, within each turn, into code/log/body sub-segments (fenced code blocks stay atomic; runs of 8+ log-like lines collapse the same way abstract.log_dedup would), then compiles the result exactly like compile_context. Exactly one of `transcript` (inline) or `path` (an absolute filesystem path, same VELESDB_MEMORY_INGEST_ROOTS allowlist as compile_context's `path` fragments but capped at 8 MiB) must be set. `segmentation.format` forces plain or jsonl instead of auto-detecting; a forced jsonl format that fails to parse is a hard error, never a silent fallback. The first turn is tagged cache-eligible when it looks like a system prompt (segmentation.cache_system_turn, default true). Returns `context` (byte-compatible with compile_context's output) plus `segmentation` — the detected format and one audit entry (turn, role, kind, byte range, fragment_id) per segment, so a caller can see exactly how the transcript was cut before trusting the compiled result.",
+        input_schema = wire_safe_input_schema::<CompileTranscriptParams>(),
+        output_schema = wire_safe_output_schema::<CompileTranscriptResult>()
+    )]
+    async fn compile_transcript(
+        &self,
+        Parameters(params): Parameters<CompileTranscriptParams>,
+    ) -> Result<Json<Value>, ErrorData> {
+        let CompileTranscriptParams {
+            query,
+            transcript,
+            path,
+            token_budget,
+            project,
+            target_model,
+            policy,
+            segmentation,
+        } = params;
+        let transcript_text = match (transcript, path) {
+            (Some(text), None) if !text.is_empty() => text,
+            (None, Some(path)) => self.resolve_transcript_path(&path)?,
+            _ => {
+                return Err(ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "exactly one of `transcript` (non-empty) or `path` must be set".to_owned(),
+                    None,
+                ));
+            }
+        };
+        let segmentation_policy = segmentation.unwrap_or_default();
+        let outcome =
+            segment_transcript(&transcript_text, &segmentation_policy).map_err(to_error)?;
+        let segments_info: Vec<SegmentInfo> = outcome
+            .segments
+            .iter()
+            .enumerate()
+            .map(|(index, segment)| SegmentInfo {
+                index,
+                turn: segment.turn,
+                role: segment.role.clone(),
+                kind: segment.kind,
+                byte_start: segment.byte_start,
+                byte_end: segment.byte_end,
+                fragment_id: fragment_id(&segment.fragment.content),
+            })
+            .collect();
+        let fragments: Vec<ContextFragment> = outcome
+            .segments
+            .into_iter()
+            .map(|segment| segment.fragment)
+            .collect();
+        let ids_as_strings = policy.as_ref().is_some_and(|p| p.ids_as_strings);
+        let request = CompileRequest {
+            query,
+            fragments,
+            project,
+            target_model,
+            token_budget,
+            memory_scope: None,
+            policy,
+        };
+        let service = Arc::clone(&self.service);
+        let compiled = tokio::task::spawn_blocking(move || {
+            service.compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
+        })
+        .await
+        .map_err(join_error)?
+        .map_err(to_error)?;
+        let result = CompileTranscriptResult {
+            context: compiled,
+            segmentation: SegmentationReport {
+                format_detected: outcome.format_detected,
+                segments: segments_info,
+                merged_segments: outcome.merged_segments,
+            },
+        };
+        Ok(Json(to_wire_value(&result, ids_as_strings)?))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -25,6 +25,7 @@ fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
         id: None,
         content: content.to_owned(),
+        path: None,
         kind: None,
         priority: None,
         metadata: None,

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -9,7 +9,8 @@ use tempfile::TempDir;
 use super::super::dto::RememberParams;
 use super::*;
 use crate::context::{
-    fragment_id, ContextAction, ContextFact, ContextFragment, MemoryScope, WorkingContext,
+    fragment_id, ContextAction, ContextFact, ContextFragment, IngestRoots, MemoryScope,
+    WorkingContext,
 };
 use crate::embedder::{DynEmbedder, HashEmbedder};
 use crate::service::MemoryService;
@@ -19,6 +20,20 @@ fn server() -> (TempDir, McpServer) {
     let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
     let service = MemoryService::open(dir.path(), embedder).expect("open memory store");
     (dir, McpServer::new(service))
+}
+
+/// A server with `dir` (or a sub-tree of it) allowlisted for path ingestion
+/// (V2b-1/V2b-2).
+fn server_with_ingest_roots(allowed: &std::path::Path) -> (TempDir, McpServer) {
+    let dir = TempDir::new().expect("create tempdir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
+    let service = MemoryService::open(dir.path(), embedder).expect("open memory store");
+    let value = std::env::join_paths([allowed.as_os_str()])
+        .expect("a single absolute path always joins")
+        .to_string_lossy()
+        .into_owned();
+    let roots = IngestRoots::parse(&value).expect("tempdir is a valid, existing directory");
+    (dir, McpServer::new(service).with_ingest_roots(roots))
 }
 
 fn fragment(content: &str) -> ContextFragment {
@@ -1000,4 +1015,134 @@ async fn test_list_working_contexts_tool_empty_for_unknown_project() {
 
     // Then it comes back empty, not an error.
     assert!(listed.sessions.is_empty());
+}
+
+#[tokio::test]
+async fn test_compile_transcript_tool_end_to_end() {
+    // Given a server and a small plain transcript with a system turn, a
+    // user turn, and an assistant turn
+    let (_dir, srv) = server();
+    let transcript = "System: be terse\nUser: what is 2+2?\nAssistant: 4\n".to_owned();
+
+    // When compiling it via compile_transcript
+    let Json(value) = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "arithmetic".to_owned(),
+            transcript: Some(transcript),
+            path: None,
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await
+        .expect("compile_transcript");
+    let out: CompileTranscriptResult = serde_json::from_value(value).expect("valid result");
+
+    // Then the compiled context carries the transcript's content, and the
+    // segmentation report accounts for every turn with a resolvable
+    // fragment_id and cache metadata on the system turn
+    assert!(out.context.content.contains('4'));
+    assert_eq!(out.segmentation.format_detected, SegmentFormat::Plain);
+    assert_eq!(out.segmentation.segments.len(), 3);
+    assert_eq!(out.segmentation.segments[0].role.as_deref(), Some("System"));
+    assert_eq!(out.segmentation.segments[1].role.as_deref(), Some("User"));
+    assert_eq!(
+        out.segmentation.segments[2].role.as_deref(),
+        Some("Assistant")
+    );
+    assert!(out.segmentation.segments.iter().all(|s| s.fragment_id > 0));
+    assert!(out
+        .context
+        .decisions
+        .iter()
+        .any(|d| d.fragment_id == out.segmentation.segments[0].fragment_id));
+}
+
+#[tokio::test]
+async fn test_compile_transcript_from_path_uses_ingest_checks() {
+    // Given a server allowlisting one directory, and a transcript file
+    // inside it
+    let allowed = TempDir::new().expect("tempdir");
+    let (_dir, srv) = server_with_ingest_roots(allowed.path());
+    let transcript_file = allowed.path().join("session.txt");
+    std::fs::write(&transcript_file, "User: hello from disk\n").expect("write transcript");
+    let requested = transcript_file.to_string_lossy().into_owned();
+
+    // When compiling via `path` inside the allowlist
+    let Json(value) = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "greeting".to_owned(),
+            transcript: None,
+            path: Some(requested),
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await
+        .expect("compile_transcript resolves the path like an ordinary ingest fragment");
+    let out: CompileTranscriptResult = serde_json::from_value(value).expect("valid result");
+    assert!(out.context.content.contains("hello from disk"));
+
+    // Given a second file OUTSIDE the allowlist
+    let outside = TempDir::new().expect("tempdir");
+    let escaping_file = outside.path().join("other.txt");
+    std::fs::write(&escaping_file, "not reachable from the allowlist").expect("write");
+    let escaping_requested = escaping_file.to_string_lossy().into_owned();
+
+    // When compiling via that `path`
+    let result = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "greeting".to_owned(),
+            transcript: None,
+            path: Some(escaping_requested),
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await;
+    let err = match result {
+        Ok(_) => panic!("path outside the ingest roots must be rejected"),
+        Err(err) => err,
+    };
+
+    // Then it fails with the same ingest security error `compile_context`
+    // would produce for an out-of-root `path` fragment — never a generic
+    // "not found". (The symlink-specific no-leak guarantee is covered by
+    // `context::ingest`'s own `outside_roots_error_never_echoes_resolved_target`.)
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("outside"), "{}", err.message);
+}
+
+#[tokio::test]
+async fn test_compile_transcript_without_ingest_roots_reports_disabled() {
+    // Given a server with NO ingest roots configured
+    let (_dir, srv) = server();
+
+    // When compiling via `path`
+    let result = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "greeting".to_owned(),
+            transcript: None,
+            path: Some("/does/not/matter.txt".to_owned()),
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await;
+    let err = match result {
+        Ok(_) => panic!("ingestion is disabled without VELESDB_MEMORY_INGEST_ROOTS"),
+        Err(err) => err,
+    };
+
+    // Then it reports the same "ingestion disabled" error as compile_context.
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("disabled"), "{}", err.message);
 }

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -1146,3 +1146,58 @@ async fn test_compile_transcript_without_ingest_roots_reports_disabled() {
     assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
     assert!(err.message.contains("disabled"), "{}", err.message);
 }
+
+#[tokio::test]
+async fn test_compile_transcript_rejects_empty_file_same_as_empty_inline_transcript() {
+    // Given a server with a real, but EMPTY, file inside the ingest
+    // allowlist — an empty inline `transcript` is already rejected
+    // (INVALID_PARAMS), but an empty file reached via `path` used to
+    // resolve cleanly and compile into a silent, zero-fragment result: the
+    // same "nothing to compile" situation reported two different ways.
+    let allowed = TempDir::new().expect("tempdir");
+    let (_dir, srv) = server_with_ingest_roots(allowed.path());
+    let empty_file = allowed.path().join("empty.txt");
+    std::fs::write(&empty_file, "").expect("write empty file");
+    let requested = empty_file.to_string_lossy().into_owned();
+
+    // When compiling via that `path`
+    let path_result = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "q".to_owned(),
+            transcript: None,
+            path: Some(requested),
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await;
+    let path_err = match path_result {
+        Ok(_) => panic!("an empty file must be rejected, not silently compiled into nothing"),
+        Err(err) => err,
+    };
+
+    // And when compiling with an empty inline transcript instead
+    let inline_result = srv
+        .compile_transcript(Parameters(CompileTranscriptParams {
+            query: "q".to_owned(),
+            transcript: Some(String::new()),
+            path: None,
+            token_budget: 10_000,
+            project: None,
+            target_model: None,
+            policy: None,
+            segmentation: None,
+        }))
+        .await;
+    let inline_err = match inline_result {
+        Ok(_) => panic!("an empty inline transcript must be rejected"),
+        Err(err) => err,
+    };
+
+    // Then both fail the same way, with the exact same actionable message
+    assert_eq!(path_err.code, ErrorCode::INVALID_PARAMS);
+    assert_eq!(inline_err.code, ErrorCode::INVALID_PARAMS);
+    assert_eq!(path_err.message, inline_err.message);
+}

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -1106,9 +1106,8 @@ async fn test_compile_transcript_from_path_uses_ingest_checks() {
             segmentation: None,
         }))
         .await;
-    let err = match result {
-        Ok(_) => panic!("path outside the ingest roots must be rejected"),
-        Err(err) => err,
+    let Err(err) = result else {
+        panic!("path outside the ingest roots must be rejected");
     };
 
     // Then it fails with the same ingest security error `compile_context`
@@ -1137,9 +1136,8 @@ async fn test_compile_transcript_without_ingest_roots_reports_disabled() {
             segmentation: None,
         }))
         .await;
-    let err = match result {
-        Ok(_) => panic!("ingestion is disabled without VELESDB_MEMORY_INGEST_ROOTS"),
-        Err(err) => err,
+    let Err(err) = result else {
+        panic!("ingestion is disabled without VELESDB_MEMORY_INGEST_ROOTS");
     };
 
     // Then it reports the same "ingestion disabled" error as compile_context.
@@ -1173,9 +1171,8 @@ async fn test_compile_transcript_rejects_empty_file_same_as_empty_inline_transcr
             segmentation: None,
         }))
         .await;
-    let path_err = match path_result {
-        Ok(_) => panic!("an empty file must be rejected, not silently compiled into nothing"),
-        Err(err) => err,
+    let Err(path_err) = path_result else {
+        panic!("an empty file must be rejected, not silently compiled into nothing");
     };
 
     // And when compiling with an empty inline transcript instead
@@ -1191,9 +1188,8 @@ async fn test_compile_transcript_rejects_empty_file_same_as_empty_inline_transcr
             segmentation: None,
         }))
         .await;
-    let inline_err = match inline_result {
-        Ok(_) => panic!("an empty inline transcript must be rejected"),
-        Err(err) => err,
+    let Err(inline_err) = inline_result else {
+        panic!("an empty inline transcript must be rejected");
     };
 
     // Then both fail the same way, with the exact same actionable message

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -11,8 +11,9 @@
 
 use serde_json::{Map, Value};
 use velesdb_memory::context::{
-    CompilePolicy, CompileRequest, CompiledContext, ContextAction, ContextCompiler,
-    ContextFragment, FidelityRisk, HeuristicEstimator, TokenEstimator,
+    segment_transcript, CompilePolicy, CompileRequest, CompiledContext, ContextAction,
+    ContextCompiler, ContextFragment, FidelityRisk, HeuristicEstimator, SegmentationPolicy,
+    TokenEstimator,
 };
 use velesdb_memory::{ErrorCategory, MemoryError};
 
@@ -512,6 +513,44 @@ fn test_compile_golden_snapshot_matches_committed_output() {
         golden,
         "compiled output drifted from the golden snapshot; if intentional, \
          re-generate tests/golden/context/compile_basic.json — actual:\n{}",
+        serde_json::to_string_pretty(&actual).expect("pretty-print actual")
+    );
+}
+
+#[test]
+fn test_compile_transcript_golden_snapshot_matches_committed_output() {
+    // Given a fixed, representative transcript (system + user + assistant
+    // turns, a fenced code block, a repeated-line log run) — segmented, then
+    // compiled exactly like `compile_context` would with the resulting
+    // fragments. Committed under tests/golden/context/; any change to it
+    // must be a conscious one (V2b-2 non-regression).
+    let transcript = "System: You are the deploy assistant.\n\
+User: what changed in the deploy pipeline?\n\
+```rust\nlet x = 42;\n```\n\
+Assistant: Never restart the primary node during a rebalance.\n\
+ERROR timeout\nERROR timeout\nERROR timeout\nERROR timeout\n\
+ERROR timeout\nERROR timeout\nERROR timeout\nERROR timeout\n";
+    let outcome = segment_transcript(transcript, &SegmentationPolicy::default())
+        .expect("a well-formed transcript segments cleanly");
+    let fragments: Vec<ContextFragment> = outcome
+        .segments
+        .into_iter()
+        .map(|segment| segment.fragment)
+        .collect();
+    let req = request(fragments, 10_000);
+
+    // When compiling the segmented fragments
+    let out = compile(&req);
+
+    // Then the output matches the committed golden snapshot exactly
+    let actual = serde_json::to_value(&out).expect("serialize output");
+    let golden: Value = serde_json::from_str(include_str!("golden/context/transcript_basic.json"))
+        .expect("parse committed golden snapshot");
+    assert_eq!(
+        actual,
+        golden,
+        "compiled transcript output drifted from the golden snapshot; if intentional, \
+         re-generate tests/golden/context/transcript_basic.json — actual:\n{}",
         serde_json::to_string_pretty(&actual).expect("pretty-print actual")
     );
 }

--- a/crates/velesdb-memory/tests/context_compiler_bdd.rs
+++ b/crates/velesdb-memory/tests/context_compiler_bdd.rs
@@ -19,6 +19,7 @@ use velesdb_memory::{ErrorCategory, MemoryError};
 /// Build a plain fragment with no id, kind, priority, or metadata.
 fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
+        path: None,
         id: None,
         content: content.to_owned(),
         kind: None,

--- a/crates/velesdb-memory/tests/context_memory_bdd.rs
+++ b/crates/velesdb-memory/tests/context_memory_bdd.rs
@@ -17,6 +17,7 @@ use velesdb_memory::{ErrorCategory, FusionOptions, HashEmbedder, MemoryService};
 
 fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
+        path: None,
         id: None,
         content: content.to_owned(),
         kind: None,

--- a/crates/velesdb-memory/tests/context_pins_bdd.rs
+++ b/crates/velesdb-memory/tests/context_pins_bdd.rs
@@ -24,6 +24,7 @@ use velesdb_memory::context::{
 
 fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
+        path: None,
         id: None,
         content: content.to_owned(),
         kind: None,

--- a/crates/velesdb-memory/tests/context_property_bdd.rs
+++ b/crates/velesdb-memory/tests/context_property_bdd.rs
@@ -71,6 +71,7 @@ fn generated_fragment(rng: &mut Lcg, pool: &mut Vec<String>) -> ContextFragment 
     };
     pool.push(content.clone());
     ContextFragment {
+        path: None,
         id: None,
         content,
         kind: if rng.below(4) == 0 {
@@ -219,6 +220,7 @@ fn test_compiler_keeps_critical_facts_a_naive_truncation_loses() {
     // at the end (where naive head-truncation always cuts).
     let mut fragments: Vec<ContextFragment> = (0..30)
         .map(|i| ContextFragment {
+            path: None,
             id: None,
             content: format!(
                 "Turn {i}: assistant explained the deploy pipeline stages and the \
@@ -235,6 +237,7 @@ fn test_compiler_keeps_critical_facts_a_naive_truncation_loses() {
         .collect();
     for constraint in &constraints {
         fragments.push(ContextFragment {
+            path: None,
             id: None,
             content: constraint.clone(),
             kind: None,
@@ -326,6 +329,7 @@ fn test_adversarial_pathological_inputs_never_panic() {
             let request = CompileRequest {
                 query: String::new(),
                 fragments: vec![ContextFragment {
+                    path: None,
                     id: None,
                     content: (*content).to_owned(),
                     kind: None,
@@ -351,6 +355,7 @@ fn test_adversarial_duplicate_avalanche_stays_linear_and_correct() {
     let content = "the deploy pipeline runs clippy before tests";
     let fragments: Vec<ContextFragment> = (0..1_000)
         .map(|_| ContextFragment {
+            path: None,
             id: None,
             content: content.to_owned(),
             kind: None,

--- a/crates/velesdb-memory/tests/golden/context/transcript_basic.json
+++ b/crates/velesdb-memory/tests/golden/context/transcript_basic.json
@@ -1,0 +1,102 @@
+{
+  "content": "System: You are the deploy assistant.\n\n\nUser: what changed in the deploy pipeline?\n\n\n```rust\nlet x = 42;\n```\n\n\nAssistant: Never restart the primary node during a rebalance.\n\n\nERROR timeout (x8)",
+  "decisions": [
+    {
+      "action": "cache",
+      "content_hash": 16851729626188896855,
+      "fragment_id": 16851729626188896855,
+      "reason": "caller marked this fragment cacheable; it forms the stable prefix",
+      "relevance": 0.3333333432674408,
+      "risk": "low",
+      "rule_id": "cache.stable_prefix"
+    },
+    {
+      "action": "preserve",
+      "content_hash": 12804954966138698420,
+      "fragment_id": 12804954966138698420,
+      "reason": "prose kept subject to budget",
+      "relevance": 1.0,
+      "risk": "low",
+      "rule_id": "preserve.default"
+    },
+    {
+      "action": "preserve",
+      "content_hash": 7816677558540495962,
+      "fragment_id": 7816677558540495962,
+      "reason": "code must survive verbatim",
+      "relevance": 0.0,
+      "risk": "low",
+      "rule_id": "preserve.code_fence"
+    },
+    {
+      "action": "preserve",
+      "content_hash": 15581793059231841206,
+      "fragment_id": 15581793059231841206,
+      "reason": "negative constraints must never be weakened",
+      "relevance": 0.1666666716337204,
+      "risk": "low",
+      "rule_id": "preserve.negative_constraint"
+    },
+    {
+      "action": "abstract",
+      "content_hash": 4635286298132093749,
+      "fragment_id": 4635286298132093749,
+      "reason": "repeated log lines collapse into one annotated line",
+      "relevance": 0.0,
+      "risk": "medium",
+      "rule_id": "abstract.log_dedup"
+    }
+  ],
+  "insights": {
+    "tokens_in": 104,
+    "tokens_out": 69,
+    "tokens_saved": 35,
+    "tokens_saved_by_rule": {
+      "abstract.log_dedup": 37
+    }
+  },
+  "retrieval_handles": [],
+  "risk": "medium",
+  "sections": [
+    {
+      "content": "System: You are the deploy assistant.\n",
+      "fragment_ids": [
+        16851729626188896855
+      ],
+      "kind": "cache"
+    },
+    {
+      "content": "User: what changed in the deploy pipeline?\n\n\n```rust\nlet x = 42;\n```\n\n\nAssistant: Never restart the primary node during a rebalance.\n\n\nERROR timeout (x8)",
+      "fragment_ids": [
+        12804954966138698420,
+        7816677558540495962,
+        15581793059231841206,
+        4635286298132093749
+      ],
+      "kind": "body"
+    }
+  ],
+  "sources": [
+    {
+      "fragment_id": 16851729626188896855,
+      "handle": "ctx://source/16851729626188896855"
+    },
+    {
+      "fragment_id": 12804954966138698420,
+      "handle": "ctx://source/12804954966138698420"
+    },
+    {
+      "fragment_id": 7816677558540495962,
+      "handle": "ctx://source/7816677558540495962"
+    },
+    {
+      "fragment_id": 15581793059231841206,
+      "handle": "ctx://source/15581793059231841206"
+    },
+    {
+      "fragment_id": 4635286298132093749,
+      "handle": "ctx://source/4635286298132093749"
+    }
+  ],
+  "warnings": []
+}

--- a/crates/velesdb-memory/tests/metadata_caps_bdd.rs
+++ b/crates/velesdb-memory/tests/metadata_caps_bdd.rs
@@ -37,6 +37,7 @@ fn metadata_of_size(target_bytes: usize) -> Map<String, Value> {
 
 fn fragment(content: &str) -> ContextFragment {
     ContextFragment {
+        path: None,
         id: None,
         content: content.to_owned(),
         kind: None,


### PR DESCRIPTION
## Summary

Stacked on V2b-1 (`feat/ingest-by-reference`, commits `7f1387b3`..`8f67b93b`) — that branch has no PR yet at the time of this push, so this PR targets `develop` directly and **includes V2b-1's commits** until V2b-1 is pushed/merged separately; rebase onto its PR once opened.

- New `compile_transcript` MCP tool: one-call shortcut over `compile_context` for a raw agent-session transcript (`transcript` XOR `path`, `token_budget`, optional `project`/`target_model`/`policy`/`segmentation`).
- New pure core `segment_transcript(text, &SegmentationPolicy) -> Result<SegmentationOutcome, MemoryError>` in `src/context/segment.rs`: deterministic, zero-regex, zero-clock transcript segmentation — format detection (plain marker table vs JSONL), turn splitting, fenced-code/log-run/body sub-segmentation, and normalization (oversized-fence rejection, body re-split, tiny-segment merging, fragment-count cap).
- `context::ingest::resolve_transcript_path` reuses the V2b-1 ingest security pipeline with a wider byte cap (`MAX_TRANSCRIPT_BYTES` = 8 MiB) since a transcript is segmented into sub-1-MiB pieces right after being read.
- New golden regression test (`tests/golden/context/transcript_basic.json`).

## Test plan

- [x] TDD: RED demonstrated (13 `segment_tests.rs` tests failed against a stubbed `segment_transcript`), then GREEN after restoring the implementation.
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p velesdb-memory` (and again with `--all-features`)
- [x] `RUSTFLAGS=-Dwarnings cargo check -p velesdb-memory --no-default-features --features context`
- [x] `cargo clippy -p velesdb-memory --all-features -- -D warnings` (and `--tests` for good measure)
- [x] `python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py` (run from workspace root against a fresh debug build) — 8-tool e2e still green; `compile_transcript` scenario deferred to V2b-3 per plan