### PR TITLE
docs(hooks): HTTPS pushurl is the SIGPIPE countermeasure (supersedes #1572)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,14 +8,16 @@
 # Pour activer: git config core.hooksPath .githooks
 #
 # NOTE SIGPIPE (exit 141): git ouvre la connexion au remote AVANT de lancer ce
-# hook et envoie le pack APRÈS sur la même connexion SSH. La validation
-# complète (~15 min) dépasse le timeout d'inactivité de la connexion, qui meurt
-# pendant les checks — git écrit alors dans un pipe fermé et sort en 141 sans
-# message, après "PASSED". Contre-mesures ici:
+# hook et envoie le pack APRÈS sur la même connexion. Si cette connexion SSH
+# meurt pendant la validation complète (~15 min), git écrit dans un pipe fermé
+# et sort en 141 sans message, après "PASSED" — le transfert n'a jamais lieu.
+# Contre-mesures ici:
 #   - stdin (liste des refs) est drainé AVANT les checks, et les sous-processus
 #     cargo reçoivent </dev/null pour ne pas consommer le pipe de git;
-#   - des keepalives SSH doivent maintenir la connexion pendant les checks:
-#     git config core.sshCommand "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=60"
+#   - pousser en HTTPS rend la coupure sans effet (advertisement et envoi du
+#     pack sont deux requêtes indépendantes, la connexion est rétablie):
+#     git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+#     git config credential.helper '!gh auth git-credential'
 # =============================================================================
 
 set -e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,17 @@ Or use the local CI script: `.\scripts\local-ci.ps1` (Full) or `.\scripts\local-
 
 Git hooks are provided in `.githooks/` — activate with: `git config core.hooksPath .githooks`
 
+> **Note (SSH pushes):** the pre-push hook runs the full validation (~15 min) while
+> git already holds the connection to GitHub open; if that SSH connection dies in
+> the meantime, `git push` exits 141 (SIGPIPE) with no error message right after
+> the validation passes. Pushing over HTTPS is immune (the ref advertisement and
+> the pack upload are independent requests):
+>
+> ```
+> git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+> git config credential.helper '!gh auth git-credential'
+> ```
+
 ## Development Setup
 
 ### Prerequisites

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -243,6 +243,10 @@ Runs automatically before each `git commit`:
 
 Activate with: `git config core.hooksPath .githooks`
 
+When pushing over SSH, also configure an HTTPS push URL so the long pre-push
+validation cannot kill the connection before the transfer (see CONTRIBUTING.md,
+"Note (SSH pushes)").
+
 ---
 
 ## Relationship with VelesDB-Premium


### PR DESCRIPTION
Rebase-free carry of #1572's remaining delta. The hook body rewrite already merged via #1567; what remained in #1572 was the **refined diagnosis** from the instrumented reproduction (idle-timeout hypothesis refuted; SSH keepalives unreliable — the pack upload reuses the pre-hook SSH connection, so HTTPS pushurl is the structural fix) plus the contributor-facing docs. This PR applies exactly that delta on current develop: hook header updated (keepalive advice → HTTPS pushurl recipe), CONTRIBUTING.md note, PROJECT_STRUCTURE.md pointer. Credit: the investigation and text come from the #1572 session.