### PR TITLE
chore(release): velesdb-memory 0.10.0 prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "rmcp",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,8 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-07-20
+
 ### Added
 
+- **Binding parity for the compiler's read tools (V2d-2/A4).**
+  `MemoryService::explain_compilation` is now a library method (extracted
+  from the MCP-only implementation, behavior byte-identical — the MCP tool
+  delegates to it), exposed as `explainCompilation` on Node and
+  `explain_compilation` on Python; `contextSavings` lands on Node; the WASM
+  binding (and the TypeScript SDK wrapping it) gains `retrieveContextSource`
+  over its in-memory, per-session store.
+- **`velesdb-memory --version` / `-V`.** The MCP server binary now
+  short-circuits the version flags before opening the store — a sanity
+  check for a fresh install that previously had no CLI surface at all.
 - **Path-referenced context fragments.** A `compile_context`/
   `explain_compilation` fragment may set `path` (an absolute filesystem
   path) instead of inline `content` to ingest a file by reference — exactly

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.9.2"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,19 +17,21 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
-> **Release 0.9.2** — agent-ergonomics cycle over the 0.9.1 memory server:
-> ids now survive float-lossy JSON clients end-to-end (`id_str` decimal-string
-> twins on every id-bearing response, string ids accepted on input, surrounding
-> whitespace tolerated), `get_info` documents all three tool families, new
-> `list_working_contexts` and `suggest_budget` tools, `compile_context` gains
-> `warnings[]` and `policy.slim_response`; published to the registries by the
-> `velesdb-memory-v0.9.2`
+> **Release 0.10.0** — the V2 wave lands: `compile_transcript` (one call
+> turns a raw agent-session transcript into deterministically segmented,
+> budget-compiled context with a full segmentation audit report),
+> path-referenced fragments (opt-in, allowlisted via
+> `VELESDB_MEMORY_INGEST_ROOTS`, symlink-safe), binding parity for the
+> compiler's read tools (`explainCompilation`/`contextSavings` on Node,
+> `explain_compilation` on Python, `retrieveContextSource` on WASM/TS), and
+> a `--version` flag; published to the registries by the
+> `velesdb-memory-v0.10.0`
 > tag, so the links below may briefly lag right after merge. `velesdb-memory`
 > ships on [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.9.2**
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.10.0**
 > and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**
 > (memory API only — the context compiler is merged on `develop` but **the
 > published 3.12.0 wheel predates it**; it ships with the next PyPI release,

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.9.2"
+version = "0.10.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release prep for the `velesdb-memory-v0.10.0` tag (the V2 wave), mirroring the 0.9.2 prep (#1492):

- `velesdb-memory` + `velesdb-node` Cargo.toml → 0.10.0
- npm `package.json` + `package-lock.json` → 0.10.0
- `server.json` (`.version` + `packages[0].version`) → 0.10.0
- `Cargo.lock` entries regenerated via `cargo check`
- README release banner rewritten for 0.10.0
- CHANGELOG stamped `[0.10.0] — 2026-07-20`, with the missing V2d-2/A4 binding-parity and `--version` entries added

Release content since 0.9.2: #1500 (path ingestion + compile_transcript), #1501 (docs), #1503 (binding parity + WASM retrieveContextSource), #1496 (--version flag + onboarding polish), #1499 (bundled-skills sync guard), #1502 (README repositioning), #1494/#1498 (release-workflow fixes, already active).