### PR TITLE
fix(ci): use an explicit spec file for the node release smoke test

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -264,11 +264,16 @@ jobs:
         # load test. To close: run the smoke test under an emulator (QEMU for arm64,
         # or a native x86 mac runner) so every shipped .node is load-verified.
         if: ${{ !matrix.cross && matrix.target != 'x86_64-apple-darwin' }}
-        # `npm test` (package.json's __test__/*.spec.mjs glob) rather than a bare
-        # `node --test __test__/` directory argument: directory args stop being
-        # recursively discovered on recent Node majors (verified failing on Node
-        # 26 locally), and the glob also picks up new spec files automatically.
-        run: npm test
+        # An explicit spec file, deliberately: a bare `node --test __test__/`
+        # directory argument stops being recursively discovered on recent Node
+        # majors, and `npm test`'s `__test__/*.spec.mjs` glob is not expanded
+        # by the Windows shell on Node 20 ("Could not find '...\*.spec.mjs'" —
+        # this exact step failed on x86_64-pc-windows-msvc for the 0.10.0 tag
+        # and skipped the npm publish). This step's only job is proving the
+        # freshly built .node addon loads on this platform; index.spec.mjs is
+        # exactly that. The full suite (including skills-sync) runs in CI via
+        # `npm test`.
+        run: node --test __test__/index.spec.mjs
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
The 0.9.2-era hardening (`npm test`) is not portable to the Windows runner: the `__test__/*.spec.mjs` glob isn't shell-expanded there (Node 20: `Could not find '...\*.spec.mjs'`), which failed `Build node (x86_64-pc-windows-msvc)` on the `velesdb-memory-v0.10.0` tag and **skipped the npm publish** (crates.io, the 5 `.mcpb` bundles and the MCP registry all published fine).

Fix: an explicit `node --test __test__/index.spec.mjs` — portable across platforms and Node majors, and scoped to this step's single purpose (prove the freshly built `.node` addon loads). The full suite including the skills-sync guard still runs in CI via `npm test`.

After merge: `workflow_dispatch` of `release-memory.yml` from `develop` with `version=0.10.0` republishes npm from crate content bit-identical to the tag.