### PR TITLE
fix(scripts): execute promise-contract validation_command for grep-checkable claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`scripts/check-promise-contract.py`**: the promise-contract guardrail
+  only ever checked that a claim's `must_contain` substring was still
+  present in the file it points at — it never executed
+  `validation_command`, so the contract could guarantee a number wasn't
+  *lost* from a doc without ever proving it was still *true*. Two real
+  drifts (a stale WASM bundle-size figure off by +25-28%, and a benchmark
+  corpus label reading 5K when the bench actually inserts 10K vectors)
+  slipped through and were only caught by a manual re-verification pass.
+  Claims in `docs/reference/promise-contract.json` now carry an explicit
+  `"executable"` flag: claims whose `validation_command` is a fast,
+  deterministic, local, no-network README-vs-committed-file comparison
+  (`grep`/file-content checks) are marked `true` and are now actually run
+  via subprocess, failing the script on a real mismatch; claims needing a
+  costly measurement (`cargo bench`, a release build, a published-package
+  download) stay `false` — documentary only — and are explicitly skipped
+  with a visible message naming the claim and the unverified command,
+  never silently ignored. 6 of 27 claims are now executed for real; 21
+  remain documentary. (issue #1518)
 - **`velesdb-memory`**: the `compile_context` prompt-cache prefix could
   churn when only the query changed. `selection_order`
   (`src/context/budget.rs`) used lexical relevance to the query as a

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -6,6 +6,7 @@
       "file": "README.md",
       "must_contain": "HNSW Search index-only (10K/768D, k=10)",
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
+      "executable": false,
       "source": "benchmarks/results/pr363_365_comparison.md (47-56µs measured) — relabeled as 'index-only' for transparency vs the canonical 450µs end-to-end number. Corpus label corrected 5K→10K on 2026-07-20: hnsw_benchmark.rs inserts 10,000 vectors; re-measured quiet (Apple M5 Pro) at 53.2 µs.",
       "last_updated": "2026-04-27"
     },
@@ -14,31 +15,37 @@
       "file": "README.md",
       "must_contain": "SIMD Dot Product (768D, AVX2)",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
+      "executable": false,
       "source": "docs/guides/TUNING_GUIDE.md"
     },
     {
       "id": "root_readme_ci_quality_gate",
       "file": "README.md",
       "must_contain": "cargo test --workspace",
-      "validation_command": "cargo test --workspace"
+      "validation_command": "cargo test --workspace",
+      "executable": false,
+      "notes": "Documentary: running the full workspace test suite from inside this fast contract-check script would duplicate the dedicated CI test job and be far too slow/costly to run on every doc/registry change."
     },
     {
       "id": "core_readme_blazing_fast",
       "file": "crates/velesdb-core/README.md",
       "must_contain": "Blazing Fast",
-      "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark"
+      "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
+      "executable": false
     },
     {
       "id": "core_readme_columnstore_claim",
       "file": "crates/velesdb-core/README.md",
       "must_contain": "ColumnStore filtering",
-      "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark"
+      "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
+      "executable": false
     },
     {
       "id": "readme_simd_dot_product_latency",
       "file": "README.md",
       "must_contain": "**21.7 ns**",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
+      "executable": false,
       "source": "docs/guides/TUNING_GUIDE.md (measured on i9-14900KF, AVX2)",
       "last_updated": "2026-03-29"
     },
@@ -47,6 +54,7 @@
       "file": "README.md",
       "must_contain": "**450 us**",
       "validation_command": "python benchmarks/velesdb_benchmark.py --recall",
+      "executable": false,
       "source": "CHANGELOG.md v1.13.0 (measured 2026-03-27, i9-14900KF, Python SDK, WAL ON; baseline preserved through the pre-seed remediation phases)",
       "last_updated": "2026-04-23"
     },
@@ -55,6 +63,7 @@
       "file": "README.md",
       "must_contain": "**55 us**",
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
+      "executable": false,
       "source": "benchmarks/results/pr363_365_comparison.md (47-56µs range)",
       "last_updated": "2026-03-29"
     },
@@ -63,6 +72,7 @@
       "file": "README.md",
       "must_contain": "**100%**",
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
+      "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md",
       "last_updated": "2026-03-18"
     },
@@ -71,6 +81,7 @@
       "file": "README.md",
       "must_contain": "| Fast | 64 | 92.2% |",
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
+      "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Fast ef=64: 92.2%)",
       "last_updated": "2026-03-29"
     },
@@ -79,6 +90,7 @@
       "file": "README.md",
       "must_contain": "| Balanced (default) | 128 | 98.8% |",
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
+      "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Balanced ef=128: 98.8%)",
       "last_updated": "2026-03-29"
     },
@@ -87,6 +99,7 @@
       "file": "README.md",
       "must_contain": "| Accurate | 512 | 100% |",
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
+      "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Accurate ef=256: 100%)",
       "last_updated": "2026-03-29"
     },
@@ -95,6 +108,7 @@
       "file": "README.md",
       "must_contain": "130x faster",
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
+      "executable": false,
       "source": "README.md: JSON scan 3.84ms vs ColumnStore 29.5us at 100K rows on the i9-14900KF reference. Hardware-dependent ratio, qualified in README since 2026-07-20: Apple M5 Pro quiet re-run measures ~50–105x (JSON scan itself ~2.8x faster there; ColumnStore absolute ~27.15 µs holds).",
       "last_updated": "2026-04-13"
     },
@@ -103,6 +117,7 @@
       "file": "docs/BENCHMARKS.md",
       "must_contain": "SIFT1M",
       "validation_command": "cargo bench -p velesdb-core --bench sift1m_recall --features bench-sift1m",
+      "executable": false,
       "source": "docs/BENCHMARKS.md section 11 (SIFT1M — Standard ANN Benchmark)",
       "last_updated": "2026-04-18",
       "notes": "Gated by --features bench-sift1m + cached download or VELESDB_SIFT1M_DIR. CI skips (feature off); run locally or on a dedicated bench runner. The `must_contain` is intentionally loose (dataset name only) until numeric ranges are populated in section 11.3 from a first stable run on reference hardware — tightening it prematurely would lock the contract around literature reference points that are not VelesDB measurements."
@@ -112,6 +127,7 @@
       "file": "README.md",
       "must_contain": "BM25 Sparse Search index-only (10K docs, top-10)",
       "validation_command": "cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus",
+      "executable": false,
       "source": "PR #621 (commit f4999a74, Phase 4.2 pre-seed remediation): 956us baseline (v1.12) -> 57.6us after linear_scan_dense + k-way merge dedup for corpus <= 100K. Relabeled 'index-only' for transparency.",
       "last_updated": "2026-04-27"
     },
@@ -120,6 +136,7 @@
       "file": "README.md",
       "must_contain": "33 ns",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
+      "executable": false,
       "source": "README.md Distance Metrics table (Cosine, 768D SIMD perf). Footnote *² documents methodology (768D AVX2 hot cache, matches table column header).",
       "last_updated": "2026-05-01"
     },
@@ -128,6 +145,7 @@
       "file": "README.md",
       "must_contain": "20 ns",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
+      "executable": false,
       "source": "README.md Distance Metrics table (Euclidean, 768D SIMD perf). Footnote *² documents methodology (768D AVX2 hot cache, matches table column header).",
       "last_updated": "2026-05-01"
     },
@@ -136,6 +154,7 @@
       "file": "README.md",
       "must_contain": "22 ns",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
+      "executable": false,
       "source": "README.md Distance Metrics table (Dot Product, 768D SIMD perf). Distinct from readme_simd_dot_product_latency (21.7 ns) which references the standalone Vector Engine summary.",
       "last_updated": "2026-05-01"
     },
@@ -144,6 +163,7 @@
       "file": "README.md",
       "must_contain": "100K rows",
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
+      "executable": false,
       "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ scopes the claim: filtering-API micro-benchmark, integer equality, 130x at 100K rows / 55x at 10K rows (docs/BENCHMARKS.md section 6); no 1M-row measurement exists. The filtering API serves SELECT WHERE via the adaptive payload mirror (collection/payload_mirror).",
       "last_updated": "2026-06-10"
     },
@@ -152,6 +172,7 @@
       "file": "README.md",
       "must_contain": "One ~9 MB binary",
       "validation_command": "cargo build --release -p velesdb-server && strip target/release/velesdb-server && du -h target/release/velesdb-server",
+      "executable": false,
       "source": "v1.18.0 stripped local builds on Apple Silicon: velesdb-server 9.1 MB, velesdb-cli 7.3 MB, velesdb-migrate 6.2 MB; v1.18.0 published release artifacts span 7.5-12.4 MB across platforms. README footnote [3] states the 7-13 MB provenance range.",
       "last_updated": "2026-06-12"
     },
@@ -160,6 +181,7 @@
       "file": "README.md",
       "must_contain": "~550 KB gzipped",
       "validation_command": "npm pack @wiscale/velesdb-wasm --dry-run  # published tarball (gzipped) ~536-550 KB",
+      "executable": false,
       "source": "@wiscale/velesdb-wasm v3.12.0 published npm package: velesdb_wasm_bg.wasm gzip -9 = 549,285 bytes (~536 KiB / ~549 kB), measured 2026-07-20. Replaces the stale ~430 KB v1.18.0 figure (+25-28% drift found by sequential re-verification).",
       "last_updated": "2026-06-12"
     },
@@ -167,7 +189,8 @@
       "id": "readme_rest_endpoint_count",
       "file": "README.md",
       "must_contain": "54 REST endpoints",
-      "validation_command": "grep -cE \"^  /\" docs/openapi.yaml  # 54 paths (61 operations counting per-verb)",
+      "validation_command": "test \"$(grep -cE '^  /' docs/openapi.yaml)\" -eq 54",
+      "executable": true,
       "source": "docs/openapi.yaml on this branch: 54 paths / 61 operations, including the relations + TTL endpoints and GET /metrics. Corroborated by crates/velesdb-server/src/routes.rs (54 .route() registrations). Endpoint count convention = OpenAPI paths.",
       "last_updated": "2026-07-10"
     },
@@ -176,6 +199,7 @@
       "file": "README.md",
       "must_contain": "**10.9 %**",
       "validation_command": "grep -qF '10.9 %' README.md && grep -qF '10.9%' examples/real-session-benchmark/README.md",
+      "executable": true,
       "source": "examples/real-session-benchmark/README.md:405 (billed campaign 2026-07-19, 19-turn cropped-screenshot session, cli runner: $0.4442 -> $0.3960 = 10.9% $ saved; raw logs examples/real-session-benchmark/results/2026-07-19-vibe-cli/) — consistency check only, no live billed re-run.",
       "last_updated": "2026-07-19"
     },
@@ -184,6 +208,7 @@
       "file": "README.md",
       "must_contain": "**21.9 %**",
       "validation_command": "grep -qF '21.9 %' README.md && grep -qF '21.9%' examples/real-session-benchmark/README.md && grep -qF '17.6%' examples/real-session-benchmark/README.md",
+      "executable": true,
       "source": "examples/real-session-benchmark/README.md:406 (billed campaign 2026-07-19, 19-turn real-Retina-screenshot session, cli runner: $0.5693 -> $0.4444 = 21.9% $ saved, 17.6% tokens saved; raw logs examples/real-session-benchmark/results/2026-07-19-day-scale/) — consistency check only, no live billed re-run.",
       "last_updated": "2026-07-19"
     },
@@ -192,6 +217,7 @@
       "file": "README.md",
       "must_contain": "**14.7 %**",
       "validation_command": "grep -qF '14.7 %' README.md && grep -qF '14.7%' examples/real-session-benchmark/README.md",
+      "executable": true,
       "source": "examples/real-session-benchmark/README.md:407 (billed campaign 2026-07-19, 36-turn day-scale session, cli runner: $1.8613 -> $1.5876 = 14.7% $ saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-long36-cli.log) — consistency check only, no live billed re-run.",
       "last_updated": "2026-07-19"
     },
@@ -200,6 +226,7 @@
       "file": "README.md",
       "must_contain": "**15.1 %**",
       "validation_command": "grep -qF '15.1 %' README.md && grep -qF '15.1%' examples/real-session-benchmark/README.md",
+      "executable": true,
       "source": "examples/real-session-benchmark/README.md:408 (billed campaign 2026-07-19, 19-turn session via direct Messages API runner: input_tokens 15.1% saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-api.log) — consistency check only, no live billed re-run.",
       "last_updated": "2026-07-19"
     },
@@ -208,6 +235,7 @@
       "file": "README.md",
       "must_contain": "**82.5 %**",
       "validation_command": "grep -qF '82.5 %' README.md && grep -qF '82.5% saved' crates/velesdb-memory/examples/context_savings/README.md && grep -qF '26533 raw -> 4647 compiled' crates/velesdb-memory/examples/context_savings/README.md",
+      "executable": true,
       "source": "crates/velesdb-memory/examples/context_savings/README.md:58 (committed 12-turn agent-session corpus, real cl100k BPE: 26533 raw -> 4647 compiled tokens = 82.5% saved) — consistency check only, no live re-run.",
       "last_updated": "2026-07-19"
     }

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Validate docs promise contract registry against repository content.
 
-Two independent gates run here:
+Three independent gates run here:
 
 1. Registry gate — every claim in ``docs/reference/promise-contract.json`` must
    still be present in the file it points at, so benchmark/headline promises
@@ -10,6 +10,21 @@ Two independent gates run here:
    associate a search-throughput claim with those Capacity Modes. Their
    collection search path stays full-precision f32, so promising throughput
    there would be false. This keeps 10.4 machine-checked alongside the registry.
+3. Executable-claim gate (issue #1518) — gate 1 only ever checked that a
+   claim's ``must_contain`` substring was still present in ``claim["file"]``.
+   It never ran ``validation_command``, so the contract could guarantee a
+   number wasn't *lost* from a doc without ever proving the number was still
+   *true* (two real drifts — a stale WASM bundle-size figure and a mislabeled
+   benchmark corpus size — slipped past it and were only caught by a manual
+   re-verification pass). Claims whose ``validation_command`` is a fast,
+   deterministic, local, no-network comparison (``grep``/file-content checks
+   between the README and a committed source file) are now marked
+   ``"executable": true`` in the registry and actually executed via
+   subprocess; a real failure fails this script. Claims that require a costly
+   measurement (``cargo bench``, a release build, a published-package
+   download) stay ``"executable": false`` — documentary only — and are
+   explicitly skipped with a visible message naming the claim and the
+   unverified command, rather than being silently ignored.
 """
 
 from __future__ import annotations
@@ -17,6 +32,7 @@ from __future__ import annotations
 import json
 import pathlib
 import re
+import subprocess
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 REGISTRY = ROOT / "docs/reference/promise-contract.json"
@@ -47,6 +63,11 @@ NEGATION_RE = re.compile(r"\b(?:no|not|never|without|zero)\b|n't", re.IGNORECASE
 
 # Window of characters before a claim word searched for a negation cue.
 NEGATION_WINDOW = 40
+
+# Wall-clock budget for one executable validation_command. These are meant to
+# be fast local grep/file-comparison checks only — anything needing longer
+# than this has no business being marked "executable": true.
+EXECUTABLE_CLAIM_TIMEOUT_SECONDS = 30
 
 
 def _doc_lines(rel_path: str, text: str) -> list[tuple[int, str]]:
@@ -129,9 +150,77 @@ def check_capacity_mode_overclaim() -> list[str]:
     return failed
 
 
+def run_validation_commands(
+    claims: list[dict],
+) -> tuple[list[str], list[str], list[str]]:
+    """Execute ``validation_command`` for every claim marked executable.
+
+    Claims without ``"executable": true`` (including claims that omit the
+    field entirely — fail-safe default) are never executed; they are
+    reported as skipped with an explicit, visible reason instead of being
+    silently ignored.
+
+    Returns ``(executed_ids, skipped_messages, failure_messages)``.
+    """
+    executed: list[str] = []
+    skipped: list[str] = []
+    failures: list[str] = []
+
+    for claim in claims:
+        claim_id = claim.get("id", "<unknown>")
+        command = claim.get("validation_command")
+
+        if not claim.get("executable", False):
+            skipped.append(
+                f"[{claim_id}] SKIPPED (documentary — requires a costly "
+                f"measurement: benchmark run / release build / published "
+                f"artifact, not auto-verified): {command!r}"
+            )
+            continue
+
+        if not command:
+            failures.append(
+                f"[{claim_id}] marked executable but has no validation_command"
+            )
+            continue
+
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=EXECUTABLE_CLAIM_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append(
+                f"[{claim_id}] validation_command timed out after "
+                f"{EXECUTABLE_CLAIM_TIMEOUT_SECONDS}s: {command!r}"
+            )
+            continue
+
+        executed.append(claim_id)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            message = (
+                f"[{claim_id}] validation_command failed (exit "
+                f"{result.returncode}): {command!r}"
+            )
+            if detail:
+                message += f" — {detail}"
+            failures.append(message)
+
+    return executed, skipped, failures
+
+
 def main() -> int:
     registry_failures = check_registry()
     overclaim_failures = check_capacity_mode_overclaim()
+
+    data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    claims = data.get("claims", [])
+    executed, skipped, execution_failures = run_validation_commands(claims)
 
     if registry_failures:
         print("Promise contract check failed:")
@@ -143,13 +232,23 @@ def main() -> int:
         for msg in overclaim_failures:
             print(f"  - {msg}")
 
-    if registry_failures or overclaim_failures:
+    if execution_failures:
+        print("Executable validation_command check failed:")
+        for msg in execution_failures:
+            print(f"  - {msg}")
+
+    if skipped:
+        print("Documentary claims not auto-verified:")
+        for msg in skipped:
+            print(f"  - {msg}")
+
+    if registry_failures or overclaim_failures or execution_failures:
         return 1
 
-    data = json.loads(REGISTRY.read_text(encoding="utf-8"))
-    claim_count = len(data.get("claims", []))
+    claim_count = len(claims)
     print(
         f"Promise contract check passed ({claim_count} claims; "
+        f"{len(executed)} executed, {len(skipped)} documentary; "
         f"{len(CAPACITY_MODE_DOCS)} capacity-mode docs clean)."
     )
     return 0

--- a/scripts/tests/test_check_promise_contract.py
+++ b/scripts/tests/test_check_promise_contract.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/check-promise-contract.py.
+
+Issue #1518: the registry gate only ever checked that a claim's
+`must_contain` substring was still present in `claim["file"]` — it never
+executed `validation_command`. That means the contract could guarantee a
+number wasn't *lost* from a doc, but never that the number was still *true*.
+Two real drifts (WASM bundle size +25-28%, HNSW bench corpus label 5K vs the
+actual 10K inserted) slipped through a manual re-verification pass instead of
+being caught by this script.
+
+These tests pin the new behavior:
+
+* A claim marked ``"executable": true`` must have its ``validation_command``
+  actually run via subprocess; a real failure of that command must fail the
+  overall check (not just a `must_contain` string check).
+* A claim marked ``"executable": false`` (or missing the key) is a
+  documentary-only claim (costly benchmark/build/network measurement) and
+  must be skipped explicitly, with a visible message identifying which claim
+  was skipped and why — never silently ignored.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-promise-contract.py"
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_promise_contract", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cpc = _load_script()
+
+
+class RunValidationCommandsTests(unittest.TestCase):
+    """Unit tests for the new executable-claim runner."""
+
+    def test_executable_claim_with_passing_command_is_executed_and_reports_no_failure(
+        self,
+    ) -> None:
+        claims = [
+            {
+                "id": "fake_passing_claim",
+                "executable": True,
+                "validation_command": "true",
+            }
+        ]
+        executed, skipped, failures = cpc.run_validation_commands(claims)
+        self.assertEqual(executed, ["fake_passing_claim"])
+        self.assertEqual(skipped, [])
+        self.assertEqual(failures, [])
+
+    def test_executable_claim_with_failing_command_is_reported_as_a_failure(self) -> None:
+        """A validation_command that actually fails (e.g. a grep that no longer
+        matches, meaning the claim it backs has drifted from reality) must
+        surface as a hard failure, not be silently swallowed."""
+        claims = [
+            {
+                "id": "fake_failing_claim",
+                "executable": True,
+                # grep -qF on a string that cannot exist in /dev/null fails (exit 1).
+                "validation_command": "grep -qF 'this-string-does-not-exist' /dev/null",
+            }
+        ]
+        executed, skipped, failures = cpc.run_validation_commands(claims)
+        self.assertEqual(executed, ["fake_failing_claim"])
+        self.assertEqual(skipped, [])
+        self.assertEqual(len(failures), 1)
+        self.assertIn("fake_failing_claim", failures[0])
+
+    def test_non_executable_claim_is_skipped_with_an_explicit_message(self) -> None:
+        claims = [
+            {
+                "id": "fake_documentary_claim",
+                "executable": False,
+                "validation_command": "cargo bench -p velesdb-core --bench some_bench",
+            }
+        ]
+        executed, skipped, failures = cpc.run_validation_commands(claims)
+        self.assertEqual(executed, [])
+        self.assertEqual(failures, [])
+        self.assertEqual(len(skipped), 1)
+        self.assertIn("fake_documentary_claim", skipped[0])
+        # The message must not be silent about *why* — it should name the
+        # command that is not being auto-verified.
+        self.assertIn("cargo bench", skipped[0])
+
+    def test_claim_missing_executable_key_defaults_to_skipped(self) -> None:
+        """A claim added to the registry without the new field must default to
+        documentary (fail-safe: never silently execute an unvetted command)."""
+        claims = [
+            {
+                "id": "fake_claim_no_field",
+                "validation_command": "true",
+            }
+        ]
+        executed, skipped, failures = cpc.run_validation_commands(claims)
+        self.assertEqual(executed, [])
+        self.assertEqual(len(skipped), 1)
+        self.assertEqual(failures, [])
+
+
+class RealRegistryExecutableClaimsTests(unittest.TestCase):
+    """Integration tests against the real docs/reference/promise-contract.json."""
+
+    def test_real_registry_executable_claims_all_pass_right_now(self) -> None:
+        """Every claim currently marked executable in the real registry must
+        have a validation_command that actually passes against the repo's
+        current state. A failure here is a genuine signal of drift — not a
+        test bug — and must not be silenced.
+        """
+        import json
+
+        data = json.loads(cpc.REGISTRY.read_text(encoding="utf-8"))
+        claims = data.get("claims", [])
+        executed, _skipped, failures = cpc.run_validation_commands(claims)
+        self.assertGreater(
+            len(executed), 0, "expected at least one claim to be marked executable"
+        )
+        self.assertEqual(failures, [], f"real executable claims failing: {failures}")
+
+    def test_real_registry_has_both_executable_and_documentary_claims(self) -> None:
+        import json
+
+        data = json.loads(cpc.REGISTRY.read_text(encoding="utf-8"))
+        claims = data.get("claims", [])
+        executable_count = sum(1 for c in claims if c.get("executable") is True)
+        documentary_count = sum(1 for c in claims if c.get("executable") is False)
+        self.assertGreater(executable_count, 0)
+        self.assertGreater(documentary_count, 0)
+        self.assertEqual(executable_count + documentary_count, len(claims))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- The promise-contract guardrail (`scripts/check-promise-contract.py`) only ever checked that a claim's `must_contain` substring was still present in the file it points at — it never executed `validation_command`. That guaranteed a README number wasn't *lost*, never that it was still *true*.
- Two real drifts slipped past it and were only caught by a manual re-verification pass on 2026-07-20: the WASM bundle size (documented ~430 KB vs the published 3.12.0 artifact's 549,285 gzipped bytes, +25-28%) and the HNSW bench corpus label (5K vs the bench's actual 10K inserted vectors).
- Added an explicit `"executable"` flag to every claim in `docs/reference/promise-contract.json`:
  - `true` (6 claims) — fast, deterministic, no-network, README-vs-committed-file `grep` comparisons. These are now actually executed via `subprocess` in `run_validation_commands()`, and a real command failure fails the whole check.
  - `false` (21 claims) — claims needing a costly measurement (`cargo bench`, a release build, an `npm pack --dry-run` against the published registry). These stay documentary-only and are explicitly skipped with a visible, non-silent message naming the claim id and the unverified command.
  - `readme_rest_endpoint_count`'s `validation_command` was tightened from a bare `grep -c` (which only checked "at least one match", so it could never actually fail) to `test "$(grep -cE '^  /' docs/openapi.yaml)" -eq 54`, so it genuinely asserts the count.
- Ran the updated script against the current repo state: all 6 now-executable claims pass — no additional drift found at this time.

## Test plan

- [x] TDD red: added `scripts/tests/test_check_promise_contract.py`; confirmed it failed before `run_validation_commands` existed (`AttributeError`), and confirmed the two "real registry" integration tests failed before the JSON gained `executable` fields.
- [x] TDD green: `python3 -m unittest discover -s scripts/tests -p "test_*.py"` → 31 tests, all pass (includes the 5 new tests plus the two pre-existing check-script suites, confirming nothing else broke).
- [x] `python3 scripts/check-promise-contract.py` → exit 0, `27 claims; 6 executed, 21 documentary; 3 capacity-mode docs clean`.
- [x] `python3 -c "import json; json.load(open('docs/reference/promise-contract.json'))"` → valid JSON.
- [x] No CI workflow changes needed — `.github/workflows/promise-contract.yml` and `propagation-guard.yml` invoke the script the same way; its CLI interface and exit-code contract are unchanged.
- [x] CHANGELOG.md updated under `[Unreleased] / Fixed`.

Closes #1518