### PR TITLE
test(conformance): extend VelesQL executor fixture beyond scalar filters

### DIFF
--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.0",
-  "description": "Executor-level VelesQL conformance: asserts result ROWS / COUNTS / ORDERING, not just that a query parses. Golden ids are derived from velesdb-core (the source of truth); other executors (WASM, CLI) must reproduce the same result set for the same dataset+query. Shared read-only dataset; ordering is on unique payload fields so results are deterministic. `cases` must pass; `known_bugs` carry the expected result for a former core bug that is now FIXED — the regression-lock test (test_velesql_executor_known_bugs) runs un-ignored and must keep passing.",
+  "version": "2.0.0",
+  "description": "Executor-level VelesQL conformance: asserts result ROWS / COUNTS / ORDERING, not just that a query parses. Golden ids are derived from velesdb-core (the source of truth); other executors (WASM, CLI) must reproduce the same result set for the same dataset+query. Shared read-only dataset; ordering is on unique payload fields so results are deterministic. `cases` must pass; `known_bugs` carry the expected result for a former core bug that is now FIXED — the regression-lock test (test_velesql_executor_known_bugs) runs un-ignored and must keep passing. Since v2.0.0 (issue #1544) the fixture also carries `extra_collections` + `join_cases` (JOIN ON/USING, core+WASM only — the CLI harness is intentionally untouched, see below), `aggregate_cases` (GROUP BY/HAVING via `execute_aggregate`, core+WASM only), `setops_cases` (UNION/INTERSECT/EXCEPT, core+WASM only, membership/count only — see `documented_divergences` D003 for why ordering is NOT asserted), `match_cases` (1-2 hop MATCH, core+WASM only, per-executor query text — see D004 for why), and `documented_divergences` (informational: known, accepted core/WASM behavioural gaps, not pass/fail cases). `cases`/`dataset`/`known_bugs` are byte-for-byte compatible with v1.0.0 so the existing CLI conformance suite (which only reads those three keys) keeps running unmodified against the original 10 cases plus the new scalar-expression cases X011-X014, which use the same single-collection `docs` dataset and are safe for CLI's strict-order comparison.",
   "dataset": {
     "collection": "docs",
     "dimension": 4,
@@ -73,6 +73,30 @@
       "query": "SELECT * FROM docs ORDER BY year ASC LIMIT 3",
       "expect_ids": [5, 1, 3],
       "note": "EPIC-081 bounded top-k, ASC direction (complements the DESC regression-lock B001): full year-ASC order [5,1,3,2,4] truncated to k=3"
+    },
+    {
+      "id": "X011",
+      "query": "SELECT * FROM docs WHERE year BETWEEN 2020 AND 2022 ORDER BY year ASC",
+      "expect_ids": [1, 3, 2],
+      "note": "issue #1544: BETWEEN range-expression evaluation in WHERE"
+    },
+    {
+      "id": "X012",
+      "query": "SELECT * FROM docs WHERE (category = 'tech' AND year >= 2022) OR category = 'other' ORDER BY year ASC",
+      "expect_ids": [5, 3, 2, 4],
+      "note": "issue #1544: parenthesized boolean expression evaluation, AND nested inside OR"
+    },
+    {
+      "id": "X013",
+      "query": "SELECT * FROM docs WHERE NOT (category = 'tech') ORDER BY year ASC",
+      "expect_ids": [5, 3],
+      "note": "issue #1544: NOT expression evaluation over a parenthesized predicate"
+    },
+    {
+      "id": "X014",
+      "query": "SELECT * FROM docs WHERE year IN (2020, 2023) ORDER BY year ASC",
+      "expect_ids": [1, 4],
+      "note": "issue #1544: IN-list expression evaluation"
     }
   ],
   "known_bugs": [
@@ -81,6 +105,202 @@
       "query": "SELECT * FROM docs WHERE year >= 2019 ORDER BY year DESC LIMIT 2",
       "expect_ids": [4, 2],
       "note": "REGRESSION LOCK (fixed): scalar ORDER BY <column> + LIMIT previously applied the LIMIT before the sort on the bounded top-k path (returned [2,1] instead of [4,2]); the bounded path now equals the unbounded path truncated to k, per KNOWN_LIMITATIONS.md #9. expect_ids is the correct, currently-asserted result."
+    }
+  ],
+  "extra_collections": [
+    {
+      "collection": "customers",
+      "dimension": 2,
+      "metric": "cosine",
+      "points": [
+        { "id": 10, "vector": [1.0, 0.0], "payload": { "name": "Alice" } },
+        { "id": 20, "vector": [0.0, 1.0], "payload": { "name": "Bob" } }
+      ]
+    },
+    {
+      "collection": "orders",
+      "dimension": 2,
+      "metric": "cosine",
+      "points": [
+        { "id": 1, "vector": [1.0, 0.0], "payload": { "customer_id": 10, "amount": 100 } },
+        { "id": 2, "vector": [0.0, 1.0], "payload": { "customer_id": 20, "amount": 200 } },
+        { "id": 3, "vector": [1.0, 0.0], "payload": { "customer_id": 10, "amount": 150 } },
+        { "id": 4, "vector": [0.0, 1.0], "payload": { "customer_id": 99, "amount": 300 } }
+      ]
+    },
+    {
+      "collection": "customers_u",
+      "dimension": 2,
+      "metric": "cosine",
+      "points": [
+        { "id": 10, "vector": [1.0, 0.0], "payload": { "name": "Alice" } },
+        { "id": 20, "vector": [0.0, 1.0], "payload": { "name": "Bob" } }
+      ]
+    },
+    {
+      "collection": "orders_u",
+      "dimension": 2,
+      "metric": "cosine",
+      "points": [
+        { "id": 10, "vector": [1.0, 0.0], "payload": { "amount": 100 } },
+        { "id": 20, "vector": [0.0, 1.0], "payload": { "amount": 200 } },
+        { "id": 99, "vector": [0.0, 1.0], "payload": { "amount": 300 } }
+      ]
+    }
+  ],
+  "join_cases": [
+    {
+      "id": "J001",
+      "query": "SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id ORDER BY orders.id ASC",
+      "expect_ids": [1, 2, 3],
+      "note": "issue #1544: INNER JOIN ON, base-table-first condition order; order id=4 (customer_id=99) has no matching customer and is dropped"
+    },
+    {
+      "id": "J002",
+      "query": "SELECT * FROM orders LEFT JOIN customers ON orders.customer_id = customers.id ORDER BY orders.id ASC",
+      "expect_ids": [1, 2, 3, 4],
+      "note": "issue #1544: LEFT JOIN keeps the unmatched left row (id=4) with NULL joined columns. Written base-table-first (orders.customer_id = customers.id) — see documented_divergences D002 for why the reversed condition order is deliberately NOT used here"
+    },
+    {
+      "id": "J003",
+      "query": "SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id WHERE customers.name = 'Alice' ORDER BY orders.id ASC",
+      "expect_ids": [1, 3],
+      "note": "issue #1544: JOIN combined with a WHERE predicate on a joined-table column"
+    },
+    {
+      "id": "J004",
+      "query": "SELECT * FROM orders_u JOIN customers_u USING (id) ORDER BY orders_u.id ASC",
+      "expect_ids": [10, 20],
+      "note": "issue #1544: JOIN USING (single column); both engines resolve USING(id) against each row's primary id, order_u id=99 has no matching customer and is dropped"
+    }
+  ],
+  "aggregate_cases": [
+    {
+      "id": "G001",
+      "query": "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY category ASC",
+      "expect_groups": [
+        { "category": "other", "n": 2 },
+        { "category": "tech", "n": 3 }
+      ],
+      "note": "issue #1544: GROUP BY with COUNT(*), executed via Database::execute_aggregate (core) / the default WASM SELECT pipeline. Uses an explicit AS alias so both engines agree on the output field name — see documented_divergences D001 for the unaliased-name gap"
+    },
+    {
+      "id": "G002",
+      "query": "SELECT category, COUNT(*) AS n FROM docs GROUP BY category HAVING COUNT(*) > 2 ORDER BY category ASC",
+      "expect_groups": [
+        { "category": "tech", "n": 3 }
+      ],
+      "note": "issue #1544: GROUP BY + HAVING filters out groups that don't satisfy the aggregate predicate"
+    },
+    {
+      "id": "G003",
+      "query": "SELECT category, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY category ASC",
+      "expect_groups": [
+        { "category": "other", "total_year": 4040.0 },
+        { "category": "tech", "total_year": 6065.0 }
+      ],
+      "note": "issue #1544: SUM aggregate per group"
+    },
+    {
+      "id": "G004",
+      "query": "SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC",
+      "expect_groups": [
+        { "category": "tech", "n": 3, "total_year": 6065.0 },
+        { "category": "other", "n": 2, "total_year": 4040.0 }
+      ],
+      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT is deliberately not exercised here — see documented_divergences D006"
+    }
+  ],
+  "setops_cases": [
+    {
+      "id": "S001",
+      "query": "SELECT * FROM docs WHERE category = 'tech' ORDER BY year ASC UNION SELECT * FROM docs WHERE category = 'other' ORDER BY year ASC",
+      "expect_ids": [1, 2, 3, 4, 5],
+      "note": "issue #1544: UNION of two disjoint partitions returns every id exactly once. Compared as a SET, not an ordered list — see documented_divergences D003"
+    },
+    {
+      "id": "S002",
+      "query": "SELECT * FROM docs WHERE category = 'tech' ORDER BY year ASC UNION SELECT * FROM docs WHERE category = 'tech' ORDER BY year ASC",
+      "expect_ids": [1, 2, 4],
+      "note": "issue #1544: UNION of a branch with itself proves de-duplication (3 ids, not 6). Compared as a SET — see documented_divergences D003"
+    },
+    {
+      "id": "S003",
+      "query": "SELECT * FROM docs WHERE year >= 2020 ORDER BY year ASC INTERSECT SELECT * FROM docs WHERE category = 'tech' ORDER BY year ASC",
+      "expect_ids": [1, 2, 4],
+      "note": "issue #1544: INTERSECT keeps only ids present in both branches. Compared as a SET — see documented_divergences D003"
+    },
+    {
+      "id": "S004",
+      "query": "SELECT * FROM docs ORDER BY year ASC EXCEPT SELECT * FROM docs WHERE category = 'other' ORDER BY year ASC",
+      "expect_ids": [1, 2, 4],
+      "note": "issue #1544: EXCEPT removes the right-hand branch's ids from the left-hand branch. Compared as a SET — see documented_divergences D003"
+    }
+  ],
+  "match_cases": [
+    {
+      "id": "M001",
+      "core_query": "SELECT * FROM people WHERE MATCH (a:Person)-[:KNOWS]->(b:Person) ORDER BY people.id ASC",
+      "wasm_query": "MATCH (a:Person@people)-[:KNOWS]->(b:Person@people) RETURN a ORDER BY a.id ASC",
+      "expect_ids": [1, 2, 3],
+      "note": "issue #1544: 1-hop MATCH. Query text differs per engine by design — see documented_divergences D004: core treats vector-collection points as graph nodes (SELECT ... WHERE MATCH over the 'people' vector collection); WASM keeps a separate in-memory graph store addressed via @collection annotations and the standalone MATCH ... RETURN form. Both graphs encode the SAME topology (chain 1->2->3->4, label KNOWS) and are asserted against the SAME golden ids"
+    },
+    {
+      "id": "M002",
+      "core_query": "SELECT * FROM people WHERE MATCH (a:Person)-[:KNOWS]->(b:Person)-[:KNOWS]->(c:Person) ORDER BY people.id ASC",
+      "wasm_query": "MATCH (a:Person@people)-[:KNOWS]->(b:Person@people)-[:KNOWS]->(c:Person@people) RETURN a ORDER BY a.id ASC",
+      "expect_ids": [1, 2],
+      "note": "issue #1544: 2-hop MATCH over the same chain topology as M001"
+    }
+  ],
+  "documented_divergences": [
+    {
+      "id": "D001",
+      "area": "aggregate default field naming",
+      "core_behavior": "unaliased aggregates use short names: COUNT(*) -> \"count\", SUM(year) -> \"sum_year\" (Collection::aggregation_result_key)",
+      "wasm_behavior": "unaliased aggregates use function-call-shaped names: COUNT(*) -> \"count(*)\", SUM(year) -> \"sum(year)\" (aggregate_default_name in velesql_aggregate.rs)",
+      "status": "accepted — not a bug; both are internally consistent, but a client selecting an unaliased aggregate across both executors sees a different JSON key. Fixture G001-G004 sidestep this by always using an explicit AS alias, which both engines honor identically",
+      "evidence": "SELECT category, COUNT(*) FROM docs GROUP BY category ORDER BY category ASC -> core: [{\"category\":\"other\",\"count\":2},...]; wasm: [{\"category\":\"other\",\"count(*)\":2},...]"
+    },
+    {
+      "id": "D002",
+      "area": "JOIN condition side order (WASM only)",
+      "core_behavior": "normalize_join_condition (query_join.rs) accepts ON in either order — `base.col = joined.col` and `joined.col = base.col` both resolve to the same match",
+      "wasm_behavior": "equality_keys/key_of (velesql_join.rs) does not normalize side order: `ON joined.col = base.col` looks up the joined-table-qualified key on the yet-unjoined base row (which never has it), so EVERY row silently comes back with NULL joined columns instead of matching — verified empirically with `LEFT JOIN customers ON customers.id = orders.customer_id` (all 4 rows got customers:null) vs the working `ON orders.customer_id = customers.id` (rows 1-3 matched, row 4 null)",
+      "status": "tracked as a real WASM gap, not fixed here (out of scope per issue #1544 — coverage of existing behaviour, not new WASM support). fixture J001/J002 are written in the working (base-table-first) order so the conformance suite stays green; the reversed order is intentionally not exercised as a passing case",
+      "evidence": "crates/velesdb-wasm/src/velesql_join.rs: equality_keys()/key_of()"
+    },
+    {
+      "id": "D003",
+      "area": "UNION/INTERSECT/EXCEPT row ordering for non-ranked branches",
+      "core_behavior": "apply_set_operation (set_operations.rs) always re-sorts the merged result by score descending, regardless of any per-branch ORDER BY; when every row has score 0.0 (no vector NEAR in either branch) the comparator sees only ties and Vec::sort_unstable_by's tie-break is not stable — order was observed to differ between two consecutive runs of the SAME core binary for the identical query",
+      "wasm_behavior": "velesql_setops.rs concatenates branches left-to-right and de-duplicates first-seen, so each branch's own ORDER BY is preserved in the final row sequence — deterministic, but not the same sequence as core's",
+      "status": "accepted — neither behaviour is wrong (SQL does not guarantee an order for UNION/INTERSECT/EXCEPT without an explicit outer ORDER BY, which this query engine does not yet apply to compound results). fixture setops_cases S001-S004 assert result MEMBERSHIP and COUNT only (ids compared as a sorted set), never exact order",
+      "evidence": "crates/velesdb-core/src/collection/search/query/set_operations.rs (score-sort); crates/velesdb-wasm/src/velesql_setops.rs (concat+dedup)"
+    },
+    {
+      "id": "D004",
+      "area": "MATCH data model (core unified vs WASM separate graph store)",
+      "core_behavior": "graph nodes ARE vector-collection points (payload `_labels` field); edges live on the same Collection via add_edge; MATCH is expressed as `SELECT ... FROM <collection> WHERE MATCH (...)`",
+      "wasm_behavior": "graph nodes/edges live in a separate in-memory graph store per name, populated via `INSERT NODE`/`INSERT EDGE`, addressed from pattern nodes via `@collection` annotations, and queried with the standalone `MATCH ... RETURN` form — there is no requirement for a same-named vector collection to exist",
+      "status": "accepted architectural difference (WASM has no persistence layer to unify with); fixture match_cases M001/M002 carry a `core_query`/`wasm_query` pair instead of one shared query string, both encoding the same graph topology, asserted against the same golden ids",
+      "evidence": "crates/velesdb-wasm/src/velesql_match.rs: inferred_graph_store(); crates/velesdb-core/src/database/query_engine.rs: execute_match_routed()"
+    },
+    {
+      "id": "D005",
+      "area": "multi-query fusion ranking (relative_score / rsf)",
+      "core_behavior": "documented in docs/reference/ECOSYSTEM_PARITY.md",
+      "wasm_behavior": "WASM-local relative_score/rsf multi-query fusion ranks differently from core",
+      "status": "pre-existing, out of scope for issue #1544 — cross-referenced here only because the issue's own description flagged it as related context",
+      "evidence": "crates/velesdb-wasm/src/fusion.rs:6-18,85-91 (per issue #1544 description); docs/reference/ECOSYSTEM_PARITY.md"
+    },
+    {
+      "id": "D006",
+      "area": "LIMIT on GROUP BY aggregate results",
+      "core_behavior": "Database::execute_aggregate / Collection::execute_grouped_aggregate never reads stmt.limit — every group is returned regardless of a trailing LIMIT clause, verified empirically with 'SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1', which returned BOTH groups",
+      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; the identical query returned only 1 row (the 'tech' group)",
+      "status": "tracked as a real core gap, not fixed here (out of scope for issue #1544 — coverage of existing behaviour, not a new feature). aggregate_cases G001-G004 deliberately do not exercise LIMIT so the fixture's shared expect_groups is correct for both engines",
+      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: execute_grouped_aggregate/build_grouped_results (no limit/truncate call); crates/velesdb-wasm/src/velesql_aggregate.rs applies the standard SELECT finalize path which includes LIMIT"
     }
   ]
 }

--- a/crates/velesdb-core/tests/velesql_executor_conformance.rs
+++ b/crates/velesdb-core/tests/velesql_executor_conformance.rs
@@ -19,6 +19,7 @@ use std::path::PathBuf;
 use serde::Deserialize;
 use serde_json::Value;
 use tempfile::TempDir;
+use velesdb_core::collection::graph::GraphEdge;
 use velesdb_core::velesql::Parser;
 use velesdb_core::{Database, DistanceMetric, Point};
 
@@ -28,6 +29,16 @@ struct Fixture {
     cases: Vec<Case>,
     #[serde(default)]
     known_bugs: Vec<Case>,
+    #[serde(default)]
+    extra_collections: Vec<Dataset>,
+    #[serde(default)]
+    join_cases: Vec<Case>,
+    #[serde(default)]
+    aggregate_cases: Vec<AggregateCase>,
+    #[serde(default)]
+    setops_cases: Vec<Case>,
+    #[serde(default)]
+    match_cases: Vec<MatchCase>,
 }
 
 #[derive(Deserialize)]
@@ -50,6 +61,38 @@ struct Case {
     id: String,
     query: String,
     expect_ids: Vec<u64>,
+}
+
+/// A GROUP BY / HAVING golden case, asserted via [`Database::execute_aggregate`]
+/// rather than [`Database::execute_query`] (issue #1544): `execute_query` only
+/// applies GROUP BY when combined with a vector `NEAR` search (diversity
+/// grouping); plain SQL aggregation is a separate entry point.
+#[derive(Deserialize)]
+struct AggregateCase {
+    id: String,
+    query: String,
+    expect_groups: Vec<Value>,
+}
+
+/// A MATCH golden case (issue #1544). Core and WASM have genuinely different
+/// graph data models (see `documented_divergences` D004 in the fixture), so
+/// each engine gets its own query text over an equivalent graph topology; only
+/// `expect_ids` is shared.
+#[derive(Deserialize)]
+struct MatchCase {
+    id: String,
+    core_query: String,
+    expect_ids: Vec<u64>,
+}
+
+/// A graph edge used to build the `people` MATCH dataset (issue #1544). Not
+/// part of the JSON fixture (which stays engine-agnostic for MATCH data) —
+/// defined here alongside the fixed topology shared with the WASM harness.
+struct FixtureEdge {
+    id: u64,
+    src: u64,
+    dst: u64,
+    label: &'static str,
 }
 
 fn fixture_path() -> PathBuf {
@@ -111,4 +154,185 @@ fn test_velesql_executor_known_bugs() {
     let fixture = load_fixture();
     let (_dir, db) = open_loaded_db(&fixture.dataset);
     assert_cases(&db, &fixture.known_bugs);
+}
+
+/// Loads the primary `dataset` plus every `extra_collections` entry into one
+/// `Database`, for JOIN cases that span more than one collection (issue #1544).
+fn open_loaded_db_multi(ds: &Dataset, extra: &[Dataset]) -> (TempDir, Database) {
+    let (dir, db) = open_loaded_db(ds);
+    for extra_ds in extra {
+        let metric = extra_ds.metric.parse().unwrap_or(DistanceMetric::Cosine);
+        db.create_collection(&extra_ds.collection, extra_ds.dimension, metric)
+            .unwrap_or_else(|e| panic!("create extra collection {}: {e}", extra_ds.collection));
+        let collection = db
+            .get_vector_collection(&extra_ds.collection)
+            .unwrap_or_else(|| panic!("get extra collection {}", extra_ds.collection));
+        let points: Vec<Point> = extra_ds
+            .points
+            .iter()
+            .map(|p| Point::new(p.id, p.vector.clone(), Some(p.payload.clone())))
+            .collect();
+        collection
+            .upsert(points)
+            .unwrap_or_else(|e| panic!("upsert extra collection {}: {e}", extra_ds.collection));
+    }
+    (dir, db)
+}
+
+/// JOIN (ON and USING) conformance against `velesdb-core` (issue #1544).
+///
+/// Uses the primary `dataset` (`docs`) plus every `extra_collections` entry
+/// (`customers`/`orders` for ON, `customers_u`/`orders_u` for USING) so the
+/// JOIN target collections exist alongside the base dataset. Reuses
+/// `assert_cases`/`Database::execute_query` exactly like the plain SELECT
+/// cases — JOIN resolution happens transparently inside `execute_query`.
+#[test]
+fn test_velesql_executor_conformance_join_cases() {
+    let fixture = load_fixture();
+    let (_dir, db) = open_loaded_db_multi(&fixture.dataset, &fixture.extra_collections);
+    assert_cases(&db, &fixture.join_cases);
+}
+
+/// GROUP BY / HAVING conformance against `velesdb-core` (issue #1544).
+///
+/// Routed through [`Database::execute_aggregate`] (not `execute_query` — see
+/// [`AggregateCase`]'s doc comment for why), and compared as JSON values
+/// rather than point ids since a GROUP BY row is an aggregated group, not a
+/// single point. Every case's query carries an explicit `ORDER BY` on the
+/// group-by column(s) so the result order is deterministic (grouping itself
+/// iterates a `HashMap` with no inherent order).
+#[test]
+fn test_velesql_executor_conformance_aggregate_cases() {
+    let fixture = load_fixture();
+    let (_dir, db) = open_loaded_db(&fixture.dataset);
+    let params = HashMap::new();
+    for case in &fixture.aggregate_cases {
+        let query = Parser::parse(&case.query)
+            .unwrap_or_else(|e| panic!("aggregate case {} failed to parse: {e}", case.id));
+        let result = db
+            .execute_aggregate(&query, &params)
+            .unwrap_or_else(|e| panic!("aggregate case {} failed to execute: {e}", case.id));
+        let groups = result
+            .as_array()
+            .unwrap_or_else(|| panic!("aggregate case {} did not return an array", case.id));
+        assert_eq!(
+            groups, &case.expect_groups,
+            "aggregate conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// UNION / INTERSECT / EXCEPT conformance against `velesdb-core` (issue #1544).
+///
+/// Compared as a **sorted set of ids**, not an ordered list: `apply_set_operation`
+/// (`set_operations.rs`) always re-sorts the merged result by score descending;
+/// when every row scores 0.0 (no vector `NEAR` in either branch) the tie-break
+/// is `Vec::sort_unstable_by`'s implementation-defined order, which was
+/// observed to differ between two consecutive runs of the same binary for the
+/// identical query. Only membership and count are part of the golden contract
+/// here (`documented_divergences` D003 in the fixture).
+#[test]
+fn test_velesql_executor_conformance_setops_cases() {
+    let fixture = load_fixture();
+    let (_dir, db) = open_loaded_db(&fixture.dataset);
+    let params = HashMap::new();
+    for case in &fixture.setops_cases {
+        let query = Parser::parse(&case.query)
+            .unwrap_or_else(|e| panic!("setops case {} failed to parse: {e}", case.id));
+        let results = db
+            .execute_query(&query, &params)
+            .unwrap_or_else(|e| panic!("setops case {} failed to execute: {e}", case.id));
+        let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        ids.sort_unstable();
+        let mut expected = case.expect_ids.clone();
+        expected.sort_unstable();
+        assert_eq!(
+            ids, expected,
+            "setops conformance mismatch (compared as a set) for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// Fixed graph topology shared by the core and WASM MATCH conformance tests
+/// (issue #1544): a 4-node chain `1 -[:KNOWS]-> 2 -[:KNOWS]-> 3 -[:KNOWS]-> 4`.
+/// Node ids and edges are identical on both sides; only the setup mechanism
+/// and query text differ (see `documented_divergences` D004 in the fixture).
+fn match_chain_edges() -> Vec<FixtureEdge> {
+    vec![
+        FixtureEdge {
+            id: 100,
+            src: 1,
+            dst: 2,
+            label: "KNOWS",
+        },
+        FixtureEdge {
+            id: 101,
+            src: 2,
+            dst: 3,
+            label: "KNOWS",
+        },
+        FixtureEdge {
+            id: 102,
+            src: 3,
+            dst: 4,
+            label: "KNOWS",
+        },
+    ]
+}
+
+/// MATCH (1- and 2-hop) conformance against `velesdb-core` (issue #1544).
+///
+/// Core treats vector-collection points as graph nodes: builds a `people`
+/// collection with a `_labels` payload field, wires up the chain topology via
+/// `Collection::add_edge`, and runs each case's `core_query`
+/// (`SELECT ... FROM people WHERE MATCH (...)`) through the same
+/// `Database::execute_query` path as every other SELECT case.
+#[test]
+fn test_velesql_executor_conformance_match_cases() {
+    let fixture = load_fixture();
+    let dir = TempDir::new().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open db");
+    db.create_collection("people", 4, DistanceMetric::Cosine)
+        .expect("create people collection");
+    let people = db
+        .get_vector_collection("people")
+        .expect("get people collection");
+    let names = ["Ann", "Bo", "Cy", "Di"];
+    let points: Vec<Point> = names
+        .iter()
+        .enumerate()
+        .map(|(idx, name)| {
+            let id = idx as u64 + 1;
+            let mut vector = vec![0.0; 4];
+            vector[idx] = 1.0;
+            Point::new(
+                id,
+                vector,
+                Some(serde_json::json!({ "_labels": ["Person"], "name": name })),
+            )
+        })
+        .collect();
+    people.upsert(points).expect("upsert people");
+    for edge in match_chain_edges() {
+        people
+            .add_edge(GraphEdge::new(edge.id, edge.src, edge.dst, edge.label).expect("build edge"))
+            .unwrap_or_else(|e| panic!("add edge {}: {e}", edge.id));
+    }
+
+    let params = HashMap::new();
+    for case in &fixture.match_cases {
+        let query = Parser::parse(&case.core_query)
+            .unwrap_or_else(|e| panic!("match case {} failed to parse: {e}", case.id));
+        let results = db
+            .execute_query(&query, &params)
+            .unwrap_or_else(|e| panic!("match case {} failed to execute: {e}", case.id));
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(
+            ids, case.expect_ids,
+            "match conformance mismatch for case {}: core_query={:?}",
+            case.id, case.core_query
+        );
+    }
 }

--- a/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
@@ -43,6 +43,16 @@ struct Fixture {
     cases: Vec<Case>,
     #[serde(default)]
     known_bugs: Vec<Case>,
+    #[serde(default)]
+    extra_collections: Vec<Dataset>,
+    #[serde(default)]
+    join_cases: Vec<Case>,
+    #[serde(default)]
+    aggregate_cases: Vec<AggregateCase>,
+    #[serde(default)]
+    setops_cases: Vec<Case>,
+    #[serde(default)]
+    match_cases: Vec<MatchCase>,
 }
 
 #[derive(Deserialize)]
@@ -64,6 +74,30 @@ struct FixturePoint {
 struct Case {
     id: String,
     query: String,
+    expect_ids: Vec<u64>,
+}
+
+/// A GROUP BY / HAVING golden case (issue #1544). Unlike core (which has a
+/// separate `execute_aggregate` entry point), WASM's default SELECT dispatch
+/// already runs the aggregation pipeline (`velesql_aggregate::apply`), so this
+/// still goes through the ordinary `execute()` — only the assertion differs
+/// (compares full JSON rows, not just ids, since a group has no natural point
+/// id).
+#[derive(Deserialize)]
+struct AggregateCase {
+    id: String,
+    query: String,
+    expect_groups: Vec<Value>,
+}
+
+/// A MATCH golden case (issue #1544). WASM addresses its graph store via
+/// `@collection`-annotated standalone `MATCH ... RETURN` queries, which is
+/// why this carries its own `wasm_query` instead of reusing `core_query` —
+/// see `documented_divergences` D004 in the fixture.
+#[derive(Deserialize)]
+struct MatchCase {
+    id: String,
+    wasm_query: String,
     expect_ids: Vec<u64>,
 }
 
@@ -90,8 +124,17 @@ fn payload_literal(v: &Value) -> String {
 /// insert contract — inline vector literals are unsupported).
 fn build_dataset(ds: &Dataset) -> DatabaseInner {
     let mut db = DatabaseInner::new();
+    seed_dataset(&mut db, ds);
+    db
+}
+
+/// Seeds one collection (`ds`) into an existing `DatabaseInner`, for cases
+/// that span more than one collection (issue #1544 JOIN cases). Extracted
+/// from `build_dataset` so both share the exact same `INSERT INTO` seeding
+/// mechanism.
+fn seed_dataset(db: &mut DatabaseInner, ds: &Dataset) {
     db.create_collection(&ds.collection, ds.dimension, &ds.metric)
-        .expect("test: create dataset collection");
+        .unwrap_or_else(|e| panic!("test: create collection {}: {e}", ds.collection));
 
     for point in &ds.points {
         let Value::Object(obj) = &point.payload else {
@@ -112,10 +155,9 @@ fn build_dataset(ds: &Dataset) -> DatabaseInner {
         let vector_json =
             serde_json::to_string(&point.vector).expect("test: serialize fixture vector");
         let params = format!("{{\"v\": {vector_json}}}");
-        execute(&mut db, &sql, Some(&params))
+        execute(db, &sql, Some(&params))
             .unwrap_or_else(|e| panic!("test: seed point {} failed: {e}", point.id));
     }
-    db
 }
 
 /// Runs every case through the WASM executor and asserts ids + ordering.
@@ -152,4 +194,216 @@ fn test_wasm_velesql_executor_known_bugs_are_correct() {
     let fixture = load_fixture();
     let mut db = build_dataset(&fixture.dataset);
     assert_cases(&mut db, &fixture.known_bugs);
+}
+
+/// UNION / INTERSECT / EXCEPT conformance against the WASM executor (issue #1544).
+///
+/// Compared as a **sorted set of ids**, not an ordered list: `velesql_setops`
+/// concatenates branches left-to-right (preserving each branch's own ORDER BY)
+/// and de-duplicates first-seen, which is a *different* — but equally valid —
+/// sequence than core's score-sort. Only membership and count are part of the
+/// golden contract (`documented_divergences` D003 in the fixture).
+#[test]
+fn test_wasm_velesql_executor_setops_cases() {
+    let fixture = load_fixture();
+    let mut db = build_dataset(&fixture.dataset);
+    for case in &fixture.setops_cases {
+        let result = execute(&mut db, &case.query, None)
+            .unwrap_or_else(|e| panic!("setops case {} failed to execute: {e}", case.id));
+        let mut ids: Vec<u64> = result
+            .rows_ref()
+            .iter()
+            .map(crate::velesql_result::QueryResultRow::id)
+            .collect();
+        ids.sort_unstable();
+        let mut expected = case.expect_ids.clone();
+        expected.sort_unstable();
+        assert_eq!(
+            ids, expected,
+            "WASM setops conformance mismatch (compared as a set) for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// JOIN (ON and USING) conformance against the WASM executor (issue #1544).
+///
+/// Seeds `docs` plus every `extra_collections` entry into one `DatabaseInner`
+/// via [`seed_dataset`], then runs each case exactly like a plain SELECT.
+/// Unlike core (whose `SearchResult.point.id` directly carries the base row's
+/// id), a WASM joined row's [`QueryResultRow::id`] is always the synthetic
+/// placeholder `0` — the real id lives in the row's flattened JSON body under
+/// the `"id"` key — so this asserts against `data_json["id"]`, not `.id()`.
+#[test]
+fn test_wasm_velesql_executor_join_cases() {
+    let fixture = load_fixture();
+    let mut db = build_dataset(&fixture.dataset);
+    for extra in &fixture.extra_collections {
+        seed_dataset(&mut db, extra);
+    }
+    for case in &fixture.join_cases {
+        let result = execute(&mut db, &case.query, None)
+            .unwrap_or_else(|e| panic!("join case {} failed to execute: {e}", case.id));
+        let ids: Vec<u64> = result
+            .rows_ref()
+            .iter()
+            .map(|row| {
+                let parsed: Value =
+                    serde_json::from_str(&row.data_json()).expect("test: parse row JSON");
+                parsed
+                    .get("id")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| panic!("join case {}: row missing numeric id", case.id))
+            })
+            .collect();
+        assert_eq!(
+            ids, case.expect_ids,
+            "WASM join conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// GROUP BY / HAVING conformance against the WASM executor (issue #1544).
+///
+/// Compared as JSON values (a group has no natural point id), mirroring the
+/// core aggregate test. Every case uses an explicit `AS` alias so the output
+/// field names agree with core's `execute_aggregate` naming — see
+/// `documented_divergences` D001 for the (deliberately unexercised) unaliased
+/// naming gap.
+#[test]
+fn test_wasm_velesql_executor_aggregate_cases() {
+    let fixture = load_fixture();
+    let mut db = build_dataset(&fixture.dataset);
+    for case in &fixture.aggregate_cases {
+        let result = execute(&mut db, &case.query, None)
+            .unwrap_or_else(|e| panic!("aggregate case {} failed to execute: {e}", case.id));
+        let groups: Vec<Value> = result
+            .rows_ref()
+            .iter()
+            .map(|row| serde_json::from_str(&row.data_json()).expect("test: parse row JSON"))
+            .collect();
+        assert_eq!(
+            groups, case.expect_groups,
+            "WASM aggregate conformance mismatch for case {}: query={:?}",
+            case.id, case.query
+        );
+    }
+}
+
+/// MATCH (1- and 2-hop) conformance against the WASM executor (issue #1544).
+///
+/// WASM keeps a graph store separate from vector collections, populated via
+/// `INSERT NODE`/`INSERT EDGE` and addressed by `@collection` annotations
+/// (see `documented_divergences` D004 in the fixture). Builds the SAME
+/// 4-node `KNOWS` chain topology as the core MATCH test
+/// (`test_velesql_executor_conformance_match_cases`) and runs each case's
+/// `wasm_query`.
+#[test]
+fn test_wasm_velesql_executor_match_cases() {
+    let fixture = load_fixture();
+    let mut db = DatabaseInner::new();
+    let names = ["Ann", "Bo", "Cy", "Di"];
+    for (i, name) in names.iter().enumerate() {
+        let id = i + 1;
+        let sql = format!(
+            "INSERT NODE INTO people (id = {id}, payload = '{{\"name\": \"{name}\", \"labels\": [\"Person\"]}}')"
+        );
+        execute(&mut db, &sql, None).unwrap_or_else(|e| panic!("test: insert node {id}: {e}"));
+    }
+    for (src, dst) in [(1, 2), (2, 3), (3, 4)] {
+        let sql =
+            format!("INSERT EDGE INTO people (source = {src}, target = {dst}, label = 'KNOWS')");
+        execute(&mut db, &sql, None)
+            .unwrap_or_else(|e| panic!("test: insert edge {src}->{dst}: {e}"));
+    }
+
+    for case in &fixture.match_cases {
+        let result = execute(&mut db, &case.wasm_query, None)
+            .unwrap_or_else(|e| panic!("match case {} failed to execute: {e}", case.id));
+        let ids: Vec<u64> = result
+            .rows_ref()
+            .iter()
+            .map(|row| {
+                let parsed: Value =
+                    serde_json::from_str(&row.data_json()).expect("test: parse row JSON");
+                parsed
+                    .get("a")
+                    .and_then(|a| a.get("id"))
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| panic!("match case {}: row missing a.id", case.id))
+            })
+            .collect();
+        assert_eq!(
+            ids, case.expect_ids,
+            "WASM match conformance mismatch for case {}: wasm_query={:?}",
+            case.id, case.wasm_query
+        );
+    }
+}
+
+/// Documents a real, currently-existing WASM JOIN gap
+/// (`documented_divergences` D002 in the fixture): `ON <base>.<col> =
+/// <joined>.<col>` matches correctly, but the reversed condition order
+/// (`ON <joined>.<col> = <base>.<col>`) fails to match ANY row and every
+/// joined column comes back NULL, because `equality_keys`/`key_of`
+/// (`velesql_join.rs`) does not normalize which side names the base vs.
+/// joined table the way core's `normalize_join_condition` does.
+///
+/// This is a **regression-lock for the current (buggy) behaviour**, not a
+/// desired outcome: fixing the underlying normalization is out of scope for
+/// issue #1544 (coverage of existing behaviour, not new WASM support). If
+/// this test starts failing because someone *fixed* the normalization, that
+/// is good news — update this test and `documented_divergences` D002 in
+/// `conformance/velesql_executor_cases.json` to match.
+#[test]
+fn test_wasm_join_condition_side_order_gap_d002() {
+    let mut db = DatabaseInner::new();
+    db.create_collection("customers", 2, "cosine")
+        .expect("test: create customers");
+    db.create_collection("orders", 2, "cosine")
+        .expect("test: create orders");
+    execute(
+        &mut db,
+        "INSERT INTO customers (id, vector, name) VALUES (10, $v, 'Alice')",
+        Some("{\"v\": [1.0, 0.0]}"),
+    )
+    .expect("test: seed customer");
+    execute(
+        &mut db,
+        "INSERT INTO orders (id, vector, customer_id) VALUES (1, $v, 10)",
+        Some("{\"v\": [1.0, 0.0]}"),
+    )
+    .expect("test: seed order");
+
+    // Working order: base-table-first. Matches.
+    let working = execute(
+        &mut db,
+        "SELECT * FROM orders LEFT JOIN customers ON orders.customer_id = customers.id",
+        None,
+    )
+    .expect("test: working-order join");
+    let working_row: Value =
+        serde_json::from_str(&working.rows_ref()[0].data_json()).expect("test: parse row");
+    assert_eq!(
+        working_row.get("name").and_then(Value::as_str),
+        Some("Alice"),
+        "base-table-first ON order should match and enrich the row with the customer name"
+    );
+
+    // Reversed order: joined-table-first. Currently fails to match (D002).
+    let reversed = execute(
+        &mut db,
+        "SELECT * FROM orders LEFT JOIN customers ON customers.id = orders.customer_id",
+        None,
+    )
+    .expect("test: reversed-order join");
+    let reversed_row: Value =
+        serde_json::from_str(&reversed.rows_ref()[0].data_json()).expect("test: parse row");
+    assert!(
+        reversed_row.get("name").is_none() || reversed_row.get("name") == Some(&Value::Null),
+        "documented WASM gap D002: joined-table-first ON order currently does NOT match \
+         (customer name should be absent/null); if this assertion now fails, the underlying \
+         bug was fixed — update documented_divergences D002 accordingly"
+    );
 }

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -363,6 +363,62 @@ directions, the deterministic ascending-id tie-break, and bounded top-k
 (`ORDER BY ... LIMIT k`, both ASC and DESC). A result-shape divergence specific
 to the WASM or CLI surface now fails CI rather than going unnoticed.
 
+**Extended coverage (issue #1544, fixture v2.0.0)**: the original 10 cases were
+all scalar WHERE + ORDER BY + LIMIT — a thin slice next to the 134
+parser-conformance cases. The fixture now also carries, checked against
+**core and WASM** (the CLI layer is unchanged — it only reads `dataset` /
+`cases` / `known_bugs`, so it keeps validating the original cases plus the new
+scalar-expression ones below, which use the same single-collection dataset):
+
+- `cases` X011–X014: WHERE-expression evaluation (`BETWEEN`, parenthesized
+  `AND`/`OR`, `NOT`, `IN`) — safe for CLI's strict-order comparison, so these
+  run on all three executors.
+- `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
+  WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
+  (col)`.
+- `aggregate_cases` G001–G004: `GROUP BY` / `HAVING` / `COUNT` / `SUM`,
+  checked via `Database::execute_aggregate` on core (not `execute_query`,
+  which only groups when combined with vector `NEAR` search) and via the
+  default SELECT pipeline on WASM.
+- `setops_cases` S001–S004: `UNION` / `INTERSECT` / `EXCEPT`, compared as a
+  **sorted set of ids**, not an ordered list (see D003 below).
+- `match_cases` M001–M002: 1- and 2-hop `MATCH`, with per-executor query text
+  (see D004 below).
+
+`documented_divergences` (informational entries in the same JSON file, not
+pass/fail cases) record real, currently-existing core↔WASM behavioural gaps
+discovered while building this coverage, so they're visible instead of
+silently relied upon:
+
+- **D001** — unaliased aggregate output field names differ (`"count"` /
+  `"sum_year"` on core vs `"count(*)"` / `"sum(year)"` on WASM); sidestepped
+  in the fixture by always using an explicit `AS` alias.
+- **D002** — WASM's `JOIN ... ON` does not normalize condition side order the
+  way core does: `ON base.col = joined.col` matches, but the reversed
+  `ON joined.col = base.col` silently returns every row with NULL joined
+  columns instead of matching. Locked as a regression test
+  (`test_wasm_join_condition_side_order_gap_d002` in
+  `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs`) rather than
+  fixed — out of scope for #1544 (coverage of existing behaviour, not new
+  WASM support).
+- **D003** — `UNION`/`INTERSECT`/`EXCEPT` row order for non-ranked (score 0.0)
+  branches is implementation-defined on both sides (core re-sorts by score
+  with an unstable tie-break that was observed to differ between two runs of
+  the *same* binary; WASM preserves branch/`ORDER BY` order via
+  concatenate-then-dedup). Only membership and count are part of the golden
+  contract.
+- **D004** — core treats vector-collection points as graph nodes (MATCH is
+  `SELECT ... FROM <coll> WHERE MATCH (...)`); WASM keeps a separate
+  in-memory graph store addressed via `@collection` annotations and the
+  standalone `MATCH ... RETURN` form. An accepted architectural difference,
+  not a bug.
+- **D005** — cross-reference to the pre-existing `relative_score`/`rsf`
+  multi-query fusion ranking divergence, already tracked in
+  `docs/reference/ECOSYSTEM_PARITY.md`.
+- **D006** — `Database::execute_aggregate` never applies `LIMIT` to the group
+  array on core (every group comes back regardless); WASM's aggregate
+  pipeline does apply `LIMIT`. Tracked, not fixed — out of scope for #1544.
+
 ### Large production files vs the NLOC/complexity gate (audit F-5.13)
 
 **Status**: documented (governance clarification). Sources: [`QUALITY_BAR.md`](../../QUALITY_BAR.md) Gates 5–6, [`.codacy.yml`](../../.codacy.yml) `engines.lizard.exclude_paths`.


### PR DESCRIPTION
## Summary
Fixes #1544. `conformance/velesql_executor_cases.json` v1.0.0 → v2.0.0:
- +18 golden cases run against BOTH core and the WASM executor: WHERE-expression evaluation (X011–X014, also covered by the untouched CLI conformance test), JOIN ON/USING (J001–J004), GROUP BY/HAVING (G001–G004), UNION/INTERSECT/EXCEPT (S001–S004, compared as sorted id sets), 1–2 hop MATCH (M001–M002, per-engine query text).
- +6 `documented_divergences` (D001–D006) — real, verified core/WASM gaps found while building this, none silently baked into goldens. Two are genuine bugs now tracked: #1555 (WASM JOIN condition-order sensitivity, regression-locked by a canary test) and #1556 (core `execute_aggregate` ignores LIMIT).

## Test plan
- [x] TDD verified by deliberately corrupting one golden each in `join_cases`/`aggregate_cases` — both core and WASM suites failed loudly, then restored.
- [x] Full workspace pre-commit gate: 630/630; core (6) and wasm (7) conformance suites green.
- [x] Fable review: every golden independently recomputed by hand — verdict MERGEABLE.