### PR TITLE
feat(memory): auto-stamp remember with a reserved _veles_date field

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Targets **0.11.0** (minor, not patch) on next release: the metadata shape
+`remember`/`recall` return changes observably for every consumer (MCP,
+Python, Node, WASM) — see "Changed" below.
+
 ### Added
 
 - **HTTPS by default for the HTTP transport.** `--http`/`VELESDB_MEMORY_HTTP=1`
@@ -27,6 +31,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the macOS login keychain (`security add-trusted-cert`, no `sudo`) and
   gained `--tls-dir` and `--skip-ca-trust` flags. See the README's "HTTP
   transport (multi-client)" section.
+- **Automatic `_veles_date` stamp.** `remember`/`remember_with_ttl` (and
+  `remember_extracted`, which delegates to `remember` per extracted fact)
+  now auto-stamp every fact's metadata with `_veles_date` — today's date as
+  a `YYYYMMDD` integer, read from the system clock at write time — unless
+  the caller already set that key explicitly (an explicit value, e.g. for
+  retroactive dating, is never overwritten). `recall_fused`'s `date_field`
+  can now be pointed at `_veles_date` to get a correct `dated_context`
+  timeline with zero caller setup — previously every temporal capability
+  depended entirely on the caller managing a numeric date field itself,
+  documented but never guaranteed. The new `AUTO_DATE_FIELD` constant is
+  exported at the crate root as the single source of truth for the key
+  name. The context compiler (`compile_context` and friends) reads no
+  clock and is unaffected — the auto-stamp lives exclusively on the
+  `remember` write path.
+
+### Changed
+
+- **Breaking (observable shape, not a compile break): `metadata` is no
+  longer `None`/`null` for a fact stored with no caller metadata.** Because
+  of the `_veles_date` auto-stamp above, `recall`/`recall_where`/
+  `recall_fused` now return `metadata: {"_veles_date": <today>}` instead of
+  `metadata: None`/`null` for such a fact, on every binding (MCP JSON-RPC,
+  Python, Node, WASM). Callers that previously branched on "metadata is
+  `None`" to mean "nothing was ever stored" should check for the
+  caller-specific key(s) they care about instead.
 
 ## [0.10.1] — 2026-07-21
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -55,10 +55,10 @@ three engines behind its memory tools:
 
 | Tool       | What it does                                               | Engines |
 |------------|------------------------------------------------------------|---------|
-| `remember` | store a fact, optionally linked + tagged with metadata, with an optional expiry (`ttl_seconds`) | Vector + Graph + ColumnStore |
+| `remember` | store a fact, optionally linked + tagged with metadata, with an optional expiry (`ttl_seconds`); every fact is auto-stamped with today's date (`_veles_date`, a `YYYYMMDD` integer) unless you set it yourself, so temporal recall (`recall_fused`'s `date_field`) works with zero setup — see [Automatic dating](#automatic-dating-_veles_date) | Vector + Graph + ColumnStore |
 | `recall`   | semantic retrieval, optional exact-match metadata filter   | Vector + ColumnStore |
 | `relate`   | create a typed edge between two memories                   | Graph |
-| `recall_fused` | recall with graph-aware re-ranking (vector + typed links fused) | Vector + Graph |
+| `recall_fused` | recall with graph-aware re-ranking (vector + typed links fused); `date_field` (e.g. the automatic `_veles_date`) also returns a chronological `dated_context` timeline + `now` anchor | Vector + Graph |
 | `recall_where` | recall filtered by typed column predicates (ranges, comparisons) | Vector + ColumnStore |
 | `forget`   | delete a memory                                            | — |
 | `why`      | recall a decision **+ its connected subgraph** (multi-hop) | Vector + Graph + ColumnStore |
@@ -72,6 +72,44 @@ your question — exactly what a pure vector search is blind to.
 By design the server exposes **memory semantics only** — never raw database
 capabilities (`query`, `create_collection`, `upsert`, `traverse`). See
 [License](#license).
+
+### Automatic dating (`_veles_date`)
+
+Every `remember`/`remember_extracted` call auto-stamps the fact's metadata with
+`_veles_date` — today's date, read from the system clock, as a `YYYYMMDD`
+integer — **unless the caller already set that key**, in which case it is
+never overwritten. This used to be entirely the caller's job (write a numeric
+date field yourself, e.g. `ts`/`occurred_at`, remember to keep it numeric);
+now it's guaranteed by the server, with zero setup:
+
+```jsonc
+// no metadata at all — still gets a date
+remember({ fact: "we chose parking_lot to avoid lock poisoning" })
+// stored metadata: { "_veles_date": 20260723 }   (today, auto-stamped)
+
+// recall_fused's date_field needs no caller-managed date field anymore
+recall_fused({ query: "why parking_lot", date_field: "_veles_date" })
+// → dated_context: "- [2026-07-23] we chose parking_lot ..."
+//   now: "2026-07-23"
+```
+
+To date a fact **retroactively** (e.g. an incident that happened last month,
+not today), set `_veles_date` explicitly in `metadata` — an explicit value is
+always respected, never replaced:
+
+```jsonc
+remember({
+  fact: "payment provider timeout set to 8s",
+  metadata: { "_veles_date": 20260610 }   // when it actually happened
+})
+```
+
+`_veles_date` behaves like ordinary metadata for every other purpose too — it
+round-trips in `recall`/`recall_where`/`recall_fused` results and can be used
+as a `recall_where` range filter (`{ field: "_veles_date", op: "ge", value:
+20260101 }`) — it is the one metadata key namespaced under the internal
+`_veles_` prefix that a caller MAY still set and see; every other `_veles_*`
+key stays fully reserved (rejected on write, stripped from every read).
 
 ## See it (offline, one command)
 
@@ -1225,9 +1263,11 @@ score = fused_norm + confidence·(rl_confidence − 0.5)·2 + recency·recency_n
   by an adversarial test).
 - **Recency contract (strict).** `recency_field: null` disables the term —
   no implicit default key exists. When set, it must name a **numeric**
-  caller metadata field on one monotone scale per batch (e.g. `YYYYMMDD`
-  integers as in dated recall, or an epoch); the scale is documented, not
-  verified. Values are min-max normalised **within the pulled batch**: the
+  caller metadata field on one monotone scale per batch (e.g. the automatic
+  `_veles_date` `YYYYMMDD` field every `remember`-d fact already carries, per
+  [Automatic dating](#automatic-dating-_veles_date), another `YYYYMMDD`
+  field, or an epoch); the scale is documented, not verified. Values are
+  min-max normalised **within the pulled batch**: the
   newest reads `1.0`, the oldest `0.0`, a memory without the key contributes
   `0` (never penalised), and a degenerate batch (`max == min`) contributes
   `0` for all. The compile pipeline never reads a clock — recency is

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -48,13 +48,20 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    decision is made or a durable fact is established, store it. Two things make it
    valuable later, so never skip them:
    - **metadata** (the `ColumnStore` facet): `{ "type": "decision"|"fact"|"incident",
-     "area": "payments", "project": "acme", "date": 20260711, "status": "active" }`
-     — this is what lets you filter/scope recall later. **Store dates and other
-     comparable values NUMERICALLY** (`20260711`, not `"2026-07-11"`):
-     `recall_where`'s range/comparison filters (`lt`/`le`/`gt`/`ge`) are
-     type-strict with no coercion (issue #1473) — a numeric filter value never
-     matches a string-stored one, silently returning nothing, no error. Plain
-     equality filters on `recall`/`recall_fused` are unaffected either way.
+     "area": "payments", "project": "acme", "status": "active" }` — this is what
+     lets you filter/scope recall later. **You do not need to manage a date field
+     yourself.** Every `remember`/`remember_extracted` call auto-stamps
+     `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
+     it, so `recall_fused(date_field="_veles_date")` gives you a chronological
+     `dated_context` timeline (plus a `now` anchor) with zero setup on your part.
+     Set `_veles_date` explicitly only to override the default — e.g. to date a
+     fact by when an incident actually happened, not when you recorded it; once
+     set, the server never overwrites it. Store any OTHER comparable value
+     NUMERICALLY too (`20260711`, not `"2026-07-11"`): `recall_where`'s
+     range/comparison filters (`lt`/`le`/`gt`/`ge`) are type-strict with no
+     coercion (issue #1473) — a numeric filter value never matches a
+     string-stored one, silently returning nothing, no error. Plain equality
+     filters on `recall`/`recall_fused` are unaffected either way.
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.

--- a/crates/velesdb-memory/src/clock.rs
+++ b/crates/velesdb-memory/src/clock.rs
@@ -1,0 +1,68 @@
+//! Wall-clock "today" as a `YYYYMMDD` integer — the single place
+//! [`crate::service::MemoryService::remember_with_ttl`] reads the system
+//! clock to auto-stamp a fact's [`crate::storage::AUTO_DATE_FIELD`] metadata.
+//!
+//! Deliberately isolated here and never used by the context compiler pipeline
+//! (`context.rs`'s `ContextCompiler::compile`), which stays clock-free and
+//! deterministic by design — the same split `context/memory_bridge.rs` already
+//! draws for its own `now_nanos`/`now_unix_secs` (event recording stamps
+//! wall-clock time; the compile pipeline itself never does). `remember` is a
+//! **write** path, already non-deterministic in call time (unlike its
+//! content-addressed id), so reading the clock here adds no new
+//! nondeterminism to anything that must replay identically.
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Today's date (UTC) as a `YYYYMMDD` integer, or `None` when no fact should
+/// be auto-stamped: `wasm32-unknown-unknown` has no `std` clock
+/// (`SystemTime::now()` aborts there — mirrors the guard in
+/// `context/memory_bridge.rs`), and a clock reporting a time before the Unix
+/// epoch is treated the same way, so a fact is never stamped with a
+/// nonsensical date.
+#[must_use]
+pub(crate) fn today_ymd() -> Option<i64> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        None
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let epoch_days = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs() / 86_400;
+        // Days since the epoch is many orders of magnitude below i64::MAX
+        // (u64::MAX / 86_400 alone would take ~2.9e11 years to overflow i64).
+        #[allow(clippy::cast_possible_wrap)]
+        let (year, month, day) = civil_from_days(epoch_days as i64);
+        Some(year * 10_000 + month * 100 + day)
+    }
+}
+
+/// Days-since-Unix-epoch → `(year, month, day)`, proleptic Gregorian
+/// calendar. Howard Hinnant's public-domain `civil_from_days` algorithm
+/// (<http://howardhinnant.github.io/date_algorithms.html#civil_from_days>),
+/// ported here rather than pulled in as a dependency — this crate has no
+/// date/time library; `dated_context.rs` already hand-rolls the inverse
+/// direction (`year/month/day` → validated `YYYYMMDD`) the same way.
+#[cfg(not(target_arch = "wasm32"))]
+fn civil_from_days(days_since_epoch: i64) -> (i64, i64, i64) {
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = z - era * 146_097; // [0, 146096]
+    let year_of_era =
+        (day_of_era - day_of_era / 1460 + day_of_era / 36_524 - day_of_era / 146_096) / 365; // [0, 399]
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100); // [0, 365]
+    let month_prime = (5 * day_of_year + 2) / 153; // [0, 11]
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1; // [1, 31]
+    let month = if month_prime < 10 {
+        month_prime + 3
+    } else {
+        month_prime - 9
+    }; // [1, 12]
+    let year = if month <= 2 { year + 1 } else { year };
+    (year, month, day)
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[path = "clock_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/clock_tests.rs
+++ b/crates/velesdb-memory/src/clock_tests.rs
@@ -1,0 +1,37 @@
+//! Unit tests for [`super::civil_from_days`] / [`super::today_ymd`] — pinned
+//! against known epoch-day references so the hand-rolled calendar conversion
+//! (no `chrono` dependency in this crate) is verified independently of
+//! whatever day the test happens to run on.
+
+use super::{civil_from_days, today_ymd};
+
+#[test]
+fn epoch_day_zero_is_1970_01_01() {
+    assert_eq!(civil_from_days(0), (1970, 1, 1));
+}
+
+#[test]
+fn day_18262_is_2020_01_01() {
+    // 1577836800 (2020-01-01T00:00:00Z) / 86400 = 18262.
+    assert_eq!(civil_from_days(18_262), (2020, 1, 1));
+}
+
+#[test]
+fn day_18321_is_the_2020_leap_day() {
+    // 18262 (2020-01-01) + 31 (January) + 28 = 18321 (2020-02-29).
+    assert_eq!(civil_from_days(18_321), (2020, 2, 29));
+}
+
+#[test]
+fn day_before_the_leap_day_is_still_february() {
+    assert_eq!(civil_from_days(18_320), (2020, 2, 28));
+}
+
+#[test]
+fn today_ymd_is_a_plausible_date() {
+    let ymd = today_ymd().expect("native target has a clock");
+    assert!(
+        (20_240_101..21_000_101).contains(&ymd),
+        "today_ymd() returned an implausible date: {ymd}"
+    );
+}

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -48,6 +48,9 @@ pub enum MemoryError {
 
     /// Caller metadata or a recall filter named a reserved key (`content` or a
     /// `_veles_`-prefixed system key), which callers may not set or filter on.
+    /// [`crate::storage::AUTO_DATE_FIELD`] is the one documented exception:
+    /// a caller MAY set it (e.g. to date a fact retroactively), so it never
+    /// raises this error.
     #[error("metadata key '{0}' is reserved")]
     ReservedKey(String),
 

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -97,6 +97,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// "recall then format" pairing lives in exactly one place and can't drift
     /// between surfaces.
     ///
+    /// `date_field` can name any caller metadata key, but passing
+    /// [`crate::storage::AUTO_DATE_FIELD`] needs zero setup: `remember`
+    /// auto-stamps that key on every fact already, so a caller gets a correct
+    /// `dated_context` without ever having managed a date field itself.
+    ///
     /// # Errors
     /// Returns [`MemoryError`] if the underlying [`Self::recall_fused`] fails.
     pub fn recall_fused_dated(

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -25,6 +25,11 @@
 //! Set" of the Software's features and breach the `VelesDB` Core License 1.0
 //! (§1, No Hosted or Managed Service). See `VISION.md` §5 and `PLAN.md` Phase 4A.
 
+/// Wall-clock "today" as a `YYYYMMDD` integer, read only by `remember`'s
+/// auto-date stamping (see [`storage::AUTO_DATE_FIELD`]) — never by the
+/// context compiler, which stays clock-free and deterministic. Internal:
+/// nothing outside the crate needs to read the clock directly.
+mod clock;
 /// The deterministic context compiler (EPIC-P-070): classify, dedup, and pack
 /// caller-supplied context fragments under a token budget — no LLM, no cloud,
 /// every decision auditable. Gated behind the default `context` feature.
@@ -120,6 +125,6 @@ pub use model::{
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};
-pub use storage::MemoryStore;
 #[cfg(feature = "persistence")]
 pub use storage::NativeStore;
+pub use storage::{MemoryStore, AUTO_DATE_FIELD};

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -67,10 +67,16 @@ pub struct Recollection {
     /// Stored fact content.
     pub content: String,
     /// Caller-supplied structured metadata stored with the fact (the `ColumnStore`
-    /// facet), with reserved system keys (`content`, `_veles_*`) excluded. `None`
-    /// when the fact carries no caller metadata. This is what makes dated recall
-    /// work: store a date (e.g. `occurred_at`) and it round-trips here, so a
-    /// `recall_where` result can be ordered into a chronological timeline.
+    /// facet), with reserved system keys (`content`, `_veles_*`) excluded —
+    /// EXCEPT [`crate::storage::AUTO_DATE_FIELD`] (`_veles_date`), the
+    /// `YYYYMMDD` date `remember` auto-stamps onto (almost) every fact, which
+    /// stays visible here on purpose so `recall_fused`'s `date_field` can read
+    /// it back with no caller effort. `None` only when the fact carries no
+    /// metadata at all AND no auto-date could be stamped (`wasm32-unknown-unknown`,
+    /// which has no clock). This is what makes dated recall work: store a date
+    /// (e.g. `occurred_at`, or just rely on the automatic `_veles_date`) and it
+    /// round-trips here, so a `recall_where`/`recall_fused` result can be
+    /// ordered into a chronological timeline.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Map<String, Value>>,
 }

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -8,9 +8,12 @@ use serde_json::{Map, Value};
 
 /// Structured metadata attached to a memory (the `ColumnStore` facet): exact-match
 /// fields like `project`, `author`, `type`, `status`, `date`. `content` and
-/// `_veles_expires_at` are reserved keys.
+/// `_veles_expires_at` are reserved keys. [`crate::storage::AUTO_DATE_FIELD`]
+/// (`_veles_date`) is auto-populated by [`MemoryService::remember_with_ttl`]
+/// with today's date unless already present — see that method's docs.
 pub type Metadata = Map<String, Value>;
 
+use crate::clock;
 use crate::embedder::Embedder;
 use crate::error::MemoryError;
 use crate::extract::Extractor;
@@ -18,7 +21,7 @@ use crate::id;
 use crate::model::{ColumnFilter, Explanation, Link, MemoryNode, Recollection};
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
-use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore};
+use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore, AUTO_DATE_FIELD};
 
 /// [`MemoryService::recall_fused`] and its helpers — split out to keep this
 /// file under the crate's 500-NLOC-per-file budget, same pattern as
@@ -113,6 +116,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// (`ColumnStore` facet) and linking it to existing memories (graph facet).
     /// Returns the stable id of the fact (idempotent on identical content).
     ///
+    /// The stored metadata is auto-stamped with today's date under
+    /// [`crate::storage::AUTO_DATE_FIELD`] unless `metadata` already carries
+    /// that key — see [`Self::remember_with_ttl`] (this method's only caller)
+    /// for the full contract.
+    ///
     /// Every link is validated — target existence AND relation label —
     /// *before* the fact is stored, so bad link input never leaves the fact
     /// half-written. If an edge write itself fails afterwards (e.g. a target
@@ -125,7 +133,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// # Errors
     /// Returns [`MemoryError::EmptyFact`] for empty/whitespace facts,
     /// [`MemoryError::ReservedKey`] if `metadata` names a reserved key
-    /// (`content` or any `_veles_`-prefixed system key),
+    /// (`content` or any `_veles_`-prefixed system key, [`crate::storage::AUTO_DATE_FIELD`]
+    /// excepted),
     /// [`MemoryError::MetadataTooLarge`] if `metadata` exceeds
     /// [`crate::limits::MAX_METADATA_BYTES`],
     /// [`MemoryError::UnknownMemory`] if a link points at a missing memory,
@@ -149,6 +158,25 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// expired facts stop being recalled. `None` (or `Some(0)`) stores the fact
     /// permanently, exactly like [`Self::remember`]. Metadata and a TTL combine:
     /// the metadata is written and the expiry preserved.
+    ///
+    /// The stored metadata is **auto-stamped with today's date** under
+    /// [`crate::storage::AUTO_DATE_FIELD`] (`_veles_date`, a `YYYYMMDD`
+    /// integer read from the system clock at write time — see
+    /// [`crate::clock::today_ymd`]) whenever `metadata` doesn't already carry
+    /// that key; an explicit value in `metadata` (e.g. to date a fact
+    /// retroactively) is never overwritten. No clock is available on
+    /// `wasm32-unknown-unknown`, so that target stamps nothing and `metadata`
+    /// passes through unchanged. This is the ONE place in the crate that
+    /// reads wall-clock time on the write path — the context compiler
+    /// (`compile_context` and friends) stays clock-free and deterministic,
+    /// unaffected by this stamp (it never re-derives a date from `now()`,
+    /// only ever reads whatever a fact already carries).
+    ///
+    /// Because [`Self::remember_extracted`] stores each extracted fact via
+    /// [`Self::remember`] (which delegates here), it gets the same auto-stamp
+    /// for free — entity hubs it also creates go through [`Self::store_fact`]
+    /// directly and are never stamped, since they are internal graph
+    /// scaffolding, not caller facts.
     ///
     /// # Errors
     /// Same as [`Self::remember`].
@@ -175,11 +203,12 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let fact_id = id::stable_id(fact);
         let embedding = self.embedder.embed(fact)?;
         let existed_before = !links.is_empty() && self.store.get(fact_id)?.is_some();
+        let stamped = stamp_with_today(metadata);
         self.store_fact(
             fact_id,
             fact,
             &embedding,
-            metadata,
+            stamped.as_ref(),
             positive_ttl(ttl_seconds),
         )?;
         // Links are fully pre-validated above, so an edge write can only
@@ -711,6 +740,24 @@ fn reject_oversized_metadata(metadata: Option<&Metadata>) -> Result<(), MemoryEr
 /// is stored permanently. Any positive value is kept as-is.
 fn positive_ttl(ttl_seconds: Option<u64>) -> Option<u64> {
     ttl_seconds.filter(|&seconds| seconds > 0)
+}
+
+/// [`MemoryService::remember_with_ttl`]'s auto-date stamp: `metadata` with
+/// today's date added under [`AUTO_DATE_FIELD`], unless `metadata` already
+/// names that key (an explicit, possibly retroactive, caller value is never
+/// overwritten) or no clock is available ([`clock::today_ymd`] returns `None`
+/// on `wasm32-unknown-unknown`). Returns an owned map either way, `None` only
+/// when there is nothing to store at all (no caller metadata AND no clock).
+fn stamp_with_today(metadata: Option<&Metadata>) -> Option<Metadata> {
+    if metadata.is_some_and(|meta| meta.contains_key(AUTO_DATE_FIELD)) {
+        return metadata.cloned();
+    }
+    let Some(today) = clock::today_ymd() else {
+        return metadata.cloned();
+    };
+    let mut stamped = metadata.cloned().unwrap_or_default();
+    stamped.insert(AUTO_DATE_FIELD.to_owned(), Value::from(today));
+    Some(stamped)
 }
 
 /// Maximum byte length for a relation label (prevents oversized graph edge labels

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -352,12 +352,33 @@ impl NativeStore {
     }
 }
 
+/// Reserved metadata key `remember`/`remember_with_ttl` auto-stamp with
+/// today's date (a `YYYYMMDD` integer, [`crate::clock::today_ymd`]) whenever
+/// the caller didn't already set it — see
+/// [`crate::service::MemoryService::remember_with_ttl`] for the full
+/// contract. A deliberate, documented **exception** to every other
+/// `_veles_`-namespaced key: [`is_reserved_key`] still names it (so it can
+/// never be confused with an arbitrary caller field), but unlike a true
+/// system key —
+/// - a caller MAY set it explicitly (to date a fact retroactively; never
+///   overwritten once present), and
+/// - it is NOT stripped from caller-facing results, so
+///   [`crate::dated_context::format_dated_context`]'s `date_field` (wired
+///   through `recall_fused`'s `date_field` parameter) can read it back with
+///   zero caller effort.
+///
+/// `pub` (re-exported at the crate root) so every caller of `date_field`
+/// names this one string in exactly one place, not a copy-pasted literal.
+pub const AUTO_DATE_FIELD: &str = "_veles_date";
+
 /// True for metadata keys the memory layer reserves: the engine's `content`
 /// payload, and any `_veles_`-namespaced system key (durable TTL, entity
-/// hubs). The single source of the reserved-key contract — the service layer
-/// (reject/strip) and every backend enforce it through this one predicate.
+/// hubs) — [`AUTO_DATE_FIELD`] EXCEPTED, since (unlike every other reserved
+/// key) it is caller-settable and caller-visible by design. The single
+/// source of the reserved-key contract — the service layer (reject/strip)
+/// and every backend enforce it through this one predicate.
 pub(crate) fn is_reserved_key(key: &str) -> bool {
-    key == "content" || key.starts_with("_veles_")
+    key != AUTO_DATE_FIELD && (key == "content" || key.starts_with("_veles_"))
 }
 
 /// Drop reserved system keys from a raw payload, and collapse an

--- a/crates/velesdb-memory/tests/auto_date_bdd.rs
+++ b/crates/velesdb-memory/tests/auto_date_bdd.rs
@@ -238,3 +238,65 @@ fn other_reserved_keys_are_still_rejected_alongside_the_auto_date_exception() {
         .expect_err("a true system key must stay rejected");
     assert!(matches!(err, velesdb_memory::MemoryError::ReservedKey(k) if k == "_veles_hub"));
 }
+
+#[test]
+fn malformed_auto_date_field_degrades_to_undated_instead_of_crashing() {
+    // `AUTO_DATE_FIELD` is a plain, unvalidated metadata value at write time
+    // (only its KEY is special-cased, never its value type/range) — a
+    // caller can set it to a string, an object, or an out-of-calendar-range
+    // integer. `dated_context::fact_date` must treat every one of these as
+    // "undated" (no timeline date, no `now` contribution), never panic.
+    let (_dir, svc) = service();
+
+    let string_valued = meta(&[(AUTO_DATE_FIELD, json!("2026-07-01"))]);
+    svc.remember(
+        "a date stored as a string, not an integer",
+        &[],
+        Some(&string_valued),
+    )
+    .expect("remember with a string-valued auto date must still be accepted");
+
+    let object_valued = meta(&[(AUTO_DATE_FIELD, json!({"year": 2026}))]);
+    svc.remember(
+        "a date stored as a nested object",
+        &[],
+        Some(&object_valued),
+    )
+    .expect("remember with an object-valued auto date must still be accepted");
+
+    // 20260231: February the 31st does not exist in any year.
+    let impossible_calendar_date = meta(&[(AUTO_DATE_FIELD, json!(20_260_231))]);
+    svc.remember(
+        "a real fact with an impossible calendar date",
+        &[],
+        Some(&impossible_calendar_date),
+    )
+    .expect("remember with an out-of-range calendar integer must still be accepted");
+
+    let (hits, ctx) = svc
+        .recall_fused_dated(
+            "date string object impossible calendar",
+            10,
+            None,
+            FusionOptions::default(),
+            AUTO_DATE_FIELD,
+        )
+        .expect("recall_fused_dated must never panic on malformed date values");
+
+    assert_eq!(hits.len(), 3, "every fact is still recalled, just undated");
+    assert_eq!(
+        ctx.now, None,
+        "no valid date exists across the batch, so `now` stays None"
+    );
+    assert!(
+        ctx.timeline
+            .contains("a real fact with an impossible calendar date"),
+        "the fact still renders in the timeline, just without a date prefix: {}",
+        ctx.timeline
+    );
+    assert!(
+        !ctx.timeline.contains('['),
+        "no `[YYYY-MM-DD]` prefix must appear when every date is malformed: {}",
+        ctx.timeline
+    );
+}

--- a/crates/velesdb-memory/tests/auto_date_bdd.rs
+++ b/crates/velesdb-memory/tests/auto_date_bdd.rs
@@ -1,0 +1,240 @@
+//! BDD integration tests for the automatic `_veles_date` stamp:
+//! `remember`/`remember_extracted` guarantee every fact carries a `YYYYMMDD`
+//! date (`velesdb_memory::AUTO_DATE_FIELD`) without the caller ever having to
+//! manage it, while still letting a caller override it explicitly (e.g. to
+//! date a fact retroactively).
+//!
+//! Before this feature, every temporal capability (`recall_where`'s date
+//! filters, `recall_fused`'s `date_field`/`dated_context`) depended entirely
+//! on the CALLER writing a numeric date field itself — documented, never
+//! guaranteed. These tests prove the guarantee end to end: an untouched
+//! `remember` call already produces a fact `recall_fused(date_field:
+//! AUTO_DATE_FIELD)` can place on a chronological timeline.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+mod common;
+
+use common::{meta, service};
+use serde_json::json;
+use velesdb_memory::{ExtractError, ExtractedFact, Extractor, FusionOptions, AUTO_DATE_FIELD};
+
+/// A loose sanity bound for "looks like today's `YYYYMMDD`": wide enough to
+/// never need updating, tight enough to catch a badly-shaped value (e.g. a
+/// raw Unix timestamp landing in this field by mistake).
+const PLAUSIBLE_YMD_RANGE: std::ops::Range<i64> = 20_240_101..21_000_101;
+
+/// A trivial extractor yielding a single fact untouched by extraction logic,
+/// just enough to exercise `remember_extracted`'s auto-stamp delegation.
+struct SingleFactExtractor;
+
+impl Extractor for SingleFactExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![ExtractedFact {
+            text: text.to_string(),
+            entities: vec!["auto-date".to_string()],
+        }])
+    }
+}
+
+// --- Nominal ---------------------------------------------------------------
+
+#[test]
+fn remember_without_metadata_auto_stamps_a_plausible_date() {
+    let (_dir, svc) = service();
+    let id = svc
+        .remember("the deploy went out this afternoon", &[], None)
+        .expect("remember");
+
+    let hits = svc
+        .recall("the deploy went out this afternoon", 5, None)
+        .expect("recall");
+    let hit = hits.iter().find(|h| h.id == id).expect("fact present");
+
+    let date = hit
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get(AUTO_DATE_FIELD))
+        .and_then(serde_json::Value::as_i64)
+        .expect("remember must auto-stamp AUTO_DATE_FIELD when metadata is absent");
+    assert!(
+        PLAUSIBLE_YMD_RANGE.contains(&date),
+        "auto-stamped date {date} is not a plausible YYYYMMDD"
+    );
+}
+
+/// The `AUTO_DATE_FIELD` value `remember` stamped onto `id` (found via a
+/// self-similar `recall` on `text`, since ids alone can't be looked up).
+fn auto_date_of(
+    svc: &velesdb_memory::MemoryService<velesdb_memory::HashEmbedder>,
+    id: u64,
+    text: &str,
+) -> i64 {
+    svc.recall(text, 5, None)
+        .expect("recall")
+        .into_iter()
+        .find(|h| h.id == id)
+        .and_then(|h| h.metadata)
+        .and_then(|m| m.get(AUTO_DATE_FIELD).and_then(serde_json::Value::as_i64))
+        .expect("fact must carry the auto date")
+}
+
+#[test]
+fn two_facts_remembered_moments_apart_get_the_same_auto_date() {
+    let (_dir, svc) = service();
+    let first = svc
+        .remember("fact one, no metadata", &[], None)
+        .expect("remember first");
+    let second = svc
+        .remember("fact two, no metadata either", &[], None)
+        .expect("remember second");
+
+    assert_eq!(
+        auto_date_of(&svc, first, "fact one, no metadata"),
+        auto_date_of(&svc, second, "fact two, no metadata either"),
+        "two facts remembered within the same test run must share the same auto date"
+    );
+}
+
+#[test]
+fn remember_with_caller_metadata_still_gets_auto_stamped() {
+    let (_dir, svc) = service();
+    let m = meta(&[("project", json!("veles"))]);
+    let id = svc
+        .remember("we shipped the release", &[], Some(&m))
+        .expect("remember with metadata");
+
+    let hits = svc
+        .recall("we shipped the release", 5, None)
+        .expect("recall");
+    let hit = hits.iter().find(|h| h.id == id).expect("fact present");
+    let metadata = hit.metadata.as_ref().expect("metadata present");
+
+    assert_eq!(
+        metadata.get("project"),
+        Some(&json!("veles")),
+        "caller metadata preserved"
+    );
+    assert!(
+        metadata.contains_key(AUTO_DATE_FIELD),
+        "auto date must be added alongside caller-supplied metadata, not instead of it"
+    );
+}
+
+#[test]
+fn remember_extracted_facts_are_also_auto_stamped() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("Alice ships the parser.", &SingleFactExtractor, None)
+        .expect("remember_extracted");
+    assert_eq!(ids.len(), 1);
+
+    let hits = svc
+        .recall("Alice ships the parser.", 5, None)
+        .expect("recall");
+    let hit = hits
+        .iter()
+        .find(|h| h.id == ids[0])
+        .expect("extracted fact present");
+
+    assert!(
+        hit.metadata
+            .as_ref()
+            .is_some_and(|m| m.contains_key(AUTO_DATE_FIELD)),
+        "remember_extracted must auto-stamp its facts exactly like remember"
+    );
+}
+
+// --- Edge (explicit override) ----------------------------------------------
+
+#[test]
+fn explicit_auto_date_field_is_never_overwritten() {
+    let (_dir, svc) = service();
+    let retroactive = meta(&[(AUTO_DATE_FIELD, json!(20_190_615))]);
+    let id = svc
+        .remember(
+            "we actually decided this back in mid-2019",
+            &[],
+            Some(&retroactive),
+        )
+        .expect("remember with explicit retroactive date must be accepted, not rejected");
+
+    let hits = svc
+        .recall("we actually decided this back in mid-2019", 5, None)
+        .expect("recall");
+    let hit = hits.iter().find(|h| h.id == id).expect("fact present");
+
+    assert_eq!(
+        hit.metadata.as_ref().and_then(|m| m.get(AUTO_DATE_FIELD)),
+        Some(&json!(20_190_615)),
+        "an explicit AUTO_DATE_FIELD value must survive untouched, never overwritten by today's date"
+    );
+}
+
+// --- recall_fused date_field end-to-end ------------------------------------
+
+#[test]
+fn recall_fused_date_field_builds_a_dated_context_from_the_auto_field() {
+    let (_dir, svc) = service();
+    // Simulate three different dates by setting AUTO_DATE_FIELD explicitly —
+    // a caller may always retroactively date a fact this way (see
+    // `explicit_auto_date_field_is_never_overwritten`); no need to mock the
+    // system clock to exercise the timeline sort/format.
+    let oldest = meta(&[(AUTO_DATE_FIELD, json!(20_230_101))]);
+    let middle = meta(&[(AUTO_DATE_FIELD, json!(20_240_601))]);
+    let newest = meta(&[(AUTO_DATE_FIELD, json!(20_250_915))]);
+
+    svc.remember("parking_lot avoids lock poisoning", &[], Some(&oldest))
+        .expect("remember oldest");
+    svc.remember("parking_lot is the mutex we chose", &[], Some(&middle))
+        .expect("remember middle");
+    svc.remember("parking_lot replaced std::sync::Mutex", &[], Some(&newest))
+        .expect("remember newest");
+
+    let (hits, ctx) = svc
+        .recall_fused_dated(
+            "parking_lot mutex lock",
+            10,
+            None,
+            FusionOptions::default(),
+            AUTO_DATE_FIELD,
+        )
+        .expect("recall_fused_dated");
+
+    assert_eq!(hits.len(), 3, "all three facts should be recalled");
+    assert_eq!(
+        ctx.now,
+        Some("2025-09-15".to_string()),
+        "`now` must be the most recent auto date across the recalled facts"
+    );
+    // Oldest-first chronological ordering in the rendered timeline.
+    let oldest_pos = ctx
+        .timeline
+        .find("2023-01-01")
+        .expect("oldest date rendered");
+    let middle_pos = ctx
+        .timeline
+        .find("2024-06-01")
+        .expect("middle date rendered");
+    let newest_pos = ctx
+        .timeline
+        .find("2025-09-15")
+        .expect("newest date rendered");
+    assert!(
+        oldest_pos < middle_pos && middle_pos < newest_pos,
+        "dated_context must render the auto-dated facts oldest-first: {}",
+        ctx.timeline
+    );
+}
+
+// --- Negative ----------------------------------------------------------------
+
+#[test]
+fn other_reserved_keys_are_still_rejected_alongside_the_auto_date_exception() {
+    let (_dir, svc) = service();
+    let bad = meta(&[("_veles_hub", json!(true))]);
+    let err = svc
+        .remember("sneaky forged hub", &[], Some(&bad))
+        .expect_err("a true system key must stay rejected");
+    assert!(matches!(err, velesdb_memory::MemoryError::ReservedKey(k) if k == "_veles_hub"));
+}

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -9,7 +9,9 @@ mod common;
 use common::{meta, service};
 use serde_json::json;
 use tempfile::TempDir;
-use velesdb_memory::{ColumnFilter, ColumnOp, HashEmbedder, MemoryError, MemoryService};
+use velesdb_memory::{
+    ColumnFilter, ColumnOp, HashEmbedder, MemoryError, MemoryService, AUTO_DATE_FIELD,
+};
 
 /// Seed one `veles`-project and one `acme`-project "auth bug" fact; returns the
 /// service plus the two ids.
@@ -347,7 +349,10 @@ fn recall_where_surfaces_the_matching_facts_metadata() {
 }
 
 #[test]
-fn recall_where_metadata_is_none_when_the_fact_has_no_metadata() {
+fn recall_where_metadata_holds_only_the_auto_date_when_the_fact_has_no_caller_metadata() {
+    // `remember` now auto-stamps every fact with `AUTO_DATE_FIELD` (see
+    // `tests/auto_date_bdd.rs`), so a caller-metadata-free fact no longer
+    // round-trips as `metadata: None` here either.
     let (_dir, svc) = service();
     let bare = svc
         .remember("a bare fact with no metadata", &[], None)
@@ -361,9 +366,11 @@ fn recall_where_metadata_is_none_when_the_fact_has_no_metadata() {
         .iter()
         .find(|h| h.id == bare)
         .expect("bare fact present");
-    assert!(
-        hit.metadata.is_none(),
-        "a fact stored without metadata must round-trip as None"
+    let metadata = hit.metadata.as_ref().expect("auto date stamped");
+    assert_eq!(
+        metadata.keys().collect::<Vec<_>>(),
+        vec![AUTO_DATE_FIELD],
+        "a fact stored without caller metadata must round-trip with only the auto date"
     );
 }
 
@@ -384,17 +391,26 @@ fn recall_where_never_leaks_reserved_keys_in_metadata() {
         .expect("recall_where unfiltered");
 
     let hit = hits.iter().find(|h| h.id == id).expect("fact present");
-    if let Some(metadata) = &hit.metadata {
-        assert!(
-            metadata.keys().all(|k| !k.starts_with("_veles_")),
-            "no `_veles_`-namespaced system key ever leaks through metadata"
-        );
-        assert_eq!(
-            metadata.get("project"),
-            Some(&json!("veles")),
-            "caller metadata still round-trips alongside the ttl"
-        );
-    }
+    let metadata = hit
+        .metadata
+        .as_ref()
+        .expect("caller metadata + auto date present");
+    assert!(
+        metadata
+            .keys()
+            .all(|k| k == AUTO_DATE_FIELD || !k.starts_with("_veles_")),
+        "no `_veles_`-namespaced system key other than the documented \
+         AUTO_DATE_FIELD exception ever leaks through metadata"
+    );
+    assert!(
+        !metadata.contains_key("_veles_expires_at"),
+        "the durable TTL's reserved key must never leak, unlike AUTO_DATE_FIELD"
+    );
+    assert_eq!(
+        metadata.get("project"),
+        Some(&json!("veles")),
+        "caller metadata still round-trips alongside the ttl"
+    );
 }
 
 #[test]

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::{meta, service};
 use serde_json::json;
-use velesdb_memory::{Link, MemoryError};
+use velesdb_memory::{Link, MemoryError, AUTO_DATE_FIELD};
 
 // --- Nominal ---------------------------------------------------------------
 
@@ -52,7 +52,11 @@ fn recall_round_trips_caller_metadata_for_dated_context() {
 }
 
 #[test]
-fn recall_metadata_is_none_when_the_fact_carries_none() {
+fn recall_metadata_holds_only_the_auto_date_when_the_fact_carries_no_caller_metadata() {
+    // Since `remember` now auto-stamps every fact with `AUTO_DATE_FIELD`
+    // (see `tests/auto_date_bdd.rs`), a fact given no caller metadata no
+    // longer round-trips as `metadata: None` — it round-trips as
+    // `Some({AUTO_DATE_FIELD: <today>})` and nothing else.
     let (_dir, svc) = service();
     svc.remember("a fact with no metadata", &[], None)
         .expect("remember");
@@ -61,7 +65,12 @@ fn recall_metadata_is_none_when_the_fact_carries_none() {
         .recall("a fact with no metadata", 5, None)
         .expect("recall");
 
-    assert_eq!(hits[0].metadata, None);
+    let metadata = hits[0].metadata.as_ref().expect("auto date stamped");
+    assert_eq!(
+        metadata.keys().collect::<Vec<_>>(),
+        vec![AUTO_DATE_FIELD],
+        "an unmetadata'd fact must carry the auto date and nothing else"
+    );
 }
 
 #[test]

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -48,13 +48,20 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    decision is made or a durable fact is established, store it. Two things make it
    valuable later, so never skip them:
    - **metadata** (the `ColumnStore` facet): `{ "type": "decision"|"fact"|"incident",
-     "area": "payments", "project": "acme", "date": 20260711, "status": "active" }`
-     — this is what lets you filter/scope recall later. **Store dates and other
-     comparable values NUMERICALLY** (`20260711`, not `"2026-07-11"`):
-     `recall_where`'s range/comparison filters (`lt`/`le`/`gt`/`ge`) are
-     type-strict with no coercion (issue #1473) — a numeric filter value never
-     matches a string-stored one, silently returning nothing, no error. Plain
-     equality filters on `recall`/`recall_fused` are unaffected either way.
+     "area": "payments", "project": "acme", "status": "active" }` — this is what
+     lets you filter/scope recall later. **You do not need to manage a date field
+     yourself.** Every `remember`/`remember_extracted` call auto-stamps
+     `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
+     it, so `recall_fused(date_field="_veles_date")` gives you a chronological
+     `dated_context` timeline (plus a `now` anchor) with zero setup on your part.
+     Set `_veles_date` explicitly only to override the default — e.g. to date a
+     fact by when an incident actually happened, not when you recorded it; once
+     set, the server never overwrites it. Store any OTHER comparable value
+     NUMERICALLY too (`20260711`, not `"2026-07-11"`): `recall_where`'s
+     range/comparison filters (`lt`/`le`/`gt`/`ge`) are type-strict with no
+     coercion (issue #1473) — a numeric filter value never matches a
+     string-stored one, silently returning nothing, no error. Plain equality
+     filters on `recall`/`recall_fused` are unaffected either way.
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -123,26 +123,40 @@ def test_recall_where_unknown_op_raises_value_error(mem):
 
 def test_recall_where_returns_stored_metadata(mem):
     # `recall_where` results carry the fact's caller-supplied metadata dict.
+    # `remember` also auto-stamps `_veles_date` (today's date, YYYYMMDD) onto
+    # every fact unless the caller already set it, so the metadata dict is
+    # no longer exactly `{"ts": ...}` — check the caller-supplied key plus
+    # the presence of the auto date, not exact dict equality.
     fid = mem.remember("we shipped the release", metadata={"ts": 20260701})
     hits = mem.recall_where("release", [("ts", "eq", 20260701)], k=5)
     hit = next(h for h in hits if h["id"] == fid)
-    assert hit["metadata"] == {"ts": 20260701}
+    assert hit["metadata"]["ts"] == 20260701
+    assert isinstance(hit["metadata"]["_veles_date"], int)
 
 
 def test_recall_also_returns_stored_metadata(mem):
     # `recall` round-trips caller metadata too (one extra by-id lookup per
     # hit), not just `recall_where` — enables dated/sorted context from any
-    # recall path.
+    # recall path. See the `_veles_date` note above.
     fid = mem.remember("paris is lovely in spring", metadata={"ts": 1})
     hits = mem.recall("paris", k=5)
     hit = next(h for h in hits if h["id"] == fid)
-    assert hit["metadata"] == {"ts": 1}
+    assert hit["metadata"]["ts"] == 1
+    assert isinstance(hit["metadata"]["_veles_date"], int)
 
 
-def test_recall_metadata_is_none_when_the_fact_carries_none(mem):
+def test_recall_metadata_holds_only_the_auto_date_when_the_fact_carries_no_caller_metadata(
+    mem,
+):
+    # `remember` now auto-stamps every fact with `_veles_date` (today's date,
+    # a YYYYMMDD integer) unless the caller already set it, so a fact given
+    # no caller metadata no longer round-trips as `metadata: None` — it
+    # round-trips as `{"_veles_date": <today>}` and nothing else.
     mem.remember("a fact with no metadata")
     hits = mem.recall("a fact with no metadata", k=5)
-    assert all(h["metadata"] is None for h in hits)
+    for h in hits:
+        assert set(h["metadata"].keys()) == {"_veles_date"}
+        assert isinstance(h["metadata"]["_veles_date"], int)
 
 
 def test_recall_fused_folds_in_a_graph_reached_fact(mem):


### PR DESCRIPTION
## Summary

- `remember`/`remember_with_ttl` (and `remember_extracted`, which delegates to `remember` per extracted fact) now auto-stamp every fact's metadata with `_veles_date` — today's date as a `YYYYMMDD` integer read from the system clock — unless the caller already set that key explicitly. An explicit value (e.g. to date a fact retroactively) is never overwritten.
- `_veles_date` is a deliberate, narrow exception to the `_veles_`-prefixed reserved-key contract (`storage::is_reserved_key`, the single source of truth): a caller MAY set it (unlike every other `_veles_*` key, which stays rejected), and it is NOT stripped from `recall`/`recall_where`/`recall_fused` results — so `recall_fused(date_field: "_veles_date")` now produces a correct `dated_context` timeline with zero caller setup.
- The clock read is isolated to a new `clock` module, called from exactly one place (`service::stamp_with_today`, itself only called from `remember_with_ttl`). The deterministic context compiler (`context.rs`'s `ContextCompiler::compile`) reads no clock and is unaffected — confirmed by grep: `today_ymd`/`clock::` appear nowhere under `src/context*`.
- `SKILL.md` and `README.md` updated: the metadata guidance no longer tells the calling agent to manage a date field itself, and a new "Automatic dating (`_veles_date`)" README section documents the behavior and the retroactive-dating override.

## Behavioral change (documented, intentional)

Since `remember` now stamps every fact, a fact given no caller metadata no longer round-trips as `metadata: None` — it round-trips as `Some({"_veles_date": <today>})`. Two pre-existing tests that asserted the old `None` invariant were updated to assert the new one (`memory_service_bdd.rs`, `columnstore_bdd.rs`).

**Cross-binding follow-up needed** (out of scope for this PR, which only touches `crates/velesdb-memory`): the Python bindings' test suite (`crates/velesdb-python/tests/test_memory_service.py`) has at least three assertions that will need the same update — `test_recall_metadata_is_none_when_the_fact_carries_none`, and two exact-dict-equality checks (`test_recall_where_returns_stored_metadata`, `test_recall_also_returns_stored_metadata`) that will now see an extra `_veles_date` key. The Node bindings' equivalent test uses property access (`.metadata?.ts`), so it is unaffected.

## Test plan

TDD: red confirmed by temporarily reverting the six implementation-touching source files (`clock.rs`, `error.rs`, `fused_recall.rs`, `lib.rs`, `model.rs`, `service.rs`, `storage.rs`) and re-running the new test file — compile failure (`AUTO_DATE_FIELD` unresolved), i.e. the guarantee did not exist. Restoring the implementation turns every new test green.

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p velesdb-memory --all-targets -- -D warnings`
- [x] `cargo test -p velesdb-memory` (352 lib tests + all integration suites, including the new `tests/auto_date_bdd.rs`: 7 tests covering auto-stamp on absence, preservation alongside caller metadata, `remember_extracted` delegation, explicit-override non-overwrite, `recall_fused`'s `date_field` end-to-end dated timeline, and the other-reserved-keys-still-rejected negative case)
- [x] Repo's own workspace-wide pre-commit hook (fmt/clippy/tests/unsafe-safety/TODO governance/secrets) passed on both commits
