### PR TITLE
test(node): tolerate Windows lock semantics when removing temp store dirs

### DIFF
--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -11,11 +11,28 @@ import { join } from 'node:path'
 
 import { MemoryService } from '../index.js'
 
+/**
+ * Remove a temp store dir, tolerating Windows lock semantics: the store's
+ * `velesdb.lock` is flock-held for the life of the MemoryService, and the
+ * NAPI finalizer that releases it is not deterministic — on Windows an
+ * lstat/unlink of a held lock file raises EPERM/EBUSY (POSIX allows it).
+ * Retry briefly, then leave the dir behind rather than failing the test:
+ * these are throwaway dirs under os.tmpdir() on ephemeral CI runners.
+ * (Seen live: the 0.10.0 release smoke test on x86_64-pc-windows-msvc.)
+ */
+function rmStoreDir(dir) {
+  try {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+  } catch (err) {
+    if (err.code !== 'EPERM' && err.code !== 'EBUSY' && err.code !== 'ENOTEMPTY') throw err
+  }
+}
+
 /** Fresh store in an isolated temp dir (one MemoryService per path). */
 function freshStore() {
   const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-'))
   const store = MemoryService.open(dir, 'hash')
-  return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+  return { store, cleanup: () => rmStoreDir(dir) }
 }
 
 test('surface allowlist — exactly the supported methods, no engine leak', () => {
@@ -672,7 +689,7 @@ test('saveWorkingContext → loadWorkingContext round-trips across processes', a
     )
     assert.deepEqual(loaded.pending_actions, working.pending_actions)
   } finally {
-    rmSync(dir, { recursive: true, force: true })
+    rmStoreDir(dir)
   }
 })
 


### PR DESCRIPTION
The node suite's temp-dir cleanup `rmSync`'d directories whose `velesdb.lock` is still flock-held by a live `MemoryService` (the NAPI finalizer is not deterministic). POSIX allows unlinking a held file; **Windows raises EPERM/EBUSY** — which failed the `x86_64-pc-windows-msvc` release smoke test on the 0.10.0 dispatch and blocked the npm publish (crates.io, mcpb bundles and the MCP registry are already live at 0.10.0).

Cleanup now routes through `rmStoreDir()`: `rmSync` with `maxRetries`, then EPERM/EBUSY/ENOTEMPTY tolerated (throwaway dirs under `os.tmpdir()` on ephemeral runners); every other error still throws.

Verified locally: `napi build` + `npm test` → 36 pass / 0 fail / 1 skipped (Ollama-gated).

After merge: re-dispatch `release-memory.yml` from `develop` with `version=0.10.0` — `Publish npm` `needs: [validate, build-node]` only, so the benign `Publish crates.io` failure (version already uploaded by the tag run) won't block it.