### PR TITLE
feat: wire VelesConfig into tauri, mobile, python and langchain/llamaindex surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`VelesConfig` on every remaining surface (issue #1549)** — after the
+  server/CLI wiring (#1565), the four surfaces that could still only open
+  the engine on core defaults now accept an explicit engine configuration,
+  all built on the same engine-only TOML loaders
+  (`load_from_path_engine_only` / `from_toml_engine_only`) with fail-fast
+  validation and the typed `ConfigError` preserved:
+  - **`tauri-plugin-velesdb`**: new plugin `Builder` with
+    `with_config(VelesConfig)` / `with_config_path(path)` (fail-fast at
+    build time), threading through the four observer×config open
+    combinations; `VelesConfig` re-exported for hosts; typed
+    `Error::ConfigLoad` variant.
+  - **`velesdb-mobile`**: `open_with_config(_toml)` and
+    `open_with_observer_and_config(_toml)` UniFFI constructors (TOML file
+    path or embedded TOML string — the string variant suits mobile asset
+    pipelines); `ConfigError` surfaced through the flat UniFFI error as
+    `VELES-009` with the full message.
+  - **`velesdb-python`**: `VelesConfigOptions` now covers the full engine
+    surface — new `SearchConfigOptions`, `HnswConfigOptions`,
+    `StorageOptions` and `QuantizationOptions` sections alongside the
+    existing `limits`, plus `VelesConfigOptions.from_toml(str)` /
+    `from_toml_path(path)`. Invalid values raise at construction or at
+    `Database(path, config=...)` open, never silently. `wal_batch` stays
+    intentionally unexposed (velesdb-premium Enterprise feature). Stubs,
+    pure-python adapter and README updated.
+  - **`langchain-velesdb` / `llamaindex-velesdb`**: every store/memory
+    entry point that creates a `Database` accepts an optional
+    `config: velesdb.VelesConfigOptions` pass-through (vector stores,
+    chat/semantic/episodic/procedural memories, native `GraphLoader`),
+    and the shared `velesdb_common.graph.open_native_graph` helper
+    forwards it too. Omitting `config` is bit-for-bit the previous
+    behaviour.
 - **`velesdb-cli`**: new `graph doctor <collection> [--purge|--stub]`
   subcommand to audit and repair legacy phantom edges -- edges present in
   a graph collection's edge store whose `source` or `target` node has no

--- a/crates/tauri-plugin-velesdb/src/error.rs
+++ b/crates/tauri-plugin-velesdb/src/error.rs
@@ -31,6 +31,21 @@ pub enum Error {
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
 
+    /// An explicit engine config file could not be loaded (issue #1549).
+    ///
+    /// Raised by `Builder::with_config_path` when the TOML file is missing,
+    /// unparsable, or fails engine validation. The typed core
+    /// [`velesdb_core::config::ConfigError`] is preserved as the source so
+    /// hosts can match on the exact failure.
+    #[error("Failed to load VelesDB config from {path}: {source}")]
+    ConfigLoad {
+        /// The config file path that failed to load.
+        path: String,
+        /// The typed core configuration error.
+        #[source]
+        source: velesdb_core::config::ConfigError,
+    },
+
     /// Serialization error.
     #[error("Serialization error: {0}")]
     Serialization(String),
@@ -56,7 +71,7 @@ impl From<Error> for CommandError {
             Error::CollectionNotFound(_) => "VELES-002",
             Error::NotFound(_) => "NOT_FOUND",
             Error::DimensionMismatch { .. } => "DIMENSION_MISMATCH",
-            Error::InvalidConfig(_) => "INVALID_CONFIG",
+            Error::InvalidConfig(_) | Error::ConfigLoad { .. } => "INVALID_CONFIG",
             Error::Serialization(_) => "SERIALIZATION_ERROR",
             Error::Io(_) => "VELES-011",
         };

--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -58,10 +58,10 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tauri::{
-    plugin::{Builder, TauriPlugin},
+    plugin::{Builder as TauriPluginBuilder, TauriPlugin},
     Manager, Runtime,
 };
 
@@ -81,6 +81,7 @@ pub mod types_graph;
 
 pub use error::{CommandError, Error, Result};
 pub use state::VelesDbState;
+pub use velesdb_core::config::VelesConfig;
 
 /// Initializes the `VelesDB` plugin with the default settings.
 ///
@@ -137,102 +138,214 @@ macro_rules! velesdb_invoke_handler {
 ///     .expect("error while running tauri application");
 /// ```
 #[must_use]
-// The body is a flat command-registration list (trivial cyclomatic complexity);
-// the line count grows linearly with the number of exposed commands.
-#[allow(clippy::too_many_lines)]
 pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
-    let db_path = path.as_ref().to_path_buf();
+    Builder::new(path).build()
+}
 
-    let builder = Builder::new("velesdb").invoke_handler(velesdb_invoke_handler!(
-        common: [
-            commands::create_collection,
-            commands::create_metadata_collection,
-            commands::delete_collection,
-            commands::list_collections,
-            commands::get_collection,
-            commands::upsert,
-            commands::upsert_metadata,
-            commands::get_points,
-            commands::delete_points,
-            commands::search,
-            commands::search_ids,
-            commands::batch_search,
-            commands::text_search,
-            commands::hybrid_search,
-            commands::multi_query_search,
-            commands_query::query,
-            commands::is_empty,
-            commands::flush,
-            commands::compact_storage,
-            commands::update_guardrails,
-            commands::get_guardrails,
-            commands::scroll_collection,
-            // Sparse vector commands
-            commands_sparse::sparse_search,
-            commands_sparse::hybrid_sparse_search,
-            commands_sparse::sparse_upsert,
-            // PQ training command
-            commands::train_pq,
-            // AgentMemory commands (EPIC-016 US-003)
-            commands_memory::semantic_store,
-            commands_memory::semantic_store_with_ttl,
-            commands_memory::semantic_query,
-            commands_memory::semantic_delete,
-            commands_memory::semantic_dimension,
-            commands_memory::semantic_serialize,
-            commands_memory::semantic_deserialize,
-            commands_memory::episodic_record,
-            commands_memory::episodic_recent,
-            commands_memory::episodic_recall_similar,
-            commands_memory::episodic_older_than,
-            commands_memory::episodic_delete,
-            commands_memory::episodic_serialize,
-            commands_memory::episodic_deserialize,
-            commands_memory::procedural_learn,
-            commands_memory::procedural_recall,
-            commands_memory::procedural_reinforce,
-            commands_memory::procedural_list_all,
-            commands_memory::procedural_delete,
-            commands_memory::procedural_serialize,
-            commands_memory::procedural_deserialize,
-            // AgentMemory TTL / eviction / snapshot-versioning / VelesQL parity
-            commands_memory::memory_set_ttl,
-            commands_memory::memory_auto_expire,
-            commands_memory::memory_evict_low_confidence,
-            commands_memory::memory_snapshot,
-            commands_memory::memory_load_latest_snapshot,
-            commands_memory::memory_load_snapshot_version,
-            commands_memory::memory_list_snapshot_versions,
-            commands_memory::memory_query_semantic,
-            commands_memory::memory_query_episodic,
-            commands_memory::memory_query_procedural,
-            // Knowledge Graph commands (EPIC-015 US-001)
-            commands_graph::create_graph_collection,
-            commands_graph::add_edge,
-            commands_graph::add_edges_batch,
-            commands_graph::get_edges,
-            commands_graph::traverse_graph,
-            commands_graph::get_node_degree,
-            commands_graph::traverse_graph_parallel,
-            // Secondary Index commands
-            commands_index::create_index,
-            commands_index::drop_index,
-            commands_index::list_indexes,
-        ],
-        persistence_only: [
-            commands::stream_insert,
-            commands::enable_streaming,
-        ],
-    ));
-    builder
-        .setup(move |app, _api| {
-            let observer = std::sync::Arc::new(observer::TauriObserver::new(app.clone()));
-            let state = VelesDbState::new_with_observer(db_path.clone(), observer);
-            app.manage(state);
-            tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
-            Ok(())
-        })
-        .build()
+/// Builder for the `VelesDB` plugin (issue #1549).
+///
+/// Lets the host application supply an explicit engine
+/// [`VelesConfig`] — either as a value ([`Builder::with_config`]) or loaded
+/// from a TOML file ([`Builder::with_config_path`]) — before building the
+/// plugin. Without a config, the database opens with core defaults, exactly
+/// like [`init_with_path`] always did.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let plugin = tauri_plugin_velesdb::Builder::new("./my_data")
+///     .with_config_path("./velesdb.toml")?  // fail-fast if missing/invalid
+///     .build();
+/// tauri::Builder::default()
+///     .plugin(plugin)
+///     .run(tauri::generate_context!())
+///     .expect("error while running tauri application");
+/// ```
+#[derive(Debug)]
+pub struct Builder {
+    path: PathBuf,
+    config: Option<VelesConfig>,
+}
+
+impl Builder {
+    /// Creates a builder for a plugin persisting under `path`.
+    #[must_use]
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            config: None,
+        }
+    }
+
+    /// Supplies an explicit engine [`VelesConfig`] value.
+    ///
+    /// The database is opened with
+    /// [`velesdb_core::Database::open_with_observer_and_config`], so every
+    /// config-honouring subsystem (HNSW defaults, WAL batching, runtime
+    /// limits, search quality) reads from this instance instead of core
+    /// defaults. Note that the core re-validates the config when the
+    /// database is opened, so an out-of-range value fails the first open.
+    #[must_use]
+    pub fn with_config(mut self, config: VelesConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Loads an engine [`VelesConfig`] from a TOML file, fail-fast.
+    ///
+    /// Only the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+    /// `[quantization]`/`[wal_batch]`) are read (via
+    /// [`VelesConfig::load_from_path_engine_only`]); any other top-level
+    /// table — e.g. a `[server]` section owned by `velesdb-server` in a
+    /// shared config file — is ignored rather than being parsed into
+    /// `VelesConfig`'s own unrelated same-named fields and spuriously
+    /// rejected. `VELESDB_*` environment variables still layer on top of
+    /// the filtered file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigLoad`] immediately — never a silent fallback
+    /// to defaults — if the file is missing, is not valid TOML, or fails
+    /// engine validation. The typed
+    /// [`velesdb_core::config::ConfigError`] is preserved as the source.
+    pub fn with_config_path<P: AsRef<Path>>(mut self, config_path: P) -> Result<Self> {
+        let config_path = config_path.as_ref();
+        if !config_path.exists() {
+            return Err(Error::ConfigLoad {
+                path: config_path.display().to_string(),
+                source: velesdb_core::config::ConfigError::FileNotFound(
+                    config_path.display().to_string(),
+                ),
+            });
+        }
+        let config = VelesConfig::load_from_path_engine_only(config_path).map_err(|source| {
+            Error::ConfigLoad {
+                path: config_path.display().to_string(),
+                source,
+            }
+        })?;
+        self.config = Some(config);
+        Ok(self)
+    }
+
+    /// Returns the engine config recorded so far, if any.
+    #[must_use]
+    pub fn config(&self) -> Option<&VelesConfig> {
+        self.config.as_ref()
+    }
+
+    /// Builds the Tauri plugin, registering every `VelesDB` command and
+    /// managing a [`VelesDbState`] that opens the database with the
+    /// recorded config (or core defaults when none was supplied).
+    #[must_use]
+    // The body is a flat command-registration list (trivial cyclomatic
+    // complexity); the line count grows linearly with the number of
+    // exposed commands.
+    #[allow(clippy::too_many_lines)]
+    pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+        let Self {
+            path: db_path,
+            config,
+        } = self;
+
+        let builder = TauriPluginBuilder::new("velesdb").invoke_handler(velesdb_invoke_handler!(
+            common: [
+                commands::create_collection,
+                commands::create_metadata_collection,
+                commands::delete_collection,
+                commands::list_collections,
+                commands::get_collection,
+                commands::upsert,
+                commands::upsert_metadata,
+                commands::get_points,
+                commands::delete_points,
+                commands::search,
+                commands::search_ids,
+                commands::batch_search,
+                commands::text_search,
+                commands::hybrid_search,
+                commands::multi_query_search,
+                commands_query::query,
+                commands::is_empty,
+                commands::flush,
+                commands::compact_storage,
+                commands::update_guardrails,
+                commands::get_guardrails,
+                commands::scroll_collection,
+                // Sparse vector commands
+                commands_sparse::sparse_search,
+                commands_sparse::hybrid_sparse_search,
+                commands_sparse::sparse_upsert,
+                // PQ training command
+                commands::train_pq,
+                // AgentMemory commands (EPIC-016 US-003)
+                commands_memory::semantic_store,
+                commands_memory::semantic_store_with_ttl,
+                commands_memory::semantic_query,
+                commands_memory::semantic_delete,
+                commands_memory::semantic_dimension,
+                commands_memory::semantic_serialize,
+                commands_memory::semantic_deserialize,
+                commands_memory::episodic_record,
+                commands_memory::episodic_recent,
+                commands_memory::episodic_recall_similar,
+                commands_memory::episodic_older_than,
+                commands_memory::episodic_delete,
+                commands_memory::episodic_serialize,
+                commands_memory::episodic_deserialize,
+                commands_memory::procedural_learn,
+                commands_memory::procedural_recall,
+                commands_memory::procedural_reinforce,
+                commands_memory::procedural_list_all,
+                commands_memory::procedural_delete,
+                commands_memory::procedural_serialize,
+                commands_memory::procedural_deserialize,
+                // AgentMemory TTL / eviction / snapshot-versioning / VelesQL parity
+                commands_memory::memory_set_ttl,
+                commands_memory::memory_auto_expire,
+                commands_memory::memory_evict_low_confidence,
+                commands_memory::memory_snapshot,
+                commands_memory::memory_load_latest_snapshot,
+                commands_memory::memory_load_snapshot_version,
+                commands_memory::memory_list_snapshot_versions,
+                commands_memory::memory_query_semantic,
+                commands_memory::memory_query_episodic,
+                commands_memory::memory_query_procedural,
+                // Knowledge Graph commands (EPIC-015 US-001)
+                commands_graph::create_graph_collection,
+                commands_graph::add_edge,
+                commands_graph::add_edges_batch,
+                commands_graph::get_edges,
+                commands_graph::traverse_graph,
+                commands_graph::get_node_degree,
+                commands_graph::traverse_graph_parallel,
+                // Secondary Index commands
+                commands_index::create_index,
+                commands_index::drop_index,
+                commands_index::list_indexes,
+            ],
+            persistence_only: [
+                commands::stream_insert,
+                commands::enable_streaming,
+            ],
+        ));
+        builder
+            .setup(move |app, _api| {
+                let observer = std::sync::Arc::new(observer::TauriObserver::new(app.clone()));
+                let state = match config {
+                    Some(config) => VelesDbState::new_with_observer_and_config(
+                        db_path.clone(),
+                        observer,
+                        config,
+                    ),
+                    None => VelesDbState::new_with_observer(db_path.clone(), observer),
+                };
+                app.manage(state);
+                tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
+                Ok(())
+            })
+            .build()
+    }
 }
 
 /// Alias for `init()` for backward compatibility.

--- a/crates/tauri-plugin-velesdb/src/state.rs
+++ b/crates/tauri-plugin-velesdb/src/state.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use velesdb_core::agent::AgentMemory;
+use velesdb_core::config::VelesConfig;
 use velesdb_core::{Database, DatabaseObserver};
 
 use crate::error::{Error, Result};
@@ -40,6 +41,12 @@ pub struct VelesDbState {
     /// Set by the plugin at setup so collection create/delete events reach the
     /// frontend regardless of the entry path. `None` falls back to a plain open.
     observer: Option<Arc<dyn DatabaseObserver>>,
+    /// Optional explicit engine [`VelesConfig`] applied when the database is
+    /// opened (issue #1549).
+    ///
+    /// `None` preserves the historical behaviour: the database opens with
+    /// core defaults, exactly as before config wiring existed.
+    config: Option<VelesConfig>,
 }
 
 impl VelesDbState {
@@ -54,22 +61,49 @@ impl VelesDbState {
     /// A new `VelesDbState` instance (database not yet opened).
     #[must_use]
     pub fn new(path: PathBuf) -> Self {
-        Self::with_observer(path, None)
+        Self::with_parts(path, None, None)
     }
 
     /// Creates a new plugin state that injects `observer` into the database when
     /// it is opened, so collection lifecycle events are forwarded to Tauri.
     #[must_use]
     pub fn new_with_observer(path: PathBuf, observer: Arc<dyn DatabaseObserver>) -> Self {
-        Self::with_observer(path, Some(observer))
+        Self::with_parts(path, Some(observer), None)
     }
 
-    fn with_observer(path: PathBuf, observer: Option<Arc<dyn DatabaseObserver>>) -> Self {
+    /// Creates a new plugin state that opens the database with an explicit
+    /// engine [`VelesConfig`] instead of core defaults (issue #1549).
+    #[must_use]
+    pub fn new_with_config(path: PathBuf, config: VelesConfig) -> Self {
+        Self::with_parts(path, None, Some(config))
+    }
+
+    /// Creates a new plugin state with both a lifecycle `observer` and an
+    /// explicit engine [`VelesConfig`] (issue #1549).
+    ///
+    /// The database is opened via
+    /// [`Database::open_with_observer_and_config`], so lifecycle events reach
+    /// Tauri *and* the engine honours the supplied config.
+    #[must_use]
+    pub fn new_with_observer_and_config(
+        path: PathBuf,
+        observer: Arc<dyn DatabaseObserver>,
+        config: VelesConfig,
+    ) -> Self {
+        Self::with_parts(path, Some(observer), Some(config))
+    }
+
+    fn with_parts(
+        path: PathBuf,
+        observer: Option<Arc<dyn DatabaseObserver>>,
+        config: Option<VelesConfig>,
+    ) -> Self {
         Self {
             db: Arc::new(RwLock::new(None)),
             memory: Arc::new(RwLock::new(None)),
             path,
             observer,
+            config,
         }
     }
 
@@ -81,9 +115,17 @@ impl VelesDbState {
     pub fn open(&self) -> Result<()> {
         let mut db_guard = self.db.write();
         if db_guard.is_none() {
-            let db = match &self.observer {
-                Some(observer) => Database::open_with_observer(&self.path, Arc::clone(observer))?,
-                None => Database::open(&self.path)?,
+            let db = match (&self.observer, &self.config) {
+                (Some(observer), Some(config)) => Database::open_with_observer_and_config(
+                    &self.path,
+                    Arc::clone(observer),
+                    config.clone(),
+                )?,
+                (Some(observer), None) => {
+                    Database::open_with_observer(&self.path, Arc::clone(observer))?
+                }
+                (None, Some(config)) => Database::open_with_config(&self.path, config.clone())?,
+                (None, None) => Database::open(&self.path)?,
             };
             *db_guard = Some(Arc::new(db));
             tracing::info!("VelesDB opened at {:?}", self.path);

--- a/crates/tauri-plugin-velesdb/tests/config_wiring.rs
+++ b/crates/tauri-plugin-velesdb/tests/config_wiring.rs
@@ -1,0 +1,240 @@
+//! Integration coverage for the engine `VelesConfig` wiring (issue #1549).
+//!
+//! Mirrors the server/CLI pattern from PR #1565: an explicit engine config
+//! (given as a value or loaded engine-only from a TOML path) must reach
+//! `Database::open_with_config` / `open_with_observer_and_config`, a missing
+//! or invalid config path must fail fast with an actionable error (never a
+//! silent fallback to defaults), and the no-config behaviour must stay
+//! byte-for-byte identical to before.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tauri::test::{mock_builder, mock_context, noop_assets};
+use tauri::Manager;
+use tauri_plugin_velesdb::{Builder, VelesDbState};
+use velesdb_core::config::VelesConfig;
+
+/// Engine config with `limits.max_collections = 1`, built through the same
+/// engine-only parser the path loader uses.
+fn one_collection_config() -> VelesConfig {
+    VelesConfig::from_toml_engine_only("[limits]\nmax_collections = 1\n")
+        .expect("test: valid engine-only config")
+}
+
+/// Proves a config is *enforced* by the opened database, not just stored:
+/// the first collection fits under `max_collections = 1`, the second must be
+/// refused by the engine.
+fn assert_limit_of_one_enforced(state: &VelesDbState) {
+    state
+        .with_db(|db| {
+            assert_eq!(db.config().limits.max_collections, 1);
+            db.create_metadata_collection("first")?;
+            Ok(())
+        })
+        .expect("test: first collection under the limit should succeed");
+
+    let err = state
+        .with_db(|db| {
+            db.create_metadata_collection("second")?;
+            Ok(())
+        })
+        .expect_err("test: second collection should be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (a) explicit config honoured
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_state_open_honours_explicit_config() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let state = VelesDbState::new_with_config(dir.path().to_path_buf(), one_collection_config());
+
+    // Act + Assert
+    assert_limit_of_one_enforced(&state);
+}
+
+#[test]
+fn test_state_open_honours_config_alongside_observer() {
+    #[derive(Default)]
+    struct CountingObserver {
+        created: AtomicUsize,
+    }
+    impl velesdb_core::DatabaseObserver for CountingObserver {
+        fn on_collection_created(
+            &self,
+            _name: &str,
+            _kind: &velesdb_core::collection::CollectionType,
+        ) {
+            self.created.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let observer = Arc::new(CountingObserver::default());
+    let state = VelesDbState::new_with_observer_and_config(
+        dir.path().to_path_buf(),
+        observer.clone(),
+        one_collection_config(),
+    );
+
+    // Act + Assert - the config is enforced...
+    assert_limit_of_one_enforced(&state);
+
+    // ...and the observer still received the successful create.
+    assert_eq!(observer.created.load(Ordering::SeqCst), 1);
+}
+
+/// End-to-end through the plugin builder: a config passed to
+/// `Builder::with_config` must reach the managed state and the opened engine.
+#[test]
+fn test_plugin_builder_with_config_reaches_managed_state() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let app = mock_builder()
+        .plugin(
+            Builder::new(dir.path())
+                .with_config(one_collection_config())
+                .build(),
+        )
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+
+    // Act + Assert
+    let state = app.state::<VelesDbState>();
+    assert_limit_of_one_enforced(&state);
+}
+
+// ---------------------------------------------------------------------------
+// (b) invalid / missing config path -> fail-fast, actionable, typed source
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_with_config_path_missing_file_fails_fast() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let missing = dir.path().join("does-not-exist.toml");
+
+    // Act
+    let err = Builder::new(dir.path())
+        .with_config_path(&missing)
+        .expect_err("test: a missing explicit config path must be an immediate error");
+
+    // Assert - actionable: the message names the offending path.
+    assert!(
+        err.to_string().contains("does-not-exist.toml"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_with_config_path_invalid_value_fails_fast_with_typed_source() {
+    // Arrange - parses fine, fails engine validation (max_collections = 0).
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let config_path = dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 0\n").expect("test: write config");
+
+    // Act
+    let err = Builder::new(dir.path())
+        .with_config_path(&config_path)
+        .expect_err("test: an invalid engine value must be an immediate error");
+
+    // Assert - the typed core ConfigError is preserved as the error source.
+    let source = std::error::Error::source(&err).expect("test: error must expose a source");
+    assert!(
+        source
+            .downcast_ref::<velesdb_core::config::ConfigError>()
+            .is_some(),
+        "source must be velesdb_core::config::ConfigError, got: {source}"
+    );
+}
+
+/// Engine-only semantics: a TOML shared with `velesdb-server` may carry a
+/// `[server]` table (its HTTP transport) whose values would be rejected by
+/// `VelesConfig`'s own unrelated `server` validation. The plugin loader must
+/// ignore non-engine sections instead of failing on them.
+#[test]
+fn test_with_config_path_ignores_non_engine_sections() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let config_path = dir.path().join("velesdb.toml");
+    std::fs::write(
+        &config_path,
+        "[server]\nport = 443\n\n[limits]\nmax_collections = 1\n",
+    )
+    .expect("test: write config");
+
+    // Act
+    let builder = Builder::new(dir.path())
+        .with_config_path(&config_path)
+        .expect("test: shell-owned [server] section must not block the plugin");
+
+    // Assert - the engine section was loaded...
+    assert_eq!(
+        builder
+            .config()
+            .expect("test: config must be loaded")
+            .limits
+            .max_collections,
+        1
+    );
+
+    // ...and it is enforced end-to-end through the built plugin.
+    let app = mock_builder()
+        .plugin(builder.build())
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+    let state = app.state::<VelesDbState>();
+    assert_limit_of_one_enforced(&state);
+}
+
+// ---------------------------------------------------------------------------
+// (c) no config -> behaviour unchanged (core defaults)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_config_opens_with_core_defaults() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let state = VelesDbState::new(dir.path().to_path_buf());
+
+    // Act + Assert
+    state
+        .with_db(|db| {
+            assert_eq!(
+                db.config().limits.max_collections,
+                velesdb_core::config::LimitsConfig::default().max_collections
+            );
+            Ok(())
+        })
+        .expect("test: open without config");
+}
+
+#[test]
+fn test_builder_without_config_opens_with_core_defaults() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let app = mock_builder()
+        .plugin(Builder::new(dir.path()).build())
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+
+    // Act + Assert
+    let state = app.state::<VelesDbState>();
+    state
+        .with_db(|db| {
+            assert_eq!(
+                db.config().limits.max_collections,
+                velesdb_core::config::LimitsConfig::default().max_collections
+            );
+            Ok(())
+        })
+        .expect("test: open without config");
+}

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -88,6 +88,39 @@ use velesdb_core::SearchQuality as CoreSearchQuality;
 // NOTE: VelesCollection moved to collection.rs (NLOC/CC resolution)
 
 // ============================================================================
+// Engine config loading (issue #1549, mobile surface)
+// ============================================================================
+
+/// Maps a [`velesdb_core::config::ConfigError`] to the FFI [`VelesError`].
+///
+/// UniFFI errors are flat records (no `#[source]` chain survives the FFI
+/// boundary), so the `ConfigError` is preserved the closest way the surface
+/// allows: routed through [`velesdb_core::Error::Config`] so the mobile error
+/// carries the canonical `VELES-009` taxonomy code, core's recoverability
+/// flag, and the full underlying `ConfigError` message.
+fn config_error(err: velesdb_core::config::ConfigError) -> VelesError {
+    velesdb_core::Error::Config(err.to_string()).into()
+}
+
+/// Loads a [`velesdb_core::config::VelesConfig`] from a TOML file, engine
+/// sections only. Fail-fast: a missing/unreadable/invalid file is an
+/// immediate typed error, never a silent fallback to defaults.
+fn load_engine_config_from_path(
+    config_path: &str,
+) -> Result<velesdb_core::config::VelesConfig, VelesError> {
+    velesdb_core::config::VelesConfig::load_from_path_engine_only(config_path).map_err(config_error)
+}
+
+/// Parses a [`velesdb_core::config::VelesConfig`] from an in-memory TOML
+/// string, engine sections only. Same fail-fast semantics as
+/// [`load_engine_config_from_path`].
+fn load_engine_config_from_toml(
+    config_toml: &str,
+) -> Result<velesdb_core::config::VelesConfig, VelesError> {
+    velesdb_core::config::VelesConfig::from_toml_engine_only(config_toml).map_err(config_error)
+}
+
+// ============================================================================
 // Database
 // ============================================================================
 
@@ -148,6 +181,136 @@ impl VelesDatabase {
     ) -> Result<Arc<Self>, VelesError> {
         let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
         let db = CoreDatabase::open_with_observer(&path, core_observer)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database configured from a TOML file on disk.
+    ///
+    /// The file is parsed with
+    /// [`VelesConfig::load_from_path_engine_only`](velesdb_core::config::VelesConfig::load_from_path_engine_only):
+    /// only the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+    /// `[quantization]`/`[wal_batch]`) are considered, any other top-level
+    /// table is dropped, and `VELESDB_*` environment variables still layer on
+    /// top of the filtered file. The database is then opened with
+    /// [`Database::open_with_config`](velesdb_core::Database::open_with_config),
+    /// so every subsystem honours the loaded values instead of core defaults.
+    ///
+    /// This is the mobile counterpart of the server/CLI `--config` wiring
+    /// (issue #1549). If the app ships its config as an in-memory string
+    /// (bundled asset, remote config), use
+    /// [`open_with_config_toml`](Self::open_with_config_toml) instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `config_path` - Path to an existing TOML configuration file
+    ///
+    /// # Errors
+    ///
+    /// Fails fast — never falls back to defaults silently — if the config
+    /// file is missing, unreadable, not valid TOML, or fails validation
+    /// (typed as a `VELES-009` configuration error), or if the database path
+    /// is invalid or cannot be accessed.
+    #[uniffi::constructor]
+    pub fn open_with_config(path: String, config_path: String) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_path(&config_path)?;
+        let db = CoreDatabase::open_with_config(&path, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database configured from an in-memory TOML string.
+    ///
+    /// Same semantics as [`open_with_config`](Self::open_with_config) but the
+    /// TOML is passed directly (parsed with
+    /// [`VelesConfig::from_toml_engine_only`](velesdb_core::config::VelesConfig::from_toml_engine_only),
+    /// no environment-variable layer) — the most portable option on mobile,
+    /// where config often lives in a bundled asset or remote-config payload
+    /// rather than a standalone file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `config_toml` - TOML configuration string (engine sections only)
+    ///
+    /// # Errors
+    ///
+    /// Fails fast — never falls back to defaults silently — if `config_toml`
+    /// is not valid TOML or fails validation (typed as a `VELES-009`
+    /// configuration error), or if the database path is invalid or cannot be
+    /// accessed.
+    #[uniffi::constructor]
+    pub fn open_with_config_toml(
+        path: String,
+        config_toml: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_toml(&config_toml)?;
+        let db = CoreDatabase::open_with_config(&path, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database with both a read-path [`MobileObserver`]
+    /// and a TOML configuration file.
+    ///
+    /// Combines [`open_with_observer`](Self::open_with_observer) (read gate)
+    /// and [`open_with_config`](Self::open_with_config) (engine config) on a
+    /// single handle via
+    /// [`Database::open_with_observer_and_config`](velesdb_core::Database::open_with_observer_and_config).
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `observer` - A Kotlin/Swift implementation of [`MobileObserver`]
+    /// * `config_path` - Path to an existing TOML configuration file
+    ///
+    /// # Errors
+    ///
+    /// Same fail-fast semantics as [`open_with_config`](Self::open_with_config).
+    #[uniffi::constructor]
+    pub fn open_with_observer_and_config(
+        path: String,
+        observer: Arc<dyn MobileObserver>,
+        config_path: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_path(&config_path)?;
+        let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
+        let db = CoreDatabase::open_with_observer_and_config(&path, core_observer, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database with both a read-path [`MobileObserver`]
+    /// and an in-memory TOML configuration string.
+    ///
+    /// Combines [`open_with_observer`](Self::open_with_observer) (read gate)
+    /// and [`open_with_config_toml`](Self::open_with_config_toml) (engine
+    /// config) on a single handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `observer` - A Kotlin/Swift implementation of [`MobileObserver`]
+    /// * `config_toml` - TOML configuration string (engine sections only)
+    ///
+    /// # Errors
+    ///
+    /// Same fail-fast semantics as
+    /// [`open_with_config_toml`](Self::open_with_config_toml).
+    #[uniffi::constructor]
+    pub fn open_with_observer_and_config_toml(
+        path: String,
+        observer: Arc<dyn MobileObserver>,
+        config_toml: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_toml(&config_toml)?;
+        let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
+        let db = CoreDatabase::open_with_observer_and_config(&path, core_observer, config)?;
         Ok(Arc::new(Self {
             inner: Arc::new(db),
         }))

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -1391,3 +1391,217 @@ fn test_open_without_observer_reads_unchanged() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, 7);
 }
+
+// =========================================================================
+// Config-aware constructor tests (issue #1549, mobile surface)
+// =========================================================================
+//
+// Before these constructors existed, `VelesDatabase` could only be opened
+// through `open` / `open_with_observer`, which always run the core engine on
+// default `VelesConfig` values — a TOML engine config (`[search]`/`[hnsw]`/
+// `[storage]`/`[limits]`/`[quantization]`/`[wal_batch]`) had no way in.
+// These tests prove the config is *enforced* by the engine (not merely
+// parsed), that invalid input fails fast with a typed error, and that the
+// pre-existing constructors keep their default behaviour.
+
+/// The core proof required by issue #1549: a `limits.max_collections` cap in
+/// the TOML string must be enforced by the opened database. First collection
+/// succeeds (within the cap), second is refused by the engine.
+#[test]
+fn test_open_with_config_toml_limit_is_enforced() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db =
+        VelesDatabase::open_with_config_toml(path, "[limits]\nmax_collections = 1\n".to_string())
+            .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {err}"
+    );
+}
+
+/// Same proof through the file-path variant (`load_from_path_engine_only`).
+#[test]
+fn test_open_with_config_path_limit_is_enforced() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = TempDir::new().unwrap();
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 1\n").unwrap();
+
+    let db = VelesDatabase::open_with_config(
+        tmp.path().to_str().unwrap().to_string(),
+        config_path.to_str().unwrap().to_string(),
+    )
+    .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {err}"
+    );
+}
+
+/// Fail-fast: a syntactically invalid TOML string must abort the open with a
+/// typed config error (core taxonomy code VELES-009), never fall back to
+/// defaults silently.
+#[test]
+fn test_open_with_config_toml_invalid_toml_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let Err(err) = VelesDatabase::open_with_config_toml(path, "not [[[ toml".to_string()) else {
+        panic!("invalid TOML must fail fast");
+    };
+    let VelesError::Database { code, message, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(
+        code, "VELES-009",
+        "config errors carry the core config code"
+    );
+    assert!(
+        message.contains("parse") || message.contains("Parse"),
+        "message should surface the underlying ConfigError, got: {message}"
+    );
+}
+
+/// Fail-fast: a TOML value rejected by `VelesConfig::validate` (here
+/// `limits.max_collections = 0`, outside `[1, cap]`) must abort the open.
+#[test]
+fn test_open_with_config_toml_invalid_value_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let Err(err) =
+        VelesDatabase::open_with_config_toml(path, "[limits]\nmax_collections = 0\n".to_string())
+    else {
+        panic!("out-of-range value must fail validation");
+    };
+    let VelesError::Database { code, message, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(code, "VELES-009");
+    assert!(
+        message.contains("max_collections"),
+        "message should name the offending key, got: {message}"
+    );
+}
+
+/// Fail-fast: a config path that does not exist must abort the open with a
+/// typed config error — never open on silent defaults.
+#[test]
+fn test_open_with_config_path_missing_file_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+    let missing = tmp.path().join("does-not-exist.toml");
+
+    let Err(err) = VelesDatabase::open_with_config(path, missing.to_str().unwrap().to_string())
+    else {
+        panic!("missing config file must fail fast");
+    };
+    let VelesError::Database { code, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(code, "VELES-009");
+}
+
+/// Observer + config: the TOML limit must be enforced AND the observer read
+/// gate must be active on the same handle.
+#[test]
+fn test_open_with_observer_and_config_toml_wires_both() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open_with_observer_and_config_toml(
+        path,
+        std::sync::Arc::new(DenyAllObserver),
+        "[limits]\nmax_collections = 1\n".to_string(),
+    )
+    .unwrap();
+
+    // Config wired: cap of 1 enforced.
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(err.to_string().contains("max_collections"));
+
+    // Observer wired: reads are denied by the gate (writes are not gated).
+    let col = db.get_collection("first".to_string()).unwrap().unwrap();
+    col.upsert(VelesPoint {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: None,
+    })
+    .unwrap();
+    let err = col
+        .search(vec![1.0, 0.0, 0.0, 0.0], 1)
+        .expect_err("deny-all observer must block the read");
+    assert!(
+        err.to_string().contains("test policy"),
+        "expected the observer's deny reason, got: {err}"
+    );
+}
+
+/// Observer + config through the file-path variant.
+#[test]
+fn test_open_with_observer_and_config_path_wires_both() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = TempDir::new().unwrap();
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 1\n").unwrap();
+
+    let db = VelesDatabase::open_with_observer_and_config(
+        tmp.path().to_str().unwrap().to_string(),
+        std::sync::Arc::new(DenyAllObserver),
+        config_path.to_str().unwrap().to_string(),
+    )
+    .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    assert!(
+        db.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+            .is_err(),
+        "cap of 1 must be enforced"
+    );
+}
+
+/// Regression guard: the pre-existing constructors keep running on core
+/// defaults (`limits.max_collections = 1000`) — adding the config-aware
+/// constructors must not change `open` / `open_with_observer` behaviour.
+#[test]
+fn test_open_without_config_keeps_default_limits() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    // Well above a cap of 1: proves no stray config is applied.
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    db.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let tmp2 = TempDir::new().unwrap();
+    let db2 = VelesDatabase::open_with_observer(
+        tmp2.path().to_str().unwrap().to_string(),
+        std::sync::Arc::new(RecordingObserver::default()),
+    )
+    .unwrap();
+    db2.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    db2.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+}

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -217,6 +217,35 @@ for result in results:
 > `sparse_index_name` and `include_vectors`, plus a fluent builder
 > (`SearchOptions().with_vector(v).with_top_k(10)`).
 
+### Engine configuration (`VelesConfigOptions`)
+
+`Database(path, config=...)` accepts a typed `VelesConfigOptions` covering
+every engine section of the core `VelesConfig`: `limits`, `search`, `hnsw`,
+`storage` and `quantization`. Build it in code or load it from a
+`velesdb.toml` (engine-only semantics: a shell-owned `[server]`/`[logging]`
+table in a shared file is ignored):
+
+```python
+from velesdb import (
+    Database, VelesConfigOptions, LimitsOptions, SearchConfigOptions,
+)
+
+# In code:
+cfg = VelesConfigOptions(
+    limits=LimitsOptions(max_collections=50),
+    search=SearchConfigOptions(default_mode="accurate", max_results=100),
+)
+db = Database("./tenant1", config=cfg)
+
+# Or from TOML (fail-fast: invalid TOML/values raise ValueError,
+# a missing file raises FileNotFoundError):
+cfg = VelesConfigOptions.from_toml_path("./velesdb.toml")
+db = Database("./tenant1", config=cfg)
+```
+
+`wal_batch` is intentionally not exposed — the concurrent WAL writer is a
+VelesDB Enterprise feature (see `docs/guides/WRITE_CONCURRENCY.md`).
+
 ### End-to-End: Text to Search Results (RAG Pipeline)
 
 VelesDB stores and searches vectors — it does not generate embeddings. Use any embedding model to convert text to vectors first.

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -27,6 +27,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     EdgeExistsError,
     FusionStrategy,
     GraphStore as _RawGraphStore,
+    HnswConfigOptions,
     HnswOptions,
     LimitsOptions,
     MemoryService,
@@ -36,9 +37,12 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     GraphSchema as PyGraphSchema,
     PyProceduralMemory,
     PySemanticMemory,
+    QuantizationOptions,
+    SearchConfigOptions,
     SearchOptions,
     SearchResult,
     STORAGE_MODES,
+    StorageOptions,
     StreamingConfig,
     StreamingIngestConfig,
     TraversalResult,
@@ -918,6 +922,16 @@ __all__ = [
     "LimitsOptions",
     "AutoReindexOptions",
     "VelesConfigOptions",
+    # Engine config sections (issue #1549). Each maps 1:1 to a `[section]`
+    # of the core `VelesConfig` TOML; attach them to `VelesConfigOptions`
+    # or load a whole file via `VelesConfigOptions.from_toml_path`.
+    # `wal_batch` is intentionally absent (velesdb-premium Enterprise —
+    # docs/guides/WRITE_CONCURRENCY.md); `server`/`logging` configure
+    # hosting shells, not the embedded engine.
+    "SearchConfigOptions",
+    "HnswConfigOptions",
+    "StorageOptions",
+    "QuantizationOptions",
     # Canonical enum name sets, single-sourced from velesdb-core (tuples of str).
     "CONDITION_TYPES",
     "DISTANCE_METRICS",

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2803,14 +2803,144 @@ class AutoReindexOptions:
         ...
 
 
+class SearchConfigOptions:
+    """Global search defaults mapped to core `SearchConfig` (`[search]`).
+
+    Distinct from the per-query :class:`SearchOptions`. Unspecified
+    fields fall back to the engine defaults (default_mode="balanced",
+    max_results=1000, query_timeout_ms=30000).
+    """
+
+    default_mode: Optional[str]
+    ef_search: Optional[int]
+    max_results: Optional[int]
+    query_timeout_ms: Optional[int]
+
+    def __init__(
+        self,
+        default_mode: Optional[str] = None,
+        ef_search: Optional[int] = None,
+        max_results: Optional[int] = None,
+        query_timeout_ms: Optional[int] = None,
+    ) -> None: ...
+
+
+class HnswConfigOptions:
+    """Database-wide HNSW defaults mapped to core `HnswConfig` (`[hnsw]`).
+
+    Distinct from the per-collection :class:`HnswOptions`. `None` fields
+    fall back to the engine defaults (m/ef_construction auto by
+    dimension, max_layers=0 = auto).
+    """
+
+    m: Optional[int]
+    ef_construction: Optional[int]
+    max_layers: Optional[int]
+
+    def __init__(
+        self,
+        m: Optional[int] = None,
+        ef_construction: Optional[int] = None,
+        max_layers: Optional[int] = None,
+    ) -> None: ...
+
+
+class StorageOptions:
+    """Storage engine settings mapped to core `StorageConfig` (`[storage]`).
+
+    Unspecified fields fall back to the engine defaults
+    (data_dir="./velesdb_data", storage_mode="mmap", mmap_cache_mb=1024,
+    vector_alignment=64).
+    """
+
+    data_dir: Optional[str]
+    storage_mode: Optional[str]
+    mmap_cache_mb: Optional[int]
+    vector_alignment: Optional[int]
+
+    def __init__(
+        self,
+        data_dir: Optional[str] = None,
+        storage_mode: Optional[str] = None,
+        mmap_cache_mb: Optional[int] = None,
+        vector_alignment: Optional[int] = None,
+    ) -> None: ...
+
+
+class QuantizationOptions:
+    """Quantization settings mapped to core `QuantizationConfig`
+    (`[quantization]`).
+
+    `mode` is one of "none", "sq8", "binary", "pq", "rabitq". The `pq_*`
+    fields are only valid with mode="pq" (where `pq_m` is required);
+    combining them with any other mode raises `ValueError`.
+    """
+
+    mode: Optional[str]
+    pq_m: Optional[int]
+    pq_k: Optional[int]
+    pq_opq_enabled: Optional[bool]
+    pq_oversampling: Optional[int]
+    rerank_enabled: Optional[bool]
+    rerank_multiplier: Optional[int]
+    auto_quantization: Optional[bool]
+    auto_quantization_threshold: Optional[int]
+
+    def __init__(
+        self,
+        mode: Optional[str] = None,
+        pq_m: Optional[int] = None,
+        pq_k: Optional[int] = None,
+        pq_opq_enabled: Optional[bool] = None,
+        pq_oversampling: Optional[int] = None,
+        rerank_enabled: Optional[bool] = None,
+        rerank_multiplier: Optional[int] = None,
+        auto_quantization: Optional[bool] = None,
+        auto_quantization_threshold: Optional[int] = None,
+    ) -> None: ...
+
+
 class VelesConfigOptions:
     """Global database-level configuration mapped to core `VelesConfig`.
 
-    Currently exposes the `limits` sub-section only. Other sub-sections
-    (search, hnsw, storage) are left at their engine defaults — user
-    tuning is done per-collection via :class:`HnswOptions`.
+    Exposes every engine section: `limits`, `search`, `hnsw`, `storage`
+    and `quantization`. Unset sections stay at their engine defaults.
+    Load a TOML file with :meth:`from_toml_path` / :meth:`from_toml`
+    (engine-only semantics: a shell-owned `[server]`/`[logging]` table
+    is ignored). `wal_batch` is intentionally not exposed — the
+    concurrent WAL writer is a velesdb-premium Enterprise feature
+    (docs/guides/WRITE_CONCURRENCY.md).
     """
 
     limits: Optional[LimitsOptions]
+    search: Optional[SearchConfigOptions]
+    hnsw: Optional[HnswConfigOptions]
+    storage: Optional[StorageOptions]
+    quantization: Optional[QuantizationOptions]
 
-    def __init__(self, limits: Optional[LimitsOptions] = None) -> None: ...
+    def __init__(
+        self,
+        limits: Optional[LimitsOptions] = None,
+        search: Optional[SearchConfigOptions] = None,
+        hnsw: Optional[HnswConfigOptions] = None,
+        storage: Optional[StorageOptions] = None,
+        quantization: Optional[QuantizationOptions] = None,
+    ) -> None: ...
+
+    @staticmethod
+    def from_toml(toml_str: str) -> "VelesConfigOptions":
+        """Load engine configuration from an in-memory TOML string.
+
+        Fail-fast: invalid TOML or an out-of-range value raises
+        `ValueError` with the typed core message.
+        """
+        ...
+
+    @staticmethod
+    def from_toml_path(path: str) -> "VelesConfigOptions":
+        """Load engine configuration from a TOML file path.
+
+        Fail-fast: a missing file raises `FileNotFoundError`; invalid
+        TOML or an out-of-range value raises `ValueError`.
+        """
+        ...

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -226,7 +226,7 @@ impl Database {
         // `'static` open closure; building the `PyObserver` stays off-GIL.
         let path_buf = PathBuf::from(path);
         let path_clone = path_buf.clone();
-        let core_config = config.map(|cfg| cfg.to_core());
+        let core_config = config.map(|cfg| cfg.to_core()).transpose()?;
         let core_observer: Option<Arc<dyn DatabaseObserver>> = observer
             .map(|cb| Arc::new(PyObserver::new(cb, observer_strict)) as Arc<dyn DatabaseObserver>);
         let db = py

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -53,7 +53,10 @@ pub use fusion::FusionStrategy;
 pub use graph::{dict_to_edge, dict_to_node, edge_to_dict, node_to_dict, traversal_to_dict};
 pub use graph_collection::{PyGraphCollection, PyGraphSchema};
 pub use graph_store::{GraphStore, StreamingConfig, TraversalResult};
-pub use options::{AutoReindexOptions, HnswOptions, LimitsOptions, VelesConfigOptions};
+pub use options::{
+    AutoReindexOptions, HnswConfigOptions, HnswOptions, LimitsOptions, QuantizationOptions,
+    SearchConfigOptions, StorageOptions, VelesConfigOptions,
+};
 pub use streaming_config::StreamingIngestConfig;
 
 use pyo3::prelude::*;

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -5,26 +5,56 @@
 //! explicit `#[pyclass]` dataclasses that map 1:1 to the core config
 //! structs.
 //!
-//! Four options types:
+//! Options types:
 //! - [`HnswOptions`] — per-collection HNSW parameters (maps to
 //!   [`velesdb_core::index::hnsw::HnswParams`])
 //! - [`LimitsOptions`] — global tenant-wide limits (maps to
 //!   [`velesdb_core::config::LimitsConfig`])
 //! - [`AutoReindexOptions`] — per-collection auto-reindex policy (maps
 //!   to [`velesdb_core::collection::auto_reindex::AutoReindexConfig`])
+//! - [`SearchConfigOptions`] / [`HnswConfigOptions`] /
+//!   [`StorageOptions`] / [`QuantizationOptions`] — engine config
+//!   sections (issue #1549; map to the same-named
+//!   `velesdb_core::config` sections)
 //! - [`VelesConfigOptions`] — global database-level configuration
-//!   wrapper (maps to [`velesdb_core::config::VelesConfig`])
+//!   wrapper (maps to [`velesdb_core::config::VelesConfig`]), with TOML
+//!   loading via `from_toml` / `from_toml_path`
 //!
 //! `WalBatchOptions` is intentionally **not** exposed: the concurrent
 //! WAL writer is a velesdb-premium Enterprise feature (see Commit 8
 //! `docs/CORE_WIRING_DEBT.md` and `docs/guides/WRITE_CONCURRENCY.md`).
 
 use pyo3::prelude::*;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use velesdb_core::collection::auto_reindex::AutoReindexConfig as CoreAutoReindexConfig;
-use velesdb_core::config::{LimitsConfig as CoreLimitsConfig, VelesConfig as CoreVelesConfig};
+use velesdb_core::config::{
+    ConfigError, HnswConfig as CoreHnswConfig, LimitsConfig as CoreLimitsConfig,
+    QuantizationConfig as CoreQuantizationConfig, QuantizationType,
+    SearchConfig as CoreSearchConfig, SearchMode, StorageConfig as CoreStorageConfig,
+    VelesConfig as CoreVelesConfig,
+};
 use velesdb_core::index::hnsw::HnswParams;
+
+/// Maps a typed core [`ConfigError`] onto the closest Python exception.
+///
+/// - missing file → `FileNotFoundError`
+/// - other IO failures → `OSError`
+/// - parse/validation failures → `ValueError` carrying the typed message
+///   (`Invalid configuration value for 'limits.max_collections': ...`)
+///
+/// Never falls back to a default configuration: every loader error is
+/// surfaced fail-fast to the Python caller.
+fn config_err_to_py(err: ConfigError) -> PyErr {
+    match err {
+        ConfigError::IoError(io) if io.kind() == std::io::ErrorKind::NotFound => {
+            pyo3::exceptions::PyFileNotFoundError::new_err(io.to_string())
+        }
+        ConfigError::IoError(io) => pyo3::exceptions::PyOSError::new_err(io.to_string()),
+        other => pyo3::exceptions::PyValueError::new_err(other.to_string()),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // HnswOptions
@@ -303,6 +333,19 @@ impl LimitsOptions {
             .unwrap_or(cfg.max_perfect_mode_vectors);
         cfg
     }
+
+    /// Builds a fully-populated options object from a core config section
+    /// (every field `Some`), so a TOML-loaded config round-trips
+    /// losslessly through [`Self::to_core`].
+    fn from_core(core: &CoreLimitsConfig) -> Self {
+        Self {
+            max_collections: Some(core.max_collections),
+            max_dimensions: Some(core.max_dimensions),
+            max_vectors_per_collection: Some(core.max_vectors_per_collection),
+            max_payload_size: Some(core.max_payload_size),
+            max_perfect_mode_vectors: Some(core.max_perfect_mode_vectors),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -428,47 +471,633 @@ impl AutoReindexOptions {
 }
 
 // ---------------------------------------------------------------------------
+// SearchConfigOptions
+// ---------------------------------------------------------------------------
+
+/// Valid values for `SearchConfigOptions.default_mode`, mirroring the
+/// serde `snake_case` names of [`SearchMode`].
+const SEARCH_MODES: &[&str] = &["fast", "balanced", "accurate", "perfect"];
+
+/// Parses a Python-side mode string into a core [`SearchMode`].
+fn parse_search_mode(mode: &str) -> PyResult<SearchMode> {
+    match mode {
+        "fast" => Ok(SearchMode::Fast),
+        "balanced" => Ok(SearchMode::Balanced),
+        "accurate" => Ok(SearchMode::Accurate),
+        "perfect" => Ok(SearchMode::Perfect),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "invalid search.default_mode '{other}' (expected one of: {SEARCH_MODES:?})"
+        ))),
+    }
+}
+
+/// Renders a core [`SearchMode`] as its Python-side mode string.
+///
+/// Fallible: [`SearchMode`] is `#[non_exhaustive]`, so a future core
+/// variant unknown to this binding is rejected loudly instead of being
+/// silently re-mapped.
+fn search_mode_str(mode: SearchMode) -> PyResult<&'static str> {
+    match mode {
+        SearchMode::Fast => Ok("fast"),
+        SearchMode::Balanced => Ok("balanced"),
+        SearchMode::Accurate => Ok("accurate"),
+        SearchMode::Perfect => Ok("perfect"),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unsupported search mode in configuration: {other:?}"
+        ))),
+    }
+}
+
+/// Global search defaults mapped to
+/// [`velesdb_core::config::SearchConfig`] (the `[search]` TOML section).
+///
+/// All fields are optional — unspecified fields fall back to the engine
+/// defaults (`default_mode="balanced"`, `max_results=1000`,
+/// `query_timeout_ms=30000`). Distinct from the per-query
+/// `SearchOptions` class, which tunes a single search call.
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct SearchConfigOptions {
+    /// Default search mode: `"fast"`, `"balanced"`, `"accurate"` or
+    /// `"perfect"`. Default: `"balanced"`.
+    #[pyo3(get, set)]
+    pub default_mode: Option<String>,
+    /// Override `ef_search` (if set, overrides the mode). Range [16, 4096].
+    #[pyo3(get, set)]
+    pub ef_search: Option<usize>,
+    /// Maximum results per query. Default: 1000.
+    #[pyo3(get, set)]
+    pub max_results: Option<usize>,
+    /// Query timeout in milliseconds (0 disables). Default: 30000.
+    #[pyo3(get, set)]
+    pub query_timeout_ms: Option<u64>,
+}
+
+#[pymethods]
+impl SearchConfigOptions {
+    #[new]
+    #[pyo3(signature = (
+        default_mode = None,
+        ef_search = None,
+        max_results = None,
+        query_timeout_ms = None,
+    ))]
+    fn new(
+        default_mode: Option<String>,
+        ef_search: Option<usize>,
+        max_results: Option<usize>,
+        query_timeout_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            default_mode,
+            ef_search,
+            max_results,
+            query_timeout_ms,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SearchConfigOptions(default_mode={:?}, ef_search={:?}, max_results={:?}, query_timeout_ms={:?})",
+            self.default_mode, self.ef_search, self.max_results, self.query_timeout_ms,
+        )
+    }
+}
+
+impl SearchConfigOptions {
+    /// Materializes into the core section, rejecting an unknown
+    /// `default_mode` string with a `ValueError`.
+    pub(crate) fn to_core(&self) -> PyResult<CoreSearchConfig> {
+        let mut cfg = CoreSearchConfig::default();
+        if let Some(ref mode) = self.default_mode {
+            cfg.default_mode = parse_search_mode(mode)?;
+        }
+        if self.ef_search.is_some() {
+            cfg.ef_search = self.ef_search;
+        }
+        cfg.max_results = self.max_results.unwrap_or(cfg.max_results);
+        cfg.query_timeout_ms = self.query_timeout_ms.unwrap_or(cfg.query_timeout_ms);
+        Ok(cfg)
+    }
+
+    /// Builds a fully-populated options object from a core section
+    /// (see [`LimitsOptions::from_core`]). `ef_search` stays `None` when
+    /// the core leaves it unset (mode-driven), preserving the override
+    /// semantics on round-trip. Fallible because [`SearchMode`] is
+    /// `#[non_exhaustive]` (see [`search_mode_str`]).
+    fn from_core(core: &CoreSearchConfig) -> PyResult<Self> {
+        Ok(Self {
+            default_mode: Some(search_mode_str(core.default_mode)?.to_string()),
+            ef_search: core.ef_search,
+            max_results: Some(core.max_results),
+            query_timeout_ms: Some(core.query_timeout_ms),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HnswConfigOptions
+// ---------------------------------------------------------------------------
+
+/// Global HNSW index defaults mapped to
+/// [`velesdb_core::config::HnswConfig`] (the `[hnsw]` TOML section).
+///
+/// Distinct from the per-collection [`HnswOptions`] passed to
+/// `Database.create_collection` — this section sets the database-wide
+/// defaults instead. `None` fields fall back to the engine defaults
+/// (`m`/`ef_construction` auto by dimension, `max_layers=0` = auto).
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct HnswConfigOptions {
+    /// Connections per node (M parameter), range [4, 128].
+    /// `None` = auto based on dimension.
+    #[pyo3(get, set)]
+    pub m: Option<usize>,
+    /// Candidate pool size during construction, range [100, 2000].
+    /// `None` = auto based on dimension.
+    #[pyo3(get, set)]
+    pub ef_construction: Option<usize>,
+    /// Maximum number of layers (0 = auto). Default: 0.
+    #[pyo3(get, set)]
+    pub max_layers: Option<usize>,
+}
+
+#[pymethods]
+impl HnswConfigOptions {
+    #[new]
+    #[pyo3(signature = (m = None, ef_construction = None, max_layers = None))]
+    fn new(m: Option<usize>, ef_construction: Option<usize>, max_layers: Option<usize>) -> Self {
+        Self {
+            m,
+            ef_construction,
+            max_layers,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "HnswConfigOptions(m={:?}, ef_construction={:?}, max_layers={:?})",
+            self.m, self.ef_construction, self.max_layers,
+        )
+    }
+}
+
+impl HnswConfigOptions {
+    pub(crate) fn to_core(&self) -> CoreHnswConfig {
+        let mut cfg = CoreHnswConfig::default();
+        if self.m.is_some() {
+            cfg.m = self.m;
+        }
+        if self.ef_construction.is_some() {
+            cfg.ef_construction = self.ef_construction;
+        }
+        cfg.max_layers = self.max_layers.unwrap_or(cfg.max_layers);
+        cfg
+    }
+
+    /// Builds an options object from a core section. `m`/`ef_construction`
+    /// stay `None` when the core leaves them auto, preserving auto-tuning
+    /// semantics on round-trip.
+    fn from_core(core: &CoreHnswConfig) -> Self {
+        Self {
+            m: core.m,
+            ef_construction: core.ef_construction,
+            max_layers: Some(core.max_layers),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StorageOptions
+// ---------------------------------------------------------------------------
+
+/// Storage engine settings mapped to
+/// [`velesdb_core::config::StorageConfig`] (the `[storage]` TOML section).
+///
+/// All fields are optional — unspecified fields fall back to the engine
+/// defaults (`data_dir="./velesdb_data"`, `storage_mode="mmap"`,
+/// `mmap_cache_mb=1024`, `vector_alignment=64`).
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct StorageOptions {
+    /// Data directory path. Default: `"./velesdb_data"`.
+    #[pyo3(get, set)]
+    pub data_dir: Option<String>,
+    /// Storage mode: `"mmap"` or `"memory"`. Default: `"mmap"`.
+    #[pyo3(get, set)]
+    pub storage_mode: Option<String>,
+    /// Mmap cache size in megabytes. Default: 1024.
+    #[pyo3(get, set)]
+    pub mmap_cache_mb: Option<usize>,
+    /// Vector alignment in bytes. Default: 64.
+    #[pyo3(get, set)]
+    pub vector_alignment: Option<usize>,
+}
+
+#[pymethods]
+impl StorageOptions {
+    #[new]
+    #[pyo3(signature = (
+        data_dir = None,
+        storage_mode = None,
+        mmap_cache_mb = None,
+        vector_alignment = None,
+    ))]
+    fn new(
+        data_dir: Option<String>,
+        storage_mode: Option<String>,
+        mmap_cache_mb: Option<usize>,
+        vector_alignment: Option<usize>,
+    ) -> Self {
+        Self {
+            data_dir,
+            storage_mode,
+            mmap_cache_mb,
+            vector_alignment,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "StorageOptions(data_dir={:?}, storage_mode={:?}, mmap_cache_mb={:?}, vector_alignment={:?})",
+            self.data_dir, self.storage_mode, self.mmap_cache_mb, self.vector_alignment,
+        )
+    }
+}
+
+impl StorageOptions {
+    pub(crate) fn to_core(&self) -> CoreStorageConfig {
+        let mut cfg = CoreStorageConfig::default();
+        if let Some(ref data_dir) = self.data_dir {
+            cfg.data_dir.clone_from(data_dir);
+        }
+        if let Some(ref storage_mode) = self.storage_mode {
+            cfg.storage_mode.clone_from(storage_mode);
+        }
+        cfg.mmap_cache_mb = self.mmap_cache_mb.unwrap_or(cfg.mmap_cache_mb);
+        cfg.vector_alignment = self.vector_alignment.unwrap_or(cfg.vector_alignment);
+        cfg
+    }
+
+    /// Builds a fully-populated options object from a core section
+    /// (see [`LimitsOptions::from_core`]).
+    fn from_core(core: &CoreStorageConfig) -> Self {
+        Self {
+            data_dir: Some(core.data_dir.clone()),
+            storage_mode: Some(core.storage_mode.clone()),
+            mmap_cache_mb: Some(core.mmap_cache_mb),
+            vector_alignment: Some(core.vector_alignment),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationOptions
+// ---------------------------------------------------------------------------
+
+/// Valid values for `QuantizationOptions.mode`, mirroring the serde tags
+/// of [`QuantizationType`].
+const QUANTIZATION_MODES: &[&str] = &["none", "sq8", "binary", "pq", "rabitq"];
+
+/// Quantization settings mapped to
+/// [`velesdb_core::config::QuantizationConfig`] (the `[quantization]`
+/// TOML section).
+///
+/// `mode` selects the algorithm (`"none"`, `"sq8"`, `"binary"`, `"pq"`,
+/// `"rabitq"`). The `pq_*` fields configure Product Quantization and are
+/// only valid with `mode="pq"` (where `pq_m` is required); combining
+/// them with any other mode raises `ValueError` — they are never
+/// silently dropped.
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct QuantizationOptions {
+    /// Quantization mode. Default: `"none"`.
+    #[pyo3(get, set)]
+    pub mode: Option<String>,
+    /// PQ: number of subspaces (dimension must be divisible by it).
+    /// Required when `mode="pq"`.
+    #[pyo3(get, set)]
+    pub pq_m: Option<usize>,
+    /// PQ: codebook size per subspace. Default: 256.
+    #[pyo3(get, set)]
+    pub pq_k: Option<usize>,
+    /// PQ: enable Optimized Product Quantization (OPQ) rotation.
+    /// Default: `False`.
+    #[pyo3(get, set)]
+    pub pq_opq_enabled: Option<bool>,
+    /// PQ: oversampling factor for training. Default: 4.
+    #[pyo3(get, set)]
+    pub pq_oversampling: Option<u32>,
+    /// Enable reranking after quantized search. Default: `True`.
+    #[pyo3(get, set)]
+    pub rerank_enabled: Option<bool>,
+    /// Reranking multiplier for candidates. Default: 2.
+    #[pyo3(get, set)]
+    pub rerank_multiplier: Option<usize>,
+    /// Auto-enable quantization for large collections. Default: `True`.
+    #[pyo3(get, set)]
+    pub auto_quantization: Option<bool>,
+    /// Vector-count threshold for auto-quantization. Default: 10000.
+    #[pyo3(get, set)]
+    pub auto_quantization_threshold: Option<usize>,
+}
+
+#[pymethods]
+impl QuantizationOptions {
+    #[new]
+    #[pyo3(signature = (
+        mode = None,
+        pq_m = None,
+        pq_k = None,
+        pq_opq_enabled = None,
+        pq_oversampling = None,
+        rerank_enabled = None,
+        rerank_multiplier = None,
+        auto_quantization = None,
+        auto_quantization_threshold = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        mode: Option<String>,
+        pq_m: Option<usize>,
+        pq_k: Option<usize>,
+        pq_opq_enabled: Option<bool>,
+        pq_oversampling: Option<u32>,
+        rerank_enabled: Option<bool>,
+        rerank_multiplier: Option<usize>,
+        auto_quantization: Option<bool>,
+        auto_quantization_threshold: Option<usize>,
+    ) -> Self {
+        Self {
+            mode,
+            pq_m,
+            pq_k,
+            pq_opq_enabled,
+            pq_oversampling,
+            rerank_enabled,
+            rerank_multiplier,
+            auto_quantization,
+            auto_quantization_threshold,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "QuantizationOptions(mode={:?}, pq_m={:?}, pq_k={:?}, pq_opq_enabled={:?}, pq_oversampling={:?}, rerank_enabled={:?}, rerank_multiplier={:?}, auto_quantization={:?}, auto_quantization_threshold={:?})",
+            self.mode,
+            self.pq_m,
+            self.pq_k,
+            self.pq_opq_enabled,
+            self.pq_oversampling,
+            self.rerank_enabled,
+            self.rerank_multiplier,
+            self.auto_quantization,
+            self.auto_quantization_threshold,
+        )
+    }
+}
+
+impl QuantizationOptions {
+    /// Returns `true` when any `pq_*` field is set.
+    fn has_pq_fields(&self) -> bool {
+        self.pq_m.is_some()
+            || self.pq_k.is_some()
+            || self.pq_opq_enabled.is_some()
+            || self.pq_oversampling.is_some()
+    }
+
+    /// Materializes the `mode` string (plus `pq_*` fields) into a core
+    /// [`QuantizationType`], failing fast on every inconsistent combination.
+    fn mode_to_core(&self) -> PyResult<QuantizationType> {
+        let mode = self.mode.as_deref().unwrap_or("none");
+        if mode != "pq" && self.has_pq_fields() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "quantization pq_m/pq_k/pq_opq_enabled/pq_oversampling require mode='pq' (got mode={mode:?})"
+            )));
+        }
+        match mode {
+            "none" => Ok(QuantizationType::None),
+            "sq8" => Ok(QuantizationType::SQ8),
+            "binary" => Ok(QuantizationType::Binary),
+            "rabitq" => Ok(QuantizationType::RaBitQ),
+            "pq" => {
+                let m = self.pq_m.ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(
+                        "quantization mode='pq' requires pq_m (number of subspaces)",
+                    )
+                })?;
+                Ok(QuantizationType::PQ {
+                    m,
+                    k: self.pq_k.unwrap_or(256),
+                    opq_enabled: self.pq_opq_enabled.unwrap_or(false),
+                    oversampling: self.pq_oversampling.or(Some(4)),
+                })
+            }
+            other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "invalid quantization.mode '{other}' (expected one of: {QUANTIZATION_MODES:?})"
+            ))),
+        }
+    }
+
+    pub(crate) fn to_core(&self) -> PyResult<CoreQuantizationConfig> {
+        let mut cfg = CoreQuantizationConfig::default();
+        cfg.mode = self.mode_to_core()?;
+        cfg.rerank_enabled = self.rerank_enabled.unwrap_or(cfg.rerank_enabled);
+        cfg.rerank_multiplier = self.rerank_multiplier.unwrap_or(cfg.rerank_multiplier);
+        cfg.auto_quantization = self.auto_quantization.unwrap_or(cfg.auto_quantization);
+        cfg.auto_quantization_threshold = self
+            .auto_quantization_threshold
+            .unwrap_or(cfg.auto_quantization_threshold);
+        Ok(cfg)
+    }
+
+    /// Builds a fully-populated options object from a core section.
+    ///
+    /// Fallible: [`QuantizationType`] is `#[non_exhaustive]`, so a future
+    /// core variant unknown to this binding is rejected loudly instead of
+    /// being silently re-mapped.
+    fn from_core(core: &CoreQuantizationConfig) -> PyResult<Self> {
+        let (mode, pq_m, pq_k, pq_opq_enabled, pq_oversampling) = match &core.mode {
+            QuantizationType::None => ("none", None, None, None, None),
+            QuantizationType::SQ8 => ("sq8", None, None, None, None),
+            QuantizationType::Binary => ("binary", None, None, None, None),
+            QuantizationType::RaBitQ => ("rabitq", None, None, None, None),
+            QuantizationType::PQ {
+                m,
+                k,
+                opq_enabled,
+                oversampling,
+            } => ("pq", Some(*m), Some(*k), Some(*opq_enabled), *oversampling),
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "unsupported quantization mode in configuration: {other:?}"
+                )));
+            }
+        };
+        Ok(Self {
+            mode: Some(mode.to_string()),
+            pq_m,
+            pq_k,
+            pq_opq_enabled,
+            pq_oversampling,
+            rerank_enabled: Some(core.rerank_enabled),
+            rerank_multiplier: Some(core.rerank_multiplier),
+            auto_quantization: Some(core.auto_quantization),
+            auto_quantization_threshold: Some(core.auto_quantization_threshold),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // VelesConfigOptions
 // ---------------------------------------------------------------------------
 
 /// Global database-level configuration exposed to Python.
 ///
-/// Maps to [`velesdb_core::config::VelesConfig`]. Currently exposes
-/// the `limits` sub-section. Other sub-sections (search, hnsw,
-/// storage, wal_batch) are left at their engine defaults — user-level
-/// tuning is done per-collection via [`HnswOptions`].
+/// Maps to [`velesdb_core::config::VelesConfig`], covering every *engine*
+/// section: `limits` ([`LimitsOptions`]), `search`
+/// ([`SearchConfigOptions`]), `hnsw` ([`HnswConfigOptions`]), `storage`
+/// ([`StorageOptions`]) and `quantization` ([`QuantizationOptions`]).
+/// Unset sections stay at their engine defaults.
+///
+/// Load from TOML with [`VelesConfigOptions::from_toml`] /
+/// [`VelesConfigOptions::from_toml_path`] (engine-only semantics — a
+/// shell-owned `[server]`/`[logging]` table in a shared file is ignored,
+/// mirroring `VelesConfig::from_toml_engine_only`).
 ///
 /// `wal_batch` is intentionally not exposed: the concurrent WAL
 /// writer is a velesdb-premium Enterprise feature. See
-/// `docs/guides/WRITE_CONCURRENCY.md`.
+/// `docs/guides/WRITE_CONCURRENCY.md`. A `[wal_batch]` TOML section is
+/// accepted by the loaders (it is a valid engine section for the
+/// server/CLI) but is not surfaced on — nor applied by — this embedded
+/// options type.
+///
+/// `server`/`logging` are likewise not exposed: they configure hosting
+/// shells, not the embedded engine surface.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct VelesConfigOptions {
     /// Tenant-wide guard-rail limits.
     #[pyo3(get, set)]
     pub limits: Option<LimitsOptions>,
+    /// Global search defaults (`[search]`).
+    #[pyo3(get, set)]
+    pub search: Option<SearchConfigOptions>,
+    /// Database-wide HNSW defaults (`[hnsw]`).
+    #[pyo3(get, set)]
+    pub hnsw: Option<HnswConfigOptions>,
+    /// Storage engine settings (`[storage]`).
+    #[pyo3(get, set)]
+    pub storage: Option<StorageOptions>,
+    /// Quantization settings (`[quantization]`).
+    #[pyo3(get, set)]
+    pub quantization: Option<QuantizationOptions>,
 }
 
 #[pymethods]
 impl VelesConfigOptions {
     #[new]
-    #[pyo3(signature = (limits = None))]
-    fn new(limits: Option<LimitsOptions>) -> Self {
-        Self { limits }
+    #[pyo3(signature = (
+        limits = None,
+        search = None,
+        hnsw = None,
+        storage = None,
+        quantization = None,
+    ))]
+    fn new(
+        limits: Option<LimitsOptions>,
+        search: Option<SearchConfigOptions>,
+        hnsw: Option<HnswConfigOptions>,
+        storage: Option<StorageOptions>,
+        quantization: Option<QuantizationOptions>,
+    ) -> Self {
+        Self {
+            limits,
+            search,
+            hnsw,
+            storage,
+            quantization,
+        }
+    }
+
+    /// Loads engine configuration from an in-memory TOML string.
+    ///
+    /// Wraps [`CoreVelesConfig::from_toml_engine_only`]: only the engine
+    /// sections are considered (a shell-owned `[server]`/`[logging]`
+    /// table is dropped before parsing), and the loaded config is
+    /// validated. Fail-fast: invalid TOML or an out-of-range value
+    /// raises `ValueError` carrying the typed core message — there is no
+    /// silent fallback to defaults.
+    ///
+    /// Every returned section is fully populated (engine defaults for
+    /// keys the TOML does not set).
+    #[staticmethod]
+    fn from_toml(toml_str: &str) -> PyResult<Self> {
+        let core = CoreVelesConfig::from_toml_engine_only(toml_str).map_err(config_err_to_py)?;
+        Self::from_core(&core)
+    }
+
+    /// Loads engine configuration from a TOML file path.
+    ///
+    /// Wraps [`CoreVelesConfig::load_from_path_engine_only`]: engine-only
+    /// section filtering plus validation, with `VELESDB_*` environment
+    /// variables layered on top of the file (mirroring the server/CLI
+    /// `--config` semantics from PR #1565). Fail-fast: a missing file
+    /// raises `FileNotFoundError`; invalid TOML or an out-of-range value
+    /// raises `ValueError` with the typed core message.
+    #[staticmethod]
+    fn from_toml_path(path: PathBuf) -> PyResult<Self> {
+        let core = CoreVelesConfig::load_from_path_engine_only(&path).map_err(config_err_to_py)?;
+        Self::from_core(&core)
     }
 
     fn __repr__(&self) -> String {
-        format!("VelesConfigOptions(limits={:?})", self.limits)
+        format!(
+            "VelesConfigOptions(limits={:?}, search={:?}, hnsw={:?}, storage={:?}, quantization={:?})",
+            self.limits, self.search, self.hnsw, self.storage, self.quantization,
+        )
     }
 }
 
 impl VelesConfigOptions {
-    pub(crate) fn to_core(&self) -> CoreVelesConfig {
+    /// Assembles the full core config and validates it, so an invalid
+    /// value fails fast as `ValueError` at `Database(..., config=...)`
+    /// time (in addition to the core-side validation in
+    /// `Database::open_with_config`).
+    pub(crate) fn to_core(&self) -> PyResult<CoreVelesConfig> {
         let mut core = CoreVelesConfig::default();
         if let Some(ref limits) = self.limits {
             core.limits = limits.to_core();
         }
-        core
+        if let Some(ref search) = self.search {
+            core.search = search.to_core()?;
+        }
+        if let Some(ref hnsw) = self.hnsw {
+            core.hnsw = hnsw.to_core();
+        }
+        if let Some(ref storage) = self.storage {
+            core.storage = storage.to_core();
+        }
+        if let Some(ref quantization) = self.quantization {
+            core.quantization = quantization.to_core()?;
+        }
+        core.validate().map_err(config_err_to_py)?;
+        Ok(core)
+    }
+
+    /// Builds a fully-populated options object from a validated core
+    /// config (every exposed section `Some`, every field set), so
+    /// [`Self::to_core`] round-trips the loaded values losslessly.
+    /// `wal_batch`/`server`/`logging` are intentionally not carried over
+    /// (see the type-level docs).
+    fn from_core(core: &CoreVelesConfig) -> PyResult<Self> {
+        Ok(Self {
+            limits: Some(LimitsOptions::from_core(&core.limits)),
+            search: Some(SearchConfigOptions::from_core(&core.search)?),
+            hnsw: Some(HnswConfigOptions::from_core(&core.hnsw)),
+            storage: Some(StorageOptions::from_core(&core.storage)),
+            quantization: Some(QuantizationOptions::from_core(&core.quantization)?),
+        })
     }
 }
 
@@ -481,6 +1110,205 @@ pub fn register_options(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<HnswOptions>()?;
     m.add_class::<LimitsOptions>()?;
     m.add_class::<AutoReindexOptions>()?;
+    m.add_class::<SearchConfigOptions>()?;
+    m.add_class::<HnswConfigOptions>()?;
+    m.add_class::<StorageOptions>()?;
+    m.add_class::<QuantizationOptions>()?;
     m.add_class::<VelesConfigOptions>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that stringify a `PyErr` need a live interpreter (error
+    /// formatting goes through the Python C-API). Idempotent.
+    fn init_python() {
+        Python::initialize();
+    }
+
+    // -- Section mapping: non-default values must propagate to core ------
+
+    #[test]
+    fn search_config_options_to_core_propagates_non_defaults() {
+        let opts = SearchConfigOptions {
+            default_mode: Some("accurate".to_string()),
+            ef_search: Some(256),
+            max_results: Some(42),
+            query_timeout_ms: Some(5_000),
+        };
+        let core = opts.to_core().expect("valid section");
+        assert!(matches!(core.default_mode, SearchMode::Accurate));
+        assert_eq!(core.ef_search, Some(256));
+        assert_eq!(core.max_results, 42);
+        assert_eq!(core.query_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn search_config_options_unset_fields_keep_engine_defaults() {
+        let core = SearchConfigOptions::default()
+            .to_core()
+            .expect("empty section is valid");
+        let defaults = CoreSearchConfig::default();
+        assert_eq!(core.max_results, defaults.max_results);
+        assert_eq!(core.ef_search, defaults.ef_search);
+        assert_eq!(core.query_timeout_ms, defaults.query_timeout_ms);
+    }
+
+    #[test]
+    fn search_config_options_rejects_unknown_mode() {
+        let opts = SearchConfigOptions {
+            default_mode: Some("warp".to_string()),
+            ..SearchConfigOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("unknown mode must fail");
+        assert!(err.to_string().contains("default_mode"));
+    }
+
+    #[test]
+    fn hnsw_config_options_to_core_propagates_non_defaults() {
+        let opts = HnswConfigOptions {
+            m: Some(32),
+            ef_construction: Some(400),
+            max_layers: Some(8),
+        };
+        let core = opts.to_core();
+        assert_eq!(core.m, Some(32));
+        assert_eq!(core.ef_construction, Some(400));
+        assert_eq!(core.max_layers, 8);
+    }
+
+    #[test]
+    fn storage_options_to_core_propagates_non_defaults() {
+        let opts = StorageOptions {
+            data_dir: Some("./custom".to_string()),
+            storage_mode: Some("memory".to_string()),
+            mmap_cache_mb: Some(256),
+            vector_alignment: Some(32),
+        };
+        let core = opts.to_core();
+        assert_eq!(core.data_dir, "./custom");
+        assert_eq!(core.storage_mode, "memory");
+        assert_eq!(core.mmap_cache_mb, 256);
+        assert_eq!(core.vector_alignment, 32);
+    }
+
+    #[test]
+    fn quantization_options_to_core_propagates_pq_mode() {
+        let opts = QuantizationOptions {
+            mode: Some("pq".to_string()),
+            pq_m: Some(8),
+            pq_k: Some(128),
+            pq_opq_enabled: Some(true),
+            rerank_enabled: Some(false),
+            rerank_multiplier: Some(3),
+            ..QuantizationOptions::default()
+        };
+        let core = opts.to_core().expect("valid pq section");
+        match core.mode {
+            QuantizationType::PQ {
+                m,
+                k,
+                opq_enabled,
+                oversampling,
+            } => {
+                assert_eq!(m, 8);
+                assert_eq!(k, 128);
+                assert!(opq_enabled);
+                assert_eq!(oversampling, Some(4), "unset oversampling → core default");
+            }
+            other => panic!("expected PQ mode, got {other:?}"),
+        }
+        assert!(!core.rerank_enabled);
+        assert_eq!(core.rerank_multiplier, 3);
+    }
+
+    #[test]
+    fn quantization_options_pq_without_m_fails() {
+        let opts = QuantizationOptions {
+            mode: Some("pq".to_string()),
+            ..QuantizationOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("pq without pq_m must fail");
+        assert!(err.to_string().contains("pq_m"));
+    }
+
+    #[test]
+    fn quantization_options_pq_fields_without_pq_mode_fail() {
+        let opts = QuantizationOptions {
+            mode: Some("sq8".to_string()),
+            pq_m: Some(8),
+            ..QuantizationOptions::default()
+        };
+        init_python();
+        let err = opts
+            .to_core()
+            .expect_err("pq fields with mode='sq8' must fail, not be dropped");
+        assert!(err.to_string().contains("pq_"));
+    }
+
+    // -- Whole-config assembly + validation ------------------------------
+
+    #[test]
+    fn veles_config_options_to_core_applies_every_section() {
+        let opts = VelesConfigOptions {
+            limits: Some(LimitsOptions {
+                max_collections: Some(5),
+                ..LimitsOptions::default()
+            }),
+            search: Some(SearchConfigOptions {
+                max_results: Some(42),
+                ..SearchConfigOptions::default()
+            }),
+            hnsw: Some(HnswConfigOptions {
+                m: Some(32),
+                ..HnswConfigOptions::default()
+            }),
+            storage: Some(StorageOptions {
+                mmap_cache_mb: Some(256),
+                ..StorageOptions::default()
+            }),
+            quantization: Some(QuantizationOptions {
+                mode: Some("sq8".to_string()),
+                ..QuantizationOptions::default()
+            }),
+        };
+        let core = opts.to_core().expect("valid full config");
+        assert_eq!(core.limits.max_collections, 5);
+        assert_eq!(core.search.max_results, 42);
+        assert_eq!(core.hnsw.m, Some(32));
+        assert_eq!(core.storage.mmap_cache_mb, 256);
+        assert!(matches!(core.quantization.mode, QuantizationType::SQ8));
+    }
+
+    #[test]
+    fn veles_config_options_to_core_validates_fail_fast() {
+        let opts = VelesConfigOptions {
+            search: Some(SearchConfigOptions {
+                max_results: Some(0),
+                ..SearchConfigOptions::default()
+            }),
+            ..VelesConfigOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("max_results=0 must fail");
+        assert!(err.to_string().contains("search.max_results"));
+    }
+
+    // -- TOML round-trip --------------------------------------------------
+
+    #[test]
+    fn from_core_round_trips_through_to_core() {
+        let toml = "[limits]\nmax_collections = 7\n\n[search]\nmax_results = 42\n";
+        let core = CoreVelesConfig::from_toml_engine_only(toml).expect("valid toml");
+        let opts = VelesConfigOptions::from_core(&core).expect("mappable config");
+        let back = opts.to_core().expect("round-trip stays valid");
+        assert_eq!(back.limits.max_collections, 7);
+        assert_eq!(back.search.max_results, 42);
+        // Untouched engine defaults survive the round-trip:
+        assert_eq!(back.storage.storage_mode, "mmap");
+    }
 }

--- a/crates/velesdb-python/tests/test_config_sections.py
+++ b/crates/velesdb-python/tests/test_config_sections.py
@@ -1,0 +1,384 @@
+"""BDD tests for issue #1549 — full engine `VelesConfig` coverage in Python.
+
+`VelesConfigOptions` historically exposed only the `limits` section. This
+suite covers the extension to the remaining *engine* sections
+(`search`, `hnsw`, `storage`, `quantization`) plus TOML loading via
+`VelesConfigOptions.from_toml` / `from_toml_path` (engine-only semantics,
+mirroring `VelesConfig::from_toml_engine_only` /
+`load_from_path_engine_only` from PR #1565).
+
+Scope guards:
+- `wal_batch` stays NOT exposed (velesdb-premium Enterprise feature —
+  see docs/guides/WRITE_CONCURRENCY.md).
+- `server` / `logging` are out of scope for the embedded surface; a TOML
+  shared with a hosting shell must still load (engine-only filtering).
+
+Test categories:
+- Nominal (>= 60%): section construction + TOML happy paths + round-trip
+  through `Database(path, config=...)`
+- Edge (~20%): defaults pass-through, engine-only section filtering
+- Negative (>= 20%): invalid TOML, invalid values, wal_batch guardrails
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import velesdb
+from velesdb import (
+    Database,
+    HnswConfigOptions,
+    LimitsOptions,
+    QuantizationOptions,
+    SearchConfigOptions,
+    StorageOptions,
+    VelesConfigOptions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db_path():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d) / "db"
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+# ---------------------------------------------------------------------------
+# Section dataclasses — nominal construction
+# ---------------------------------------------------------------------------
+
+
+def test_search_config_options_default_is_all_none():
+    opts = SearchConfigOptions()
+    assert opts.default_mode is None
+    assert opts.ef_search is None
+    assert opts.max_results is None
+    assert opts.query_timeout_ms is None
+
+
+def test_search_config_options_explicit_fields():
+    opts = SearchConfigOptions(
+        default_mode="accurate", ef_search=256, max_results=42, query_timeout_ms=5_000
+    )
+    assert opts.default_mode == "accurate"
+    assert opts.ef_search == 256
+    assert opts.max_results == 42
+    assert opts.query_timeout_ms == 5_000
+
+
+def test_hnsw_config_options_default_is_all_none():
+    opts = HnswConfigOptions()
+    assert opts.m is None
+    assert opts.ef_construction is None
+    assert opts.max_layers is None
+
+
+def test_hnsw_config_options_explicit_fields():
+    opts = HnswConfigOptions(m=32, ef_construction=400, max_layers=8)
+    assert opts.m == 32
+    assert opts.ef_construction == 400
+    assert opts.max_layers == 8
+
+
+def test_storage_options_default_is_all_none():
+    opts = StorageOptions()
+    assert opts.data_dir is None
+    assert opts.storage_mode is None
+    assert opts.mmap_cache_mb is None
+    assert opts.vector_alignment is None
+
+
+def test_storage_options_explicit_fields():
+    opts = StorageOptions(
+        data_dir="./data", storage_mode="memory", mmap_cache_mb=256, vector_alignment=32
+    )
+    assert opts.data_dir == "./data"
+    assert opts.storage_mode == "memory"
+    assert opts.mmap_cache_mb == 256
+    assert opts.vector_alignment == 32
+
+
+def test_quantization_options_default_is_all_none():
+    opts = QuantizationOptions()
+    assert opts.mode is None
+    assert opts.pq_m is None
+    assert opts.pq_k is None
+    assert opts.pq_opq_enabled is None
+    assert opts.pq_oversampling is None
+    assert opts.rerank_enabled is None
+    assert opts.rerank_multiplier is None
+    assert opts.auto_quantization is None
+    assert opts.auto_quantization_threshold is None
+
+
+def test_quantization_options_explicit_sq8():
+    opts = QuantizationOptions(mode="sq8", rerank_enabled=False, rerank_multiplier=3)
+    assert opts.mode == "sq8"
+    assert opts.rerank_enabled is False
+    assert opts.rerank_multiplier == 3
+
+
+def test_quantization_options_explicit_pq():
+    opts = QuantizationOptions(mode="pq", pq_m=8, pq_k=128, pq_opq_enabled=True)
+    assert opts.mode == "pq"
+    assert opts.pq_m == 8
+    assert opts.pq_k == 128
+    assert opts.pq_opq_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# VelesConfigOptions — new section kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_veles_config_options_accepts_all_engine_sections():
+    cfg = VelesConfigOptions(
+        limits=LimitsOptions(max_collections=10),
+        search=SearchConfigOptions(max_results=100),
+        hnsw=HnswConfigOptions(m=16),
+        storage=StorageOptions(mmap_cache_mb=128),
+        quantization=QuantizationOptions(mode="sq8"),
+    )
+    assert cfg.limits.max_collections == 10
+    assert cfg.search.max_results == 100
+    assert cfg.hnsw.m == 16
+    assert cfg.storage.mmap_cache_mb == 128
+    assert cfg.quantization.mode == "sq8"
+
+
+def test_veles_config_options_sections_default_to_none():
+    cfg = VelesConfigOptions()
+    assert cfg.limits is None
+    assert cfg.search is None
+    assert cfg.hnsw is None
+    assert cfg.storage is None
+    assert cfg.quantization is None
+
+
+def test_new_section_classes_are_exported_from_top_level():
+    for name in (
+        "SearchConfigOptions",
+        "HnswConfigOptions",
+        "StorageOptions",
+        "QuantizationOptions",
+    ):
+        assert name in velesdb.__all__, f"{name} missing from velesdb.__all__"
+
+
+# ---------------------------------------------------------------------------
+# Sections are actually applied at Database open time
+# ---------------------------------------------------------------------------
+
+
+def test_database_open_applies_search_section(tmp_db_path):
+    """An out-of-range `search.max_results` must be rejected at open —
+    proof the section reaches the core engine config (not dropped)."""
+    cfg = VelesConfigOptions(search=SearchConfigOptions(max_results=0))
+    with pytest.raises(ValueError, match="search.max_results"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_applies_hnsw_section(tmp_db_path):
+    cfg = VelesConfigOptions(hnsw=HnswConfigOptions(m=2))  # < 4 → invalid
+    with pytest.raises(ValueError, match="hnsw.m"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_applies_storage_section(tmp_db_path):
+    cfg = VelesConfigOptions(storage=StorageOptions(storage_mode="floppy"))
+    with pytest.raises(ValueError, match="storage.storage_mode"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_invalid_search_mode(tmp_db_path):
+    cfg = VelesConfigOptions(search=SearchConfigOptions(default_mode="warp"))
+    with pytest.raises(ValueError, match="default_mode"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_pq_without_m(tmp_db_path):
+    cfg = VelesConfigOptions(quantization=QuantizationOptions(mode="pq"))
+    with pytest.raises(ValueError, match="pq_m"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_pq_fields_without_pq_mode(tmp_db_path):
+    """pq_* fields with a non-pq mode must fail fast, never be silently
+    dropped."""
+    cfg = VelesConfigOptions(quantization=QuantizationOptions(mode="sq8", pq_m=8))
+    with pytest.raises(ValueError, match="pq_"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_with_valid_full_config_works(tmp_db_path):
+    cfg = VelesConfigOptions(
+        limits=LimitsOptions(max_collections=3),
+        search=SearchConfigOptions(default_mode="fast", max_results=50),
+        hnsw=HnswConfigOptions(m=16, ef_construction=200),
+        storage=StorageOptions(storage_mode="mmap", mmap_cache_mb=64),
+        quantization=QuantizationOptions(mode="none"),
+    )
+    db = Database(str(tmp_db_path), config=cfg)
+    db.create_collection("ok", dimension=4)
+    assert db.list_collections() == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# TOML loading — nominal
+# ---------------------------------------------------------------------------
+
+FULL_TOML = """
+[search]
+default_mode = "accurate"
+ef_search = 256
+max_results = 42
+query_timeout_ms = 5000
+
+[hnsw]
+m = 32
+ef_construction = 400
+max_layers = 8
+
+[storage]
+data_dir = "./custom_data"
+storage_mode = "memory"
+mmap_cache_mb = 256
+vector_alignment = 32
+
+[limits]
+max_collections = 5
+max_dimensions = 512
+
+[quantization]
+rerank_enabled = false
+rerank_multiplier = 3
+auto_quantization = false
+auto_quantization_threshold = 50000
+"""
+
+
+def test_from_toml_happy_path_populates_every_section():
+    cfg = VelesConfigOptions.from_toml(FULL_TOML)
+    assert cfg.search.default_mode == "accurate"
+    assert cfg.search.ef_search == 256
+    assert cfg.search.max_results == 42
+    assert cfg.search.query_timeout_ms == 5000
+    assert cfg.hnsw.m == 32
+    assert cfg.hnsw.ef_construction == 400
+    assert cfg.hnsw.max_layers == 8
+    assert cfg.storage.data_dir == "./custom_data"
+    assert cfg.storage.storage_mode == "memory"
+    assert cfg.storage.mmap_cache_mb == 256
+    assert cfg.storage.vector_alignment == 32
+    assert cfg.limits.max_collections == 5
+    assert cfg.limits.max_dimensions == 512
+    assert cfg.quantization.rerank_enabled is False
+    assert cfg.quantization.rerank_multiplier == 3
+    assert cfg.quantization.auto_quantization is False
+    assert cfg.quantization.auto_quantization_threshold == 50000
+
+
+def test_from_toml_unset_sections_carry_engine_defaults():
+    """A TOML with only [limits] still yields fully-populated sections
+    (engine defaults), so `to_core` round-trips losslessly."""
+    cfg = VelesConfigOptions.from_toml("[limits]\nmax_collections = 7\n")
+    assert cfg.limits.max_collections == 7
+    # Engine defaults surfaced, not None:
+    assert cfg.search.max_results == 1000
+    assert cfg.search.default_mode == "balanced"
+    assert cfg.storage.storage_mode == "mmap"
+    assert cfg.quantization.mode == "none"
+
+
+def test_from_toml_pq_mode_round_trips():
+    cfg = VelesConfigOptions.from_toml(
+        '[quantization]\nmode = { type = "pq", m = 8 }\n'
+    )
+    assert cfg.quantization.mode == "pq"
+    assert cfg.quantization.pq_m == 8
+    assert cfg.quantization.pq_k == 256  # core default k
+
+
+def test_from_toml_path_happy_path(tmp_dir):
+    path = tmp_dir / "velesdb.toml"
+    path.write_text(FULL_TOML)
+    cfg = VelesConfigOptions.from_toml_path(str(path))
+    assert cfg.limits.max_collections == 5
+    assert cfg.search.default_mode == "accurate"
+
+
+def test_from_toml_config_is_applied_by_database(tmp_db_path):
+    """End-to-end: a TOML-limit of 1 collection must be enforced by a
+    Database opened with the loaded config."""
+    cfg = VelesConfigOptions.from_toml("[limits]\nmax_collections = 1\n")
+    db = Database(str(tmp_db_path), config=cfg)
+    db.create_collection("a", dimension=4)
+    with pytest.raises(Exception):
+        db.create_collection("b", dimension=4)
+
+
+def test_from_toml_ignores_shell_owned_server_section():
+    """Engine-only semantics (PR #1565): a shell-owned [server] table with
+    a low bind port must not leak into the engine config nor fail
+    validation; the genuine engine sections still apply."""
+    cfg = VelesConfigOptions.from_toml(
+        "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n"
+    )
+    assert cfg.limits.max_collections == 5
+
+
+# ---------------------------------------------------------------------------
+# TOML loading — negative (fail-fast, typed messages)
+# ---------------------------------------------------------------------------
+
+
+def test_from_toml_invalid_syntax_raises_value_error():
+    with pytest.raises(ValueError):
+        VelesConfigOptions.from_toml("this is [not valid toml")
+
+
+def test_from_toml_invalid_value_carries_typed_config_error():
+    """`limits.max_collections = 0` must surface the core ConfigError
+    message (key + range), never fall back to defaults silently."""
+    with pytest.raises(ValueError, match="limits.max_collections"):
+        VelesConfigOptions.from_toml("[limits]\nmax_collections = 0\n")
+
+
+def test_from_toml_path_missing_file_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        VelesConfigOptions.from_toml_path("/nonexistent/velesdb.toml")
+
+
+# ---------------------------------------------------------------------------
+# wal_batch stays unexposed (velesdb-premium Enterprise feature)
+# ---------------------------------------------------------------------------
+
+
+def test_veles_config_options_rejects_wal_batch_kwarg():
+    with pytest.raises(TypeError):
+        VelesConfigOptions(wal_batch={"enabled": True})  # type: ignore[call-arg]
+
+
+def test_veles_config_options_has_no_wal_batch_attribute():
+    assert not hasattr(VelesConfigOptions(), "wal_batch")
+
+
+def test_from_toml_does_not_surface_wal_batch_section():
+    """[wal_batch] in a TOML is valid engine input for the server/CLI, but
+    the embedded Python surface does not expose it (Enterprise-only —
+    docs/guides/WRITE_CONCURRENCY.md)."""
+    cfg = VelesConfigOptions.from_toml("[wal_batch]\nenabled = true\n")
+    assert not hasattr(cfg, "wal_batch")

--- a/integrations/common/src/velesdb_common/graph.py
+++ b/integrations/common/src/velesdb_common/graph.py
@@ -76,7 +76,9 @@ def is_timeout_exception(exc: Exception) -> bool:
     return isinstance(exc, TimeoutError)
 
 
-def open_native_graph(db_path: str, collection_name: str) -> Any:
+def open_native_graph(
+    db_path: str, collection_name: str, config: Any = None
+) -> Any:
     """Open a native VelesDB graph collection.
 
     Shared implementation for both integrations.
@@ -91,6 +93,10 @@ def open_native_graph(db_path: str, collection_name: str) -> Any:
     Args:
         db_path: Filesystem path to the VelesDB database directory.
         collection_name: Name of the graph collection to open.
+        config: Optional ``velesdb.VelesConfigOptions`` engine
+            configuration, forwarded verbatim to ``velesdb.Database`` at
+            open time.  ``None`` (default) opens the database exactly as
+            before.
 
     Returns:
         PyGraphCollection instance.
@@ -107,7 +113,10 @@ def open_native_graph(db_path: str, collection_name: str) -> Any:
             "Install it with: pip install velesdb"
         ) from exc
 
-    db = velesdb.Database(db_path)
+    if config is not None:
+        db = velesdb.Database(db_path, config=config)
+    else:
+        db = velesdb.Database(db_path)
     graph = db.get_graph_collection(collection_name)
     if graph is None:
         raise ValueError(

--- a/integrations/common/tests/test_graph.py
+++ b/integrations/common/tests/test_graph.py
@@ -1,6 +1,9 @@
+import pytest
+
 from velesdb_common.graph import (
     build_graph_rest_payload,
     is_timeout_exception,
+    open_native_graph,
 )
 
 
@@ -36,3 +39,39 @@ def test_is_timeout_exception_with_timeout():
 def test_is_timeout_exception_with_other():
     exc = ValueError("Some error")
     assert is_timeout_exception(exc) is False
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).calls.append((args, kwargs))
+
+    def get_graph_collection(self, name):
+        return object()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    velesdb = pytest.importorskip("velesdb")
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+def test_open_native_graph_forwards_config(tmp_path, recording_db):
+    """Issue #1549: a provided config is forwarded verbatim to Database."""
+    config = object()  # opaque pass-through payload
+    graph = open_native_graph(str(tmp_path), "kg", config=config)
+    assert graph is not None
+    assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+
+def test_open_native_graph_no_config_call_unchanged(tmp_path, recording_db):
+    """Without config the historical Database(path) call is preserved."""
+    graph = open_native_graph(str(tmp_path), "kg")
+    assert graph is not None
+    assert recording_db.calls == [((str(tmp_path),), {})]

--- a/integrations/langchain/src/langchain_velesdb/_common.py
+++ b/integrations/langchain/src/langchain_velesdb/_common.py
@@ -22,10 +22,32 @@ from velesdb_common.graph import (  # noqa: F401
 __all__ = [
     "make_initial_id_counter", "build_graph_rest_payload",
     "is_timeout_exception", "open_native_graph", "parse_graph_traverse_response",
-    "payload_to_doc_parts", "validate_queries_batch",
+    "payload_to_doc_parts", "validate_queries_batch", "open_database",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def open_database(path: str, config: Any = None) -> Any:
+    """Open a :class:`velesdb.Database`, forwarding ``config`` only when set.
+
+    ``config`` is an opaque pass-through of ``velesdb.VelesConfigOptions``:
+    whatever the caller provides is handed to the binding verbatim.  When
+    ``config`` is ``None`` the call is identical to the historical
+    ``velesdb.Database(path)`` so default behaviour never changes.
+
+    Args:
+        path: Filesystem path to the VelesDB database directory.
+        config: Optional ``velesdb.VelesConfigOptions`` applied at open time.
+
+    Returns:
+        An open ``velesdb.Database`` handle.
+    """
+    import velesdb
+
+    if config is not None:
+        return velesdb.Database(path, config=config)
+    return velesdb.Database(path)
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/langchain/src/langchain_velesdb/graph_retriever.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_retriever.py
@@ -209,14 +209,22 @@ class GraphRetriever(BaseRetriever):
         return graph
 
     def _open_graph_from_path(self) -> Any:
-        """Open graph collection by resolving db_path (fallback path)."""
+        """Open graph collection by resolving db_path (fallback path).
+
+        Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+        when present — the same source ``_get_db()`` uses — so the graph
+        database is opened with the same engine configuration.
+        """
         resolved_path = self.db_path or _infer_db_path(self.vector_store)
         if resolved_path is None:
             raise ValueError(
                 "Native mode requires 'db_path' or a vector store with a "
                 "'_db_path' / '_path' attribute."
             )
-        return open_native_graph(resolved_path, self.graph_collection_name)
+        config = getattr(self.vector_store, "_config", None)
+        return open_native_graph(
+            resolved_path, self.graph_collection_name, config=config
+        )
 
     def _get_relevant_documents(
         self,

--- a/integrations/langchain/src/langchain_velesdb/memory.py
+++ b/integrations/langchain/src/langchain_velesdb/memory.py
@@ -18,7 +18,10 @@ import json
 from typing import Any, Dict, List, Optional, Union
 import time
 
-from langchain_velesdb._common import make_initial_id_counter
+from langchain_velesdb._common import (
+    make_initial_id_counter,
+    open_database as _open_database,
+)
 from velesdb_common.memory import (
     chronological,
     format_procedural_results,
@@ -90,6 +93,9 @@ class VelesDBChatMemory(BaseChatMemory):
         human_prefix: Prefix for human messages (default: "Human")
         ai_prefix: Prefix for AI messages (default: "AI")
         return_messages: Return messages as objects vs string (default: False)
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBChatMemory(path="./chat_data")
@@ -126,10 +132,11 @@ class VelesDBChatMemory(BaseChatMemory):
         dimension: int = 384,
         window: int = 20,
         embedding: Optional[Any] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
         **kwargs,
     ):
         super().__init__(path=path, dimension=dimension, window=window, **kwargs)
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._embedding = embedding
         self._message_counter = make_initial_id_counter()
@@ -234,6 +241,9 @@ class VelesDBSemanticMemory:
         path: Path to VelesDB database directory
         dimension: Embedding dimension (must match your embeddings)
         embedding: LangChain Embeddings instance for encoding
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> from langchain_openai import OpenAIEmbeddings
@@ -245,7 +255,13 @@ class VelesDBSemanticMemory:
         >>> facts = memory.query("What is the capital of France?", k=3)
     """
 
-    def __init__(self, path: str, embedding: Any, dimension: Optional[int] = None):
+    def __init__(
+        self,
+        path: str,
+        embedding: Any,
+        dimension: Optional[int] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
+    ):
         self.path = path
         self.embedding = embedding
 
@@ -255,7 +271,7 @@ class VelesDBSemanticMemory:
             dimension = len(sample)
 
         self.dimension = dimension
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._fact_counter = make_initial_id_counter()
 
@@ -331,6 +347,9 @@ class VelesDBProceduralMemory:
             ``pattern`` string passed to :meth:`recall`.  Required for
             text-based recall; omit if you will always supply a raw
             embedding vector directly.
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> from langchain_velesdb import VelesDBProceduralMemory
@@ -350,9 +369,10 @@ class VelesDBProceduralMemory:
         path: str,
         dimension: int = 384,
         embeddings: Optional[Any] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
     ) -> None:
         self.path = path
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._procedural = self._memory.procedural
         self._embeddings = embeddings

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -38,7 +38,10 @@ from langchain_velesdb.security import (
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
-from langchain_velesdb._common import payload_to_doc_parts
+from langchain_velesdb._common import (
+    open_database as _open_database,
+    payload_to_doc_parts,
+)
 from langchain_velesdb.point_builder import build_point as _build_point, flush_stream_batches as _flush_stream_batches
 from langchain_velesdb.search_ops import SearchOpsMixin
 from langchain_velesdb.graph_ops import GraphOpsMixin
@@ -86,6 +89,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         metric: str = "cosine",
         storage_mode: str = "full",
         search_quality: Optional[str] = None,
+        config: Optional[velesdb.VelesConfigOptions] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -117,6 +121,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
                 ``"adaptive:MIN:MAX"``. ``None`` uses the built-in search.
                 Per-call override: pass ``search_quality=`` to
                 :meth:`similarity_search_with_score`.
+            config: Optional :class:`velesdb.VelesConfigOptions` engine
+                configuration, forwarded verbatim to ``velesdb.Database``
+                when the connection is opened. ``None`` (default) keeps the
+                engine defaults — the database is opened exactly as before.
             **kwargs: Additional arguments passed to the database.
 
         Raises:
@@ -139,6 +147,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             self._search_quality = validate_search_quality(search_quality)
 
         self._embedding = embedding
+        self._config = config
         self._db: Optional[velesdb.Database] = None
         self._collection: Optional[velesdb.Collection] = None
 
@@ -155,7 +164,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     def _get_db(self) -> velesdb.Database:
         """Get or create the database connection."""
         if self._db is None:
-            self._db = velesdb.Database(self._path)
+            self._db = _open_database(self._path, self._config)
         return self._db
 
     def _get_collection(self, dimension: int) -> velesdb.Collection:
@@ -327,7 +336,9 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             path: Path to database directory.
             collection_name: Name of the collection.
             metric: Distance metric.
-            **kwargs: Additional arguments.
+            **kwargs: Additional constructor arguments (e.g. ``config=``
+                for a :class:`velesdb.VelesConfigOptions` engine
+                configuration), forwarded to :meth:`__init__`.
 
         Returns:
             VelesDBVectorStore instance with texts added.

--- a/integrations/langchain/tests/test_config_passthrough.py
+++ b/integrations/langchain/tests/test_config_passthrough.py
@@ -1,0 +1,136 @@
+"""Tests for VelesConfigOptions pass-through to velesdb.Database.
+
+Covers issue #1549: every entry point that opens a ``velesdb.Database``
+must accept an optional ``config`` and forward it verbatim, while the
+no-config path must keep calling ``velesdb.Database(path)`` exactly as
+before.
+
+Run with: pytest tests/test_config_passthrough.py -v
+"""
+
+from typing import Any, List, Tuple
+
+import pytest
+
+try:
+    import velesdb
+    from langchain_velesdb import VelesDBVectorStore
+    from langchain_velesdb.memory import (
+        VelesDBChatMemory,
+        VelesDBProceduralMemory,
+        VelesDBSemanticMemory,
+    )
+    from langchain_core.embeddings import Embeddings
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+class FakeEmbeddings(Embeddings):
+    """Deterministic embeddings for testing."""
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+class _FakeAgentMemory:
+    """Minimal stand-in for the agent memory service."""
+
+    def __init__(self) -> None:
+        self.episodic = object()
+        self.semantic = object()
+        self.procedural = object()
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls: List[Tuple[tuple, dict]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).calls.append((args, kwargs))
+
+    def agent_memory(self, dimension: int = 384) -> _FakeAgentMemory:
+        return _FakeAgentMemory()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+@pytest.fixture
+def config() -> Any:
+    """A real VelesConfigOptions instance (opaque pass-through payload)."""
+    return velesdb.VelesConfigOptions()
+
+
+class TestVectorStoreConfigPassthrough:
+    """VelesDBVectorStore forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=str(tmp_path),
+            config=config,
+        )
+        store._get_db()
+        assert recording_db.calls == [((store._path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=str(tmp_path),
+        )
+        store._get_db()
+        assert recording_db.calls == [((store._path,), {})]
+
+
+class TestChatMemoryConfigPassthrough:
+    """VelesDBChatMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBChatMemory(path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBChatMemory(path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestSemanticMemoryConfigPassthrough:
+    """VelesDBSemanticMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBSemanticMemory(
+            path=str(tmp_path),
+            embedding=FakeEmbeddings(),
+            dimension=4,
+            config=config,
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBSemanticMemory(
+            path=str(tmp_path),
+            embedding=FakeEmbeddings(),
+            dimension=4,
+        )
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestProceduralMemoryConfigPassthrough:
+    """VelesDBProceduralMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBProceduralMemory(path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBProceduralMemory(path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]

--- a/integrations/langchain/tests/test_config_passthrough.py
+++ b/integrations/langchain/tests/test_config_passthrough.py
@@ -15,6 +15,7 @@ import pytest
 try:
     import velesdb
     from langchain_velesdb import VelesDBVectorStore
+    from langchain_velesdb.graph_retriever import GraphRetriever
     from langchain_velesdb.memory import (
         VelesDBChatMemory,
         VelesDBProceduralMemory,
@@ -54,6 +55,9 @@ class _RecordingDatabase:
 
     def agent_memory(self, dimension: int = 384) -> _FakeAgentMemory:
         return _FakeAgentMemory()
+
+    def get_graph_collection(self, name: str) -> Any:
+        return object()
 
 
 @pytest.fixture
@@ -120,6 +124,36 @@ class TestSemanticMemoryConfigPassthrough:
             path=str(tmp_path),
             embedding=FakeEmbeddings(),
             dimension=4,
+        )
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class _StoreWithoutGetDb:
+    """Fake vector store lacking _get_db, forcing the open_native_graph path."""
+
+    def __init__(self, path: str, config: Any = None) -> None:
+        self._path = path
+        self._config = config
+
+
+class TestGraphRetrieverConfigPassthrough:
+    """GraphRetriever's path fallback forwards the store's config."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = _StoreWithoutGetDb(str(tmp_path), config=config)
+        GraphRetriever(
+            vector_store=store,
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = _StoreWithoutGetDb(str(tmp_path))
+        GraphRetriever(
+            vector_store=store,
+            mode="native",
+            graph_collection_name="kg",
         )
         assert recording_db.calls == [((str(tmp_path),), {})]
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/_common.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/_common.py
@@ -5,6 +5,8 @@ Not part of the public API — import from the top-level package instead.
 
 from __future__ import annotations
 
+from typing import Any
+
 # Re-export shared helpers so existing intra-package imports keep working.
 from velesdb_common.ids import make_initial_id_counter  # noqa: F401
 from velesdb_common.graph import (  # noqa: F401
@@ -17,4 +19,27 @@ from velesdb_common.graph import (  # noqa: F401
 __all__ = [
     "make_initial_id_counter", "build_graph_rest_payload",
     "is_timeout_exception", "open_native_graph", "parse_graph_traverse_response",
+    "open_database",
 ]
+
+
+def open_database(path: str, config: Any = None) -> Any:
+    """Open a :class:`velesdb.Database`, forwarding ``config`` only when set.
+
+    ``config`` is an opaque pass-through of ``velesdb.VelesConfigOptions``:
+    whatever the caller provides is handed to the binding verbatim.  When
+    ``config`` is ``None`` the call is identical to the historical
+    ``velesdb.Database(path)`` so default behaviour never changes.
+
+    Args:
+        path: Filesystem path to the VelesDB database directory.
+        config: Optional ``velesdb.VelesConfigOptions`` applied at open time.
+
+    Returns:
+        An open ``velesdb.Database`` handle.
+    """
+    import velesdb
+
+    if config is not None:
+        return velesdb.Database(path, config=config)
+    return velesdb.Database(path)

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
@@ -24,6 +24,8 @@ import logging
 
 from velesdb_common.ids import stable_hash_id
 
+from llamaindex_velesdb._common import open_database as _open_database
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -42,6 +44,10 @@ def _generate_id(name: str, entity_type: str) -> int:
 def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]:
     """Open a native graph collection from the vector store's database path.
 
+    Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+    when present, so the graph database is opened with the same engine
+    configuration as the vector store.
+
     Args:
         vector_store: VelesDBVectorStore instance.
         collection_name: Name of the graph collection.
@@ -50,7 +56,7 @@ def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]
         PyGraphCollection instance, or None if unavailable.
     """
     db_path: Optional[str] = None
-    for attr in ("_db_path", "_path", "_data_path"):
+    for attr in ("_db_path", "_path", "path", "_data_path"):
         candidate = getattr(vector_store, attr, None)
         if candidate is not None:
             db_path = str(candidate)
@@ -59,13 +65,14 @@ def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]
     if db_path is None:
         logger.debug(
             "Cannot open native graph collection: vector store has no "
-            "_db_path / _path attribute."
+            "_db_path / _path / path attribute."
         )
         return None
 
+    config = getattr(vector_store, "_config", None)
+
     try:
-        import velesdb  # type: ignore[import]
-        db = velesdb.Database(db_path)
+        db = _open_database(db_path, config)
         graph = db.get_graph_collection(collection_name)
         if graph is None:
             logger.debug(

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
@@ -231,14 +231,24 @@ class GraphRetriever(BaseRetriever):
     def _open_graph_from_path(
         self, db_path: Optional[str], collection_name: str
     ) -> Any:
-        """Open graph collection by resolving db_path (fallback path)."""
+        """Open graph collection by resolving db_path (fallback path).
+
+        Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+        when present — the same source ``_get_db()`` uses — so the graph
+        database is opened with the same engine configuration.
+        """
         resolved_path = db_path or _infer_db_path(self._index)
         if resolved_path is None:
             raise ValueError(
                 "Native mode requires 'db_path' or an index whose vector store "
                 "exposes a '_db_path' / '_path' attribute."
             )
-        return open_native_graph(resolved_path, collection_name)
+        try:
+            vs = self._index._vector_store
+        except AttributeError:
+            vs = None
+        config = getattr(vs, "_config", None)
+        return open_native_graph(resolved_path, collection_name, config=config)
 
     def _infer_collection_name(self) -> str:
         """Try to infer collection name from the index's vector store."""

--- a/integrations/llamaindex/src/llamaindex_velesdb/memory.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/memory.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, List, Optional, Union
 
 import velesdb
 
-from llamaindex_velesdb._common import make_initial_id_counter
+from llamaindex_velesdb._common import (
+    make_initial_id_counter,
+    open_database as _open_database,
+)
 from velesdb_common.memory import (
     chronological,
     format_procedural_results,
@@ -38,10 +41,15 @@ class _VelesDBMemoryBase:
     ``db_path`` validation and ``agent_memory`` setup in every ``__init__``.
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
         if not db_path:
             raise ValueError("db_path must not be empty")
-        self._db = velesdb.Database(db_path)
+        self._db = _open_database(db_path, config)
         self._dimension = dimension
         self._memory = self._db.agent_memory(dimension=dimension)
 
@@ -55,6 +63,9 @@ class VelesDBSemanticMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBSemanticMemory(db_path="./data", dimension=768)
@@ -127,6 +138,9 @@ class VelesDBEpisodicMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBEpisodicMemory(db_path="./data")
@@ -134,8 +148,13 @@ class VelesDBEpisodicMemory(_VelesDBMemoryBase):
         >>> recent = memory.recall(query_embedding, top_k=5)
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
-        super().__init__(db_path, dimension)
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
+        super().__init__(db_path, dimension, config)
         self._event_counter = make_initial_id_counter()
 
     def record_event(
@@ -252,6 +271,9 @@ class VelesDBChatMemory(_VelesDBMemoryBase):
         dimension: Embedding dimension of the underlying store (default: 384).
         human_prefix: Prefix used for human turns in the string view.
         ai_prefix: Prefix used for AI turns in the string view.
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBChatMemory(db_path="./chat")
@@ -266,8 +288,9 @@ class VelesDBChatMemory(_VelesDBMemoryBase):
         dimension: int = 384,
         human_prefix: str = "Human",
         ai_prefix: str = "AI",
+        config: Optional[velesdb.VelesConfigOptions] = None,
     ) -> None:
-        super().__init__(db_path, dimension)
+        super().__init__(db_path, dimension, config)
         self._human_prefix = human_prefix
         self._ai_prefix = ai_prefix
         self._message_counter = make_initial_id_counter()
@@ -372,6 +395,9 @@ class VelesDBProceduralMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBProceduralMemory(db_path="./data", dimension=384)
@@ -381,8 +407,13 @@ class VelesDBProceduralMemory(_VelesDBMemoryBase):
         >>> memory.reinforce("deploy_app", success=True)
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
-        super().__init__(db_path, dimension)
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
+        super().__init__(db_path, dimension, config)
         self._name_to_id: Dict[str, int] = {}
         self._id_counter = make_initial_id_counter()
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -32,6 +32,7 @@ from llamaindex_velesdb.security import (
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
+from llamaindex_velesdb._common import open_database as _open_database
 from llamaindex_velesdb.filter_ops import metadata_filters_to_core_filter
 from llamaindex_velesdb.node_builder import (
     validate_all_embeddings as _validate_all_embeddings,
@@ -121,6 +122,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     _collection: Optional[velesdb.Collection] = PrivateAttr(default=None)
     _dimension: Optional[int] = PrivateAttr(default=None)
     _search_quality: Optional[str] = PrivateAttr(default=None)
+    _config: Optional[velesdb.VelesConfigOptions] = PrivateAttr(default=None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -131,6 +133,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         metric: str = "cosine",
         storage_mode: str = "full",
         search_quality: Optional[str] = None,
+        config: Optional[velesdb.VelesConfigOptions] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -160,6 +163,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
                 ``"autotune"``, ``"custom:N"``, ``"adaptive:MIN:MAX"``.
                 ``None`` uses the built-in search. Per-call override:
                 pass ``search_quality=`` to :meth:`query`.
+            config: Optional :class:`velesdb.VelesConfigOptions` engine
+                configuration, forwarded verbatim to ``velesdb.Database``
+                when the connection is opened. ``None`` (default) keeps the
+                engine defaults — the database is opened exactly as before.
             **kwargs: Additional arguments.
 
         Raises:
@@ -191,6 +198,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             **kwargs,
         )
         self._search_quality = validated_quality
+        self._config = config
 
     # ------------------------------------------------------------------
     # Static / class helpers
@@ -256,7 +264,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     def _get_db(self) -> velesdb.Database:
         """Get or create the database connection."""
         if self._db is None:
-            self._db = velesdb.Database(self.path)
+            self._db = _open_database(self.path, self._config)
         return self._db
 
     def _get_collection(self, dimension: int) -> velesdb.Collection:

--- a/integrations/llamaindex/tests/test_config_passthrough.py
+++ b/integrations/llamaindex/tests/test_config_passthrough.py
@@ -16,6 +16,7 @@ try:
     import velesdb
     from llamaindex_velesdb import VelesDBVectorStore
     from llamaindex_velesdb.graph_loader import GraphLoader
+    from llamaindex_velesdb.graph_retriever import GraphRetriever
     from llamaindex_velesdb.memory import (
         VelesDBChatMemory,
         VelesDBEpisodicMemory,
@@ -107,6 +108,43 @@ class TestMemoryConfigPassthrough:
     )
     def test_no_config_call_unchanged(self, tmp_path, recording_db, memory_cls):
         memory_cls(db_path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class _StoreWithoutGetDb:
+    """Fake vector store lacking _get_db, forcing the open_native_graph path."""
+
+    def __init__(self, path: str, config: Any = None) -> None:
+        self._path = path
+        self._config = config
+
+
+class _FakeIndex:
+    """Fake VectorStoreIndex exposing only a vector store."""
+
+    def __init__(self, vector_store: Any) -> None:
+        self._vector_store = vector_store
+
+
+class TestGraphRetrieverConfigPassthrough:
+    """GraphRetriever's path fallback forwards the store's config."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = _StoreWithoutGetDb(str(tmp_path), config=config)
+        GraphRetriever(
+            index=_FakeIndex(store),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = _StoreWithoutGetDb(str(tmp_path))
+        GraphRetriever(
+            index=_FakeIndex(store),
+            mode="native",
+            graph_collection_name="kg",
+        )
         assert recording_db.calls == [((str(tmp_path),), {})]
 
 

--- a/integrations/llamaindex/tests/test_config_passthrough.py
+++ b/integrations/llamaindex/tests/test_config_passthrough.py
@@ -1,0 +1,126 @@
+"""Tests for VelesConfigOptions pass-through to velesdb.Database.
+
+Covers issue #1549: every entry point that opens a ``velesdb.Database``
+must accept an optional ``config`` and forward it verbatim, while the
+no-config path must keep calling ``velesdb.Database(path)`` exactly as
+before.
+
+Run with: pytest tests/test_config_passthrough.py -v
+"""
+
+from typing import Any, List, Tuple
+
+import pytest
+
+try:
+    import velesdb
+    from llamaindex_velesdb import VelesDBVectorStore
+    from llamaindex_velesdb.graph_loader import GraphLoader
+    from llamaindex_velesdb.memory import (
+        VelesDBChatMemory,
+        VelesDBEpisodicMemory,
+        VelesDBProceduralMemory,
+        VelesDBSemanticMemory,
+    )
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+class _FakeAgentMemory:
+    """Minimal stand-in for the agent memory service."""
+
+    def __init__(self) -> None:
+        self.episodic = object()
+        self.semantic = object()
+        self.procedural = object()
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls: List[Tuple[tuple, dict]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).calls.append((args, kwargs))
+
+    def agent_memory(self, dimension: int = 384) -> _FakeAgentMemory:
+        return _FakeAgentMemory()
+
+    def get_graph_collection(self, name: str) -> Any:
+        return object()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+@pytest.fixture
+def config() -> Any:
+    """A real VelesConfigOptions instance (opaque pass-through payload)."""
+    return velesdb.VelesConfigOptions()
+
+
+class TestVectorStoreConfigPassthrough:
+    """VelesDBVectorStore forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(path=str(tmp_path), config=config)
+        store._get_db()
+        assert recording_db.calls == [((store.path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(path=str(tmp_path))
+        store._get_db()
+        assert recording_db.calls == [((store.path,), {})]
+
+
+class TestMemoryConfigPassthrough:
+    """All four memory classes forward config to velesdb.Database."""
+
+    @pytest.mark.parametrize(
+        "memory_cls",
+        [
+            VelesDBSemanticMemory,
+            VelesDBEpisodicMemory,
+            VelesDBChatMemory,
+            VelesDBProceduralMemory,
+        ],
+    )
+    def test_config_forwarded_to_database(
+        self, tmp_path, recording_db, config, memory_cls
+    ):
+        memory_cls(db_path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    @pytest.mark.parametrize(
+        "memory_cls",
+        [
+            VelesDBSemanticMemory,
+            VelesDBEpisodicMemory,
+            VelesDBChatMemory,
+            VelesDBProceduralMemory,
+        ],
+    )
+    def test_no_config_call_unchanged(self, tmp_path, recording_db, memory_cls):
+        memory_cls(db_path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestGraphLoaderConfigPassthrough:
+    """GraphLoader reuses the vector store's config for the native graph DB."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(path=str(tmp_path), config=config)
+        recording_db.calls = []
+        GraphLoader(store, graph_collection_name="kg")
+        assert recording_db.calls == [((store.path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(path=str(tmp_path))
+        recording_db.calls = []
+        GraphLoader(store, graph_collection_name="kg")
+        assert recording_db.calls == [((store.path,), {})]


### PR DESCRIPTION
Closes #1549

Completes the VelesConfig-at-open campaign started by #1565 (server/CLI): the four remaining surfaces can now open the engine with an explicit, validated configuration instead of silently running on core defaults. All four follow the same pattern — engine-only TOML loaders (`load_from_path_engine_only` / `from_toml_engine_only`), fail-fast validation, typed `ConfigError` preserved.

## Per surface

- **tauri-plugin-velesdb** — plugin `Builder` (`with_config` / `with_config_path`, fail-fast at build time), 4 observer×config open combinations, typed `Error::ConfigLoad`, `VelesConfig` re-exported. 8 new tests (red-first: E0603/E0599 before impl).
- **velesdb-mobile** — `open_with_config(_toml)` / `open_with_observer_and_config(_toml)` UniFFI constructors (file path + embedded TOML string variants), `ConfigError` → `VELES-009` through the flat FFI error. 8 new tests (red-first: 7×E0599).
- **velesdb-python** — full engine coverage of `VelesConfigOptions`: new `SearchConfigOptions` / `HnswConfigOptions` / `StorageOptions` / `QuantizationOptions` + `from_toml` / `from_toml_path`; validation raises at construction or open, never silent; `wal_batch` intentionally unexposed (Enterprise). Stubs, pure-python adapter, README updated. 31 new pytest cases red-first + 11 Rust unit tests; full binding suite 545 passed.
- **langchain / llamaindex** — `config: Optional[velesdb.VelesConfigOptions]` pass-through on every Database-creating entry point (stores, 4 memory classes each, native GraphLoader) plus the shared `velesdb_common.graph.open_native_graph`. `None` = bit-for-bit previous call. Suites: common 106, langchain 235, llamaindex 240 passed (all red-first).

## Integration validation (on the merged branch)

- `cargo fmt --all --check` clean; CI-exact clippy (`--workspace --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -D warnings -D clippy::pedantic`) clean
- `cargo test -p tauri-plugin-velesdb -p velesdb-mobile`: 248 passed, 0 failed
- Python-side suites run per-package as listed above

## Release note

`velesdb-common` version floor in langchain/llamaindex `pyproject.toml` must be bumped to the release version at release-prep time (both now call `open_native_graph(..., config=...)`).