### PR TITLE
fix(hooks): drain git's ref list before pre-push checks to avoid exit 141

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,6 +6,16 @@
 # Ce hook s'exécute AVANT chaque git push.
 #
 # Pour activer: git config core.hooksPath .githooks
+#
+# NOTE SIGPIPE (exit 141): git ouvre la connexion au remote AVANT de lancer ce
+# hook et envoie le pack APRÈS sur la même connexion SSH. La validation
+# complète (~15 min) dépasse le timeout d'inactivité de la connexion, qui meurt
+# pendant les checks — git écrit alors dans un pipe fermé et sort en 141 sans
+# message, après "PASSED". Contre-mesures ici:
+#   - stdin (liste des refs) est drainé AVANT les checks, et les sous-processus
+#     cargo reçoivent </dev/null pour ne pas consommer le pipe de git;
+#   - des keepalives SSH doivent maintenir la connexion pendant les checks:
+#     git config core.sshCommand "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=60"
 # =============================================================================
 
 set -e
@@ -23,42 +33,52 @@ echo "  VelesDB-Core Pre-push Validation"
 echo "═══════════════════════════════════════════════════════════════════"
 echo -e "${NC}"
 
-# Détection de la branche cible
-while read local_ref local_sha remote_ref remote_sha; do
-    if [[ "$remote_ref" == *"main"* ]] || [[ "$remote_ref" == *"develop"* ]]; then
-        echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
-        echo -e "${YELLOW}   Running full CI validation...${NC}"
-        
-        # 1. Formatting
-        echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
-        if ! cargo fmt --all -- --check; then
-            echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Formatting OK${NC}"
-        
-        # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
-        if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings; then
-            echo -e "${RED}❌ Clippy found issues${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Clippy OK${NC}"
-        
-        # 3. Tests (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
-        if ! cargo test --workspace --exclude velesdb-python; then
-            echo -e "${RED}❌ Tests failed${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Tests OK${NC}"
-        
-        # 4. Security (non-blocking)
-        echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
-        cargo deny check 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
-        
-        echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
-    fi
+# Drainer TOUT stdin d'abord: git écrit "local_ref local_sha remote_ref
+# remote_sha" par ref poussée. Lire avant les checks garantit que le pipe est
+# consommé même si un check échoue (set -e) ou lit stdin.
+protected_push=false
+# shellcheck disable=SC2034 # local_ref/local_sha/remote_sha documentent le format
+while read -r local_ref local_sha remote_ref remote_sha; do
+    case "$remote_ref" in
+        refs/heads/main|refs/heads/develop)
+            protected_push=true
+            echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
+            ;;
+    esac
 done
+
+if [[ "$protected_push" == true ]]; then
+    echo -e "${YELLOW}   Running full CI validation...${NC}"
+
+    # 1. Formatting
+    echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
+    if ! cargo fmt --all -- --check </dev/null; then
+        echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Formatting OK${NC}"
+
+    # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
+    if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings </dev/null; then
+        echo -e "${RED}❌ Clippy found issues${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Clippy OK${NC}"
+
+    # 3. Tests (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
+    if ! cargo test --workspace --exclude velesdb-python </dev/null; then
+        echo -e "${RED}❌ Tests failed${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Tests OK${NC}"
+
+    # 4. Security (non-blocking)
+    echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
+    cargo deny check </dev/null 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
+
+    echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
+fi
 
 exit 0


### PR DESCRIPTION
## Problem

Long pushes to protected branches died with a bare exit 141 (SIGPIPE) *after* printing `Pre-push validation PASSED!`. git opens the SSH connection to the remote before running the hook and sends the pack afterwards on the same connection; the ~15 min full validation exceeded the connection's idle timeout, and git then wrote to a dead pipe.

Two aggravating factors in the old hook:
- the full validation ran *inside* the `while read` loop over git's ref list, so stdin was left unconsumed when a check failed (`set -e`);
- the `cargo` children inherited git's stdin pipe and could consume it.

## Fix

- Drain the entire ref list up front, only *flagging* protected-branch pushes, then run the 4 checks once after the loop.
- Every `cargo` invocation gets `</dev/null`.
- Documented the SSH keepalive counter-measure in the header: `git config core.sshCommand "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=60"`.

Tooling-only change (shell hook), no crate code touched; `bash -n` clean, shellcheck directive for the intentionally unused read variables.