### PR TITLE
fix(core): apply OFFSET/LIMIT to GROUP BY results after ORDER BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-core`**: `Database::execute_aggregate` now applies the
+  statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
+  the WASM aggregate pipeline (executor-conformance divergence D006). As in
+  WASM, there is no default cap: a LIMIT-less GROUP BY still returns every
+  group. Conformance fixture gains case G005 locking the behaviour on both
+  engines. (issue #1556)
 - **`scripts/check-promise-contract.py`**: the promise-contract guardrail
   only ever checked that a claim's `must_contain` substring was still
   present in the file it points at — it never executed

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -208,7 +208,15 @@
         { "category": "tech", "n": 3, "total_year": 6065.0 },
         { "category": "other", "n": 2, "total_year": 4040.0 }
       ],
-      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT is deliberately not exercised here — see documented_divergences D006"
+      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT on grouped rows is exercised by G005"
+    },
+    {
+      "id": "G005",
+      "query": "SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1",
+      "expect_groups": [
+        { "category": "tech", "n": 3, "total_year": 6065.0 }
+      ],
+      "note": "issue #1556: LIMIT applies to the ordered group rows in both engines (was documented_divergences D006 — core returned every group)"
     }
   ],
   "setops_cases": [
@@ -297,10 +305,10 @@
     {
       "id": "D006",
       "area": "LIMIT on GROUP BY aggregate results",
-      "core_behavior": "Database::execute_aggregate / Collection::execute_grouped_aggregate never reads stmt.limit — every group is returned regardless of a trailing LIMIT clause, verified empirically with 'SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1', which returned BOTH groups",
-      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; the identical query returned only 1 row (the 'tech' group)",
-      "status": "tracked as a real core gap, not fixed here (out of scope for issue #1544 — coverage of existing behaviour, not a new feature). aggregate_cases G001-G004 deliberately do not exercise LIMIT so the fixture's shared expect_groups is correct for both engines",
-      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: execute_grouped_aggregate/build_grouped_results (no limit/truncate call); crates/velesdb-wasm/src/velesql_aggregate.rs applies the standard SELECT finalize path which includes LIMIT"
+      "core_behavior": "RESOLVED (issue #1556): build_grouped_results now applies OFFSET/LIMIT after ORDER BY, with no default cap — a LIMIT-less GROUP BY still returns every group",
+      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; both engines now agree",
+      "status": "resolved by issue #1556 — aggregate case G005 exercises LIMIT on grouped rows and is asserted by both engines; unit coverage in crates/velesdb-core/tests/velesql_group_by_limit.rs",
+      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: build_grouped_results applies skip(offset)/take(limit) after sort; crates/velesdb-wasm/src/velesql_select.rs: finalize_aggregated routes through apply_limit_offset with u64::MAX default"
     }
   ]
 }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -44,6 +44,8 @@ impl Collection {
             group_by_columns,
             having,
             stmt.order_by.as_deref(),
+            stmt.limit,
+            stmt.offset,
         );
 
         Ok(serde_json::Value::Array(results))
@@ -179,13 +181,19 @@ impl Collection {
         Ok(())
     }
 
-    /// Builds the result array from grouped aggregators, applying HAVING and ORDER BY.
+    /// Builds the result array from grouped aggregators, applying HAVING,
+    /// ORDER BY, then OFFSET/LIMIT (issue #1556). Unlike plain SELECT there is
+    /// no default cap: a LIMIT-less GROUP BY returns every group, matching the
+    /// WASM aggregate pipeline.
+    #[allow(clippy::too_many_arguments)]
     fn build_grouped_results(
         groups: HashMap<GroupKey, Aggregator>,
         aggregations: &[AggregateFunction],
         group_by_columns: &[String],
         having: Option<&HavingClause>,
         order_by: Option<&[crate::velesql::SelectOrderBy]>,
+        limit: Option<u64>,
+        offset: Option<u64>,
     ) -> Vec<serde_json::Value> {
         let mut results = Vec::new();
 
@@ -213,6 +221,12 @@ impl Collection {
 
         if let Some(order_by) = order_by {
             Self::sort_aggregation_results(&mut results, order_by);
+        }
+
+        let skip = usize::try_from(offset.unwrap_or(0)).unwrap_or(usize::MAX);
+        let take = limit.map_or(usize::MAX, |l| usize::try_from(l).unwrap_or(usize::MAX));
+        if skip > 0 || take < results.len() {
+            results = results.into_iter().skip(skip).take(take).collect();
         }
 
         results

--- a/crates/velesdb-core/tests/velesql_group_by_limit.rs
+++ b/crates/velesdb-core/tests/velesql_group_by_limit.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "persistence")]
+//! Reproducer for issue #1556: `Database::execute_aggregate` must apply the
+//! statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
+//! the WASM aggregate pipeline (`finalize_aggregated` routes group rows
+//! through `apply_limit_offset` with no default cap — a LIMIT-less GROUP BY
+//! still returns every group).
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use velesdb_core::velesql::Parser;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+/// Three groups by construction: tech (3 rows), other (2 rows), misc (1 row).
+fn open_grouped_db() -> (TempDir, Database) {
+    let dir = TempDir::new().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open db");
+    db.create_collection("docs", 2, DistanceMetric::Cosine)
+        .expect("create collection");
+    let collection = db.get_vector_collection("docs").expect("get collection");
+    let rows = [
+        (1, "tech", 2020),
+        (2, "tech", 2021),
+        (3, "tech", 2024),
+        (4, "other", 2019),
+        (5, "other", 2021),
+        (6, "misc", 2022),
+    ];
+    let points: Vec<Point> = rows
+        .iter()
+        .map(|(id, category, year)| {
+            Point::new(
+                *id,
+                vec![0.1, 0.2],
+                Some(json!({ "category": category, "year": year })),
+            )
+        })
+        .collect();
+    collection.upsert(points).expect("upsert");
+    (dir, db)
+}
+
+fn run_aggregate(db: &Database, sql: &str) -> Vec<Value> {
+    let query = Parser::parse(sql).expect("parse");
+    let result = db
+        .execute_aggregate(&query, &HashMap::new())
+        .expect("execute_aggregate");
+    result.as_array().expect("array result").clone()
+}
+
+#[test]
+fn group_by_limit_truncates_ordered_groups() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1",
+    );
+    assert_eq!(
+        groups,
+        vec![json!({ "category": "tech", "n": 3 })],
+        "LIMIT 1 must keep only the first group after ORDER BY"
+    );
+}
+
+#[test]
+fn group_by_offset_skips_leading_groups() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1 OFFSET 1",
+    );
+    assert_eq!(
+        groups,
+        vec![json!({ "category": "other", "n": 2 })],
+        "OFFSET must skip already-ordered groups before LIMIT applies"
+    );
+}
+
+#[test]
+fn group_by_offset_only_drops_prefix_without_capping() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC OFFSET 1",
+    );
+    assert_eq!(
+        groups,
+        vec![
+            json!({ "category": "other", "n": 2 }),
+            json!({ "category": "misc", "n": 1 })
+        ],
+        "OFFSET without LIMIT must return every remaining group"
+    );
+}
+
+#[test]
+fn group_by_without_limit_returns_every_group() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC",
+    );
+    assert_eq!(
+        groups.len(),
+        3,
+        "a LIMIT-less GROUP BY must not be capped by any default SELECT limit"
+    );
+}

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -422,10 +422,12 @@ scalar-expression ones below, which use the same single-collection dataset):
 - `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
   WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
   (col)`.
-- `aggregate_cases` G001–G004: `GROUP BY` / `HAVING` / `COUNT` / `SUM`,
-  checked via `Database::execute_aggregate` on core (not `execute_query`,
-  which only groups when combined with vector `NEAR` search) and via the
-  default SELECT pipeline on WASM.
+- `aggregate_cases` G001–G005: `GROUP BY` / `HAVING` / `COUNT` / `SUM` /
+  `LIMIT`, checked via `Database::execute_aggregate` on core (not
+  `execute_query`, which only groups when combined with vector `NEAR`
+  search) and via the default SELECT pipeline on WASM. G005 (issue #1556)
+  locks `LIMIT` truncation on grouped results — formerly D006 below, now
+  resolved on both engines.
 - `setops_cases` S001–S004: `UNION` / `INTERSECT` / `EXCEPT`, compared as a
   **sorted set of ids**, not an ordered list (see D003 below).
 - `match_cases` M001–M002: 1- and 2-hop `MATCH`, with per-executor query text
@@ -461,9 +463,12 @@ silently relied upon:
 - **D005** — cross-reference to the pre-existing `relative_score`/`rsf`
   multi-query fusion ranking divergence, already tracked in
   `docs/reference/ECOSYSTEM_PARITY.md`.
-- **D006** — `Database::execute_aggregate` never applies `LIMIT` to the group
-  array on core (every group comes back regardless); WASM's aggregate
-  pipeline does apply `LIMIT`. Tracked, not fixed — out of scope for #1544.
+- ~~D006~~ — **fixed 2026-07-24** (issue #1556):
+  `Collection::build_grouped_results` now applies `OFFSET`/`LIMIT` to grouped
+  results after `ORDER BY`, matching the WASM aggregate pipeline (no default
+  cap — a LIMIT-less `GROUP BY` still returns every group). Locked by
+  `aggregate_cases` G005 above and
+  `crates/velesdb-core/tests/velesql_group_by_limit.rs`.
 
 ### Large production files vs the NLOC/complexity gate (audit F-5.13)
 


### PR DESCRIPTION
Closes #1556

## Problem

`Database::execute_aggregate` never read `stmt.limit`/`stmt.offset` for grouped queries — every group came back regardless of a trailing `LIMIT` clause, while the WASM aggregate pipeline routes group rows through the standard `skip(offset).take(limit)` finalize path. Tracked as executor-conformance divergence **D006**.

## Fix

`build_grouped_results` now truncates after HAVING and ORDER BY, mirroring WASM semantics exactly (`finalize_aggregated` → `apply_limit_offset` with `u64::MAX` default): **no default cap**, so a LIMIT-less GROUP BY still returns every group.

## TDD

- `crates/velesdb-core/tests/velesql_group_by_limit.rs` reproduced the divergence **red-first**: LIMIT ignored, OFFSET ignored, OFFSET-without-LIMIT ignored (3 failures before the fix, plus a passing no-LIMIT guard).
- Conformance fixture gains aggregate case **G005** (`… GROUP BY category ORDER BY n DESC, category ASC LIMIT 1` → the `tech` group only), asserted by both the core and WASM runners; D006 is marked resolved with updated evidence.

## Validation

- `cargo test -p velesdb-core --test velesql_group_by_limit --features persistence` → 4/4
- `cargo test -p velesdb-core --test velesql_executor_conformance --features persistence` → 6/6 (includes G005)
- All 78 core tests matching `agg` green; `cargo fmt --check` and `cargo clippy -p velesdb-core --all-targets -D warnings` clean.