### PR TITLE
ci(node): add a Windows leg to the PR node-binding CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,6 +603,121 @@ jobs:
           node --test examples/real-session-benchmark/test/facts-survive.test.mjs
 
   # ===========================================================================
+  # Node Binding — path filter for the Windows leg below (#1515).
+  #
+  # Cheap ubuntu job (1x billing multiplier) that decides whether the Windows
+  # job actually needs to build anything. The `pull_request` trigger at the
+  # top of this file is intentionally NOT path-filtered (see the big comment
+  # there — a path filter on `pull_request` can make a required check-run
+  # simply never appear, permanently blocking merge). So this filtering can't
+  # live in a job-level `if:`, which would produce the same "skipped, not
+  # absent" trap only one level down; instead it runs unconditionally and
+  # exposes an output that gates the actual work inside the Windows job's
+  # steps, so that job always reports success/failure, never skipped.
+  # ===========================================================================
+  node-windows-changed:
+    name: Node Binding (Windows) — path filter
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history: a shallow (depth-1) PR checkout only fetches the
+          # merge commit itself, not the base commit `git diff` needs below.
+          fetch-depth: 0
+
+      - name: Determine if crates/velesdb-node changed
+        id: filter
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+          if [[ -z "$BASE_SHA" || "$BASE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            BASE_SHA="$(git rev-list --max-parents=0 HEAD)"
+          fi
+          if git diff --name-only "$BASE_SHA" "${{ github.sha }}" | grep -q '^crates/velesdb-node/'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "crates/velesdb-node/** changed — Windows leg will build."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "crates/velesdb-node/** unchanged — Windows leg will no-op (cost guard)."
+          fi
+
+  # ===========================================================================
+  # Node Binding Tests (Windows) — #1515.
+  #
+  # velesdb-memory-v0.10.0 needed three successive Windows-only fixes (#1509,
+  # #1510, #1511), each found by the release workflow's
+  # x86_64-pc-windows-msvc leg AFTER merge, because PR-time CI only ever
+  # built/tested the addon on Linux. This job closes that gap by running the
+  # same build + test on every PR that touches crates/velesdb-node/**.
+  #
+  # It deliberately reuses the EXACT sequence release-memory.yml's
+  # `build-node` job now uses for x86_64-pc-windows-msvc, instead of
+  # reinventing one that could reintroduce the same bugs:
+  #   - `npx napi build --platform` — identical build invocation (debug
+  #     profile here, same as the Linux node-binding-tests job above).
+  #   - `node --test __test__/index.spec.mjs` instead of `npm test` — #1509:
+  #     `npm test`'s `__test__/*.spec.mjs` glob (package.json) is not
+  #     shell-expanded by npm's Windows shell wrapper on Node 20, so
+  #     `npm test` fails outright with "Could not find '...\*.spec.mjs'"
+  #     before a single test runs. `index.spec.mjs` is also exactly the file
+  #     that carries the two other Windows fixes (#1510's rmSync/EPERM
+  #     tolerance, #1511's fileURLToPath cross-process path fix), so running
+  #     it here would have caught all three pre-merge.
+  #   Coverage gap (tracked, matches the release job's own tradeoff): this
+  #   only runs index.spec.mjs, not the full `__test__/*.spec.mjs` suite
+  #   (remember_extracted.integration + skills-sync are Linux-only for now).
+  #   The full suite still runs on every PR via the Linux node-binding-tests
+  #   job above.
+  # ===========================================================================
+  node-binding-tests-windows:
+    name: Node Binding Tests (Windows)
+    runs-on: windows-latest
+    needs: [test, node-windows-changed]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+        with:
+          node-version: '20'
+
+      - name: Install stable Rust toolchain
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+        with:
+          shared-key: "velesdb-ci-node-windows"
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+
+      # Debug profile, same rationale as the Linux job above. Explicit spec
+      # file (not `npm test`) — see the job-level comment for why (#1509).
+      - name: Build napi addon + run Node tests (Windows)
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+        working-directory: crates/velesdb-node
+        shell: bash
+        run: |
+          npm install --no-audit --no-fund
+          npx napi build --platform
+          node --test __test__/index.spec.mjs
+
+      - name: Skipped — crates/velesdb-node/** unchanged
+        if: needs.node-windows-changed.outputs.relevant != 'true'
+        shell: bash
+        run: echo "No changes under crates/velesdb-node/ on this PR — Windows build skipped to save CI minutes."
+
+  # ===========================================================================
   # Coverage (main seulement)
   # ===========================================================================
   coverage:
@@ -850,7 +965,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, wasm-check, openapi-drift, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, sonarcloud]
+    needs: [lint, test, security, wasm-check, openapi-drift, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, sonarcloud]
     if: always()
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -868,5 +983,6 @@ jobs:
           [[ "${{ needs.python-sdk-tests.result }}" == "success" ]] && \
           [[ "${{ needs.python-integrations.result }}" == "success" ]] && \
           [[ "${{ needs.node-binding-tests.result }}" == "success" ]] && \
+          [[ "${{ needs.node-binding-tests-windows.result }}" == "success" ]] && \
           [[ "${{ needs.security.result }}" == "success" ]] && \
           echo "✅ CI passed" || { echo "❌ CI failed"; exit 1; }


### PR DESCRIPTION
## Summary

Three Windows-only bugs (#1509, #1510, #1511) each blocked the `velesdb-memory-v0.10.0` npm publish and were only found by the **release** workflow's `x86_64-pc-windows-msvc` leg — because PR-time CI (`ci.yml`) only ever built/tested the napi addon on Linux (`node-binding-tests`, ubuntu-latest).

This adds a Windows leg to PR-time CI so these classes of bug are caught before merge, not during a release cut.

## What changed (`.github/workflows/ci.yml`)

- **`node-windows-changed`** (ubuntu-latest, cheap/1x-billed): computes whether the PR's diff touches `crates/velesdb-node/**` (same `git diff --name-only $BASE_SHA $GITHUB_SHA` pattern already used by the `lint` job's SAFETY-template/TODO checks), and exposes `relevant` as a job output.
- **`node-binding-tests-windows`** (windows-latest): builds the napi addon and runs the Node test suite, gated behind that output. It deliberately reuses the *exact* sequence `release-memory.yml`'s `build-node` job now uses for `x86_64-pc-windows-msvc`, instead of reinventing one that could reintroduce the same bugs:
  - `npx napi build --platform` — identical build invocation to the Linux job (debug profile).
  - `node --test __test__/index.spec.mjs` instead of `npm test` — **#1509**: `npm test`'s `__test__/*.spec.mjs` glob (`package.json`) is not shell-expanded by npm's Windows shell wrapper on Node 20, so `npm test` fails outright (`Could not find '...\*.spec.mjs'`) before a single test runs. `index.spec.mjs` also happens to be exactly the file carrying the other two Windows fixes (**#1510**'s `rmSync`/EPERM tolerance, **#1511**'s `fileURLToPath` cross-process path fix) — running it here would have caught all three pre-merge.
- `ci-success` now also requires `node-binding-tests-windows`.

## Why the path filter is inside the job, not a job-level `if:`

The top of `ci.yml` has a long-standing comment explaining why the `pull_request` trigger itself is *not* path-filtered: a path filter there means GitHub creates **zero** check-runs for a non-matching PR, which silently blocks merge forever on a required check (hit in production on PR #1465). The same trap applies one level down to a job-level `if:` on a required job — a skipped job is not a failed job, but it's also not the success state `ci-success` checks for.

So `node-binding-tests-windows` always runs (always produces a check-run), and the per-step `if: needs.node-windows-changed.outputs.relevant == 'true'` gates the actual napi build/test — paying the Windows-runner cost only when `crates/velesdb-node/**` actually changed, while still reporting success/failure deterministically for the required check.

## Coverage tradeoff (tracked, matches the release job's own tradeoff)

This Windows leg only runs `index.spec.mjs`, not the full `__test__/*.spec.mjs` suite (`remember_extracted.integration.spec.mjs` and `skills-sync.spec.mjs` stay Linux-only for now, same as the release smoke test). The full suite still runs on every PR via the existing Linux `node-binding-tests` job's `npm test`.

## Test plan

- [ ] CI green on this PR (touches `crates/velesdb-node/**`? no — expect `node-windows-changed` to report `relevant=false` and the Windows job to no-op/succeed cheaply)
- [ ] Manually verify by touching a file under `crates/velesdb-node/` in a follow-up smoke PR, confirming `node-binding-tests-windows` actually builds and runs `index.spec.mjs` on `windows-latest`
- [ ] Confirm `ci-success` still passes with the new job wired in

Closes #1515