### PR TITLE
docs: post-0.11.0 freshness wave — align every stale claim with shipped code

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/vele
 
 Want the memory used *continuously*, not just available? [`integrations/agent-hooks/`](integrations/agent-hooks/README.md) wires `SessionStart`/`Stop`/`PreCompact` hooks that resume and save the working context automatically — one global install covers every project. No Rust toolchain? `npm i @wiscale/velesdb-memory-node`.
 
-Want Claude Code, Claude Desktop, and Windsurf sharing the *same* memory instead of one client at a time? [`scripts/install-memory-daemon.sh`](crates/velesdb-memory/README.md#http-transport-multi-client) runs `velesdb-memory` as a single local HTTP daemon and wires every client to it.
+Want Claude Code, Claude Desktop, Windsurf, and Devin CLI sharing the *same* memory instead of one client at a time? [`scripts/install-memory-daemon.sh`](crates/velesdb-memory/README.md#http-transport-multi-client) runs `velesdb-memory` as a single local daemon — HTTPS by default, with a natively generated local CA — and wires every client to it.
 
 <details>
 <summary><strong>Other install paths — Rust, Docker, WASM, REST server</strong></summary>
@@ -211,7 +211,7 @@ mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason �
 
 ![recall() finds the booking but misses the reason; why() reaches it through typed links, across a session restart](examples/agent_memory/why_across_sessions.gif)
 
-Memories are permanent by default; `forget(id)` deletes one, `ttl_seconds` gives a fact a durable expiry. Same wedge in **Python**, **Node** (`@wiscale/velesdb-memory-node`), as a local **[MCP server](crates/velesdb-memory)**, and in-memory in the **[TypeScript SDK](sdks/typescript)** (browser, no server).
+Memories are permanent by default; `forget(id)` deletes one, `ttl_seconds` gives a fact a durable expiry. Every `remember` auto-stamps the day it was stored (`_veles_date`, a `YYYYMMDD` integer — never overwritten if you set it yourself), so dated, recency-weighted recall (`recall_fused`) works with zero setup. Same wedge in **Python**, **Node** (`@wiscale/velesdb-memory-node`), as a local **[MCP server](crates/velesdb-memory)**, and in-memory in the **[TypeScript SDK](sdks/typescript)** (browser, no server).
 
 <details>
 <summary><strong>Proof it's not a weak-embedder trick — 4 runnable demos + benchmark position</strong></summary>

--- a/crates/tauri-plugin-velesdb/CHANGELOG.md
+++ b/crates/tauri-plugin-velesdb/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> **Versioning note (2026-07-23)** — the crate and its guest-js package now
+> track the VelesDB workspace version (3.12.0, `version.workspace = true`);
+> the `[1.11.1]` heading below is the last release under the plugin's old
+> independent versioning scheme. Changes since then are tracked under
+> Unreleased until the next tagged workspace release.
+
 ### Refactored
 - **Types consolidation** — `SearchResult` is now `pub type SearchResult = velesdb_core::api_types::SearchResultResponse`
   (type alias). Default value functions (`default_metric`, `default_top_k`, etc.) re-exported from core.

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -18,7 +18,7 @@ A Tauri plugin for **VelesDB** — Vector search in desktop applications.
 - **Secondary Indexes** — Create/drop metadata indexes for faster filtered search
 - **Knowledge Graph** — Add edges, traverse (BFS/DFS), multi-source parallel BFS, node degrees
 - **VelesQL** — SQL-like query language for advanced searches
-- **Agent Memory** — Semantic memory store and query for AI agents
+- **Agent Memory** — Semantic, episodic, and procedural memory for AI agents (record/recall/learn + snapshots)
 - **Streaming Insert** — High-throughput bulk insert with persistence
 - **Quantization** — PQ training for memory-efficient storage
 - **Event System** — Real-time notifications for data changes

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -53,7 +53,9 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
      yourself.** Every `remember`/`remember_extracted` call auto-stamps
      `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
      it, so `recall_fused(date_field="_veles_date")` gives you a chronological
-     `dated_context` timeline (plus a `now` anchor) with zero setup on your part.
+     `dated_context` timeline (plus a `now` anchor) with zero setup on your part
+     (Node binding: the dated variant is its own method,
+     `recallFusedDated(query, k, filter, opts, "_veles_date")`).
      Set `_veles_date` explicitly only to override the default — e.g. to date a
      fact by when an incident actually happened, not when you recorded it; once
      set, the server never overwrites it. Store any OTHER comparable value

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -420,7 +420,7 @@ options:
 ## 🔧 CLI Reference
 
 ```
-velesdb-migrate 3.8.0
+velesdb-migrate 3.12.0
 Migrate vectors from other databases to VelesDB
 
 USAGE:

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -1,6 +1,6 @@
 # VelesDB Mobile
 
-_Last updated: 2026-06-14._
+_Last updated: 2026-07-23._
 
 Native bindings for **iOS** (Swift) and **Android** (Kotlin) via [UniFFI](https://mozilla.github.io/uniffi-rs/).
 
@@ -150,19 +150,25 @@ cargo run -p velesdb-mobile --bin uniffi-bindgen -- generate \
 | Method | Description |
 |--------|-------------|
 | `VelesDatabase.open(path)` | Opens or creates a database at the specified path (named constructor — use `.open(...)`) |
+| `VelesDatabase.openWithObserver(path, observer)` | Opens with a read-path `MobileObserver` attached — your Swift/Kotlin callback can audit **and deny** reads (`MobileAccessDecision`) |
+| `updateGuardrails(limits)` | Live-updates query guardrail limits (`MobileQueryLimits`) |
 | `createCollection(name, dimension, metric)` | Creates a new vector collection |
 | `createCollectionWithStorage(name, dimension, metric, storageMode)` | Creates collection with quantized storage |
 | `createMetadataCollection(name)` | Creates a metadata-only collection (no vectors) |
+| `createGraphCollection(name)` | Creates a graph collection (schemaless) |
+| `createGraphCollectionWithEmbeddings(name, dimension, metric)` | Creates a graph collection whose nodes carry embeddings |
 | `getCollection(name)` | Gets a collection by name (returns nil/null if not found) |
 | `listCollections()` | Lists all collection names |
 | `deleteCollection(name)` | Deletes a collection |
 | `trainPq(collectionName, config)` | Trains Product Quantization on a collection |
+| `executeQuery(query, params)` | Full VelesQL pass-through (SELECT/NEAR/MATCH incl. cross-collection `@collection`, aggregates) |
 
 ### VelesCollection
 
 | Method | Description |
 |--------|-------------|
 | `search(vector, limit)` | Finds k nearest neighbors |
+| `searchWithQuality(vector, limit, quality)` | Search with a `SearchQuality` preset (`Fast`/`Balanced`/`Accurate`/`Perfect`/`Custom`/`Adaptive`) |
 | `searchWithFilter(vector, limit, filterJson)` | Search with metadata filter |
 | `multiQuerySearch(vectors, limit, strategy)` | Multi-query fusion (MQG) |
 | `multiQuerySearchWithFilter(vectors, limit, strategy, filterJson)` | Multi-query fusion with metadata filter |

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -5,8 +5,10 @@ Node.js addon (napi-rs).** Same hardened Rust as the MCP server and the Python
 binding; no network service. Under the hood it fuses vector + graph + columnar,
 which is *how* it remembers, connects, and explains.
 
-`remember` / `recall` / `recallWhere` / `relate` / `forget` / `why` /
-`rememberExtracted` / `compileContext`. The differentiator is **`why()`**: it
+`remember` / `recall` / `recallWhere` / `recallFused` / `recallFusedDated` /
+`relate` / `forget` / `why` / `feedback` / `rememberExtracted` /
+`compileContext` / `contextSavings` / `explainCompilation` /
+`retrieveContextSource` / working contexts. The differentiator is **`why()`**: it
 answers a question with the best-matching memory *plus its connected subgraph*
 — related facts a plain vector recall is blind to. `compileContext` applies
 the same explainability to your token bill: deterministic context compression
@@ -110,12 +112,11 @@ binding-wide differences: id fields (`fragment_id`, `content_hash`,
 strings, and the *top-level* result keys follow the binding's camelCase
 (`out.retrievalHandles` — nested trees keep the wire's snake_case). `tokens_saved` is a local estimate, not billed tokens. The bundled
 [`velesdb-context-optimizer` skill](./skills/velesdb-context-optimizer/SKILL.md)
-teaches an agent the full workflow, including when *not* to compress —
-written against the MCP server's full tool set, so its `explain_compilation`
-and `context_savings` steps assume an MCP-connected agent: this Node binding
-does not expose those two methods itself (only `compileContext`,
-`retrieveContextSource`, save/load working context, and `feedback`). Install
-the skill into your agent's skills directory:
+teaches an agent the full workflow, including when *not* to compress. The
+binding exposes the compiler's read tools natively too: `explainCompilation`
+and `contextSavings` (alongside `compileContext`, `retrieveContextSource`,
+save/load working context, and `feedback`) — only `compileTranscript` remains
+MCP-only for now. Install the skill into your agent's skills directory:
 
 ```bash
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -53,7 +53,9 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
      yourself.** Every `remember`/`remember_extracted` call auto-stamps
      `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
      it, so `recall_fused(date_field="_veles_date")` gives you a chronological
-     `dated_context` timeline (plus a `now` anchor) with zero setup on your part.
+     `dated_context` timeline (plus a `now` anchor) with zero setup on your part
+     (Node binding: the dated variant is its own method,
+     `recallFusedDated(query, k, filter, opts, "_veles_date")`).
      Set `_veles_date` explicitly only to override the default — e.g. to date a
      fact by when an incident actually happened, not when you recorded it; once
      set, the server never overwrites it. Store any OTHER comparable value

--- a/docs/guides/TEMPORAL_MEMORY.md
+++ b/docs/guides/TEMPORAL_MEMORY.md
@@ -1,20 +1,30 @@
 # Temporal Memory: Dated Recall + a Reasoning Scaffold
 
 Teaches you to build "temporal memory" — recalling and reasoning about *when*
-things happened — entirely on top of existing `velesdb-memory` capabilities.
-There is no new API here: `remember` already accepts arbitrary metadata, and
-`recall_where` now returns that metadata (including a stored date) alongside
-each fact. Turning a dated timeline into a temporal *answer* ("how long ago
-was X?", "what happened before Y?") is your own LLM's job — this guide gives
-you a copy-paste prompt recipe for that part, not a library function.
+things happened — on top of `velesdb-memory`'s capabilities. Since 0.11.0,
+every `remember` **auto-stamps** a reserved `_veles_date` metadata field
+(`YYYYMMDD` integer, the day the fact was stored) — so a dated timeline works
+with zero setup, and `recall_fused(date_field="_veles_date")` recency-weights
+it out of the box. Storing your own *domain* date (when the event happened,
+not when it was stored) still works exactly as below. Turning a dated
+timeline into a temporal *answer* ("how long ago was X?", "what happened
+before Y?") is your own LLM's job — this guide gives you a copy-paste prompt
+recipe for that part, not a library function.
 
 ## Store dated facts
 
-Store a fact with a metadata key that holds a date. The key name and the date
-format are entirely your choice — `velesdb-memory` treats metadata as opaque,
-caller-defined key/value pairs (it imposes nothing beyond rejecting reserved
-`_veles_*` keys and the `content` key). A `YYYYMMDD` integer is a convenient
-convention because it sorts and range-filters correctly as a plain number:
+Two dates matter, and they are different things:
+
+- **`_veles_date`** (automatic since 0.11.0) — when the fact was *stored*.
+  Written by `remember` unless you set it yourself (a caller-supplied value
+  is never overwritten). This is the one `_veles_*` key that round-trips out
+  of recall — every other `_veles_*` key stays reserved and rejected.
+- **Your own key** (e.g. `occurred_at`) — when the event *happened*. The key
+  name and format are your choice; `velesdb-memory` treats metadata as
+  opaque, caller-defined key/value pairs (it imposes nothing beyond rejecting
+  the other reserved `_veles_*` keys and the `content` key). A `YYYYMMDD`
+  integer is a convenient convention because it sorts and range-filters
+  correctly as a plain number:
 
 ```python
 from velesdb import MemoryService

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-15 (v3.12.0; velesdb-memory 0.7.0)
+Last updated: 2026-07-23 (v3.12.0; velesdb-memory 0.11.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 
@@ -54,15 +54,17 @@ Legend: ✅ full support | ⚠️ partial / limited | ❌ not supported | N/A no
 
 ### Notes
 
-- **Cross-Collection MATCH**: Core and Server support `@collection` annotation on MATCH node patterns. Python bindings support via `_collection` param. CLI supports via `\use`. WASM, Mobile, Tauri, and integrations do not yet expose this feature.
+- **Cross-Collection MATCH**: Core and Server support `@collection` annotation on MATCH node patterns. Python bindings support via `_collection` param. CLI supports via `\use`. Mobile reaches it through `execute_query` (full VelesQL pass-through, `crates/velesdb-mobile/src/lib.rs:342`). WASM, Tauri, and integrations do not yet expose this feature.
 - **Batch Operations**: WASM and Mobile use streaming chunked inserts instead of single-call bulk to stay within memory constraints. WASM additionally exposes a single-call raw-bulk path via `VectorStore.insertBatchRaw` (see the Raw-Bulk Insert note).
 - **Streaming Ingestion** (2026-06-14): Core, Server (`POST /collections/{name}/stream/enable` + `/stream/insert`), Python, Tauri, Mobile (`enableStreaming()` / `streamInsert()` on its own tokio streaming runtime), and the TS SDK (`enableStreaming()` / `streamInsert()`, REST backend) support the bounded ingestion channel. The CLI reaches it ⚠️ via the embedded core path with no dedicated REPL command. WASM throws `NOT_SUPPORTED` (no persistence layer). LangChain and LlamaIndex expose ⚠️ streaming via `stream_insert()`/`add_texts_streaming()`/`add_streaming()`, which forward to `collection.stream_insert` (caller is responsible for `enable_streaming`; covered by mock-collection unit tests). Only the Haystack integration does not yet expose it.
 - **Raw-Bulk Insert** (2026-06-14): the zero-copy raw-bulk path is now exposed by Core (`upsert_bulk_from_raw`), Server (`POST /collections/{name}/points/raw`, VRB1 binary), the TS SDK (`upsertBatchRaw`), WASM (`VectorStore.insertBatchRaw(ids, vectors, dim)`, writing into its in-memory buffer), and the CLI (`velesdb data import <file.bin>`, VRB1 binary). Mobile remains a follow-up. All surfaces share the one `velesdb_core::wire::vrb1` codec.
 - **Multi-Query Fusion (RSF/Weighted)** (2026-06-14): WASM's multi-query `fuse_results` now delegates **4 of its 5 strategies** (`average`, `maximum`, `weighted`, `rrf`) to the canonical `velesdb_core::FusionStrategy::fuse`, so the browser engine reproduces core's ranking 1:1 for those (`crates/velesdb-wasm/src/fusion.rs`; equivalence pinned by `test_fuse_results_matches_core_ordering`). The fifth strategy, `relative_score` / `rsf`, is **intentionally kept WASM-local**: core's `RelativeScore` is a two-branch (dense + sparse) weighted sum that zero-fills documents missing from a branch and discards branches beyond index 1, whereas WASM's is an N-branch equal-weight average that skips missing branches. The two semantics yield different rankings, so converging WASM onto core would silently change WASM search results — that convergence is a product decision deferred to a follow-up, and `relative_score` behaviour is unchanged. (This is the multi-query fusion entry point; the VelesQL `USING FUSION (...)` clause executor in `velesql_fusion.rs` already builds every strategy — including RSF — directly from `velesdb_core::fusion::FusionStrategy`.) LangChain and LlamaIndex expose RSF/Weighted through `multi_query_search(fusion=...)`, which delegates to the shared `velesdb_common.fusion.build_fusion_strategy` (builds `weighted()` and `relative_score()`). Haystack reaches RSF/Weighted/RRF/etc. fusion via its own `VelesDBDocumentStore.embedding_retrieval(fusion=..., fusion_params=...)`, which delegates to `velesdb_common.fusion.build_fusion_strategy` and `Collection.multi_query_search`.
 - **Sparse Vector Search (named indexes) — LangChain/LlamaIndex**: ⚠️ query-side only. Both integrations forward a `sparse_index_name` argument to the underlying `collection.search`/`hybrid_search`, so an existing named sparse index can be *queried*. Named sparse indexes are also created on the upsert/write path: passing a named mapping such as `{"bge_m3": {0: 1.5}}` to `add_texts`/`add`/`add_bulk` (LC/LI) or `write_documents` (Haystack) creates the named index, validated by `velesdb_common.security.validate_named_sparse_vector`.
+- **LangGraph integration** (2026-07-23): `integrations/langgraph` ships memory tools only (`remember`/`recall`/`relate`/`why` via `make_memory_tools`). It is deliberately narrow — no vector-store surface — and is not yet a column in the matrices above. Known gaps tracked as issues: no `forget`/`feedback` tools, plain `recall` only (no `recall_where`/`recall_fused(date_field=…)`, so the 0.11.0 auto `_veles_date` stamp never reaches the agent), no working-context tools.
+- **Auto `_veles_date` stamp (velesdb-memory 0.11.0)**: every `remember` now auto-stamps a reserved `_veles_date` metadata field (`YYYYMMDD`, caller-set value never overwritten), making `recall_fused(date_field=…)` work with zero setup. Surfaced by delegation in Python (`tests/test_memory_service.py` asserts the stamp), WASM, and Node (`recallFusedDated`); the TS SDK ships `recallFusedDated` but does not yet document or type `_veles_date`; LangGraph's plain `recall` tool drops metadata entirely (see above).
 - **Graph Operations (WASM)**: Basic node/edge CRUD is supported; multi-hop traversal and MATCH queries are limited.
 - **VelesQL (LangChain/LlamaIndex/Haystack)**: Pass-through to Python bindings works for simple queries; full parser integration is not surfaced in the integration API.
-- **Haystack DocumentStore protocol limits**: The Haystack 2.x `DocumentStore` ABC exposes `write_documents`, `filter_documents`, `embedding_retrieval`, `count_documents`, and `delete_documents`. BM25 / hybrid retrieval requires a separate `Retriever` component (planned follow-up). Graph collections, agent memory, and sparse-named indexes are intentionally `N/A` because they have no idiomatic mapping in Haystack's protocol and are reachable through the raw `velesdb` Python wrapper if needed.
+- **Haystack DocumentStore protocol limits**: The Haystack 2.x `DocumentStore` ABC exposes `write_documents`, `filter_documents`, `embedding_retrieval`, `count_documents`, and `delete_documents`. Dense retrieval in pipelines ships as the dedicated `VelesDBEmbeddingRetriever` component (`integrations/haystack/src/haystack_velesdb/retriever.py`); BM25/hybrid retriever components remain a follow-up. Graph collections, agent memory, and sparse-named indexes are intentionally `N/A` because they have no idiomatic mapping in Haystack's protocol and are reachable through the raw `velesdb` Python wrapper if needed.
 - **Collection Types (Metadata)**: WASM and integration SDKs expose metadata collections with reduced column-type support.
 - **Property Indexes (WASM)**: Disabled by design — no persistence layer means indexes cannot survive page reloads.
 - **Quantization (RaBitQ)**: Experimental across all surfaces; API is unstable.
@@ -186,7 +188,7 @@ All 4 strategies (`RRF`, `Weighted`, `Maximum`, `RSF`) plus `Average` are suppor
 
 ### SearchQuality — 7/10
 
-4 HNSW presets (`Fast`, `Balanced`, `Accurate`, `Perfect`) plus `Custom(usize)` and `Adaptive`. WASM, Mobile, and Tauri use brute-force search (no HNSW), so `SearchQuality` is not applicable.
+4 HNSW presets (`Fast`, `Balanced`, `Accurate`, `Perfect`) plus `Custom(usize)` and `Adaptive`. WASM uses brute-force search (no HNSW), so `SearchQuality` is not applicable there; Mobile and Tauri are HNSW-backed via core defaults and expose the presets (`crates/velesdb-mobile/src/types.rs` `SearchQuality`, `crates/tauri-plugin-velesdb/src/helpers.rs` `parse_search_quality`).
 
 | Component | Status | Notes |
 |-----------|--------|-------|
@@ -194,10 +196,10 @@ All 4 strategies (`RRF`, `Weighted`, `Maximum`, `RSF`) plus `Average` are suppor
 | Server | ✅ | |
 | Python | ✅ | |
 | WASM | N/A | Brute-force only, no HNSW index |
-| Mobile | N/A | Brute-force only, no HNSW index |
+| Mobile | ✅ | `SearchQuality` enum mapped to core (`search_with_quality`) |
 | CLI | ✅ | |
 | TS SDK | ✅ | |
-| Tauri | N/A | Brute-force only, no HNSW index |
+| Tauri | ✅ | `search_quality` param + `hnsw_m`/`hnsw_ef_construction` at creation |
 | LangChain | ✅ | |
 | LlamaIndex | ✅ | |
 | Haystack | ✅ | |
@@ -255,4 +257,4 @@ collection creation; only Haystack is limited by its DocumentStore protocol.
    targeting already works).
 7. Propagate `@collection` cross-collection MATCH to WASM, Mobile, Tauri, LangChain, LlamaIndex, and Haystack.
 8. Add cross-collection vector search (`similarity()` on `@collection`-annotated nodes).
-9. **Read-path gate (observer) parity (audit F-5.4).** The 3.10.0 read-path gate — `velesdb_core::observer` + `database::gated_search` / `authorize_read` (scope AND-composed with the caller filter, fail-closed on non-filterable paths) — is wired into **`velesdb-server`** (search/match/graph handlers) and **`velesdb-python`** (`.search()` gating). `tauri-plugin-velesdb` ships a **notify-only** observer (no deny). **`velesdb-node`** (memory-only, out of scope by design), **`velesdb-mobile`**, and **`velesdb-wasm`** expose **no** observer, so the gate is inactive there. This is a **parity gap, not a vulnerability**: the core contract is fail-open *only when no observer is registered* (no policy ⇒ no denial to enforce), so an ungated binding simply has no governance layer to bypass. Governance-sensitive deployments must use the server or Python surface. Wiring an observer hook into mobile/wasm is a follow-up; node is intentionally excluded (it never touches the gated core `Collection`).
+9. **Read-path gate (observer) parity (audit F-5.4).** The 3.10.0 read-path gate — `velesdb_core::observer` + `database::gated_search` / `authorize_read` (scope AND-composed with the caller filter, fail-closed on non-filterable paths) — is wired into **`velesdb-server`** (search/match/graph handlers) and **`velesdb-python`** (`.search()` gating). `tauri-plugin-velesdb` ships a **notify-only** observer (no deny). **`velesdb-mobile`** now ships a deny-capable observer (`open_with_observer` + `MobileObserver`/`MobileAccessDecision`, `crates/velesdb-mobile/src/lib.rs:145`). **`velesdb-node`** (memory-only, out of scope by design) and **`velesdb-wasm`** expose **no** observer, so the gate is inactive there. This is a **parity gap, not a vulnerability**: the core contract is fail-open *only when no observer is registered* (no policy ⇒ no denial to enforce), so an ungated binding simply has no governance layer to bypass. Governance-sensitive deployments must use the server or Python surface. Wiring an observer hook into mobile/wasm is a follow-up; node is intentionally excluded (it never touches the gated core `Collection`).

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -2,9 +2,10 @@
 
 Complete REST API documentation for VelesDB.
 
-> **Last updated**: 2026-06-12 (VelesDB v2.0.0). The machine-readable source of
+> **Last updated**: 2026-07-23 (VelesDB v3.12.0). The machine-readable source of
 > truth is [`docs/openapi.yaml`](../openapi.yaml), regenerated from the server's
-> annotated handlers; this page is the human-readable companion.
+> annotated handlers and drift-checked in CI; this page is the human-readable
+> companion.
 
 ## Base URL
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -2,9 +2,15 @@
 
 Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB) -- the local-first vector database for AI and RAG. Sub-millisecond semantic search in Browser and Node.js.
 
-> The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md) (which additionally exposes `retrieveContextSource` for externalized-source retrieval).
+> The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
 **v3.12.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+
+## What's New in v3.12.0
+
+- **Dated recall**: `recallFusedDated(query, …, dateField)` returns fused recall plus a chronological `dated_context` timeline with a `now` anchor. Pairs with `velesdb-memory` 0.11.0's automatic `_veles_date` stamp (every `remember` stores today's date as a `YYYYMMDD` integer under the reserved `_veles_date` metadata key unless you set it yourself) — pass `"_veles_date"` as the date field and a zero-setup timeline comes back.
+- **Compiler read tools in the browser**: `retrieveContextSource` retrieves the exact original content behind a compiled fragment (externalized sources included), directly from the WASM engine.
+- **Since 3.6.0 (3.7–3.11 recap)**: `compileContext` on the `MemoryService` (deterministic context compression, media fragments included), working-context `save`/`load`/`list` for cross-session resumption, `bulkDelete` over `POST points/delete`, and automatic retry with exponential backoff on 429/503 (idempotent methods only, capped `Retry-After`).
 
 ## What's New in v3.6.0
 

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -344,15 +344,15 @@ export class MemoryService {
         error instanceof Error ? error : undefined
       );
     }
-    // Capability floor, checked at runtime because the declared dependency
-    // range (^3.0.0) admits older builds: the memory wedge shipped in wasm
-    // 3.6.0, and an existing project's lockfile may still resolve an
-    // earlier version. Fail with the actionable cause, not a generic
-    // load error.
+    // Capability floor, checked at runtime because a stale lockfile can
+    // resolve a wasm build older than the declared range (^3.8.0, the
+    // floor this SDK's full memory surface — media fragments,
+    // retrieveContextSource — needs; the wedge itself first shipped in
+    // 3.6.0). Fail with the actionable cause, not a generic load error.
     if (typeof mod.MemoryService !== 'function') {
       throw new ConnectionError(
         'The resolved @wiscale/velesdb-wasm build does not ship MemoryService — ' +
-          'the memory wedge requires @wiscale/velesdb-wasm >= 3.6.0 ' +
+          'the memory wedge requires @wiscale/velesdb-wasm >= 3.8.0 ' +
           '(update the dependency in your lockfile)'
       );
     }


### PR DESCRIPTION
## Summary
Output of tonight's core-parity audit (38-agent sweep, every finding re-verified by hand against code before editing):

- **ECOSYSTEM_PARITY.md** — header to 2026-07-23 / memory 0.11.0 (was 2026-07-15 / 0.7.0, four minors behind); Mobile & Tauri corrected from "brute-force, SearchQuality N/A" to HNSW-backed with presets; Mobile's deny-capable observer and `execute_query` cross-collection MATCH path recorded; Haystack `VelesDBEmbeddingRetriever` no longer "planned follow-up"; new notes for the LangGraph integration and the auto `_veles_date` stamp.
- **TEMPORAL_MEMORY.md** — was actively wrong since 0.11.0 ("There is no new API here", "`_veles_*` keys rejected"): now documents the auto `_veles_date` stamp vs caller-owned domain dates.
- **velesdb-node README** — denied exposing `explainCompilation`/`contextSavings`; both are bound (`src/lib.rs:378`/`347`). Headline API list completed. Both synced SKILL.md copies note the Node `recallFusedDated` call shape (skills-sync guard: 2/2 pass).
- **TS SDK** — "What's New" ladder was stuck at v3.6.0 under a v3.12.0 header: added a 3.12 entry (`recallFusedDated` + `retrieveContextSource`, which the README claimed was Node-only) and a 3.7–3.11 recap; the runtime capability-floor error message now states the real `>= 3.8.0` wasm floor (`tsc --noEmit` clean).
- **Mobile README** — date refreshed; `openWithObserver`, `updateGuardrails`, graph constructors, `executeQuery`, `searchWithQuality` documented.
- **Tauri** — README understated agent memory (episodic/procedural commands exist in `commands_memory.rs`); CHANGELOG gains a versioning note (last heading 1.11.1 vs workspace 3.12.0).
- **migrate README** — CLI block said 3.8.0; **api-reference.md** — stamp said v2.0.0.
- **Root README** — daemon line gains Devin CLI + HTTPS-by-default; memory section mentions the auto `_veles_date` stamp.

## Test plan
- [x] `node --test crates/velesdb-node/__test__/skills-sync.spec.mjs` — 2/2 pass
- [x] `npx tsc --noEmit` in sdks/typescript — clean
- [x] Every factual claim grep-verified against source before the edit