### PR TITLE
fix(wasm): orient JOIN ON condition by joined-table side, not position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-wasm`**: the VelesQL JOIN executor no longer depends on which
+  side of the `ON` condition names the joined table. `ON joined.col =
+  base.col` used to match nothing (NULL joined columns on every row);
+  `equality_keys` now orients the condition like core's
+  `normalize_join_condition`. Conformance join case J005 locks both engines
+  (was executor-conformance divergence D002). (issue #1555)
 - **`velesdb-core`**: `Database::execute_aggregate` now applies the
   statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
   the WASM aggregate pipeline (executor-conformance divergence D006). As in

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -159,13 +159,19 @@
       "id": "J002",
       "query": "SELECT * FROM orders LEFT JOIN customers ON orders.customer_id = customers.id ORDER BY orders.id ASC",
       "expect_ids": [1, 2, 3, 4],
-      "note": "issue #1544: LEFT JOIN keeps the unmatched left row (id=4) with NULL joined columns. Written base-table-first (orders.customer_id = customers.id) — see documented_divergences D002 for why the reversed condition order is deliberately NOT used here"
+      "note": "issue #1544: LEFT JOIN keeps the unmatched left row (id=4) with NULL joined columns. Written base-table-first (orders.customer_id = customers.id); the reversed order is exercised by J005 (issue #1555)"
     },
     {
       "id": "J003",
       "query": "SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id WHERE customers.name = 'Alice' ORDER BY orders.id ASC",
       "expect_ids": [1, 3],
       "note": "issue #1544: JOIN combined with a WHERE predicate on a joined-table column"
+    },
+    {
+      "id": "J005",
+      "query": "SELECT * FROM orders JOIN customers ON customers.id = orders.customer_id ORDER BY orders.id ASC",
+      "expect_ids": [1, 2, 3],
+      "note": "issue #1555: identical to J001 but with the ON condition written joined-table-first — both engines must orient the condition by which side names the joined table (was documented_divergences D002)"
     },
     {
       "id": "J004",
@@ -273,10 +279,10 @@
     {
       "id": "D002",
       "area": "JOIN condition side order (WASM only)",
-      "core_behavior": "normalize_join_condition (query_join.rs) accepts ON in either order — `base.col = joined.col` and `joined.col = base.col` both resolve to the same match",
-      "wasm_behavior": "equality_keys/key_of (velesql_join.rs) does not normalize side order: `ON joined.col = base.col` looks up the joined-table-qualified key on the yet-unjoined base row (which never has it), so EVERY row silently comes back with NULL joined columns instead of matching — verified empirically with `LEFT JOIN customers ON customers.id = orders.customer_id` (all 4 rows got customers:null) vs the working `ON orders.customer_id = customers.id` (rows 1-3 matched, row 4 null)",
-      "status": "tracked as a real WASM gap, not fixed here (out of scope per issue #1544 — coverage of existing behaviour, not new WASM support). fixture J001/J002 are written in the working (base-table-first) order so the conformance suite stays green; the reversed order is intentionally not exercised as a passing case",
-      "evidence": "crates/velesdb-wasm/src/velesql_join.rs: equality_keys()/key_of()"
+      "core_behavior": "normalize_join_condition (search/query/join.rs) accepts ON in either order — `base.col = joined.col` and `joined.col = base.col` both resolve to the same match",
+      "wasm_behavior": "RESOLVED (issue #1555): equality_keys (velesql_join.rs) now orients the condition by which side targets the join alias (or raw table name), mirroring core; both orders resolve identically",
+      "status": "resolved by issue #1555 — join case J005 exercises the joined-table-first order on both engines; the former regression-lock canary test is now a parity lock (test_wasm_join_condition_side_order_parity_1555)",
+      "evidence": "crates/velesdb-wasm/src/velesql_join.rs: equality_keys() orientation; crates/velesdb-core/src/collection/search/query/join.rs: normalize_join_condition()"
     },
     {
       "id": "D003",

--- a/crates/velesdb-wasm/CHANGELOG.md
+++ b/crates/velesdb-wasm/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-sourcing; output is unchanged. (Issue #1545.)
 
 ### Fixed
+- **JOIN `ON` condition side order (#1555)**: `ON joined.col = base.col`
+  silently matched nothing (every row came back with NULL joined columns)
+  because the join key resolution read the two sides of the condition
+  positionally. `equality_keys` now orients the condition by which side
+  names the joined table (alias or raw table name), mirroring
+  `velesdb-core`'s `normalize_join_condition` — both `ON` orders resolve
+  identically. Conformance case J005 locks the parity on both engines.
 - **SQ8 quantization parity with `velesdb-core` (#1543)**: the WASM SQ8
   encode/decode paths (`store_insert::encode_sq8`, `store_get::decode_sq8`,
   `vector_ops::ScratchBuffer::decode_sq8`) used an ad hoc `1e-10`

--- a/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
@@ -342,22 +342,14 @@ fn test_wasm_velesql_executor_match_cases() {
     }
 }
 
-/// Documents a real, currently-existing WASM JOIN gap
-/// (`documented_divergences` D002 in the fixture): `ON <base>.<col> =
-/// <joined>.<col>` matches correctly, but the reversed condition order
-/// (`ON <joined>.<col> = <base>.<col>`) fails to match ANY row and every
-/// joined column comes back NULL, because `equality_keys`/`key_of`
-/// (`velesql_join.rs`) does not normalize which side names the base vs.
-/// joined table the way core's `normalize_join_condition` does.
-///
-/// This is a **regression-lock for the current (buggy) behaviour**, not a
-/// desired outcome: fixing the underlying normalization is out of scope for
-/// issue #1544 (coverage of existing behaviour, not new WASM support). If
-/// this test starts failing because someone *fixed* the normalization, that
-/// is good news — update this test and `documented_divergences` D002 in
-/// `conformance/velesql_executor_cases.json` to match.
+/// Parity lock for issue #1555 (formerly `documented_divergences` D002):
+/// the ON condition must match regardless of which side names the joined
+/// table. `equality_keys` (`velesql_join.rs`) now orients the condition by
+/// which `ColumnRef` targets the join alias, mirroring core's
+/// `normalize_join_condition`, so `ON <joined>.<col> = <base>.<col>`
+/// resolves identically to `ON <base>.<col> = <joined>.<col>`.
 #[test]
-fn test_wasm_join_condition_side_order_gap_d002() {
+fn test_wasm_join_condition_side_order_parity_1555() {
     let mut db = DatabaseInner::new();
     db.create_collection("customers", 2, "cosine")
         .expect("test: create customers");
@@ -391,7 +383,8 @@ fn test_wasm_join_condition_side_order_gap_d002() {
         "base-table-first ON order should match and enrich the row with the customer name"
     );
 
-    // Reversed order: joined-table-first. Currently fails to match (D002).
+    // Reversed order: joined-table-first. Must match exactly like the
+    // base-table-first form (issue #1555).
     let reversed = execute(
         &mut db,
         "SELECT * FROM orders LEFT JOIN customers ON customers.id = orders.customer_id",
@@ -400,10 +393,9 @@ fn test_wasm_join_condition_side_order_gap_d002() {
     .expect("test: reversed-order join");
     let reversed_row: Value =
         serde_json::from_str(&reversed.rows_ref()[0].data_json()).expect("test: parse row");
-    assert!(
-        reversed_row.get("name").is_none() || reversed_row.get("name") == Some(&Value::Null),
-        "documented WASM gap D002: joined-table-first ON order currently does NOT match \
-         (customer name should be absent/null); if this assertion now fails, the underlying \
-         bug was fixed — update documented_divergences D002 accordingly"
+    assert_eq!(
+        reversed_row.get("name").and_then(Value::as_str),
+        Some("Alice"),
+        "joined-table-first ON order must resolve identically to base-table-first (issue #1555)"
     );
 }

--- a/crates/velesdb-wasm/src/velesql_join.rs
+++ b/crates/velesdb-wasm/src/velesql_join.rs
@@ -191,7 +191,23 @@ fn reject_unsupported_join(join: &JoinClause) -> Result<(), String> {
 /// "alias.column on right side".
 fn equality_keys(join: &JoinClause, alias: &str) -> Result<(String, String), String> {
     if let Some(cond) = &join.condition {
-        return Ok((key_of(&cond.left, alias), key_of(&cond.right, alias)));
+        // Orient the condition by which side targets the joined table, the
+        // same way core's `normalize_join_condition` does (issue #1555):
+        // the base-side ref is looked up on the accumulated row, the
+        // join-side ref on the scanned right row — regardless of which side
+        // of `ON` named which table. The joined table is addressable by its
+        // alias or by its raw table name even when aliased.
+        let is_join_side = |r: &velesdb_core::velesql::ColumnRef| {
+            r.table
+                .as_deref()
+                .is_some_and(|t| t == alias || t == join.table)
+        };
+        let (base_ref, join_ref) = if !is_join_side(&cond.left) || is_join_side(&cond.right) {
+            (&cond.left, &cond.right)
+        } else {
+            (&cond.right, &cond.left)
+        };
+        return Ok((key_of(base_ref, alias), key_of(join_ref, alias)));
     }
     if let Some(cols) = &join.using_columns {
         if let Some(first) = cols.first() {

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -419,9 +419,9 @@ scalar-expression ones below, which use the same single-collection dataset):
 - `cases` X011–X014: WHERE-expression evaluation (`BETWEEN`, parenthesized
   `AND`/`OR`, `NOT`, `IN`) — safe for CLI's strict-order comparison, so these
   run on all three executors.
-- `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
-  WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
-  (col)`.
+- `join_cases` J001–J005: `JOIN ... ON` (both condition-side orders on both
+  engines — J005 locks the joined-table-first order, issue #1555) and
+  `JOIN ... USING (col)`.
 - `aggregate_cases` G001–G005: `GROUP BY` / `HAVING` / `COUNT` / `SUM` /
   `LIMIT`, checked via `Database::execute_aggregate` on core (not
   `execute_query`, which only groups when combined with vector `NEAR`
@@ -441,14 +441,13 @@ silently relied upon:
 - **D001** — unaliased aggregate output field names differ (`"count"` /
   `"sum_year"` on core vs `"count(*)"` / `"sum(year)"` on WASM); sidestepped
   in the fixture by always using an explicit `AS` alias.
-- **D002** — WASM's `JOIN ... ON` does not normalize condition side order the
-  way core does: `ON base.col = joined.col` matches, but the reversed
-  `ON joined.col = base.col` silently returns every row with NULL joined
-  columns instead of matching. Locked as a regression test
-  (`test_wasm_join_condition_side_order_gap_d002` in
-  `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs`) rather than
-  fixed — out of scope for #1544 (coverage of existing behaviour, not new
-  WASM support).
+- ~~D002~~ — **fixed 2026-07-24** (issue #1555): WASM's `equality_keys` now
+  orients the `ON` condition by which side names the joined table (alias or
+  raw table name), mirroring core's `normalize_join_condition` — both
+  condition-side orders resolve identically. Locked by `join_cases` J005
+  above and the parity test
+  (`test_wasm_join_condition_side_order_parity_1555` in
+  `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs`).
 - **D003** — `UNION`/`INTERSECT`/`EXCEPT` row order for non-ranked (score 0.0)
   branches is implementation-defined on both sides (core re-sorts by score
   with an unstable tie-break that was observed to differ between two runs of


### PR DESCRIPTION
Closes #1555

**Stacked on #1569** (shared CHANGELOG/conformance-fixture regions) — will be rebased onto `develop` and retargeted once #1569 merges.

## Problem

The WASM VelesQL JOIN executor read the two sides of `ON a.x = b.y` positionally: left side looked up on the accumulated base row, right side on the scanned joined row. Writing the condition joined-table-first (`ON customers.id = orders.customer_id`) matched **nothing** — every row silently came back with NULL joined columns — while core's `normalize_join_condition` accepts either order. Tracked as executor-conformance divergence **D002**.

## Fix

`equality_keys` now orients the condition by which `ColumnRef` targets the join alias (or the raw table name when aliased), mirroring core exactly. Unqualified and both-sides-qualified conditions keep their previous positional behaviour.

## TDD

- The D002 regression-lock canary was flipped **red-first** into a parity lock (`test_wasm_join_condition_side_order_parity_1555`): reversed-order `ON` must enrich the row exactly like base-table-first order. Verified failing before the fix, green after.
- Conformance join case **J005** (J001 with the `ON` sides reversed) asserts the parity on both engines; D002 marked resolved with updated evidence, stale J002 note refreshed.

## Validation

- `cargo test -p velesdb-wasm` → 653 passed, 0 failed (full native suite)
- Core conformance 6/6, WASM conformance 7/7 (both include J005)
- `cargo fmt --check` and `cargo clippy -p velesdb-wasm --all-targets -D warnings` clean