### PR TITLE
feat(server,cli): wire --config to the core engine (VelesConfig)

### DIFF
--- a/crates/velesdb-cli/src/graph_handlers.rs
+++ b/crates/velesdb-cli/src/graph_handlers.rs
@@ -4,7 +4,7 @@
 //! to keep file sizes under 500 NLOC per code-quality rules.
 
 use colored::Colorize;
-use std::path::PathBuf;
+use std::path::Path;
 use velesdb_core::collection::graph::TraversalConfig;
 use velesdb_core::GraphEdge;
 
@@ -15,10 +15,10 @@ use crate::helpers;
 
 /// Open a graph collection from a database path.
 pub(crate) fn open_graph(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
 ) -> anyhow::Result<velesdb_core::GraphCollection> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     db.get_graph_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Graph collection '{}' not found", collection))
 }
@@ -30,7 +30,7 @@ fn edges_to_json_value(edges: &[GraphEdge]) -> serde_json::Value {
 }
 
 pub(crate) fn handle_add_edge(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     id: u64,
     source: u64,
@@ -54,7 +54,7 @@ pub(crate) fn handle_add_edge(
 }
 
 pub(crate) fn handle_get_edges(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     label: Option<&str>,
     format: &str,
@@ -72,7 +72,7 @@ pub(crate) fn handle_get_edges(
 }
 
 pub(crate) fn handle_degree(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     node_id: u64,
     format: &str,
@@ -92,7 +92,7 @@ pub(crate) fn handle_degree(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn handle_traverse(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     source: u64,
     algorithm: TraverseAlgo,
@@ -135,7 +135,7 @@ pub(crate) fn handle_traverse(
 }
 
 pub(crate) fn handle_neighbors(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     node_id: u64,
     direction: Direction,
@@ -171,7 +171,7 @@ pub(crate) fn handle_neighbors(
 }
 
 pub(crate) fn handle_store_payload(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     node_id: u64,
     payload_str: &str,
@@ -192,7 +192,7 @@ pub(crate) fn handle_store_payload(
 }
 
 pub(crate) fn handle_get_payload(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     node_id: u64,
 ) -> anyhow::Result<()> {
@@ -208,7 +208,7 @@ pub(crate) fn handle_get_payload(
 }
 
 pub(crate) fn handle_remove_edge(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     edge_id: u64,
 ) -> anyhow::Result<()> {
@@ -231,7 +231,7 @@ pub(crate) fn handle_remove_edge(
     Ok(())
 }
 
-pub(crate) fn handle_count(path: &PathBuf, collection: &str, format: &str) -> anyhow::Result<()> {
+pub(crate) fn handle_count(path: &Path, collection: &str, format: &str) -> anyhow::Result<()> {
     let col = open_graph(path, collection)?;
     let count = col.edge_count();
     let node_count = col.all_node_ids().len();
@@ -251,7 +251,7 @@ pub(crate) fn handle_count(path: &PathBuf, collection: &str, format: &str) -> an
 }
 
 pub(crate) fn handle_graph_search(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     vector_json: &str,
     top_k: usize,
@@ -295,7 +295,7 @@ pub(crate) fn handle_graph_search(
 }
 
 pub(crate) fn handle_graph_nodes(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     page: usize,
     format: &str,
@@ -327,7 +327,7 @@ pub(crate) fn handle_graph_nodes(
 /// Scans a graph collection for legacy phantom edges and reports them, or
 /// repairs them when `--purge`/`--stub` is passed. Read-only by default.
 pub(crate) fn handle_graph_doctor(
-    path: &PathBuf,
+    path: &Path,
     collection: &str,
     purge: bool,
     stub: bool,

--- a/crates/velesdb-cli/src/handlers/collections.rs
+++ b/crates/velesdb-cli/src/handlers/collections.rs
@@ -16,7 +16,7 @@ pub fn handle_create_vector_collection(
     metric: MetricArg,
     storage: StorageModeArg,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     db.create_vector_collection_with_options(name, dimension, metric.into(), storage.into())?;
 
     println!(
@@ -32,7 +32,7 @@ pub fn handle_create_vector_collection(
 
 /// Handles the `create-graph-collection` subcommand.
 pub fn handle_create_graph_collection(path: &Path, name: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let schema = velesdb_core::GraphSchema::schemaless();
     db.create_graph_collection(name, schema)?;
 
@@ -46,7 +46,7 @@ pub fn handle_create_graph_collection(path: &Path, name: &str) -> Result<()> {
 
 /// Handles the `create-metadata-collection` subcommand.
 pub fn handle_create_metadata_collection(path: &Path, name: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     db.create_metadata_collection(name)?;
 
     println!(
@@ -59,7 +59,7 @@ pub fn handle_create_metadata_collection(path: &Path, name: &str) -> Result<()> 
 
 /// Handles the `delete-collection` subcommand with optional confirmation.
 pub fn handle_delete_collection(path: &Path, name: &str, force: bool) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
 
     if !force {
         if !confirm_deletion(name)? {

--- a/crates/velesdb-cli/src/handlers/data.rs
+++ b/crates/velesdb-cli/src/handlers/data.rs
@@ -16,7 +16,7 @@ pub fn handle_export(
     output: Option<PathBuf>,
     include_vectors: bool,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db.get_vector_collection(collection).ok_or_else(|| {
         anyhow::anyhow!(
             "Vector collection '{}' not found. Export requires a vector collection.",
@@ -90,7 +90,7 @@ pub fn handle_import(
     batch_size: usize,
     progress: bool,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(database)?;
+    let db = crate::helpers::open_database(database)?;
     let config = import::ImportConfig {
         collection,
         dimension,
@@ -137,7 +137,7 @@ fn print_import_summary(stats: &import::ImportStats) {
 
 /// Handles the `get` subcommand: retrieves a single point by ID.
 pub fn handle_get(path: &Path, collection: &str, id: u64, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Collection '{}' not found", collection))?;
@@ -191,7 +191,7 @@ pub fn handle_upsert(
     vector: Option<String>,
     payload: Option<String>,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;
@@ -236,7 +236,7 @@ fn parse_payload_json(raw: Option<String>) -> Result<Option<serde_json::Value>> 
 
 /// Handles the `delete-points` subcommand: removes points by ID.
 pub fn handle_delete_points(path: &Path, collection: &str, ids: &[u64]) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;
@@ -261,7 +261,7 @@ pub fn handle_scroll(
     cursor: Option<u64>,
     format: &str,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Collection '{}' not found", collection))?;
@@ -332,7 +332,7 @@ fn print_scroll_table(batch: &velesdb_core::ScrollBatch, collection: &str) {
 pub fn handle_stream_insert(path: &Path, collection: &str, batch_size: usize) -> Result<()> {
     use std::io::BufRead;
 
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;

--- a/crates/velesdb-cli/src/handlers/index.rs
+++ b/crates/velesdb-cli/src/handlers/index.rs
@@ -38,7 +38,7 @@ fn handle_index_create(
     index_type: IndexTypeArg,
     label: Option<&str>,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;
@@ -89,7 +89,7 @@ fn handle_index_drop(
     label: &str,
     property: &str,
 ) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;
@@ -120,7 +120,7 @@ fn handle_index_drop(
 
 /// Lists all indexes on a collection.
 fn handle_index_list(path: &std::path::Path, collection: &str, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let col = db
         .get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Vector collection '{}' not found", collection))?;

--- a/crates/velesdb-cli/src/handlers/info.rs
+++ b/crates/velesdb-cli/src/handlers/info.rs
@@ -9,7 +9,7 @@ use crate::collection_helpers;
 
 /// Handles the `info` subcommand: prints database overview.
 pub fn handle_info(path: &Path) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     println!("VelesDB Database: {}", path.display());
     println!("Collections:");
     for name in db.list_collections() {
@@ -44,7 +44,7 @@ fn print_collection_summary(db: &velesdb_core::Database, name: &str) {
 
 /// Handles the `list` subcommand: lists all collections.
 pub fn handle_list(path: &Path, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let collections = db.list_collections();
 
     if format == "json" {
@@ -164,7 +164,7 @@ fn print_collection_row(db: &velesdb_core::Database, name: &str) {
 
 /// Handles the `show` subcommand: shows detailed info about one collection.
 pub fn handle_show(path: &Path, collection: &str, samples: usize, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let typed = collection_helpers::resolve_collection(&db, collection)
         .ok_or_else(|| anyhow::anyhow!("Collection '{}' not found", collection))?;
     let type_label = collection_helpers::collection_type_label(&db, collection);
@@ -291,7 +291,7 @@ fn show_metadata(
 
 /// Handles the `analyze` subcommand: collection statistics.
 pub fn handle_analyze(path: &Path, collection: &str, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let stats = db
         .analyze_collection(collection)
         .map_err(|e| anyhow::anyhow!("Analyze error: {}", e))?;

--- a/crates/velesdb-cli/src/handlers/search.rs
+++ b/crates/velesdb-cli/src/handlers/search.rs
@@ -26,7 +26,7 @@ pub fn handle_multi_search(
 
 /// Opens a database and returns the named vector collection.
 fn open_vector_collection(path: &Path, collection: &str) -> Result<velesdb_core::VectorCollection> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     db.get_vector_collection(collection)
         .ok_or_else(|| anyhow::anyhow!("Collection '{}' not found", collection))
 }

--- a/crates/velesdb-cli/src/handlers/tools.rs
+++ b/crates/velesdb-cli/src/handlers/tools.rs
@@ -37,7 +37,7 @@ pub fn handle_simd(action: SimdAction) {
 
 /// Handles the `explain` subcommand: query execution plan.
 pub fn handle_explain(path: &Path, query: &str, format: &str) -> Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = crate::helpers::open_database(path)?;
     let parsed = velesdb_core::velesql::Parser::parse(query)
         .map_err(|e| anyhow::anyhow!("Parse error: {e}"))?;
 

--- a/crates/velesdb-cli/src/helpers.rs
+++ b/crates/velesdb-cli/src/helpers.rs
@@ -5,10 +5,98 @@
 //! in two or more CLI modules.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
-use velesdb_core::{Point, VectorCollection};
+use velesdb_core::{Database, Point, VectorCollection};
+
+// ---------------------------------------------------------------------------
+// Global `--config` wiring (issue #1549)
+// ---------------------------------------------------------------------------
+//
+// Every CLI command that opens a database — the REPL and every one-shot
+// subcommand — funnels through `open_database` below, so the top-level
+// `--config`/`VELESDB_CONFIG` flag only needs to be captured once (in
+// `main::cli_main`) rather than threaded through two dozen handler
+// signatures. The explicit-parameter variant (`open_database_with_config`)
+// is what's actually unit-tested; the global is a thin, side-effect-free
+// lookup on top of it.
+
+/// Process-wide `--config` path, set once at startup by `main::cli_main`.
+/// `None` means the flag was not passed — every command opens the database
+/// with core defaults, exactly like before this flag existed.
+static CONFIG_PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Records the `--config`/`VELESDB_CONFIG` path parsed from the CLI.
+///
+/// Must be called exactly once, before any command dispatch that might open
+/// a database. Idempotent by construction (`OnceLock`): a second call is a
+/// silent no-op, which only matters for tests that exercise `cli_main`
+/// in-process — production `main()` calls it exactly once.
+pub fn set_config_path(path: Option<PathBuf>) {
+    let _ = CONFIG_PATH.set(path);
+}
+
+/// Opens a database at `path`, honouring the global `--config` path if
+/// [`set_config_path`] recorded one.
+///
+/// # Errors
+///
+/// See [`open_database_with_config`].
+pub fn open_database(path: &Path) -> Result<Database> {
+    let config_path = CONFIG_PATH
+        .get()
+        .and_then(Option::as_ref)
+        .map(PathBuf::as_path);
+    open_database_with_config(path, config_path)
+}
+
+/// Opens a database at `path`, optionally loading the core
+/// [`velesdb_core::config::VelesConfig`] (search/HNSW/storage/limits/
+/// quantization/WAL batching) from `config_path` first.
+///
+/// - `config_path: None` — behaves exactly like [`Database::open`] (core
+///   defaults), unchanged from before this flag existed.
+/// - `config_path: Some(file)` — the TOML file **must** exist and pass
+///   [`velesdb_core::config::VelesConfig::load_from_path_engine_only`]
+///   validation. A missing file or an invalid engine value is a fail-fast,
+///   actionable error — never a silent fallback to defaults. The
+///   underlying typed [`velesdb_core::config::ConfigError`] is preserved
+///   as the error source.
+///
+///   Only the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+///   `[quantization]`/`[wal_batch]`) are read; any other top-level table —
+///   notably `[server]`/`[auth]`/`[tls]`/`[cors]`, which `--config` files
+///   shared with `velesdb-server` legitimately use for its own HTTP
+///   transport — is silently ignored rather than being parsed into
+///   `VelesConfig`'s own same-named (but unrelated) `server`/`logging`
+///   fields and rejected by validation rules that were never meant for
+///   that value (e.g. `velesdb-server`'s `[server] port = 443` would
+///   otherwise trip `VelesConfig`'s `server.port >= 1024` rule). `VELESDB_*`
+///   env vars still override values from the (filtered) file.
+///
+/// # Errors
+///
+/// Returns an error if `config_path` is `Some` and the file is missing or
+/// fails to parse/validate, or if opening the database itself fails (e.g.
+/// a stale lock file, a corrupt collection on disk).
+pub fn open_database_with_config(path: &Path, config_path: Option<&Path>) -> Result<Database> {
+    match config_path {
+        None => Ok(Database::open(path)?),
+        Some(cfg) => {
+            if !cfg.exists() {
+                anyhow::bail!("config file not found: {}", cfg.display());
+            }
+            let config = velesdb_core::config::VelesConfig::load_from_path_engine_only(cfg)
+                .map_err(|e| {
+                    anyhow::anyhow!("failed to load VelesDB config from {}: {e}", cfg.display())
+                })?;
+            Ok(Database::open_with_config(path, config)?)
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Import batch helpers
@@ -204,6 +292,118 @@ pub fn write_export_file(records: &[serde_json::Value], filename: &str) -> Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------
+    // `open_database_with_config` (issue #1549 — CLI `--config` wiring)
+    // -----------------------------------------------------------------
+    //
+    // These exercise `open_database_with_config` directly (the
+    // process-global `open_database`/`set_config_path` pair is a thin
+    // wrapper covered indirectly through the binary's `--config` flag).
+
+    #[test]
+    fn test_no_config_path_opens_with_core_defaults() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let db = open_database_with_config(dir.path(), None).expect("test: open without config");
+        assert_eq!(
+            db.config().limits.max_collections,
+            velesdb_core::config::LimitsConfig::default().max_collections
+        );
+    }
+
+    #[test]
+    fn test_custom_toml_limit_is_actually_enforced_not_just_parsed() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let toml_dir = tempfile::tempdir().expect("test: config dir");
+        let config_path = toml_dir.path().join("velesdb.toml");
+        std::fs::write(&config_path, "[limits]\nmax_collections = 1\n")
+            .expect("test: write config");
+
+        let db = open_database_with_config(dir.path(), Some(&config_path))
+            .expect("test: open with custom config");
+
+        // Sanity: the value really was parsed onto the running config.
+        assert_eq!(db.config().limits.max_collections, 1);
+
+        // Proof it's *enforced*, not just parsed: first collection succeeds,
+        // second is refused by the engine because of the configured cap.
+        db.create_vector_collection_with_options(
+            "first",
+            4,
+            velesdb_core::DistanceMetric::Cosine,
+            velesdb_core::StorageMode::Full,
+        )
+        .expect("test: first collection under the limit should succeed");
+
+        let err = db
+            .create_vector_collection_with_options(
+                "second",
+                4,
+                velesdb_core::DistanceMetric::Cosine,
+                velesdb_core::StorageMode::Full,
+            )
+            .expect_err("test: second collection should be refused by the configured limit");
+        assert!(
+            err.to_string().contains("max_collections"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// Regression test (Fable review finding): a `velesdb.toml` shared with
+    /// `velesdb-server` may legitimately have `[server] port = 443` (that
+    /// binary's own HTTP bind port). Before the fix this also landed in
+    /// `VelesConfig`'s own unrelated `server.port` field and was rejected
+    /// by its `>= 1024` rule, so opening the *same* file from the CLI
+    /// failed even though the CLI never reads `[server]` at all.
+    #[test]
+    fn test_shell_owned_server_section_does_not_block_cli_open() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let toml_dir = tempfile::tempdir().expect("test: config dir");
+        let config_path = toml_dir.path().join("velesdb.toml");
+        std::fs::write(
+            &config_path,
+            "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n",
+        )
+        .expect("test: write config");
+
+        let db = open_database_with_config(dir.path(), Some(&config_path))
+            .expect("a shell-owned [server] port=443 must not block CLI database open");
+        assert_eq!(db.config().limits.max_collections, 5);
+    }
+
+    #[test]
+    fn test_explicit_missing_config_path_fails_fast_no_silent_default() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let missing = std::path::Path::new("/nonexistent/velesdb-issue-1549.toml");
+
+        let err = match open_database_with_config(dir.path(), Some(missing)) {
+            Err(e) => e,
+            Ok(_) => panic!("test: missing explicit config path must error, not fall back"),
+        };
+        assert!(
+            err.to_string().contains("config file not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_invalid_config_value_surfaces_typed_config_error_fail_fast() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let toml_dir = tempfile::tempdir().expect("test: config dir");
+        let config_path = toml_dir.path().join("velesdb.toml");
+        // max_collections = 0 is out of range (validate_limits requires >= 1).
+        std::fs::write(&config_path, "[limits]\nmax_collections = 0\n")
+            .expect("test: write config");
+
+        let err = match open_database_with_config(dir.path(), Some(&config_path)) {
+            Err(e) => e,
+            Ok(_) => panic!("test: invalid value must fail fast, not silently default"),
+        };
+        assert!(
+            err.to_string().contains("limits.max_collections"),
+            "unexpected error: {err}"
+        );
+    }
 
     #[test]
     fn test_point_payload_to_row_with_payload() {

--- a/crates/velesdb-cli/src/main.rs
+++ b/crates/velesdb-cli/src/main.rs
@@ -56,6 +56,7 @@ mod repl_search_cmds;
 mod session;
 
 use clap::Parser;
+use std::path::PathBuf;
 
 use commands::{CollectionCommands, Commands, DataCommands, QueryCommands};
 
@@ -68,6 +69,13 @@ use commands::{CollectionCommands, Commands, DataCommands, QueryCommands};
 )]
 #[command(propagate_version = true, disable_help_subcommand = false)]
 struct Cli {
+    /// Path to a VelesDB TOML config file (search/HNSW/storage/limits/WAL
+    /// batching). Applies to every command that opens a database, including
+    /// the REPL. An invalid or missing path fails fast — never silently
+    /// falls back to defaults.
+    #[arg(long = "config", global = true, env = "VELESDB_CONFIG")]
+    config: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -87,6 +95,9 @@ fn cli_main() -> anyhow::Result<()> {
     );
 
     let cli = Cli::parse();
+    // Recorded once here; every command that opens a database (REPL and
+    // one-shot alike) reads it back via `helpers::open_database`.
+    helpers::set_config_path(cli.config);
     dispatch(cli.command)
 }
 
@@ -266,7 +277,7 @@ fn dispatch_query(
     collection: Option<&str>,
     format: &str,
 ) -> anyhow::Result<()> {
-    let db = velesdb_core::Database::open(path)?;
+    let db = helpers::open_database(path)?;
     let result = repl::execute_query(&db, query, collection, None)?;
     repl::print_result(&result, format);
     Ok(())

--- a/crates/velesdb-cli/src/repl.rs
+++ b/crates/velesdb-cli/src/repl.rs
@@ -85,7 +85,7 @@ pub fn run(path: PathBuf) -> Result<()> {
         ".quit".yellow()
     );
 
-    let db = Database::open(&path).context("Failed to open database")?;
+    let db = crate::helpers::open_database(&path).context("Failed to open database")?;
 
     let mut rl: Editor<ReplHelper, DefaultHistory> = Editor::new()?;
     rl.set_helper(Some(ReplHelper));

--- a/crates/velesdb-cli/tests/cli_integration_tests.rs
+++ b/crates/velesdb-cli/tests/cli_integration_tests.rs
@@ -559,3 +559,109 @@ fn test_repl_help() {
         .success()
         .stdout(predicate::str::contains("REPL"));
 }
+
+// =============================================================================
+// Global `--config` Flag Tests (issue #1549)
+//
+// `--config`/`VELESDB_CONFIG` loads the core `VelesConfig` (search/HNSW/
+// storage/limits/WAL batching) and opens the database with
+// `Database::open_with_config` instead of silently applying core defaults.
+// Semantics: fail-fast on a missing/invalid explicit path (never a silent
+// fallback), and the loaded values must be *enforced*, not just parsed.
+// =============================================================================
+
+#[test]
+fn test_global_config_flag_documented_in_help() {
+    velesdb_cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--config"));
+}
+
+#[test]
+fn test_config_missing_explicit_path_fails_fast() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_db");
+    fs::create_dir_all(&db_path).unwrap();
+
+    velesdb_cmd()
+        .arg("--config")
+        .arg("/nonexistent/velesdb-issue-1549.toml")
+        .arg("info")
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("config file not found"));
+}
+
+#[test]
+fn test_config_invalid_value_fails_fast_with_typed_error() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_db");
+    fs::create_dir_all(&db_path).unwrap();
+    let config_path = temp_dir.path().join("velesdb.toml");
+    // max_collections = 0 is out of range — must surface the core
+    // ConfigError, not silently fall back to the default.
+    fs::write(&config_path, "[limits]\nmax_collections = 0\n").unwrap();
+
+    velesdb_cmd()
+        .arg("--config")
+        .arg(&config_path)
+        .arg("info")
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("limits.max_collections"));
+}
+
+#[test]
+fn test_config_custom_toml_limit_is_enforced_end_to_end() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_db");
+    fs::create_dir_all(&db_path).unwrap();
+    let config_path = temp_dir.path().join("velesdb.toml");
+    fs::write(&config_path, "[limits]\nmax_collections = 1\n").unwrap();
+
+    // First collection is within the configured cap.
+    velesdb_cmd()
+        .arg("--config")
+        .arg(&config_path)
+        .args(["collection", "create"])
+        .arg(&db_path)
+        .arg("first")
+        .args(["--dimension", "4"])
+        .assert()
+        .success();
+
+    // Second collection proves the limit is actually enforced by the
+    // running database, not just parsed from the TOML.
+    velesdb_cmd()
+        .arg("--config")
+        .arg(&config_path)
+        .args(["collection", "create"])
+        .arg(&db_path)
+        .arg("second")
+        .args(["--dimension", "4"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("max_collections"));
+}
+
+#[test]
+fn test_config_flag_works_after_subcommand_too() {
+    // `global = true` in clap means `--config` is accepted both before and
+    // after the subcommand — verify the latter position also works.
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test_db");
+    fs::create_dir_all(&db_path).unwrap();
+
+    velesdb_cmd()
+        .arg("info")
+        .arg(&db_path)
+        .arg("--config")
+        .arg("/nonexistent/velesdb-issue-1549.toml")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("config file not found"));
+}

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -375,6 +375,93 @@ impl VelesConfig {
         Ok(config)
     }
 
+    /// The top-level TOML tables that belong to the *engine* — as opposed
+    /// to `server` and `logging`, which are also fields on this struct but
+    /// exist for standalone/embedded consumers of `VelesConfig`. A hosting
+    /// shell (e.g. `velesdb-server`) that owns its own same-named
+    /// `[server]` table in the same file — different shape, different
+    /// meaning (HTTP bind port vs. this struct's own `server.port`) — would
+    /// otherwise have that table parsed into *this* struct too and
+    /// rejected by [`Self::validate`]'s rules for a value it was never
+    /// meant to apply to. See [`Self::load_from_path_engine_only`].
+    const ENGINE_SECTIONS: &'static [&'static str] = &[
+        "search",
+        "hnsw",
+        "storage",
+        "limits",
+        "quantization",
+        "wal_batch",
+    ];
+
+    /// Drops every top-level TOML table not in [`Self::ENGINE_SECTIONS`].
+    fn filter_to_engine_sections(raw: &str) -> Result<String, ConfigError> {
+        let mut doc: toml::Value =
+            toml::from_str(raw).map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        if let Some(table) = doc.as_table_mut() {
+            table.retain(|k, _| Self::ENGINE_SECTIONS.contains(&k));
+        }
+        toml::to_string(&doc).map_err(|e| ConfigError::ParseError(e.to_string()))
+    }
+
+    /// Loads configuration from a specific file path, considering **only**
+    /// the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+    /// `[quantization]`/`[wal_batch]`) and silently dropping any other
+    /// top-level table before parsing — notably `[server]` and `[logging]`.
+    ///
+    /// Use this instead of [`Self::load_from_path`] when the TOML file is
+    /// **shared** with a hosting shell that owns its own `[server]`/
+    /// `[auth]`/`[tls]`/`[cors]`/... sections under possibly-colliding
+    /// keys — e.g. `velesdb-server --config` reads the same file for its
+    /// own HTTP transport settings (`[server].port` = the bind port) *and*
+    /// for this engine config. Without filtering, `[server] port = 443`
+    /// (a perfectly legitimate low bind port, e.g. behind `setcap`/a
+    /// privileged process) would also land in *this* struct's
+    /// `server.port` and be rejected by [`Self::validate`]'s `port >=
+    /// 1024` rule — a spurious failure with nothing to do with the actual
+    /// value being configured.
+    ///
+    /// As with [`Self::load_from_path`], `VELESDB_*` environment variables
+    /// are layered on top of the (filtered) file and can still override an
+    /// engine value — e.g. `VELESDB_LIMITS_MAX_COLLECTIONS=5` overrides a
+    /// `[limits] max_collections` from the file. Env vars for non-engine
+    /// sections (`VELESDB_SERVER_*`, `VELESDB_LOGGING_*`, ...) are
+    /// harmless here: they don't match any field once those sections are
+    /// filtered out of the base document, so they're ignored the same way
+    /// an unrecognised key always is.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read, is not valid TOML, or
+    /// fails validation.
+    pub fn load_from_path_engine_only<P: AsRef<Path>>(path: P) -> Result<Self, ConfigError> {
+        let raw = std::fs::read_to_string(path.as_ref())?;
+        let filtered = Self::filter_to_engine_sections(&raw)?;
+
+        let figment = Figment::new()
+            .merge(Serialized::defaults(Self::default()))
+            .merge(Toml::string(&filtered))
+            .merge(Env::prefixed("VELESDB_").split("_").lowercase(false));
+
+        let config: Self = figment
+            .extract()
+            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Same as [`Self::load_from_path_engine_only`] but from an in-memory
+    /// TOML string, with no environment-variable layer — mirrors how
+    /// [`Self::from_toml`] relates to [`Self::load_from_path`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `toml_str` is not valid TOML or fails
+    /// validation.
+    pub fn from_toml_engine_only(toml_str: &str) -> Result<Self, ConfigError> {
+        let filtered = Self::filter_to_engine_sections(toml_str)?;
+        Self::from_toml(&filtered)
+    }
+
     // Validation is in config_validation.rs
 
     /// Returns the effective `ef_search` value.
@@ -392,5 +479,109 @@ impl VelesConfig {
     /// Returns an error if serialization fails.
     pub fn to_toml(&self) -> Result<String, ConfigError> {
         toml::to_string_pretty(self).map_err(|e| ConfigError::ParseError(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod shared_toml_tests {
+    use super::*;
+
+    /// Documents why `_engine_only` exists: `[server] port = 443` is a
+    /// legitimate low HTTP bind port for a hosting shell (e.g.
+    /// `velesdb-server` behind `setcap`), but fed through the
+    /// whole-struct loader it lands in *this* crate's own `server.port`
+    /// and trips `validate_server`'s `>= 1024` rule — a real, reproducible
+    /// bug when a shell shares its `velesdb.toml` with `VelesConfig`
+    /// as-is (not a regression test to "fix" — `load_from_path` is
+    /// correct for standalone/embedded use where `[server]` truly
+    /// belongs to `VelesConfig`).
+    #[test]
+    fn test_load_from_path_whole_struct_rejects_shell_owned_low_port() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let path = dir.path().join("velesdb.toml");
+        std::fs::write(
+            &path,
+            "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n",
+        )
+        .expect("test: write toml");
+
+        let err = VelesConfig::load_from_path(&path).expect_err(
+            "whole-struct loader must still reject port=443 via its own server section",
+        );
+        assert!(
+            err.to_string().contains("server.port"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The actual fix: a shell-owned `[server] port = 443` no longer
+    /// leaks into `VelesConfig`'s own `server` section, and the genuine
+    /// engine section (`[limits]`) is still applied.
+    #[test]
+    fn test_load_from_path_engine_only_ignores_shell_owned_server_section() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let path = dir.path().join("velesdb.toml");
+        std::fs::write(
+            &path,
+            "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n",
+        )
+        .expect("test: write toml");
+
+        let config = VelesConfig::load_from_path_engine_only(&path)
+            .expect("engine-only loader must ignore the shell-owned [server] section");
+
+        // The engine section came through.
+        assert_eq!(config.limits.max_collections, 5);
+        // The shell-owned [server] section did NOT — the struct's own
+        // `server.port` stays at its default, proving the table was
+        // dropped rather than parsed-then-happening-to-pass-validation.
+        assert_eq!(config.server.port, ServerConfig::default().port);
+    }
+
+    #[test]
+    fn test_from_toml_engine_only_ignores_shell_owned_server_section() {
+        let config = VelesConfig::from_toml_engine_only(
+            "[server]\nport = 443\n\n[limits]\nmax_collections = 7\n",
+        )
+        .expect("engine-only parser must ignore the shell-owned [server] section");
+
+        assert_eq!(config.limits.max_collections, 7);
+        assert_eq!(config.server.port, ServerConfig::default().port);
+    }
+
+    #[test]
+    fn test_load_from_path_engine_only_still_applies_non_server_engine_sections() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let path = dir.path().join("velesdb.toml");
+        std::fs::write(
+            &path,
+            "[hnsw]\nm = 24\n\n[wal_batch]\nenabled = true\ncommit_delay_us = 250\n",
+        )
+        .expect("test: write toml");
+
+        let config = VelesConfig::load_from_path_engine_only(&path)
+            .expect("engine-only loader must still apply hnsw/wal_batch");
+
+        assert_eq!(config.hnsw.m, Some(24));
+        assert!(config.wal_batch.enabled);
+        assert_eq!(config.wal_batch.commit_delay_us, 250);
+    }
+
+    #[test]
+    fn test_load_from_path_engine_only_missing_file_errors() {
+        let missing = std::path::Path::new("/nonexistent/velesdb-issue-1549-engine-only.toml");
+        assert!(VelesConfig::load_from_path_engine_only(missing).is_err());
+    }
+
+    #[test]
+    fn test_from_toml_engine_only_invalid_value_still_fails_typed() {
+        // max_collections = 0 is out of range — the fix must not silently
+        // swallow real validation errors, only shell-owned sections.
+        let err = VelesConfig::from_toml_engine_only("[limits]\nmax_collections = 0\n")
+            .expect_err("out-of-range engine value must still fail");
+        assert!(
+            err.to_string().contains("limits.max_collections"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -11,19 +11,34 @@ use std::path::{Path, PathBuf};
 // ============================================================================
 
 /// Loads the core [`velesdb_core::config::VelesConfig`] (search/HNSW/storage/
-/// limits/WAL batching) from the same TOML file consumed by
+/// limits/quantization/WAL batching) from the same TOML file consumed by
 /// [`ServerConfig::load`] for the server-transport sections (`[server]`,
 /// `[auth]`, `[tls]`, `[cors]`).
 ///
-/// The two structs deserialize independently from the same file — core's
-/// `#[serde(default)]` sections silently ignore keys they don't recognise
-/// (e.g. `[server].data_dir`), so one `velesdb.toml` can carry both the
-/// server-transport settings and the engine settings without conflict.
+/// The two structs deserialize independently from the same file, but
+/// **`VelesConfig` also has its own `[server]` and `[logging]` fields**
+/// (for standalone/embedded consumers) that collide in key name — not
+/// meaning — with this crate's own `[server]` transport section. A
+/// `[server] port = 443` meant as this crate's HTTP bind port would
+/// otherwise *also* land in `VelesConfig.server.port` and be rejected by
+/// its `>= 1024` validation rule, a spurious failure unrelated to the
+/// value actually being configured. This function therefore uses
+/// [`velesdb_core::config::VelesConfig::load_from_path_engine_only`],
+/// which parses **only** the engine sections (`[search]`/`[hnsw]`/
+/// `[storage]`/`[limits]`/`[quantization]`/`[wal_batch]`) and silently
+/// drops every other top-level table before validating — so
+/// `[server]`/`[auth]`/`[tls]`/`[cors]` stay exclusively owned by
+/// [`ServerConfig::load`].
+///
+/// `VELESDB_*` environment variables still layer on top of the (filtered)
+/// file, same as [`velesdb_core::config::VelesConfig::load_from_path`] —
+/// e.g. `VELESDB_LIMITS_MAX_COLLECTIONS=5` overrides a `[limits]` value
+/// from the file even though the file is filtered first.
 ///
 /// - `config_path: Some(path)` — the caller passed `--config`/`VELESDB_CONFIG`
 ///   explicitly. The file **must** exist and pass
-///   [`velesdb_core::config::VelesConfig::load_from_path`] validation —
-///   never a silent fallback to defaults on a broken path.
+///   `load_from_path_engine_only` validation — never a silent fallback to
+///   defaults on a broken path.
 /// - `config_path: None` — mirrors [`load_toml_file`]'s default-file
 ///   behaviour: falls back to `velesdb.toml` in the current directory if
 ///   present (still validated, so a malformed default file still fails
@@ -54,7 +69,7 @@ pub fn load_core_config(
         }
     };
 
-    velesdb_core::config::VelesConfig::load_from_path(&path).map_err(|e| {
+    velesdb_core::config::VelesConfig::load_from_path_engine_only(&path).map_err(|e| {
         anyhow::anyhow!(
             "failed to load VelesDB core config from {}: {e}",
             path.display()
@@ -570,6 +585,29 @@ mod tests {
         let config = load_core_config(&Some(config_path)).expect("test: load valid config");
         assert_eq!(config.limits.max_collections, 3);
         assert_eq!(config.hnsw.m, Some(24));
+    }
+
+    /// Regression test (Fable review finding on issue #1549): a legitimate
+    /// low HTTP bind port in this crate's own `[server]` section used to
+    /// also get parsed into `VelesConfig`'s own (unrelated) `server.port`
+    /// field and rejected by its `>= 1024` validation rule — a spurious
+    /// startup failure for a config file that was otherwise entirely
+    /// valid. `load_core_config` must ignore `[server]` (and any other
+    /// non-engine section) entirely, while still applying the real engine
+    /// sections from the same file.
+    #[test]
+    fn test_load_core_config_ignores_shell_owned_server_section_low_port() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let config_path = dir.path().join("velesdb.toml");
+        std::fs::write(
+            &config_path,
+            "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n",
+        )
+        .expect("test: write config");
+
+        let config = load_core_config(&Some(config_path))
+            .expect("a shell-owned [server] port=443 must not fail core config loading");
+        assert_eq!(config.limits.max_collections, 5);
     }
 
     #[test]

--- a/crates/velesdb-server/src/config.rs
+++ b/crates/velesdb-server/src/config.rs
@@ -7,6 +7,62 @@ use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 // ============================================================================
+// Core engine configuration (issue #1549)
+// ============================================================================
+
+/// Loads the core [`velesdb_core::config::VelesConfig`] (search/HNSW/storage/
+/// limits/WAL batching) from the same TOML file consumed by
+/// [`ServerConfig::load`] for the server-transport sections (`[server]`,
+/// `[auth]`, `[tls]`, `[cors]`).
+///
+/// The two structs deserialize independently from the same file — core's
+/// `#[serde(default)]` sections silently ignore keys they don't recognise
+/// (e.g. `[server].data_dir`), so one `velesdb.toml` can carry both the
+/// server-transport settings and the engine settings without conflict.
+///
+/// - `config_path: Some(path)` — the caller passed `--config`/`VELESDB_CONFIG`
+///   explicitly. The file **must** exist and pass
+///   [`velesdb_core::config::VelesConfig::load_from_path`] validation —
+///   never a silent fallback to defaults on a broken path.
+/// - `config_path: None` — mirrors [`load_toml_file`]'s default-file
+///   behaviour: falls back to `velesdb.toml` in the current directory if
+///   present (still validated, so a malformed default file still fails
+///   fast), otherwise core defaults apply.
+///
+/// # Errors
+///
+/// Returns an error if an explicit path is missing, or if the file fails to
+/// parse or validate. The underlying typed
+/// [`velesdb_core::config::ConfigError`] is preserved as the error source so
+/// callers can match on it if needed.
+pub fn load_core_config(
+    config_path: &Option<PathBuf>,
+) -> anyhow::Result<velesdb_core::config::VelesConfig> {
+    let path = match config_path {
+        Some(p) => {
+            if !p.exists() {
+                anyhow::bail!("config file not found: {}", p.display());
+            }
+            p.clone()
+        }
+        None => {
+            let default_path = PathBuf::from("velesdb.toml");
+            if !default_path.exists() {
+                return Ok(velesdb_core::config::VelesConfig::default());
+            }
+            default_path
+        }
+    };
+
+    velesdb_core::config::VelesConfig::load_from_path(&path).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to load VelesDB core config from {}: {e}",
+            path.display()
+        )
+    })
+}
+
+// ============================================================================
 // TOML file configuration (all fields optional)
 // ============================================================================
 
@@ -457,6 +513,64 @@ pub fn parse_api_keys_env() -> Option<Vec<String>> {
 mod tests {
     use super::*;
     use std::io::Write;
+
+    // ====================================================================
+    // `load_core_config` (issue #1549 — server `--config` wiring)
+    // ====================================================================
+
+    #[test]
+    fn test_load_core_config_none_returns_defaults_when_no_default_file() {
+        // No explicit path, and no `velesdb.toml` in cwd (the test binary's
+        // cwd is the crate root, which has no such file) — core defaults.
+        let config = load_core_config(&None).expect("test: default core config");
+        assert_eq!(
+            config.limits.max_collections,
+            velesdb_core::config::LimitsConfig::default().max_collections
+        );
+    }
+
+    #[test]
+    fn test_load_core_config_explicit_missing_path_fails_fast() {
+        let missing = PathBuf::from("/nonexistent/velesdb-issue-1549-server.toml");
+        let err = load_core_config(&Some(missing)).expect_err(
+            "test: an explicit but missing config path must error, not silently default",
+        );
+        assert!(
+            err.to_string().contains("config file not found"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_core_config_explicit_invalid_value_fails_fast_typed() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let config_path = dir.path().join("velesdb.toml");
+        // max_collections = 0 is out of range (validate_limits requires >= 1).
+        std::fs::write(&config_path, "[limits]\nmax_collections = 0\n")
+            .expect("test: write config");
+
+        let err = load_core_config(&Some(config_path))
+            .expect_err("test: invalid value must fail fast with a typed ConfigError");
+        assert!(
+            err.to_string().contains("limits.max_collections"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_load_core_config_explicit_valid_path_applies_sections() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let config_path = dir.path().join("velesdb.toml");
+        std::fs::write(
+            &config_path,
+            "[limits]\nmax_collections = 3\n\n[hnsw]\nm = 24\n",
+        )
+        .expect("test: write config");
+
+        let config = load_core_config(&Some(config_path)).expect("test: load valid config");
+        assert_eq!(config.limits.max_collections, 3);
+        assert_eq!(config.hnsw.m, Some(24));
+    }
 
     #[test]
     fn test_binds_publicly() {

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -34,9 +34,12 @@ use velesdb_server::{
 struct Args {
     /// Path to velesdb.toml configuration file. Configures both the
     /// server transport ([server]/[auth]/[tls]/[cors]) and the core engine
-    /// ([search]/[hnsw]/[storage]/[limits]/[wal_batch]). An invalid or
-    /// missing explicit path fails fast at startup — never a silent
-    /// fallback to defaults.
+    /// ([search]/[hnsw]/[storage]/[limits]/[quantization]/[wal_batch]) —
+    /// only these engine sections are read into the core config, so a
+    /// same-named [server]/[logging] table stays exclusively the
+    /// server's own. VELESDB_* env vars still override values from the
+    /// file. An invalid or missing explicit path fails fast at startup —
+    /// never a silent fallback to defaults.
     #[arg(short, long, env = "VELESDB_CONFIG")]
     config: Option<PathBuf>,
 

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -19,7 +19,10 @@ use velesdb_core::Database;
 use velesdb_server::ApiDoc;
 use velesdb_server::{
     auth::{auth_middleware, AuthState},
-    config::{build_cors_layer, parse_api_keys_env, CliOverrides, CorsConfig, ServerConfig},
+    config::{
+        build_cors_layer, load_core_config, parse_api_keys_env, CliOverrides, CorsConfig,
+        ServerConfig,
+    },
     routes::api_routes,
     AppState, OnboardingMetrics,
 };
@@ -29,7 +32,11 @@ use velesdb_server::{
 #[command(name = "velesdb-server")]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Path to velesdb.toml configuration file
+    /// Path to velesdb.toml configuration file. Configures both the
+    /// server transport ([server]/[auth]/[tls]/[cors]) and the core engine
+    /// ([search]/[hnsw]/[storage]/[limits]/[wal_batch]). An invalid or
+    /// missing explicit path fails fast at startup — never a silent
+    /// fallback to defaults.
     #[arg(short, long, env = "VELESDB_CONFIG")]
     config: Option<PathBuf>,
 
@@ -116,8 +123,11 @@ fn log_cors_config(cors: &CorsConfig) {
     }
 }
 
-fn init_app_state(data_dir: &str) -> anyhow::Result<Arc<AppState>> {
-    let db = Database::open(data_dir)?;
+fn init_app_state(
+    data_dir: &str,
+    core_config: velesdb_core::config::VelesConfig,
+) -> anyhow::Result<Arc<AppState>> {
+    let db = Database::open_with_config(data_dir, core_config)?;
     let state = Arc::new(AppState {
         db,
         onboarding_metrics: OnboardingMetrics::default(),
@@ -411,9 +421,15 @@ async fn main() -> anyhow::Result<()> {
     configure_tracing();
 
     let args = Args::parse();
+    let config_path = args.config.clone();
     let cli = build_cli_overrides(args);
     let cfg = ServerConfig::load(cli)?;
     cfg.validate()?;
+
+    // Fail-fast: an explicit `--config`/`VELESDB_CONFIG` path that is
+    // missing or fails validation aborts startup here with the typed core
+    // `ConfigError` — never a silent fallback to engine defaults.
+    let core_config = load_core_config(&config_path)?;
 
     log_startup(&cfg);
 
@@ -426,7 +442,7 @@ async fn main() -> anyhow::Result<()> {
         "core".to_string(),
     );
 
-    let state = init_app_state(&cfg.data_dir)?;
+    let state = init_app_state(&cfg.data_dir, core_config)?;
     let auth_state = AuthState::new(cfg.api_keys.clone());
     let app = build_router(state.clone(), auth_state, cfg.rate_limit, &cfg.cors)?;
 

--- a/crates/velesdb-server/tests/common/mod.rs
+++ b/crates/velesdb-server/tests/common/mod.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::{get, patch, post},
     Router,
 };
+use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -139,6 +140,27 @@ pub fn create_test_app_with_observer(
 ) -> Router {
     let db =
         Database::open_with_observer(temp_dir.path(), observer).expect("Failed to open database");
+    base_routes().with_state(app_state_from_db(db))
+}
+
+/// Helper to create a test app whose database is opened through the
+/// server's own [`velesdb_server::config::load_core_config`] +
+/// [`Database::open_with_config`] path — the exact same wiring
+/// `main::init_app_state` uses in production. Exercises the real
+/// `--config`/`VELESDB_CONFIG` code path (issue #1549) rather than a
+/// hand-rolled substitute, so tests built on this helper prove the TOML
+/// file's settings are actually applied to the running database.
+///
+/// # Panics
+///
+/// Panics if the config file fails to load/validate or the database fails
+/// to open — both are test setup failures, not part of the behaviour under
+/// test.
+pub fn create_test_app_with_core_config(temp_dir: &TempDir, config_path: &Path) -> Router {
+    let core_config = velesdb_server::config::load_core_config(&Some(config_path.to_path_buf()))
+        .expect("Failed to load core config");
+    let db = Database::open_with_config(temp_dir.path(), core_config)
+        .expect("Failed to open database with core config");
     base_routes().with_state(app_state_from_db(db))
 }
 

--- a/crates/velesdb-server/tests/config_wiring_tests.rs
+++ b/crates/velesdb-server/tests/config_wiring_tests.rs
@@ -1,5 +1,5 @@
 //! Integration tests for the server's `--config`/`VELESDB_CONFIG` wiring
-//! (issue #1549: "VelesConfig (TOML) cannot be passed at `Database::open`").
+//! (issue #1549: "`VelesConfig` (TOML) cannot be passed at `Database::open`").
 //!
 //! Before this fix, `main::init_app_state` always called `Database::open`,
 //! so the `--config` flag only ever reached the server-transport settings

--- a/crates/velesdb-server/tests/config_wiring_tests.rs
+++ b/crates/velesdb-server/tests/config_wiring_tests.rs
@@ -1,0 +1,130 @@
+//! Integration tests for the server's `--config`/`VELESDB_CONFIG` wiring
+//! (issue #1549: "VelesConfig (TOML) cannot be passed at `Database::open`").
+//!
+//! Before this fix, `main::init_app_state` always called `Database::open`,
+//! so the `--config` flag only ever reached the server-transport settings
+//! (`[server]`/`[auth]`/`[tls]`/`[cors]`) and the core engine
+//! (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/`[wal_batch]`) silently ran
+//! on defaults no matter what the TOML said.
+//!
+//! These tests exercise `config::load_core_config` +
+//! `Database::open_with_config` through the exact helper
+//! (`common::create_test_app_with_core_config`) that mirrors
+//! `main::init_app_state`, so a regression here means the real binary
+//! regressed too.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+async fn create_collection(app: axum::Router, name: &str) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/collections")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    json!({ "name": name, "dimension": 4, "metric": "cosine" }).to_string(),
+                ))
+                .expect("Failed to build request"),
+        )
+        .await
+        .expect("Request failed");
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let json: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+/// The core proof required by issue #1549: a `limits.max_collections` set
+/// in the TOML consumed via `--config` must be *enforced* by the running
+/// server, not merely parsed and discarded. First collection succeeds
+/// (within the cap), second is refused by the engine.
+#[tokio::test]
+async fn test_custom_toml_limit_is_enforced_by_the_running_server() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config_dir = TempDir::new().expect("Failed to create config dir");
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 1\n")
+        .expect("Failed to write config");
+
+    let app = common::create_test_app_with_core_config(&temp_dir, &config_path);
+    let (status, _body) = create_collection(app.clone(), "first").await;
+    assert_eq!(status, StatusCode::CREATED, "first collection must succeed");
+
+    let (status, body) = create_collection(app, "second").await;
+    assert_ne!(
+        status,
+        StatusCode::CREATED,
+        "second collection must be refused by the configured limit"
+    );
+    let message = body["error"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {message}"
+    );
+}
+
+/// Without `--config`, behaviour is unchanged: core defaults apply, so
+/// creating a handful of collections still works.
+#[tokio::test]
+async fn test_no_config_path_keeps_core_defaults() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let core_config = velesdb_server::config::load_core_config(&None)
+        .expect("Failed to load default core config");
+    assert_eq!(
+        core_config.limits.max_collections,
+        velesdb_core::config::LimitsConfig::default().max_collections
+    );
+
+    let db = velesdb_core::Database::open_with_config(temp_dir.path(), core_config)
+        .expect("Failed to open database");
+    db.create_vector_collection_with_options(
+        "a",
+        4,
+        velesdb_core::DistanceMetric::Cosine,
+        velesdb_core::StorageMode::Full,
+    )
+    .expect("collection creation should succeed under default limits");
+}
+
+/// An explicit `--config` path that does not exist must fail fast — the
+/// caller (`main::main`) never reaches `Database::open_with_config` with a
+/// silently-defaulted config.
+#[tokio::test]
+async fn test_explicit_missing_config_path_fails_fast_before_database_open() {
+    let missing = std::path::PathBuf::from("/nonexistent/velesdb-issue-1549-server.toml");
+    let err = velesdb_server::config::load_core_config(&Some(missing))
+        .expect_err("a missing explicit config path must error, not silently default");
+    assert!(
+        err.to_string().contains("config file not found"),
+        "unexpected error: {err}"
+    );
+}
+
+/// An explicit `--config` path with an out-of-range value must fail fast
+/// with the typed core `ConfigError`, not a generic/opaque failure.
+#[tokio::test]
+async fn test_explicit_invalid_value_fails_fast_with_typed_config_error() {
+    let config_dir = TempDir::new().expect("Failed to create config dir");
+    let config_path = config_dir.path().join("velesdb.toml");
+    // max_collections = 0 is out of range (validate_limits requires >= 1).
+    std::fs::write(&config_path, "[limits]\nmax_collections = 0\n")
+        .expect("Failed to write config");
+
+    let err = velesdb_server::config::load_core_config(&Some(config_path))
+        .expect_err("an invalid value must fail fast with a typed ConfigError");
+    assert!(
+        err.to_string().contains("limits.max_collections"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/velesdb-server/tests/config_wiring_tests.rs
+++ b/crates/velesdb-server/tests/config_wiring_tests.rs
@@ -74,6 +74,54 @@ async fn test_custom_toml_limit_is_enforced_by_the_running_server() {
     );
 }
 
+/// Regression test (Fable review finding): a TOML file with a legitimate
+/// low `[server] port = 443` (this crate's own HTTP transport section —
+/// e.g. running behind `setcap`/a privileged process) plus a genuine
+/// engine section must still start the server successfully, and the
+/// engine section must be applied. Before the fix, `[server] port = 443`
+/// also landed in `VelesConfig`'s own `server.port` field and was
+/// rejected by its `>= 1024` validation rule, aborting startup with
+/// "server.port value 443 must be >= 1024" even though the value was
+/// never meant for that struct.
+#[tokio::test]
+async fn test_shell_owned_server_port_below_1024_does_not_block_startup() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config_dir = TempDir::new().expect("Failed to create config dir");
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(
+        &config_path,
+        "[server]\nport = 443\n\n[limits]\nmax_collections = 2\n",
+    )
+    .expect("Failed to write config");
+
+    // Mirrors `main::init_app_state`: must not error just because the
+    // file's [server] section has a value that's invalid for
+    // `VelesConfig`'s own (irrelevant, in this context) server.port field.
+    let app = common::create_test_app_with_core_config(&temp_dir, &config_path);
+
+    let (status, _body) = create_collection(app.clone(), "first").await;
+    assert_eq!(status, StatusCode::CREATED, "server must have started");
+
+    let (status, _body) = create_collection(app.clone(), "second").await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "second collection is within the configured max_collections=2 cap"
+    );
+
+    let (status, body) = create_collection(app, "third").await;
+    assert_ne!(
+        status,
+        StatusCode::CREATED,
+        "third collection exceeds the configured cap"
+    );
+    let message = body["error"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {message}"
+    );
+}
+
 /// Without `--config`, behaviour is unchanged: core defaults apply, so
 /// creating a handful of collections still works.
 #[tokio::test]

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -32,15 +32,65 @@ VelesDB supports 3 levels of configuration:
 
 ### File Search Paths
 
-VelesDB looks for `velesdb.toml` in the following order:
+`VelesConfig::load()` (used when no explicit path is given) only ever looks
+at `./velesdb.toml` in the current working directory. There is **no**
+`~/.config/velesdb/`, `%APPDATA%\velesdb\`, or `/etc/velesdb/` search — if
+you previously read that here, it described a search path that was never
+implemented. If no `./velesdb.toml` is found, core defaults are used.
 
-1. `./velesdb.toml` (current directory)
-2. `$VELESDB_CONFIG` (environment variable)
-3. `~/.config/velesdb/velesdb.toml` (Linux/macOS)
-4. `%APPDATA%\velesdb\velesdb.toml` (Windows)
-5. `/etc/velesdb/velesdb.toml` (system-wide)
+To point at a file anywhere else, pass it explicitly:
 
-If no file is found, default values are used.
+| Binary | Flag | Env var |
+|--------|------|---------|
+| `velesdb-server` | `--config <path>` | `VELESDB_CONFIG` |
+| `velesdb` (CLI) | `--config <path>` (global — REPL and every one-shot command) | `VELESDB_CONFIG` |
+
+Both binaries can load the **same** file, but only the *engine* sections —
+`[search]`, `[hnsw]`, `[storage]`, `[limits]`, `[quantization]`,
+`[wal_batch]` — reach `VelesConfig` and, via
+[`Database::open_with_config`](../../crates/velesdb-core/src/database/mod.rs),
+the running engine. Every other top-level table is silently dropped before
+`VelesConfig` ever sees it — most importantly `[server]`, `[auth]`,
+`[tls]`, `[cors]`, which stay exclusively `velesdb-server`'s own transport
+config. This matters because `VelesConfig` *also* has its own same-named
+`[server]`/`[logging]` fields (for standalone/embedded use), which don't
+mean the same thing: a perfectly legitimate `velesdb-server --config`
+value like `[server] port = 443` (its HTTP bind port, e.g. behind
+`setcap`) would otherwise land in `VelesConfig`'s own `server.port` too
+and get rejected by its `>= 1024` validation rule — a startup failure with
+nothing to do with the value you actually set. Both binaries filter the
+file down to the engine sections before parsing it as `VelesConfig`, so
+this can't happen.
+
+`VELESDB_*` environment variables still layer on top of the (filtered)
+file, same as `VelesConfig::load`/`load_from_path` — e.g.
+`VELESDB_LIMITS_MAX_COLLECTIONS=5` overrides a `[limits] max_collections`
+value from the file, and `velesdb-server`'s own `VELESDB_PORT`/
+`VELESDB_HOST`/... env vars (mapped to its transport `Args`, not to
+`VelesConfig`) keep working exactly as before.
+
+**Semantics are fail-fast**: an explicit `--config`/`VELESDB_CONFIG` path
+that is missing, malformed, or fails validation aborts startup (server) or
+the command (CLI) with the typed `ConfigError` — it never silently falls
+back to defaults. Omitting the flag entirely is unaffected: both binaries
+behave exactly as before this option was wired (core defaults, or
+`./velesdb.toml` if present).
+
+```bash
+# Server: engine + transport settings from one file
+velesdb-server --config /etc/velesdb/velesdb.toml
+VELESDB_CONFIG=/etc/velesdb/velesdb.toml velesdb-server
+
+# CLI: applies to the REPL...
+velesdb --config ./velesdb.toml repl ./my_database
+# ...and to one-shot commands (flag may come before or after the subcommand)
+velesdb collection create ./my_database docs --dimension 768 --config ./velesdb.toml
+```
+
+> Some other VelesDB surfaces (Tauri desktop shell, mobile bindings, the
+> Python SDK's `VelesConfigOptions`, and the LangChain/LlamaIndex
+> integrations) do not yet accept a `VelesConfig` at open time — tracked in
+> [issue #1549](https://github.com/cyberlife-coder/velesdb/issues/1549).
 
 ---
 
@@ -375,6 +425,10 @@ Configuration follows this priority order (from lowest to highest):
 5. Runtime override (REPL \set, VelesQL WITH, API params)
 ```
 
+> `--config`/`VELESDB_CONFIG` isn't a level in this chain — it *selects*
+> which file fills level 2, for both `velesdb-server` and the `velesdb` CLI.
+> See [File Search Paths](#file-search-paths) above for its exact semantics.
+
 ### Resolution Example
 
 ```toml
@@ -645,18 +699,24 @@ WARN: limits.max_perfect_mode_vectors=5000000 allows slow bruteforce on large da
 WARN: premium.hot_reload=true but no valid license key found
 ```
 
-### Validation Command
+### Validating a Config File
+
+There is no dedicated `velesdb config validate`/`show`/`init` subcommand.
+Instead, `--config` itself doubles as the validation entry point: pointing
+either binary at a file validates it fail-fast, before anything else runs.
 
 ```bash
-# Valider un fichier de configuration
-velesdb config validate ./velesdb.toml
+# CLI — fails immediately if the file is missing or invalid, before opening
+# any database (works with any subcommand, e.g. `info`):
+velesdb --config ./velesdb.toml info ./my_database
 
-# Afficher la configuration effective (avec env vars appliquées)
-velesdb config show
-
-# Générer un fichier de configuration par défaut
-velesdb config init > velesdb.toml
+# Server — fails immediately at startup, before binding a socket:
+velesdb-server --config ./velesdb.toml
 ```
+
+A missing path prints `config file not found: <path>`; an invalid value
+prints the typed `ConfigError` (e.g. `Invalid configuration value for
+'limits.max_collections': ...`) naming the offending key.
 
 ---
 


### PR DESCRIPTION
## Summary
Refs #1549 (two of six surfaces; the rest stay tracked on the issue).
- **Server**: `--config`/`VELESDB_CONFIG` now loads a validated `VelesConfig` and opens the engine with it (`Database::open_with_config`) — engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/`[wal_batch]`) finally reach the engine. Fail-fast on a missing/invalid explicit path with the typed `ConfigError`, never a silent fallback.
- **CLI**: global `--config` flag (REPL + every one-shot command), same fail-fast semantics.
- **Fable-review blocker fixed**: a combined TOML's `[server] port = 443` (legitimate transport config) was rejected by core's own `[server]` validation. New core loaders `from_toml_engine_only`/`load_from_path_engine_only` parse ONLY engine sections (other top-level tables stripped); standalone `load_from_path` behavior unchanged (test documents it). Docs corrected (`CONFIGURATION.md` described never-implemented search paths and subcommands); `Env::prefixed("VELESDB_")` override behavior documented.

## Test plan
- [x] TDD red→green incl. e2e: `[server] port = 443` + `[limits] max_collections` → server starts AND the limit is enforced (not just parsed); CLI assert_cmd e2e ×5.
- [x] Full `cargo test -p velesdb-core/-server/-cli` green; fmt/clippy `-D warnings` clean.