### PR TITLE
fix(hooks): pre-push exit 141 (SIGPIPE) — drain refs, exact branch match, HTTPS push doc

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,6 +6,18 @@
 # Ce hook s'exécute AVANT chaque git push.
 #
 # Pour activer: git config core.hooksPath .githooks
+#
+# NOTE SIGPIPE (exit 141): git ouvre la connexion au remote AVANT de lancer ce
+# hook et envoie le pack APRÈS sur la même connexion. Si cette connexion SSH
+# meurt pendant la validation complète (~15 min), git écrit dans un pipe fermé
+# et sort en 141 sans message, après "PASSED" — le transfert n'a jamais lieu.
+# Contre-mesures ici:
+#   - stdin (liste des refs) est drainé AVANT les checks, et les sous-processus
+#     cargo reçoivent </dev/null pour ne pas consommer le pipe de git;
+#   - pousser en HTTPS rend la coupure sans effet (advertisement et envoi du
+#     pack sont deux requêtes indépendantes, la connexion est rétablie):
+#     git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+#     git config credential.helper '!gh auth git-credential'
 # =============================================================================
 
 set -e
@@ -23,42 +35,52 @@ echo "  VelesDB-Core Pre-push Validation"
 echo "═══════════════════════════════════════════════════════════════════"
 echo -e "${NC}"
 
-# Détection de la branche cible
-while read local_ref local_sha remote_ref remote_sha; do
-    if [[ "$remote_ref" == *"main"* ]] || [[ "$remote_ref" == *"develop"* ]]; then
-        echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
-        echo -e "${YELLOW}   Running full CI validation...${NC}"
-        
-        # 1. Formatting
-        echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
-        if ! cargo fmt --all -- --check; then
-            echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Formatting OK${NC}"
-        
-        # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
-        if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings; then
-            echo -e "${RED}❌ Clippy found issues${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Clippy OK${NC}"
-        
-        # 3. Tests (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
-        if ! cargo test --workspace --exclude velesdb-python; then
-            echo -e "${RED}❌ Tests failed${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Tests OK${NC}"
-        
-        # 4. Security (non-blocking)
-        echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
-        cargo deny check 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
-        
-        echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
-    fi
+# Drainer TOUT stdin d'abord: git écrit "local_ref local_sha remote_ref
+# remote_sha" par ref poussée. Lire avant les checks garantit que le pipe est
+# consommé même si un check échoue (set -e) ou lit stdin.
+protected_push=false
+# shellcheck disable=SC2034 # local_ref/local_sha/remote_sha documentent le format
+while read -r local_ref local_sha remote_ref remote_sha; do
+    case "$remote_ref" in
+        refs/heads/main|refs/heads/develop)
+            protected_push=true
+            echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
+            ;;
+    esac
 done
+
+if [[ "$protected_push" == true ]]; then
+    echo -e "${YELLOW}   Running full CI validation...${NC}"
+
+    # 1. Formatting
+    echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
+    if ! cargo fmt --all -- --check </dev/null; then
+        echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Formatting OK${NC}"
+
+    # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
+    if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings </dev/null; then
+        echo -e "${RED}❌ Clippy found issues${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Clippy OK${NC}"
+
+    # 3. Tests (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
+    if ! cargo test --workspace --exclude velesdb-python </dev/null; then
+        echo -e "${RED}❌ Tests failed${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Tests OK${NC}"
+
+    # 4. Security (non-blocking)
+    echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
+    cargo deny check </dev/null 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
+
+    echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
+fi
 
 exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,17 @@ Or use the local CI script: `.\scripts\local-ci.ps1` (Full) or `.\scripts\local-
 
 Git hooks are provided in `.githooks/` — activate with: `git config core.hooksPath .githooks`
 
+> **Note (SSH pushes):** the pre-push hook runs the full validation (~15 min) while
+> git already holds the connection to GitHub open; if that SSH connection dies in
+> the meantime, `git push` exits 141 (SIGPIPE) with no error message right after
+> the validation passes. Pushing over HTTPS is immune (the ref advertisement and
+> the pack upload are independent requests):
+>
+> ```
+> git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+> git config credential.helper '!gh auth git-credential'
+> ```
+
 ## Development Setup
 
 ### Prerequisites

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -243,6 +243,10 @@ Runs automatically before each `git commit`:
 
 Activate with: `git config core.hooksPath .githooks`
 
+When pushing over SSH, also configure an HTTPS push URL so the long pre-push
+validation cannot kill the connection before the transfer (see CONTRIBUTING.md,
+"Note (SSH pushes)").
+
 ---
 
 ## Relationship with VelesDB-Premium


### PR DESCRIPTION
## Problem

Since #1540 made `.githooks/pre-push` executable, pushes that trigger the full validation fail with a **silent exit 141 (SIGPIPE)** right after `Pre-push validation PASSED!` — the transfer never happens. Reproduced 3× on 2026-07-23 evening; `--no-verify` works.

## Root cause (reproduced, instrumented)

`git push` opens the connection to the remote and reads the ref advertisement **before** running the pre-push hook, then sends the pack **on the same connection**. The full validation takes ~15 min (cargo test alone: 865 s warm). An instrumented repro (`GIT_TRACE_PACKET` + `ssh -vv`, 900 s delay hook) shows GitHub closing the idle SSH push session after **~360 s** (a `keepalive@openssh.com` probe, then channel EOF, `Connection to github.com closed by remote host`). When the hook finishes, git writes the push commands into the dead pipe → SIGPIPE → exit 141 with no error message.

Notes from the investigation:
- A raw idle `ssh git-receive-pack` connection survives 25 min; only real push sessions are reaped early (~6 min), so client keepalives were not relied upon as a fix.
- The old glob matched **any** ref containing `main`/`develop` — e.g. `chore/backmerge-main-*` — so ordinary chore branches also paid the 15-min validation and hit the bug.
- Checks ran once **per matching ref**, cargo children inherited git's ref pipe as stdin, and stdin was left undrained when a check failed.

## Fix

- **Hook**: drain the ref list from stdin fully before any check, match protected branches exactly (`refs/heads/main|develop`), run the validation once, give every cargo invocation `</dev/null`, and document the mechanism in the header.
- **Transport (documented in CONTRIBUTING.md / PROJECT_STRUCTURE.md)**: configure an HTTPS push URL:
  ```
  git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
  git config credential.helper '!gh auth git-credential'
  ```
  Over stateless HTTP the ref advertisement and the pack upload are independent requests, so a connection dropped during the validation window is harmless. Fetch stays on SSH.

## Verification

- A/B with a 900 s delay hook on a real push: **SSH → exit 141** at 902 s (connection died at 360 s); **HTTPS → clean protocol response** after the same delay.
- This branch itself was pushed over HTTPS **with the 900 s delay hook active and no `--no-verify`** — end-to-end proof.
- Hook logic tested with stubbed cargo: single validation run for a protected ref among several, fast path for feature branches and for names like `maintenance`, cargo stdin verified empty.
