### PR TITLE
fix(memory): make the compile_context cache prefix query-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-memory`**: the `compile_context` prompt-cache prefix could
+  churn when only the query changed. `selection_order`
+  (`src/context/budget.rs`) used lexical relevance to the query as a
+  packing tie-break for every fragment, including `cache: true` ones — so
+  when a budget was too tight to fit two same-priority cache-marked
+  fragments, a query change alone could flip which one won, silently
+  changing the byte content of the Cache section and defeating provider
+  prompt-caching on exactly the turn a new question was asked. A
+  cache-marked fragment's rank now never consults relevance, in either
+  direction: it always outranks a non-cache fragment of the same
+  criticality/priority (a fixed, query-independent tier), and two
+  cache-marked fragments tied on priority fall straight to `seq`.
+  **Trade-off, assumed:** cache stability over relevance, for cache-marked
+  fragments only — a more-relevant non-cache fragment can now lose a
+  tight-budget race it would have won before this fix against a same-tier
+  cache fragment. Non-cache fragments are unaffected. (issue #1455)
 - **`velesdb-memory`**: a permanent `ctx://source/` handle could expire
   silently — a source first written under a TTL was never promoted when a
   later compile asked for permanent storage. Storage now applies a

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The `compile_context` prompt-cache prefix could churn when only the query
+  changed: `selection_order` (`src/context/budget.rs`) used lexical
+  relevance to the query as a packing tie-break for every fragment,
+  including `cache: true` ones, so when a budget was too tight to fit two
+  same-priority cache-marked fragments, a query change alone could flip
+  which one won, silently changing the Cache section's bytes and defeating
+  provider prompt-caching on exactly the turn a new question was asked. A
+  cache-marked fragment's rank now never consults relevance: it always
+  outranks a non-cache fragment at the same criticality/priority (a fixed,
+  query-independent tier), and two cache-marked fragments tied on priority
+  fall straight to `seq`. **Trade-off, assumed:** cache stability over
+  relevance, for cache-marked fragments only — a more-relevant non-cache
+  fragment can now lose a tight-budget race it would have won before this
+  fix against a same-tier cache fragment. Non-cache fragments are
+  unaffected. (issue #1455)
+
 ## [0.10.0] — 2026-07-20
 
 ### Added

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -537,16 +537,17 @@ latency. The committed
 harness measures the `cache: true` prefix's byte stability directly: across
 10 consecutive compiles with changing volatile content, the cache section is
 a byte-identical **100 % stable prefix on all 9 consecutive turn pairs**
-(reproducible: two full 10-turn runs, byte-identical). **Known limitation:**
-that measurement holds the query fixed across turns; the cache prefix is
-byte-stable only at a *fixed* query today — when two same-priority
-cache-marked fragments compete under a budget too tight for both, a query
-change can reorder them (relevance is one of the packing tie-breakers), so
-a caller who marks more than one fragment cacheable and expects a
-query-agnostic prefix should keep the budget generous enough for all of
-them, or track
-[issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455) for
-the fix. That tri-engine path — the one `memory_scope` drives inside `compile_context` — looks like this:
+(reproducible: two full 10-turn runs, byte-identical). That measurement
+holds the query fixed across turns; the guarantee also holds when the query
+*changes* ([issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455),
+fixed): a `cache: true` fragment's rank never consults relevance, so when a
+budget is too tight for every cache-marked fragment, which ones survive is
+decided by priority then input order alone — never by lexical relevance to
+the query — so the Cache prefix stays byte-identical across a query change
+at a fixed fragment set and budget. The accepted trade-off: a same-tier
+non-cache fragment that is more relevant to the query can still lose that
+tight-budget race to a cache-marked fragment (stability wins over relevance,
+but only for cache-marked fragments). That tri-engine path — the one `memory_scope` drives inside `compile_context` — looks like this:
 
 ![tri-engine retrieval: query seeds an HNSW vector search, a graph walk follows relate edges, fusion combines both, then ranking produces the result](docs/diagrams/tri-engine.svg)
 

--- a/crates/velesdb-memory/src/context.rs
+++ b/crates/velesdb-memory/src/context.rs
@@ -618,6 +618,9 @@ fn pack_items(
             critical: analysis.rule.critical,
             priority: analysis.priority,
             relevance: analysis.relevance,
+            // Query-independent selection tier (issue #1455): see
+            // `budget::selection_order`.
+            cache: analysis.rule.action == ContextAction::Cache,
             pieces: pieces(analysis, &chunk_policy, estimator),
         })
         .collect()

--- a/crates/velesdb-memory/src/context/budget.rs
+++ b/crates/velesdb-memory/src/context/budget.rs
@@ -7,8 +7,26 @@
 //! output provably fits.
 //!
 //! Selection is a deterministic total order — critical first, then caller
-//! priority, then relevance, then input order — with `seq` as the final
-//! tie-break so equal fragments can never swap places between runs.
+//! priority, then a cache/non-cache tier, then relevance (non-cache items
+//! only), then input order — with `seq` as the final tie-break so equal
+//! fragments can never swap places between runs.
+//!
+//! **Trade-off (issue #1455): cache stability over relevance, for
+//! cache-marked fragments only.** A `cache: true` fragment (the
+//! `cache.stable_prefix` classification) forms the provider prompt-cache
+//! prefix, whose entire value is being byte-identical across turns. Ranking
+//! it by lexical relevance to the query — like every other fragment — would
+//! let a query change alone decide which of two same-priority cache
+//! fragments wins a tight budget, silently changing the prefix's bytes and
+//! defeating the provider cache on exactly the turn a new question is
+//! asked. So a cache-marked fragment's rank never consults relevance, in
+//! either direction: it always outranks a non-cache fragment of the same
+//! criticality/priority (a fixed, query-independent tier — see
+//! [`selection_order`]), and two cache-marked fragments tied on priority
+//! fall straight to `seq`. Non-cache fragments are unaffected: relevance
+//! remains their tie-break, exactly as before. The accepted cost: a
+//! more-relevant non-cache fragment can lose a tight-budget race it would
+//! have won pre-#1455 against a same-tier cache fragment.
 
 use super::estimator::TokenEstimator;
 
@@ -39,8 +57,16 @@ pub(crate) struct PackItem {
     pub critical: bool,
     /// Caller priority (higher first).
     pub priority: u8,
-    /// Lexical relevance to the query (higher first).
+    /// Lexical relevance to the query (higher first). Never consulted for a
+    /// `cache`-marked item — see the module trade-off note and
+    /// [`selection_order`].
     pub relevance: f32,
+    /// Whether this fragment classified as `cache.stable_prefix` (the
+    /// provider prompt-cache prefix). Cache-marked items rank ahead of
+    /// non-cache items at the same criticality/priority, and break ties
+    /// among themselves on `seq` alone — never on `relevance` — so their
+    /// selection is fully query-independent (issue #1455).
+    pub cache: bool,
     /// The fragment's text, pre-cut into orderly pieces (chunks); packing
     /// takes a prefix of them.
     pub pieces: Vec<Piece>,
@@ -62,8 +88,18 @@ pub(crate) fn pack(items: &[PackItem], usable: u64, estimator: &dyn TokenEstimat
     taken
 }
 
-/// Item indices in packing order: critical desc, priority desc, relevance
-/// desc, seq asc.
+/// Item indices in packing order: critical desc, priority desc, cache
+/// (cache-marked before non-cache) desc, relevance desc (non-cache items
+/// only — see the module trade-off note), seq asc.
+///
+/// The cache tier is decided purely from each item's own `cache` flag, never
+/// from `relevance`, so it can never be perturbed by a query change: two
+/// cache-marked items always tie it (falling to `seq`), and a cache-marked
+/// item always beats a non-cache one at the same criticality/priority. Only
+/// once both sides of a comparison are confirmed non-cache does `relevance`
+/// enter at all — the query can reorder non-cache fragments among
+/// themselves exactly as before, but can never move a cache-marked fragment
+/// relative to anything else.
 fn selection_order(items: &[PackItem]) -> Vec<usize> {
     let mut order: Vec<usize> = (0..items.len()).collect();
     order.sort_by(|&a, &b| {
@@ -72,7 +108,16 @@ fn selection_order(items: &[PackItem]) -> Vec<usize> {
             .critical
             .cmp(&left.critical)
             .then_with(|| right.priority.cmp(&left.priority))
-            .then_with(|| right.relevance.total_cmp(&left.relevance))
+            .then_with(|| right.cache.cmp(&left.cache))
+            .then_with(|| {
+                if left.cache {
+                    // Both cache-marked (the tie-break above matched): never
+                    // consult relevance — fall straight through to `seq`.
+                    std::cmp::Ordering::Equal
+                } else {
+                    right.relevance.total_cmp(&left.relevance)
+                }
+            })
             .then_with(|| left.seq.cmp(&right.seq))
     });
     order

--- a/crates/velesdb-memory/src/context/budget_tests.rs
+++ b/crates/velesdb-memory/src/context/budget_tests.rs
@@ -4,11 +4,25 @@ use super::*;
 use crate::context::estimator::HeuristicEstimator;
 
 fn item(seq: usize, critical: bool, priority: u8, relevance: f32, pieces: &[&str]) -> PackItem {
+    cache_item(seq, critical, priority, relevance, false, pieces)
+}
+
+/// Like [`item`], but with an explicit `cache` flag — for tests exercising
+/// the cache/non-cache selection tier (issue #1455).
+fn cache_item(
+    seq: usize,
+    critical: bool,
+    priority: u8,
+    relevance: f32,
+    cache: bool,
+    pieces: &[&str],
+) -> PackItem {
     PackItem {
         seq,
         critical,
         priority,
         relevance,
+        cache,
         pieces: pieces
             .iter()
             .map(|p| Piece {
@@ -27,6 +41,7 @@ fn media_item(seq: usize, critical: bool, precomputed_cost: u64) -> PackItem {
         critical,
         priority: 0,
         relevance: 0.0,
+        cache: false,
         pieces: vec![Piece {
             text: String::new(),
             cost: Some(precomputed_cost),
@@ -151,4 +166,60 @@ fn test_pack_precomputed_cost_piece_is_atomic_never_partially_taken() {
     let items = vec![media_item(0, true, 1_000_000)];
     let taken = pack(&items, 10, &HeuristicEstimator);
     assert_eq!(taken, vec![0]);
+}
+
+// === Cache selection tier (issue #1455) =====================================
+//
+// A cache-marked item's rank must never consult `relevance` — neither
+// against another cache item nor against a non-cache one — so two
+// same-priority cache items always resolve on `seq` alone, and a cache item
+// always beats a same-tier non-cache item regardless of how relevant that
+// non-cache item is to the (here, simulated by a raw `relevance` field)
+// query.
+
+#[test]
+fn test_pack_two_cache_items_ignore_relevance_and_break_ties_on_seq() {
+    // Same critical/priority, cache-marked, but relevance strongly favors
+    // item 1 — if relevance were consulted, item 1 would win. It must not.
+    let items = vec![
+        cache_item(0, true, 0, 0.1, true, &[PIECE]),
+        cache_item(1, true, 0, 0.9, true, &[PIECE]),
+    ];
+    let taken = pack(&items, 3, &HeuristicEstimator);
+    assert_eq!(
+        taken,
+        vec![1, 0],
+        "earlier seq must win between two cache items regardless of relevance"
+    );
+}
+
+#[test]
+fn test_pack_cache_item_beats_higher_relevance_non_cache_item_at_same_tier() {
+    // Item 0 is non-cache with high relevance; item 1 is cache-marked with
+    // low relevance. Pre-#1455 behavior would let relevance decide (item 0
+    // wins); the fix requires the cache item to win instead, so the cache
+    // prefix never depends on a competing non-cache fragment's relevance.
+    let items = vec![
+        cache_item(0, true, 0, 0.9, false, &[PIECE]),
+        cache_item(1, true, 0, 0.1, true, &[PIECE]),
+    ];
+    let taken = pack(&items, 3, &HeuristicEstimator);
+    assert_eq!(
+        taken,
+        vec![0, 1],
+        "the cache-marked item must win the tight budget over a more relevant non-cache item"
+    );
+}
+
+#[test]
+fn test_pack_non_cache_items_still_use_relevance_unaffected_by_cache_tier() {
+    // No cache items in play at all: behavior must be byte-identical to
+    // pre-#1455 — relevance still breaks priority ties among non-cache
+    // fragments.
+    let items = vec![
+        cache_item(0, false, 0, 0.2, false, &[PIECE]),
+        cache_item(1, false, 0, 0.8, false, &[PIECE]),
+    ];
+    let taken = pack(&items, 3, &HeuristicEstimator);
+    assert_eq!(taken, vec![0, 1], "higher relevance must still pack first");
 }

--- a/crates/velesdb-memory/tests/context_pins_bdd.rs
+++ b/crates/velesdb-memory/tests/context_pins_bdd.rs
@@ -74,14 +74,19 @@ fn cache_section_content(out: &CompiledContext) -> Option<String> {
 
 // === Pin (a): cache-prefix byte stability under a CHANGING query ===========
 //
-// `selection_order` (crates/velesdb-memory/src/context/budget.rs:67-78)
-// ranks same-critical, same-priority fragments by lexical relevance to the
-// request's query — and `cache.stable_prefix` marks BOTH of two
-// caller-marked-cache fragments critical with the default priority. Under a
-// budget tight enough for only one of them, the query alone decides which
-// one wins the Cache section. The crate's committed measurement harness
+// Fixed by issue #1455: `selection_order`
+// (crates/velesdb-memory/src/context/budget.rs) used to rank same-critical,
+// same-priority fragments by lexical relevance to the request's query — and
+// `cache.stable_prefix` marks BOTH of two caller-marked-cache fragments
+// critical with the default priority, so under a budget tight enough for
+// only one of them, the query alone decided which one won the Cache
+// section. A cache-marked fragment's rank now never consults relevance (see
+// the `selection_order`/`PackItem::cache` doc comments): two cache-marked
+// fragments tied on priority fall straight to `seq`, so the winner is fixed
+// regardless of the query. The crate's committed measurement harness
 // (`examples/context_savings/real_measures/cache_prefix.mjs`) only ever
-// re-runs the SAME query across turns, so it never exercises this path.
+// re-runs the SAME query across turns, so it never exercised this path —
+// this test is what does.
 
 #[test]
 fn test_cache_prefix_pin_under_a_changing_query_and_a_tight_budget() {
@@ -128,29 +133,29 @@ fn test_cache_prefix_pin_under_a_changing_query_and_a_tight_budget() {
     let cache_mongo_query =
         cache_section_content(&out_mongo_query).expect("a Cache section must exist");
 
-    // PIN of the REAL behavior observed: the two cache-marked fragments tie
-    // on criticality and priority, so relevance (query-dependent) picks the
-    // winner — the Cache prefix is NOT byte-stable across a query change
-    // under a budget too tight for both. This is a real limitation of the
-    // "stable prefix for provider prompt caching" claim: it holds only when
-    // the query stays fixed (exactly what the committed harness measures),
-    // not across an arbitrary query change. See the crate README's
-    // prompt-cache section and the tracking issue linked there.
-    assert_ne!(
+    // FIX (issue #1455): the two cache-marked fragments tie on criticality
+    // and priority; `selection_order` now breaks that tie on `seq` alone,
+    // never on relevance, so the SAME fragment wins the tight budget
+    // regardless of which query was asked — the Cache prefix is byte-stable
+    // across a query change, exactly the guarantee prompt-caching providers
+    // need.
+    assert_eq!(
         cache_redis_query, cache_mongo_query,
-        "documented limitation regressed: the cache prefix used to churn under a \
-         changing query and a tight budget (query-dependent relevance breaks the \
-         tie between two equally-critical cache fragments) — if this now passes \
-         because the prefix is stable, the README/skill limitation note this test \
-         guards should be revisited, not just this assertion"
+        "the cache prefix must be byte-identical regardless of the query: a \
+         cache-marked fragment's selection must never depend on relevance \
+         (issue #1455)"
     );
+    // The winner is deterministic (seq asc: the redis fragment is first in
+    // `fragments()`), independent of which query was compiled against —
+    // pinning that "who wins" is itself query-independent, not just that
+    // both queries happen to agree.
     assert!(
         cache_redis_query.contains("redis"),
-        "the higher-relevance-for-this-query fragment must win: {cache_redis_query}"
+        "the earlier-seq cache fragment must win deterministically: {cache_redis_query}"
     );
     assert!(
-        cache_mongo_query.contains("mongo"),
-        "the higher-relevance-for-this-query fragment must win: {cache_mongo_query}"
+        !cache_redis_query.contains("mongo"),
+        "the losing cache fragment must not partially leak into the prefix: {cache_redis_query}"
     );
 }
 

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -68,14 +68,17 @@ with steps 1-3.
    dump, a code block, a constraint). Tag `kind` when you know it
    (`"code"`, `"log"`); mark caller-pinned text `metadata: {"verbatim": true}`
    and stable preambles `metadata: {"cache": true}` (they form the stable
-   prefix, maximizing provider prompt-cache hits). Two caveats: a media
+   prefix, maximizing provider prompt-cache hits). One caveat: a media
    fragment ignores `cache: true` (it always classifies `media.atomic` and
-   packs in the body, never the cache prefix); and the prefix is
-   byte-stable only at a *fixed* query — under a budget too tight for every
-   cache-marked fragment, a query change can reorder them (see the crate
-   README's prompt-cache section and
-   [issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455)),
-   so size the budget generously for anything marked cacheable.
+   packs in the body, never the cache prefix). The prefix is byte-stable
+   across a query change too, even under a budget too tight for every
+   cache-marked fragment — a cache-marked fragment's rank never consults
+   relevance, so which ones survive a tight budget depends only on
+   priority and input order, never the query
+   ([issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455),
+   fixed; see the crate README's prompt-cache section). Trade-off: a
+   same-tier non-cache fragment more relevant to the query can still lose
+   that tight-budget race to a cache-marked fragment.
 4. **Set the budget.** `token_budget` = the model window share you want the
    context to occupy, minus your expected response length (or set
    `policy.response_reserve_tokens`). Don't know the target model's context

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -68,14 +68,17 @@ with steps 1-3.
    dump, a code block, a constraint). Tag `kind` when you know it
    (`"code"`, `"log"`); mark caller-pinned text `metadata: {"verbatim": true}`
    and stable preambles `metadata: {"cache": true}` (they form the stable
-   prefix, maximizing provider prompt-cache hits). Two caveats: a media
+   prefix, maximizing provider prompt-cache hits). One caveat: a media
    fragment ignores `cache: true` (it always classifies `media.atomic` and
-   packs in the body, never the cache prefix); and the prefix is
-   byte-stable only at a *fixed* query — under a budget too tight for every
-   cache-marked fragment, a query change can reorder them (see the crate
-   README's prompt-cache section and
-   [issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455)),
-   so size the budget generously for anything marked cacheable.
+   packs in the body, never the cache prefix). The prefix is byte-stable
+   across a query change too, even under a budget too tight for every
+   cache-marked fragment — a cache-marked fragment's rank never consults
+   relevance, so which ones survive a tight budget depends only on
+   priority and input order, never the query
+   ([issue #1455](https://github.com/cyberlife-coder/VelesDB/issues/1455),
+   fixed; see the crate README's prompt-cache section). Trade-off: a
+   same-tier non-cache fragment more relevant to the query can still lose
+   that tight-budget race to a cache-marked fragment.
 4. **Set the budget.** `token_budget` = the model window share you want the
    context to occupy, minus your expected response length (or set
    `policy.response_reserve_tokens`). Don't know the target model's context


### PR DESCRIPTION
Closes #1455.

Two same-priority `cache: true` fragments competing for a budget too tight for both were ranked by lexical relevance to the query — so changing the query alone could flip which one survived, churning the Cache section's bytes on exactly the turn a new question is asked (defeating provider prompt-caching).

**Fix**: cache-marked fragments now form a fixed, query-independent tier in `selection_order` (critical desc → priority desc → cache tier → relevance for non-cache only → seq). Two cache fragments tied on priority fall straight to `seq`; relevance is never consulted for them, in either direction. **Accepted trade-off (documented in the module, the skill, and both CHANGELOGs): cache stability over relevance, for cache-marked fragments only.**

TDD: the pinned red-turned-documented test (`context_pins_bdd.rs::test_cache_prefix_pin_under_a_changing_query_and_a_tight_budget`) now asserts the CORRECT behavior — byte-stable prefix under a changing query — plus new `budget_tests.rs` coverage of the tier ordering. Gates: fmt ✓, `cargo test -p velesdb-memory` 17/17 blocks ✓, workspace-grade pedantic clippy ✓, promise-contract 27 claims ✓, bundled skill copy synced (skills-sync guard) ✓.