### PR TITLE
fix(velesdb-memory): rename similarly-named locals in ymd_to_ordinal

### DIFF
--- a/crates/velesdb-memory/examples/locomo/dump.rs
+++ b/crates/velesdb-memory/examples/locomo/dump.rs
@@ -225,9 +225,9 @@ fn ymd_to_ordinal(ts: i64) -> Option<i64> {
     let y = if month <= 2 { year - 1 } else { year };
     let era = if y >= 0 { y } else { y - 399 } / 400;
     let yoe = y - era * 400;
-    let mp = (month + 9) % 12;
-    let doy = (153 * mp + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let month_shifted = (month + 9) % 12;
+    let day_of_year = (153 * month_shifted + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + day_of_year;
     Some(era * 146_097 + doe - 719_468)
 }
 


### PR DESCRIPTION
## Description

`cargo clippy -p velesdb-memory --all-targets --features ollama -- -D warnings` fails on `crates/velesdb-memory/examples/locomo/dump.rs` with the pedantic `clippy::similar_names` lint (enabled workspace-wide via `[workspace.lints.clippy] pedantic = "warn"` in the root `Cargo.toml`):

```
error: binding's name is too similar to existing binding
  --> crates/velesdb-memory/examples/locomo/dump.rs:229:9
   |
229 |     let doy = (153 * mp + 2) / 5 + day - 1;
```

This is in `ymd_to_ordinal` (Howard Hinnant's `days_from_civil` algorithm), introduced in #1301, unrelated to any other current work.

Fix: renamed `mp` → `month_shifted` and `doy` → `day_of_year` so the names no longer collide under clippy's similarity check. The algorithm itself is untouched.

Fixes # (no tracked issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- `cargo clippy -p velesdb-memory --all-targets --features ollama -- -D warnings` — passes cleanly
- `cargo build --example locomo --features ollama -p velesdb-memory` — compiles
- `cargo test -p velesdb-memory --features ollama --example locomo -- dump` — all 6 `dump::tests` pass (`ymd_to_ordinal_spans_known_dates`, `ymd_to_ordinal_rejects_bad_month_or_day`, etc.), confirming no behavior change

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: per `rust-toolchain.toml`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Purely a local-variable rename to satisfy a pedantic lint; no functional change.
