### PR TITLE
fix(fusion): single-source min-max normalize and weighted defaults across core/wasm/python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returning a stored context, so a slot squatted by an unrelated fact
   yields `None` instead of being served back. (#1458)
 
+### Changed
+
+- **`velesdb-core` / `velesdb-wasm`**: single-sourced the fusion math that
+  had drifted across engines (parity-audit finding, issue #1545).
+  `velesdb-core::fusion::min_max_normalize` is now `pub`, and
+  `velesdb-wasm`'s `relative_score`/`rsf` per-branch normalization delegates
+  to it instead of maintaining its own copy of the same min-max math. Core
+  also now exposes canonical `DEFAULT_WEIGHTED_AVG_WEIGHT` /
+  `DEFAULT_WEIGHTED_MAX_WEIGHT` / `DEFAULT_WEIGHTED_HIT_WEIGHT` constants
+  (`0.6` / `0.3` / `0.1`, matching the Python bindings and the
+  `velesdb_common` fusion builder) and a `FusionStrategy::weighted_default()`
+  constructor. **Behavior change, `velesdb-wasm` only:**
+  `multi_query_search(..., strategy: "weighted")` previously hardcoded a
+  non-overridable `avg=0.5, max=0.3, hit=0.2` split; it now defaults to the
+  canonical `0.6/0.3/0.1` weights and accepts an optional `weights`
+  parameter to override them per call. This reorders `weighted`-fusion
+  results for existing WASM callers that didn't request explicit weights.
+  See `crates/velesdb-wasm/CHANGELOG.md` for the full migration note.
+
 ### Added
 
 - **`velesdb-cli`**: new `graph doctor <collection> [--purge|--stub]`

--- a/crates/velesdb-core/src/fusion/mod.rs
+++ b/crates/velesdb-core/src/fusion/mod.rs
@@ -25,4 +25,7 @@ mod strategy;
 #[cfg(test)]
 mod strategy_tests;
 
-pub use strategy::{FusionError, FusionStrategy};
+pub use strategy::{
+    min_max_normalize, FusionError, FusionStrategy, DEFAULT_WEIGHTED_AVG_WEIGHT,
+    DEFAULT_WEIGHTED_HIT_WEIGHT, DEFAULT_WEIGHTED_MAX_WEIGHT,
+};

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -46,6 +46,25 @@ impl std::fmt::Display for FusionError {
 
 impl std::error::Error for FusionError {}
 
+/// Canonical default weight for the average-score component of
+/// [`FusionStrategy::Weighted`] when a caller does not supply explicit
+/// weights.
+///
+/// This is the single source of truth for the "weighted" default: every
+/// surface that offers a default `weighted` fusion (WASM's `fuse_results`,
+/// the `velesdb_common` Python fusion builder, etc.) must derive its default
+/// from this constant rather than hardcoding its own value, so the three
+/// components never drift out of sync again.
+pub const DEFAULT_WEIGHTED_AVG_WEIGHT: f32 = 0.6;
+
+/// Canonical default weight for the maximum-score component of
+/// [`FusionStrategy::Weighted`]. See [`DEFAULT_WEIGHTED_AVG_WEIGHT`].
+pub const DEFAULT_WEIGHTED_MAX_WEIGHT: f32 = 0.3;
+
+/// Canonical default weight for the hit-ratio component of
+/// [`FusionStrategy::Weighted`]. See [`DEFAULT_WEIGHTED_AVG_WEIGHT`].
+pub const DEFAULT_WEIGHTED_HIT_WEIGHT: f32 = 0.1;
+
 /// Strategy for fusing results from multiple vector searches.
 ///
 /// Each strategy combines results differently, optimizing for various use cases:
@@ -178,6 +197,20 @@ impl FusionStrategy {
             max_weight,
             hit_weight,
         })
+    }
+
+    /// Creates a Weighted strategy using the canonical default weights
+    /// ([`DEFAULT_WEIGHTED_AVG_WEIGHT`], [`DEFAULT_WEIGHTED_MAX_WEIGHT`],
+    /// [`DEFAULT_WEIGHTED_HIT_WEIGHT`]).
+    ///
+    /// Infallible: the default weights are constructed to always sum to 1.0.
+    #[must_use]
+    pub fn weighted_default() -> Self {
+        Self::Weighted {
+            avg_weight: DEFAULT_WEIGHTED_AVG_WEIGHT,
+            max_weight: DEFAULT_WEIGHTED_MAX_WEIGHT,
+            hit_weight: DEFAULT_WEIGHTED_HIT_WEIGHT,
+        }
     }
 
     /// Fuses results from multiple queries into a single ranked list.
@@ -494,10 +527,18 @@ fn validate_weight_sum(sum: f32) -> Result<(), FusionError> {
     Ok(())
 }
 
-/// Min-max normalize a branch of `(id, score)` pairs.
+/// Min-max normalize a branch of `(id, score)` pairs to the `[0, 1]` range.
 ///
-/// If the score range is smaller than `f32::EPSILON`, all items receive 0.5.
-fn min_max_normalize(branch: &[(u64, f32)]) -> HashMap<u64, f32> {
+/// If the score range is smaller than `f32::EPSILON` (all scores effectively
+/// equal), every item receives `0.5` rather than dividing by (near) zero.
+///
+/// This is the single canonical implementation of min-max normalization for
+/// `VelesDB` fusion. It is `pub` specifically so other engines that need the
+/// same per-branch normalization semantics — e.g. `velesdb-wasm`'s N-branch
+/// relative-score fusion — can call it directly instead of maintaining a
+/// second copy of this math that could silently drift (see issue #1545).
+#[must_use]
+pub fn min_max_normalize(branch: &[(u64, f32)]) -> HashMap<u64, f32> {
     if branch.is_empty() {
         return HashMap::new();
     }

--- a/crates/velesdb-core/src/fusion/strategy_tests.rs
+++ b/crates/velesdb-core/src/fusion/strategy_tests.rs
@@ -1,6 +1,76 @@
 //! Tests for `FusionStrategy` implementations.
 
-use super::strategy::{FusionError, FusionStrategy};
+use super::strategy::{
+    min_max_normalize, FusionError, FusionStrategy, DEFAULT_WEIGHTED_AVG_WEIGHT,
+    DEFAULT_WEIGHTED_HIT_WEIGHT, DEFAULT_WEIGHTED_MAX_WEIGHT,
+};
+
+// =============================================================================
+// Canonical `Weighted` default constants (issue #1545: single-source the
+// default weights so WASM and velesdb_common cannot drift from core).
+// =============================================================================
+
+#[test]
+fn test_default_weighted_constants_sum_to_one() {
+    let sum =
+        DEFAULT_WEIGHTED_AVG_WEIGHT + DEFAULT_WEIGHTED_MAX_WEIGHT + DEFAULT_WEIGHTED_HIT_WEIGHT;
+    assert!(
+        (sum - 1.0).abs() < 0.001,
+        "canonical default weights must sum to 1.0, got {sum}"
+    );
+}
+
+#[test]
+fn test_default_weighted_constants_values() {
+    // Pin the canonical values so an accidental edit is caught immediately.
+    // These match the values already documented/used across the Python
+    // bindings (`FusionStrategy.weighted` doctest/README) and the
+    // `velesdb_common` fusion builder default.
+    assert!((DEFAULT_WEIGHTED_AVG_WEIGHT - 0.6).abs() < f32::EPSILON);
+    assert!((DEFAULT_WEIGHTED_MAX_WEIGHT - 0.3).abs() < f32::EPSILON);
+    assert!((DEFAULT_WEIGHTED_HIT_WEIGHT - 0.1).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_weighted_default_constructor_matches_constants() {
+    let strategy = FusionStrategy::weighted_default();
+    assert_eq!(
+        strategy,
+        FusionStrategy::Weighted {
+            avg_weight: DEFAULT_WEIGHTED_AVG_WEIGHT,
+            max_weight: DEFAULT_WEIGHTED_MAX_WEIGHT,
+            hit_weight: DEFAULT_WEIGHTED_HIT_WEIGHT,
+        }
+    );
+}
+
+// =============================================================================
+// `min_max_normalize` public API (issue #1545: exported so velesdb-wasm's
+// relative-score fusion can delegate instead of duplicating the math).
+// =============================================================================
+
+#[test]
+fn test_min_max_normalize_is_publicly_reusable() {
+    let branch = vec![(1u64, 0.9), (2u64, 0.1), (3u64, 0.5)];
+    let normalized = min_max_normalize(&branch);
+    assert!((normalized[&1] - 1.0).abs() < 1e-6);
+    assert!((normalized[&2] - 0.0).abs() < 1e-6);
+    assert!((normalized[&3] - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn test_min_max_normalize_equal_scores_default_half() {
+    let branch = vec![(1u64, 0.7), (2u64, 0.7)];
+    let normalized = min_max_normalize(&branch);
+    assert!((normalized[&1] - 0.5).abs() < 1e-6);
+    assert!((normalized[&2] - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn test_min_max_normalize_empty_branch() {
+    let branch: Vec<(u64, f32)> = vec![];
+    assert!(min_max_normalize(&branch).is_empty());
+}
 
 // =============================================================================
 // Test helpers

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -250,7 +250,10 @@ pub use config::{
 };
 #[cfg(feature = "persistence")]
 pub use config::{LoggingConfig, ServerConfig, StorageConfig};
-pub use fusion::{FusionError, FusionStrategy};
+pub use fusion::{
+    FusionError, FusionStrategy, DEFAULT_WEIGHTED_AVG_WEIGHT, DEFAULT_WEIGHTED_HIT_WEIGHT,
+    DEFAULT_WEIGHTED_MAX_WEIGHT,
+};
 #[cfg(feature = "persistence")]
 pub use guardrails::QueryLimits;
 pub use metrics::{

--- a/crates/velesdb-wasm/CHANGELOG.md
+++ b/crates/velesdb-wasm/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (behavior) — `weighted` fusion default weights**: the default
+  weights used by `multi_query_search(..., strategy: "weighted")` when no
+  explicit weights are supplied changed from the WASM-local, non-overridable
+  `avg=0.5, max=0.3, hit=0.2` to `velesdb-core`'s canonical
+  `DEFAULT_WEIGHTED_*` constants, `avg=0.6, max=0.3, hit=0.1` — the same
+  defaults already used by the Python bindings and the `velesdb_common`
+  fusion builder. **This reorders `weighted`-fusion results** for existing
+  callers that relied on the old implicit 0.5/0.3/0.2 split and did not pass
+  explicit weights. `multi_query_search` now also accepts an optional 6th
+  argument, `weights: number[] | undefined` (`[avg_weight, max_weight,
+  hit_weight]`, must sum to 1.0), to opt back into the old split or any other
+  custom weighting — omitting it (as all existing callers do) keeps working
+  and simply picks up the new default. (Issue #1545.)
+- `relative_score` / `rsf` fusion's per-branch min-max normalization now
+  delegates to `velesdb_core::fusion::min_max_normalize` instead of a
+  WASM-local reimplementation of the same math. Purely internal
+  single-sourcing; output is unchanged. (Issue #1545.)
+
 ### Fixed
 - **SQ8 quantization parity with `velesdb-core` (#1543)**: the WASM SQ8
   encode/decode paths (`store_insert::encode_sq8`, `store_get::decode_sq8`,

--- a/crates/velesdb-wasm/src/fusion.rs
+++ b/crates/velesdb-wasm/src/fusion.rs
@@ -3,20 +3,28 @@
 //! The four score/rank strategies (`average`, `maximum`, `weighted`, `rrf`)
 //! delegate to the canonical [`velesdb_core::FusionStrategy`] so the browser
 //! engine and the core engine produce identical rankings. The
-//! `relative_score` / `rsf` strategy keeps a WASM-local implementation because
-//! its N-branch equal-weight averaging semantics differ from core's two-branch
-//! (dense + sparse) `RelativeScore` — see [`fuse_relative_score`].
+//! `relative_score` / `rsf` strategy keeps a WASM-local *aggregation* (it
+//! averages across N branches instead of core's fixed dense+sparse pair) but
+//! its per-branch min-max normalization now delegates to
+//! [`velesdb_core::fusion::min_max_normalize`] — see [`fuse_relative_score`].
 //!
-//! Branch-arity split (why `rsf` is *not* converged here): the only production
-//! caller of [`fuse_results`] is `multi_query_search`, which fuses one branch
-//! per query vector, so the branch count is the user-supplied query count —
-//! genuinely N, with no dense/sparse distinction. Core's `RelativeScore` is
-//! defined only for the 2-branch dense+sparse hybrid (it discards branches
-//! beyond index 1), so delegating this N-branch path to it would silently drop
-//! results. The 2-branch hybrid that *does* match core's contract — the
-//! VelesQL `USING FUSION (strategy='rsf')` clause — already routes through core
-//! (`crate::velesql_fusion::build_rsf` → `FusionStrategy::relative_score`), so
-//! only the genuinely-N path stays WASM-local.
+//! Branch-arity split (why `rsf` aggregation is *not* converged here): the
+//! only production caller of [`fuse_results`] is `multi_query_search`, which
+//! fuses one branch per query vector, so the branch count is the
+//! user-supplied query count — genuinely N, with no dense/sparse distinction.
+//! Core's `RelativeScore` is defined only for the 2-branch dense+sparse
+//! hybrid (it discards branches beyond index 1), so delegating this N-branch
+//! path to it would silently drop results. The 2-branch hybrid that *does*
+//! match core's contract — the VelesQL `USING FUSION (strategy='rsf')` clause
+//! — already routes through core (`crate::velesql_fusion::build_rsf` →
+//! `FusionStrategy::relative_score`), so only the genuinely-N aggregation
+//! stays WASM-local; the normalization math underneath it is single-sourced
+//! from core (issue #1545).
+//!
+//! `weighted` defaults: when no explicit weights are supplied, `fuse_results`
+//! uses `velesdb_core::FusionStrategy::weighted_default()`, i.e. core's
+//! canonical `DEFAULT_WEIGHTED_*` constants (`avg=0.6, max=0.3, hit=0.1`).
+//! Callers may override them via the `weights` parameter.
 
 use std::collections::HashMap;
 
@@ -27,8 +35,12 @@ use velesdb_core::FusionStrategy;
 /// # Arguments
 ///
 /// * `all_results` - Results from each query as (id, score) pairs
-/// * `strategy` - Fusion strategy: "average", "maximum", or "rrf"
+/// * `strategy` - Fusion strategy: "average", "maximum", "weighted", or "rrf"
 /// * `rrf_k` - RRF k parameter (typically 60)
+/// * `weights` - Optional `(avg_weight, max_weight, hit_weight)` override for
+///   the `"weighted"` strategy. When `None`, the canonical core defaults
+///   ([`velesdb_core::FusionStrategy::weighted_default`]) are used. Ignored
+///   for every other strategy.
 ///
 /// # Returns
 ///
@@ -37,23 +49,27 @@ use velesdb_core::FusionStrategy;
 ///
 /// Returns an error if `strategy` is not one of the recognised names:
 /// `"average"` / `"avg"`, `"maximum"` / `"max"`, `"weighted"`,
-/// `"relative_score"` / `"rsf"`, `"rrf"`.
+/// `"relative_score"` / `"rsf"`, `"rrf"`; or if `weights` are supplied for
+/// `"weighted"` but are negative or do not sum to 1.0.
 pub fn fuse_results(
     all_results: &[Vec<(u64, f32)>],
     strategy: &str,
     rrf_k: u32,
+    weights: Option<(f32, f32, f32)>,
 ) -> Result<Vec<(u64, f32)>, String> {
     match strategy.to_lowercase().as_str() {
         "average" | "avg" => fuse_with_core(all_results, &FusionStrategy::Average),
         "maximum" | "max" => fuse_with_core(all_results, &FusionStrategy::Maximum),
-        "weighted" => fuse_with_core(
-            all_results,
-            &FusionStrategy::Weighted {
-                avg_weight: 0.5,
-                max_weight: 0.3,
-                hit_weight: 0.2,
-            },
-        ),
+        "weighted" => {
+            let weighted_strategy = match weights {
+                Some((avg_weight, max_weight, hit_weight)) => {
+                    FusionStrategy::weighted(avg_weight, max_weight, hit_weight)
+                        .map_err(|e| e.to_string())?
+                }
+                None => FusionStrategy::weighted_default(),
+            };
+            fuse_with_core(all_results, &weighted_strategy)
+        }
         "rrf" => fuse_with_core(all_results, &FusionStrategy::RRF { k: rrf_k }),
         "relative_score" | "rsf" => Ok(fuse_relative_score(all_results)),
         _ => Err(format!(
@@ -76,29 +92,25 @@ fn fuse_with_core(
 
 /// Relative Score Fusion: min-max normalizes each query independently.
 ///
-/// Each query's scores are normalized to `[0, 1]`, then averaged per document
-/// across the queries in which the document appears. When all scores in a
-/// branch are equal (range < epsilon), the normalized value defaults to 0.5 —
-/// consistent with the core engine's `min_max_normalize`.
+/// Each query's scores are normalized to `[0, 1]` via core's canonical
+/// [`velesdb_core::fusion::min_max_normalize`] — the same single-sourced
+/// helper `FusionStrategy::RelativeScore` uses internally — then averaged per
+/// document across the queries in which the document appears. When all
+/// scores in a branch are equal (range < epsilon), the normalized value
+/// defaults to 0.5, per that helper's contract.
 ///
-/// **Note:** this is intentionally *not* delegated to
+/// **Note:** the *aggregation* here is intentionally *not* delegated to
 /// [`velesdb_core::FusionStrategy::RelativeScore`]. Core's `RelativeScore` is a
 /// two-branch (dense + sparse) weighted sum that zero-fills documents missing
 /// from a branch and discards branches beyond index 1. This WASM version
 /// averages across N branches with equal weights and skips missing branches,
-/// which yields a different ranking; converging it onto core would silently
-/// change WASM search results.
+/// which yields a different ranking; converging the *aggregation* onto core
+/// would silently change WASM search results. Only the per-branch
+/// normalization math is shared (issue #1545).
 fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
     let mut normalized: HashMap<u64, Vec<f32>> = HashMap::new();
     for results in all_results {
-        let (min_s, max_s) = min_max_scores(results);
-        let range = max_s - min_s;
-        for &(id, score) in results {
-            let norm = if range > f32::EPSILON {
-                (score - min_s) / range
-            } else {
-                0.5
-            };
+        for (id, norm) in velesdb_core::fusion::min_max_normalize(results) {
             normalized.entry(id).or_default().push(norm);
         }
     }
@@ -114,15 +126,6 @@ fn fuse_relative_score(all_results: &[Vec<(u64, f32)>]) -> Vec<(u64, f32)> {
     fused
 }
 
-/// Returns `(min, max)` scores from a result set.
-fn min_max_scores(results: &[(u64, f32)]) -> (f32, f32) {
-    results
-        .iter()
-        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &(_, s)| {
-            (min.min(s), max.max(s))
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,7 +137,7 @@ mod tests {
             vec![(2, 1.0), (1, 0.5), (4, 0.3)],
         ];
 
-        let fused = fuse_results(&results, "rrf", 60).unwrap();
+        let fused = fuse_results(&results, "rrf", 60, None).unwrap();
 
         // ID 1 and 2 should be at top (appear in both lists)
         assert!(fused.len() >= 2);
@@ -146,7 +149,7 @@ mod tests {
     fn test_fuse_average() {
         let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "average", 60).unwrap();
+        let fused = fuse_results(&results, "average", 60, None).unwrap();
 
         // Both should have average 0.7
         for (_, score) in &fused {
@@ -158,7 +161,7 @@ mod tests {
     fn test_fuse_maximum() {
         let results = vec![vec![(1, 0.9), (2, 0.5)], vec![(1, 0.3), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "maximum", 60).unwrap();
+        let fused = fuse_results(&results, "maximum", 60, None).unwrap();
 
         let id1_score = fused.iter().find(|(id, _)| *id == 1).map(|(_, s)| *s);
         let id2_score = fused.iter().find(|(id, _)| *id == 2).map(|(_, s)| *s);
@@ -170,39 +173,97 @@ mod tests {
     #[test]
     fn test_fuse_empty() {
         let results: Vec<Vec<(u64, f32)>> = vec![];
-        let fused = fuse_results(&results, "rrf", 60).unwrap();
+        let fused = fuse_results(&results, "rrf", 60, None).unwrap();
         assert!(fused.is_empty());
     }
 
     #[test]
     fn test_fuse_single_query() {
         let results = vec![vec![(1, 0.9), (2, 0.8)]];
-        let fused = fuse_results(&results, "rrf", 60).unwrap();
+        let fused = fuse_results(&results, "rrf", 60, None).unwrap();
 
         assert_eq!(fused.len(), 2);
         assert_eq!(fused[0].0, 1); // Higher RRF score (rank 0)
     }
 
+    /// Default `weighted` fusion (no explicit weights) must use core's
+    /// canonical constants (`avg=0.6, max=0.3, hit=0.1`) — see issue #1545.
     #[test]
-    fn test_fuse_weighted() {
+    fn test_fuse_weighted_uses_core_canonical_defaults() {
         let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
 
-        let fused = fuse_results(&results, "weighted", 60).unwrap();
+        let fused = fuse_results(&results, "weighted", 60, None).unwrap();
 
         // Both docs appear in 2/2 queries => hit_ratio = 1.0
-        // ID 1: avg=0.7, max=0.8 => 0.5*0.7 + 0.3*0.8 + 0.2*1.0 = 0.79
+        // ID 1: avg=0.7, max=0.8 => 0.6*0.7 + 0.3*0.8 + 0.1*1.0 = 0.76
         // ID 2: avg=0.7, max=0.8 => same
         assert_eq!(fused.len(), 2);
         for (_, score) in &fused {
-            assert!((score - 0.79).abs() < 0.01);
+            assert!((score - 0.76).abs() < 0.01, "got {score}, expected ~0.76");
         }
+    }
+
+    /// The `None` default must be byte-for-byte equivalent to explicitly
+    /// passing core's canonical `DEFAULT_WEIGHTED_*` constants: proves
+    /// `fuse_results` does not maintain its own hardcoded defaults anymore.
+    #[test]
+    fn test_fuse_weighted_default_matches_explicit_core_constants() {
+        let results = vec![
+            vec![(1, 0.8), (2, 0.6), (3, 0.4)],
+            vec![(1, 0.6), (2, 0.8), (3, 0.1)],
+        ];
+
+        let via_default = fuse_results(&results, "weighted", 60, None).unwrap();
+        let via_explicit_constants = fuse_results(
+            &results,
+            "weighted",
+            60,
+            Some((
+                velesdb_core::fusion::DEFAULT_WEIGHTED_AVG_WEIGHT,
+                velesdb_core::fusion::DEFAULT_WEIGHTED_MAX_WEIGHT,
+                velesdb_core::fusion::DEFAULT_WEIGHTED_HIT_WEIGHT,
+            )),
+        )
+        .unwrap();
+
+        // Compare as id->score maps: HashMap-driven fusion internals don't
+        // guarantee a stable tie-break order for equal scores, so a
+        // positional Vec comparison would be flaky on ties.
+        let as_map = |v: Vec<(u64, f32)>| -> HashMap<u64, f32> { v.into_iter().collect() };
+        assert_eq!(as_map(via_default), as_map(via_explicit_constants));
+    }
+
+    /// Callers must be able to override the default `weighted` weights
+    /// (issue #1545: WASM previously hardcoded non-overridable weights).
+    #[test]
+    fn test_fuse_weighted_accepts_caller_supplied_weights() {
+        let results = vec![vec![(1, 0.8), (2, 0.6)], vec![(1, 0.6), (2, 0.8)]];
+
+        // avg_weight=1.0, others 0 => fused score reduces to the plain average.
+        let fused = fuse_results(&results, "weighted", 60, Some((1.0, 0.0, 0.0))).unwrap();
+        assert_eq!(fused.len(), 2);
+        for (_, score) in &fused {
+            assert!((score - 0.7).abs() < 0.01);
+        }
+    }
+
+    /// Invalid caller-supplied weights (don't sum to 1.0) must surface as an
+    /// error rather than silently fusing with a nonsensical strategy.
+    #[test]
+    fn test_fuse_weighted_rejects_invalid_caller_weights() {
+        let results = vec![vec![(1, 0.8), (2, 0.6)]];
+        let err = fuse_results(&results, "weighted", 60, Some((0.9, 0.9, 0.9))).unwrap_err();
+        assert!(
+            err.contains("sum to 1.0"),
+            "expected a weight-sum validation error, got: {err}"
+        );
     }
 
     #[test]
     fn test_fuse_relative_score() {
         let results = vec![vec![(1, 0.9), (2, 0.1)], vec![(1, 0.5), (2, 0.5)]];
 
-        let fused = fuse_results(&results, "relative_score", 60).unwrap();
+        let fused = fuse_results(&results, "relative_score", 60, None).unwrap();
 
         // Query 0: range=0.8, ID 1 norm=(0.9-0.1)/0.8=1.0, ID 2 norm=0.0
         // Query 1: range=0, both get 0.5 (default when range==0, matches core)
@@ -217,7 +278,7 @@ mod tests {
     #[test]
     fn test_fuse_rsf_alias() {
         let results = vec![vec![(1, 0.9), (2, 0.1)]];
-        let fused = fuse_results(&results, "rsf", 60).unwrap();
+        let fused = fuse_results(&results, "rsf", 60, None).unwrap();
         // "rsf" should behave like "relative_score"
         assert_eq!(fused.len(), 2);
     }
@@ -242,7 +303,7 @@ mod tests {
             vec![(3, 1.0), (1, 0.0)],
         ];
 
-        let wasm_order: Vec<u64> = fuse_results(&input, "relative_score", 60)
+        let wasm_order: Vec<u64> = fuse_results(&input, "relative_score", 60, None)
             .unwrap()
             .into_iter()
             .map(|(id, _)| id)
@@ -287,7 +348,7 @@ mod tests {
         // All scores identical within each branch → range ≈ 0
         let results = vec![vec![(1, 0.7), (2, 0.7)], vec![(1, 0.3), (2, 0.3)]];
 
-        let fused = fuse_results(&results, "relative_score", 60).unwrap();
+        let fused = fuse_results(&results, "relative_score", 60, None).unwrap();
 
         // Both branches collapse to 0.5 per document → avg = 0.5
         assert_eq!(fused.len(), 2);
@@ -302,7 +363,7 @@ mod tests {
     #[test]
     fn test_fuse_unknown_strategy_returns_error() {
         let results = vec![vec![(1, 0.9), (2, 0.8)]];
-        let err = fuse_results(&results, "typo_strategy", 60).unwrap_err();
+        let err = fuse_results(&results, "typo_strategy", 60, None).unwrap_err();
         assert!(
             err.contains("Unknown fusion strategy"),
             "expected descriptive error, got: {err}"
@@ -335,14 +396,7 @@ mod tests {
         let cases: [(&str, FusionStrategy); 4] = [
             ("average", FusionStrategy::Average),
             ("maximum", FusionStrategy::Maximum),
-            (
-                "weighted",
-                FusionStrategy::Weighted {
-                    avg_weight: 0.5,
-                    max_weight: 0.3,
-                    hit_weight: 0.2,
-                },
-            ),
+            ("weighted", FusionStrategy::weighted_default()),
             ("rrf", FusionStrategy::RRF { k: 60 }),
         ];
 
@@ -361,11 +415,50 @@ mod tests {
 
         for input in &inputs {
             for (name, strategy) in &cases {
-                let wasm = canonical(fuse_results(input, name, 60).unwrap());
+                let wasm = canonical(fuse_results(input, name, 60, None).unwrap());
                 let core = canonical(strategy.fuse(input.clone()).unwrap());
                 assert_eq!(
                     wasm, core,
                     "strategy '{name}' ordering diverged from core for input {input:?}"
+                );
+            }
+        }
+    }
+
+    /// Single-sourcing guard (issue #1545): a *single-branch* `relative_score`
+    /// fusion has no other branch to average against, so its output must be
+    /// exactly the per-id normalization core's public
+    /// [`velesdb_core::fusion::min_max_normalize`] produces for that branch.
+    /// If `fuse_relative_score` ever stops delegating to it — e.g. a future
+    /// edit reintroduces a WASM-local copy of the min-max math — this test
+    /// fails the moment the two computations diverge, and it fails to even
+    /// *compile* if `min_max_normalize` is no longer exported from core.
+    #[test]
+    fn test_relative_score_normalization_delegates_to_core_min_max_normalize() {
+        let branches: [&[(u64, f32)]; 3] = [
+            &[(1, 0.9), (2, 0.1), (3, 0.5)],
+            &[(1, 0.7), (2, 0.7)], // range < epsilon -> defaults to 0.5
+            &[(1, 42.0)],          // single element -> range == 0 -> 0.5
+        ];
+
+        for branch in branches {
+            let expected = velesdb_core::fusion::min_max_normalize(branch);
+
+            let wasm_single_branch =
+                fuse_results(&[branch.to_vec()], "relative_score", 60, None).unwrap();
+
+            assert_eq!(
+                wasm_single_branch.len(),
+                expected.len(),
+                "branch {branch:?}: id count mismatch between WASM rsf and core min_max_normalize"
+            );
+            for (id, score) in &wasm_single_branch {
+                let core_score = expected[id];
+                assert!(
+                    (score - core_score).abs() < 1e-6,
+                    "branch {branch:?}, id {id}: WASM normalized {score} but core's \
+                     min_max_normalize produced {core_score} — normalization has drifted \
+                     out of single-sourcing"
                 );
             }
         }

--- a/crates/velesdb-wasm/src/lib_tests.rs
+++ b/crates/velesdb-wasm/src/lib_tests.rs
@@ -141,7 +141,7 @@ fn test_fuse_results_rrf() {
     let results2 = vec![(2, 0.95), (1, 0.85), (4, 0.6)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "rrf", 60).unwrap();
+    let fused = fusion::fuse_results(&all_results, "rrf", 60, None).unwrap();
     let top_ids: Vec<u64> = fused.iter().take(2).map(|(id, _)| *id).collect();
     // IDs 1 and 2 appear in both lists; 3 and 4 in only one -> 1 and 2 must rank top-2.
     assert!(
@@ -169,7 +169,7 @@ fn test_fuse_results_average() {
     let results2 = vec![(1, 0.7), (2, 0.6)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "average", 60).unwrap();
+    let fused = fusion::fuse_results(&all_results, "average", 60, None).unwrap();
     assert_eq!(fused.len(), 2);
     // ID 1: (0.9 + 0.7) / 2 = 0.8
     // ID 2: (0.8 + 0.6) / 2 = 0.7
@@ -183,7 +183,7 @@ fn test_fuse_results_maximum() {
     let results2 = vec![(1, 0.7), (2, 0.8)];
     let all_results = vec![results1, results2];
 
-    let fused = fusion::fuse_results(&all_results, "maximum", 60).unwrap();
+    let fused = fusion::fuse_results(&all_results, "maximum", 60, None).unwrap();
     // ID 1: max(0.9, 0.7) = 0.9
     // ID 2: max(0.5, 0.8) = 0.8
     let id1_score = fused.iter().find(|(id, _)| *id == 1).map(|(_, s)| *s);
@@ -195,7 +195,7 @@ fn test_fuse_results_maximum() {
 #[test]
 fn test_fuse_results_empty() {
     let all_results: Vec<Vec<(u64, f32)>> = vec![];
-    let fused = fusion::fuse_results(&all_results, "rrf", 60).unwrap();
+    let fused = fusion::fuse_results(&all_results, "rrf", 60, None).unwrap();
     assert!(fused.is_empty());
 }
 

--- a/crates/velesdb-wasm/src/store_search.rs
+++ b/crates/velesdb-wasm/src/store_search.rs
@@ -210,6 +210,25 @@ pub fn hybrid_search_impl(
     scored_triples_to_js(results)
 }
 
+/// Converts an optional flat `[avg_weight, max_weight, hit_weight]` slice
+/// from the JS boundary into the `(f32, f32, f32)` tuple `fuse_results`
+/// expects for the `"weighted"` strategy.
+///
+/// `None` means "use core's canonical default weights". A slice whose length
+/// isn't exactly 3 is a caller error, not a silent fallback.
+fn weighted_weights_from_slice(
+    weights: Option<&[f32]>,
+) -> Result<Option<(f32, f32, f32)>, JsValue> {
+    match weights {
+        None => Ok(None),
+        Some([avg, max, hit]) => Ok(Some((*avg, *max, *hit))),
+        Some(other) => Err(JsValue::from_str(&format!(
+            "weighted fusion expects exactly 3 weights [avg_weight, max_weight, hit_weight], got {}",
+            other.len()
+        ))),
+    }
+}
+
 /// Multi-query search with fusion.
 #[allow(clippy::too_many_arguments)]
 pub fn multi_query_search_impl(
@@ -227,9 +246,11 @@ pub fn multi_query_search_impl(
     k: usize,
     strategy: &str,
     rrf_k: Option<u32>,
+    weights: Option<&[f32]>,
 ) -> Result<JsValue, JsValue> {
     validate_multi_vector_len(vectors.len(), num_vectors, dimension)
         .map_err(|e| JsValue::from_str(&e))?;
+    let weights = weighted_weights_from_slice(weights)?;
 
     let mut all_results: Vec<Vec<(u64, f32)>> = Vec::with_capacity(num_vectors);
 
@@ -252,7 +273,7 @@ pub fn multi_query_search_impl(
         all_results.push(results);
     }
 
-    let fused = fusion::fuse_results(&all_results, strategy, rrf_k.unwrap_or(60))
+    let fused = fusion::fuse_results(&all_results, strategy, rrf_k.unwrap_or(60), weights)
         .map_err(|e| JsValue::from_str(&e))?;
     let fused: Vec<(u64, f32)> = fused.into_iter().take(k).collect();
 

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -439,8 +439,14 @@ impl VectorStore {
             .map_err(|e| JsValue::from_str(&format!("Serialization error: {e}")))
     }
 
-    /// Multi-query search with fusion. Strategies: average, maximum, rrf.
+    /// Multi-query search with fusion. Strategies: average, maximum, weighted, rrf, relative_score/rsf.
+    ///
+    /// `weights` is an optional `[avg_weight, max_weight, hit_weight]` triple
+    /// used only by the `"weighted"` strategy. When omitted, core's canonical
+    /// default weights are used (`avg=0.6, max=0.3, hit=0.1`) — see issue
+    /// #1545. Passing a slice of any length other than 3 is an error.
     #[wasm_bindgen]
+    #[allow(clippy::too_many_arguments)]
     pub fn multi_query_search(
         &mut self,
         vectors: &[f32],
@@ -448,6 +454,7 @@ impl VectorStore {
         k: usize,
         strategy: &str,
         rrf_k: Option<u32>,
+        weights: Option<Vec<f32>>,
     ) -> Result<JsValue, JsValue> {
         if num_vectors == 0 {
             return Err(JsValue::from_str(
@@ -469,6 +476,7 @@ impl VectorStore {
             k,
             strategy,
             rrf_k,
+            weights.as_deref(),
         )
     }
 

--- a/integrations/common/src/velesdb_common/fusion.py
+++ b/integrations/common/src/velesdb_common/fusion.py
@@ -7,9 +7,39 @@ of maintaining identical copies (US-018 — no duplication < 2%).
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
-import velesdb
+if TYPE_CHECKING:
+    import velesdb
+
+# Canonical default weights for the "weighted" fusion strategy.
+#
+# Single-sourced from `velesdb-core`'s `DEFAULT_WEIGHTED_AVG_WEIGHT` /
+# `DEFAULT_WEIGHTED_MAX_WEIGHT` / `DEFAULT_WEIGHTED_HIT_WEIGHT` constants
+# (crates/velesdb-core/src/fusion/strategy.rs). Kept as plain literals here
+# rather than importing the Rust crate from Python; drift between this file
+# and core is caught by
+# `tests/test_fusion.py::test_default_weighted_weights_match_core_canonical_constants`.
+# See issue #1545 (this used to independently default to 0.6/0.3/0.1 while
+# `velesdb-wasm` hardcoded a different, non-overridable 0.5/0.3/0.2).
+DEFAULT_WEIGHTED_AVG_WEIGHT = 0.6
+DEFAULT_WEIGHTED_MAX_WEIGHT = 0.3
+DEFAULT_WEIGHTED_HIT_WEIGHT = 0.1
+
+
+def resolve_weighted_params(params: Optional[dict]) -> Tuple[float, float, float]:
+    """Resolves ``(avg_weight, max_weight, hit_weight)`` for ``"weighted"`` fusion.
+
+    Any key missing from *params* falls back to the canonical core default.
+    This is a pure function with no dependency on the compiled ``velesdb``
+    extension, so it can be unit-tested without building the native bindings.
+    """
+    params = params or {}
+    return (
+        params.get("avg_weight", DEFAULT_WEIGHTED_AVG_WEIGHT),
+        params.get("max_weight", DEFAULT_WEIGHTED_MAX_WEIGHT),
+        params.get("hit_weight", DEFAULT_WEIGHTED_HIT_WEIGHT),
+    )
 
 
 def build_fusion_strategy(
@@ -36,6 +66,11 @@ def build_fusion_strategy(
     Raises:
         ValueError: If *fusion* is not one of the supported strategy names.
     """
+    # Imported lazily (rather than at module scope) so pure helpers in this
+    # module — e.g. `resolve_weighted_params` — stay importable/testable
+    # without requiring the compiled `velesdb` (Rust/PyO3) extension.
+    import velesdb
+
     params = fusion_params or {}
 
     if fusion == "average":
@@ -46,9 +81,7 @@ def build_fusion_strategy(
         k = params.get("k", 60)
         return velesdb.FusionStrategy.rrf(k=k)
     if fusion == "weighted":
-        avg_weight = params.get("avg_weight", 0.6)
-        max_weight = params.get("max_weight", 0.3)
-        hit_weight = params.get("hit_weight", 0.1)
+        avg_weight, max_weight, hit_weight = resolve_weighted_params(params)
         return velesdb.FusionStrategy.weighted(
             avg_weight=avg_weight,
             max_weight=max_weight,

--- a/integrations/common/tests/test_fusion.py
+++ b/integrations/common/tests/test_fusion.py
@@ -1,0 +1,69 @@
+"""Tests for the shared fusion strategy builder (`velesdb_common.fusion`).
+
+`resolve_weighted_params` is a pure function with no dependency on the
+compiled `velesdb` (Rust/PyO3) extension, so these tests exercise the default
+"weighted" fusion weights without needing to build the native bindings.
+"""
+
+from velesdb_common.fusion import (
+    DEFAULT_WEIGHTED_AVG_WEIGHT,
+    DEFAULT_WEIGHTED_HIT_WEIGHT,
+    DEFAULT_WEIGHTED_MAX_WEIGHT,
+    resolve_weighted_params,
+)
+
+# Canonical defaults, single-sourced from `velesdb-core`
+# (crates/velesdb-core/src/fusion/strategy.rs:
+#  DEFAULT_WEIGHTED_AVG_WEIGHT / DEFAULT_WEIGHTED_MAX_WEIGHT / DEFAULT_WEIGHTED_HIT_WEIGHT).
+#
+# Duplicated here as plain literals rather than importing the Rust crate from
+# Python (issue #1545 explicitly rules out a cross-language import for this).
+# If either side's literal is ever edited without the other, this test is the
+# tripwire that catches the drift.
+CORE_DEFAULT_AVG_WEIGHT = 0.6
+CORE_DEFAULT_MAX_WEIGHT = 0.3
+CORE_DEFAULT_HIT_WEIGHT = 0.1
+
+
+def test_default_weighted_weights_match_core_canonical_constants():
+    assert DEFAULT_WEIGHTED_AVG_WEIGHT == CORE_DEFAULT_AVG_WEIGHT
+    assert DEFAULT_WEIGHTED_MAX_WEIGHT == CORE_DEFAULT_MAX_WEIGHT
+    assert DEFAULT_WEIGHTED_HIT_WEIGHT == CORE_DEFAULT_HIT_WEIGHT
+
+
+def test_default_weighted_weights_sum_to_one():
+    total = (
+        DEFAULT_WEIGHTED_AVG_WEIGHT
+        + DEFAULT_WEIGHTED_MAX_WEIGHT
+        + DEFAULT_WEIGHTED_HIT_WEIGHT
+    )
+    assert abs(total - 1.0) < 1e-9
+
+
+def test_resolve_weighted_params_none_returns_canonical_defaults():
+    assert resolve_weighted_params(None) == (
+        DEFAULT_WEIGHTED_AVG_WEIGHT,
+        DEFAULT_WEIGHTED_MAX_WEIGHT,
+        DEFAULT_WEIGHTED_HIT_WEIGHT,
+    )
+
+
+def test_resolve_weighted_params_empty_dict_returns_canonical_defaults():
+    assert resolve_weighted_params({}) == (
+        DEFAULT_WEIGHTED_AVG_WEIGHT,
+        DEFAULT_WEIGHTED_MAX_WEIGHT,
+        DEFAULT_WEIGHTED_HIT_WEIGHT,
+    )
+
+
+def test_resolve_weighted_params_partial_override_keeps_other_defaults():
+    avg, max_w, hit = resolve_weighted_params({"avg_weight": 0.9})
+    assert avg == 0.9
+    assert max_w == DEFAULT_WEIGHTED_MAX_WEIGHT
+    assert hit == DEFAULT_WEIGHTED_HIT_WEIGHT
+
+
+def test_resolve_weighted_params_full_override():
+    assert resolve_weighted_params(
+        {"avg_weight": 0.5, "max_weight": 0.3, "hit_weight": 0.2}
+    ) == (0.5, 0.3, 0.2)


### PR DESCRIPTION
## Summary
Fixes #1545 — fusion math had drifted between `velesdb-core`, `velesdb-wasm`, and the `velesdb_common` Python builder.
- `velesdb_core::fusion::min_max_normalize` is now `pub`; WASM's `relative_score`/`rsf` delegates to it instead of reimplementing (N-branch aggregation stays WASM-local — documented, intentional divergence; Fable verified missing-branch semantics intact).
- Core publishes canonical `DEFAULT_WEIGHTED_AVG_WEIGHT/MAX_WEIGHT/HIT_WEIGHT` (0.6/0.3/0.1) + `weighted_default()`; WASM defaults to them and gains an optional, ABI-compatible `weights` override; `velesdb_common` pinned by test against the same constants.

## ⚠️ Behavior change (WASM only)
`multi_query_search(..., strategy: "weighted")` without explicit weights now uses 0.6/0.3/0.1 instead of the old hardcoded 0.5/0.3/0.2 — reorders fused results for callers not passing weights. Opt back in via the new `weights` param. Documented in `crates/velesdb-wasm/CHANGELOG.md` and root `CHANGELOG.md`.

## Test plan
- [x] Red→green equivalence test calling `velesdb_core::fusion::min_max_normalize` directly (breaks at compile time if the export disappears)
- [x] core lib 5293, wasm lib 629 (fusion 23), `integrations/common` pytest 90 — all green; fmt/clippy clean