### PR TITLE
test(ts-sdk): align wasm-floor assertions with the corrected >= 3.8.0 message

### DIFF
--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -127,19 +127,19 @@ describe('MemoryService', () => {
     });
 
     it('init() names the wasm version floor when the resolved build lacks MemoryService', async () => {
-      // Simulates a stale lockfile resolving a pre-3.6.0 @wiscale/velesdb-wasm
-      // (the declared range ^3.0.0 admits builds without the memory wedge).
+      // Simulates a stale lockfile resolving a @wiscale/velesdb-wasm build
+      // older than the ^3.8.0 floor the SDK's full memory surface needs.
       const saved = mockWasmModule.MemoryService;
       (mockWasmModule as { MemoryService?: unknown }).MemoryService = undefined;
       try {
         const stale = new MemoryService();
         const rejection = stale.init();
         await expect(rejection).rejects.toBeInstanceOf(ConnectionError);
-        await expect(rejection).rejects.toThrow(/>= 3\.6\.0/);
+        await expect(rejection).rejects.toThrow(/>= 3\.8\.0/);
         // A retry after the failed init runs a fresh load (the memoized
         // in-flight promise is cleared on settle) and must fail the same
         // way — never spuriously resolve with a null inner store.
-        await expect(stale.init()).rejects.toThrow(/>= 3\.6\.0/);
+        await expect(stale.init()).rejects.toThrow(/>= 3\.8\.0/);
         expect(stale.isInitialized()).toBe(false);
       } finally {
         mockWasmModule.MemoryService = saved;


### PR DESCRIPTION
## Summary
- #1541 corrected the runtime capability-floor error message (`>= 3.8.0`, the real floor) but missed two vitest assertions pinning the old text — the TypeScript SDK Check is red on develop (and the failure rode into main via sync #1551). This aligns the assertions and the test's comment.

## Test plan
- [x] `npx vitest run tests/memory.test.ts` — 34/34 pass.