### PR TITLE
feat(memory): wire Devin CLI in the installer, stop writing a dead Claude Desktop entry

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `scripts/install-memory-daemon.sh` now wires **Devin CLI**
+  (`~/.config/devin/config.json`) alongside Claude Code, Claude Desktop and
+  Windsurf; documented in the README's stdio and HTTP-transport client
+  sections.
+
+### Fixed
+
+- The installer no longer writes a `type:"http"` entry into
+  `claude_desktop_config.json` — confirmed Desktop's config file never reads
+  that shape (silently ignored). It now prints the Settings → Connectors →
+  Add custom connector instructions instead, matching what the README already
+  documented.
+
 ## [0.11.0] — 2026-07-23
 
 Minor, not patch: the metadata shape `remember`/`recall` return changes

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -302,8 +302,13 @@ claude mcp add velesdb-memory \
 That's it — jump straight to [teach your agent the flow](#teach-your-agent-the-flow-skill)
 below. Using a different client instead? Expand for its config:
 
+> **macOS, and want several clients sharing one memory?** Skip everything
+> below and run `./scripts/install-memory-daemon.sh` instead — it builds,
+> runs, and wires Claude Code / Claude Desktop / Windsurf / Devin CLI to a
+> single shared daemon in one command (see "HTTP transport" further down).
+
 <details>
-<summary><strong>Cursor, Cline, Zed, Codex CLI, opencode, Claude Desktop, Windsurf</strong></summary>
+<summary><strong>Cursor, Cline, Zed, Codex CLI, opencode, Claude Desktop, Windsurf, Devin CLI</strong></summary>
 
 **Cursor** — `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (per project)
 
@@ -366,6 +371,16 @@ env = { VELESDB_MEMORY_PATH = "/home/you/.velesdb-memory" }
 
 ```json
 { "mcpServers": { "velesdb-memory": {
+  "command": "/home/you/.cargo/bin/velesdb-memory",
+  "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
+} } }
+```
+
+**Devin CLI** — `~/.config/devin/config.json` (its `mcpServers` block sits
+inside a top-level `{"version": 1, ...}` envelope, unlike the clients above)
+
+```json
+{ "version": 1, "mcpServers": { "velesdb-memory": {
   "command": "/home/you/.cargo/bin/velesdb-memory",
   "env": { "VELESDB_MEMORY_PATH": "/home/you/.velesdb-memory" }
 } } }
@@ -581,11 +596,20 @@ This gives Desktop its own separate memory, not shared with the daemon.
 } } }
 ```
 
+**Devin CLI** — `~/.config/devin/config.json`
+
+```json
+{ "version": 1, "mcpServers": { "velesdb-memory": {
+  "url": "https://127.0.0.1:18090/mcp",
+  "transport": "http"
+} } }
+```
+
 `scripts/install-memory-daemon.sh` automates all of this end to end: building
 with the right features, running the daemon (as a macOS `launchd` agent),
 trusting the local CA in your login keychain, and wiring Claude Code / Claude
-Desktop / Windsurf — see `--help` for flags (`--embedder`, `--port`,
-`--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
+Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
+`--port`, `--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
 `--uninstall`, …).
 
 ## Teach your agent the flow (skill)

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -30,7 +30,7 @@
 #   --ollama-model=MODEL     Ollama embedding model (default: all-minilm)
 #   --ttl=SECONDS            Default TTL for new facts (default: prompted, empty = permanent)
 #   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
-#   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf
+#   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   --skip-ca-trust          Skip trusting the local CA in the login keychain
 #   --force-restart          Reload the daemon even if already running
 #   --uninstall              Remove the daemon and all client wiring (store and TLS material/CA
@@ -81,6 +81,7 @@ PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
 BIN_PATH="$HOME/.cargo/bin/velesdb-memory"
 DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 WINDSURF_CONFIG="$HOME/.codeium/windsurf/mcp_config.json"
+DEVIN_CONFIG="$HOME/.config/devin/config.json"
 
 print_usage() {
   sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
@@ -538,27 +539,43 @@ wire_json_client() {
   fi
 }
 
+# Claude Desktop is a DIFFERENT mechanism than every other client here:
+# claude_desktop_config.json (the file every other JSON client uses) never
+# reads a url/type:"http" entry — confirmed it does not even try to connect —
+# so writing one there (as this script used to) silently does nothing. The
+# only way to wire Desktop to the daemon is its own UI. This function prints
+# that instruction instead of touching the config file.
 wire_claude_desktop() {
-  wire_json_client "claude-desktop" "$DESKTOP_CONFIG" \
-    '.mcpServers["velesdb-memory"] = {"type":"http","url":"https://127.0.0.1:'"$PORT"'/mcp"}' \
-    1
-  if ! should_skip "claude-desktop"; then
-    echo -e "${YELLOW}⚠️  HTTP support is not confirmed for Claude Desktop. If it fails to connect after a restart, use this stdio fallback instead:${NC}"
-    cat <<EOF
-{ "mcpServers": { "velesdb-memory": {
-  "command": "$BIN_PATH",
-  "env": { "VELESDB_MEMORY_PATH": "<a-DIFFERENT-directory-than-$STORE>" }
-} } }
-EOF
-    echo -e "${YELLOW}   Use a DIFFERENT VELESDB_MEMORY_PATH than the daemon's store — pointed at the same one, the${NC}"
-    echo -e "${YELLOW}   fallback process and the daemon would fight over the same flock (DatabaseLocked).${NC}"
+  if should_skip "claude-desktop"; then
+    echo -e "${YELLOW}⏭  Skipping Claude Desktop (--skip-client).${NC}"
+    return 0
   fi
+  echo ""
+  echo -e "${BLUE}🖥  Claude Desktop — different mechanism than every other client here:${NC}"
+  echo -e "${YELLOW}   its config file does not support HTTP (a url/type:\"http\" entry there is silently${NC}"
+  echo -e "${YELLOW}   ignored). Add it yourself, once, via the UI instead:${NC}"
+  echo -e "${YELLOW}   Settings → Connectors → Add custom connector, then paste:${NC}"
+  echo "     https://127.0.0.1:$PORT/mcp"
+  echo -e "${YELLOW}   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.${NC}"
+  echo -e "${YELLOW}   Prefer not to use the Connectors UI? A stdio fallback still works — see the README's${NC}"
+  echo -e "${YELLOW}   \"Configure your client\" section (use a DIFFERENT VELESDB_MEMORY_PATH than $STORE,${NC}"
+  echo -e "${YELLOW}   or the fallback process and the daemon will fight over the same flock).${NC}"
 }
 
 wire_windsurf() {
   wire_json_client "windsurf" "$WINDSURF_CONFIG" \
     '.mcpServers["velesdb-memory"] = {"serverUrl":"https://127.0.0.1:'"$PORT"'/mcp"}' \
     0
+}
+
+# Devin CLI's config wraps mcpServers in a top-level {"version": 1, ...}
+# envelope (unlike every other client here) — `.version //= 1` sets it only
+# if absent, so a re-run never clobbers a newer schema version Devin itself
+# might have written.
+wire_devin() {
+  wire_json_client "devin" "$DEVIN_CONFIG" \
+    '.version //= 1 | .mcpServers["velesdb-memory"] = {"url":"https://127.0.0.1:'"$PORT"'/mcp","transport":"http"}' \
+    1
 }
 
 # ---- 7. Uninstall -----------------------------------------------------
@@ -574,7 +591,7 @@ do_uninstall() {
   fi
 
   if command -v jq >/dev/null 2>&1; then
-    for cfg in "$DESKTOP_CONFIG" "$WINDSURF_CONFIG"; do
+    for cfg in "$DESKTOP_CONFIG" "$WINDSURF_CONFIG" "$DEVIN_CONFIG"; do
       if [ -f "$cfg" ] && jq -e . "$cfg" >/dev/null 2>&1; then
         local tmp
         tmp="$(mktemp)"
@@ -613,7 +630,7 @@ print_summary() {
   else
     echo -e "  Daemon:    ${YELLOW}not started (non-macOS)${NC}"
   fi
-  for client in claude-code claude-desktop windsurf; do
+  for client in claude-code claude-desktop windsurf devin; do
     if should_skip "$client"; then
       echo "  $client: skipped (--skip-client)"
     else
@@ -639,6 +656,7 @@ main() {
   wire_claude_code
   wire_claude_desktop
   wire_windsurf
+  wire_devin
   print_summary
 }
 


### PR DESCRIPTION
## Summary
- `scripts/install-memory-daemon.sh` now wires **Devin CLI** (`~/.config/devin/config.json`, `{"version":1,"mcpServers":{...}}` envelope) alongside Claude Code / Claude Desktop / Windsurf.
- The installer no longer writes `{"type":"http","url":...}` into `claude_desktop_config.json` — confirmed Desktop's config file never reads that shape (silently ignored). It now prints the Settings → Connectors → Add custom connector instructions instead, matching what the README already documented.
- README: added Devin CLI to both the stdio and HTTP-transport client sections, and pointed the top of "Configure your client" at the installer for macOS users who'd otherwise stop at the manual stdio config and miss it.

## Why now
Found tonight while debugging a real Devin CLI → daemon connection failure: no doc/installer coverage for Devin, and independently, the Claude Desktop wiring turned out to be a no-op that's been silently doing nothing.

## Test plan
- [x] `bash -n scripts/install-memory-daemon.sh`
- [x] Verified the new Devin `jq` filter directly: produces correct output against an empty config, and is non-destructive against a config with pre-existing unrelated `mcpServers` entries.