### PR TITLE
feat(memory): Windows onboarding for the memory daemon

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -11,6 +11,16 @@
 # crate depends on velesdb-core ^3.3.0, which is already on crates.io, so the
 # package is dry-run validated up front (unlike workspace dependents, which
 # cannot be dry-run before core is published).
+#
+# This pipeline also builds and attaches per-platform "daemon archives"
+# (build-daemon-archive / publish-daemon-archive below): the .mcpb bundles
+# published separately by release-mcpb.yml are built with DEFAULT features
+# (stdio only — no `http`/`ollama`), so they can't run as the shared
+# multi-client daemon scripts/install-memory-daemon.{sh,ps1} set up. The
+# daemon archives are the SAME crate built with `--features ollama,http`
+# instead, letting `--from-release` / `-FromRelease` in those install
+# scripts install a working daemon binary with no Rust toolchain on the
+# target machine.
 name: Release velesdb-memory
 
 on:
@@ -30,6 +40,10 @@ on:
         default: true
       publish_npm:
         description: 'Publish @wiscale/velesdb-memory-node to npm'
+        type: boolean
+        default: true
+      publish_daemon_archive:
+        description: 'Build and attach the --features ollama,http daemon archives to the GitHub Release'
         type: boolean
         default: true
 
@@ -355,3 +369,157 @@ jobs:
             echo "❌ npm publish FAILED for @wiscale/velesdb-memory-node@$VERSION (auth/registry error, NOT already-published)"
             exit 1
           fi
+
+  # ===========================================================================
+  # 5. Build the daemon binary for each platform (--features ollama,http)
+  # ===========================================================================
+  #
+  # Same crate/bin as the default-feature .mcpb bundles in release-mcpb.yml,
+  # built with the daemon's actual feature set instead. `ollama` stays a
+  # compile-time opt-in only because the runtime VELESDB_MEMORY_EMBEDDER=ollama
+  # switch needs the code present to select at all — the embedder choice
+  # itself is still a pure runtime decision either way (see build_daemon /
+  # Build-Daemon in the install scripts, which always request both features
+  # regardless of which embedder the user picks).
+  build-daemon-archive:
+    name: Build daemon archive (${{ matrix.target }})
+    needs: validate
+    if: github.event_name == 'push' || inputs.publish_daemon_archive
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: aarch64-apple-darwin,      host: macos-latest,   archive: tar.gz }
+          - { target: x86_64-apple-darwin,       host: macos-latest,   archive: tar.gz }
+          - { target: x86_64-unknown-linux-gnu,  host: ubuntu-latest,  archive: tar.gz }
+          - { target: aarch64-unknown-linux-gnu, host: ubuntu-latest,  archive: tar.gz, cross: true }
+          - { target: x86_64-pc-windows-msvc,    host: windows-latest, archive: zip }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: ${{ matrix.target }}
+
+      # rust-toolchain.toml pins the build to its own toolchain, which rustup
+      # auto-installs WITHOUT the cross-compilation target added above (the
+      # action only adds it to `stable`) — same fix as release-mcpb.yml's
+      # equivalent step, needed for the same reason (E0463 otherwise).
+      - name: Add target to the pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install aarch64 linux cross linker
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: "release-memory-daemon-${{ matrix.target }}"
+
+      - name: Build velesdb-memory (--features ollama,http)
+        run: cargo build --release --locked -p velesdb-memory --bin velesdb-memory --target ${{ matrix.target }} --features ollama,http
+
+      - name: Package archive + checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          STAGE="daemon-stage"
+          rm -rf "$STAGE" && mkdir -p "$STAGE"
+
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            EXE="velesdb-memory.exe"
+            cp "target/${{ matrix.target }}/release/${EXE}" "$STAGE/${EXE}"
+            ASSET="velesdb-memory-daemon-${{ matrix.target }}.zip"
+            # Portable zip (no `zip` binary on Windows runners) — same
+            # technique as release-mcpb.yml's bundle step.
+            python3 - "$STAGE" "$ASSET" <<'PYZIP'
+          import os, sys, zipfile
+          stage, asset = sys.argv[1], sys.argv[2]
+          with zipfile.ZipFile(asset, "w", zipfile.ZIP_DEFLATED) as z:
+              for root, _, files in os.walk(stage):
+                  for f in files:
+                      full = os.path.join(root, f)
+                      arc = os.path.relpath(full, stage).replace(os.sep, "/")
+                      z.write(full, arc)
+          print("zipped", asset)
+          PYZIP
+          else
+            EXE="velesdb-memory"
+            cp "target/${{ matrix.target }}/release/${EXE}" "$STAGE/${EXE}"
+            chmod +x "$STAGE/${EXE}"
+            ASSET="velesdb-memory-daemon-${{ matrix.target }}.tar.gz"
+            tar -C "$STAGE" -czf "$ASSET" "${EXE}"
+          fi
+
+          # sha256sum isn't guaranteed on every runner (macOS ships `shasum`
+          # instead) — python3's hashlib is on all three, so use that for one
+          # consistent "<hex>  <filename>" line the install scripts can parse
+          # the same way on every platform.
+          python3 -c "
+          import hashlib, sys
+          h = hashlib.sha256()
+          with open(sys.argv[1], 'rb') as f:
+              for chunk in iter(lambda: f.read(1 << 20), b''):
+                  h.update(chunk)
+          print(f'{h.hexdigest()}  {sys.argv[1]}')
+          " "$ASSET" > "${ASSET}.sha256"
+
+          echo "ASSET=${ASSET}" >> "$GITHUB_ENV"
+          echo "Built ${ASSET} ($(cat "${ASSET}.sha256"))"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: daemon-archive-${{ matrix.target }}
+          path: |
+            ${{ env.ASSET }}
+            ${{ env.ASSET }}.sha256
+          if-no-files-found: error
+
+  # ===========================================================================
+  # 6. Attach the daemon archives to the GitHub Release
+  # ===========================================================================
+  #
+  # release-mcpb.yml separately creates/updates the SAME velesdb-memory-vX.Y.Z
+  # release for its .mcpb bundles, triggered by the same tag push — so this
+  # job's "create if missing, `|| true` on the race" is not optional
+  # defensiveness, it is load-bearing: both workflows can hit `gh release
+  # create` for the same tag within moments of each other. Whichever loses
+  # that race gets a harmless "already exists" failure (swallowed by
+  # `|| true`) and both proceed straight to `gh release upload`, which is
+  # idempotent per file (`--clobber`).
+  publish-daemon-archive:
+    name: Attach daemon archives to release
+    needs: [validate, build-daemon-archive]
+    if: github.event_name == 'push' || inputs.publish_daemon_archive
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Download all daemon archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: daemon-archives
+          pattern: daemon-archive-*
+          merge-multiple: true
+
+      - name: Attach archives to the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: velesdb-memory-v${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          # --latest=false: same reasoning as release-mcpb.yml — the
+          # velesdb-memory release must never become the repo's "Latest
+          # release" (that belongs to the workspace vX.Y.Z release).
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$TAG" --latest=false --notes "velesdb-memory $TAG — daemon archives (--features ollama,http) for install-memory-daemon.sh/.ps1 --from-release." || true
+          fi
+          ls -la daemon-archives/
+          gh release upload "$TAG" daemon-archives/* --clobber

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -658,6 +658,18 @@ prebuilt `velesdb-memory-daemon-<target>.{tar.gz,zip}` archive from a
 `velesdb-memory-vX.Y.Z` GitHub Release, verify its checksum, and install the
 binary straight to the expected path — no cargo, no local build. Defaults to
 the latest published `velesdb-memory-vX.Y.Z` release when no tag is given.
+
+Checksum verification is **blocking by default**: if the release's `.sha256`
+sidecar can't be fetched, or the downloaded archive doesn't match it, the
+install aborts rather than silently installing an unverified binary. Pass
+`--skip-checksum` (`.sh`) / `-SkipChecksum` (`.ps1`) to opt out. Be clear
+about what this checksum actually proves: it's a plain SHA-256 published
+alongside the archive on the same GitHub Release, so it verifies **transfer
+integrity** (the bytes weren't corrupted or truncated in flight) — it is
+**not** a cryptographic signature and does not by itself prove the archive's
+*authenticity* (anyone who could tamper with the archive could regenerate a
+matching checksum next to it).
+
 **This path only becomes active from the first release published after this
 change** — `release-memory.yml`'s `build-daemon-archive` job produces these
 archives, but the `velesdb-memory-v0.11.0` release (and everything before it)

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -302,10 +302,13 @@ claude mcp add velesdb-memory \
 That's it — jump straight to [teach your agent the flow](#teach-your-agent-the-flow-skill)
 below. Using a different client instead? Expand for its config:
 
-> **macOS, and want several clients sharing one memory?** Skip everything
-> below and run `./scripts/install-memory-daemon.sh` instead — it builds,
-> runs, and wires Claude Code / Claude Desktop / Windsurf / Devin CLI to a
-> single shared daemon in one command (see "HTTP transport" further down).
+> **Want several clients sharing one memory?** Skip everything below and run
+> `./scripts/install-memory-daemon.sh` (macOS — full daemon automation; on
+> Linux it still builds and wires clients but skips daemon setup, see the
+> script's own non-macOS notice) or `pwsh -File scripts/install-memory-daemon.ps1`
+> (Windows 10/11 — full daemon automation via a Scheduled Task) instead — it
+> builds, runs, and wires Claude Code / Claude Desktop / Windsurf / Devin CLI
+> to a single shared daemon in one command (see "HTTP transport" further down).
 
 <details>
 <summary><strong>Cursor, Cline, Zed, Codex CLI, opencode, Claude Desktop, Windsurf, Devin CLI</strong></summary>
@@ -465,9 +468,9 @@ cargo install velesdb-memory --features http,ollama
 velesdb-memory --http
 # [velesdb-memory] HTTPS server listening on https://127.0.0.1:18090/mcp
 # [velesdb-memory] Local CA: /home/you/.velesdb-memory-tls/ca-cert.pem — a client only needs to
-# trust this once (see ./scripts/install-memory-daemon.sh, which does this automatically on
-# macOS); every future leaf certificate this daemon issues is signed by the same CA and is
-# trusted automatically after that.
+# trust this once (see ./scripts/install-memory-daemon.sh — install-memory-daemon.ps1 on
+# Windows — which does this automatically); every future leaf certificate this daemon issues
+# is signed by the same CA and is trusted automatically after that.
 ```
 
 - `--http` / `VELESDB_MEMORY_HTTP=1` — serve over streamable-HTTP instead of stdio.
@@ -516,6 +519,15 @@ hand, it prints the exact command:
 security add-trusted-cert -r trustRoot -p ssl \
   -k ~/Library/Keychains/login.keychain-db \
   ~/.velesdb-memory-tls/ca-cert.pem
+```
+
+On Windows, `scripts/install-memory-daemon.ps1` does the equivalent into the
+**CurrentUser\Root** certificate store (no admin rights needed), checking the
+CA's thumbprint first so a re-run never re-imports it. If it times out or you'd
+rather do it by hand:
+
+```powershell
+certutil -addstore -user Root "$env:USERPROFILE\.velesdb-memory-tls\ca-cert.pem"
 ```
 
 Node-based tools (Claude Code's CLI, Electron apps like Claude Desktop) don't
@@ -605,12 +617,55 @@ This gives Desktop its own separate memory, not shared with the daemon.
 } } }
 ```
 
-`scripts/install-memory-daemon.sh` automates all of this end to end: building
-with the right features, running the daemon (as a macOS `launchd` agent),
-trusting the local CA in your login keychain, and wiring Claude Code / Claude
-Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
+`scripts/install-memory-daemon.sh` automates all of this end to end on
+macOS: building with the right features, running the daemon (as a `launchd`
+agent), trusting the local CA in your login keychain, and wiring Claude Code /
+Claude Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
 `--port`, `--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
-`--uninstall`, …).
+`--from-release`, `--uninstall`, …).
+
+### Windows
+
+`scripts/install-memory-daemon.ps1` (`pwsh -File scripts/install-memory-daemon.ps1`,
+PowerShell 7+ on Windows 10/11) is the same automation with the same flags
+(PowerShell-cased: `-Embedder`, `-Port`, `-Store`, `-TlsDir`, `-Ttl`,
+`-SkipClient`, `-SkipCaTrust`, `-FromRelease`, `-Uninstall`, …), adapted to
+Windows in three places:
+
+- **Daemon**: a per-user **Scheduled Task** (`\VelesDB\MemoryDaemon`,
+  triggered at logon) instead of a `launchd` agent — a Windows *service*
+  needs admin rights, which this installer never asks for. Since a Scheduled
+  Task action carries no environment block, the daemon's env vars are baked
+  into a small generated wrapper (`%LOCALAPPDATA%\velesdb-memory\run-daemon.cmd`)
+  that the task launches; daemon logs land in
+  `%LOCALAPPDATA%\velesdb-memory\logs\`.
+- **CA trust**: the **`Cert:\CurrentUser\Root`** certificate store instead of
+  the login keychain — also no admin rights needed (see "The local CA" above
+  for the exact command).
+- **Client config paths**: Claude Desktop
+  `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
+  written by the installer, same as macOS), Windsurf
+  `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
+  `%APPDATA%\devin\config.json`.
+
+### Installing the daemon without a Rust toolchain
+
+Both installers default to `cargo install --features ollama,http`, which
+needs a Rust toolchain on the machine. Pass `--from-release[=TAG]` (`.sh`) or
+`-FromRelease` / `-FromReleaseTag <TAG>` (`.ps1`, which has no PowerShell
+equivalent of the shell flag's optional inline value) to instead download a
+prebuilt `velesdb-memory-daemon-<target>.{tar.gz,zip}` archive from a
+`velesdb-memory-vX.Y.Z` GitHub Release, verify its checksum, and install the
+binary straight to the expected path — no cargo, no local build. Defaults to
+the latest published `velesdb-memory-vX.Y.Z` release when no tag is given.
+**This path only becomes active from the first release published after this
+change** — `release-memory.yml`'s `build-daemon-archive` job produces these
+archives, but the `velesdb-memory-v0.11.0` release (and everything before it)
+predates it and carries no such asset, so `--from-release` against `v0.11.0`
+fails with a clear 404-explaining message rather than a bare curl/`Invoke-WebRequest`
+error. This is a **different artifact** than the `.mcpb` bundles on the same
+release: those are built with default features (stdio only) for MCP-registry
+clients and cannot run as this daemon.
 
 ## Teach your agent the flow (skill)
 

--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -1,0 +1,758 @@
+# =============================================================================
+# VelesDB Memory Daemon Installer — Windows
+# =============================================================================
+# PowerShell mirror of scripts/install-memory-daemon.sh (read that script's
+# header first — same rationale, same daemon, same client wiring). This file
+# only documents where Windows *diverges* from the macOS original:
+#
+#   - No launchd on Windows, and a Windows *service* needs an admin install.
+#     Instead this script registers a per-user **Scheduled Task** (folder
+#     `\VelesDB\`, trigger "at logon") — `Register-ScheduledJob` is
+#     deprecated, so this uses `Register-ScheduledTask`. A Scheduled Task
+#     action carries no environment block, so the daemon's env vars
+#     (VELESDB_MEMORY_PATH, etc.) are baked into a tiny generated wrapper
+#     `run-daemon.cmd` that `set`s them and then execs the binary — the
+#     task's Action just launches that wrapper.
+#   - CA trust targets the **CurrentUser\Root** certificate store (no admin
+#     needed), via `certutil -addstore -user Root` — chosen over
+#     `Import-Certificate` because certutil accepts the daemon's PEM output
+#     natively across PowerShell versions, matching the "prefer certutil for
+#     compat" guidance this script follows. Idempotency is checked by
+#     thumbprint before importing, same spirit as the macOS strict-curl
+#     ground-truth check.
+#   - Client config paths follow Windows conventions: Claude Desktop
+#     `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
+#     written here, same as macOS), Windsurf
+#     `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
+#     `%APPDATA%\devin\config.json` (documented at
+#     https://cli.devin.ai/docs/reference/configuration/config-file — Devin's
+#     own docs give the Windows path explicitly, unlike most of this
+#     ecosystem, so no guessing needed).
+#   - JSON is edited with ConvertFrom-Json/ConvertTo-Json (no jq dependency
+#     on Windows), with the same timestamped-backup-before-write policy.
+#
+# Everything else — flags, defaults, the "never delete local state" uninstall
+# policy, the HTTPS-by-default daemon, the four wired clients — is the same
+# product as scripts/install-memory-daemon.sh; read that file for the "why".
+#
+# Usage:
+#   pwsh -File scripts/install-memory-daemon.ps1 [flags]
+#   pwsh -File scripts/install-memory-daemon.ps1 -Uninstall
+#
+# Flags:
+#   -Embedder <hash|ollama>   Embedding backend (default: prompted, or 'hash' in non-interactive)
+#   -Port <port>              HTTP port (default: 18090)
+#   -Store <path>             Store directory (default: $env:USERPROFILE\.velesdb-memory)
+#   -TlsDir <path>            TLS material (CA + leaf cert) directory (default: $env:USERPROFILE\.velesdb-memory-tls)
+#   -OllamaUrl <url>          Ollama endpoint (default: http://localhost:11434)
+#   -OllamaModel <model>      Ollama embedding model (default: all-minilm)
+#   -Ttl <seconds>            Default TTL for new facts (default: prompted, empty = permanent)
+#   -Yes                      Assume yes to interactive prompts (e.g. `ollama pull`)
+#   -SkipClient <name>        Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
+#   -SkipCaTrust              Skip trusting the local CA in the CurrentUser\Root store
+#   -ForceRestart             Re-register/restart the scheduled task even if already running
+#   -FromRelease              Install the prebuilt daemon binary from a GitHub Release archive
+#                             instead of building with cargo (see -FromReleaseTag). PowerShell
+#                             parameter binding has no "flag with optional inline value" shape
+#                             (unlike the shell script's `--from-release[=TAG]`), so the tag is a
+#                             separate parameter here.
+#   -FromReleaseTag <tag>     Pin the release tag to install from (default: latest
+#                             velesdb-memory-v* release). Implies -FromRelease.
+#   -Uninstall                Remove the scheduled task and all client wiring (store and TLS
+#                             material/CA trust are NEVER touched — same "never delete local
+#                             state" policy as the store)
+#   -Help                     Show this help
+# =============================================================================
+
+[CmdletBinding()]
+param(
+    [ValidateSet('', 'hash', 'ollama')]
+    [string]$Embedder = '',
+
+    [int]$Port = 18090,
+
+    [string]$Store = "$env:USERPROFILE\.velesdb-memory",
+
+    # Sibling of the default store, matching velesdb_memory::tls::default_tls_dir —
+    # deliberately NOT nested inside Store (independent lifecycles: wiping the store
+    # to reset memory shouldn't also invalidate a CA Windows has been told to trust).
+    [string]$TlsDir = "$env:USERPROFILE\.velesdb-memory-tls",
+
+    [string]$OllamaUrl = 'http://localhost:11434',
+
+    [string]$OllamaModel = 'all-minilm',
+
+    [string]$Ttl = '',
+
+    [switch]$Yes,
+
+    [string[]]$SkipClient = @(),
+
+    [switch]$SkipCaTrust,
+
+    [switch]$ForceRestart,
+
+    [switch]$FromRelease,
+
+    [string]$FromReleaseTag = '',
+
+    [switch]$Uninstall,
+
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# -FromReleaseTag implies -FromRelease (mirrors the shell script's `--from-release[=TAG]`
+# accepting an inline tag without a separate boolean flag).
+if ($FromReleaseTag -ne '') { $FromRelease = $true }
+
+# ---- Fixed locations -------------------------------------------------------
+$RepoOwner = 'cyberlife-coder'
+$RepoName = 'VelesDB'
+$RepoSlug = "$RepoOwner/$RepoName"
+
+$TaskFolder = '\VelesDB\'
+$TaskName = 'MemoryDaemon'
+$ConfigRoot = "$env:LOCALAPPDATA\velesdb-memory"
+$LogsDir = "$ConfigRoot\logs"
+$WrapperPath = "$ConfigRoot\run-daemon.cmd"
+$BinDir = "$env:USERPROFILE\.cargo\bin"
+$BinPath = "$BinDir\velesdb-memory.exe"
+$DesktopConfig = "$env:APPDATA\Claude\claude_desktop_config.json"
+$WindsurfConfig = "$env:USERPROFILE\.codeium\windsurf\mcp_config.json"
+# Documented at https://cli.devin.ai/docs/reference/configuration/config-file
+# ("%APPDATA%\devin\config.json" on Windows) — unlike most of this ecosystem,
+# Devin's own docs give the Windows path explicitly, so this isn't a guess.
+$DevinConfig = "$env:APPDATA\devin\config.json"
+
+function Write-Info { param([string]$Message) Write-Host $Message -ForegroundColor Blue }
+function Write-Success { param([string]$Message) Write-Host $Message -ForegroundColor Green }
+function Write-Warn { param([string]$Message) Write-Host $Message -ForegroundColor Yellow }
+function Write-ErrorMsg { param([string]$Message) Write-Host $Message -ForegroundColor Red }
+
+function Show-Usage {
+    # Reprint the flag block from this file's own header — keeps `-Help`
+    # honest (it can never drift from the comment a reader actually sees).
+    $lines = Get-Content -Path $PSCommandPath -TotalCount 70
+    ($lines | Select-Object -Skip 1) | ForEach-Object {
+        if ($_ -match '^# ?(.*)$') { Write-Host $Matches[1] } else { Write-Host '' }
+    }
+}
+
+if ($Help) { Show-Usage; exit 0 }
+
+function Test-Interactive {
+    # Mirrors the shell script's `[ -t 0 ]`: only prompt when there's a real
+    # console attached, not under CI / a redirected pipe.
+    -not [System.Console]::IsInputRedirected
+}
+
+# Built inline (not via a helper function) deliberately: a function returning
+# an empty collection gets unrolled to $null by PowerShell's pipeline output
+# semantics (a real footgun here — -SkipClient is usually empty), so this
+# constructs the HashSet directly into the script-scope variable instead.
+$script:SkipSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$SkipClient)
+
+function Test-ShouldSkip {
+    param([string]$Name)
+    $script:SkipSet.Contains($Name)
+}
+
+# ---- 1. Preflight -----------------------------------------------------------
+function Invoke-Preflight {
+    if (-not $FromRelease -and -not (Get-Command cargo -ErrorAction SilentlyContinue)) {
+        Write-ErrorMsg "'cargo' not found — install Rust via https://rustup.rs then relaunch this script (or use -FromRelease to install a prebuilt binary instead)."
+        exit 1
+    }
+
+    try {
+        $script:RepoRoot = (git rev-parse --show-toplevel 2>$null)
+        if (-not $script:RepoRoot) { throw 'not a git checkout' }
+    } catch {
+        Write-ErrorMsg 'Not inside a git checkout of VelesDB — run this script from within the repo.'
+        exit 1
+    }
+
+    $listener = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($listener) {
+        $proc = Get-Process -Id $listener.OwningProcess -ErrorAction SilentlyContinue
+        $procPath = if ($proc) { $proc.Path } else { $null }
+        if ($procPath -ne $BinPath) {
+            $procName = if ($proc) { $proc.ProcessName } else { 'unknown' }
+            Write-ErrorMsg "Port $Port is already in use by another process ($procName, pid $($listener.OwningProcess))."
+            Write-ErrorMsg "Re-run with -Port <other-port>, or stop that process first."
+            exit 1
+        }
+    }
+}
+
+# ---- 2. Embedder resolution --------------------------------------------------
+function Resolve-Embedder {
+    if ($script:Embedder -ne '') { return }
+
+    if (Test-Interactive) {
+        Write-Host ''
+        Write-Info 'Which embedder should velesdb-memory use?'
+        Write-Host '  1) hash    (offline, deterministic — default)'
+        Write-Host '  2) ollama  (semantic recall — needs a local Ollama)'
+        $choice = Read-Host 'Choice [1]'
+        switch ($choice) {
+            '2' { $script:Embedder = 'ollama' }
+            { $_ -in @('', '1') } { $script:Embedder = 'hash' }
+            default {
+                Write-ErrorMsg "Invalid choice: $choice"
+                exit 1
+            }
+        }
+    } else {
+        $script:Embedder = 'hash'
+        Write-Warn "[velesdb-memory] Using the default 'hash' embedder: deterministic and fully offline, but NOT semantic — recall matches surface form, not meaning. Re-run with -Embedder ollama for real semantic recall."
+    }
+}
+
+# ---- 2b. TTL resolution -------------------------------------------------------
+# $script:TtlExplicitlySet is set once in Main (from $PSBoundParameters, before
+# any nested function call makes it awkward to re-probe) and read here.
+function Resolve-Ttl {
+    if (-not $script:TtlExplicitlySet -and (Test-Interactive)) {
+        Write-Host ''
+        $script:Ttl = Read-Host 'Default TTL in seconds for new facts (empty = permanent)'
+    }
+
+    if ($script:Ttl -ne '' -and $script:Ttl -notmatch '^[0-9]+$') {
+        Write-ErrorMsg "-Ttl must be a non-negative integer (seconds), got '$script:Ttl'"
+        exit 1
+    }
+}
+
+# ---- 3. Ollama setup (only when Embedder = ollama) ---------------------------
+function Get-NormalizedModelTag {
+    param([string]$Model)
+    if ($Model -match ':') { $Model } else { "$Model`:latest" }
+}
+
+function Initialize-Ollama {
+    if ($script:Embedder -ne 'ollama') { return }
+
+    if (-not (Get-Command ollama -ErrorAction SilentlyContinue)) {
+        Write-ErrorMsg "'ollama' not found. See https://ollama.com/download for Windows install instructions."
+        exit 1
+    }
+
+    try {
+        $tags = Invoke-RestMethod -Uri "$OllamaUrl/api/tags" -TimeoutSec 2 -ErrorAction Stop
+    } catch {
+        Write-ErrorMsg "Ollama does not respond on $OllamaUrl — launch the Ollama app or run ``ollama serve``."
+        exit 1
+    }
+
+    $wanted = Get-NormalizedModelTag -Model $OllamaModel
+    $have = @($tags.models | Where-Object { $_.name -eq $wanted }).Count
+
+    if ($have -eq 0) {
+        if ($Yes) {
+            Write-Warn "Pulling Ollama model '$OllamaModel'..."
+            ollama pull $OllamaModel
+        } elseif (Test-Interactive) {
+            $reply = Read-Host "Model '$OllamaModel' not found locally. Pull it now? [y/N]"
+            if ($reply -match '^(y|yes)$') {
+                ollama pull $OllamaModel
+            } else {
+                Write-ErrorMsg "Run this first: ollama pull $OllamaModel"
+                exit 1
+            }
+        } else {
+            Write-ErrorMsg "Model '$OllamaModel' not found locally. Run: ollama pull $OllamaModel"
+            exit 1
+        }
+    }
+}
+
+# ---- 4. Build (cargo) or install a prebuilt release archive -----------------
+function Build-Daemon {
+    Write-Warn 'Building velesdb-memory (--features ollama,http)...'
+    # Always both features regardless of the runtime embedder choice above:
+    # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
+    # choice, so flipping it later is a restart, never a rebuild.
+    cargo install --path "$script:RepoRoot/crates/velesdb-memory" --bin velesdb-memory `
+        --features ollama,http --force
+    if ($LASTEXITCODE -ne 0) {
+        Write-ErrorMsg 'cargo install failed.'
+        exit 1
+    }
+}
+
+function Resolve-LatestReleaseTag {
+    # GitHub returns releases newest-first; velesdb-memory ships its own
+    # velesdb-memory-vX.Y.Z tags (decoupled from the workspace vX.Y.Z line —
+    # see release-memory.yml), created with --latest=false so they never
+    # become the repo's overall "Latest release". A plain /releases/latest
+    # call would therefore miss them entirely — list and filter instead.
+    # HARDENING (same limitation as the shell installer's equivalent lookup):
+    # only the first page (100 releases) is scanned; if velesdb-memory ever
+    # accumulates more than 100 releases without pruning, pass -FromReleaseTag
+    # explicitly instead of relying on this default.
+    try {
+        $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$RepoSlug/releases?per_page=100" -TimeoutSec 10
+    } catch {
+        Write-ErrorMsg "Could not list releases for $RepoSlug`: $($_.Exception.Message)"
+        exit 1
+    }
+    $tag = $releases |
+        Where-Object { $_.tag_name -match '^velesdb-memory-v[0-9]+\.[0-9]+\.[0-9]+$' -and -not $_.prerelease } |
+        Select-Object -First 1 -ExpandProperty tag_name
+    if (-not $tag) {
+        Write-ErrorMsg "No published velesdb-memory-vX.Y.Z release found on $RepoSlug — this path needs a release that carries the daemon archive (see the README's -FromRelease note)."
+        exit 1
+    }
+    $tag
+}
+
+function Install-FromRelease {
+    $tag = if ($FromReleaseTag -ne '') { $FromReleaseTag } else { Resolve-LatestReleaseTag }
+    $target = 'x86_64-pc-windows-msvc'
+    $asset = "velesdb-memory-daemon-$target.zip"
+    $baseUrl = "https://github.com/$RepoSlug/releases/download/$tag"
+
+    Write-Warn "Installing velesdb-memory from release $tag ($asset)..."
+
+    $tempDir = Join-Path $env:TEMP "velesdb-memory-daemon-$tag"
+    New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+    $archivePath = Join-Path $tempDir $asset
+    $checksumPath = "$archivePath.sha256"
+
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $archivePath -ErrorAction Stop
+    } catch {
+        Write-ErrorMsg "Failed to download $baseUrl/$asset — this tag may predate the daemon archive (added in the release-memory.yml workflow after 0.11.0). $($_.Exception.Message)"
+        exit 1
+    }
+
+    $checksumOk = $true
+    try {
+        Invoke-WebRequest -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath -ErrorAction Stop
+        $expected = (Get-Content $checksumPath -Raw).Split(' ')[0].Trim().ToLowerInvariant()
+        $actual = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($expected -ne $actual) {
+            Write-ErrorMsg "Checksum mismatch for $asset — expected $expected, got $actual. Aborting (the archive may be corrupt or tampered)."
+            exit 1
+        }
+        Write-Success 'Checksum verified.'
+    } catch {
+        $checksumOk = $false
+        Write-Warn "No .sha256 sidecar found for $asset — installing without checksum verification."
+    }
+
+    $extractDir = Join-Path $tempDir 'extracted'
+    Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+    $exe = Get-ChildItem -Path $extractDir -Filter 'velesdb-memory.exe' -Recurse | Select-Object -First 1
+    if (-not $exe) {
+        Write-ErrorMsg "velesdb-memory.exe not found inside $asset — unexpected archive layout."
+        exit 1
+    }
+
+    New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
+    Copy-Item -Path $exe.FullName -Destination $BinPath -Force
+    Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    Write-Success "Installed $BinPath from $tag$(if (-not $checksumOk) { ' (unverified — no checksum published for this tag)' })."
+}
+
+# ---- 5. Scheduled Task daemon -------------------------------------------------
+function New-DaemonWrapper {
+    New-Item -ItemType Directory -Force -Path $ConfigRoot | Out-Null
+    New-Item -ItemType Directory -Force -Path $LogsDir | Out-Null
+
+    # Empty TTL means "permanent" (VELESDB_MEMORY_DEFAULT_TTL unset) — matches
+    # the server's own default, so the line is omitted entirely rather than
+    # set to an empty value.
+    $ttlLine = if ($script:Ttl -ne '') { "set VELESDB_MEMORY_DEFAULT_TTL=$script:Ttl" } else { '' }
+
+    # A Scheduled Task action carries no environment block of its own, so this
+    # wrapper is how the daemon's env vars actually reach the process — the
+    # task just launches this .cmd. Output is redirected here too, since
+    # Register-ScheduledTask has no stdout/stderr-path equivalent to launchd's
+    # StandardOutPath/StandardErrorPath.
+    $content = @"
+@echo off
+set VELESDB_MEMORY_PATH=$script:Store
+set VELESDB_MEMORY_TLS_DIR=$script:TlsDir
+set VELESDB_MEMORY_EMBEDDER=$script:Embedder
+set VELESDB_MEMORY_OLLAMA_URL=$OllamaUrl
+set VELESDB_MEMORY_OLLAMA_MODEL=$OllamaModel
+$ttlLine
+"$BinPath" --http --http-port $Port >> "$LogsDir\daemon.out.log" 2>> "$LogsDir\daemon.err.log"
+"@
+    Set-Content -Path $WrapperPath -Value $content -Encoding ASCII
+}
+
+function Wait-DaemonHealth {
+    param([string]$CaCertPath)
+    Write-Warn 'Waiting for the daemon to answer /health...'
+    $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+    if (-not $curl) {
+        Write-Warn 'curl.exe not found (expected on Windows 10 1803+/11) — skipping the active health check. Verify manually once the daemon starts.'
+        return
+    }
+    for ($waited = 0; $waited -lt 5; $waited++) {
+        & $curl.Source -fsS --max-time 1 --cacert $CaCertPath "https://127.0.0.1:$Port/health" *> $null
+        if ($LASTEXITCODE -eq 0) { return }
+        Start-Sleep -Seconds 1
+    }
+    Write-Warn "No response from /health within 5s — check $LogsDir\daemon.err.log"
+}
+
+function Set-Daemon {
+    $script:DaemonAlreadyRunning = $false
+    $caCert = "$script:TlsDir\ca-cert.pem"
+
+    $existingTask = Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder -ErrorAction SilentlyContinue
+
+    if ($existingTask -and -not $ForceRestart) {
+        Write-Success "$TaskFolder$TaskName is already registered — skipping (pass -ForceRestart to reload)."
+        $script:DaemonAlreadyRunning = $true
+        if ($existingTask.State -ne 'Running') {
+            Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder
+        }
+        # Still (re-)attempt CA trust even when the task itself isn't
+        # restarted — a task can be "already registered" from a run that
+        # predates the CA existing yet, which would otherwise leave the
+        # local CA permanently untrusted.
+        Wait-DaemonHealth -CaCertPath $caCert
+        Enable-LocalCaTrust -CaCertPath $caCert
+        return
+    }
+
+    if ($existingTask) {
+        Write-Warn "-ForceRestart: unregistering the existing $TaskFolder$TaskName..."
+        Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder -Confirm:$false -ErrorAction SilentlyContinue
+    }
+
+    New-DaemonWrapper
+
+    $action = New-ScheduledTaskAction -Execute $WrapperPath
+    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) `
+        -ExecutionTimeLimit ([TimeSpan]::Zero)
+    # RunLevel Limited: a *user*-level task, deliberately not "Highest" — this
+    # installer never needs, and never asks for, admin rights.
+    $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+
+    Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder -Action $action `
+        -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null
+
+    Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder
+
+    Wait-DaemonHealth -CaCertPath $caCert
+    Enable-LocalCaTrust -CaCertPath $caCert
+}
+
+# Run a script block with a hard wall-clock timeout, mirroring the shell
+# script's `run_with_timeout` — used below because `certutil -addstore` can
+# in principle block on a confirmation dialog, and this script must never
+# hang forever waiting on it.
+function Invoke-WithTimeout {
+    param(
+        [int]$Seconds,
+        [string]$FilePath,
+        [string[]]$ArgumentList
+    )
+    $proc = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -NoNewWindow -PassThru
+    if (-not $proc.WaitForExit($Seconds * 1000)) {
+        try { $proc.Kill() } catch {}
+        return $false
+    }
+    return $proc.ExitCode -eq 0
+}
+
+# ---- 5b. Trust the local CA in the CurrentUser\Root store --------------------
+function Enable-LocalCaTrust {
+    param([string]$CaCertPath)
+
+    if ($SkipCaTrust) {
+        Write-Warn 'Skipping CA trust (-SkipCaTrust).'
+        return
+    }
+    if (-not (Test-Path $CaCertPath)) {
+        Write-Warn "No CA certificate at $CaCertPath (daemon may not have started — see the /health warning above) — skipping CA trust."
+        return
+    }
+
+    # Ground-truth idempotency check first, same as the macOS script: if a
+    # strict HTTPS request already succeeds against the SYSTEM/user trust
+    # store, the CA is already trusted — skip re-running certutil.
+    $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+    if ($curl) {
+        & $curl.Source -fsS --max-time 2 "https://127.0.0.1:$Port/health" *> $null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Success 'Local CA already trusted (strict HTTPS request to the daemon succeeded).'
+            return
+        }
+    }
+
+    # Belt-and-braces: also check by thumbprint before importing, so a
+    # `certutil` failure that still left the cert present doesn't loop.
+    try {
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($CaCertPath)
+        $existing = Get-ChildItem Cert:\CurrentUser\Root | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+        if ($existing) {
+            Write-Success 'Local CA already present in Cert:\CurrentUser\Root (by thumbprint) — skipping import.'
+            return
+        }
+    } catch {
+        Write-Warn "Could not read $CaCertPath as a certificate to check its thumbprint — attempting import anyway."
+    }
+
+    Write-Host ''
+    Write-Info "Trusting the local CA in your user certificate store ($CaCertPath)..."
+    Write-Warn '   Windows may show a security warning dialog — approve it within 60s. Without this,'
+    Write-Warn '   HTTPS clients that verify certificates strictly (browsers, plain curl) will reject'
+    Write-Warn '   this daemon''s certificate until you trust it, here or by hand later.'
+
+    # certutil (not Import-Certificate) — accepts the daemon's PEM output
+    # directly and natively targets the per-user store with `-user`, no admin
+    # rights needed, and behaves consistently across PowerShell versions.
+    $ok = Invoke-WithTimeout -Seconds 60 -FilePath 'certutil.exe' -ArgumentList @('-addstore', '-user', 'Root', "`"$CaCertPath`"")
+    if ($ok) {
+        Write-Success 'Local CA trusted in Cert:\CurrentUser\Root.'
+    } else {
+        Write-Warn '   Could not confirm the CA trust automatically (no response within 60s, or the'
+        Write-Warn '   command failed). The daemon is still up and serving HTTPS — this only affects'
+        Write-Warn '   clients that verify certificates strictly. Run this yourself to finish:'
+        Write-Host "     certutil -addstore -user Root `"$CaCertPath`""
+    }
+}
+
+# ---- 6. Client wiring ---------------------------------------------------------
+function Set-ClaudeCodeClient {
+    if (Test-ShouldSkip 'claude-code') {
+        Write-Warn 'Skipping Claude Code (-SkipClient).'
+        return
+    }
+    if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
+        Write-Warn "'claude' CLI not found — skipping Claude Code wiring."
+        return
+    }
+
+    claude mcp remove velesdb-memory -s user *> $null
+    claude mcp add --transport http --scope user velesdb-memory "https://127.0.0.1:$Port/mcp" *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Success "Claude Code wired (user scope) -> https://127.0.0.1:$Port/mcp"
+        Write-Warn '   Note: project/local-scope entries (if any) are not touched — check with `claude mcp list`.'
+        Write-Warn '   Note: Node-based tools don''t always consult the Windows certificate store for TLS'
+        Write-Warn '   trust. If Claude Code reports a certificate error despite the CA trust step above, set:'
+        Write-Warn "     `$env:NODE_EXTRA_CA_CERTS = `"$script:TlsDir\ca-cert.pem`""
+    } else {
+        Write-ErrorMsg 'Failed to wire Claude Code.'
+    }
+}
+
+# Claude Desktop is a DIFFERENT mechanism than every other client here:
+# claude_desktop_config.json never reads a url/type:"http" entry (confirmed on
+# macOS, same binary/config format on Windows) — the only way to wire Desktop
+# to the daemon is its own UI. This prints that instruction instead of
+# touching the config file, same as the shell script.
+function Set-ClaudeDesktopClient {
+    if (Test-ShouldSkip 'claude-desktop') {
+        Write-Warn 'Skipping Claude Desktop (-SkipClient).'
+        return
+    }
+    Write-Host ''
+    Write-Info 'Claude Desktop — different mechanism than every other client here:'
+    Write-Warn "   its config file ($DesktopConfig) does not support HTTP (a url/type:`"http`" entry"
+    Write-Warn '   there is silently ignored). Add it yourself, once, via the UI instead:'
+    Write-Warn '   Settings -> Connectors -> Add custom connector, then paste:'
+    Write-Host "     https://127.0.0.1:$Port/mcp"
+    Write-Warn '   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.'
+    Write-Warn '   Prefer not to use the Connectors UI? A stdio fallback still works — see the README''s'
+    Write-Warn "   `"Configure your client`" section (use a DIFFERENT VELESDB_MEMORY_PATH than $script:Store,"
+    Write-Warn '   or the fallback process and the daemon will fight over the same lock).'
+}
+
+# Set-JsonClient NAME CONFIG_PATH MUTATOR REQUIRE_EXISTING_DIR
+# REQUIRE_EXISTING_DIR skips (rather than creates) the client's config
+# directory when absent — used for Devin, whose directory only exists if the
+# CLI itself is installed; Windsurf's is created if missing (same split as
+# the shell script's wire_json_client callers).
+function Set-JsonClient {
+    param(
+        [string]$Name,
+        [string]$ConfigPath,
+        [scriptblock]$Mutator,
+        [bool]$RequireExistingDir
+    )
+    if (Test-ShouldSkip $Name) {
+        Write-Warn "Skipping $Name (-SkipClient)."
+        return
+    }
+
+    $configDir = Split-Path -Path $ConfigPath -Parent
+    if ($RequireExistingDir -and -not (Test-Path $configDir)) {
+        Write-Warn "$Name not detected (no $configDir) — skipping."
+        return
+    }
+    New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+
+    $existed = Test-Path $ConfigPath
+    if (-not $existed) {
+        Set-Content -Path $ConfigPath -Value '{}'
+    }
+
+    try {
+        $raw = Get-Content -Path $ConfigPath -Raw
+        $json = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-ErrorMsg "$ConfigPath is not valid JSON — fix or remove it manually, then re-run."
+        return
+    }
+
+    if ($existed) {
+        $backup = "$ConfigPath.bak.$([DateTimeOffset]::UtcNow.ToUnixTimeSeconds())"
+        Copy-Item -Path $ConfigPath -Destination $backup
+    }
+
+    try {
+        $json = & $Mutator $json
+        ($json | ConvertTo-Json -Depth 10) | Set-Content -Path $ConfigPath
+        Write-Success "$Name wired -> $ConfigPath"
+    } catch {
+        Write-ErrorMsg "Failed to update $ConfigPath`: $($_.Exception.Message)"
+    }
+}
+
+function Set-WindsurfClient {
+    Set-JsonClient -Name 'windsurf' -ConfigPath $WindsurfConfig -RequireExistingDir $false -Mutator {
+        param($json)
+        if (-not $json.PSObject.Properties['mcpServers']) {
+            $json | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue ([PSCustomObject]@{})
+        }
+        $entry = [PSCustomObject]@{ serverUrl = "https://127.0.0.1:$Port/mcp" }
+        if ($json.mcpServers.PSObject.Properties['velesdb-memory']) {
+            $json.mcpServers.'velesdb-memory' = $entry
+        } else {
+            $json.mcpServers | Add-Member -NotePropertyName 'velesdb-memory' -NotePropertyValue $entry
+        }
+        $json
+    }
+}
+
+# Devin CLI's config wraps mcpServers in a top-level {"version": 1, ...}
+# envelope (unlike every other client here) — version is set only if absent,
+# so a re-run never clobbers a newer schema version Devin itself might have
+# written.
+function Set-DevinClient {
+    Set-JsonClient -Name 'devin' -ConfigPath $DevinConfig -RequireExistingDir $true -Mutator {
+        param($json)
+        if (-not $json.PSObject.Properties['version']) {
+            $json | Add-Member -NotePropertyName 'version' -NotePropertyValue 1
+        }
+        if (-not $json.PSObject.Properties['mcpServers']) {
+            $json | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue ([PSCustomObject]@{})
+        }
+        $entry = [PSCustomObject]@{ url = "https://127.0.0.1:$Port/mcp"; transport = 'http' }
+        if ($json.mcpServers.PSObject.Properties['velesdb-memory']) {
+            $json.mcpServers.'velesdb-memory' = $entry
+        } else {
+            $json.mcpServers | Add-Member -NotePropertyName 'velesdb-memory' -NotePropertyValue $entry
+        }
+        $json
+    }
+}
+
+# ---- 7. Uninstall --------------------------------------------------------------
+function Invoke-Uninstall {
+    Write-Warn 'Uninstalling the velesdb-memory daemon and client wiring...'
+
+    Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskFolder -Confirm:$false -ErrorAction SilentlyContinue
+    Remove-Item -Path $WrapperPath -Force -ErrorAction SilentlyContinue
+
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        claude mcp remove velesdb-memory -s user *> $null
+    }
+
+    foreach ($cfg in @($DesktopConfig, $WindsurfConfig, $DevinConfig)) {
+        if (Test-Path $cfg) {
+            try {
+                $json = Get-Content -Path $cfg -Raw | ConvertFrom-Json -ErrorAction Stop
+                if ($json.PSObject.Properties['mcpServers'] -and $json.mcpServers.PSObject.Properties['velesdb-memory']) {
+                    $json.mcpServers.PSObject.Properties.Remove('velesdb-memory')
+                    ($json | ConvertTo-Json -Depth 10) | Set-Content -Path $cfg
+                }
+            } catch {
+                Write-Warn "Skipped $cfg (not valid JSON)."
+            }
+        }
+    }
+
+    Write-Success "Uninstalled. The store ($Store by default) and the TLS material/CA ($TlsDir by default)"
+    Write-Success '   were both left untouched — same policy as the store: nothing local is ever deleted by'
+    Write-Success '   an uninstall. This also means the certificate trust you approved earlier stays valid, so a'
+    Write-Success '   future reinstall needs no new trust prompt. Remove either by hand if you want them gone.'
+}
+
+# ---- 8. Summary -----------------------------------------------------------------
+function Show-Summary {
+    Write-Host ''
+    Write-Info '==============================================='
+    Write-Info '  velesdb-memory daemon — summary'
+    Write-Info '==============================================='
+    Write-Host "  Embedder:  $script:Embedder"
+    Write-Host "  Port:      $Port"
+    Write-Host "  Store:     $script:Store"
+    Write-Host "  TLS CA:    $script:TlsDir\ca-cert.pem"
+    Write-Host "  TTL:       $(if ($script:Ttl -ne '') { $script:Ttl } else { 'permanent (no expiry)' })"
+
+    $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+    $up = $false
+    if ($curl) {
+        & $curl.Source -fsS --max-time 1 --cacert "$script:TlsDir\ca-cert.pem" "https://127.0.0.1:$Port/health" *> $null
+        $up = ($LASTEXITCODE -eq 0)
+    }
+    if ($up) {
+        $suffix = if ($script:DaemonAlreadyRunning) { ' (already registered, not restarted)' } else { '' }
+        Write-Host "  Daemon:    " -NoNewline
+        Write-Success "running -> https://127.0.0.1:$Port/mcp$suffix"
+    } else {
+        Write-Host "  Daemon:    " -NoNewline
+        Write-Warn "not confirmed up — check $LogsDir\daemon.err.log"
+    }
+
+    foreach ($client in @('claude-code', 'claude-desktop', 'windsurf', 'devin')) {
+        if (Test-ShouldSkip $client) {
+            Write-Host "  $client`: skipped (-SkipClient)"
+        } else {
+            Write-Host "  $client`: wired (see log above for details/warnings)"
+        }
+    }
+    Write-Host ''
+}
+
+# ---- Main -----------------------------------------------------------------------
+function Main {
+    if ($Uninstall) {
+        Invoke-Uninstall
+        exit 0
+    }
+
+    # Resolve the TTL "was it explicitly passed" flag before Set-StrictMode's
+    # automatic-variable checks make $PSBoundParameters awkward to probe twice.
+    $script:TtlExplicitlySet = $PSBoundParameters.ContainsKey('Ttl')
+
+    Invoke-Preflight
+    Resolve-Embedder
+    Resolve-Ttl
+    Initialize-Ollama
+    if ($FromRelease) { Install-FromRelease } else { Build-Daemon }
+    Set-Daemon
+    Set-ClaudeCodeClient
+    Set-ClaudeDesktopClient
+    Set-WindsurfClient
+    Set-DevinClient
+    Show-Summary
+}
+
+Main

--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -58,6 +58,10 @@
 #                             separate parameter here.
 #   -FromReleaseTag <tag>     Pin the release tag to install from (default: latest
 #                             velesdb-memory-v* release). Implies -FromRelease.
+#   -SkipChecksum             Install a -FromRelease archive even if its .sha256 can't be
+#                             fetched/verified (default: this is a hard error — the checksum
+#                             only proves transfer integrity, not authenticity, but skipping it
+#                             silently is worse). No effect without -FromRelease.
 #   -Uninstall                Remove the scheduled task and all client wiring (store and TLS
 #                             material/CA trust are NEVER touched — same "never delete local
 #                             state" policy as the store)
@@ -96,6 +100,8 @@ param(
 
     [string]$FromReleaseTag = '',
 
+    [switch]$SkipChecksum,
+
     [switch]$Uninstall,
 
     [switch]$Help
@@ -103,6 +109,18 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# Captured HERE, at true script scope, not inside `function Main` further
+# down: `$PSBoundParameters` is per-function-scope in PowerShell, so reading
+# it from inside a nested function (even one invoked directly from the
+# script's own top level, like Main) sees THAT function's own bound
+# parameters — Main takes none, so `$PSBoundParameters.ContainsKey('Ttl')`
+# there is unconditionally $false, no matter what the caller passed on the
+# command line. This bit an earlier version of this script: `-Ttl 3600`
+# would still get silently re-prompted-and-overwritten by Resolve-Ttl in an
+# interactive session, because the "was -Ttl explicitly passed" check was
+# reading the wrong scope's (always-empty) bound-parameters set.
+$script:ScriptBoundParameters = $PSBoundParameters
 
 # -FromReleaseTag implies -FromRelease (mirrors the shell script's `--from-release[=TAG]`
 # accepting an inline tag without a separate boolean flag).
@@ -213,8 +231,9 @@ function Resolve-Embedder {
 }
 
 # ---- 2b. TTL resolution -------------------------------------------------------
-# $script:TtlExplicitlySet is set once in Main (from $PSBoundParameters, before
-# any nested function call makes it awkward to re-probe) and read here.
+# $script:TtlExplicitlySet is set once in Main (from $script:ScriptBoundParameters,
+# captured at true script scope — see its own comment for why not
+# $PSBoundParameters here) and read below.
 function Resolve-Ttl {
     if (-not $script:TtlExplicitlySet -and (Test-Interactive)) {
         Write-Host ''
@@ -327,22 +346,35 @@ function Install-FromRelease {
         Invoke-WebRequest -Uri "$baseUrl/$asset" -OutFile $archivePath -ErrorAction Stop
     } catch {
         Write-ErrorMsg "Failed to download $baseUrl/$asset — this tag may predate the daemon archive (added in the release-memory.yml workflow after 0.11.0). $($_.Exception.Message)"
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
         exit 1
     }
 
-    $checksumOk = $true
-    try {
-        Invoke-WebRequest -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath -ErrorAction Stop
+    # Blocking by default: a checksum that can't be fetched/verified is
+    # treated the same as a mismatch (installing an unverified binary
+    # silently is worse than a loud failure). -SkipChecksum is the explicit
+    # opt-out. Note this only proves TRANSFER integrity (the bytes weren't
+    # corrupted/truncated in flight) — it is not a cryptographic signature,
+    # so it does not by itself prove the archive is authentic; the README's
+    # "Installing the daemon without a Rust toolchain" section says so too.
+    if ($SkipChecksum) {
+        Write-Warn "Skipping checksum verification (-SkipChecksum) — the downloaded archive's integrity will not be checked."
+    } else {
+        try {
+            Invoke-WebRequest -Uri "$baseUrl/$asset.sha256" -OutFile $checksumPath -ErrorAction Stop
+        } catch {
+            Write-ErrorMsg "Could not fetch the checksum for $asset ($baseUrl/$asset.sha256) — aborting rather than installing an unverified binary. Pass -SkipChecksum to install anyway (not recommended)."
+            Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+            exit 1
+        }
         $expected = (Get-Content $checksumPath -Raw).Split(' ')[0].Trim().ToLowerInvariant()
         $actual = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
         if ($expected -ne $actual) {
             Write-ErrorMsg "Checksum mismatch for $asset — expected $expected, got $actual. Aborting (the archive may be corrupt or tampered)."
+            Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
             exit 1
         }
-        Write-Success 'Checksum verified.'
-    } catch {
-        $checksumOk = $false
-        Write-Warn "No .sha256 sidecar found for $asset — installing without checksum verification."
+        Write-Success 'Checksum verified (transfer integrity — not a signature of authenticity).'
     }
 
     $extractDir = Join-Path $tempDir 'extracted'
@@ -351,6 +383,7 @@ function Install-FromRelease {
     $exe = Get-ChildItem -Path $extractDir -Filter 'velesdb-memory.exe' -Recurse | Select-Object -First 1
     if (-not $exe) {
         Write-ErrorMsg "velesdb-memory.exe not found inside $asset — unexpected archive layout."
+        Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
         exit 1
     }
 
@@ -358,7 +391,7 @@ function Install-FromRelease {
     Copy-Item -Path $exe.FullName -Destination $BinPath -Force
     Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
 
-    Write-Success "Installed $BinPath from $tag$(if (-not $checksumOk) { ' (unverified — no checksum published for this tag)' })."
+    Write-Success "Installed $BinPath from $tag$(if ($SkipChecksum) { ' (unverified — -SkipChecksum)' })."
 }
 
 # ---- 5. Scheduled Task daemon -------------------------------------------------
@@ -368,8 +401,11 @@ function New-DaemonWrapper {
 
     # Empty TTL means "permanent" (VELESDB_MEMORY_DEFAULT_TTL unset) — matches
     # the server's own default, so the line is omitted entirely rather than
-    # set to an empty value.
-    $ttlLine = if ($script:Ttl -ne '') { "set VELESDB_MEMORY_DEFAULT_TTL=$script:Ttl" } else { '' }
+    # set to an empty value. Quoted (`set "VAR=value"`, not bare `set VAR=value`)
+    # so a value containing `&`, `|`, `<`, `>`, `^`, or trailing spaces — a
+    # store/TLS path or Ollama URL isn't guaranteed to avoid all of those —
+    # doesn't get parsed as a batch operator instead of literal text.
+    $ttlLine = if ($script:Ttl -ne '') { "set `"VELESDB_MEMORY_DEFAULT_TTL=$script:Ttl`"" } else { '' }
 
     # A Scheduled Task action carries no environment block of its own, so this
     # wrapper is how the daemon's env vars actually reach the process — the
@@ -378,15 +414,31 @@ function New-DaemonWrapper {
     # StandardOutPath/StandardErrorPath.
     $content = @"
 @echo off
-set VELESDB_MEMORY_PATH=$script:Store
-set VELESDB_MEMORY_TLS_DIR=$script:TlsDir
-set VELESDB_MEMORY_EMBEDDER=$script:Embedder
-set VELESDB_MEMORY_OLLAMA_URL=$OllamaUrl
-set VELESDB_MEMORY_OLLAMA_MODEL=$OllamaModel
+chcp 65001 >nul
+set "VELESDB_MEMORY_PATH=$script:Store"
+set "VELESDB_MEMORY_TLS_DIR=$script:TlsDir"
+set "VELESDB_MEMORY_EMBEDDER=$script:Embedder"
+set "VELESDB_MEMORY_OLLAMA_URL=$OllamaUrl"
+set "VELESDB_MEMORY_OLLAMA_MODEL=$OllamaModel"
 $ttlLine
 "$BinPath" --http --http-port $Port >> "$LogsDir\daemon.out.log" 2>> "$LogsDir\daemon.err.log"
 "@
-    Set-Content -Path $WrapperPath -Value $content -Encoding ASCII
+
+    # cmd.exe decodes a batch file using its active code page, which by
+    # default is NOT UTF-8 — a non-ASCII $env:USERPROFILE (an accented
+    # Windows username, e.g. a French "Céline") would otherwise get
+    # corrupted when this file's UTF-8 bytes are misread, breaking every
+    # `set` line that embeds $Store/$TlsDir/$BinPath. `chcp 65001` (above,
+    # first line after @echo off — that ordering matters) switches cmd.exe's
+    # active code page to UTF-8 for the rest of THIS script's execution
+    # before any non-ASCII line is parsed. That only works paired with an
+    # actual UTF-8-encoded file — hence -Encoding utf8NoBOM below (no BOM:
+    # a BOM before `@echo off` is a known way to corrupt a batch file's
+    # first line on some cmd.exe versions). cmd.exe also expects CRLF line
+    # endings, so normalize explicitly rather than relying on how this
+    # script's own here-string literal happens to be checked out.
+    $content = ($content -replace "`r`n", "`n") -replace "`n", "`r`n"
+    Set-Content -Path $WrapperPath -Value $content -Encoding utf8NoBOM -NoNewline
 }
 
 function Wait-DaemonHealth {
@@ -738,9 +790,11 @@ function Main {
         exit 0
     }
 
-    # Resolve the TTL "was it explicitly passed" flag before Set-StrictMode's
-    # automatic-variable checks make $PSBoundParameters awkward to probe twice.
-    $script:TtlExplicitlySet = $PSBoundParameters.ContainsKey('Ttl')
+    # Read from $script:ScriptBoundParameters (captured at true script scope,
+    # above the param() block) — NOT $PSBoundParameters here, which inside
+    # this function would be Main's own (always-empty) bound parameters. See
+    # the comment where $script:ScriptBoundParameters is assigned.
+    $script:TtlExplicitlySet = $script:ScriptBoundParameters.ContainsKey('Ttl')
 
     Invoke-Preflight
     Resolve-Embedder

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -44,6 +44,10 @@
 #                            latest published velesdb-memory-vX.Y.Z release). Needs no Rust
 #                            toolchain. Only active from the first release that publishes the
 #                            archive onward — see the README's "HTTP transport" section.
+#   --skip-checksum          Install a --from-release archive even if its .sha256 can't be
+#                            fetched/verified (default: this is a hard error — the checksum
+#                            only proves transfer integrity, not authenticity, but skipping it
+#                            silently is worse). No effect without --from-release.
 #   --uninstall              Remove the daemon and all client wiring (store and TLS material/CA
 #                            trust are NEVER touched — same "never delete local state" policy)
 #   -h, --help               Show this help
@@ -88,6 +92,7 @@ SKIP_CLIENTS=""
 SKIP_CA_TRUST=0
 FROM_RELEASE=0
 FROM_RELEASE_TAG=""
+SKIP_CHECKSUM=0
 
 PLIST_LABEL="com.velesdb.memory"
 PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
@@ -98,7 +103,7 @@ DEVIN_CONFIG="$HOME/.config/devin/config.json"
 RELEASE_REPO="cyberlife-coder/VelesDB"
 
 print_usage() {
-  sed -n '2,49p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -117,6 +122,7 @@ for arg in "$@"; do
     --force-restart) FORCE_RESTART=1 ;;
     --from-release) FROM_RELEASE=1 ;;
     --from-release=*) FROM_RELEASE=1; FROM_RELEASE_TAG="${arg#*=}" ;;
+    --skip-checksum) SKIP_CHECKSUM=1 ;;
     --uninstall) UNINSTALL=1 ;;
     -h|--help) print_usage; exit 0 ;;
     *)
@@ -356,7 +362,21 @@ install_from_release() {
     exit 1
   fi
 
-  if curl -fsSL --max-time 10 -o "$checksum_path" "$base_url/$asset.sha256" 2>/dev/null; then
+  # Blocking by default: a checksum that can't be fetched/verified is
+  # treated the same as a mismatch (installing an unverified binary
+  # silently is worse than a loud failure). --skip-checksum is the explicit
+  # opt-out. This only proves TRANSFER integrity (the bytes weren't
+  # corrupted/truncated in flight) — it is not a cryptographic signature, so
+  # it does not by itself prove the archive is authentic; the README's
+  # "Installing the daemon without a Rust toolchain" section says so too.
+  if [ "$SKIP_CHECKSUM" = "1" ]; then
+    echo -e "${YELLOW}⚠️  Skipping checksum verification (--skip-checksum) — the downloaded archive's integrity will not be checked.${NC}"
+  else
+    if ! curl -fsSL --max-time 10 -o "$checksum_path" "$base_url/$asset.sha256" 2>/dev/null; then
+      echo -e "${RED}❌ could not fetch the checksum for $asset ($base_url/$asset.sha256) — aborting rather than installing an unverified binary. Pass --skip-checksum to install anyway (not recommended).${NC}"
+      rm -rf "$tmp_dir"
+      exit 1
+    fi
     expected="$(awk '{print $1}' "$checksum_path")"
     if command -v sha256sum >/dev/null 2>&1; then
       actual="$(sha256sum "$archive_path" | awk '{print $1}')"
@@ -368,9 +388,7 @@ install_from_release() {
       rm -rf "$tmp_dir"
       exit 1
     fi
-    echo -e "${GREEN}✅ Checksum verified.${NC}"
-  else
-    echo -e "${YELLOW}⚠️  No .sha256 sidecar found for $asset — installing without checksum verification.${NC}"
+    echo -e "${GREEN}✅ Checksum verified (transfer integrity — not a signature of authenticity).${NC}"
   fi
 
   tar -xzf "$archive_path" -C "$tmp_dir"
@@ -385,7 +403,7 @@ install_from_release() {
   chmod +x "$BIN_PATH"
   rm -rf "$tmp_dir"
 
-  echo -e "${GREEN}✅ Installed $BIN_PATH from $tag${NC}"
+  echo -e "${GREEN}✅ Installed $BIN_PATH from $tag$([ "$SKIP_CHECKSUM" = "1" ] && echo ' (unverified — --skip-checksum)')${NC}"
 }
 
 # ---- 5. launchd daemon (macOS only) ----------------------------------------

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -17,6 +17,12 @@
 # step 5's "Trusting the local CA" output for what that step actually did on
 # THIS run (macOS may require you to approve a system prompt).
 #
+# Windows has no macOS-equivalent launchd/keychain, so it gets its own mirror
+# instead of a branch in this file: scripts/install-memory-daemon.ps1 (run as
+# `pwsh -File scripts/install-memory-daemon.ps1`) — a per-user Scheduled Task
+# instead of a launchd agent, CurrentUser\Root instead of the login keychain,
+# same daemon, same client wiring, same flags (PowerShell-cased).
+#
 # Usage:
 #   ./scripts/install-memory-daemon.sh [flags]
 #   ./scripts/install-memory-daemon.sh --uninstall
@@ -33,6 +39,11 @@
 #   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   --skip-ca-trust          Skip trusting the local CA in the login keychain
 #   --force-restart          Reload the daemon even if already running
+#   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http) from a
+#                            GitHub Release archive instead of `cargo install` (default TAG: the
+#                            latest published velesdb-memory-vX.Y.Z release). Needs no Rust
+#                            toolchain. Only active from the first release that publishes the
+#                            archive onward — see the README's "HTTP transport" section.
 #   --uninstall              Remove the daemon and all client wiring (store and TLS material/CA
 #                            trust are NEVER touched — same "never delete local state" policy)
 #   -h, --help               Show this help
@@ -75,6 +86,8 @@ FORCE_RESTART=0
 UNINSTALL=0
 SKIP_CLIENTS=""
 SKIP_CA_TRUST=0
+FROM_RELEASE=0
+FROM_RELEASE_TAG=""
 
 PLIST_LABEL="com.velesdb.memory"
 PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
@@ -82,9 +95,10 @@ BIN_PATH="$HOME/.cargo/bin/velesdb-memory"
 DESKTOP_CONFIG="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
 WINDSURF_CONFIG="$HOME/.codeium/windsurf/mcp_config.json"
 DEVIN_CONFIG="$HOME/.config/devin/config.json"
+RELEASE_REPO="cyberlife-coder/VelesDB"
 
 print_usage() {
-  sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,49p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -101,6 +115,8 @@ for arg in "$@"; do
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
     --skip-ca-trust) SKIP_CA_TRUST=1 ;;
     --force-restart) FORCE_RESTART=1 ;;
+    --from-release) FROM_RELEASE=1 ;;
+    --from-release=*) FROM_RELEASE=1; FROM_RELEASE_TAG="${arg#*=}" ;;
     --uninstall) UNINSTALL=1 ;;
     -h|--help) print_usage; exit 0 ;;
     *)
@@ -120,8 +136,9 @@ should_skip() {
 
 # ---- 1. Preflight -------------------------------------------------------
 preflight() {
-  if ! command -v cargo >/dev/null 2>&1; then
+  if [ "$FROM_RELEASE" != "1" ] && ! command -v cargo >/dev/null 2>&1; then
     echo -e "${RED}❌ 'cargo' not found — install Rust via https://rustup.rs then relaunch this script${NC}"
+    echo -e "${RED}   (or pass --from-release to install a prebuilt binary instead — see --help)${NC}"
     exit 1
   fi
 
@@ -254,6 +271,121 @@ build_daemon() {
   # choice, so flipping it later is a restart, never a rebuild.
   cargo install --path "$REPO_ROOT/crates/velesdb-memory" --bin velesdb-memory \
     --features ollama,http --force
+}
+
+# ---- 4b. --from-release: install a prebuilt daemon binary, no cargo needed --
+# Mirrors build_daemon()'s guarantee (--features ollama,http) without a Rust
+# toolchain, by downloading the same binary release-memory.yml's
+# build-daemon-archive job produces. Only active from the first release that
+# ships the archive onward (added after 0.11.0) — an older/pinned tag simply
+# 404s, with a message saying so rather than a bare curl error.
+detect_release_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$os" in
+    Darwin)
+      case "$arch" in
+        arm64) echo "aarch64-apple-darwin" ;;
+        x86_64) echo "x86_64-apple-darwin" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    Linux)
+      case "$arch" in
+        x86_64) echo "x86_64-unknown-linux-gnu" ;;
+        aarch64|arm64) echo "aarch64-unknown-linux-gnu" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# GitHub returns releases newest-first; velesdb-memory-vX.Y.Z tags are
+# created with --latest=false (see release-memory.yml) so they never become
+# the repo's overall "Latest release" — a plain /releases/latest call would
+# miss them entirely, so this lists and filters instead.
+# HARDENING: only the first page (100 releases) is scanned; if velesdb-memory
+# ever accumulates more than 100 releases without pruning, pass
+# --from-release=<tag> explicitly instead of relying on this default.
+resolve_latest_release_tag() {
+  require_jq
+  local releases tag
+  releases="$(curl -fsS --max-time 10 "https://api.github.com/repos/$RELEASE_REPO/releases?per_page=100")" || {
+    echo -e "${RED}❌ could not list releases for $RELEASE_REPO${NC}" >&2
+    exit 1
+  }
+  tag="$(echo "$releases" | jq -r '
+    [.[] | select(.tag_name | test("^velesdb-memory-v[0-9]+\\.[0-9]+\\.[0-9]+$")) | select(.prerelease | not) | .tag_name]
+    | first // empty
+  ')"
+  if [ -z "$tag" ]; then
+    echo -e "${RED}❌ no published velesdb-memory-vX.Y.Z release found on $RELEASE_REPO — this path needs a release that carries the daemon archive (see the README's --from-release note)${NC}" >&2
+    exit 1
+  fi
+  echo "$tag"
+}
+
+install_from_release() {
+  local tag target asset base_url tmp_dir archive_path checksum_path expected actual
+
+  if [ -n "$FROM_RELEASE_TAG" ]; then
+    tag="$FROM_RELEASE_TAG"
+  else
+    tag="$(resolve_latest_release_tag)"
+  fi
+
+  target="$(detect_release_target)" || {
+    echo -e "${RED}❌ unsupported platform ($(uname -s) $(uname -m)) for --from-release — drop the flag to build from source with cargo instead${NC}"
+    exit 1
+  }
+
+  asset="velesdb-memory-daemon-${target}.tar.gz"
+  base_url="https://github.com/$RELEASE_REPO/releases/download/$tag"
+
+  echo -e "${YELLOW}📥 Installing velesdb-memory from release $tag ($asset)...${NC}"
+
+  tmp_dir="$(mktemp -d)"
+  archive_path="$tmp_dir/$asset"
+  checksum_path="$archive_path.sha256"
+
+  if ! curl -fsSL --max-time 60 -o "$archive_path" "$base_url/$asset"; then
+    echo -e "${RED}❌ failed to download $base_url/$asset — this tag may predate the daemon archive (added after 0.11.0)${NC}"
+    rm -rf "$tmp_dir"
+    exit 1
+  fi
+
+  if curl -fsSL --max-time 10 -o "$checksum_path" "$base_url/$asset.sha256" 2>/dev/null; then
+    expected="$(awk '{print $1}' "$checksum_path")"
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual="$(sha256sum "$archive_path" | awk '{print $1}')"
+    else
+      actual="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+    fi
+    if [ "$expected" != "$actual" ]; then
+      echo -e "${RED}❌ checksum mismatch for $asset — expected $expected, got $actual. Aborting (the archive may be corrupt or tampered).${NC}"
+      rm -rf "$tmp_dir"
+      exit 1
+    fi
+    echo -e "${GREEN}✅ Checksum verified.${NC}"
+  else
+    echo -e "${YELLOW}⚠️  No .sha256 sidecar found for $asset — installing without checksum verification.${NC}"
+  fi
+
+  tar -xzf "$archive_path" -C "$tmp_dir"
+  if [ ! -f "$tmp_dir/velesdb-memory" ]; then
+    echo -e "${RED}❌ velesdb-memory binary not found inside $asset — unexpected archive layout${NC}"
+    rm -rf "$tmp_dir"
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$BIN_PATH")"
+  cp "$tmp_dir/velesdb-memory" "$BIN_PATH"
+  chmod +x "$BIN_PATH"
+  rm -rf "$tmp_dir"
+
+  echo -e "${GREEN}✅ Installed $BIN_PATH from $tag${NC}"
 }
 
 # ---- 5. launchd daemon (macOS only) ----------------------------------------
@@ -651,7 +783,11 @@ main() {
   resolve_embedder
   resolve_ttl
   setup_ollama
-  build_daemon
+  if [ "$FROM_RELEASE" = "1" ]; then
+    install_from_release
+  else
+    build_daemon
+  fi
   setup_daemon
   wire_claude_code
   wire_claude_desktop


### PR DESCRIPTION
## Summary

- Adds `scripts/install-memory-daemon.ps1`, a PowerShell mirror of
  `scripts/install-memory-daemon.sh` for Windows 10/11: a per-user
  Scheduled Task instead of launchd, `Cert:\CurrentUser\Root` (via
  `certutil`, thumbprint-checked) instead of the login keychain, and the
  same four clients wired (Claude Code, Claude Desktop instructions-only,
  Windsurf, Devin CLI — Devin's Windows config path taken from its own
  documented reference, not guessed).
- Adds `--from-release[=TAG]` / `-FromRelease [-FromReleaseTag]` to both
  installers: install the prebuilt `--features ollama,http` daemon binary
  from a GitHub Release archive (checksum-verified) instead of
  `cargo install`, for machines with no Rust toolchain.
- `.github/workflows/release-memory.yml`: new `build-daemon-archive` /
  `publish-daemon-archive` jobs publish
  `velesdb-memory-daemon-<target>.{tar.gz,zip}` (+ `.sha256`) for macOS
  arm64/x64, Linux x64/arm64, and Windows x64, attached to the same
  `velesdb-memory-vX.Y.Z` release `release-mcpb.yml` manages. This is a
  different artifact than the `.mcpb` bundles (default/stdio-only
  features, MCP-registry clients) — those can't run as this daemon.
- README: documents the Windows installer, the `CurrentUser\Root` CA-trust
  command, and `--from-release` on both platforms. Explicitly notes this
  path is only active from the first release built after this change —
  `v0.11.0` and earlier carry no daemon archive.

## Test plan

Verified on this (macOS) machine:

- [x] `bash -n scripts/install-memory-daemon.sh` — clean
- [x] `shellcheck -x scripts/install-memory-daemon.sh` — no warnings
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/release-memory.yml'))"` — parses
- [x] PowerShell 7.6.4 installed locally (`brew install powershell`) to validate the new script for real, not just by inspection:
  - `[System.Management.Automation.Language.Parser]::ParseFile(...)` — 0 errors
  - Dot-sourced every function and exercised the platform-independent ones directly: `-Help`, embedder/TTL resolution, JSON client wiring (Windsurf/Devin — create, preserve-other-entries, re-run-doesn't-clobber-`version`, timestamped backup, invalid-JSON handling, `RequireExistingDir` skip behavior), the generated `run-daemon.cmd` wrapper content, uninstall's JSON cleanup, and `Resolve-LatestReleaseTag` / `install_from_release`'s 404 path against the **real** `cyberlife-coder/VelesDB` GitHub API (correctly resolved `velesdb-memory-v0.11.0` as latest, correctly failed with a clear message since that release predates the daemon archive)
  - This caught and fixed a real bug: an empty `-SkipClient` array made a helper function return `$null` (PowerShell unrolls empty collections returned from a function) — fixed by constructing the `HashSet` inline instead of through a function call
  - PSScriptAnalyzer: ~30 warnings, all `Write-Host`/unused-parameter-false-positive/`ShouldProcess`-advisory style, at the same rate as this repo's existing `scripts/install.ps1` (20) and `scripts/local-ci.ps1` (33) — not new problems
- [x] Extracted the workflow's `Package archive + checksum` step via real YAML parsing (confirms GitHub Actions' block-scalar dedent, not just visual inspection) and ran it end-to-end locally for both the `tar.gz` and `zip` branches against fake binaries — archives built, checksums generated and verified with `shasum -a 256 -c`, contents at the paths both installers expect

**Not verifiable without a Windows machine** (disclosed, not claimed as tested):
- The actual Scheduled Task registration/logon-trigger behavior (`Register-ScheduledTask`, `Get-ScheduledTask`, `Unregister-ScheduledTask` — genuinely Windows-only cmdlets, unavailable even under PowerShell 7 on macOS)
- `certutil -addstore -user Root` / `Cert:\CurrentUser\Root` actually trusting a cert end-to-end (only the thumbprint-comparison logic was validated)
- `Get-NetTCPConnection` port-in-use preflight
- `curl.exe`'s presence/behavior as shipped on Windows 10 1803+/11 (assumed per Microsoft's own documentation, not directly observed)
- The full daemon lifecycle (build → task starts → `/health` responds → CA trust → client wiring) as one continuous run on real Windows

One residual uncertainty: Devin CLI's Windows config path (`%APPDATA%\devin\config.json`) is taken from Devin's own docs (https://cli.devin.ai/docs/reference/configuration/config-file), not hand-verified against a live Devin install.