### PR TITLE
feat(wasm,ts-sdk): expose working-context save/load/list on WASM and TS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Agents burn most of their budget re-reading redundant context. The memory layer 
 | **MCP server** ([`velesdb-memory`](crates/velesdb-memory)) + **Rust** | Full set: `compile_context`, `compile_transcript`, `retrieve_context_source`, `context_savings`, `save/load/list_working_contexts`, `explain_compilation` — MCP covers any other client |
 | **Node** ([`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node)) | `compileContext`, `retrieveContextSource`, `save/loadWorkingContext`, `feedback` — parity for `contextSavings`/`explainCompilation` in progress |
 | **Python** (`pip install velesdb`) | Same set as Node plus `context_savings` merged on `develop`; the published wheel predates it — until the next release, Python agents reach the compiler through the MCP server |
-| **WASM / TypeScript SDK** | `compileContext` alone, in-memory — no working-context persistence on this surface |
+| **WASM / TypeScript SDK** | `compileContext`, `retrieveContextSource`, `save/loadWorkingContext`, `listWorkingContexts` — all in-memory, intra-session only: useful to carry state across two calls in the same page load, not to resume after a reload (no IndexedDB/disk backend yet, [#1517](https://github.com/cyberlife-coder/VelesDB/issues/1517)) |
 
 </details>
 

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -25,7 +25,9 @@ use serde::Serialize;
 use serde_json::Value;
 use wasm_bindgen::prelude::*;
 
-use velesdb_memory::context::{CompilePolicy, CompileRequest, ContextCompiler};
+use velesdb_memory::context::{
+    CompilePolicy, CompileRequest, ContextCompiler, WorkingContext, WorkingContextSession,
+};
 use velesdb_memory::{
     ColumnFilter, ColumnOp, Explanation, FusionOptions, HashEmbedder, MemoryEdge, MemoryError,
     MemoryNode, MemoryService, Metadata, Recollection,
@@ -75,6 +77,16 @@ fn parse_id(s: &str) -> Result<u64, JsValue> {
 /// `velesdb_memory::context::wire`, not duplicated here.
 fn stringify_id_fields(value: &mut Value) {
     velesdb_memory::context::wire::stringify_id_fields(value);
+}
+
+/// The inverse of [`stringify_id_fields`]: recursively rewrite every
+/// `context` id field given in the binding's decimal-string form back into
+/// the numeric form the domain types deserialize (used by
+/// [`WasmMemoryService::save_working_context`], the same helper the Node
+/// binding applies before deserializing a `WorkingContext`). Shared with the
+/// Node binding via `velesdb_memory::context::wire`, not duplicated here.
+fn parse_id_fields(value: &mut Value) -> Result<(), JsValue> {
+    velesdb_memory::context::wire::parse_id_fields(value).map_err(invalid_input)
 }
 
 /// Accept `fragments[].id` in decimal-string form (the Node binding's
@@ -541,6 +553,95 @@ impl WasmMemoryService {
         map.insert("handle".to_owned(), Value::String(handle.to_owned()));
         to_js(&Value::Object(map))
     }
+
+    /// Persist the agent's distilled working state under `project` +
+    /// `session` (idempotent upsert: saving again replaces the previous
+    /// state), for later resumption (#1517, option 2). Same wire shape as
+    /// the Node binding's `saveWorkingContext` — the request's own field
+    /// names (`goal`, `active_constraints`, `decisions`, …), decimal-string
+    /// ids — pure delegation to `velesdb_memory`'s bridge, no reshaping.
+    /// Resolves to the stored fact id as a decimal string.
+    ///
+    /// **In-memory semantics**: like [`Self::compile_context`], this is
+    /// backed entirely by this session's [`WasmStore`] — there is no
+    /// filesystem or IndexedDB persistence behind this binding. A "saved"
+    /// working context disappears the moment the page (or worker) that
+    /// created this `MemoryService` instance is gone. This is useful to
+    /// carry state between two calls made within the SAME page load (e.g.
+    /// across two `compileContext` calls), not to resume a session after a
+    /// reload — that would need a real browser-storage backend, which does
+    /// not exist yet.
+    #[wasm_bindgen(js_name = saveWorkingContext)]
+    pub fn save_working_context(
+        &self,
+        project: &str,
+        session: &str,
+        working: JsValue,
+    ) -> Result<String, JsValue> {
+        let mut working: Value = serde_wasm_bindgen::from_value(working)
+            .map_err(|e| invalid_input(format!("invalid working context: {e}")))?;
+        parse_id_fields(&mut working)?;
+        let working: WorkingContext = serde_json::from_value(working)
+            .map_err(|e| invalid_input(format!("invalid working context: {e}")))?;
+        self.inner
+            .save_working_context(project, session, &working)
+            .map(id_to_string)
+            .map_err(to_js_err)
+    }
+
+    /// The working context previously saved under `project` + `session` —
+    /// `null` in JS when there is none, the start-of-session mirror of
+    /// [`Self::save_working_context`] (#1517, option 2).
+    ///
+    /// **In-memory semantics**: see [`Self::save_working_context`]'s doc
+    /// comment — this only ever resolves what THIS session's [`WasmStore`]
+    /// still holds; nothing persists across a page reload.
+    #[wasm_bindgen(js_name = loadWorkingContext)]
+    pub fn load_working_context(&self, project: &str, session: &str) -> Result<JsValue, JsValue> {
+        let loaded = self
+            .inner
+            .load_working_context(project, session)
+            .map_err(to_js_err)?;
+        match loaded {
+            Some(working) => {
+                let mut value = serde_json::to_value(&working)
+                    .map_err(|e| structured_js_error(CODE_INTERNAL, &format!("serialize: {e}")))?;
+                stringify_id_fields(&mut value);
+                to_js(&value)
+            }
+            None => Ok(JsValue::NULL),
+        }
+    }
+
+    /// Every session ever saved under `project`'s working-context index,
+    /// most-recently-saved first: resolves to `{sessions: [{session,
+    /// saved_at}]}` — empty (never an error) when the project never saved
+    /// anything (#1517, option 2).
+    ///
+    /// **In-memory semantics**: see [`Self::save_working_context`]'s doc
+    /// comment — reflects only what this session's [`WasmStore`] currently
+    /// holds, never a cross-session/browser-restart view.
+    #[wasm_bindgen(js_name = listWorkingContexts)]
+    pub fn list_working_contexts(&self, project: &str) -> Result<JsValue, JsValue> {
+        let sessions = self
+            .inner
+            .list_working_contexts(project)
+            .map_err(to_js_err)?;
+        let value = serde_json::to_value(SessionsOut { sessions })
+            .map_err(|e| structured_js_error(CODE_INTERNAL, &format!("serialize: {e}")))?;
+        to_js(&value)
+    }
+}
+
+/// Wire envelope for [`WasmMemoryService::list_working_contexts`]: same
+/// shape as the MCP `list_working_contexts` tool's result
+/// (`{sessions: [...]}`), field names left as `WorkingContextSession`
+/// serializes them (`session`, `saved_at`) — no camelCase remapping, for the
+/// same reason `compile_context`/`retrieveContextSource` don't reshape their
+/// output either.
+#[derive(Serialize)]
+struct SessionsOut {
+    sessions: Vec<WorkingContextSession>,
 }
 
 #[cfg(test)]

--- a/crates/velesdb-wasm/tests/memory_wedge_web.rs
+++ b/crates/velesdb-wasm/tests/memory_wedge_web.rs
@@ -388,3 +388,114 @@ fn retrieve_context_source_unknown_handle_rejects_with_not_found() {
         .unwrap();
     assert_eq!(code, "NOT_FOUND");
 }
+
+// --- saveWorkingContext / loadWorkingContext / listWorkingContexts (#1517) --
+//
+// Issue #1517's decision (Option 2): expose these three on WASM/TS with a
+// clearly documented INTRA-SESSION semantics — same caveat already pinned
+// above for `compile_context`/`retrieveContextSource`: this binding's
+// `WasmStore` is in-memory only, so a "saved" working context disappears on
+// page reload. Useful to carry state between two calls within the SAME
+// page load; not real cross-session persistence (no IndexedDB backend yet).
+
+/// Save then load within the same session round-trips byte-identical,
+/// including a `u64::MAX` id field (`decisions[].fragment_id`) — proves ids
+/// never pass through a JS number on this path either, matching
+/// `compile_context_round_trips_with_string_ids`.
+#[wasm_bindgen_test]
+fn save_then_load_working_context_round_trips_within_session() {
+    let svc = WasmMemoryService::new(16);
+    let working = js_sys::JSON::parse(
+        r#"{
+            "goal": "ship the canary fix",
+            "active_constraints": [],
+            "verified_facts": [],
+            "open_hypotheses": [],
+            "decisions": [
+                {"fragment_id": "18446744073709551615", "rule_id": "media.atomic"}
+            ],
+            "exact_evidence": [],
+            "pending_actions": ["roll back if error rate spikes"]
+        }"#,
+    )
+    .unwrap();
+
+    let id = svc
+        .save_working_context("veles", "session-a", working.clone())
+        .unwrap();
+    assert!(!id.is_empty(), "save resolves to a non-empty fact id");
+
+    let loaded = svc.load_working_context("veles", "session-a").unwrap();
+    assert!(
+        !loaded.is_instance_of::<js_sys::Map>(),
+        "loaded working context must be a plain object"
+    );
+    let goal = js_sys::Reflect::get(&loaded, &"goal".into())
+        .unwrap()
+        .as_string()
+        .unwrap();
+    assert_eq!(goal, "ship the canary fix");
+
+    let decisions = js_sys::Reflect::get(&loaded, &"decisions".into()).unwrap();
+    let first = js_sys::Reflect::get(&decisions, &0.into()).unwrap();
+    let fragment_id = js_sys::Reflect::get(&first, &"fragment_id".into())
+        .unwrap()
+        .as_string()
+        .expect("fragment_id must cross back as a decimal string, not a number");
+    assert_eq!(fragment_id, "18446744073709551615", "u64::MAX round-trips");
+
+    let pending = js_sys::Reflect::get(&loaded, &"pending_actions".into()).unwrap();
+    let first_action = js_sys::Reflect::get(&pending, &0.into())
+        .unwrap()
+        .as_string()
+        .unwrap();
+    assert_eq!(first_action, "roll back if error rate spikes");
+}
+
+/// Nothing saved under a project + session pair loads back as `null` in JS —
+/// mirroring the Node binding's `loadWorkingContext` contract — never an
+/// error, and never a forged/leaked value from an unrelated slot.
+#[wasm_bindgen_test]
+fn load_working_context_returns_null_when_nothing_saved() {
+    let svc = WasmMemoryService::new(16);
+    let loaded = svc
+        .load_working_context("veles", "never-saved-session")
+        .unwrap();
+    assert!(
+        loaded.is_null(),
+        "an unsaved project+session pair must load back as null"
+    );
+}
+
+/// `listWorkingContexts` surfaces every session saved under a project,
+/// most-recently-saved first, and stays empty (not an error) for a project
+/// that never saved anything.
+#[wasm_bindgen_test]
+fn list_working_contexts_lists_saved_sessions_for_a_project() {
+    let svc = WasmMemoryService::new(16);
+    let empty = js_sys::JSON::parse(r#"{}"#).unwrap();
+
+    svc.save_working_context("veles", "session-a", empty.clone())
+        .unwrap();
+    svc.save_working_context("veles", "session-b", empty)
+        .unwrap();
+
+    let listed = svc.list_working_contexts("veles").unwrap();
+    let sessions = js_sys::Reflect::get(&listed, &"sessions".into()).unwrap();
+    let length = js_sys::Reflect::get(&sessions, &"length".into())
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32;
+    assert_eq!(length, 2, "both saved sessions must be listed");
+
+    let empty_project = svc.list_working_contexts("never-used-project").unwrap();
+    let empty_sessions = js_sys::Reflect::get(&empty_project, &"sessions".into()).unwrap();
+    let empty_length = js_sys::Reflect::get(&empty_sessions, &"length".into())
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32;
+    assert_eq!(
+        empty_length, 0,
+        "a project that never saved anything lists no sessions"
+    );
+}

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -132,6 +132,47 @@ export interface ContextSource {
   [key: string]: unknown;
 }
 
+/**
+ * The distilled working state of an agent session, persisted and reloaded
+ * via {@link MemoryService.saveWorkingContext} /
+ * {@link MemoryService.loadWorkingContext} (#1517). Same wire shape as the
+ * Node binding's `WorkingContext` (snake_case keys); nested fact/decision
+ * shapes are kept as `unknown` here, matching {@link CompiledContext}'s own
+ * convention for wire-shaped sub-objects this SDK does not otherwise need
+ * to inspect.
+ */
+export interface WorkingContext {
+  /** What the session is trying to achieve. */
+  goal?: string;
+  /** Constraints currently in force (never compressed away). */
+  active_constraints?: unknown[];
+  /** Facts that were verified, with their sources. */
+  verified_facts?: unknown[];
+  /** Hypotheses still open. */
+  open_hypotheses?: unknown[];
+  /** Decisions taken so far (`{fragment_id, rule_id}`, `fragment_id` a decimal string). */
+  decisions?: unknown[];
+  /** Exact evidence the session relies on (verbatim, addressable). */
+  exact_evidence?: unknown[];
+  /** Actions still to do. */
+  pending_actions?: string[];
+  [key: string]: unknown;
+}
+
+/** One session recorded in a project's working-context index (output of {@link MemoryService.listWorkingContexts}). */
+export interface WorkingContextSession {
+  /** The session id, as passed to {@link MemoryService.saveWorkingContext}. */
+  session: string;
+  /** Unix seconds this session was last saved. */
+  saved_at: number;
+}
+
+/** Result of {@link MemoryService.listWorkingContexts}. */
+export interface ListWorkingContextsResult {
+  /** Every session saved under this project, most-recently-saved first. */
+  sessions: WorkingContextSession[];
+}
+
 /** A structured predicate for {@link MemoryService.recallWhere}. */
 export interface MemoryColumnFilter {
   /** Metadata field name (alphanumeric/underscore). */
@@ -221,6 +262,9 @@ interface WasmMemoryServiceInstance {
   why(decision: string, maxHops: number | null | undefined, filter: unknown): unknown;
   compileContext(request: unknown): unknown;
   retrieveContextSource(handle: string): unknown;
+  saveWorkingContext(project: string, session: string, working: unknown): string;
+  loadWorkingContext(project: string, session: string): unknown;
+  listWorkingContexts(project: string): unknown;
   free(): void;
 }
 
@@ -518,6 +562,64 @@ export class MemoryService {
   retrieveContextSource(handle: string): Promise<ContextSource> {
     return wrapWasmCall(
       () => this.ensureInitialized().retrieveContextSource(handle) as ContextSource
+    );
+  }
+
+  /**
+   * Persist the agent's distilled working state under `project` + `session`
+   * (idempotent upsert: saving again replaces the previous state), for
+   * later resumption (#1517, option 2). Same wire shape as the Node
+   * binding's `saveWorkingContext`. Resolves to the stored fact id as a
+   * decimal string.
+   *
+   * **In-memory semantics**: like {@link compileContext}, this is backed
+   * entirely by this session's in-memory wasm store — there is no
+   * filesystem or IndexedDB persistence behind this binding. A "saved"
+   * working context disappears the moment this `MemoryService` instance
+   * (and the page/worker that created it) is gone. This is useful to carry
+   * state between two calls made within the SAME page load (e.g. across two
+   * {@link compileContext} calls), not to resume a session after a reload —
+   * that would need a real browser-storage backend, which does not exist
+   * yet.
+   */
+  saveWorkingContext(
+    project: string,
+    session: string,
+    working: WorkingContext
+  ): Promise<string> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().saveWorkingContext(project, session, working) as string
+    );
+  }
+
+  /**
+   * The working context previously saved under `project` + `session` —
+   * `null` when there is none, the start-of-session mirror of
+   * {@link saveWorkingContext} (#1517, option 2).
+   *
+   * **In-memory semantics**: see {@link saveWorkingContext}'s doc comment —
+   * this only ever resolves what THIS session's in-memory store still
+   * holds; nothing persists across a page reload.
+   */
+  loadWorkingContext(project: string, session: string): Promise<WorkingContext | null> {
+    return wrapWasmCall(
+      () =>
+        this.ensureInitialized().loadWorkingContext(project, session) as WorkingContext | null
+    );
+  }
+
+  /**
+   * Every session ever saved under `project`'s working-context index,
+   * most-recently-saved first — empty (never an error) when the project
+   * never saved anything (#1517, option 2).
+   *
+   * **In-memory semantics**: see {@link saveWorkingContext}'s doc comment —
+   * reflects only what this session's in-memory store currently holds,
+   * never a cross-session/browser-restart view.
+   */
+  listWorkingContexts(project: string): Promise<ListWorkingContextsResult> {
+    return wrapWasmCall(
+      () => this.ensureInitialized().listWorkingContexts(project) as ListWorkingContextsResult
     );
   }
 }

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -49,6 +49,15 @@ class MockWasmMemoryService {
     handle: 'ctx://source/123',
     content: 'the original fragment text',
   }));
+  saveWorkingContext = vi.fn(() => '42');
+  loadWorkingContext = vi.fn(() => ({
+    goal: 'ship the canary fix',
+    decisions: [{ fragment_id: '18446744073709551615', rule_id: 'media.atomic' }],
+    pending_actions: ['roll back if error rate spikes'],
+  }));
+  listWorkingContexts = vi.fn(() => ({
+    sessions: [{ session: 'session-a', saved_at: 1731000000 }],
+  }));
   free = vi.fn();
 
   constructor(public dimension: number) {
@@ -281,6 +290,38 @@ describe('MemoryService', () => {
       const resolved = await memory.retrieveContextSource('ctx://source/456');
       expect(resolved.media?.bytes_b64).toBe('aGVsbG8=');
       expect(resolved.media?.mime).toBe('image/png');
+    });
+
+    it('saveWorkingContext() delegates project/session/working and returns the fact id', async () => {
+      const working = { goal: 'ship the canary fix', pending_actions: ['watch error rate'] };
+      const id = await memory.saveWorkingContext('veles', 'session-a', working);
+      expect(lastMockInstance!.saveWorkingContext).toHaveBeenCalledWith(
+        'veles',
+        'session-a',
+        working
+      );
+      expect(id).toBe('42');
+    });
+
+    it('loadWorkingContext() returns the mocked working context, decimal ids intact', async () => {
+      const loaded = await memory.loadWorkingContext('veles', 'session-a');
+      expect(lastMockInstance!.loadWorkingContext).toHaveBeenCalledWith('veles', 'session-a');
+      expect(loaded?.goal).toBe('ship the canary fix');
+      const decisions = loaded?.decisions as Array<{ fragment_id: string }>;
+      expect(decisions[0].fragment_id).toBe('18446744073709551615');
+    });
+
+    it('loadWorkingContext() returns null when nothing was saved', async () => {
+      lastMockInstance!.loadWorkingContext.mockReturnValueOnce(null);
+      const loaded = await memory.loadWorkingContext('veles', 'never-saved-session');
+      expect(loaded).toBeNull();
+    });
+
+    it('listWorkingContexts() delegates the project and returns the sessions', async () => {
+      const result = await memory.listWorkingContexts('veles');
+      expect(lastMockInstance!.listWorkingContexts).toHaveBeenCalledWith('veles');
+      expect(result.sessions).toHaveLength(1);
+      expect(result.sessions[0].session).toBe('session-a');
     });
 
     it('why() returns the explanation subgraph', async () => {


### PR DESCRIPTION
## Summary
- Issue #1517's decision (option 2): expose `saveWorkingContext` / `loadWorkingContext` / `listWorkingContexts` on the WASM binding and the TypeScript SDK, following the `retrieveContextSource` (V2d-2, PR #1503) pattern — with a clearly documented **intra-session** semantics caveat, since the WASM `MemoryService` store is in-memory only (no IndexedDB/disk persistence).
- `crates/velesdb-wasm/src/memory_service.rs`: three new `wasm_bindgen` methods delegating to `velesdb-memory`'s existing bridge (`save_working_context`/`load_working_context`/`list_working_contexts`), reusing the id-field decimal-string wire contract (adds a `parse_id_fields` wrapper symmetric to the existing `stringify_id_fields` one).
- `sdks/typescript/src/memory.ts`: `WorkingContext` / `WorkingContextSession` / `ListWorkingContextsResult` types plus the three wrapper methods, same doc-comment caveat as `compileContext`/`retrieveContextSource`.
- `README.md`: updates the "Tool parity by surface" table's WASM/TS row — no longer "no working-context persistence on this surface"; now lists the three methods with the intra-session caveat and links #1517.

## Test plan
- [x] RED confirmed: stashed the WASM implementation, `wasm-pack test --node -- --test memory_wedge_web` fails to compile (`method not found`) on the 3 new tests.
- [x] GREEN: same suite passes 14/14 after restoring the implementation.
- [x] RED confirmed: stashed the TS SDK implementation, `vitest run tests/memory.test.ts` fails 4 tests (`is not a function`).
- [x] GREEN: same suite passes 34/34 after restoring the implementation.
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown`
- [x] `cargo clippy -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo test -p velesdb-wasm --lib` (625 passed)
- [x] `wasm-pack test --node -- --test memory_wedge_web` (14 passed)
- [x] `npm run typecheck`, `npm run lint`, `npm test` in `sdks/typescript` (903 passed)
- [x] `python3 scripts/check-promise-contract.py` stays green after the README edit
- [x] Full pre-commit hook (fmt + clippy + workspace tests + safety/TODO/secrets checks) passed

Closes #1517
