### PR TITLE
feat(memory): streamable-HTTP transport + automated multi-client daemon installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,18 +4580,28 @@ checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "futures",
+ "http",
+ "http-body",
+ "http-body-util",
  "pastey",
  "pin-project-lite",
+ "rand 0.10.2",
+ "reqwest",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -5394,6 +5404,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -6768,6 +6791,7 @@ dependencies = [
 name = "velesdb-memory"
 version = "0.10.1"
 dependencies = [
+ "axum",
  "criterion",
  "rmcp",
  "schemars 1.2.1",
@@ -6776,6 +6800,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "ureq",
  "velesdb-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,6 +6237,7 @@ dependencies = [
  "bytes",
  "http",
  "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "tower-layer",
@@ -6793,6 +6794,7 @@ version = "0.10.1"
 dependencies = [
  "axum",
  "criterion",
+ "futures",
  "rmcp",
  "schemars 1.2.1",
  "serde",
@@ -6801,6 +6803,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
+ "tower-http 0.7.0",
  "ureq",
  "velesdb-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ authors = ["Julien Lange <contact@wiscale.fr>"]
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1.52", features = ["full"] }
+tokio-util = "0.7"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -68,6 +68,11 @@ tempfile = "3"
 serde_json = { workspace = true }
 tokio = { workspace = true }
 criterion = { workspace = true }
+# MCP client-side streamable-HTTP transport, dev-only: drives the `http`
+# feature's server transport in tests/http_transport.rs with a real client
+# (the same one exercised by rmcp's own upstream test suite) rather than
+# hand-rolled JSON-RPC-over-HTTP requests.
+rmcp = { version = "2.0.0", features = ["client", "transport-streamable-http-client-reqwest"] }
 
 [[bin]]
 name = "velesdb-memory"
@@ -102,6 +107,15 @@ path = "src/lib.rs"
 
 [lints]
 workspace = true
+
+# Round-trips real MCP calls (initialize/remember/recall) plus a 20-way
+# concurrency stress test over the streamable-HTTP transport built by the
+# `http` feature (router only — no subprocess). Needs the dev-dependency
+# rmcp client transport above, so it only builds under that feature.
+[[test]]
+name = "http_transport"
+path = "tests/http_transport.rs"
+required-features = ["http"]
 
 [[example]]
 name = "multihop"

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -44,6 +44,20 @@ ureq = { version = "2", optional = true, default-features = false }
 # `CancellationToken` used to drive graceful shutdown of the HTTP listener.
 axum = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
+# Bounds the /mcp request body: rmcp's StreamableHttpService reads the body
+# directly via `Body::collect` (see `expect_json` in rmcp's
+# `transport::common::server_side_http`), bypassing axum's own `Bytes`/`Json`
+# extractor-based `DefaultBodyLimit` entirely — that middleware only patches
+# what those specific extractors read, so it is a no-op for a raw
+# `nest_service` tower::Service like this one. `RequestBodyLimitLayer`
+# instead wraps the actual `http_body::Body` (`http_body_util::Limited`)
+# before it reaches the inner service, so it works regardless of how the
+# body is consumed downstream.
+tower-http = { workspace = true, optional = true, features = ["limit"] }
+# `futures::Stream`, the bound `rmcp::SessionManager`'s streaming methods
+# return — needed to forward them from `BoundedSessionManager` (src/http/
+# session_limit.rs) to the wrapped `LocalSessionManager`.
+futures = { version = "0.3", optional = true }
 
 [features]
 # The MCP server transport + binary, and the native file-backed store, are on
@@ -58,7 +72,7 @@ mcp = ["dep:rmcp", "dep:tokio", "persistence"]
 # velesdb-memory` still produces the tiny, fully-offline stdio-only binary —
 # only the installer script opts a LOCAL build into this at build time; the
 # hash/ollama embedder choice stays a pure runtime switch either way.
-http = ["mcp", "dep:axum", "dep:tokio-util", "rmcp/transport-streamable-http-server"]
+http = ["mcp", "dep:axum", "dep:tokio-util", "dep:tower-http", "dep:futures", "rmcp/transport-streamable-http-server"]
 # The deterministic context compiler (EPIC-P-070). Zero new dependencies and
 # `persistence`-free by design, so a wasm-style `default-features = false`
 # consumer can enable it alone; the memory-backed selection layer inside it is

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -33,11 +33,17 @@ schemars = "1"
 # The MCP server stack — optional, behind the (default) `mcp` feature. Library
 # consumers (e.g. the language bindings) build with `default-features = false`
 # to get the memory core without the `rmcp`/`tokio` server dependencies.
-rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io"], optional = true }
+rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"], optional = true }
 tokio = { workspace = true, optional = true }
 # Optional real-recall backend (off by default). HTTP-only to a local Ollama;
 # `default-features = false` drops TLS to keep the binary small.
 ureq = { version = "2", optional = true, default-features = false }
+# HTTP transport (multi-client daemon), behind the `http` feature only — the
+# default binary stays offline/stdio-only. `axum`/`tower` are already
+# workspace dependencies (velesdb-server); `tokio-util` provides the
+# `CancellationToken` used to drive graceful shutdown of the HTTP listener.
+axum = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
 
 [features]
 # The MCP server transport + binary, and the native file-backed store, are on
@@ -45,6 +51,14 @@ ureq = { version = "2", optional = true, default-features = false }
 # defaults to pick only what they need.
 default = ["mcp", "persistence", "context"]
 mcp = ["dep:rmcp", "dep:tokio", "persistence"]
+# Streamable-HTTP transport (multi-client daemon mode, see the README's "HTTP
+# transport" section): lets several MCP clients share ONE `velesdb-memory`
+# process instead of each spawning its own stdio process and fighting over
+# the store's single-writer flock. Off by default so `cargo install
+# velesdb-memory` still produces the tiny, fully-offline stdio-only binary —
+# only the installer script opts a LOCAL build into this at build time; the
+# hash/ollama embedder choice stays a pure runtime switch either way.
+http = ["mcp", "dep:axum", "dep:tokio-util", "rmcp/transport-streamable-http-server"]
 # The deterministic context compiler (EPIC-P-070). Zero new dependencies and
 # `persistence`-free by design, so a wasm-style `default-features = false`
 # consumer can enable it alone; the memory-backed selection layer inside it is
@@ -115,6 +129,14 @@ workspace = true
 [[test]]
 name = "http_transport"
 path = "tests/http_transport.rs"
+required-features = ["http"]
+
+# A second `--http` daemon against a store another process already holds
+# must fail fast with the same actionable lock message as the stdio path
+# (#1448) — proving the flock guard isn't a stdio-only regression risk.
+[[test]]
+name = "http_lock_contention"
+path = "tests/http_lock_contention.rs"
 required-features = ["http"]
 
 [[example]]

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -347,6 +347,13 @@ velesdb-memory --http
 - `--http-port <PORT>` / `VELESDB_MEMORY_HTTP_BIND=<host:port>` — override the
   bind address (default `127.0.0.1:18090`; `--http-port` overrides just the
   port on top of `VELESDB_MEMORY_HTTP_BIND`).
+- The transport has **no authentication** — anyone who can reach the socket
+  gets full `remember`/`recall`/`relate` access to the store. That's fine for
+  the default loopback-only bind (only processes on the same machine can
+  reach it), so a non-loopback `VELESDB_MEMORY_HTTP_BIND` host is refused at
+  startup unless you also set `VELESDB_MEMORY_HTTP_ALLOW_REMOTE=1`. Only set
+  that if you're putting an authenticating reverse proxy in front — never
+  point the bare daemon at a network-reachable address.
 - `GET /health` — plain 200 OK liveness probe (no MCP handshake needed) —
   what the installer script and CI use to confirm the daemon is up.
 - The store's `flock` is unchanged: a *second* `velesdb-memory --http` (or a

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -356,6 +356,17 @@ velesdb-memory --http
   point the bare daemon at a network-reachable address.
 - `GET /health` — plain 200 OK liveness probe (no MCP handshake needed) —
   what the installer script and CI use to confirm the daemon is up.
+- `VELESDB_MEMORY_HTTP_MAX_BODY_BYTES` — max size of a single `/mcp` request
+  body, in bytes (default 16 MiB). A misbehaving or hostile client sending an
+  oversized request is rejected instead of having its body buffered into
+  memory unbounded.
+- `VELESDB_MEMORY_HTTP_MAX_SESSIONS` — max number of concurrent MCP sessions
+  (default 64). Each session holds a worker task and a couple of small
+  bounded channels — cheap individually, but with no ceiling on the *count* a
+  client that opens sessions without closing them (malicious, or just buggy)
+  could otherwise grow that without bound. 64 is generous headroom for this
+  daemon's actual shape: a handful of local, cooperating clients, not a
+  public service.
 - The store's `flock` is unchanged: a *second* `velesdb-memory --http` (or a
   stray stdio process) against the same store still fails fast with the same
   actionable lock message — the daemon is the ONE process that opens the

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -303,6 +303,103 @@ env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 } } }
 ```
 
+**Claude Desktop** — `claude_desktop_config.json` (macOS:
+`~/Library/Application Support/Claude/claude_desktop_config.json`)
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "command": "/home/you/.cargo/bin/velesdb-memory",
+  "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
+} } }
+```
+
+**Windsurf** — `~/.codeium/windsurf/mcp_config.json`
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "command": "/home/you/.cargo/bin/velesdb-memory",
+  "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
+} } }
+```
+
+## HTTP transport (multi-client)
+
+Every config above spawns its own `velesdb-memory` process over stdio — and
+the store's single-writer `flock` means only ONE of those processes can hold
+it open at a time, so only one client can actually use memory at once.
+Switching a client mid-session, or running two clients side by side, fails
+with an opaque `Storage(DatabaseLocked)`.
+
+The fix: build with `--features http` and run ONE `velesdb-memory --http`
+daemon that every client connects to instead of spawning its own process.
+The hash/ollama embedder choice stays a pure runtime switch either way — only
+the transport changes.
+
+```bash
+cargo install velesdb-memory --features http,ollama
+# → still opt into `ollama` at BUILD time only if you want that embedder available;
+#   VELESDB_MEMORY_EMBEDDER stays a runtime choice regardless (see "Embedding backend" below)
+velesdb-memory --http
+# [velesdb-memory] HTTP server listening on http://127.0.0.1:18090/mcp
+```
+
+- `--http` / `VELESDB_MEMORY_HTTP=1` — serve over streamable-HTTP instead of stdio.
+- `--http-port <PORT>` / `VELESDB_MEMORY_HTTP_BIND=<host:port>` — override the
+  bind address (default `127.0.0.1:18090`; `--http-port` overrides just the
+  port on top of `VELESDB_MEMORY_HTTP_BIND`).
+- `GET /health` — plain 200 OK liveness probe (no MCP handshake needed) —
+  what the installer script and CI use to confirm the daemon is up.
+- The store's `flock` is unchanged: a *second* `velesdb-memory --http` (or a
+  stray stdio process) against the same store still fails fast with the same
+  actionable lock message — the daemon is the ONE process that opens the
+  store; every client just connects to it over the network.
+
+Point each client's config at the daemon instead of a local binary:
+
+**Claude Code**
+
+```bash
+claude mcp add --transport http velesdb-memory http://127.0.0.1:18090/mcp
+```
+
+**Cursor** / **Cline** — same `mcpServers` files as above, `type: "http"` instead of `command`:
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "type": "http",
+  "url": "http://127.0.0.1:18090/mcp"
+} } }
+```
+
+**Claude Desktop**
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "type": "http",
+  "url": "http://127.0.0.1:18090/mcp"
+} } }
+```
+
+> HTTP support is not confirmed for this client — if it doesn't connect
+> after a restart, fall back to the stdio block above. Point the fallback's
+> `VELESDB_MEMORY_PATH` at a **different** directory than the daemon's store:
+> pointed at the same one, the fallback process and the daemon would fight
+> over the same `flock`, reproducing the exact `DatabaseLocked` problem this
+> section exists to avoid.
+
+**Windsurf** — `~/.codeium/windsurf/mcp_config.json`
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "serverUrl": "http://127.0.0.1:18090/mcp"
+} } }
+```
+
+`scripts/install-memory-daemon.sh` automates all of this end to end: building
+with the right features, running the daemon (as a macOS `launchd` agent), and
+wiring Claude Code / Claude Desktop / Windsurf — see `--help` for flags
+(`--embedder`, `--port`, `--store`, `--skip-client`, `--uninstall`, …).
+
 ## Teach your agent the flow (skill)
 
 Wiring the MCP server gives your agent the *tools*; it doesn't tell it *when* to

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -1,0 +1,73 @@
+//! Streamable-HTTP transport (multi-client mode).
+//!
+//! `velesdb-memory` speaks stdio by default: every MCP client (Claude Code,
+//! Claude Desktop, Windsurf, …) spawns its own server process, and the
+//! store's single-writer `flock` (`velesdb-core`'s `Database::open_impl`)
+//! then lets only ONE of those processes actually hold the store open —
+//! every other client's session fails with `Storage(DatabaseLocked)`.
+//!
+//! This module is the fix: one process, reachable over HTTP, that several
+//! clients connect to concurrently. It only builds the [`Router`]; binding a
+//! [`tokio::net::TcpListener`] and driving `axum::serve` is the binary's job
+//! (`src/main.rs`), so the router can also be mounted directly in tests
+//! (`tests/http_transport.rs`) with no subprocess involved.
+//!
+//! Concurrent requests need no *application*-level locking beyond what
+//! [`McpServer`] already has: `velesdb-core`'s `Database` protects its
+//! collections internally with a `parking_lot::RwLock`, so many HTTP
+//! sessions calling `remember`/`recall` at once are already safe. The
+//! store's `flock` is untouched by this module — it still guards
+//! cross-*process* access exactly as it does for stdio, which is why a
+//! second `velesdb-memory --http` against the same store still fails fast
+//! with the same actionable lock message (see `open_store_with_actionable_lock_error`
+//! in `src/main.rs`).
+
+use std::sync::Arc;
+
+use axum::routing::get;
+use axum::Router;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use tokio_util::sync::CancellationToken;
+
+use crate::mcp::McpServer;
+
+/// Default bind address for `--http` / `VELESDB_MEMORY_HTTP=1` when neither
+/// `VELESDB_MEMORY_HTTP_BIND` nor `--http-port` overrides it. Loopback-only:
+/// this is a local multi-client daemon, not a public listener.
+pub const DEFAULT_HTTP_BIND: &str = "127.0.0.1:18090";
+
+/// Build the axum [`Router`] serving the MCP streamable-HTTP transport at
+/// `/mcp` and a plain liveness probe at `/health` (used by the installer
+/// script and CI to confirm the daemon is up without speaking MCP itself).
+///
+/// [`McpServer`] is cheaply [`Clone`] (an `Arc`-wrapped
+/// [`MemoryService`](crate::service::MemoryService) internally), so the
+/// `service_factory` closure below just clones the handle per session
+/// rather than reopening the store.
+///
+/// `cancellation_token` is the caller's shutdown handle: cancelling it (or
+/// any parent token it was derived from) stops accepting new HTTP-transport
+/// sessions and tears down the ones in flight. The binary derives it from
+/// its own shutdown token; tests derive it from a token they cancel at the
+/// end of the test to stop the server cleanly.
+pub fn router(server: McpServer, cancellation_token: CancellationToken) -> Router {
+    let mcp_service: StreamableHttpService<McpServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            move || Ok(server.clone()),
+            Arc::new(LocalSessionManager::default()),
+            StreamableHttpServerConfig::default().with_cancellation_token(cancellation_token),
+        );
+    Router::new()
+        .nest_service("/mcp", mcp_service)
+        .route("/health", get(health))
+}
+
+/// Liveness probe: 200 OK with no body semantics beyond "the process is up
+/// and its HTTP listener is accepting requests". Deliberately doesn't touch
+/// the store — a store-level health check would need a blocking read and
+/// isn't what callers (the installer's `curl` wait loop, CI) are checking
+/// for here.
+async fn health() -> &'static str {
+    "OK"
+}

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -29,13 +29,62 @@ use axum::Router;
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
 use tokio_util::sync::CancellationToken;
+use tower_http::limit::RequestBodyLimit;
 
 use crate::mcp::McpServer;
+
+mod session_limit;
+
+use session_limit::BoundedSessionManager;
 
 /// Default bind address for `--http` / `VELESDB_MEMORY_HTTP=1` when neither
 /// `VELESDB_MEMORY_HTTP_BIND` nor `--http-port` overrides it. Loopback-only:
 /// this is a local multi-client daemon, not a public listener.
 pub const DEFAULT_HTTP_BIND: &str = "127.0.0.1:18090";
+
+/// Default max size (bytes) of a single `/mcp` HTTP request body when
+/// `VELESDB_MEMORY_HTTP_MAX_BODY_BYTES` is unset — 16 MiB. Generous headroom
+/// above the largest single field cap enforced deeper in the stack
+/// ([`crate::limits::MAX_TRANSCRIPT_BYTES`], 8 MiB) to cover JSON-RPC framing
+/// and multi-field payloads, while still bounding the raw allocation an
+/// unauthenticated-by-design loopback client can force before any
+/// application-level check ever runs (see [`RequestBodyLimit`] in [`router`]).
+pub const DEFAULT_HTTP_MAX_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Resolve the `/mcp` request body limit from
+/// `VELESDB_MEMORY_HTTP_MAX_BODY_BYTES`. Unset, unparseable, or `0` falls
+/// back to [`DEFAULT_HTTP_MAX_BODY_BYTES`] — a `0` limit would reject every
+/// request, including `initialize`, bricking the daemon.
+#[must_use]
+pub fn http_max_body_bytes_from_env() -> usize {
+    std::env::var("VELESDB_MEMORY_HTTP_MAX_BODY_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&bytes| bytes > 0)
+        .unwrap_or(DEFAULT_HTTP_MAX_BODY_BYTES)
+}
+
+/// Default max number of concurrent MCP sessions when
+/// `VELESDB_MEMORY_HTTP_MAX_SESSIONS` is unset — 64. This is a local
+/// multi-client daemon (a handful of editors/agents on one machine), not a
+/// public service, so this is generous headroom rather than a tight budget;
+/// its purpose is only to put a ceiling on `LocalSessionManager`'s session
+/// map, which [`rmcp`] otherwise grows without bound (see
+/// [`session_limit`] for the full rationale).
+pub const DEFAULT_HTTP_MAX_SESSIONS: usize = 64;
+
+/// Resolve the max concurrent session count from
+/// `VELESDB_MEMORY_HTTP_MAX_SESSIONS`. Unset, unparseable, or `0` falls back
+/// to [`DEFAULT_HTTP_MAX_SESSIONS`] — a `0` limit would reject every session,
+/// including the first, bricking the daemon.
+#[must_use]
+pub fn http_max_sessions_from_env() -> usize {
+    std::env::var("VELESDB_MEMORY_HTTP_MAX_SESSIONS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_HTTP_MAX_SESSIONS)
+}
 
 /// Build the axum [`Router`] serving the MCP streamable-HTTP transport at
 /// `/mcp` and a plain liveness probe at `/health` (used by the installer
@@ -51,15 +100,47 @@ pub const DEFAULT_HTTP_BIND: &str = "127.0.0.1:18090";
 /// sessions and tears down the ones in flight. The binary derives it from
 /// its own shutdown token; tests derive it from a token they cancel at the
 /// end of the test to stop the server cleanly.
+///
+/// Two DoS guards wrap the `/mcp` service, both absent from rmcp's own
+/// defaults (see each item's doc comment for why they matter and why the
+/// obvious axum-level fix does not apply to a raw `nest_service`):
+/// - [`RequestBodyLimit`] bounds a single request body
+///   ([`http_max_body_bytes_from_env`]).
+/// - [`BoundedSessionManager`] bounds concurrent sessions
+///   ([`http_max_sessions_from_env`]).
 pub fn router(server: McpServer, cancellation_token: CancellationToken) -> Router {
-    let mcp_service: StreamableHttpService<McpServer, LocalSessionManager> =
+    router_with_limits(
+        server,
+        cancellation_token,
+        http_max_body_bytes_from_env(),
+        http_max_sessions_from_env(),
+    )
+}
+
+/// [`router`], but with the two DoS guards' limits passed explicitly instead
+/// of read from the environment. `router` itself is the thin, env-reading
+/// wrapper adversarial tests (`tests/http_transport.rs`) skip in favor of
+/// this — process-wide env vars are shared, mutable global state, and
+/// `cargo test` runs a crate's tests in parallel by default, so a test that
+/// wants a tiny `max_body_bytes`/`max_sessions` to actually exercise a
+/// rejection would otherwise race every other test reading the same
+/// variables in the same process.
+#[doc(hidden)]
+pub fn router_with_limits(
+    server: McpServer,
+    cancellation_token: CancellationToken,
+    max_body_bytes: usize,
+    max_sessions: usize,
+) -> Router {
+    let session_manager = BoundedSessionManager::new(LocalSessionManager::default(), max_sessions);
+    let mcp_service: StreamableHttpService<McpServer, BoundedSessionManager<LocalSessionManager>> =
         StreamableHttpService::new(
             move || Ok(server.clone()),
-            Arc::new(LocalSessionManager::default()),
+            Arc::new(session_manager),
             StreamableHttpServerConfig::default().with_cancellation_token(cancellation_token),
         );
     Router::new()
-        .nest_service("/mcp", mcp_service)
+        .nest_service("/mcp", RequestBodyLimit::new(mcp_service, max_body_bytes))
         .route("/health", get(health))
 }
 

--- a/crates/velesdb-memory/src/http/session_limit.rs
+++ b/crates/velesdb-memory/src/http/session_limit.rs
@@ -1,0 +1,468 @@
+//! Caps the number of concurrent MCP sessions a [`SessionManager`] will
+//! create.
+//!
+//! `rmcp`'s `LocalSessionManager` (the in-memory session store [`router`](
+//! super::router) uses) has no such cap built in: `create_session` always
+//! succeeds and inserts into its `sessions` map, so a client that opens
+//! sessions without ever closing them — malicious, or just buggy — can grow
+//! that map without bound. Each session spawns its own worker task plus two
+//! bounded mpsc channels (`SessionConfig::channel_capacity`, 16 by default)
+//! — individually small, but with no ceiling on the session COUNT the
+//! aggregate is unbounded, exactly the shape of resource exhaustion this
+//! module exists to close off.
+//!
+//! [`BoundedSessionManager`] wraps any [`SessionManager`] and refuses
+//! `create_session`/`restore_session` once `max_sessions` sessions are
+//! outstanding. It tracks the count itself (an [`AtomicUsize`]) rather than
+//! reaching into a specific implementation's internals, so it works for
+//! `LocalSessionManager` today and for any future custom `SessionManager`
+//! (e.g. a Redis-backed one) the same way.
+//!
+//! # Caveat inherited from `rmcp`
+//!
+//! A session that goes idle past its `SessionConfig::keep_alive` timeout has
+//! its worker task exit — but nothing calls [`SessionManager::close_session`]
+//! for it (confirmed against rmcp 2.2.0: `LocalSessionManager`'s `sessions`
+//! map is touched only by `create_session`, `close_session`, and
+//! `restore_session`; there is no reaper). So our counter, like the
+//! underlying map, only shrinks on an explicit close (an HTTP DELETE from a
+//! well-behaved client) — pure inactivity never frees a slot. In this
+//! daemon's actual deployment (a handful of local, cooperating MCP clients)
+//! that only matters over very long uptimes; a full fix belongs upstream in
+//! `rmcp`, not here.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::Stream;
+use rmcp::model::{ClientJsonRpcMessage, ServerJsonRpcMessage};
+use rmcp::transport::streamable_http_server::session::{
+    RestoreOutcome, ServerSseMessage, SessionId, SessionManager,
+};
+use thiserror::Error;
+
+/// Wraps `inner: SM`, refusing new sessions once `max_sessions` are live.
+#[derive(Debug)]
+pub struct BoundedSessionManager<SM> {
+    inner: SM,
+    max_sessions: usize,
+    live: AtomicUsize,
+}
+
+impl<SM> BoundedSessionManager<SM> {
+    pub fn new(inner: SM, max_sessions: usize) -> Self {
+        Self {
+            inner,
+            max_sessions,
+            live: AtomicUsize::new(0),
+        }
+    }
+
+    /// Reserve one slot, or refuse if `max_sessions` is already reached.
+    /// CAS loop (not load-then-store) so two concurrent callers can't both
+    /// observe room for the last slot and overshoot the bound.
+    fn try_reserve(&self) -> bool {
+        loop {
+            let current = self.live.load(Ordering::Acquire);
+            if current >= self.max_sessions {
+                return false;
+            }
+            if self
+                .live
+                .compare_exchange_weak(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    /// Release a slot reserved by [`try_reserve`](Self::try_reserve) that
+    /// turned out not to correspond to a real live session (creation
+    /// failed, or `restore_session` didn't actually create one). Saturating:
+    /// never underflows even if called more than its matching reserve.
+    fn release(&self) {
+        let _ = self
+            .live
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                Some(n.saturating_sub(1))
+            });
+    }
+}
+
+/// Error type for [`BoundedSessionManager`]: either its own bound was hit,
+/// or the wrapped `SessionManager` failed on its own terms.
+#[derive(Debug, Error)]
+pub enum BoundedSessionManagerError<E> {
+    /// `max_sessions` concurrent MCP sessions are already live.
+    #[error("too many concurrent MCP sessions (max {0}); close an existing one and retry")]
+    TooManySessions(usize),
+    /// The wrapped session manager itself failed.
+    #[error(transparent)]
+    Inner(#[from] E),
+}
+
+impl<SM> SessionManager for BoundedSessionManager<SM>
+where
+    SM: SessionManager,
+{
+    type Error = BoundedSessionManagerError<SM::Error>;
+    type Transport = SM::Transport;
+
+    async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+        if !self.try_reserve() {
+            return Err(BoundedSessionManagerError::TooManySessions(
+                self.max_sessions,
+            ));
+        }
+        match self.inner.create_session().await {
+            Ok(created) => Ok(created),
+            Err(e) => {
+                self.release();
+                Err(e.into())
+            }
+        }
+    }
+
+    async fn initialize_session(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<ServerJsonRpcMessage, Self::Error> {
+        self.inner
+            .initialize_session(id, message)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn has_session(&self, id: &SessionId) -> Result<bool, Self::Error> {
+        self.inner.has_session(id).await.map_err(Into::into)
+    }
+
+    async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        let result = self.inner.close_session(id).await;
+        if result.is_ok() {
+            self.release();
+        }
+        result.map_err(Into::into)
+    }
+
+    async fn create_stream(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        self.inner
+            .create_stream(id, message)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn accept_message(
+        &self,
+        id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<(), Self::Error> {
+        self.inner
+            .accept_message(id, message)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn create_standalone_stream(
+        &self,
+        id: &SessionId,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        self.inner
+            .create_standalone_stream(id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn resume(
+        &self,
+        id: &SessionId,
+        last_event_id: String,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        self.inner
+            .resume(id, last_event_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn restore_session(
+        &self,
+        id: SessionId,
+    ) -> Result<RestoreOutcome<Self::Transport>, Self::Error> {
+        if !self.try_reserve() {
+            return Err(BoundedSessionManagerError::TooManySessions(
+                self.max_sessions,
+            ));
+        }
+        match self.inner.restore_session(id).await {
+            Ok(outcome @ RestoreOutcome::Restored(_)) => Ok(outcome),
+            // `AlreadyPresent`/`NotSupported` (and any future variant): no
+            // new session was actually created, release the reservation.
+            Ok(other) => {
+                self.release();
+                Ok(other)
+            }
+            Err(e) => {
+                self.release();
+                Err(e.into())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+impl<E> BoundedSessionManagerError<E> {
+    fn is_too_many_sessions(&self) -> bool {
+        matches!(self, Self::TooManySessions(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::transport::Transport;
+    use rmcp::RoleServer;
+    use std::sync::Mutex;
+
+    /// `SessionManager::Transport` must implement `Transport<RoleServer>`,
+    /// which rules out a bare `()` — this is the smallest thing that
+    /// qualifies, and every method is unreachable because these tests only
+    /// exercise `BoundedSessionManager`'s bookkeeping, never the transport.
+    #[derive(Debug)]
+    struct FakeTransport;
+
+    impl Transport<RoleServer> for FakeTransport {
+        type Error = FakeError;
+
+        fn send(
+            &mut self,
+            _item: ServerJsonRpcMessage,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+            std::future::ready(Err(FakeError("FakeTransport::send unreachable".into())))
+        }
+
+        fn receive(
+            &mut self,
+        ) -> impl std::future::Future<Output = Option<ClientJsonRpcMessage>> + Send {
+            std::future::ready(None)
+        }
+
+        fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+            std::future::ready(Err(FakeError("FakeTransport::close unreachable".into())))
+        }
+    }
+
+    /// A tiny in-memory `SessionManager` fake: just enough surface to drive
+    /// `BoundedSessionManager`'s own logic without pulling in
+    /// `LocalSessionManager`'s full worker/channel machinery. Each "session"
+    /// is nothing but an id in a `Vec`.
+    #[derive(Debug, Default)]
+    struct FakeSessionManager {
+        sessions: Mutex<Vec<SessionId>>,
+    }
+
+    #[derive(Debug, Error)]
+    #[error("fake session manager error: {0}")]
+    struct FakeError(String);
+
+    impl SessionManager for FakeSessionManager {
+        type Error = FakeError;
+        type Transport = FakeTransport;
+
+        async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+            let id: SessionId = format!("fake-{}", uuid_like()).into();
+            self.sessions.lock().expect("lock").push(id.clone());
+            Ok((id, FakeTransport))
+        }
+
+        async fn initialize_session(
+            &self,
+            _id: &SessionId,
+            _message: ClientJsonRpcMessage,
+        ) -> Result<ServerJsonRpcMessage, Self::Error> {
+            unimplemented!("not exercised by these tests")
+        }
+
+        async fn has_session(&self, id: &SessionId) -> Result<bool, Self::Error> {
+            Ok(self.sessions.lock().expect("lock").contains(id))
+        }
+
+        async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+            let mut sessions = self.sessions.lock().expect("lock");
+            let before = sessions.len();
+            sessions.retain(|existing| existing != id);
+            if sessions.len() == before {
+                return Err(FakeError(format!("no such session: {id}")));
+            }
+            Ok(())
+        }
+
+        async fn create_stream(
+            &self,
+            _id: &SessionId,
+            _message: ClientJsonRpcMessage,
+        ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+        {
+            Ok(futures::stream::empty())
+        }
+
+        async fn accept_message(
+            &self,
+            _id: &SessionId,
+            _message: ClientJsonRpcMessage,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        async fn create_standalone_stream(
+            &self,
+            _id: &SessionId,
+        ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+        {
+            Ok(futures::stream::empty())
+        }
+
+        async fn resume(
+            &self,
+            _id: &SessionId,
+            _last_event_id: String,
+        ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+        {
+            Ok(futures::stream::empty())
+        }
+    }
+
+    fn uuid_like() -> u64 {
+        use std::sync::atomic::AtomicU64;
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[tokio::test]
+    async fn create_session_succeeds_under_the_limit() {
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 2);
+        assert!(manager.create_session().await.is_ok());
+        assert!(manager.create_session().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn create_session_refuses_past_the_limit() {
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 2);
+        manager.create_session().await.expect("first session");
+        manager.create_session().await.expect("second session");
+
+        let err = manager
+            .create_session()
+            .await
+            .expect_err("third session must be refused");
+        assert!(err.is_too_many_sessions());
+    }
+
+    #[tokio::test]
+    async fn closing_a_session_frees_a_slot_for_a_new_one() {
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 1);
+        let (id, _transport) = manager.create_session().await.expect("first session");
+        manager
+            .create_session()
+            .await
+            .expect_err("second session must be refused while the first is live");
+
+        manager
+            .close_session(&id)
+            .await
+            .expect("close first session");
+        assert!(
+            manager.create_session().await.is_ok(),
+            "closing the first session must free its slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_create_session_does_not_leak_a_reserved_slot() {
+        // FakeSessionManager::create_session never fails on its own, so
+        // drive this through a manager wrapping ONE that always fails, and
+        // confirm the reservation `try_reserve` took is released — i.e. the
+        // bound isn't silently consumed by inner failures.
+        #[derive(Debug, Default)]
+        struct AlwaysFails;
+
+        impl SessionManager for AlwaysFails {
+            type Error = FakeError;
+            type Transport = FakeTransport;
+
+            async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+                Err(FakeError("always fails".into()))
+            }
+
+            async fn initialize_session(
+                &self,
+                _id: &SessionId,
+                _message: ClientJsonRpcMessage,
+            ) -> Result<ServerJsonRpcMessage, Self::Error> {
+                unimplemented!()
+            }
+
+            async fn has_session(&self, _id: &SessionId) -> Result<bool, Self::Error> {
+                Ok(false)
+            }
+
+            async fn close_session(&self, _id: &SessionId) -> Result<(), Self::Error> {
+                Ok(())
+            }
+
+            async fn create_stream(
+                &self,
+                _id: &SessionId,
+                _message: ClientJsonRpcMessage,
+            ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+            {
+                Ok(futures::stream::empty())
+            }
+
+            async fn accept_message(
+                &self,
+                _id: &SessionId,
+                _message: ClientJsonRpcMessage,
+            ) -> Result<(), Self::Error> {
+                Ok(())
+            }
+
+            async fn create_standalone_stream(
+                &self,
+                _id: &SessionId,
+            ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+            {
+                Ok(futures::stream::empty())
+            }
+
+            async fn resume(
+                &self,
+                _id: &SessionId,
+                _last_event_id: String,
+            ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error>
+            {
+                Ok(futures::stream::empty())
+            }
+        }
+
+        let manager = BoundedSessionManager::new(AlwaysFails, 1);
+        manager
+            .create_session()
+            .await
+            .expect_err("inner always fails");
+        // If the reservation had leaked, this would also be refused with
+        // `TooManySessions` instead of the inner's own error.
+        let err = manager
+            .create_session()
+            .await
+            .expect_err("inner still always fails");
+        assert!(
+            !err.is_too_many_sessions(),
+            "a failed create must not leak its reservation: {err}"
+        );
+    }
+}

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -41,6 +41,13 @@ pub mod extract;
 /// [`service::MemoryService::recall_fused`]. Internal: callers reach it only
 /// through that method.
 mod fusion;
+/// The streamable-HTTP transport (multi-client mode): lets several MCP
+/// clients share ONE `velesdb-memory` process instead of each spawning its
+/// own stdio process and fighting over the store's single-writer `flock`.
+/// Gated behind the (non-default) `http` feature — see the module docs and
+/// the crate README's "HTTP transport (multi-client)" section.
+#[cfg(feature = "http")]
+pub mod http;
 /// Content-addressed memory ids — internal; ids surface through the service API.
 pub(crate) mod id;
 /// Resource caps (DoS limits) shared by every adapter — the single source of

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -1,4 +1,4 @@
-//! `velesdb-memory` — MCP memory server binary (stdio transport).
+//! `velesdb-memory` — MCP memory server binary (stdio transport by default).
 //!
 //! Serves the memory tools over stdio so any MCP client (Claude Code, Cursor,
 //! Cline, Zed, …) can use it locally. The store never leaves the machine.
@@ -13,6 +13,12 @@
 //! `path` instead of inline `content`; unset disables that field entirely.
 //! Run with `--version` (or `-V`) to print the binary's version and exit,
 //! without opening the store.
+//!
+//! When built with `--features http`, pass `--http` (or set
+//! `VELESDB_MEMORY_HTTP=1`) to serve over the streamable-HTTP transport
+//! instead of stdio — letting several MCP clients share ONE process instead
+//! of each fighting over the store's single-writer `flock`. See
+//! `velesdb_memory::http` and the README's "HTTP transport" section.
 
 use std::time::Duration;
 
@@ -21,12 +27,14 @@ use velesdb_memory::mcp::McpServer;
 use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+
     // Handled before anything else touches the filesystem or the embedder:
     // `--version`/`-V` must work even when the store path is unwritable or
     // absent (e.g. a fresh dev running it once to sanity-check the install),
     // so it short-circuits ahead of the store open below.
-    if std::env::args()
-        .nth(1)
+    if args
+        .get(1)
         .is_some_and(|arg| arg == "--version" || arg == "-V")
     {
         println!("velesdb-memory {}", env!("CARGO_PKG_VERSION"));
@@ -44,6 +52,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let original_parent = 0_u32;
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
 
+    // Decided here, ahead of the (possibly seconds-long) embedder probe and
+    // store open, same manual-parsing style as `--version` above (no `clap`
+    // for a two-flag CLI) — but the transport choice itself only affects how
+    // the server is *served*, further down, since store opening (and its
+    // `flock`) is identical either way.
+    let http_bind = requested_http_bind(&args);
+
     // All synchronous setup (env probing, blocking HTTP to Ollama, disk open)
     // runs here, before the async runtime starts, so we never block a tokio
     // worker thread on a synchronous operation.
@@ -52,13 +67,112 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let server = apply_ingest_roots(apply_default_ttl(build_server(service)?)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
-        spawn_orphan_watchdog(original_parent);
-        let running = server
-            .serve((tokio::io::stdin(), tokio::io::stdout()))
-            .await?;
-        running.waiting().await?;
-        Ok::<(), Box<dyn std::error::Error>>(())
+        match http_bind {
+            #[cfg(feature = "http")]
+            Some(bind_addr) => serve_http(server, bind_addr).await,
+            #[cfg(not(feature = "http"))]
+            Some(_never) => unreachable!(
+                "requested_http_bind only returns Some when built with --features http"
+            ),
+            None => {
+                // The orphan watchdog only makes sense for stdio: it exists to
+                // detect a *client process* dying without closing our stdin
+                // (#1448). An HTTP daemon has no such single-client lifecycle
+                // to watch — it's meant to outlive any one client — so it is
+                // never spawned in HTTP mode.
+                spawn_orphan_watchdog(original_parent);
+                let running = server
+                    .serve((tokio::io::stdin(), tokio::io::stdout()))
+                    .await?;
+                running.waiting().await?;
+                Ok::<(), Box<dyn std::error::Error>>(())
+            }
+        }
     })
+}
+
+/// Detect the streamable-HTTP transport request (`--http` flag or
+/// `VELESDB_MEMORY_HTTP=1`) and resolve the bind address it should serve on,
+/// BEFORE the store is opened. Returns `None` for the default stdio
+/// transport.
+///
+/// Without the `http` feature, `--http`/`VELESDB_MEMORY_HTTP=1` is rejected
+/// with an actionable message instead of silently falling back to stdio —
+/// the binary was built without the code to honor the request at all.
+#[cfg(feature = "http")]
+fn requested_http_bind(args: &[String]) -> Option<String> {
+    let http_flag = args.iter().any(|arg| arg == "--http");
+    let http_env = std::env::var("VELESDB_MEMORY_HTTP").as_deref() == Ok("1");
+    if !http_flag && !http_env {
+        return None;
+    }
+
+    let port_override = args
+        .iter()
+        .position(|arg| arg == "--http-port")
+        .and_then(|flag_index| args.get(flag_index + 1));
+
+    let default_bind = std::env::var("VELESDB_MEMORY_HTTP_BIND")
+        .unwrap_or_else(|_| velesdb_memory::http::DEFAULT_HTTP_BIND.to_owned());
+
+    let bind_addr = match port_override {
+        Some(port) => match default_bind.rsplit_once(':') {
+            Some((host, _existing_port)) => format!("{host}:{port}"),
+            None => format!("127.0.0.1:{port}"),
+        },
+        None => default_bind,
+    };
+    Some(bind_addr)
+}
+
+/// See the `http`-feature variant above. Without `http`, no bind address can
+/// ever be resolved — the binary has no HTTP transport built in — so a
+/// `--http`/`VELESDB_MEMORY_HTTP=1` request fails fast with guidance instead
+/// of being silently ignored (which would otherwise look like the server
+/// just hung, or served the wrong transport).
+#[cfg(not(feature = "http"))]
+fn requested_http_bind(args: &[String]) -> Option<String> {
+    let http_flag = args.iter().any(|arg| arg == "--http");
+    let http_env = std::env::var("VELESDB_MEMORY_HTTP").as_deref() == Ok("1");
+    if http_flag || http_env {
+        eprintln!(
+            "[velesdb-memory] --http / VELESDB_MEMORY_HTTP=1 requires a binary built with \
+             `--features http` (e.g. `cargo install velesdb-memory --features http`) — \
+             this binary was built without it"
+        );
+        std::process::exit(1);
+    }
+    None
+}
+
+/// Serve the MCP server over the streamable-HTTP transport (multi-client
+/// mode): binds `bind_addr`, mounts [`velesdb_memory::http::router`], and
+/// runs until either the process receives Ctrl-C or the returned future is
+/// dropped (e.g. process termination) — a background daemon (launchd,
+/// systemd) is expected to just kill the process on stop, which is safe: the
+/// store's `flock` is released by the kernel on exit regardless (see the
+/// orphan-watchdog docs above).
+#[cfg(feature = "http")]
+async fn serve_http(
+    server: McpServer,
+    bind_addr: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ct = tokio_util::sync::CancellationToken::new();
+    let app = velesdb_memory::http::router(server, ct.child_token());
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
+    eprintln!("[velesdb-memory] HTTP server listening on http://{bind_addr}/mcp");
+
+    let ctrl_c_ct = ct.clone();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            ctrl_c_ct.cancel();
+        }
+    });
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+        .await?;
+    Ok(())
 }
 
 /// How often the orphan watchdog re-checks its parent pid. The MCP stdio

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -122,7 +122,46 @@ fn requested_http_bind(args: &[String]) -> Option<String> {
         },
         None => default_bind,
     };
+
+    // The router (`velesdb_memory::http::router`) authenticates no one: any
+    // caller that can reach the socket gets full `remember`/`recall`/`relate`
+    // access to the store. That's only safe because the default bind is
+    // loopback-only. `VELESDB_MEMORY_HTTP_BIND` lets the *port* be
+    // overridden freely, but overriding the *host* to something reachable
+    // off-box would turn an unauthenticated local daemon into an
+    // unauthenticated network service — so that requires an explicit,
+    // separate opt-in rather than falling out of a bind-address typo.
+    if !is_loopback_host(&bind_addr)
+        && std::env::var("VELESDB_MEMORY_HTTP_ALLOW_REMOTE").as_deref() != Ok("1")
+    {
+        eprintln!(
+            "[velesdb-memory] refusing to bind the HTTP transport to '{bind_addr}': it is not a \
+             loopback address, and the streamable-HTTP transport has no authentication — anyone \
+             who can reach that socket gets full read/write access to the store. Set \
+             VELESDB_MEMORY_HTTP_ALLOW_REMOTE=1 to override (put an authenticating reverse proxy \
+             in front first)."
+        );
+        std::process::exit(1);
+    }
+
     Some(bind_addr)
+}
+
+/// Whether `bind_addr`'s host component (`host:port` or `[ipv6]:port`)
+/// resolves to a loopback address. Used to gate non-local HTTP binds behind
+/// an explicit opt-in — see `requested_http_bind` above. An unparseable host
+/// (e.g. a hostname like `mcp.example.com` rather than a literal IP) is
+/// treated as non-loopback: `TcpListener::bind` does its own DNS resolution
+/// later, so this is a conservative pre-check, not the only one.
+#[cfg(feature = "http")]
+fn is_loopback_host(bind_addr: &str) -> bool {
+    let host = bind_addr
+        .rsplit_once(':')
+        .map_or(bind_addr, |(host, _port)| host)
+        .trim_start_matches('[')
+        .trim_end_matches(']');
+    host.parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_loopback())
 }
 
 /// See the `http`-feature variant above. Without `http`, no bind address can
@@ -447,4 +486,24 @@ fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 #[cfg(not(feature = "ollama"))]
 fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
     Err("the 'ollama' embedder requires building with `--features ollama`".into())
+}
+
+#[cfg(all(test, feature = "http"))]
+mod tests {
+    use super::is_loopback_host;
+
+    #[test]
+    fn loopback_v4_and_v6_are_recognized() {
+        assert!(is_loopback_host("127.0.0.1:18090"));
+        assert!(is_loopback_host("127.0.0.5:18090"));
+        assert!(is_loopback_host("[::1]:18090"));
+    }
+
+    #[test]
+    fn non_loopback_hosts_are_rejected() {
+        assert!(!is_loopback_host("0.0.0.0:18090"));
+        assert!(!is_loopback_host("192.168.1.10:18090"));
+        assert!(!is_loopback_host("[::]:18090"));
+        assert!(!is_loopback_host("mcp.example.com:18090"));
+    }
 }

--- a/crates/velesdb-memory/tests/http_lock_contention.rs
+++ b/crates/velesdb-memory/tests/http_lock_contention.rs
@@ -1,0 +1,158 @@
+//! A second `velesdb-memory --http` daemon on the same store (#1448-style
+//! regression, HTTP variant).
+//!
+//! The store's single-writer `flock` (`velesdb-core`'s `Database::open_impl`)
+//! guards cross-*process* access identically no matter which transport a
+//! process serves over — HTTP is meant to let many CLIENTS share ONE daemon
+//! *process*, not to let two daemon processes share one store. A second
+//! `--http` process against a store another process already holds must fail
+//! fast with the same actionable lock message the stdio path already has
+//! (`mcp_lifecycle.rs`'s `database_locked_at_startup_prints_actionable_guidance_and_exits_nonzero`),
+//! proving `open_store_with_actionable_lock_error` runs identically ahead of
+//! either transport rather than being a stdio-only guard that regressed once
+//! HTTP was added.
+
+use std::io::Read;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Upper bound on how long the first daemon is given to log that it's
+/// listening (proof the store was opened and the HTTP listener bound) before
+/// the test gives up and fails loudly instead of hanging.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Upper bound on how long the contending second daemon is given to fail
+/// and exit after hitting the locked store.
+const CONTENDER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn spawn_http_daemon(store_path: &std::path::Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .arg("--http")
+        .arg("--http-port")
+        .arg("0") // OS-assigned ephemeral port — this test only cares about
+        // the STORE lock, never about a port collision between the two
+        // daemons, so each gets its own free port.
+        .env("VELESDB_MEMORY_PATH", store_path)
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn velesdb-memory --http")
+}
+
+/// Read stderr lines on a helper thread until one contains `needle` (proof
+/// the daemon reached that log line) or `timeout` elapses. Mirrors
+/// `mcp_lifecycle.rs`'s `read_line_with_timeout` pattern: a direct blocking
+/// read has no deadline, and if the process under test hangs, a bare
+/// `read_to_string` would hang this test (and the suite) right along with
+/// it.
+fn wait_for_stderr_line(
+    mut stderr: impl Read + Send + 'static,
+    needle: &'static str,
+    timeout: Duration,
+) -> bool {
+    use std::io::{BufRead, BufReader};
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let reader = BufReader::new(&mut stderr);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            let found = line.contains(needle);
+            let _ = tx.send(line);
+            if found {
+                return;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return false;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(line) if line.contains(needle) => return true,
+            Ok(_) => {} // keep waiting for the needle line
+            Err(_) => return false,
+        }
+    }
+}
+
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn drain_with_timeout<R: Read + Send + 'static>(mut reader: R, timeout: Duration) -> String {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = reader.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx.recv_timeout(timeout).unwrap_or_default()
+}
+
+#[test]
+fn second_http_daemon_on_same_store_fails_with_actionable_lock_message() {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+
+    let mut holder = spawn_http_daemon(store_dir.path());
+    let holder_stderr = holder.stderr.take().expect("holder stderr must be piped");
+    let holder_up = wait_for_stderr_line(holder_stderr, "HTTP server listening", STARTUP_TIMEOUT);
+    if !holder_up {
+        let _ = holder.kill();
+        let _ = holder.wait();
+        panic!(
+            "first HTTP daemon never logged its listening line within {STARTUP_TIMEOUT:?} — \
+             it must be up (store opened, port bound) before this test can prove anything \
+             about a second daemon contending on the same store"
+        );
+    }
+
+    // Second daemon, same store, while the first is still up and holding the
+    // flock — exactly the #1448 scenario, just over HTTP instead of stdio.
+    let mut contender = spawn_http_daemon(store_dir.path());
+    let contender_stderr = contender
+        .stderr
+        .take()
+        .expect("contender stderr must be piped");
+    drop(contender.stdout.take());
+
+    let status = wait_for_exit(&mut contender, CONTENDER_EXIT_TIMEOUT).unwrap_or_else(|| {
+        let _ = contender.kill();
+        let _ = contender.wait();
+        panic!(
+            "a second --http daemon opening an already-locked store did not exit within \
+             {CONTENDER_EXIT_TIMEOUT:?} — startup must fail fast (bounded retry), not hang, \
+             exactly like the stdio path (#1448)"
+        );
+    });
+    assert!(
+        !status.success(),
+        "a second --http daemon opening an already-locked store must exit non-zero, got: {status:?}"
+    );
+
+    let stderr_text = drain_with_timeout(contender_stderr, Duration::from_secs(2));
+    let lower = stderr_text.to_lowercase();
+    assert!(
+        lower.contains("velesdb_memory_path") && lower.contains("pkill"),
+        "expected the same actionable lock-contention message the stdio path prints \
+         (naming VELESDB_MEMORY_PATH as the escape hatch and pkill as the fix), \
+         got: {stderr_text:?}"
+    );
+
+    let _ = holder.kill();
+    let _ = holder.wait();
+}

--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -1,0 +1,270 @@
+//! HTTP (streamable) transport for the MCP server — multi-client mode.
+//!
+//! `velesdb-memory` today only speaks stdio: every MCP client (Claude Code,
+//! Claude Desktop, Windsurf, …) spawns its own server process, and the
+//! store's single-writer `flock` means only one of those processes can
+//! actually hold the store open at a time — so only one client can use
+//! memory at once. The fix is a single HTTP daemon multiple clients share.
+//!
+//! These tests build the axum [`Router`](axum::Router) directly via
+//! `velesdb_memory::http::router` (no subprocess) and drive it with a real
+//! MCP client over the streamable-HTTP transport (`rmcp`'s own client-side
+//! transport, the same one exercised by rmcp's upstream test suite), bound
+//! to an OS-assigned loopback port so tests never collide on a fixed one.
+//!
+//! The concurrency test is the risk this transport exists to retire:
+//! `Database`'s internal `RwLock` (velesdb-core) makes concurrent requests
+//! against the ONE shared store safe in-process — the `flock` only ever
+//! guarded cross-*process* access, which HTTP sidesteps entirely by having
+//! exactly one process own the store. Twenty simultaneous `remember`s (and a
+//! `remember`+`recall` mix) must all complete with no panic and no deadlock.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
+use serde_json::{json, Map, Value};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use velesdb_memory::mcp::McpServer;
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+/// A running HTTP transport for a test: the bound address, the server task
+/// (drive it to completion via [`shutdown`]), the token that stops it, and
+/// the store's `TempDir` (kept alive for the test's duration — dropping it
+/// early would delete the store out from under the server).
+struct TestServer {
+    addr: SocketAddr,
+    handle: JoinHandle<()>,
+    ct: CancellationToken,
+    _store_dir: tempfile::TempDir,
+}
+
+/// Cancel the server's token and wait for its task to actually finish —
+/// every test must call this before returning so a failed/hung shutdown
+/// surfaces as a test failure instead of a silently leaked task.
+async fn shutdown(server: TestServer) {
+    server.ct.cancel();
+    server
+        .handle
+        .await
+        .expect("http server task must not panic");
+}
+
+/// Spin up the HTTP transport on `127.0.0.1:0` (OS-assigned port) backed by
+/// a fresh scratch store — the same `HashEmbedder` + `MemoryService::open`
+/// setup `src/mcp/server_tests.rs` uses for the stdio-side unit tests, just
+/// wrapped in the new HTTP router instead of called directly.
+async fn spawn_http_server() -> TestServer {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let server = McpServer::new(service);
+
+    let ct = CancellationToken::new();
+    let app = velesdb_memory::http::router(server, ct.child_token());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("read bound local addr");
+
+    let shutdown_ct = ct.clone();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled_owned().await })
+            .await;
+    });
+
+    TestServer {
+        addr,
+        handle,
+        ct,
+        _store_dir: store_dir,
+    }
+}
+
+/// Complete the MCP `initialize` handshake against `addr`'s `/mcp` endpoint
+/// and return the connected client. `ServiceExt::serve` performs
+/// `initialize` as part of establishing the session, so a successful
+/// `connect` IS the initialize round trip.
+async fn connect(addr: SocketAddr) -> RunningService<RoleClient, ClientInfo> {
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("MCP initialize handshake over HTTP")
+}
+
+fn as_args(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        other => panic!("expected a JSON object, got {other:?}"),
+    }
+}
+
+/// Call `remember` over HTTP and return the fact's `id_str`.
+async fn remember(client: &RunningService<RoleClient, ClientInfo>, fact: &str) -> String {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("remember").with_arguments(as_args(json!({ "fact": fact }))),
+        )
+        .await
+        .expect("remember call over HTTP");
+    let structured = result
+        .structured_content
+        .expect("remember returns structured_content");
+    structured["id_str"]
+        .as_str()
+        .expect("id_str is a string")
+        .to_owned()
+}
+
+/// Call `recall` over HTTP and return whether any hit's `content` exactly
+/// matches `needle`.
+async fn recall_contains(
+    client: &RunningService<RoleClient, ClientInfo>,
+    query: &str,
+    needle: &str,
+) -> bool {
+    let result = client
+        .call_tool(CallToolRequestParams::new("recall").with_arguments(as_args(json!({
+            "query": query,
+            "limit": 50,
+        }))))
+        .await
+        .expect("recall call over HTTP");
+    let structured = result
+        .structured_content
+        .expect("recall returns structured_content");
+    let memories = structured["memories"]
+        .as_array()
+        .expect("memories is an array");
+    memories
+        .iter()
+        .any(|memory| memory["content"].as_str() == Some(needle))
+}
+
+#[tokio::test]
+async fn initialize_round_trip_succeeds_over_http() {
+    let server = spawn_http_server().await;
+
+    let client = connect(server.addr).await;
+    let info = client
+        .peer_info()
+        .expect("server must advertise its info during initialize");
+    assert_eq!(info.server_info.name, "velesdb-memory");
+
+    shutdown(server).await;
+}
+
+#[tokio::test]
+async fn remember_then_recall_roundtrip_over_http() {
+    let server = spawn_http_server().await;
+    let client = connect(server.addr).await;
+
+    let fact = "HTTP transport lets many MCP clients share one memory daemon";
+    let id_str = remember(&client, fact).await;
+    assert!(!id_str.is_empty(), "remember must return a non-empty id");
+
+    let found = recall_contains(&client, "HTTP transport memory daemon", fact).await;
+    assert!(found, "the remembered fact must be recallable over HTTP");
+
+    shutdown(server).await;
+}
+
+/// The central risk this transport exists to retire: 20 simultaneous
+/// `remember` calls against the ONE shared store, all through the SAME HTTP
+/// connection's session, must all succeed with unique ids and never panic —
+/// proving `Database`'s internal locking (velesdb-core) is enough on its own
+/// without the process-level `flock` (which never applied here — HTTP is
+/// single-process by construction).
+#[tokio::test]
+async fn twenty_concurrent_remembers_all_succeed_with_unique_ids() {
+    let server = spawn_http_server().await;
+    let client = Arc::new(connect(server.addr).await);
+
+    let mut tasks = Vec::with_capacity(20);
+    for i in 0..20 {
+        let client = Arc::clone(&client);
+        tasks.push(tokio::spawn(async move {
+            remember(&client, &format!("concurrent fact number {i}")).await
+        }));
+    }
+
+    let mut ids = std::collections::HashSet::new();
+    for task in tasks {
+        let id = task.await.expect("remember task must not panic");
+        assert!(ids.insert(id), "remember must never return a duplicate id");
+    }
+    assert_eq!(ids.len(), 20, "all 20 concurrent remembers must succeed");
+
+    drop(client);
+    shutdown(server).await;
+}
+
+/// A mixed `remember` + `recall` race: proves the HTTP transport has no
+/// deadlock or corruption when reads and writes overlap, then — after the
+/// race settles — that every fact written during it is actually recallable
+/// (not silently dropped or corrupted by the concurrent access).
+#[tokio::test]
+async fn concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable() {
+    let server = spawn_http_server().await;
+    let client = Arc::new(connect(server.addr).await);
+
+    remember(&client, "seed fact alpha for the concurrency race").await;
+    remember(&client, "seed fact beta for the concurrency race").await;
+
+    let mut remember_tasks = Vec::with_capacity(10);
+    for i in 0..10 {
+        let client = Arc::clone(&client);
+        remember_tasks.push(tokio::spawn(async move {
+            remember(&client, &format!("racing fact {i}")).await
+        }));
+    }
+
+    let mut recall_tasks = Vec::with_capacity(10);
+    for _ in 0..10 {
+        let client = Arc::clone(&client);
+        recall_tasks.push(tokio::spawn(async move {
+            // Never asserted mid-race: the race may see a fact before it is
+            // durably stored. This only proves recall doesn't panic/hang
+            // while writes are in flight.
+            let _ = recall_contains(&client, "racing fact", "irrelevant").await;
+        }));
+    }
+
+    for task in remember_tasks {
+        task.await.expect("remember task must not panic");
+    }
+    for task in recall_tasks {
+        task.await.expect("recall task must not panic during the race");
+    }
+
+    for i in 0..10 {
+        let fact = format!("racing fact {i}");
+        assert!(
+            recall_contains(&client, &fact, &fact).await,
+            "fact {i} written during the concurrent race must be recallable afterwards"
+        );
+    }
+    assert!(
+        recall_contains(
+            &client,
+            "seed fact",
+            "seed fact alpha for the concurrency race"
+        )
+        .await
+    );
+
+    drop(client);
+    shutdown(server).await;
+}

--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -20,7 +20,6 @@
 //! `remember`+`recall` mix) must all complete with no panic and no deadlock.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use rmcp::model::{CallToolRequestParams, ClientInfo};
 use rmcp::service::RunningService;
@@ -136,10 +135,12 @@ async fn recall_contains(
     needle: &str,
 ) -> bool {
     let result = client
-        .call_tool(CallToolRequestParams::new("recall").with_arguments(as_args(json!({
-            "query": query,
-            "limit": 50,
-        }))))
+        .call_tool(
+            CallToolRequestParams::new("recall").with_arguments(as_args(json!({
+                "query": query,
+                "limit": 50,
+            }))),
+        )
         .await
         .expect("recall call over HTTP");
     let structured = result
@@ -153,7 +154,7 @@ async fn recall_contains(
         .any(|memory| memory["content"].as_str() == Some(needle))
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn initialize_round_trip_succeeds_over_http() {
     let server = spawn_http_server().await;
 
@@ -166,7 +167,7 @@ async fn initialize_round_trip_succeeds_over_http() {
     shutdown(server).await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn remember_then_recall_roundtrip_over_http() {
     let server = spawn_http_server().await;
     let client = connect(server.addr).await;
@@ -182,20 +183,22 @@ async fn remember_then_recall_roundtrip_over_http() {
 }
 
 /// The central risk this transport exists to retire: 20 simultaneous
-/// `remember` calls against the ONE shared store, all through the SAME HTTP
-/// connection's session, must all succeed with unique ids and never panic —
-/// proving `Database`'s internal locking (velesdb-core) is enough on its own
-/// without the process-level `flock` (which never applied here — HTTP is
-/// single-process by construction).
-#[tokio::test]
+/// `remember` calls against the ONE shared store — each from its OWN
+/// connected client, exactly like 20 real MCP clients (Claude Code, Claude
+/// Desktop, Windsurf, …) sharing one daemon rather than each spawning its
+/// own stdio process — must all succeed with unique ids and never panic.
+/// This proves `Database`'s internal locking (velesdb-core) is enough on its
+/// own without the process-level `flock`, which never applies here: HTTP
+/// concurrency is many *sessions* in ONE process, not many processes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn twenty_concurrent_remembers_all_succeed_with_unique_ids() {
     let server = spawn_http_server().await;
-    let client = Arc::new(connect(server.addr).await);
 
     let mut tasks = Vec::with_capacity(20);
     for i in 0..20 {
-        let client = Arc::clone(&client);
+        let addr = server.addr;
         tasks.push(tokio::spawn(async move {
+            let client = connect(addr).await;
             remember(&client, &format!("concurrent fact number {i}")).await
         }));
     }
@@ -207,34 +210,37 @@ async fn twenty_concurrent_remembers_all_succeed_with_unique_ids() {
     }
     assert_eq!(ids.len(), 20, "all 20 concurrent remembers must succeed");
 
-    drop(client);
     shutdown(server).await;
 }
 
-/// A mixed `remember` + `recall` race: proves the HTTP transport has no
-/// deadlock or corruption when reads and writes overlap, then — after the
-/// race settles — that every fact written during it is actually recallable
-/// (not silently dropped or corrupted by the concurrent access).
-#[tokio::test]
+/// A mixed `remember` + `recall` race (again, one connection per task —
+/// many concurrent clients, not multiplexed calls on one session): proves
+/// the HTTP transport has no deadlock or corruption when reads and writes
+/// overlap, then — after the race settles — that every fact written during
+/// it is actually recallable (not silently dropped or corrupted).
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable() {
     let server = spawn_http_server().await;
-    let client = Arc::new(connect(server.addr).await);
 
-    remember(&client, "seed fact alpha for the concurrency race").await;
-    remember(&client, "seed fact beta for the concurrency race").await;
+    let seed_client = connect(server.addr).await;
+    remember(&seed_client, "seed fact alpha for the concurrency race").await;
+    remember(&seed_client, "seed fact beta for the concurrency race").await;
+    drop(seed_client);
 
     let mut remember_tasks = Vec::with_capacity(10);
     for i in 0..10 {
-        let client = Arc::clone(&client);
+        let addr = server.addr;
         remember_tasks.push(tokio::spawn(async move {
+            let client = connect(addr).await;
             remember(&client, &format!("racing fact {i}")).await
         }));
     }
 
     let mut recall_tasks = Vec::with_capacity(10);
     for _ in 0..10 {
-        let client = Arc::clone(&client);
+        let addr = server.addr;
         recall_tasks.push(tokio::spawn(async move {
+            let client = connect(addr).await;
             // Never asserted mid-race: the race may see a fact before it is
             // durably stored. This only proves recall doesn't panic/hang
             // while writes are in flight.
@@ -246,25 +252,27 @@ async fn concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable
         task.await.expect("remember task must not panic");
     }
     for task in recall_tasks {
-        task.await.expect("recall task must not panic during the race");
+        task.await
+            .expect("recall task must not panic during the race");
     }
 
+    let verify_client = connect(server.addr).await;
     for i in 0..10 {
         let fact = format!("racing fact {i}");
         assert!(
-            recall_contains(&client, &fact, &fact).await,
+            recall_contains(&verify_client, &fact, &fact).await,
             "fact {i} written during the concurrent race must be recallable afterwards"
         );
     }
     assert!(
         recall_contains(
-            &client,
+            &verify_client,
             "seed fact",
             "seed fact alpha for the concurrency race"
         )
         .await
     );
+    drop(verify_client);
 
-    drop(client);
     shutdown(server).await;
 }

--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -27,10 +27,12 @@ use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::{RoleClient, ServiceExt};
 use serde_json::{json, Map, Value};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use velesdb_memory::http::DEFAULT_HTTP_MAX_SESSIONS;
 use velesdb_memory::mcp::McpServer;
 use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
 
@@ -59,8 +61,23 @@ async fn shutdown(server: TestServer) {
 /// Spin up the HTTP transport on `127.0.0.1:0` (OS-assigned port) backed by
 /// a fresh scratch store — the same `HashEmbedder` + `MemoryService::open`
 /// setup `src/mcp/server_tests.rs` uses for the stdio-side unit tests, just
-/// wrapped in the new HTTP router instead of called directly.
+/// wrapped in the new HTTP router instead of called directly. Uses the same
+/// body/session limits `router()` defaults to in production.
 async fn spawn_http_server() -> TestServer {
+    spawn_http_server_with_limits(
+        velesdb_memory::http::DEFAULT_HTTP_MAX_BODY_BYTES,
+        velesdb_memory::http::DEFAULT_HTTP_MAX_SESSIONS,
+    )
+    .await
+}
+
+/// [`spawn_http_server`], but with the two DoS-guard limits passed
+/// explicitly — for the adversarial tests below that need a tiny limit to
+/// actually trip within a fast, deterministic test. Deliberately does NOT go
+/// through env vars: `cargo test` runs a crate's tests in parallel by
+/// default, and process-wide env vars are shared mutable state that would
+/// race every other test in this binary reading the same variables.
+async fn spawn_http_server_with_limits(max_body_bytes: usize, max_sessions: usize) -> TestServer {
     let store_dir = tempfile::tempdir().expect("create scratch store dir");
     let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
     let service =
@@ -68,7 +85,12 @@ async fn spawn_http_server() -> TestServer {
     let server = McpServer::new(service);
 
     let ct = CancellationToken::new();
-    let app = velesdb_memory::http::router(server, ct.child_token());
+    let app = velesdb_memory::http::router_with_limits(
+        server,
+        ct.child_token(),
+        max_body_bytes,
+        max_sessions,
+    );
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind ephemeral loopback port");
@@ -274,5 +296,86 @@ async fn concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable
     );
     drop(verify_client);
 
+    shutdown(server).await;
+}
+
+/// Adversarial: the two DoS guards `router()` wraps `/mcp` in (2026-07-22
+/// OOM audit) must actually reject what they claim to bound, not just exist
+/// as unused configuration. `RequestBodyLimit` rejects a request whose
+/// `Content-Length` already exceeds the configured limit before reading any
+/// of the body (see `tower_http::limit::service::RequestBodyLimit::call`) —
+/// exercised here with a hand-rolled request over a raw `TcpStream` rather
+/// than the rmcp client, since a well-behaved MCP client has no way to send
+/// a request this shape.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn oversized_request_body_is_rejected_by_content_length() {
+    const TINY_MAX_BODY_BYTES: usize = 1024;
+    let server =
+        spawn_http_server_with_limits(TINY_MAX_BODY_BYTES, DEFAULT_HTTP_MAX_SESSIONS).await;
+
+    let mut stream = tokio::net::TcpStream::connect(server.addr)
+        .await
+        .expect("connect a raw TCP stream to the HTTP transport");
+    let claimed_len = TINY_MAX_BODY_BYTES * 100;
+    let request = format!(
+        "POST /mcp HTTP/1.1\r\n\
+         Host: {addr}\r\n\
+         Content-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n\
+         Content-Length: {claimed_len}\r\n\
+         Connection: close\r\n\
+         \r\n",
+        addr = server.addr
+    );
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .expect("write the oversized request's headers");
+    // Deliberately never write the (huge, nonexistent) body: a limit
+    // enforced only after buffering it would hang/OOM right here instead of
+    // responding — the property under test.
+
+    let mut response = Vec::new();
+    stream
+        .read_to_end(&mut response)
+        .await
+        .expect("read the response before the body would ever be sent");
+    let response = String::from_utf8_lossy(&response);
+    let status_line = response.lines().next().unwrap_or_default();
+    assert!(
+        status_line.contains("413"),
+        "expected a 413 Payload Too Large for a {claimed_len}-byte body against a \
+         {TINY_MAX_BODY_BYTES}-byte limit, got: {status_line:?}"
+    );
+
+    shutdown(server).await;
+}
+
+/// Adversarial: `BoundedSessionManager` (`src/http/session_limit.rs`) must
+/// actually refuse a session past `max_sessions`, not just track a counter
+/// nobody reads. `max_sessions = 1` here — the first `connect()` must
+/// succeed and consume the only slot, the second must fail while the first
+/// is still open.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn session_beyond_the_configured_cap_is_refused() {
+    const MAX_SESSIONS: usize = 1;
+    let server = spawn_http_server_with_limits(
+        velesdb_memory::http::DEFAULT_HTTP_MAX_BODY_BYTES,
+        MAX_SESSIONS,
+    )
+    .await;
+
+    let first_client = connect(server.addr).await;
+
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{}/mcp", server.addr)),
+    );
+    let second_attempt = ClientInfo::default().serve(transport).await;
+    assert!(
+        second_attempt.is_err(),
+        "a second session must be refused while the first (the only slot, max_sessions=1) is open"
+    );
+
+    drop(first_client);
     shutdown(server).await;
 }

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -1,0 +1,483 @@
+#!/bin/bash
+# =============================================================================
+# VelesDB Memory Daemon Installer
+# =============================================================================
+# `velesdb-memory` normally speaks stdio: every MCP client (Claude Code,
+# Claude Desktop, Windsurf, …) spawns its own server process, and the
+# store's single-writer flock lets only ONE of those processes actually hold
+# it open — so only one client can use memory at a time. This script builds
+# `velesdb-memory` with the HTTP transport, runs ONE daemon (a macOS launchd
+# agent), and wires every supported client to it instead.
+#
+# Usage:
+#   ./scripts/install-memory-daemon.sh [flags]
+#   ./scripts/install-memory-daemon.sh --uninstall
+#
+# Flags:
+#   --embedder=hash|ollama   Embedding backend (default: prompted, or 'hash' in CI/non-tty)
+#   --port=PORT              HTTP port (default: 18090)
+#   --store=PATH             Store directory (default: $HOME/.velesdb-memory)
+#   --ollama-url=URL         Ollama endpoint (default: http://localhost:11434)
+#   --ollama-model=MODEL     Ollama embedding model (default: all-minilm)
+#   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
+#   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf
+#   --force-restart          Reload the daemon even if already running
+#   --uninstall              Remove the daemon and all client wiring (store is NEVER deleted)
+#   -h, --help               Show this help
+# =============================================================================
+
+set -e
+
+# Colors (same palette as scripts/install.sh)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ---- require_jq: copied verbatim (in spirit) from the guard already used by
+# integrations/agent-hooks/claude-code/hooks/lib/common.sh — every JSON edit
+# in this script goes through jq to get escaping right, so fail loudly (not
+# silently) if it's missing.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "install-memory-daemon.sh: 'jq' is required but was not found on PATH." >&2
+    exit 1
+  fi
+}
+
+# ---- Defaults -------------------------------------------------------------
+EMBEDDER=""
+PORT="18090"
+STORE="$HOME/.velesdb-memory"
+OLLAMA_URL="http://localhost:11434"
+OLLAMA_MODEL="all-minilm"
+ASSUME_YES=0
+FORCE_RESTART=0
+UNINSTALL=0
+SKIP_CLIENTS=""
+
+PLIST_LABEL="com.velesdb.memory"
+PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+BIN_PATH="$HOME/.cargo/bin/velesdb-memory"
+DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+WINDSURF_CONFIG="$HOME/.codeium/windsurf/mcp_config.json"
+
+print_usage() {
+  sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ---- 0. Parse flags ---------------------------------------------------
+for arg in "$@"; do
+  case "$arg" in
+    --embedder=*) EMBEDDER="${arg#*=}" ;;
+    --port=*) PORT="${arg#*=}" ;;
+    --store=*) STORE="${arg#*=}" ;;
+    --ollama-url=*) OLLAMA_URL="${arg#*=}" ;;
+    --ollama-model=*) OLLAMA_MODEL="${arg#*=}" ;;
+    --yes) ASSUME_YES=1 ;;
+    --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
+    --force-restart) FORCE_RESTART=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    -h|--help) print_usage; exit 0 ;;
+    *)
+      echo -e "${RED}❌ Unknown flag: $arg${NC}"
+      print_usage
+      exit 1
+      ;;
+  esac
+done
+
+should_skip() {
+  case " $SKIP_CLIENTS " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# ---- 1. Preflight -------------------------------------------------------
+preflight() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo -e "${RED}❌ 'cargo' not found — install Rust via https://rustup.rs then relaunch this script${NC}"
+    exit 1
+  fi
+
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo -e "${RED}❌ not inside a git checkout of VelesDB — run this script from within the repo${NC}"
+    exit 1
+  }
+
+  if [ "$(uname -s)" = "Darwin" ]; then
+    DAEMON_SUPPORTED=1
+  else
+    DAEMON_SUPPORTED=0
+    echo -e "${YELLOW}⚠️  Non-macOS host detected — step 5 (launchd daemon) is macOS-only.${NC}"
+    echo -e "${YELLOW}   Generate a systemd unit yourself; this script still builds the binary and wires clients.${NC}"
+  fi
+}
+
+# ---- 2. Embedder resolution ----------------------------------------------
+resolve_embedder() {
+  if [ -n "$EMBEDDER" ]; then
+    case "$EMBEDDER" in
+      hash|ollama) return ;;
+      *)
+        echo -e "${RED}❌ --embedder must be 'hash' or 'ollama', got '$EMBEDDER'${NC}"
+        exit 1
+        ;;
+    esac
+  fi
+
+  if [ -t 0 ]; then
+    echo ""
+    echo -e "${BLUE}Which embedder should velesdb-memory use?${NC}"
+    echo "  1) hash    (offline, deterministic — default)"
+    echo "  2) ollama  (semantic recall — needs a local Ollama)"
+    printf 'Choice [1]: '
+    read -r choice
+    case "$choice" in
+      2) EMBEDDER="ollama" ;;
+      ""|1) EMBEDDER="hash" ;;
+      *)
+        echo -e "${RED}❌ invalid choice: $choice${NC}"
+        exit 1
+        ;;
+    esac
+  else
+    EMBEDDER="hash"
+    echo -e "${YELLOW}[velesdb-memory] Using the default 'hash' embedder: deterministic and fully offline, but NOT semantic — recall matches surface form, not meaning. Re-run with --embedder=ollama for real semantic recall.${NC}" >&2
+  fi
+}
+
+# ---- 3. Ollama setup (only when EMBEDDER=ollama) --------------------------
+normalize_model_tag() {
+  case "$1" in
+    *:*) echo "$1" ;;
+    *) echo "$1:latest" ;;
+  esac
+}
+
+setup_ollama() {
+  [ "$EMBEDDER" = "ollama" ] || return 0
+
+  if ! command -v ollama >/dev/null 2>&1; then
+    echo -e "${RED}❌ 'ollama' not found.${NC}"
+    case "$(uname -s)" in
+      Darwin) echo "   Install it with: brew install ollama" ;;
+      Linux) echo "   Install it with: curl -fsSL https://ollama.com/install.sh | sh" ;;
+      *) echo "   See https://ollama.com/download" ;;
+    esac
+    exit 1
+  fi
+
+  local tags_file
+  tags_file="$(mktemp)"
+  if ! curl -fsS --max-time 2 "$OLLAMA_URL/api/tags" >"$tags_file" 2>/dev/null; then
+    rm -f "$tags_file"
+    echo -e "${RED}❌ Ollama does not respond on $OLLAMA_URL — launch the Ollama app or run \`ollama serve\`${NC}"
+    exit 1
+  fi
+
+  require_jq
+  local wanted have
+  wanted="$(normalize_model_tag "$OLLAMA_MODEL")"
+  have="$(jq -r --arg want "$wanted" '[.models[]?.name | select(. == $want)] | length' "$tags_file" 2>/dev/null || echo 0)"
+  rm -f "$tags_file"
+
+  if [ "${have:-0}" = "0" ]; then
+    if [ "$ASSUME_YES" = "1" ]; then
+      echo -e "${YELLOW}📥 Pulling Ollama model '$OLLAMA_MODEL'...${NC}"
+      ollama pull "$OLLAMA_MODEL"
+    elif [ -t 0 ]; then
+      printf 'Model '\''%s'\'' not found locally. Pull it now? [y/N] ' "$OLLAMA_MODEL"
+      read -r reply
+      case "$reply" in
+        y|Y|yes|YES) ollama pull "$OLLAMA_MODEL" ;;
+        *)
+          echo -e "${RED}❌ Run this first: ollama pull $OLLAMA_MODEL${NC}"
+          exit 1
+          ;;
+      esac
+    else
+      echo -e "${RED}❌ Model '$OLLAMA_MODEL' not found locally. Run: ollama pull $OLLAMA_MODEL${NC}"
+      exit 1
+    fi
+  fi
+}
+
+# ---- 4. Build --------------------------------------------------------------
+build_daemon() {
+  echo -e "${YELLOW}🔨 Building velesdb-memory (--features ollama,http)...${NC}"
+  # Always both features regardless of the runtime embedder choice above:
+  # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
+  # choice, so flipping it later is a restart, never a rebuild.
+  cargo install --path "$REPO_ROOT/crates/velesdb-memory" --bin velesdb-memory \
+    --features ollama,http --force
+}
+
+# ---- 5. launchd daemon (macOS only) ----------------------------------------
+setup_daemon() {
+  DAEMON_ALREADY_RUNNING=0
+  if [ "$DAEMON_SUPPORTED" != "1" ]; then
+    echo -e "${YELLOW}⏭  Skipping daemon setup (non-macOS) — start \`velesdb-memory --http --http-port $PORT\` yourself.${NC}"
+    return 0
+  fi
+
+  local uid
+  uid="$(id -u)"
+
+  if launchctl print "gui/$uid/$PLIST_LABEL" >/dev/null 2>&1; then
+    if [ "$FORCE_RESTART" != "1" ]; then
+      echo -e "${GREEN}✅ $PLIST_LABEL is already loaded — skipping (pass --force-restart to reload).${NC}"
+      DAEMON_ALREADY_RUNNING=1
+      return 0
+    fi
+    echo -e "${YELLOW}🔁 --force-restart: unloading the existing $PLIST_LABEL...${NC}"
+    launchctl bootout "gui/$uid/$PLIST_LABEL" 2>/dev/null || true
+  fi
+
+  if command -v lsof >/dev/null 2>&1; then
+    local holder_pid holder_cmd
+    holder_pid="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null | head -1 || true)"
+    if [ -n "$holder_pid" ]; then
+      holder_cmd="$(ps -o comm= -p "$holder_pid" 2>/dev/null || true)"
+      if [ "$holder_cmd" != "$BIN_PATH" ]; then
+        echo -e "${RED}❌ Port $PORT is already in use by another process ($holder_cmd, pid $holder_pid).${NC}"
+        echo -e "${RED}   Re-run with --port=<other-port>, or stop that process first.${NC}"
+        exit 1
+      fi
+    fi
+  fi
+
+  mkdir -p "$HOME/Library/Logs/velesdb-memory"
+  mkdir -p "$(dirname "$PLIST_PATH")"
+
+  cat > "$PLIST_PATH" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$PLIST_LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$BIN_PATH</string>
+    <string>--http</string>
+    <string>--http-port</string>
+    <string>$PORT</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VELESDB_MEMORY_PATH</key><string>$STORE</string>
+    <key>VELESDB_MEMORY_EMBEDDER</key><string>$EMBEDDER</string>
+    <key>VELESDB_MEMORY_OLLAMA_URL</key><string>$OLLAMA_URL</string>
+    <key>VELESDB_MEMORY_OLLAMA_MODEL</key><string>$OLLAMA_MODEL</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$HOME/Library/Logs/velesdb-memory/daemon.out.log</string>
+  <key>StandardErrorPath</key><string>$HOME/Library/Logs/velesdb-memory/daemon.err.log</string>
+</dict>
+</plist>
+PLIST
+
+  local bootstrap_output=""
+  if ! bootstrap_output="$(launchctl bootstrap "gui/$uid" "$PLIST_PATH" 2>&1)"; then
+    case "$bootstrap_output" in
+      *"Input/output error"*)
+        echo -e "${YELLOW}⚠️  bootstrap hit an I/O error — retrying after a bootout...${NC}"
+        launchctl bootout "gui/$uid/$PLIST_LABEL" 2>/dev/null || true
+        launchctl bootstrap "gui/$uid" "$PLIST_PATH"
+        ;;
+      *"Service is disabled"*)
+        echo -e "${YELLOW}⚠️  Service is disabled — enabling and retrying...${NC}"
+        launchctl enable "gui/$uid/$PLIST_LABEL"
+        launchctl bootstrap "gui/$uid" "$PLIST_PATH"
+        ;;
+      *"Permission denied"*|*"Operation not permitted"*)
+        echo -e "${RED}❌ Permission denied writing/loading $PLIST_PATH — check MDM restrictions or admin rights.${NC}"
+        exit 1
+        ;;
+      *)
+        echo -e "${RED}❌ launchctl bootstrap failed:${NC}"
+        echo "$bootstrap_output"
+        exit 1
+        ;;
+    esac
+  fi
+  launchctl enable "gui/$uid/$PLIST_LABEL"
+
+  echo -e "${YELLOW}⏳ Waiting for the daemon to answer /health...${NC}"
+  local waited=0
+  while ! curl -fsS --max-time 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
+    waited=$((waited + 1))
+    if [ "$waited" -ge 5 ]; then
+      echo -e "${YELLOW}⚠️  No response from /health within 5s — check $HOME/Library/Logs/velesdb-memory/daemon.err.log${NC}"
+      break
+    fi
+    sleep 1
+  done
+}
+
+# ---- 6. Client wiring -------------------------------------------------
+wire_claude_code() {
+  if should_skip "claude-code"; then
+    echo -e "${YELLOW}⏭  Skipping Claude Code (--skip-client).${NC}"
+    return 0
+  fi
+  if ! command -v claude >/dev/null 2>&1; then
+    echo -e "${YELLOW}⏭  'claude' CLI not found — skipping Claude Code wiring.${NC}"
+    return 0
+  fi
+
+  claude mcp remove velesdb-memory -s user >/dev/null 2>&1 || true
+  if claude mcp add --transport http --scope user velesdb-memory "http://127.0.0.1:$PORT/mcp" >/dev/null; then
+    echo -e "${GREEN}✅ Claude Code wired (user scope) → http://127.0.0.1:$PORT/mcp${NC}"
+    echo -e "${YELLOW}   Note: project/local-scope entries (if any) are not touched — check with \`claude mcp list\`.${NC}"
+  else
+    echo -e "${RED}❌ Failed to wire Claude Code.${NC}"
+  fi
+}
+
+# wire_json_client NAME CONFIG_PATH JQ_FILTER REQUIRE_EXISTING_DIR
+# REQUIRE_EXISTING_DIR=1 skips (rather than creating) the client's config
+# directory when absent — used for Claude Desktop, whose directory only
+# exists if the app itself is installed; Windsurf's is created if missing.
+wire_json_client() {
+  local name="$1" config_path="$2" jq_filter="$3" require_existing_dir="$4"
+  if should_skip "$name"; then
+    echo -e "${YELLOW}⏭  Skipping $name (--skip-client).${NC}"
+    return 0
+  fi
+
+  local config_dir
+  config_dir="$(dirname "$config_path")"
+  if [ "$require_existing_dir" = "1" ] && [ ! -d "$config_dir" ]; then
+    echo -e "${YELLOW}⏭  $name not detected (no $config_dir) — skipping.${NC}"
+    return 0
+  fi
+  mkdir -p "$config_dir"
+
+  require_jq
+  local existed=0
+  [ -f "$config_path" ] && existed=1
+  if [ "$existed" = "0" ]; then
+    echo '{}' > "$config_path"
+  fi
+  if ! jq -e . "$config_path" >/dev/null 2>&1; then
+    echo -e "${RED}❌ $config_path is not valid JSON — fix or remove it manually, then re-run.${NC}"
+    return 0
+  fi
+  if [ "$existed" = "1" ]; then
+    cp "$config_path" "${config_path}.bak.$(date +%s)"
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  if jq "$jq_filter" "$config_path" > "$tmp"; then
+    mv "$tmp" "$config_path"
+    echo -e "${GREEN}✅ $name wired → $config_path${NC}"
+  else
+    rm -f "$tmp"
+    echo -e "${RED}❌ failed to update $config_path${NC}"
+  fi
+}
+
+wire_claude_desktop() {
+  wire_json_client "claude-desktop" "$DESKTOP_CONFIG" \
+    '.mcpServers["velesdb-memory"] = {"type":"http","url":"http://127.0.0.1:'"$PORT"'/mcp"}' \
+    1
+  if ! should_skip "claude-desktop"; then
+    echo -e "${YELLOW}⚠️  HTTP support is not confirmed for Claude Desktop. If it fails to connect after a restart, use this stdio fallback instead:${NC}"
+    cat <<EOF
+{ "mcpServers": { "velesdb-memory": {
+  "command": "$BIN_PATH",
+  "env": { "VELESDB_MEMORY_PATH": "<a-DIFFERENT-directory-than-$STORE>" }
+} } }
+EOF
+    echo -e "${YELLOW}   Use a DIFFERENT VELESDB_MEMORY_PATH than the daemon's store — pointed at the same one, the${NC}"
+    echo -e "${YELLOW}   fallback process and the daemon would fight over the same flock (DatabaseLocked).${NC}"
+  fi
+}
+
+wire_windsurf() {
+  wire_json_client "windsurf" "$WINDSURF_CONFIG" \
+    '.mcpServers["velesdb-memory"] = {"serverUrl":"http://127.0.0.1:'"$PORT"'/mcp"}' \
+    0
+}
+
+# ---- 7. Uninstall -----------------------------------------------------
+do_uninstall() {
+  echo -e "${YELLOW}🗑  Uninstalling the velesdb-memory daemon and client wiring...${NC}"
+  local uid
+  uid="$(id -u)"
+  launchctl bootout "gui/$uid/$PLIST_LABEL" >/dev/null 2>&1 || true
+  rm -f "$PLIST_PATH"
+
+  if command -v claude >/dev/null 2>&1; then
+    claude mcp remove velesdb-memory -s user >/dev/null 2>&1 || true
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    for cfg in "$DESKTOP_CONFIG" "$WINDSURF_CONFIG"; do
+      if [ -f "$cfg" ] && jq -e . "$cfg" >/dev/null 2>&1; then
+        local tmp
+        tmp="$(mktemp)"
+        jq 'del(.mcpServers["velesdb-memory"])' "$cfg" > "$tmp" && mv "$tmp" "$cfg"
+      fi
+    done
+  fi
+
+  echo -e "${GREEN}✅ Uninstalled. The store ($STORE by default) was left untouched.${NC}"
+}
+
+# ---- 8. Summary -------------------------------------------------------
+print_summary() {
+  echo ""
+  echo -e "${BLUE}═══════════════════════════════════════════${NC}"
+  echo -e "${BLUE}  velesdb-memory daemon — summary${NC}"
+  echo -e "${BLUE}═══════════════════════════════════════════${NC}"
+  echo "  Embedder:  $EMBEDDER"
+  echo "  Port:      $PORT"
+  echo "  Store:     $STORE"
+  if [ "$DAEMON_SUPPORTED" = "1" ]; then
+    if curl -fsS --max-time 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      if [ "$DAEMON_ALREADY_RUNNING" = "1" ]; then
+        echo -e "  Daemon:    ${GREEN}running${NC} → http://127.0.0.1:$PORT/mcp (already loaded, not restarted)"
+      else
+        echo -e "  Daemon:    ${GREEN}running${NC} → http://127.0.0.1:$PORT/mcp"
+      fi
+    else
+      echo -e "  Daemon:    ${YELLOW}not confirmed up${NC} — check $HOME/Library/Logs/velesdb-memory/daemon.err.log"
+    fi
+  else
+    echo -e "  Daemon:    ${YELLOW}not started (non-macOS)${NC}"
+  fi
+  for client in claude-code claude-desktop windsurf; do
+    if should_skip "$client"; then
+      echo "  $client: skipped (--skip-client)"
+    else
+      echo "  $client: wired (see log above for details/warnings)"
+    fi
+  done
+  echo ""
+}
+
+# ---- Main -------------------------------------------------------------
+main() {
+  if [ "$UNINSTALL" = "1" ]; then
+    do_uninstall
+    exit 0
+  fi
+
+  preflight
+  resolve_embedder
+  setup_ollama
+  build_daemon
+  setup_daemon
+  wire_claude_code
+  wire_claude_desktop
+  wire_windsurf
+  print_summary
+}
+
+main

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -164,7 +164,11 @@ setup_ollama() {
     echo -e "${RED}❌ 'ollama' not found.${NC}"
     case "$(uname -s)" in
       Darwin) echo "   Install it with: brew install ollama" ;;
-      Linux) echo "   Install it with: curl -fsSL https://ollama.com/install.sh | sh" ;;
+      # Deliberately not an inline `curl | sh` one-liner: install-time
+      # guidance text shouldn't itself model piping a remote script
+      # straight into a shell. Point at Ollama's own install page instead,
+      # same as the generic fallback below.
+      Linux) echo "   See https://ollama.com/download for Linux install instructions" ;;
       *) echo "   See https://ollama.com/download" ;;
     esac
     exit 1


### PR DESCRIPTION
## Summary
- **Part 1 — HTTP transport**: adds a non-default `http` feature to `velesdb-memory`. `--http`/`--http-port` (or `VELESDB_MEMORY_HTTP`/`VELESDB_MEMORY_HTTP_BIND`) serve the MCP server over rmcp's streamable-HTTP transport instead of stdio, so several MCP clients (Claude Code, Claude Desktop, Windsurf, …) can share ONE daemon process instead of each spawning its own stdio process and fighting over the store's single-writer `flock`. The hash/ollama embedder choice stays a pure `VELESDB_MEMORY_EMBEDDER` runtime switch either way — never a build-time one. New `/health` liveness endpoint. Default binary is unchanged: stdio-only, tiny, offline.
- **Part 2 — installer**: `scripts/install-memory-daemon.sh` builds the daemon (`--features ollama,http`, always both regardless of the runtime embedder choice), runs it as a macOS `launchd` agent, and wires Claude Code / Claude Desktop / Windsurf to it. `--uninstall` reverses everything without ever touching the store. Non-macOS: builds + wires clients, skips the daemon step with a clear note.

## TDD (RED → GREEN)
Commit `8fc9ff11` is the RED commit: `tests/http_transport.rs` was written against a `velesdb_memory::http::router` that didn't exist yet, gated via a new `[[test]] required-features = ["http"]` Cargo.toml entry (so it doesn't break default builds). Captured red:

```
$ cargo test -p velesdb-memory --features http --no-run
error: the package 'velesdb-memory' does not contain this feature: http
help: there is a similarly named feature: mcp
```

Commit `97560778` is GREEN: adds the `http` feature, `src/http.rs` (the router), and wires `main.rs`. All 4 `http_transport` tests + the adversarial `http_lock_contention` test pass.

## Gates
| Gate | Result |
|---|---|
| `cargo fmt --all --check` | PASS |
| `cargo clippy -p velesdb-memory --all-targets --features http,ollama -- -D warnings` | PASS. (Was blocked on a pre-existing, unrelated `clippy::similar_names` failure in `examples/locomo/dump.rs:229`, introduced in `efd3aea6` #1301 long before this branch — fixed upstream on `develop` by #1525 and picked up by this branch's rebase onto it.) |
| `cargo test -p velesdb-memory --features http` | PASS — 347 (default-feature unit tests, unaffected) + all http-gated suites, including the new ones |
| `cargo test -p velesdb-memory` (default features, no `http`) | PASS — confirms zero regression for the default stdio-only build |
| `cargo check --workspace` | PASS |
| `shellcheck scripts/install-memory-daemon.sh` | PASS (clean, after fixing one SC2034 unused-var warning) |

## Deviations from the plan (with justification)
1. Concurrency tests use one HTTP connection per task, not one shared session. The plan didn't mandate either; sharing ONE `RunningService`/session across 20 concurrent `call_tool` invocations reproducibly hung (confirmed via `sample` stack traces: both concurrency tests stuck in `mio::…::select`, zero CPU). Per-task-own-connection is both more representative of the real scenario this feature targets (independent MCP client processes, each with their own session) and avoids relying on undocumented concurrent-call-multiplexing semantics of rmcp's client-side streamable-HTTP transport that aren't exercised anywhere in rmcp's own upstream test suite either.
2. `#[tokio::test(flavor = "multi_thread", worker_threads = 8)]` on all 4 `http_transport` tests, matching the real production runtime (`tokio::runtime::Runtime::new()` in `main.rs` is multi-thread by default) more faithfully than the macro's single-thread default. **Correction (2026-07-22): the single-thread test runtime was NOT the root cause of the earlier hang**, despite what an earlier revision of this description claimed. The hang was a real, mechanically-confirmed deadlock in `velesdb-core`'s `Collection` locking (flat CPU time over 25s, not starvation; zero rmcp/axum/tower frames in the stuck call chain) — two independent root causes: rayon pool exhaustion in `crates/velesdb-core/src/collection/core/crud.rs`, and an ABBA lock-order inversion across `get_raw` and 7 other `Collection` read-path sites. Both fixed on `develop` via #1527. Full investigation trail (repro, stack samples) archived at `.investigation/http-deadlock-2026-07-22/`. This PR's own concurrency tests (`twenty_concurrent_remembers_all_succeed_with_unique_ids`, `concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable`) hung before the core fix landed; re-run 20x each with a hard per-run timeout after rebasing onto `develop` (which now includes #1527): 40/40 passed, zero hangs, zero orphan processes left behind.
3. ~~Pre-existing clippy failure in `examples/locomo/dump.rs` left as-is~~ — resolved upstream (#1525, see Gates table); no longer a deviation.
4. **Added during the 2026-07-22 OOM audit** (not in the original plan, follow-up from the deadlock investigation): `router()` now bounds the two things rmcp's own defaults leave unbounded on `/mcp` — request body size (`tower_http::limit::RequestBodyLimit`, since rmcp's `StreamableHttpService` reads the body directly via `Body::collect`, bypassing axum's extractor-based `DefaultBodyLimit` entirely) and concurrent session count (`BoundedSessionManager`, wrapping `LocalSessionManager`, whose session map otherwise grows without bound). Both configurable (`VELESDB_MEMORY_HTTP_MAX_BODY_BYTES`, `VELESDB_MEMORY_HTTP_MAX_SESSIONS`), both covered by new adversarial tests. Per-fact size was already bounded independent of transport (`crate::limits::MAX_FACT_BYTES`, enforced in the tool handlers) — not touched. Full audit notes, including what was checked and deliberately left alone (session-manager's own zombie-session gap, upstream in `rmcp`; the installer's launchd plist has no memory ulimit, consistent with every other daemon in this repo — none has one either), are in the PR review thread.

## Blockers
None. No permission was refused for any step — `launchctl`, `~/Library/LaunchAgents`, and `cargo install` were never invoked for real (the installer's daemon step and full end-to-end client wiring need a real macOS run outside this sandboxed environment to verify beyond static/syntax checks). What WAS verified in-sandbox: `bash -n`, `shellcheck`, `--help`, a real `--uninstall` dry run (confirmed no-op via `claude mcp list` — no prior `velesdb-memory` user-scope entry existed), and the `jq` filters exercised standalone against mock Desktop/Windsurf config files (add + del round-trip, existing keys preserved).

## Test plan
- [x] `cargo test -p velesdb-memory --features http` — all pass
- [x] `cargo test -p velesdb-memory` (default features) — all pass, no regression
- [x] `cargo fmt --all --check`
- [x] `shellcheck scripts/install-memory-daemon.sh`
- [ ] Manual: run `./scripts/install-memory-daemon.sh` on a real macOS machine and confirm the launchd agent + all three client wirings end to end (not exercised in this sandbox)


