### PR TITLE
fix(core): apply LIMIT/OFFSET to GROUP BY aggregate results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-core`**: `Collection::execute_grouped_aggregate` (GROUP BY)
+  ignored `LIMIT`/`OFFSET` entirely — every group was returned regardless of
+  a trailing `LIMIT` clause, diverging from the WASM aggregate pipeline and
+  from core's own non-aggregate SELECT path, both of which already apply
+  `OFFSET`-then-`LIMIT`. Found while extending the executor conformance
+  fixture (documented as `documented_divergences` D006 in
+  `conformance/velesql_executor_cases.json`). `build_grouped_results` now
+  applies `OFFSET`/`LIMIT` after `ORDER BY` (SQL-standard order: WHERE →
+  GROUP BY → HAVING → ORDER BY → OFFSET → LIMIT); a `LIMIT`-less `GROUP BY`
+  still returns every group, matching prior behavior and WASM's semantics.
+  Locked by fixture case G005 and new `velesdb-core` BDD tests. (issue
+  #1556)
 - **`scripts/check-promise-contract.py`**: the promise-contract guardrail
   only ever checked that a claim's `must_contain` substring was still
   present in the file it points at — it never executed

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -208,7 +208,15 @@
         { "category": "tech", "n": 3, "total_year": 6065.0 },
         { "category": "other", "n": 2, "total_year": 4040.0 }
       ],
-      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT is deliberately not exercised here — see documented_divergences D006"
+      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key"
+    },
+    {
+      "id": "G005",
+      "query": "SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1",
+      "expect_groups": [
+        { "category": "tech", "n": 3, "total_year": 6065.0 }
+      ],
+      "note": "issue #1556: LIMIT truncates GROUP BY results — regression lock for the fix to Collection::build_grouped_results (previously core ignored stmt.limit and returned both groups; was documented_divergences D006, now resolved on both engines)"
     }
   ],
   "setops_cases": [
@@ -293,14 +301,6 @@
       "wasm_behavior": "WASM-local relative_score/rsf multi-query fusion ranks differently from core",
       "status": "pre-existing, out of scope for issue #1544 — cross-referenced here only because the issue's own description flagged it as related context",
       "evidence": "crates/velesdb-wasm/src/fusion.rs:6-18,85-91 (per issue #1544 description); docs/reference/ECOSYSTEM_PARITY.md"
-    },
-    {
-      "id": "D006",
-      "area": "LIMIT on GROUP BY aggregate results",
-      "core_behavior": "Database::execute_aggregate / Collection::execute_grouped_aggregate never reads stmt.limit — every group is returned regardless of a trailing LIMIT clause, verified empirically with 'SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1', which returned BOTH groups",
-      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; the identical query returned only 1 row (the 'tech' group)",
-      "status": "tracked as a real core gap, not fixed here (out of scope for issue #1544 — coverage of existing behaviour, not a new feature). aggregate_cases G001-G004 deliberately do not exercise LIMIT so the fixture's shared expect_groups is correct for both engines",
-      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: execute_grouped_aggregate/build_grouped_results (no limit/truncate call); crates/velesdb-wasm/src/velesql_aggregate.rs applies the standard SELECT finalize path which includes LIMIT"
     }
   ]
 }

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -44,6 +44,8 @@ impl Collection {
             group_by_columns,
             having,
             stmt.order_by.as_deref(),
+            stmt.offset,
+            stmt.limit,
         );
 
         Ok(serde_json::Value::Array(results))
@@ -179,13 +181,16 @@ impl Collection {
         Ok(())
     }
 
-    /// Builds the result array from grouped aggregators, applying HAVING and ORDER BY.
+    /// Builds the result array from grouped aggregators, applying HAVING, ORDER BY,
+    /// and OFFSET/LIMIT (in that SQL-standard order — see `select_dispatch.rs`).
     fn build_grouped_results(
         groups: HashMap<GroupKey, Aggregator>,
         aggregations: &[AggregateFunction],
         group_by_columns: &[String],
         having: Option<&HavingClause>,
         order_by: Option<&[crate::velesql::SelectOrderBy]>,
+        offset: Option<u64>,
+        limit: Option<u64>,
     ) -> Vec<serde_json::Value> {
         let mut results = Vec::new();
 
@@ -213,6 +218,17 @@ impl Collection {
 
         if let Some(order_by) = order_by {
             Self::sort_aggregation_results(&mut results, order_by);
+        }
+
+        // SQL-standard: OFFSET applied after ORDER BY, before LIMIT. A LIMIT-less
+        // GROUP BY returns every group (no default cap), matching the WASM
+        // aggregate pipeline (see conformance/velesql_executor_cases.json D006).
+        if let Some(offset) = offset {
+            let skip = usize::try_from(offset).unwrap_or(usize::MAX);
+            results = results.into_iter().skip(skip).collect();
+        }
+        if let Some(limit) = limit {
+            results.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
         }
 
         results

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -38,15 +38,8 @@ impl Collection {
         let groups =
             self.scan_and_group(stmt, aggregations, group_by_columns, max_groups, params)?;
 
-        let results = Self::build_grouped_results(
-            groups,
-            aggregations,
-            group_by_columns,
-            having,
-            stmt.order_by.as_deref(),
-            stmt.offset,
-            stmt.limit,
-        );
+        let results =
+            Self::build_grouped_results(groups, aggregations, group_by_columns, having, stmt);
 
         Ok(serde_json::Value::Array(results))
     }
@@ -188,9 +181,7 @@ impl Collection {
         aggregations: &[AggregateFunction],
         group_by_columns: &[String],
         having: Option<&HavingClause>,
-        order_by: Option<&[crate::velesql::SelectOrderBy]>,
-        offset: Option<u64>,
-        limit: Option<u64>,
+        stmt: &crate::velesql::SelectStatement,
     ) -> Vec<serde_json::Value> {
         let mut results = Vec::new();
 
@@ -216,18 +207,19 @@ impl Collection {
             results.push(serde_json::Value::Object(row));
         }
 
-        if let Some(order_by) = order_by {
+        if let Some(order_by) = stmt.order_by.as_deref() {
             Self::sort_aggregation_results(&mut results, order_by);
         }
 
         // SQL-standard: OFFSET applied after ORDER BY, before LIMIT. A LIMIT-less
         // GROUP BY returns every group (no default cap), matching the WASM
-        // aggregate pipeline (see conformance/velesql_executor_cases.json D006).
-        if let Some(offset) = offset {
+        // aggregate pipeline (see conformance/velesql_executor_cases.json, resolved
+        // documented_divergences D006).
+        if let Some(offset) = stmt.offset {
             let skip = usize::try_from(offset).unwrap_or(usize::MAX);
             results = results.into_iter().skip(skip).collect();
         }
-        if let Some(limit) = limit {
+        if let Some(limit) = stmt.limit {
             results.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
         }
 

--- a/crates/velesdb-core/tests/bdd/aggregation.rs
+++ b/crates/velesdb-core/tests/bdd/aggregation.rs
@@ -666,3 +666,116 @@ fn test_group_by_without_limit_returns_all_groups() {
         groups.len()
     );
 }
+
+// =========================================================================
+// Scenario 19: OFFSET without LIMIT skips groups on GROUP BY results (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_with_offset_only() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category ORDER BY category ASC OFFSET 1",
+    )
+    .expect("test: GROUP BY OFFSET without LIMIT");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    let categories: Vec<&str> = groups
+        .iter()
+        .filter_map(|g| g.get("category")?.as_str())
+        .collect();
+    assert_eq!(
+        categories,
+        vec!["clothing", "electronics"],
+        "OFFSET 1 without LIMIT should skip the first group and return the rest"
+    );
+}
+
+// =========================================================================
+// Scenario 20: LIMIT combined with HAVING on GROUP BY results (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_having_then_limit() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    // HAVING COUNT(*) >= 3 keeps all 3 categories (electronics=3, books=3,
+    // clothing=4); LIMIT 1 must then truncate what HAVING already filtered,
+    // never the other way around.
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category HAVING COUNT(*) >= 3 ORDER BY category ASC LIMIT 1",
+    )
+    .expect("test: GROUP BY HAVING then LIMIT");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert_eq!(
+        groups.len(),
+        1,
+        "LIMIT 1 should apply after HAVING's 3-group result, got {}",
+        groups.len()
+    );
+    assert_eq!(
+        groups[0].get("category").and_then(|v| v.as_str()),
+        Some("books"),
+        "HAVING should keep all 3 categories, then LIMIT 1 (ORDER BY category ASC) keeps 'books'"
+    );
+}
+
+// =========================================================================
+// Scenario 21: LIMIT 0 on GROUP BY returns empty (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_limit_zero_returns_empty() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category LIMIT 0",
+    )
+    .expect("test: GROUP BY LIMIT 0");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert!(
+        groups.is_empty(),
+        "LIMIT 0 on GROUP BY should return 0 groups, got {}",
+        groups.len()
+    );
+}
+
+// =========================================================================
+// Scenario 22: OFFSET beyond group count returns empty (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_offset_beyond_group_count_returns_empty() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category OFFSET 100",
+    )
+    .expect("test: GROUP BY OFFSET beyond group count");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert!(
+        groups.is_empty(),
+        "OFFSET 100 on 3 groups should return empty, got {}",
+        groups.len()
+    );
+}

--- a/crates/velesdb-core/tests/bdd/aggregation.rs
+++ b/crates/velesdb-core/tests/bdd/aggregation.rs
@@ -573,3 +573,96 @@ fn test_having_with_gte_operator() {
         groups.len()
     );
 }
+
+// =========================================================================
+// Scenario 16: LIMIT truncates GROUP BY results (issue #1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_with_limit_truncates_groups() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category ORDER BY category ASC LIMIT 2",
+    )
+    .expect("test: GROUP BY LIMIT");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert_eq!(
+        groups.len(),
+        2,
+        "LIMIT 2 should truncate 3 groups down to 2, got {}",
+        groups.len()
+    );
+
+    let categories: Vec<&str> = groups
+        .iter()
+        .filter_map(|g| g.get("category")?.as_str())
+        .collect();
+    assert_eq!(
+        categories,
+        vec!["books", "clothing"],
+        "LIMIT should keep the first 2 groups in ORDER BY category ASC order"
+    );
+}
+
+// =========================================================================
+// Scenario 17: OFFSET skips groups before LIMIT on GROUP BY results (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_with_offset_and_limit() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category ORDER BY category ASC LIMIT 1 OFFSET 1",
+    )
+    .expect("test: GROUP BY OFFSET LIMIT");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert_eq!(
+        groups.len(),
+        1,
+        "OFFSET 1 LIMIT 1 should return exactly 1 group, got {}",
+        groups.len()
+    );
+    assert_eq!(
+        groups[0].get("category").and_then(|v| v.as_str()),
+        Some("clothing"),
+        "OFFSET 1 should skip 'books' and return the second group 'clothing'"
+    );
+}
+
+// =========================================================================
+// Scenario 18: GROUP BY without LIMIT still returns every group (#1556)
+// =========================================================================
+
+#[test]
+fn test_group_by_without_limit_returns_all_groups() {
+    let (_dir, db) = create_test_db();
+    setup_orders_collection(&db);
+
+    let result = execute_aggregate_sql(
+        &db,
+        "SELECT category, COUNT(*) FROM orders GROUP BY category",
+    )
+    .expect("test: GROUP BY without LIMIT");
+
+    let groups = result
+        .as_array()
+        .expect("test: aggregation should return array");
+    assert_eq!(
+        groups.len(),
+        3,
+        "A LIMIT-less GROUP BY must return every group (no default cap), got {}",
+        groups.len()
+    );
+}

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -422,10 +422,12 @@ scalar-expression ones below, which use the same single-collection dataset):
 - `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
   WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
   (col)`.
-- `aggregate_cases` G001–G004: `GROUP BY` / `HAVING` / `COUNT` / `SUM`,
+- `aggregate_cases` G001–G005: `GROUP BY` / `HAVING` / `COUNT` / `SUM` / `LIMIT`,
   checked via `Database::execute_aggregate` on core (not `execute_query`,
   which only groups when combined with vector `NEAR` search) and via the
-  default SELECT pipeline on WASM.
+  default SELECT pipeline on WASM. G005 (issue #1556) locks `LIMIT`
+  truncation on grouped results — formerly D006 below, now resolved on both
+  engines.
 - `setops_cases` S001–S004: `UNION` / `INTERSECT` / `EXCEPT`, compared as a
   **sorted set of ids**, not an ordered list (see D003 below).
 - `match_cases` M001–M002: 1- and 2-hop `MATCH`, with per-executor query text
@@ -461,9 +463,10 @@ silently relied upon:
 - **D005** — cross-reference to the pre-existing `relative_score`/`rsf`
   multi-query fusion ranking divergence, already tracked in
   `docs/reference/ECOSYSTEM_PARITY.md`.
-- **D006** — `Database::execute_aggregate` never applies `LIMIT` to the group
-  array on core (every group comes back regardless); WASM's aggregate
-  pipeline does apply `LIMIT`. Tracked, not fixed — out of scope for #1544.
+- ~~D006~~ — **fixed 2026-07-24** ([issue #1556](https://github.com/cyberlife-coder/VelesDB/issues/1556)):
+  `Collection::build_grouped_results` now applies `OFFSET`/`LIMIT` to grouped
+  results after `ORDER BY`, matching the WASM aggregate pipeline and the
+  core non-aggregate SELECT path. Locked by `aggregate_cases` G005 above.
 
 ### Large production files vs the NLOC/complexity gate (audit F-5.13)
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

This branch targets `develop`, consistent with the bug-fix scope of this change.

## Description

`Collection::execute_grouped_aggregate` (the `GROUP BY` execution path) never read `stmt.limit`/`stmt.offset` — every group was returned regardless of a trailing `LIMIT` clause. This diverged from:
- the WASM aggregate pipeline, which already applies `LIMIT`/`OFFSET` to grouped results the same as a plain `SELECT`, and
- core's own non-aggregate `SELECT` path (`apply_select_postprocessing` in `select_dispatch.rs`) and compound-query path (`mod.rs`), both of which already apply `OFFSET`-then-`LIMIT`.

This was found and documented while extending the executor conformance fixture (issue #1544, divergence `D006` in `conformance/velesql_executor_cases.json`).

Fixes #1556

## What changed

- `Collection::build_grouped_results` (`crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs`) now applies `OFFSET`/`LIMIT` after `ORDER BY`, matching the SQL-standard order already used elsewhere in the codebase: `WHERE → GROUP BY → HAVING → ORDER BY → OFFSET → LIMIT`. A `LIMIT`-less `GROUP BY` still returns every group (no default cap), matching prior behavior and WASM's semantics.
- The function now takes `&SelectStatement` directly (like `apply_select_postprocessing` already does) instead of unpacking `order_by`/`offset`/`limit` at the call site, keeping the signature at 5 params instead of growing to 7.
- Added conformance fixture case `G005` (`conformance/velesql_executor_cases.json`), which runs against **both** `velesdb-core` and `velesdb-wasm` via the shared executor-conformance test harness — verified both engines now agree.
- Removed the now-resolved `documented_divergences` `D006` entry from the fixture, and updated `docs/reference/KNOWN_LIMITATIONS.md` to mark it fixed (with date).
- Added 7 new BDD regression tests in `crates/velesdb-core/tests/bdd/aggregation.rs`: `LIMIT` truncation, `OFFSET`+`LIMIT`, `LIMIT`-less (all groups), `OFFSET`-only (no `LIMIT`), `LIMIT` combined with `HAVING` (proves ordering — `HAVING` filters before `LIMIT` truncates), `LIMIT 0`, and `OFFSET` beyond the group count.
- `CHANGELOG.md` entry under `[Unreleased] → Fixed`.

This PR went through an independent adversarial review (5 perspectives: correctness, performance, security/DoS, simplicity/DRY, maintainability/test coverage) before being finalized; the review's two actionable findings (signature growth, missing edge-case tests) are both addressed in the second commit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests (BDD suite, `crates/velesdb-core/tests/bdd/aggregation.rs`)
- [x] Integration tests (conformance fixture, run against core + WASM + CLI)

**Test Configuration:**
- OS: Linux
- Rust version: workspace toolchain (stable)

Local gates, all green:
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean (no unsafe touched)
- `cargo test -p velesdb-core --lib --features persistence,gpu,update-check` — 5401 passed, 0 failed
- `cargo test -p velesdb-core --test bdd -- aggregation` — 22 passed, 0 failed (7 new)
- `cargo test -p velesdb-core --test velesql_executor_conformance` — 6 passed, 0 failed
- `cargo test -p velesdb-wasm --lib -- velesql_executor_conformance` — 7 passed, 0 failed (confirms G005 passes identically on both engines)
- `cargo test -p velesdb-cli --test velesql_executor_conformance` — 2 passed, 0 failed
- `cargo test --doc -p velesdb-core --features persistence,gpu,update-check` — 50 passed, 0 failed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code (plus an independent 5-perspective adversarial review)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — this PR does not add or modify `unsafe` code.

## Additional Notes

No behavior change for `LIMIT`-less `GROUP BY` queries (still returns every group). No breaking change to any public API or REST contract — `LIMIT`/`OFFSET` on `GROUP BY` previously being ignored was a silent correctness gap, not a documented/relied-upon behavior.
