### PR TITLE
chore(release): bump velesdb-memory/velesdb-node to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "axum",
  "criterion",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Targets **0.11.0** (minor, not patch) on next release: the metadata shape
-`remember`/`recall` return changes observably for every consumer (MCP,
-Python, Node, WASM) — see "Changed" below.
+## [0.11.0] — 2026-07-23
+
+Minor, not patch: the metadata shape `remember`/`recall` return changes
+observably for every consumer (MCP, Python, Node, WASM) — see "Changed"
+below.
 
 ### Added
 

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,23 +17,28 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
-> **Release 0.10.1** — patch over the V2 wave: the `compile_context`
-> prompt-cache prefix is now query-independent (issue #1455), so a new
-> question no longer churns the cached prefix. 0.10.0 brought: `compile_transcript` (one call
-> turns a raw agent-session transcript into deterministically segmented,
-> budget-compiled context with a full segmentation audit report),
-> path-referenced fragments (opt-in, allowlisted via
-> `VELESDB_MEMORY_INGEST_ROOTS`, symlink-safe), binding parity for the
-> compiler's read tools (`explainCompilation`/`contextSavings` on Node,
-> `explain_compilation` on Python, `retrieveContextSource` on WASM/TS), and
-> a `--version` flag; published to the registries by the
-> `velesdb-memory-v0.10.1`
+> **Release 0.11.0** — multi-client memory: a single local `velesdb-memory
+> --http` daemon (see "HTTP transport (multi-client)" below) now lets Claude
+> Code, Claude Desktop, and Windsurf share the *same* memory instead of one
+> client at a time, and serves **HTTPS by default** with a natively-generated
+> local CA (no external `mkcert`/proxy) — some MCP clients refuse a
+> non-`https://` URL even for `127.0.0.1`. `scripts/install-memory-daemon.sh`
+> automates the whole setup, including trusting the CA. Every `remember` now
+> auto-stamps a `_veles_date` field (`YYYYMMDD`, never overwritten if you set
+> it yourself), so `recall_fused`'s `date_field` works with zero setup — this
+> is the metadata-shape change that makes this a **minor**, not patch,
+> release (a fact stored with no caller metadata no longer round-trips as
+> `metadata: None`). Also fixes two independent deadlocks under concurrent
+> `remember`/`recall` load found while building the daemon (rayon pool
+> exhaustion + a lock-ordering inversion) — real risk for any consumer, not
+> just the new HTTP transport, since both bugs lived in the shared storage
+> layer. Published to the registries by the `velesdb-memory-v0.11.0`
 > tag, so the links below may briefly lag right after merge. `velesdb-memory`
 > ships on [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.10.1**
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.11.0**
 > and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**
 > (memory API only — the context compiler is merged on `develop` but **the
 > published 3.12.0 wheel predates it**; it ships with the next PyPI release,

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.10.1"
+version = "0.11.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release mineure (pas patch — changement de forme observable de `metadata`, voir CHANGELOG) pour la vague de ce soir : daemon HTTP multi-client avec HTTPS par défaut, horodatage automatique `_veles_date`, et deux fix de deadlock indépendants dans la couche de stockage partagée.

Bump : `crates/velesdb-memory/Cargo.toml`, `crates/velesdb-node/Cargo.toml`, `package.json`, `package-lock.json` (racine + `packages[""]`), `server.json` (racine + entrée cargo registry), `Cargo.lock` (via `cargo check`, pas de mise à jour globale), bannière README, stamp CHANGELOG.

Vérifié : `scripts/check-version-sync.py` — toutes les versions correspondent. `cargo test -p velesdb-memory --features http --lib` — 361/361 verts.

Une fois mergée, je tague `velesdb-memory-v0.11.0` sur le commit résultant pour déclencher la publication (crates.io, npm, bundles `.mcpb` + registre MCP).
