### PR TITLE
fix(ci): migrate release-mcpb artifact actions to Node 24

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -154,7 +154,7 @@ jobs:
           echo "Built ${ASSET}"
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mcpb-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download all bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: bundles
           merge-multiple: true


### PR DESCRIPTION
## Why

Every \`release-mcpb.yml\` run emits the runner deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/upload-artifact@v4 / actions/download-artifact@v4.

Confirmed on the latest run (velesdb-memory-v0.11.0, run 30028492431). Same migration as velesdb-private #186/#187/#188.

## What

- \`actions/upload-artifact@v4\` → \`043fb46d…\` (v7.0.1, node24) — inputs used (\`name\`, \`path\`, \`if-no-files-found\`) unchanged in v7.
- \`actions/download-artifact@v4\` → \`3e5f45b2…\` (v8.0.1, node24) — inputs used (\`path\`, \`merge-multiple\`) unchanged in v8.

SHA-pinned to the exact revisions already used by the other workflows in this repo.

## Audit of all other workflows

Swept every \`uses:\` across \`.github/workflows/\` and resolved each pinned ref's \`runs.using\` upstream:

- All other \`actions/*\`, \`docker/*\`, Swatinem/rust-cache, softprops/action-gh-release, sonarqube-scan, github-script, setup-java: already **node24** (or composite/docker — no Node runtime).
- \`PyO3/maturin-action@db323e2c\` (release.yml): verified still fetchable and already **node24** — no change needed.
- \`contributor-assistant/github-action\` (cla.yml): still **node20 upstream, including master and latest v2.6.1** — no Node 24 release exists yet, so the CLA Assistant warning will remain until upstream ships one. Out of scope here.

## Verification

- Deprecation annotations on recent runs: only the two artifact actions above (release-mcpb) + contributor-assistant (cla.yml) trigger it; CI on develop is clean.
- \`release-mcpb.yml\` only runs on \`velesdb-memory-v*\` tags / manual dispatch (which republishes to the MCP registry, so not triggered as a test). The warning disappearance will be observable on the next velesdb-memory release run; the fix is deterministic — both target versions declare \`runs.using: node24\`.