### PR TITLE
feat(memory): serve the HTTP transport over HTTPS by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +462,9 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1221,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1285,20 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -3529,6 +3591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,6 +3756,16 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -4403,6 +4484,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4520,6 +4615,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4681,6 +4777,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -6795,14 +6900,23 @@ dependencies = [
  "axum",
  "criterion",
  "futures",
+ "hyper",
+ "hyper-util",
+ "rcgen",
+ "reqwest",
  "rmcp",
+ "rustls",
+ "rustls-pemfile",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",
+ "time",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
  "tower-http 0.7.0",
  "ureq",
  "velesdb-core",
@@ -8077,6 +8191,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8103,6 +8235,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **HTTPS by default for the HTTP transport.** `--http`/`VELESDB_MEMORY_HTTP=1`
+  now serves TLS by default, terminated with a self-signed local CA + a
+  short-lived `localhost`/`127.0.0.1`/`::1` leaf certificate, both generated
+  natively (`rcgen`, no shelled-out `mkcert`/`openssl`) and cached at
+  `$VELESDB_MEMORY_TLS_DIR` (default `~/.velesdb-memory-tls`, a sibling of
+  the store). The CA is generated once and never regenerated once present —
+  a client only needs to trust it once, and every future leaf cert (even
+  across restarts) is trusted automatically after that. Some MCP clients
+  (Claude Desktop's "Add custom connector" UI) refuse a non-`https://` URL
+  even for `127.0.0.1`, which this closes. `--http-insecure` /
+  `VELESDB_MEMORY_HTTP_INSECURE=1` opts back into plain HTTP (loud warning
+  at startup) for local debugging or when a trusted TLS-terminating proxy
+  already sits in front. `scripts/install-memory-daemon.sh` adds the CA to
+  the macOS login keychain (`security add-trusted-cert`, no `sudo`) and
+  gained `--tls-dir` and `--skip-ca-trust` flags. See the README's "HTTP
+  transport (multi-client)" section.
+
 ## [0.10.1] — 2026-07-21
 
 ### Fixed

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -58,6 +58,37 @@ tower-http = { workspace = true, optional = true, features = ["limit"] }
 # return — needed to forward them from `BoundedSessionManager` (src/http/
 # session_limit.rs) to the wrapped `LocalSessionManager`.
 futures = { version = "0.3", optional = true }
+# Native (no shelled-out mkcert/openssl) local CA + leaf certificate
+# generation for HTTPS-by-default (see `src/tls.rs`). `x509-parser` is needed
+# for `Issuer::from_ca_cert_pem` — reloading a CA already persisted to disk
+# without regenerating it (see the module docs for why that matters: clients
+# only need to trust the CA ONCE). Default features (`crypto`, `pem`,
+# `ring`) already cover key generation/PEM (de)serialization.
+rcgen = { version = "0.14", optional = true, features = ["x509-parser"] }
+# `CertificateParams::not_before`/`not_after` are `time::OffsetDateTime` —
+# rcgen's own public field type, not re-exported, so constructing "now" and
+# "now + N days" needs `time` directly. Version pinned to match rcgen's own
+# `^0.3.6` requirement.
+time = { version = "0.3", optional = true }
+# TLS termination for the HTTP transport — same stack `velesdb-server`
+# already uses (`src/tls.rs` there), reused here rather than adding
+# `axum-server` as a second, independent TLS dependency (see `src/tls.rs`'s
+# module docs for the full rationale). `ring` matches `velesdb-server`'s
+# choice, kept explicit (rather than relying on a process-wide default
+# `CryptoProvider`) since the `reqwest` dev-dependency below links a
+# different backend (`aws-lc-rs`) into the very same test binaries.
+rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "logging", "std", "tls12"] }
+tokio-rustls = { version = "0.26", optional = true }
+rustls-pemfile = { version = "2", optional = true }
+# Manual TLS accept loop: `axum::serve` has no listener abstraction for a
+# pre-handshake `TlsAcceptor`, so an accepted TLS connection is served
+# through `hyper`'s own connection builder instead (identical to
+# `velesdb-server`'s `spawn_tls_connection`).
+hyper = { version = "1", optional = true }
+hyper-util = { version = "0.1", optional = true, features = ["tokio", "server-auto"] }
+# `tower::ServiceExt::oneshot` drives the axum `Router` (a `tower::Service`)
+# for a single request inside the manual TLS accept loop.
+tower = { workspace = true, optional = true }
 
 [features]
 # The MCP server transport + binary, and the native file-backed store, are on
@@ -72,7 +103,22 @@ mcp = ["dep:rmcp", "dep:tokio", "persistence"]
 # velesdb-memory` still produces the tiny, fully-offline stdio-only binary —
 # only the installer script opts a LOCAL build into this at build time; the
 # hash/ollama embedder choice stays a pure runtime switch either way.
-http = ["mcp", "dep:axum", "dep:tokio-util", "dep:tower-http", "dep:futures", "rmcp/transport-streamable-http-server"]
+http = [
+    "mcp",
+    "dep:axum",
+    "dep:tokio-util",
+    "dep:tower-http",
+    "dep:futures",
+    "dep:rcgen",
+    "dep:time",
+    "dep:rustls",
+    "dep:tokio-rustls",
+    "dep:rustls-pemfile",
+    "dep:hyper",
+    "dep:hyper-util",
+    "dep:tower",
+    "rmcp/transport-streamable-http-server",
+]
 # The deterministic context compiler (EPIC-P-070). Zero new dependencies and
 # `persistence`-free by design, so a wasm-style `default-features = false`
 # consumer can enable it alone; the memory-backed selection layer inside it is
@@ -99,8 +145,20 @@ criterion = { workspace = true }
 # MCP client-side streamable-HTTP transport, dev-only: drives the `http`
 # feature's server transport in tests/http_transport.rs with a real client
 # (the same one exercised by rmcp's own upstream test suite) rather than
-# hand-rolled JSON-RPC-over-HTTP requests.
-rmcp = { version = "2.0.0", features = ["client", "transport-streamable-http-client-reqwest"] }
+# hand-rolled JSON-RPC-over-HTTP requests. `reqwest` additionally turns on
+# rmcp's own `reqwest?/rustls` alias so the `reqwest::Client` it hands back
+# has a TLS backend at all — needed by tests/http_tls.rs, which builds its
+# OWN `reqwest::Client`s (one trusting nothing extra, one trusting the
+# generated local CA via `add_root_certificate`) and hands them to
+# `StreamableHttpClientTransport::with_client` for the RED/GREEN proof.
+rmcp = { version = "2.0.0", features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
+# Same crate + version rmcp's reqwest transport resolves to (Cargo unifies
+# the two into one compiled `reqwest`), named directly here so
+# tests/http_tls.rs can construct `reqwest::Client`/`reqwest::Certificate`
+# itself rather than only via rmcp's convenience constructors. `blocking` is
+# for tests/http_insecure_process.rs's synchronous polling of a spawned
+# subprocess (that test is plain `#[test]`, not `#[tokio::test]`).
+reqwest = { version = "0.13", features = ["blocking"] }
 
 [[bin]]
 name = "velesdb-memory"
@@ -151,6 +209,25 @@ required-features = ["http"]
 [[test]]
 name = "http_lock_contention"
 path = "tests/http_lock_contention.rs"
+required-features = ["http"]
+
+# RED/GREEN proof that the HTTP transport's TLS termination is real, not a
+# no-op: a client that does NOT trust the freshly-generated local CA must
+# fail the handshake, and one that does must complete a full
+# remember/recall round trip. See `src/tls.rs` for the CA/leaf generation
+# this exercises.
+[[test]]
+name = "http_tls"
+path = "tests/http_tls.rs"
+required-features = ["http"]
+
+# Process-level proof of the `--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1`
+# escape hatch: spawns the actual compiled binary (not the in-process
+# router) and confirms it serves plain HTTP, since that flag is parsed in
+# `src/main.rs` before any router/TLS code runs.
+[[test]]
+name = "http_insecure_process"
+path = "tests/http_insecure_process.rs"
 required-features = ["http"]
 
 [[example]]

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -394,27 +394,84 @@ daemon that every client connects to instead of spawning its own process.
 The hash/ollama embedder choice stays a pure runtime switch either way — only
 the transport changes.
 
+The daemon serves **HTTPS by default**, terminated with a CA + leaf
+certificate it generates itself — no `mkcert`/`openssl`/reverse proxy to
+install. Some MCP clients (e.g. Claude Desktop's "Add custom connector" UI)
+refuse any URL that isn't `https://`, even for `127.0.0.1`, so plain HTTP is
+no longer viable as the default.
+
 ```bash
 cargo install velesdb-memory --features http,ollama
 # → still opt into `ollama` at BUILD time only if you want that embedder available;
 #   VELESDB_MEMORY_EMBEDDER stays a runtime choice regardless (see "Embedding backend" below)
 velesdb-memory --http
-# [velesdb-memory] HTTP server listening on http://127.0.0.1:18090/mcp
+# [velesdb-memory] HTTPS server listening on https://127.0.0.1:18090/mcp
+# [velesdb-memory] Local CA: /home/you/.velesdb-memory-tls/ca-cert.pem — a client only needs to
+# trust this once (see ./scripts/install-memory-daemon.sh, which does this automatically on
+# macOS); every future leaf certificate this daemon issues is signed by the same CA and is
+# trusted automatically after that.
 ```
 
 - `--http` / `VELESDB_MEMORY_HTTP=1` — serve over streamable-HTTP instead of stdio.
 - `--http-port <PORT>` / `VELESDB_MEMORY_HTTP_BIND=<host:port>` — override the
   bind address (default `127.0.0.1:18090`; `--http-port` overrides just the
   port on top of `VELESDB_MEMORY_HTTP_BIND`).
+- `--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1` — opt OUT of HTTPS and
+  serve plain HTTP instead, printing a loud warning at startup. For local
+  debugging, or when a trusted TLS-terminating proxy already sits in front —
+  not for normal use.
 - The transport has **no authentication** — anyone who can reach the socket
-  gets full `remember`/`recall`/`relate` access to the store. That's fine for
-  the default loopback-only bind (only processes on the same machine can
-  reach it), so a non-loopback `VELESDB_MEMORY_HTTP_BIND` host is refused at
-  startup unless you also set `VELESDB_MEMORY_HTTP_ALLOW_REMOTE=1`. Only set
-  that if you're putting an authenticating reverse proxy in front — never
-  point the bare daemon at a network-reachable address.
+  gets full `remember`/`recall`/`relate` access to the store. HTTPS-by-default
+  protects the bytes on the wire from anyone else on the same machine reading
+  them, but it is not access control: that's still the default loopback-only
+  bind (only processes on the same machine can reach it at all), so a
+  non-loopback `VELESDB_MEMORY_HTTP_BIND` host is refused at startup unless
+  you also set `VELESDB_MEMORY_HTTP_ALLOW_REMOTE=1`. Only set that if you're
+  putting an authenticating reverse proxy in front — never point the bare
+  daemon at a network-reachable address.
+
+### The local CA
+
+On first start, the daemon generates a self-signed root CA and caches it at
+`$VELESDB_MEMORY_TLS_DIR` (default `~/.velesdb-memory-tls`, a sibling of the
+default store — deliberately not nested inside it, since wiping the store to
+reset your memory shouldn't also invalidate a CA your OS has been told to
+trust). **The CA is never regenerated once it exists** — that's the entire
+point of caching it: trust it once, and every leaf certificate it signs
+afterwards (including ones re-issued across restarts) is automatically
+trusted with no further action. The leaf certificate itself (for
+`localhost`/`127.0.0.1`/`::1`) is short-lived (30 days) and silently re-issued
+— re-signed by the same CA, no new trust required — on every daemon start.
+
+The CA's private key is written with `0600` permissions (owner-read/write
+only) and its directory with `0700`; only the certificate itself
+(`ca-cert.pem`) is meant to be handed to a trust store or another machine.
+
+`scripts/install-memory-daemon.sh` adds the CA to your macOS **login**
+keychain (not the system one — no `sudo` needed) as a trusted root for SSL,
+so a strict HTTPS client (a browser, plain `curl`) connects with no warning.
+macOS may show a system prompt (Touch ID / password) to confirm this — the
+installer waits up to 60s for it; if it times out or you'd rather do it by
+hand, it prints the exact command:
+
+```bash
+security add-trusted-cert -r trustRoot -p ssl \
+  -k ~/Library/Keychains/login.keychain-db \
+  ~/.velesdb-memory-tls/ca-cert.pem
+```
+
+Node-based tools (Claude Code's CLI, Electron apps like Claude Desktop) don't
+always consult the OS keychain for TLS trust the way `curl`/Safari do. If one
+of them still reports a certificate error after the keychain step above,
+point it at the CA directly:
+
+```bash
+export NODE_EXTRA_CA_CERTS="$HOME/.velesdb-memory-tls/ca-cert.pem"
+```
+
 - `GET /health` — plain 200 OK liveness probe (no MCP handshake needed) —
-  what the installer script and CI use to confirm the daemon is up.
+  what the installer script and CI use to confirm the daemon is up (over
+  HTTPS too, once TLS is the transport).
 - `VELESDB_MEMORY_HTTP_MAX_BODY_BYTES` — max size of a single `/mcp` request
   body, in bytes (default 16 MiB). A misbehaving or hostile client sending an
   oversized request is rejected instead of having its body buffered into
@@ -436,7 +493,7 @@ Point each client's config at the daemon instead of a local binary:
 **Claude Code**
 
 ```bash
-claude mcp add --transport http velesdb-memory http://127.0.0.1:18090/mcp
+claude mcp add --transport http velesdb-memory https://127.0.0.1:18090/mcp
 ```
 
 **Cursor** / **Cline** — same `mcpServers` files as above, `type: "http"` instead of `command`:
@@ -444,7 +501,7 @@ claude mcp add --transport http velesdb-memory http://127.0.0.1:18090/mcp
 ```json
 { "mcpServers": { "velesdb-memory": {
   "type": "http",
-  "url": "http://127.0.0.1:18090/mcp"
+  "url": "https://127.0.0.1:18090/mcp"
 } } }
 ```
 
@@ -453,7 +510,7 @@ claude mcp add --transport http velesdb-memory http://127.0.0.1:18090/mcp
 ```json
 { "mcpServers": { "velesdb-memory": {
   "type": "http",
-  "url": "http://127.0.0.1:18090/mcp"
+  "url": "https://127.0.0.1:18090/mcp"
 } } }
 ```
 
@@ -468,14 +525,16 @@ claude mcp add --transport http velesdb-memory http://127.0.0.1:18090/mcp
 
 ```json
 { "mcpServers": { "velesdb-memory": {
-  "serverUrl": "http://127.0.0.1:18090/mcp"
+  "serverUrl": "https://127.0.0.1:18090/mcp"
 } } }
 ```
 
 `scripts/install-memory-daemon.sh` automates all of this end to end: building
-with the right features, running the daemon (as a macOS `launchd` agent), and
-wiring Claude Code / Claude Desktop / Windsurf — see `--help` for flags
-(`--embedder`, `--port`, `--store`, `--ttl`, `--skip-client`, `--uninstall`, …).
+with the right features, running the daemon (as a macOS `launchd` agent),
+trusting the local CA in your login keychain, and wiring Claude Code / Claude
+Desktop / Windsurf — see `--help` for flags (`--embedder`, `--port`,
+`--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
+`--uninstall`, …).
 
 ## Teach your agent the flow (skill)
 

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -8,9 +8,17 @@
 //!
 //! This module is the fix: one process, reachable over HTTP, that several
 //! clients connect to concurrently. It only builds the [`Router`]; binding a
-//! [`tokio::net::TcpListener`] and driving `axum::serve` is the binary's job
-//! (`src/main.rs`), so the router can also be mounted directly in tests
-//! (`tests/http_transport.rs`) with no subprocess involved.
+//! [`tokio::net::TcpListener`] and actually serving connections — plain via
+//! `axum::serve`, or TLS via this module's own [`serve_tls`] — is the
+//! binary's job (`src/main.rs`), so the router can also be mounted directly
+//! in tests (`tests/http_transport.rs`) with no subprocess involved.
+//!
+//! Serving is HTTPS by default (see `crate::tls` for the locally-generated
+//! CA/leaf certificates this needs); plain HTTP remains available as an
+//! explicit opt-out (`--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1`,
+//! see `src/main.rs`) for local debugging or when a trusted TLS-terminating
+//! proxy already sits in front. This module's own [`Router`]/[`router`] are
+//! identical either way — only the transport wrapped around them differs.
 //!
 //! Concurrent requests need no *application*-level locking beyond what
 //! [`McpServer`] already has: `velesdb-core`'s `Database` protects its
@@ -151,4 +159,77 @@ pub fn router_with_limits(
 /// for here.
 async fn health() -> &'static str {
     "OK"
+}
+
+/// Serve `app` over TLS on `listener`, terminating each accepted connection
+/// with `acceptor` — the HTTPS-by-default path for the HTTP transport (see
+/// the crate's `src/tls.rs` for how `acceptor` is built, and its module
+/// docs for why this is a manual accept loop rather than `axum::serve` or
+/// `axum-server`).
+///
+/// Runs until `cancellation_token` is cancelled: new connections stop being
+/// accepted, and the loop returns once every already-in-flight connection's
+/// handler task has also observed the cancellation and finished (each
+/// handler is spawned but this function doesn't return until the accept
+/// loop itself exits, matching `router`'s cancellation-token contract —
+/// callers that also want to wait for in-flight requests to *drain* should
+/// track their own handle, as `main.rs`'s plain-HTTP path does via
+/// `axum::serve`'s `with_graceful_shutdown`).
+///
+/// A per-connection TLS handshake failure (e.g. a client that doesn't trust
+/// the CA — exactly what `tests/http_tls.rs`'s RED case exercises) is
+/// swallowed here rather than propagated: one bad client must not take down
+/// the daemon or any other in-flight session, mirroring how a rejected
+/// `accept()` on a healthy plain-HTTP listener doesn't either.
+pub async fn serve_tls(
+    app: Router,
+    listener: tokio::net::TcpListener,
+    acceptor: tokio_rustls::TlsAcceptor,
+    cancellation_token: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                match result {
+                    Ok((stream, _peer_addr)) => {
+                        spawn_tls_connection(stream, acceptor.clone(), app.clone());
+                    }
+                    Err(_err) => {
+                        // Transient accept() failures (e.g. the process is
+                        // near its fd limit) shouldn't kill the daemon —
+                        // the next accept() attempt is the recovery path,
+                        // same posture as velesdb-server's tls_accept_loop.
+                    }
+                }
+            }
+            () = cancellation_token.cancelled() => break,
+        }
+    }
+}
+
+/// Complete one connection's TLS handshake and serve it via `hyper`'s auto
+/// (HTTP/1.1 or HTTP/2) connection builder, routing every request through
+/// `app`. A failed handshake (untrusted cert, protocol mismatch, ...) just
+/// drops the connection — see [`serve_tls`]'s docs for why that's
+/// deliberate.
+fn spawn_tls_connection(
+    stream: tokio::net::TcpStream,
+    acceptor: tokio_rustls::TlsAcceptor,
+    app: Router,
+) {
+    tokio::spawn(async move {
+        let Ok(tls_stream) = acceptor.accept(stream).await else {
+            return;
+        };
+
+        let io = hyper_util::rt::TokioIo::new(tls_stream);
+        let hyper_service = hyper::service::service_fn(move |request| {
+            let app = app.clone();
+            async move { tower::ServiceExt::oneshot(app, request).await }
+        });
+
+        let _ = hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+            .serve_connection_with_upgrades(io, hyper_service)
+            .await;
+    });
 }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -73,6 +73,12 @@ pub mod service;
 /// default, file-backed [`storage::NativeStore`]. Implement `MemoryStore` to
 /// run the wedge over a different backend (e.g. an in-memory one for WASM).
 pub mod storage;
+/// Locally-generated TLS material (a cached self-signed CA + short-lived
+/// leaf certs) for the streamable-HTTP transport's HTTPS-by-default
+/// listener — see the module docs for the full design rationale. Gated
+/// behind `http` since it exists only to serve that transport.
+#[cfg(feature = "http")]
+pub mod tls;
 
 /// Default embedding dimension — the single source of truth, taken from the
 /// SDK's own default so the server, library, and tests never restate the

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -19,6 +19,15 @@
 //! instead of stdio — letting several MCP clients share ONE process instead
 //! of each fighting over the store's single-writer `flock`. See
 //! `velesdb_memory::http` and the README's "HTTP transport" section.
+//!
+//! The HTTP transport serves HTTPS by default, terminated with a locally
+//! generated CA + leaf certificate (see `velesdb_memory::tls` — no external
+//! `mkcert`/`openssl`/reverse proxy required; some MCP clients, e.g. Claude
+//! Desktop's "Add custom connector", refuse any URL that isn't `https://`,
+//! even for `127.0.0.1`). Pass `--http-insecure` (or set
+//! `VELESDB_MEMORY_HTTP_INSECURE=1`) to fall back to plain HTTP instead —
+//! for local debugging, or when a trusted TLS-terminating proxy already
+//! sits in front.
 
 use std::time::Duration;
 
@@ -69,7 +78,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::runtime::Runtime::new()?.block_on(async move {
         match http_bind {
             #[cfg(feature = "http")]
-            Some(bind_addr) => serve_http(server, bind_addr).await,
+            Some(request) => serve_http(server, request).await,
             #[cfg(not(feature = "http"))]
             Some(_never) => unreachable!(
                 "requested_http_bind only returns Some when built with --features http"
@@ -91,16 +100,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
 }
 
+/// A resolved `--http`/`VELESDB_MEMORY_HTTP=1` request: where to bind, and
+/// whether TLS should be skipped (`--http-insecure` /
+/// `VELESDB_MEMORY_HTTP_INSECURE=1` — see [`requested_http_bind`]).
+#[cfg(feature = "http")]
+struct HttpServeRequest {
+    bind_addr: String,
+    insecure: bool,
+}
+
 /// Detect the streamable-HTTP transport request (`--http` flag or
-/// `VELESDB_MEMORY_HTTP=1`) and resolve the bind address it should serve on,
-/// BEFORE the store is opened. Returns `None` for the default stdio
-/// transport.
+/// `VELESDB_MEMORY_HTTP=1`) and resolve how it should be served, BEFORE the
+/// store is opened. Returns `None` for the default stdio transport.
 ///
 /// Without the `http` feature, `--http`/`VELESDB_MEMORY_HTTP=1` is rejected
 /// with an actionable message instead of silently falling back to stdio —
 /// the binary was built without the code to honor the request at all.
 #[cfg(feature = "http")]
-fn requested_http_bind(args: &[String]) -> Option<String> {
+fn requested_http_bind(args: &[String]) -> Option<HttpServeRequest> {
     let http_flag = args.iter().any(|arg| arg == "--http");
     let http_env = std::env::var("VELESDB_MEMORY_HTTP").as_deref() == Ok("1");
     if !http_flag && !http_env {
@@ -144,7 +161,23 @@ fn requested_http_bind(args: &[String]) -> Option<String> {
         std::process::exit(1);
     }
 
-    Some(bind_addr)
+    // `--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1` is the explicit
+    // opt-out of HTTPS-by-default (see the crate-level doc comment above and
+    // `velesdb_memory::tls`'s module docs for why HTTPS is the default at
+    // all) — an "insecure escape hatch, loud at startup" flag, same shape as
+    // `VELESDB_MEMORY_HTTP_ALLOW_REMOTE` above. Kept as its own flag rather
+    // than folded into that one: that one is about *who* can reach the
+    // socket, this one is about *whether the bytes on the wire are
+    // encrypted* — independent axes, and conflating them would make an
+    // operator who only wants one silently get the other too.
+    let insecure_flag = args.iter().any(|arg| arg == "--http-insecure");
+    let insecure_env = std::env::var("VELESDB_MEMORY_HTTP_INSECURE").as_deref() == Ok("1");
+    let insecure = insecure_flag || insecure_env;
+
+    Some(HttpServeRequest {
+        bind_addr,
+        insecure,
+    })
 }
 
 /// Whether `bind_addr`'s host component (`host:port` or `[ipv6]:port`)
@@ -185,21 +218,31 @@ fn requested_http_bind(args: &[String]) -> Option<String> {
 }
 
 /// Serve the MCP server over the streamable-HTTP transport (multi-client
-/// mode): binds `bind_addr`, mounts [`velesdb_memory::http::router`], and
-/// runs until either the process receives Ctrl-C or the returned future is
-/// dropped (e.g. process termination) — a background daemon (launchd,
+/// mode): binds `request.bind_addr`, mounts [`velesdb_memory::http::router`],
+/// and runs until either the process receives Ctrl-C or the returned future
+/// is dropped (e.g. process termination) — a background daemon (launchd,
 /// systemd) is expected to just kill the process on stop, which is safe: the
 /// store's `flock` is released by the kernel on exit regardless (see the
 /// orphan-watchdog docs above).
+///
+/// HTTPS by default (a locally-generated CA + leaf cert — see
+/// `velesdb_memory::tls`), unless `request.insecure` opts out
+/// (`--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1`), in which case
+/// this serves plain HTTP via `axum::serve` exactly as before HTTPS
+/// support was added.
 #[cfg(feature = "http")]
 async fn serve_http(
     server: McpServer,
-    bind_addr: String,
+    request: HttpServeRequest,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let HttpServeRequest {
+        bind_addr,
+        insecure,
+    } = request;
+
     let ct = tokio_util::sync::CancellationToken::new();
     let app = velesdb_memory::http::router(server, ct.child_token());
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
-    eprintln!("[velesdb-memory] HTTP server listening on http://{bind_addr}/mcp");
 
     let ctrl_c_ct = ct.clone();
     tokio::spawn(async move {
@@ -208,9 +251,34 @@ async fn serve_http(
         }
     });
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move { ct.cancelled_owned().await })
-        .await?;
+    if insecure {
+        eprintln!(
+            "[velesdb-memory] WARNING: --http-insecure / VELESDB_MEMORY_HTTP_INSECURE=1 is set — \
+             serving PLAIN HTTP (no TLS) on http://{bind_addr}/mcp. Every request is readable by \
+             anyone who can reach that socket (loopback-only by default — see \
+             VELESDB_MEMORY_HTTP_ALLOW_REMOTE above). Use this only for local debugging, or when \
+             a trusted TLS-terminating proxy already sits in front."
+        );
+        eprintln!("[velesdb-memory] HTTP server listening on http://{bind_addr}/mcp");
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move { ct.cancelled_owned().await })
+            .await?;
+        return Ok(());
+    }
+
+    let tls_dir = velesdb_memory::tls::tls_dir_from_env();
+    let material = velesdb_memory::tls::ensure_tls_material(&tls_dir)?;
+    let acceptor = velesdb_memory::tls::tls_acceptor_from_material(&material)?;
+    eprintln!("[velesdb-memory] HTTPS server listening on https://{bind_addr}/mcp");
+    eprintln!(
+        "[velesdb-memory] Local CA: {} — a client only needs to trust this once (see \
+         ./scripts/install-memory-daemon.sh, which does this automatically on macOS); every \
+         future leaf certificate this daemon issues is signed by the same CA and is trusted \
+         automatically after that.",
+        material.ca_cert_path.display()
+    );
+
+    velesdb_memory::http::serve_tls(app, listener, acceptor, ct).await;
     Ok(())
 }
 

--- a/crates/velesdb-memory/src/tls.rs
+++ b/crates/velesdb-memory/src/tls.rs
@@ -205,22 +205,26 @@ fn create_private_dir(dir: &Path) -> Result<(), TlsError> {
     set_permissions(dir, 0o700)
 }
 
-/// Load the CA from `dir` if both its cert and key are already present
-/// (never regenerating one that exists — see module docs for why that
-/// matters), otherwise generate a fresh self-signed CA and persist it.
-/// Either way, returns an [`Issuer`] ready to sign a leaf certificate.
-fn ensure_ca(dir: &Path) -> Result<Issuer<'static, KeyPair>, TlsError> {
+/// Load the CA from `dir` if both its cert and key are already present —
+/// `None` if either is missing, meaning the caller must generate a fresh one.
+/// Never regenerates one that exists (see module docs for why that matters).
+fn load_existing_ca(dir: &Path) -> Result<Option<Issuer<'static, KeyPair>>, TlsError> {
     let ca_cert_path = dir.join(CA_CERT_FILE);
     let ca_key_path = dir.join(CA_KEY_FILE);
 
-    if ca_cert_path.exists() && ca_key_path.exists() {
-        let ca_cert_pem = read_to_string(&ca_cert_path)?;
-        let ca_key_pem = read_to_string(&ca_key_path)?;
-        let key_pair = KeyPair::from_pem(&ca_key_pem)?;
-        let issuer = Issuer::from_ca_cert_pem(&ca_cert_pem, key_pair)?;
-        return Ok(issuer);
+    if !ca_cert_path.exists() || !ca_key_path.exists() {
+        return Ok(None);
     }
 
+    let ca_cert_pem = read_to_string(&ca_cert_path)?;
+    let ca_key_pem = read_to_string(&ca_key_path)?;
+    let key_pair = KeyPair::from_pem(&ca_key_pem)?;
+    Ok(Some(Issuer::from_ca_cert_pem(&ca_cert_pem, key_pair)?))
+}
+
+/// Generate a fresh self-signed CA and persist it to `dir` (cert `0644`,
+/// private key `0600`).
+fn generate_new_ca(dir: &Path) -> Result<Issuer<'static, KeyPair>, TlsError> {
     let key_pair = KeyPair::generate()?;
     let mut params = CertificateParams::new(Vec::<String>::new())?;
     params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -234,10 +238,24 @@ fn ensure_ca(dir: &Path) -> Result<Issuer<'static, KeyPair>, TlsError> {
 
     let ca_cert = params.self_signed(&key_pair)?;
 
-    write_file(&ca_cert_path, ca_cert.pem().as_bytes(), 0o644)?;
-    write_file(&ca_key_path, key_pair.serialize_pem().as_bytes(), 0o600)?;
+    write_file(&dir.join(CA_CERT_FILE), ca_cert.pem().as_bytes(), 0o644)?;
+    write_file(
+        &dir.join(CA_KEY_FILE),
+        key_pair.serialize_pem().as_bytes(),
+        0o600,
+    )?;
 
     Ok(Issuer::new(params, key_pair))
+}
+
+/// Load the CA from `dir` if already present, otherwise generate and persist
+/// a fresh self-signed one. Either way, returns an [`Issuer`] ready to sign a
+/// leaf certificate.
+fn ensure_ca(dir: &Path) -> Result<Issuer<'static, KeyPair>, TlsError> {
+    match load_existing_ca(dir)? {
+        Some(issuer) => Ok(issuer),
+        None => generate_new_ca(dir),
+    }
 }
 
 /// Issue a fresh leaf certificate for `localhost`/`127.0.0.1`/`::1`, signed

--- a/crates/velesdb-memory/src/tls.rs
+++ b/crates/velesdb-memory/src/tls.rs
@@ -1,0 +1,394 @@
+//! Locally-generated TLS material for the streamable-HTTP transport.
+//!
+//! Claude Desktop's "Add custom connector" UI refuses any URL that isn't
+//! `https://`, even for `127.0.0.1` — so the HTTP transport (see
+//! [`crate::http`]) now terminates TLS itself by default, with no external
+//! dependency (no shelled-out `mkcert`/`openssl`, no reverse proxy the user
+//! has to install and keep running).
+//!
+//! The approach: a self-signed root CA is generated ONCE and cached on disk
+//! (see [`tls_dir_from_env`]); it signs short-lived `localhost`/`127.0.0.1`
+//! leaf certificates that are silently re-issued on every daemon start. A
+//! client (browser, `curl`, Claude Desktop) that has been told to trust the
+//! CA once — `scripts/install-memory-daemon.sh` adds it to the macOS login
+//! keychain — then trusts every future leaf cert it signs with no further
+//! action, even across daemon restarts and leaf renewals, because the CA's
+//! own key never changes. [`ensure_tls_material`] is what enforces that:
+//! it reloads an existing CA from disk instead of regenerating one whenever
+//! both `ca-cert.pem` and `ca-key.pem` are already present.
+//!
+//! # Why manual `tokio_rustls` instead of `axum-server`
+//! `crates/velesdb-server` already terminates TLS this way (its own
+//! `src/tls.rs` builds a [`tokio_rustls::TlsAcceptor`]; its `src/main.rs`
+//! runs the accept loop). Reusing that exact pattern here — a
+//! [`tokio_rustls::TlsAcceptor`] wrapping each accepted `TcpStream`, served
+//! through `hyper_util`'s auto h1/h2 connection builder — rather than
+//! adding `axum-server` as a second, independent TLS dependency, keeps the
+//! workspace's TLS story to one crate family (`rustls`/`tokio-rustls`/
+//! `rustls-pemfile`, already pinned in `Cargo.lock`) and avoids
+//! re-litigating `axum-server`'s own rustls-version compatibility against
+//! `axum 0.8` for what both crates ultimately do the same way underneath.
+//! [`crate::http::serve_tls`] is the accept-loop half of this; this module
+//! is only the certificate material.
+//!
+//! # An explicit `CryptoProvider`, not the process-wide default
+//! [`tls_acceptor_from_material`] builds its [`rustls::ServerConfig`] with
+//! `ServerConfig::builder_with_provider(..)` and an explicit
+//! `rustls::crypto::ring::default_provider()`, rather than the ambient
+//! `ServerConfig::builder()` (which resolves the process-wide default
+//! `CryptoProvider`). That default is genuinely ambiguous here: the
+//! `reqwest` dev-dependency (pulled in by rmcp's streamable-HTTP client
+//! transport, used by `tests/http_tls.rs`) links `rustls` with the
+//! `aws-lc-rs` backend, while this module always wants `ring` (matching
+//! `velesdb-server`'s choice) — and both backends end up linked into the
+//! SAME test binary. Relying on "whichever one calls
+//! `CryptoProvider::install_default()` first" would make the test suite's
+//! behavior depend on initialization order between unrelated crates.
+//! Passing the provider explicitly sidesteps that entirely.
+
+use std::fs;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
+    Issuer, KeyPair, KeyUsagePurpose, SanType,
+};
+use time::{Duration as TimeDuration, OffsetDateTime};
+
+/// File names inside the TLS material directory (see [`tls_dir_from_env`]).
+/// `ca-cert.pem` is public (safe to hand to `security add-trusted-cert`,
+/// safe to be world-readable); the two `*-key.pem` files are private and are
+/// always written with `0600` permissions (see [`set_permissions`]).
+pub const CA_CERT_FILE: &str = "ca-cert.pem";
+const CA_KEY_FILE: &str = "ca-key.pem";
+const LEAF_CERT_FILE: &str = "leaf-cert.pem";
+const LEAF_KEY_FILE: &str = "leaf-key.pem";
+
+/// Leaf certs are silently re-issued on every daemon start (see module
+/// docs), so a short lifetime costs nothing in UX while shrinking the
+/// exposure window of a leaf private key that — unlike the CA's — is
+/// rewritten to disk on every run. 30 days is generous headroom for a
+/// daemon left running unattended over a long weekend without a restart.
+const LEAF_CERT_LIFETIME_DAYS: i64 = 30;
+
+/// The CA is meant to be trusted once and left alone indefinitely (that's
+/// the entire point of caching it — see module docs), so it gets a long,
+/// "effectively permanent for this use case" lifetime rather than the
+/// leaf's short one.
+const CA_CERT_LIFETIME_DAYS: i64 = 3650;
+
+/// Backdate `not_before` by this much on every generated certificate, to
+/// absorb clock skew between "when this process thinks it is" and "when the
+/// TLS client checking the cert's validity window thinks it is" — cheap
+/// insurance against a leap-second/NTP hiccup rejecting a cert the instant
+/// it's minted.
+const NOT_BEFORE_SLACK_HOURS: i64 = 1;
+
+/// Errors from generating or loading local TLS material. Deliberately
+/// distinct from [`crate::error::MemoryError`] — these are infra/filesystem
+/// concerns, not store/domain ones.
+#[derive(Debug, thiserror::Error)]
+pub enum TlsError {
+    #[error("failed to create TLS material directory {path}: {source}")]
+    CreateDir { path: PathBuf, source: io::Error },
+    #[error("failed to read {path}: {source}")]
+    Read { path: PathBuf, source: io::Error },
+    #[error("failed to write {path}: {source}")]
+    Write { path: PathBuf, source: io::Error },
+    #[error("failed to set permissions on {path}: {source}")]
+    Permissions { path: PathBuf, source: io::Error },
+    #[error("certificate generation failed: {0}")]
+    Rcgen(#[from] rcgen::Error),
+    #[error("invalid generated TLS certificate/key material: {0}")]
+    Rustls(#[from] rustls::Error),
+    #[error("failed to parse generated leaf certificate PEM: {0}")]
+    PemCert(io::Error),
+    #[error("failed to parse generated leaf private key PEM: {0}")]
+    PemKey(io::Error),
+    #[error("generated leaf material contained no private key")]
+    NoPrivateKey,
+}
+
+/// A leaf certificate + private key (PEM), ready to serve, plus the CA's
+/// public certificate path (for callers — the installer, startup banner —
+/// that need to point a user or `security add-trusted-cert` at it).
+pub struct TlsMaterial {
+    pub cert_pem: Vec<u8>,
+    pub key_pem: Vec<u8>,
+    pub ca_cert_path: PathBuf,
+}
+
+/// Default TLS material directory when `VELESDB_MEMORY_TLS_DIR` is unset: a
+/// sibling of the default store (`~/.velesdb-memory`), deliberately NOT
+/// nested inside it. The store and the CA have independent lifecycles — a
+/// user who wipes `~/.velesdb-memory` to reset their memory shouldn't also
+/// silently invalidate a CA their OS (or a client like Claude Desktop) has
+/// already been told to trust, and vice versa. Mirrors `default_store_path`
+/// in `src/main.rs`: a stable home-based path, since an MCP client launches
+/// this process with an unpredictable working directory.
+#[must_use]
+pub fn default_tls_dir() -> PathBuf {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|h| !h.is_empty());
+    match home {
+        Some(home) => Path::new(&home).join(".velesdb-memory-tls"),
+        None => PathBuf::from("./velesdb-memory-tls"),
+    }
+}
+
+/// Resolve the TLS material directory from `VELESDB_MEMORY_TLS_DIR`, falling
+/// back to [`default_tls_dir`] when unset.
+#[must_use]
+pub fn tls_dir_from_env() -> PathBuf {
+    std::env::var_os("VELESDB_MEMORY_TLS_DIR").map_or_else(default_tls_dir, PathBuf::from)
+}
+
+/// Ensure a local CA exists at `dir` (generating one on first use, reusing
+/// it otherwise — see module docs), then issue a fresh short-lived leaf
+/// certificate signed by it. Creates `dir` (and sets its permissions) if
+/// needed.
+///
+/// # Errors
+/// Returns [`TlsError`] if `dir` cannot be created/written to, or if
+/// certificate generation/parsing fails.
+pub fn ensure_tls_material(dir: &Path) -> Result<TlsMaterial, TlsError> {
+    create_private_dir(dir)?;
+    let issuer = ensure_ca(dir)?;
+    let (cert_pem, key_pem) = issue_leaf_cert(dir, &issuer)?;
+    Ok(TlsMaterial {
+        cert_pem,
+        key_pem,
+        ca_cert_path: dir.join(CA_CERT_FILE),
+    })
+}
+
+/// Build a [`tokio_rustls::TlsAcceptor`] from generated [`TlsMaterial`],
+/// using an explicit `ring` [`rustls::crypto::CryptoProvider`] — see the
+/// module docs for why that's explicit rather than ambient.
+///
+/// # Errors
+/// Returns [`TlsError`] if the PEM material fails to parse, or if `rustls`
+/// rejects the resulting configuration.
+pub fn tls_acceptor_from_material(
+    material: &TlsMaterial,
+) -> Result<tokio_rustls::TlsAcceptor, TlsError> {
+    let certs: Vec<_> = rustls_pemfile::certs(&mut &material.cert_pem[..])
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(TlsError::PemCert)?;
+    let key = rustls_pemfile::private_key(&mut &material.key_pem[..])
+        .map_err(TlsError::PemKey)?
+        .ok_or(TlsError::NoPrivateKey)?;
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let config = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_no_client_auth()
+        .with_single_cert(certs, key)?;
+
+    Ok(tokio_rustls::TlsAcceptor::from(Arc::new(config)))
+}
+
+/// Create `dir` if missing and lock it down to the owning user (`0700`) —
+/// belt-and-suspenders alongside the per-file `0600` on the two private key
+/// files: even a directory listing of a world-readable dir would leak that
+/// a CA key exists here and its filename, so the directory itself is
+/// private too.
+fn create_private_dir(dir: &Path) -> Result<(), TlsError> {
+    fs::create_dir_all(dir).map_err(|source| TlsError::CreateDir {
+        path: dir.to_owned(),
+        source,
+    })?;
+    set_permissions(dir, 0o700)
+}
+
+/// Load the CA from `dir` if both its cert and key are already present
+/// (never regenerating one that exists — see module docs for why that
+/// matters), otherwise generate a fresh self-signed CA and persist it.
+/// Either way, returns an [`Issuer`] ready to sign a leaf certificate.
+fn ensure_ca(dir: &Path) -> Result<Issuer<'static, KeyPair>, TlsError> {
+    let ca_cert_path = dir.join(CA_CERT_FILE);
+    let ca_key_path = dir.join(CA_KEY_FILE);
+
+    if ca_cert_path.exists() && ca_key_path.exists() {
+        let ca_cert_pem = read_to_string(&ca_cert_path)?;
+        let ca_key_pem = read_to_string(&ca_key_path)?;
+        let key_pair = KeyPair::from_pem(&ca_key_pem)?;
+        let issuer = Issuer::from_ca_cert_pem(&ca_cert_pem, key_pair)?;
+        return Ok(issuer);
+    }
+
+    let key_pair = KeyPair::generate()?;
+    let mut params = CertificateParams::new(Vec::<String>::new())?;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    params.not_before = OffsetDateTime::now_utc() - TimeDuration::hours(NOT_BEFORE_SLACK_HOURS);
+    params.not_after = OffsetDateTime::now_utc() + TimeDuration::days(CA_CERT_LIFETIME_DAYS);
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, "VelesDB Memory Local CA");
+    dn.push(DnType::OrganizationName, "VelesDB Memory (local)");
+    params.distinguished_name = dn;
+
+    let ca_cert = params.self_signed(&key_pair)?;
+
+    write_file(&ca_cert_path, ca_cert.pem().as_bytes(), 0o644)?;
+    write_file(&ca_key_path, key_pair.serialize_pem().as_bytes(), 0o600)?;
+
+    Ok(Issuer::new(params, key_pair))
+}
+
+/// Issue a fresh leaf certificate for `localhost`/`127.0.0.1`/`::1`, signed
+/// by `issuer`, and persist it to `dir` (rewriting any previous leaf —
+/// silent renewal, no new trust required, see module docs). Returns the PEM
+/// bytes directly so the caller doesn't have to re-read them from disk.
+fn issue_leaf_cert(
+    dir: &Path,
+    issuer: &Issuer<'_, KeyPair>,
+) -> Result<(Vec<u8>, Vec<u8>), TlsError> {
+    let leaf_key = KeyPair::generate()?;
+    let mut params = CertificateParams::new(vec!["localhost".to_owned()])?;
+    params.subject_alt_names = vec![
+        SanType::DnsName("localhost".try_into()?),
+        SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        SanType::IpAddress(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+    ];
+    let mut dn = DistinguishedName::new();
+    dn.push(DnType::CommonName, "localhost");
+    params.distinguished_name = dn;
+    params.is_ca = IsCa::NoCa;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    params.not_before = OffsetDateTime::now_utc() - TimeDuration::hours(NOT_BEFORE_SLACK_HOURS);
+    params.not_after = OffsetDateTime::now_utc() + TimeDuration::days(LEAF_CERT_LIFETIME_DAYS);
+
+    let cert = params.signed_by(&leaf_key, issuer)?;
+    let cert_pem = cert.pem().into_bytes();
+    let key_pem = leaf_key.serialize_pem().into_bytes();
+
+    write_file(&dir.join(LEAF_CERT_FILE), &cert_pem, 0o644)?;
+    write_file(&dir.join(LEAF_KEY_FILE), &key_pem, 0o600)?;
+
+    Ok((cert_pem, key_pem))
+}
+
+fn read_to_string(path: &Path) -> Result<String, TlsError> {
+    fs::read_to_string(path).map_err(|source| TlsError::Read {
+        path: path.to_owned(),
+        source,
+    })
+}
+
+fn write_file(path: &Path, bytes: &[u8], mode: u32) -> Result<(), TlsError> {
+    fs::write(path, bytes).map_err(|source| TlsError::Write {
+        path: path.to_owned(),
+        source,
+    })?;
+    set_permissions(path, mode)
+}
+
+/// Set Unix permission bits on `path`. The private key files (`0600`) are
+/// the real security boundary here — see the `# Decisions` note in this
+/// crate's task history: a private key readable by other local users would
+/// let them impersonate this daemon's TLS identity to any client that
+/// trusts the CA.
+#[cfg(unix)]
+fn set_permissions(path: &Path, mode: u32) -> Result<(), TlsError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|source| {
+        TlsError::Permissions {
+            path: path.to_owned(),
+            source,
+        }
+    })
+}
+
+/// No POSIX mode bits on Windows. The files already live under the current
+/// user's profile directory (`default_tls_dir`'s `USERPROFILE` fallback),
+/// which is private-by-default under the OS's own ACLs — a deliberate
+/// no-op rather than a partial/misleading permissions story, same pattern
+/// as `spawn_orphan_watchdog` in `src/main.rs` being Unix-only.
+#[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
+fn set_permissions(_path: &Path, _mode: u32) -> Result<(), TlsError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_a_ca_and_leaf_cert_on_first_use() {
+        let dir = tempfile::tempdir().expect("create scratch dir");
+        let material = ensure_tls_material(dir.path()).expect("generate TLS material");
+
+        assert!(!material.cert_pem.is_empty());
+        assert!(!material.key_pem.is_empty());
+        assert!(material.ca_cert_path.exists());
+        assert!(dir.path().join(CA_KEY_FILE).exists());
+    }
+
+    #[test]
+    fn reuses_the_same_ca_across_calls() {
+        let dir = tempfile::tempdir().expect("create scratch dir");
+        let first = ensure_tls_material(dir.path()).expect("first generation");
+        let ca_pem_first =
+            std::fs::read_to_string(&first.ca_cert_path).expect("read CA cert after first run");
+
+        let second = ensure_tls_material(dir.path()).expect("second generation");
+        let ca_pem_second =
+            std::fs::read_to_string(&second.ca_cert_path).expect("read CA cert after second run");
+
+        assert_eq!(
+            ca_pem_first, ca_pem_second,
+            "the CA must never be regenerated once it exists on disk"
+        );
+    }
+
+    #[test]
+    fn leaf_cert_is_re_issued_on_every_call() {
+        let dir = tempfile::tempdir().expect("create scratch dir");
+        let first = ensure_tls_material(dir.path()).expect("first generation");
+        let second = ensure_tls_material(dir.path()).expect("second generation");
+
+        assert_ne!(
+            first.cert_pem, second.cert_pem,
+            "the leaf certificate is expected to be freshly re-issued (renewed) on every start"
+        );
+    }
+
+    #[test]
+    fn builds_a_tls_acceptor_from_generated_material() {
+        let dir = tempfile::tempdir().expect("create scratch dir");
+        let material = ensure_tls_material(dir.path()).expect("generate TLS material");
+        tls_acceptor_from_material(&material).expect("build TLS acceptor from valid material");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_key_files_are_not_group_or_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create scratch dir");
+        ensure_tls_material(dir.path()).expect("generate TLS material");
+
+        for key_file in [CA_KEY_FILE, LEAF_KEY_FILE] {
+            let path = dir.path().join(key_file);
+            let mode = std::fs::metadata(&path)
+                .unwrap_or_else(|_| panic!("stat {key_file}"))
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o077,
+                0,
+                "{key_file} must not be group/world readable or writable (mode {mode:o})"
+            );
+        }
+    }
+}

--- a/crates/velesdb-memory/tests/http_insecure_process.rs
+++ b/crates/velesdb-memory/tests/http_insecure_process.rs
@@ -1,0 +1,148 @@
+//! Process-level proof of the `--http-insecure` /
+//! `VELESDB_MEMORY_HTTP_INSECURE=1` escape hatch: HTTPS-by-default is
+//! decided in `src/main.rs`, BEFORE `velesdb_memory::http::router` is ever
+//! built, so an in-process test against the router (as `tests/http_tls.rs`
+//! and `tests/http_transport.rs` use) can't exercise that decision — only
+//! spawning the actual compiled binary can.
+//!
+//! Anti-hang / anti-orphan discipline: every subprocess spawned here is
+//! wrapped in a guard that SIGKILLs and reaps it on drop (including on test
+//! panic, via the guard's `Drop` impl), and every wait on the daemon
+//! becoming ready is bounded by an explicit timeout — never an unbounded
+//! poll loop.
+
+use std::io::{BufRead, BufReader};
+use std::net::TcpListener as StdTcpListener;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Owns a spawned `velesdb-memory` child process and guarantees it is
+/// killed and reaped when dropped — including when a test panics before
+/// reaching its own explicit cleanup, so a failing assertion here can never
+/// leak a daemon that keeps listening on the test's port.
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Spawn a thread that continuously drains `child`'s stderr into a shared
+/// buffer and return a handle to read it back at any point.
+///
+/// This is NOT optional plumbing: `child` is a long-running daemon that
+/// never closes its stderr on its own, so a synchronous
+/// `stderr.read_to_string(..)` call would block until EOF — i.e. forever,
+/// for as long as the daemon stays up. Draining continuously on a
+/// background thread instead means (a) the child's stderr pipe never fills
+/// up and makes IT block on a write(), and (b) this test can inspect
+/// whatever has been captured so far without ever blocking on the child's
+/// lifetime.
+fn drain_stderr(child: &mut Child) -> Arc<Mutex<String>> {
+    let buffer = Arc::new(Mutex::new(String::new()));
+    let stderr = child
+        .stderr
+        .take()
+        .expect("child spawned with Stdio::piped() stderr");
+    let buffer_writer = Arc::clone(&buffer);
+    std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            let Ok(line) = line else { break };
+            if let Ok(mut buffer) = buffer_writer.lock() {
+                buffer.push_str(&line);
+                buffer.push('\n');
+            }
+        }
+    });
+    buffer
+}
+
+/// Bind an OS-assigned loopback port, read it back, then release it
+/// immediately so the subprocess can bind the same port — a brief race in
+/// theory, but the same "ask the OS for a free port, then reuse the number"
+/// pattern process-level tests use throughout this codebase (there is no
+/// portable way to hand a `--http-port 0`-launched *subprocess*'s
+/// OS-assigned port back to the parent other than parsing its stderr, which
+/// `serve_http`'s current banner does not support for `bind_addr:0`).
+fn pick_free_port() -> u16 {
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind ephemeral port to pick one");
+    listener.local_addr().expect("read bound local addr").port()
+}
+
+/// Locate the `velesdb-memory` binary built by `cargo test` for this crate
+/// (same directory Cargo places integration test binaries' sibling `deps/`
+/// output next to). `env!("CARGO_BIN_EXE_velesdb-memory")` is Cargo's own
+/// supported mechanism for exactly this — it also guarantees the binary is
+/// built with the SAME feature set this test binary was compiled with
+/// (`--features http`), since `required-features = ["http"]` on this test
+/// target means it never even builds without it.
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_velesdb-memory")
+}
+
+/// Poll `http://127.0.0.1:{port}/health` until it answers or `timeout`
+/// elapses. Bounded — never an unbounded loop — so a daemon that fails to
+/// start turns into a clear test failure instead of a hang.
+fn wait_for_plain_http_health(port: u16, timeout: Duration) -> Result<(), String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut last_err = String::from("never attempted");
+    while std::time::Instant::now() < deadline {
+        match reqwest::blocking::get(format!("http://127.0.0.1:{port}/health")) {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(response) => last_err = format!("non-success status: {}", response.status()),
+            Err(err) => last_err = err.to_string(),
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Err(format!("daemon never answered /health in time: {last_err}"))
+}
+
+/// `--http-insecure` must serve plain HTTP (no TLS) despite HTTPS now being
+/// the default — the documented fallback for local debugging or when a
+/// trusted TLS-terminating proxy already sits in front (see the
+/// `--http-insecure` doc comment on `requested_http_bind` in `src/main.rs`).
+#[test]
+fn http_insecure_flag_serves_plain_http() {
+    let port = pick_free_port();
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+
+    let mut child = Command::new(binary_path())
+        .arg("--http")
+        .arg("--http-insecure")
+        .arg("--http-port")
+        .arg(port.to_string())
+        .env("VELESDB_MEMORY_PATH", store_dir.path())
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn velesdb-memory --http --http-insecure");
+    let stderr_output = drain_stderr(&mut child);
+    let mut guard = ChildGuard(child);
+
+    let ready = wait_for_plain_http_health(port, Duration::from_secs(10));
+
+    // A plain (non-TLS) GET succeeding is the actual proof; the drained
+    // stderr (daemon startup banner, any bind error) is only for a useful
+    // failure message.
+    let stderr_output = stderr_output.lock().expect("stderr buffer lock").clone();
+
+    assert!(
+        ready.is_ok(),
+        "expected --http-insecure to serve plain HTTP reachable at /health: {ready:?}\nstderr:\n{stderr_output}"
+    );
+
+    // Explicit shutdown before the guard's Drop runs too, so a failure to
+    // terminate surfaces as part of THIS test rather than silently in a
+    // background drop.
+    guard.0.kill().expect("kill the insecure daemon");
+    guard
+        .0
+        .wait()
+        .expect("reap the insecure daemon after kill — no orphan process");
+}

--- a/crates/velesdb-memory/tests/http_lock_contention.rs
+++ b/crates/velesdb-memory/tests/http_lock_contention.rs
@@ -11,6 +11,13 @@
 //! proving `open_store_with_actionable_lock_error` runs identically ahead of
 //! either transport rather than being a stdio-only guard that regressed once
 //! HTTP was added.
+//!
+//! Both daemons pass `--http-insecure`: the store-lock contention this test
+//! proves is orthogonal to TLS (it fires before either daemon's transport,
+//! plain or TLS, ever starts accepting connections — see
+//! `open_store_with_actionable_lock_error` in `src/main.rs`, which runs
+//! ahead of `serve_http`), so there is no reason to also pay for generating
+//! TLS material twice here.
 
 use std::io::Read;
 use std::process::{Child, Command, Stdio};
@@ -28,6 +35,7 @@ const CONTENDER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 fn spawn_http_daemon(store_path: &std::path::Path) -> Child {
     Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
         .arg("--http")
+        .arg("--http-insecure")
         .arg("--http-port")
         .arg("0") // OS-assigned ephemeral port — this test only cares about
         // the STORE lock, never about a port collision between the two

--- a/crates/velesdb-memory/tests/http_tls.rs
+++ b/crates/velesdb-memory/tests/http_tls.rs
@@ -1,0 +1,231 @@
+//! RED/GREEN proof that the HTTP transport's HTTPS-by-default listener is
+//! real TLS termination, not a rubber-stamp: a client that does NOT trust
+//! the freshly-generated local CA must fail the handshake (RED — proves
+//! there's no `--insecure`-style bypass hiding underneath), and a client
+//! configured to trust exactly that CA must complete a full
+//! `remember`/`recall` MCP round trip over it (GREEN).
+//!
+//! Mirrors `tests/http_transport.rs`'s in-process pattern (bind
+//! `127.0.0.1:0`, build the router directly, no subprocess) but adds a real
+//! TLS accept loop (`velesdb_memory::http::serve_tls`) in front of it, fed
+//! by CA/leaf material freshly generated per test
+//! (`velesdb_memory::tls::ensure_tls_material`) into a scratch `TempDir` —
+//! a fresh, randomly-keyed CA can never coincidentally already be trusted by
+//! the machine running the test, so these tests are hermetic regardless of
+//! whatever `scripts/install-memory-daemon.sh` may have done to this
+//! machine's real login keychain in the past.
+
+use std::net::SocketAddr;
+
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
+use serde_json::{json, Map, Value};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use velesdb_memory::mcp::McpServer;
+use velesdb_memory::tls::TlsMaterial;
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+/// A running HTTPS transport for a test — the bound address, the accept
+/// loop's task (drive it to completion via [`shutdown`]), the token that
+/// stops it, and the two `TempDir`s (store + TLS material) kept alive for
+/// the test's duration.
+struct TlsTestServer {
+    addr: SocketAddr,
+    handle: JoinHandle<()>,
+    ct: CancellationToken,
+    ca_cert_path: std::path::PathBuf,
+    _store_dir: tempfile::TempDir,
+    _tls_dir: tempfile::TempDir,
+}
+
+async fn shutdown(server: TlsTestServer) {
+    server.ct.cancel();
+    server
+        .handle
+        .await
+        .expect("http TLS server task must not panic");
+}
+
+/// Spin up the HTTPS transport on `127.0.0.1:0` (OS-assigned port) backed by
+/// a fresh scratch store AND a fresh, freshly-generated local CA — see the
+/// module docs for why a fresh-per-test CA keeps these tests hermetic.
+async fn spawn_https_server() -> TlsTestServer {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let server = McpServer::new(service);
+
+    let tls_dir = tempfile::tempdir().expect("create scratch TLS material dir");
+    let material: TlsMaterial = velesdb_memory::tls::ensure_tls_material(tls_dir.path())
+        .expect("generate fresh CA + leaf certificate");
+    let ca_cert_path = material.ca_cert_path.clone();
+    let acceptor = velesdb_memory::tls::tls_acceptor_from_material(&material)
+        .expect("build TLS acceptor from freshly generated material");
+
+    let ct = CancellationToken::new();
+    let app = velesdb_memory::http::router(server, ct.child_token());
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("read bound local addr");
+
+    let serve_ct = ct.clone();
+    let handle = tokio::spawn(async move {
+        velesdb_memory::http::serve_tls(app, listener, acceptor, serve_ct).await;
+    });
+
+    TlsTestServer {
+        addr,
+        handle,
+        ct,
+        ca_cert_path,
+        _store_dir: store_dir,
+        _tls_dir: tls_dir,
+    }
+}
+
+/// A `reqwest::Client` that trusts only the ambient system/bundled roots —
+/// deliberately NOT told about the test's freshly-generated CA. This is the
+/// RED case's client: it must reject the server's certificate.
+fn client_trusting_nothing_extra() -> reqwest::Client {
+    reqwest::Client::builder()
+        .build()
+        .expect("build default reqwest client")
+}
+
+/// A `reqwest::Client` that additionally trusts `ca_cert_path`'s CA, on top
+/// of the ambient system/bundled roots — the GREEN case's client.
+fn client_trusting_ca(ca_cert_path: &std::path::Path) -> reqwest::Client {
+    let ca_pem = std::fs::read(ca_cert_path).expect("read generated CA certificate");
+    let ca_cert = reqwest::Certificate::from_pem(&ca_pem).expect("parse generated CA certificate");
+    reqwest::Client::builder()
+        .add_root_certificate(ca_cert)
+        .build()
+        .expect("build reqwest client trusting the generated CA")
+}
+
+/// Complete the MCP `initialize` handshake against `addr`'s `/mcp` endpoint
+/// over HTTPS using `client`, and return the connected client.
+async fn connect_https(
+    addr: SocketAddr,
+    client: reqwest::Client,
+) -> RunningService<RoleClient, ClientInfo> {
+    let transport = StreamableHttpClientTransport::with_client(
+        client,
+        StreamableHttpClientTransportConfig::with_uri(format!("https://{addr}/mcp")),
+    );
+    ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("MCP initialize handshake over HTTPS")
+}
+
+fn as_args(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        other => panic!("expected a JSON object, got {other:?}"),
+    }
+}
+
+async fn remember(client: &RunningService<RoleClient, ClientInfo>, fact: &str) -> String {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("remember").with_arguments(as_args(json!({ "fact": fact }))),
+        )
+        .await
+        .expect("remember call over HTTPS");
+    let structured = result
+        .structured_content
+        .expect("remember returns structured_content");
+    structured["id_str"]
+        .as_str()
+        .expect("id_str is a string")
+        .to_owned()
+}
+
+async fn recall_contains(
+    client: &RunningService<RoleClient, ClientInfo>,
+    query: &str,
+    needle: &str,
+) -> bool {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("recall").with_arguments(as_args(json!({
+                "query": query,
+                "limit": 50,
+            }))),
+        )
+        .await
+        .expect("recall call over HTTPS");
+    let structured = result
+        .structured_content
+        .expect("recall returns structured_content");
+    let memories = structured["memories"]
+        .as_array()
+        .expect("memories is an array");
+    memories
+        .iter()
+        .any(|memory| memory["content"].as_str() == Some(needle))
+}
+
+/// RED: a client that does not trust the freshly-generated local CA must
+/// fail to complete even a plain HTTPS GET against `/health` — proving the
+/// server is doing real certificate-chain validation-worthy TLS, not
+/// accepting any handshake.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_not_trusting_the_local_ca_is_rejected() {
+    let server = spawn_https_server().await;
+
+    let client = client_trusting_nothing_extra();
+    let result = client
+        .get(format!("https://{}/health", server.addr))
+        .send()
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a client that doesn't trust the freshly-generated CA must be rejected, got: {result:?}"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.is_connect() || err.is_request(),
+        "expected a TLS/connect-level failure (untrusted certificate), got: {err:?}"
+    );
+
+    shutdown(server).await;
+}
+
+/// GREEN: a client configured to trust exactly the generated CA completes
+/// the TLS handshake and a full MCP `remember`/`recall` round trip over it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn client_trusting_the_local_ca_completes_remember_recall_roundtrip() {
+    let server = spawn_https_server().await;
+
+    let client = client_trusting_ca(&server.ca_cert_path);
+    let health = client
+        .get(format!("https://{}/health", server.addr))
+        .send()
+        .await
+        .expect("HTTPS GET /health must succeed once the CA is trusted");
+    assert!(health.status().is_success());
+
+    let mcp_client = connect_https(server.addr, client).await;
+
+    let fact = "HTTPS transport with a locally-trusted CA lets remember/recall round-trip";
+    let id_str = remember(&mcp_client, fact).await;
+    assert!(!id_str.is_empty(), "remember must return a non-empty id");
+    assert!(
+        recall_contains(&mcp_client, "locally-trusted CA", fact).await,
+        "recall must surface the fact just remembered over HTTPS"
+    );
+
+    drop(mcp_client);
+    shutdown(server).await;
+}

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -9,6 +9,14 @@
 # `velesdb-memory` with the HTTP transport, runs ONE daemon (a macOS launchd
 # agent), and wires every supported client to it instead.
 #
+# The daemon serves HTTPS by default (a locally-generated CA + leaf
+# certificate — some clients, e.g. Claude Desktop's "Add custom connector"
+# UI, refuse any URL that isn't `https://`, even for 127.0.0.1). This script
+# additionally trusts that CA in your macOS login keychain so a strict HTTPS
+# client (a browser, `curl` without --cacert) connects with no warning — see
+# step 5's "Trusting the local CA" output for what that step actually did on
+# THIS run (macOS may require you to approve a system prompt).
+#
 # Usage:
 #   ./scripts/install-memory-daemon.sh [flags]
 #   ./scripts/install-memory-daemon.sh --uninstall
@@ -17,13 +25,16 @@
 #   --embedder=hash|ollama   Embedding backend (default: prompted, or 'hash' in CI/non-tty)
 #   --port=PORT              HTTP port (default: 18090)
 #   --store=PATH             Store directory (default: $HOME/.velesdb-memory)
+#   --tls-dir=PATH           TLS material (CA + leaf cert) directory (default: $HOME/.velesdb-memory-tls)
 #   --ollama-url=URL         Ollama endpoint (default: http://localhost:11434)
 #   --ollama-model=MODEL     Ollama embedding model (default: all-minilm)
 #   --ttl=SECONDS            Default TTL for new facts (default: prompted, empty = permanent)
 #   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
 #   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf
+#   --skip-ca-trust          Skip trusting the local CA in the login keychain
 #   --force-restart          Reload the daemon even if already running
-#   --uninstall              Remove the daemon and all client wiring (store is NEVER deleted)
+#   --uninstall              Remove the daemon and all client wiring (store and TLS material/CA
+#                            trust are NEVER touched — same "never delete local state" policy)
 #   -h, --help               Show this help
 # =============================================================================
 
@@ -51,6 +62,10 @@ require_jq() {
 EMBEDDER=""
 PORT="18090"
 STORE="$HOME/.velesdb-memory"
+# Sibling of the default store, matching velesdb_memory::tls::default_tls_dir
+# — deliberately NOT nested inside STORE (see that function's doc comment:
+# the store and the CA have independent lifecycles).
+TLS_DIR="$HOME/.velesdb-memory-tls"
 OLLAMA_URL="http://localhost:11434"
 OLLAMA_MODEL="all-minilm"
 TTL=""
@@ -59,6 +74,7 @@ ASSUME_YES=0
 FORCE_RESTART=0
 UNINSTALL=0
 SKIP_CLIENTS=""
+SKIP_CA_TRUST=0
 
 PLIST_LABEL="com.velesdb.memory"
 PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
@@ -67,7 +83,7 @@ DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.j
 WINDSURF_CONFIG="$HOME/.codeium/windsurf/mcp_config.json"
 
 print_usage() {
-  sed -n '2,27p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -76,11 +92,13 @@ for arg in "$@"; do
     --embedder=*) EMBEDDER="${arg#*=}" ;;
     --port=*) PORT="${arg#*=}" ;;
     --store=*) STORE="${arg#*=}" ;;
+    --tls-dir=*) TLS_DIR="${arg#*=}" ;;
     --ollama-url=*) OLLAMA_URL="${arg#*=}" ;;
     --ollama-model=*) OLLAMA_MODEL="${arg#*=}" ;;
     --ttl=*) TTL="${arg#*=}"; TTL_SET=1 ;;
     --yes) ASSUME_YES=1 ;;
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
+    --skip-ca-trust) SKIP_CA_TRUST=1 ;;
     --force-restart) FORCE_RESTART=1 ;;
     --uninstall) UNINSTALL=1 ;;
     -h|--help) print_usage; exit 0 ;;
@@ -298,6 +316,7 @@ setup_daemon() {
   <key>EnvironmentVariables</key>
   <dict>
     <key>VELESDB_MEMORY_PATH</key><string>$STORE</string>
+    <key>VELESDB_MEMORY_TLS_DIR</key><string>$TLS_DIR</string>
     <key>VELESDB_MEMORY_EMBEDDER</key><string>$EMBEDDER</string>
     <key>VELESDB_MEMORY_OLLAMA_URL</key><string>$OLLAMA_URL</string>
     <key>VELESDB_MEMORY_OLLAMA_MODEL</key><string>$OLLAMA_MODEL</string>
@@ -337,9 +356,15 @@ PLIST
   fi
   launchctl enable "gui/$uid/$PLIST_LABEL"
 
+  # The daemon serves HTTPS by default and generates its CA + leaf cert on
+  # first start (see velesdb_memory::tls) — this internal health check uses
+  # --cacert to trust exactly THAT CA rather than the system trust store, so
+  # it succeeds immediately regardless of whether (or how quickly) the
+  # keychain-trust step below completes.
+  local ca_cert="$TLS_DIR/ca-cert.pem"
   echo -e "${YELLOW}⏳ Waiting for the daemon to answer /health...${NC}"
   local waited=0
-  while ! curl -fsS --max-time 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
+  while ! curl -fsS --max-time 1 --cacert "$ca_cert" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; do
     waited=$((waited + 1))
     if [ "$waited" -ge 5 ]; then
       echo -e "${YELLOW}⚠️  No response from /health within 5s — check $HOME/Library/Logs/velesdb-memory/daemon.err.log${NC}"
@@ -347,6 +372,87 @@ PLIST
     fi
     sleep 1
   done
+
+  trust_local_ca "$ca_cert"
+}
+
+# Run "$@" with a hard wall-clock timeout of $1 seconds, killing it (and
+# reaping it, so it never lingers as an orphan) if it's still running past
+# the deadline. macOS ships no `timeout(1)`/`gtimeout` by default, so this is
+# a portable bash implementation — used below because `security
+# add-trusted-cert` can block indefinitely on a system authorization prompt
+# (see trust_local_ca), and this script must never hang forever waiting on
+# it.
+run_with_timeout() {
+  local secs="$1"
+  shift
+  "$@" &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$secs" ]; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
+# ---- 5b. Trust the local CA in the macOS login keychain --------------------
+# `security add-trusted-cert` (no `-d`, so it targets the USER trust-settings
+# domain, not the admin one — no sudo needed) does two things: (1) import the
+# certificate item into the keychain (fast, no prompt), and (2) write a Trust
+# Settings record marking it as a trusted root for SSL (this is the part that
+# actually makes a strict TLS client accept it). Empirically, step (2) can
+# block on a macOS system authorization prompt (Touch ID / password) that
+# only an interactive login session can answer — there is no way to detect
+# in advance whether THIS run will show one, so this is wrapped in
+# `run_with_timeout` and, on timeout or failure, falls back to printing the
+# exact command to run by hand instead of leaving the terminal stuck.
+trust_local_ca() {
+  local ca_cert="$1"
+
+  if [ "$SKIP_CA_TRUST" = "1" ]; then
+    echo -e "${YELLOW}⏭  Skipping CA trust (--skip-ca-trust).${NC}"
+    return 0
+  fi
+  if [ "$DAEMON_SUPPORTED" != "1" ]; then
+    return 0
+  fi
+  if ! command -v security >/dev/null 2>&1; then
+    echo -e "${YELLOW}⚠️  'security' CLI not found — skipping automatic CA trust.${NC}"
+    return 0
+  fi
+  if [ ! -f "$ca_cert" ]; then
+    echo -e "${YELLOW}⚠️  No CA certificate at $ca_cert (daemon may not have started — see the /health warning above) — skipping CA trust.${NC}"
+    return 0
+  fi
+
+  local keychain
+  keychain="$(security default-keychain -d user 2>/dev/null | tr -d '[:space:]"')"
+  if [ -z "$keychain" ]; then
+    keychain="$HOME/Library/Keychains/login.keychain-db"
+  fi
+  local trust_cmd=(security add-trusted-cert -r trustRoot -p ssl -k "$keychain" "$ca_cert")
+
+  echo ""
+  echo -e "${BLUE}🔐 Trusting the local CA in your login keychain (${ca_cert})...${NC}"
+  echo -e "${YELLOW}   macOS may show a system prompt asking you to approve this (Touch ID / password) —${NC}"
+  echo -e "${YELLOW}   approve it within 60s. Without this, HTTPS clients that verify certificates strictly${NC}"
+  echo -e "${YELLOW}   (browsers, plain \`curl\`) will reject this daemon's certificate until you trust it,${NC}"
+  echo -e "${YELLOW}   here or by hand later.${NC}"
+
+  if run_with_timeout 60 "${trust_cmd[@]}"; then
+    echo -e "${GREEN}✅ Local CA trusted in your login keychain.${NC}"
+  else
+    echo -e "${YELLOW}⚠️  Could not confirm the CA trust automatically (no response to the system prompt within${NC}"
+    echo -e "${YELLOW}   60s, or the command failed). The daemon is still up and serving HTTPS — this only${NC}"
+    echo -e "${YELLOW}   affects clients that verify certificates strictly. Run this yourself to finish:${NC}"
+    echo "     ${trust_cmd[*]}"
+  fi
 }
 
 # ---- 6. Client wiring -------------------------------------------------
@@ -361,9 +467,12 @@ wire_claude_code() {
   fi
 
   claude mcp remove velesdb-memory -s user >/dev/null 2>&1 || true
-  if claude mcp add --transport http --scope user velesdb-memory "http://127.0.0.1:$PORT/mcp" >/dev/null; then
-    echo -e "${GREEN}✅ Claude Code wired (user scope) → http://127.0.0.1:$PORT/mcp${NC}"
+  if claude mcp add --transport http --scope user velesdb-memory "https://127.0.0.1:$PORT/mcp" >/dev/null; then
+    echo -e "${GREEN}✅ Claude Code wired (user scope) → https://127.0.0.1:$PORT/mcp${NC}"
     echo -e "${YELLOW}   Note: project/local-scope entries (if any) are not touched — check with \`claude mcp list\`.${NC}"
+    echo -e "${YELLOW}   Note: Node-based tools don't always consult the macOS keychain for TLS trust. If Claude${NC}"
+    echo -e "${YELLOW}   Code reports a certificate error despite the CA trust step above, set:${NC}"
+    echo -e "${YELLOW}     export NODE_EXTRA_CA_CERTS=\"$TLS_DIR/ca-cert.pem\"${NC}"
   else
     echo -e "${RED}❌ Failed to wire Claude Code.${NC}"
   fi
@@ -415,7 +524,7 @@ wire_json_client() {
 
 wire_claude_desktop() {
   wire_json_client "claude-desktop" "$DESKTOP_CONFIG" \
-    '.mcpServers["velesdb-memory"] = {"type":"http","url":"http://127.0.0.1:'"$PORT"'/mcp"}' \
+    '.mcpServers["velesdb-memory"] = {"type":"http","url":"https://127.0.0.1:'"$PORT"'/mcp"}' \
     1
   if ! should_skip "claude-desktop"; then
     echo -e "${YELLOW}⚠️  HTTP support is not confirmed for Claude Desktop. If it fails to connect after a restart, use this stdio fallback instead:${NC}"
@@ -432,7 +541,7 @@ EOF
 
 wire_windsurf() {
   wire_json_client "windsurf" "$WINDSURF_CONFIG" \
-    '.mcpServers["velesdb-memory"] = {"serverUrl":"http://127.0.0.1:'"$PORT"'/mcp"}' \
+    '.mcpServers["velesdb-memory"] = {"serverUrl":"https://127.0.0.1:'"$PORT"'/mcp"}' \
     0
 }
 
@@ -458,7 +567,10 @@ do_uninstall() {
     done
   fi
 
-  echo -e "${GREEN}✅ Uninstalled. The store ($STORE by default) was left untouched.${NC}"
+  echo -e "${GREEN}✅ Uninstalled. The store ($STORE by default) and the TLS material/CA ($TLS_DIR by default)${NC}"
+  echo -e "${GREEN}   were both left untouched — same policy as the store: nothing local is ever deleted by${NC}"
+  echo -e "${GREEN}   an uninstall. This also means the keychain trust you approved earlier stays valid, so a${NC}"
+  echo -e "${GREEN}   future reinstall needs no new trust prompt. Remove either by hand if you want them gone.${NC}"
 }
 
 # ---- 8. Summary -------------------------------------------------------
@@ -470,13 +582,14 @@ print_summary() {
   echo "  Embedder:  $EMBEDDER"
   echo "  Port:      $PORT"
   echo "  Store:     $STORE"
+  echo "  TLS CA:    $TLS_DIR/ca-cert.pem"
   echo "  TTL:       ${TTL:-permanent (no expiry)}"
   if [ "$DAEMON_SUPPORTED" = "1" ]; then
-    if curl -fsS --max-time 1 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    if curl -fsS --max-time 1 --cacert "$TLS_DIR/ca-cert.pem" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
       if [ "$DAEMON_ALREADY_RUNNING" = "1" ]; then
-        echo -e "  Daemon:    ${GREEN}running${NC} → http://127.0.0.1:$PORT/mcp (already loaded, not restarted)"
+        echo -e "  Daemon:    ${GREEN}running${NC} → https://127.0.0.1:$PORT/mcp (already loaded, not restarted)"
       else
-        echo -e "  Daemon:    ${GREEN}running${NC} → http://127.0.0.1:$PORT/mcp"
+        echo -e "  Daemon:    ${GREEN}running${NC} → https://127.0.0.1:$PORT/mcp"
       fi
     else
       echo -e "  Daemon:    ${YELLOW}not confirmed up${NC} — check $HOME/Library/Logs/velesdb-memory/daemon.err.log"


### PR DESCRIPTION
## Summary

`velesdb-memory`'s streamable-HTTP transport (`--http` / `VELESDB_MEMORY_HTTP=1`) ran in plain HTTP. Wiring it into Claude Desktop's "Add custom connector" UI surfaced that Desktop refuses any URL that isn't `https://`, even for `127.0.0.1` — so plain HTTP is no longer viable as the default.

- **Native local CA + leaf cert (`crates/velesdb-memory/src/tls.rs`)**: a self-signed root CA is generated once via `rcgen` (no shelled-out `mkcert`/`openssl`) and cached at `$VELESDB_MEMORY_TLS_DIR` (default `~/.velesdb-memory-tls`, a sibling of the store — independent lifecycle from `~/.velesdb-memory`). **The CA is never regenerated once it exists on disk** — trusting it is a one-time action. It signs short-lived (30-day) `localhost`/`127.0.0.1`/`::1` leaf certificates that are silently re-issued (re-signed by the same CA, no new trust needed) on every daemon start. Private key files are written `0600`, their directory `0700`.
- **TLS termination (`src/http.rs::serve_tls`, wired from `src/main.rs`)**: `tokio_rustls::TlsAcceptor` + `hyper`'s auto h1/h2 connection builder, terminating each accepted connection and driving the existing axum `Router` via `tower::ServiceExt::oneshot` — the same pattern `velesdb-server`'s `src/tls.rs`/accept loop already uses, reused here instead of adding `axum-server` as a second, independent TLS dependency. The `ServerConfig` is built with an *explicit* `ring` `CryptoProvider` (`ServerConfig::builder_with_provider`) rather than the process-wide default, since the `reqwest` dev-dependency links a different backend (`aws-lc-rs`) into the same test binaries — see `tls.rs`'s module docs for the full rationale.
- **`--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1`**: explicit opt-out back to plain HTTP (loud startup warning), for local debugging or when a trusted TLS-terminating proxy already sits in front — same "insecure escape hatch" shape used elsewhere in the codebase.
- **Installer (`scripts/install-memory-daemon.sh`)**: adds the CA to the macOS **login** keychain (`security add-trusted-cert -r trustRoot -p ssl`, no `sudo`/system store) as a trusted SSL root; new `--tls-dir` and `--skip-ca-trust` flags. The daemon's own internal `/health` readiness check uses `--cacert` against the generated CA directly, so it never depends on the keychain step's outcome.
- **README** ("HTTP transport (multi-client)" section) documents HTTPS-by-default, the CA/keychain story, the `--http-insecure` fallback, and a `NODE_EXTRA_CA_CERTS` note for Node-based clients that don't consult the OS keychain.

## Empirical proof (see report for full transcript)

- RED: a strict `curl` (no `--cacert`, no `-k`) against a freshly-generated CA/leaf fails with `SSL certificate problem: unable to get local issuer certificate` (exit 60).
- GREEN: the same request with `--cacert <generated CA>` succeeds; `tests/http_tls.rs` proves the same thing at the Rust level end-to-end, including a full `remember`/`recall` MCP round trip over HTTPS.
- Keychain trust (`security add-trusted-cert`): the certificate *item* import into the login keychain is fast and non-interactive, but the *trust-settings* write blocked indefinitely on a macOS system authorization prompt in this environment — genuinely interactive, not a bug in the command. The installer wraps this step in a hard 60s timeout and prints the exact manual fallback command either way, documented in the README and the script's own output.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p velesdb-memory --all-targets --features http,ollama -- -D warnings`
- [x] `cargo test -p velesdb-memory --features http` (all suites, including new `http_tls` RED/GREEN and `http_insecure_process`)
- [x] `python3 scripts/check_prod_unwraps.py` clean for `crates/velesdb-memory/src`
- [x] Empirical keychain trust attempt on macOS (see above)
- [ ] Full installer script run against a real macOS session (not run here — would modify the reviewer's live launchd/keychain/client configs; left for manual verification)