### PR TITLE
fix(velesdb-memory): segmentation error taxonomy and partitioned jsonl re-split ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with a visible message naming the claim and the unverified command,
   never silently ignored. 6 of 27 claims are now executed for real; 21
   remain documentary. (issue #1518)
+- **`velesdb-memory`**: two `compile_transcript`/`segment_transcript`
+  adversarial-review follow-ups from #1500, deliberately deferred (issue
+  #1516). **(1) Error taxonomy — potentially breaking for a caller
+  matching on the error variant/message.** A forced
+  `segmentation.format: "jsonl"` that failed to parse used to surface as
+  `MemoryError::ContextOverLimit` with a misleading "over limit" prefix on
+  what is really a format/parsing failure, not a budget breach. It now
+  surfaces as a new, dedicated `MemoryError::SegmentationError` variant.
+  Both stay in the same `INVALID_PARAMS`-category MCP taxonomy (JSON-RPC
+  code unchanged), so an MCP client only sees the error message change;
+  a Rust caller of `velesdb-memory` directly that pattern-matched on
+  `MemoryError::ContextOverLimit` for this specific case must now match
+  `MemoryError::SegmentationError` instead. A genuine budget/cap breach
+  (transcript over the byte cap, an unsplittable oversized fence, too many
+  fragments after merging) is unaffected — still `ContextOverLimit`. **(2)
+  Duplicated ranges.** Re-splitting a `content_override` (a `jsonl` line
+  whose decoded `content` alone exceeded `MAX_FRAGMENT_BYTES`, over 1 MiB)
+  used to give every resulting child segment the SAME original line's byte
+  range, so `segmentation.segments` reported overlapping ranges —
+  contradicting the partition property `compile_transcript` advertises.
+  Each child now gets a distinct, non-overlapping sub-range of the
+  original line, proportional to its share of the decoded content (a
+  JSONL line's raw JSON-escaped bytes have no byte-exact mapping back to
+  the decoded text, so the split is proportional, not byte-precise) —
+  `segmentation.segments` now partitions the transcript exactly in every
+  case, including this one.
 - **`velesdb-memory`**: the `compile_context` prompt-cache prefix could
   churn when only the query changed. `selection_order`
   (`src/context/budget.rs`) used lexical relevance to the query as a

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -20,7 +20,9 @@
 //! 1. **Format detection** ([`detect_and_segment`]): `jsonl` when every
 //!    non-empty line parses as a `{role, content}` JSON object, `plain`
 //!    otherwise. A caller-forced format that does not parse is a hard error —
-//!    never a silent fallback to the other format.
+//!    never a silent fallback to the other format — surfaced as
+//!    [`crate::error::MemoryError::SegmentationError`] (a FORMAT failure,
+//!    distinct from a budget/cap breach; see below).
 //! 2. **Turns**: `jsonl` — one line, one turn, `role` taken directly from the
 //!    parsed JSON. `plain` — a CLOSED table of markers (`"System:"`,
 //!    `"User:"`, `"Human:"`, `"Assistant:"`, `"AI:"`, `"Tool:"`,
@@ -45,12 +47,19 @@
 //!    [`crate::limits::MAX_FRAGMENTS`] segments after merging is a hard,
 //!    actionable error ("raise `min_segment_bytes`") — never a silent drop.
 //!
-//! Every error surfaces as [`crate::error::MemoryError::ContextOverLimit`] or
+//! A genuine budget/cap breach (transcript over
+//! [`crate::limits::MAX_TRANSCRIPT_BYTES`], an unsplittable oversized fence,
+//! or too many fragments after merging) surfaces as
+//! [`crate::error::MemoryError::ContextOverLimit`]; a FORMAT/parsing failure
+//! (a forced `jsonl` line that does not parse) surfaces as the distinct
+//! [`crate::error::MemoryError::SegmentationError`] (issue #1516, m2 — kept
+//! separate precisely so a caller filtering on the error message cannot
+//! confuse a malformed-input error for a size breach, even though both map
+//! to the same `INVALID_PARAMS`-category MCP code). A `path`-sourced
+//! transcript can additionally fail with
 //! [`crate::error::MemoryError::IngestDisabled`]/[`crate::error::MemoryError::IngestOutsideRoots`]/
-//! [`crate::error::MemoryError::IngestPath`] (the last three only for a
-//! `path`-sourced transcript, via [`super::ingest::resolve_transcript_path`])
-//! — the same `INVALID_PARAMS`-category taxonomy `compile_context` already
-//! uses, deliberately not a new variant for this PR.
+//! [`crate::error::MemoryError::IngestPath`], via
+//! [`super::ingest::resolve_transcript_path`].
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -195,10 +204,12 @@ pub struct SegmentationOutcome {
 ///
 /// # Errors
 /// [`MemoryError::ContextOverLimit`] when `text` exceeds
-/// [`MAX_TRANSCRIPT_BYTES`], when [`SegmentFormat::Jsonl`] is forced but a
-/// line does not parse as a `{role, content}` object, when an unsplittable
-/// fence exceeds [`MAX_FRAGMENT_BYTES`], or when the segment count after
-/// merging still exceeds [`MAX_FRAGMENTS`].
+/// [`MAX_TRANSCRIPT_BYTES`], when an unsplittable fence exceeds
+/// [`MAX_FRAGMENT_BYTES`], or when the segment count after merging still
+/// exceeds [`MAX_FRAGMENTS`] — all genuine budget/cap breaches.
+/// [`MemoryError::SegmentationError`] when [`SegmentFormat::Jsonl`] is forced
+/// but a line does not parse as a `{role, content}` object — a FORMAT
+/// failure, not a budget breach (issue #1516, m2).
 pub fn segment_transcript(
     text: &str,
     policy: &SegmentationPolicy,
@@ -262,7 +273,7 @@ fn detect_and_segment(
     match requested {
         SegmentFormat::Plain => Ok((SegmentFormat::Plain, plain_pieces(text))),
         SegmentFormat::Jsonl => {
-            let pieces = jsonl_pieces(text).map_err(MemoryError::ContextOverLimit)?;
+            let pieces = jsonl_pieces(text).map_err(MemoryError::SegmentationError)?;
             Ok((SegmentFormat::Jsonl, pieces))
         }
         SegmentFormat::Auto => {
@@ -559,12 +570,17 @@ fn resplit_one(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<R
 
 /// Re-split a `body` piece over [`MAX_FRAGMENT_BYTES`] with [`chunk_text`] —
 /// the same re-chunker `compile_context` itself uses for an oversized
-/// fragment. A `jsonl` piece's decoded `content_override` has no
-/// byte-aligned mapping back to the raw (JSON-escaped) source line, so its
-/// re-split children all keep the ORIGINAL line's full byte range — a
-/// documented, deliberately narrow trade-off: the byte-range-covers-the-
-/// transcript property holds at the turn level regardless, and a single
-/// JSONL line's `content` exceeding 1 MiB is an extreme edge case.
+/// fragment. A `jsonl` piece's decoded `content_override` has no byte-exact
+/// mapping back to the raw (JSON-escaped) source line, so its re-split
+/// children cannot each carry a byte-precise slice of the line the way a
+/// plain-text `body` piece's children do; instead
+/// [`partition_range_by_weight`] divides the ORIGINAL line's byte range
+/// across the children proportionally to each child's share of the decoded
+/// content, which keeps the partition property `compile_transcript`
+/// advertises (no overlap, no gap, covers exactly the parent range) without
+/// claiming a provenance the JSON escaping makes impossible (issue #1516,
+/// m3 — previously every child kept the full, identical parent range,
+/// which duplicated it across `segmentation.segments`).
 fn resplit_body(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<RawPiece> {
     let effective_len = piece
         .content_override
@@ -574,16 +590,22 @@ fn resplit_body(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<
         return vec![piece];
     }
     match &piece.content_override {
-        Some(content) => chunk_text(content, chunk_policy)
-            .into_iter()
-            .map(|chunk| RawPiece {
-                kind: SegmentKind::Body,
-                range: piece.range.clone(),
-                turn: piece.turn,
-                role: piece.role.clone(),
-                content_override: Some(chunk.text),
-            })
-            .collect(),
+        Some(content) => {
+            let chunks = chunk_text(content, chunk_policy);
+            let weights: Vec<usize> = chunks.iter().map(|chunk| chunk.text.len()).collect();
+            let ranges = partition_range_by_weight(&piece.range, &weights);
+            chunks
+                .into_iter()
+                .zip(ranges)
+                .map(|(chunk, range)| RawPiece {
+                    kind: SegmentKind::Body,
+                    range,
+                    turn: piece.turn,
+                    role: piece.role.clone(),
+                    content_override: Some(chunk.text),
+                })
+                .collect()
+        }
         None => chunk_text(&text[piece.range.clone()], chunk_policy)
             .into_iter()
             .map(|chunk| RawPiece {
@@ -596,6 +618,47 @@ fn resplit_body(text: &str, piece: RawPiece, chunk_policy: &ChunkPolicy) -> Vec<
             })
             .collect(),
     }
+}
+
+/// Divide `range` into `weights.len()` contiguous, non-overlapping
+/// sub-ranges that exactly partition it (no gap, no overlap, first starts at
+/// `range.start`, last ends at `range.end`), each sized proportionally to
+/// its matching entry in `weights` (typically a re-split child's decoded
+/// content length). Used by [`resplit_body`] for a `jsonl` piece's
+/// `content_override` children, whose decoded text has no byte-exact
+/// mapping back into the raw (JSON-escaped) source range: this gives each
+/// child a distinct, deterministic slice of the parent range instead of
+/// every child duplicating the whole thing (issue #1516, m3).
+///
+/// Every prefix sum is monotonically non-decreasing (weights are
+/// non-negative and `range.len()` and the total weight are both fixed), so
+/// the resulting boundaries never go backwards — the partition property
+/// holds even when a weight is `0` (an empty chunk gets an empty
+/// sub-range) or when `weights` sums to `0` (falls back to handing the
+/// whole range to the last entry, cursor stays at `range.start` for every
+/// other one).
+fn partition_range_by_weight(range: &Range<usize>, weights: &[usize]) -> Vec<Range<usize>> {
+    debug_assert!(!weights.is_empty(), "must have at least one child");
+    let total: usize = weights.iter().sum::<usize>().max(1);
+    let span = range.len();
+    let mut start = range.start;
+    let mut cumulative = 0_usize;
+    let last_index = weights.len() - 1;
+    weights
+        .iter()
+        .enumerate()
+        .map(|(index, weight)| {
+            cumulative += weight;
+            let end = if index == last_index {
+                range.end
+            } else {
+                range.start + (span * cumulative) / total
+            };
+            let sub_range = start..end;
+            start = end;
+            sub_range
+        })
+        .collect()
 }
 
 /// Re-split a `log` piece over [`MAX_FRAGMENT_BYTES`] on LINE boundaries —

--- a/crates/velesdb-memory/src/context/segment_tests.rs
+++ b/crates/velesdb-memory/src/context/segment_tests.rs
@@ -86,12 +86,121 @@ fn jsonl_roles_detected_and_forced_format_errors_on_bad_line() {
     let err = segment_transcript(bad, &jsonl_policy).expect_err("bad line must error");
 
     // Then it is a hard, actionable error — never a silent fallback to plain
+    // — and it is the dedicated `SegmentationError` variant (m2, issue
+    // #1516): a bad-format parse failure is not a budget breach, so it must
+    // not surface as `ContextOverLimit` (whose "over limit" wording would be
+    // misleading for a caller filtering on the message).
     match err {
-        MemoryError::ContextOverLimit(msg) => {
+        MemoryError::SegmentationError(msg) => {
             assert!(msg.contains("line 2"), "{msg}");
         }
-        other => panic!("expected ContextOverLimit, got {other:?}"),
+        other => panic!("expected SegmentationError, got {other:?}"),
     }
+}
+
+#[test]
+fn forced_jsonl_no_nonblank_line_is_also_segmentation_error() {
+    // Given a "transcript" forced to jsonl that has no non-blank line at
+    // all (jsonl_pieces' other failure mode, distinct from a bad line)
+    let blank_only = "\n\n";
+    let mut jsonl_policy = policy();
+    jsonl_policy.format = SegmentFormat::Jsonl;
+
+    // When forcing jsonl on it
+    let err = segment_transcript(blank_only, &jsonl_policy).expect_err("must error");
+
+    // Then it is still SegmentationError, not ContextOverLimit — same
+    // rationale as the bad-line case above.
+    match err {
+        MemoryError::SegmentationError(_) => {}
+        other => panic!("expected SegmentationError, got {other:?}"),
+    }
+}
+
+#[test]
+fn genuine_budget_breaches_still_return_context_over_limit() {
+    // Non-regression (m2, issue #1516): introducing `SegmentationError` for
+    // format/parsing failures must not change the variant for a REAL
+    // budget/cap breach — those keep returning `ContextOverLimit` exactly
+    // as before.
+    use crate::limits::MAX_TRANSCRIPT_BYTES;
+
+    // Transcript over the byte cap
+    let too_big = "a".repeat(MAX_TRANSCRIPT_BYTES + 1);
+    let err = segment_transcript(&too_big, &policy()).expect_err("over cap");
+    assert!(
+        matches!(err, MemoryError::ContextOverLimit(_)),
+        "expected ContextOverLimit, got {err:?}"
+    );
+
+    // Too many fragments after merging
+    let mut many_turns = String::new();
+    for i in 0..=MAX_FRAGMENTS {
+        writeln!(many_turns, "User: turn {i}").expect("write to String never fails");
+    }
+    let mut tight_policy = policy();
+    tight_policy.min_segment_bytes = 0;
+    let err = segment_transcript(&many_turns, &tight_policy).expect_err("over fragment cap");
+    assert!(
+        matches!(err, MemoryError::ContextOverLimit(_)),
+        "expected ContextOverLimit, got {err:?}"
+    );
+
+    // An unsplittable oversized fence
+    let mut fenced = String::from("```\n");
+    fenced.push_str(&"a".repeat(MAX_FRAGMENT_BYTES + 1));
+    fenced.push_str("\n```\n");
+    let err = segment_transcript(&fenced, &policy()).expect_err("oversized fence");
+    assert!(
+        matches!(err, MemoryError::ContextOverLimit(_)),
+        "expected ContextOverLimit, got {err:?}"
+    );
+}
+
+#[test]
+fn resplit_jsonl_content_override_children_get_distinct_nonoverlapping_ranges() {
+    // Given one jsonl line whose *decoded* content alone exceeds
+    // MAX_FRAGMENT_BYTES (m3, issue #1516): re-split into several children,
+    // none of which has a byte-exact mapping back to the raw JSON-escaped
+    // source line — but the partition property `compile_transcript`
+    // advertises must still hold across those children.
+    let big_content = "a".repeat((MAX_FRAGMENT_BYTES * 2) + 100);
+    let line = serde_json::json!({"role": "user", "content": big_content}).to_string();
+    let mut text = line;
+    text.push('\n');
+
+    let mut jsonl_policy = policy();
+    jsonl_policy.format = SegmentFormat::Jsonl;
+
+    let outcome = segment_transcript(&text, &jsonl_policy).expect("segments");
+
+    // More than one child was produced — the whole point of the test
+    assert!(outcome.segments.len() > 1, "{outcome:?}");
+
+    // Every child stays under the fragment cap
+    for segment in &outcome.segments {
+        assert!(
+            segment.fragment.content.len() <= MAX_FRAGMENT_BYTES,
+            "child of {} bytes exceeds the cap",
+            segment.fragment.content.len()
+        );
+    }
+
+    // No two children overlap, and together they partition the whole line
+    // exactly — no gaps, no duplicated ranges.
+    let mut ranges: Vec<(usize, usize)> = outcome
+        .segments
+        .iter()
+        .map(|s| (s.byte_start, s.byte_end))
+        .collect();
+    ranges.sort_unstable();
+    let mut cursor = 0_usize;
+    for (start, end) in ranges {
+        assert_eq!(start, cursor, "gap or overlap at byte {cursor}");
+        assert!(start <= end, "inverted range {start}..{end}");
+        cursor = end;
+    }
+    assert_eq!(cursor, text.len(), "children must partition the whole line");
 }
 
 #[test]

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -107,6 +107,21 @@ pub enum MemoryError {
     #[error("context request over limit: {0}")]
     ContextOverLimit(String),
 
+    /// A transcript segmentation request failed because of the transcript's
+    /// FORMAT, not its size — e.g. `segmentation.format: "jsonl"` forced on
+    /// a line that does not parse as a `{role, content}` JSON object (see
+    /// [`crate::context::segment::segment_transcript`]). Deliberately
+    /// distinct from [`Self::ContextOverLimit`] (issue #1516, m2): a parsing
+    /// failure is not a budget/cap breach, so a caller filtering on the
+    /// error message no longer sees the misleading "over limit" wording for
+    /// what is really a malformed-input error. Same
+    /// [`ErrorCategory::InvalidInput`] classification as `ContextOverLimit`
+    /// (both map to `INVALID_PARAMS` over MCP) — only the variant, and the
+    /// message, differ.
+    #[cfg(feature = "context")]
+    #[error("transcript segmentation error: {0}")]
+    SegmentationError(String),
+
     /// A `ctx://source/<hash>` handle was malformed or nothing is stored
     /// under it (the source was never stored, expired, or was forgotten).
     #[cfg(feature = "context")]
@@ -206,7 +221,9 @@ impl MemoryError {
             | Self::InvalidRelation(_)
             | Self::MetadataTooLarge { .. } => ErrorCategory::InvalidInput,
             #[cfg(feature = "context")]
-            Self::ContextBudget { .. } | Self::ContextOverLimit(_) => ErrorCategory::InvalidInput,
+            Self::ContextBudget { .. } | Self::ContextOverLimit(_) | Self::SegmentationError(_) => {
+                ErrorCategory::InvalidInput
+            }
             #[cfg(feature = "context")]
             Self::IngestDisabled | Self::IngestOutsideRoots(_) | Self::IngestPath(_) => {
                 ErrorCategory::InvalidInput

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -267,10 +267,14 @@ pub(super) struct SegmentInfo {
     /// `"body"`, `"code"`, or `"log"`.
     pub kind: SegmentKind,
     /// Start byte offset (inclusive) in the original transcript. For a
-    /// `jsonl` transcript this is the raw JSON line's span, not an offset
-    /// into the decoded `content` (see [`SegmentationReport::segments`]'s
-    /// struct docs for the one documented edge case where two segments can
-    /// report the SAME range).
+    /// `jsonl` transcript this is a slice of the raw JSON line's span, not
+    /// an offset into the decoded `content` — a JSONL line's decoded text
+    /// has no byte-exact mapping back into the raw (JSON-escaped) source
+    /// bytes, so when a single line's decoded content is re-split (over
+    /// [`crate::limits::MAX_FRAGMENT_BYTES`]) each child's range is a
+    /// proportional, non-overlapping share of the line's raw range rather
+    /// than a byte-precise one. Every segment's range is still distinct and
+    /// non-overlapping (see [`SegmentationReport::segments`]'s struct docs).
     pub byte_start: usize,
     /// End byte offset (exclusive) in the original transcript. Same caveat
     /// as `byte_start`.
@@ -287,16 +291,18 @@ pub(super) struct SegmentationReport {
     /// `"plain"` or `"jsonl"` — the format actually used, never `"auto"`
     /// even when the request asked for it.
     pub format_detected: SegmentFormat,
-    /// Every segment, in transcript order. **Documented edge case:** a
-    /// single `jsonl` line whose decoded `content` alone exceeds
-    /// [`crate::limits::MAX_FRAGMENT_BYTES`] (1 MiB) is re-split into
-    /// several segments (`compile_context` still gets sub-1-MiB fragments),
-    /// but every child segment reports the SAME `byte_start`/`byte_end` —
-    /// the original JSON line's span — because a JSONL line's decoded text
-    /// has no byte-aligned mapping back into the raw (JSON-escaped) source
-    /// bytes (see `resplit_body` in `context::segment`). An extreme edge
-    /// case (one transcript line over 1 MiB of decoded content); every
-    /// other segment kind keeps a unique, non-overlapping range.
+    /// Every segment, in transcript order, with byte ranges that partition
+    /// the transcript exactly — no gaps, no overlaps, even for a `jsonl`
+    /// line whose decoded `content` alone exceeds
+    /// [`crate::limits::MAX_FRAGMENT_BYTES`] (1 MiB) and gets re-split into
+    /// several segments (`compile_context` still gets sub-1-MiB fragments):
+    /// each child's range is a proportional, non-overlapping share of the
+    /// original JSON line's raw span rather than a byte-exact one, since a
+    /// JSONL line's decoded text has no byte-aligned mapping back into the
+    /// raw (JSON-escaped) source bytes (see `resplit_body` in
+    /// `context::segment`). An extreme edge case (one transcript line over
+    /// 1 MiB of decoded content), but even then every segment keeps a
+    /// distinct, non-overlapping range.
     pub segments: Vec<SegmentInfo>,
     /// How many segments [`SegmentationPolicy::min_segment_bytes`] merging
     /// eliminated.
@@ -400,16 +406,20 @@ impl McpServer {
         Ok(Json(to_wire_value(&compiled, ids_as_strings)?))
     }
 
-    /// **Error taxonomy caveat (acted in PR #1500 review):** every
-    /// segmentation failure — oversized fence, forced `jsonl` that fails to
-    /// parse, too many fragments after merging, transcript over
+    /// **Error taxonomy (issue #1516, m2 — refines the PR #1500 review
+    /// note):** a genuine budget/cap breach — oversized fence, too many
+    /// fragments after merging, transcript over
     /// [`crate::limits::MAX_TRANSCRIPT_BYTES`] — surfaces as
-    /// [`crate::error::MemoryError::ContextOverLimit`] with a
-    /// segmentation-specific message, deliberately reusing
-    /// `compile_context`'s existing `INVALID_PARAMS`-category taxonomy
-    /// rather than minting a new variant for this PR. Revisit if the
-    /// overloaded variant makes segmentation errors hard for a caller to
-    /// distinguish from an ordinary budget/fragment-count error.
+    /// [`crate::error::MemoryError::ContextOverLimit`]. A forced `jsonl`
+    /// format that fails to parse is a FORMAT failure, not a size breach, so
+    /// it surfaces as the distinct
+    /// [`crate::error::MemoryError::SegmentationError`] instead — no longer
+    /// the misleading "over limit" wording. Both variants still map to the
+    /// same `INVALID_PARAMS`-category MCP code (`ContextOverLimit` and
+    /// `SegmentationError` are both [`crate::error::ErrorCategory::InvalidInput`]),
+    /// so this only changes how a caller who inspects `MemoryError`
+    /// programmatically (e.g. via the Rust crate directly, not over MCP)
+    /// tells the two apart.
     #[tool(
         name = "compile_transcript",
         description = "One-call shortcut over compile_context for a raw agent-session transcript: deterministically segments it into turns (plain marker-based — System:/User:/Human:/Assistant:/AI:/Tool:/### User/### Assistant — or JSONL, one line per turn) and, within each turn, into code/log/body sub-segments (fenced code blocks stay atomic; runs of 8+ log-like lines collapse the same way abstract.log_dedup would), then compiles the result exactly like compile_context. Exactly one of `transcript` (inline) or `path` (an absolute filesystem path, same VELESDB_MEMORY_INGEST_ROOTS allowlist as compile_context's `path` fragments but capped at 8 MiB) must be set. `segmentation.format` forces plain or jsonl instead of auto-detecting; a forced jsonl format that fails to parse is a hard error, never a silent fallback. The first turn is tagged cache-eligible when it looks like a system prompt (segmentation.cache_system_turn, default true). Returns `context` (byte-compatible with compile_context's output) plus `segmentation` — the detected format and one audit entry (turn, role, kind, byte range, fragment_id) per segment, so a caller can see exactly how the transcript was cut before trusting the compiled result.",


### PR DESCRIPTION
## Summary

V2b adversarial-review follow-ups from #1500 (m2 + m3), deliberately deferred, now addressed.

- **m2 — error taxonomy**: a forced `segmentation.format: "jsonl"` that fails to parse used to surface as `MemoryError::ContextOverLimit` with a misleading "over limit" prefix on what is really a parsing/format failure, not a budget breach. Added a dedicated `MemoryError::SegmentationError` variant for this case. `ContextOverLimit` stays reserved for genuine budget/cap breaches (transcript byte cap, oversized fence, fragment-count cap after merging). Both map to the same `INVALID_PARAMS`-category MCP code, so this is invisible over the wire — but **potentially breaking for a Rust caller of `velesdb-memory` directly** who pattern-matches on `MemoryError::ContextOverLimit` for this specific parse-failure case; see the CHANGELOG entry.
- **m3 — duplicated ranges**: re-splitting a `jsonl` line's `content_override` (when a single line's decoded content exceeds `MAX_FRAGMENT_BYTES`, over 1 MiB) used to give every child segment the SAME original line's byte range, so `segmentation.segments` reported overlapping ranges — contradicting the partition property `compile_transcript` advertises. Fixed by giving each child a distinct, non-overlapping sub-range of the original line, proportional to its share of the decoded content (a new `partition_range_by_weight` helper in `segment.rs`). A byte-exact mapping back to the raw JSON-escaped source is still impossible (documented), but the partition invariant now holds unconditionally — no more doc-only caveat needed in the MCP tool's rustdoc.

## Test plan

- [x] TDD: red tests written first (new variant expected, non-overlapping ranges expected) — confirmed to fail to compile / fail before the fix
- [x] `cargo fmt --all -- --check` — EXIT=0
- [x] `cargo test -p velesdb-memory` (default features) — 347+ tests, 0 failed — EXIT=0
- [x] `cargo test -p velesdb-memory --all-features` — 356 tests, 0 failed, 1 ignored — EXIT=0
- [x] `cargo clippy -p velesdb-memory --all-targets -- -D warnings -D clippy::pedantic` — EXIT=0
- [x] `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` — EXIT=0
- [x] Repo pre-commit hook (fmt + clippy + unsafe-block check + full workspace tests) — passed

Closes #1516