### PR TITLE
test(node): make the cross-process child require path Windows-valid

### DIFF
--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { MemoryService } from '../index.js'
 
@@ -670,7 +671,7 @@ test('saveWorkingContext → loadWorkingContext round-trips across processes', a
     // deterministically when it exits — a block-scoped handle in this
     // process would keep the lock until GC).
     const script = `
-      const { MemoryService } = require(${JSON.stringify(new URL('../index.js', import.meta.url).pathname)})
+      const { MemoryService } = require(${JSON.stringify(fileURLToPath(new URL('../index.js', import.meta.url)))})
       const store = MemoryService.open(${JSON.stringify(dir)}, 'hash')
       store.saveWorkingContext('veles', 'session-1', ${JSON.stringify(working)}).then((id) => {
         if (!/^\\d+$/.test(id)) throw new Error('id must be a decimal string, got: ' + id)


### PR DESCRIPTION
Third and last Windows blocker on the 0.10.0 npm publish: the cross-process working-context test handed its child `new URL('../index.js', import.meta.url).pathname` — a `/D:/...` URL-style path `require()` cannot resolve on Windows (MODULE_NOT_FOUND on `x86_64-pc-windows-msvc`, surfaced once #1510's lock fix let the suite reach test 30). `fileURLToPath()` is platform-correct everywhere.

Verified locally: `napi build` + `npm test` → 36 pass / 0 fail / 1 skipped. The remaining tests past this one use no child processes or raw URL paths.

After merge + green CI: re-dispatch `release-memory.yml` `version=0.10.0` to publish npm.