### PR TITLE
fix(deps): bump plist to 1.10.0, resolving quick-xml DoS advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,9 +3828,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -4174,9 +4174,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/demos/tauri-rag-app/src-tauri/Cargo.lock
+++ b/demos/tauri-rag-app/src-tauri/Cargo.lock
@@ -3378,9 +3378,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -3603,9 +3603,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -5,10 +5,11 @@ db-path = "~/.cargo/advisory-db"
 # (a) confirm the upstream constraint still holds (transitive still
 # present, no fix released), and bump the "Last reviewed" date in the
 # block-level comment below, or (b) remove the ignore if the transitive
-# is gone or the advisory has been patched. The current pass landed on
-# 2026-05-15 (see PR #811).
+# is gone or the advisory has been patched. The 2026-05-15 pass landed in
+# PR #811; the 2026-07-22 pass removed the quick-xml/plist entries below
+# (upstream fix released) and touched nothing else.
 #
-# Last reviewed: 2026-05-15
+# Last reviewed: 2026-07-22
 ignore = [
     # ── Tauri Linux GTK3 transitives ──────────────────────────────────
     # These travel with the GTK3 desktop backend that Tauri 2.x still
@@ -45,18 +46,10 @@ ignore = [
     { id = "RUSTSEC-2025-0098", reason = "unic-ucd-version: tauri transitive, unmaintained" },
     { id = "RUSTSEC-2025-0100", reason = "unic-ucd-ident: tauri transitive, unmaintained" },
 
-    # ── quick-xml / plist transitive (tauri Info.plist tooling) ────────
-    # quick-xml 0.38.4 comes in via plist 1.8.0 (tauri's Info.plist reader/
-    # writer, tauri-codegen/tauri-utils/tauri-build all depend on it too).
-    # Both advisories are XML-parsing DoS only (quadratic attribute scan /
-    # unbounded namespace allocation) — not memory-unsafety, and only
-    # reachable if this stack parses untrusted XML, which it doesn't (local
-    # Info.plist files only). No fix yet: plist's latest release (1.9.0,
-    # 2026-04-26) still requires quick-xml ^0.39.2; the advisories need
-    # >=0.41.0. Revisit when plist ships a release depending on quick-xml
-    # >=0.41 (tracked upstream: https://github.com/ebarnard/rust-plist).
-    { id = "RUSTSEC-2026-0194", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
-    { id = "RUSTSEC-2026-0195", reason = "quick-xml: tauri/plist transitive, DoS-only, no fix yet (plist 1.9.0 caps at quick-xml 0.39)" },
+    # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (quick-xml DoS via plist, tauri
+    # Info.plist tooling) resolved 2026-07-22: plist 1.10.0 now requires
+    # quick-xml >=0.41.0. `cargo update -p plist` in both lockfiles (root +
+    # demos/tauri-rag-app/src-tauri) picked up the fix; no ignore needed.
 
     # ── velesdb-cli transitive ────────────────────────────────────────
     { id = "RUSTSEC-2024-0384", reason = "instant: velesdb-cli transitive (clap/indicatif chain), unmaintained" },


### PR DESCRIPTION
## Description

Resolves the 2 Dependabot alerts on the default branch (1 high, 1 low — `cargo audit` reports both as 7.5/high): `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195`, both in `quick-xml` 0.38.4:
- Quadratic run time when checking a start tag for duplicate attribute names
- Unbounded namespace-declaration allocation enabling memory-exhaustion DoS

`quick-xml` 0.38.4 was pulled in transitively via `plist` 1.8.0 (tauri's Info.plist reader/writer — `tauri-utils`/`tauri-codegen`/`tauri-build` all depend on it). Both advisories were tracked as accepted-risk `deny.toml` ignores since 2026-05-15, with no upstream fix available at the time.

**Fix:** `plist` 1.10.0 (released after the last review pass) now requires `quick-xml >=0.41.0`, resolving both advisories outright — no more need to carry the ignore.

## Changes

- `Cargo.lock` (root workspace): `cargo update -p plist` → `plist 1.8.0 → 1.10.0`, `quick-xml 0.38.4 → 0.41.0`.
- `demos/tauri-rag-app/src-tauri/Cargo.lock`: same bump. This demo is `cargo-deny`-excluded from the root workspace and carries its own lockfile (per the existing `deny.toml` comments), so it needed the same update separately to actually pick up the fix.
- `deny.toml`: removed the now-unreachable `RUSTSEC-2026-0194`/`RUSTSEC-2026-0195` ignore entries and bumped the "Last reviewed" date/note.

No source code changes — dependency version bump only.

## Type of Change

- [x] 🔒 Security fix (dependency vulnerability)

## How Has This Been Tested?

- `cargo update -p plist` in both lockfiles — resolves cleanly, MSRV (1.90, workspace-pinned) comfortably covers `plist` 1.10.0's own MSRV (1.88.0).
- `cargo tree -p tauri-plugin-velesdb -i quick-xml` and `cargo tree -i quick-xml` (from the demo dir) — confirm `quick-xml 0.41.0` is the sole resolved version in both dependency graphs, with the full `plist → tauri-utils/tauri-codegen/tauri-build → tauri` chain shown.
- `cargo deny check advisories` (root workspace) — `advisories ok`, no unmatched-ignore warnings after removing the two entries.
- Full native build of `tauri-plugin-velesdb` (GTK3/webkit2gtk system libs) could not be exercised in this sandbox (package fetch from the Ubuntu mirror failed for unrelated reasons); CI's `Security Audit` / `Lint & Format` jobs install those system libs and will give the real build signal. This is a lockfile-only change with no source edits, so the compile risk is low.

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: per `rust-toolchain.toml` (1.90)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes — not independently re-run beyond `cargo deny`/`cargo tree` above (no Rust source changed)

## Additional Notes

Prompted by the two Dependabot alerts GitHub reports on every push to this repo (`1 high, 1 low`) — traced to these exact two RustSec IDs via local `cargo audit` against `develop`'s `Cargo.lock`.
