### PR TITLE
fix(memory): harness-proof MCP tool parameter wire contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-memory` (MCP)**: tool parameters are now harness-proof on both
+  wire directions. Real MCP client harnesses were observed serializing
+  non-string arguments as JSON-encoded strings once their view of the
+  advertised schema degraded — `save_working_context`'s `working` object
+  arrived as `"{\"goal\": ...}"` and the call failed with `invalid type:
+  string, expected struct WorkingContext`, silently losing session
+  handoffs; `recall_fused` rejected `limit: "6"` and stringified `filter`
+  objects the same way. Two-sided fix, same defensive-interop class as the
+  #1468 string-id contract: (1) `$ref`-only top-level parameter schemas are
+  now inlined so every parameter advertises a direct `type` keyword
+  (`working` exposes `type: object`); (2) a lenient deserializer on every
+  non-string tool parameter accepts the properly-typed value first and
+  falls back to parsing a JSON-encoded string, with a precise error when
+  neither form fits.
 - **`velesdb-wasm`**: the VelesQL JOIN executor no longer depends on which
   side of the `ON` condition names the joined table. `ON joined.col =
   base.col` used to match nothing (NULL joined columns on every row);

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -38,6 +38,7 @@ use crate::extract::DynExtractor;
 mod context_tools;
 
 mod dto;
+mod wire;
 use dto::{
     ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, RecallFusedParams,
     RecallFusedResult, RecallParams, RecallResult, RecallWhereParams, RelateParams, RelateResult,

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -81,6 +81,7 @@ fn wire_safe_input_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
     });
     let mut map = (*schema).clone();
     crate::schema::widen_id_properties(&mut map, &["id"]);
+    crate::schema::inline_ref_only_properties(&mut map);
     Arc::new(map)
 }
 
@@ -99,6 +100,7 @@ pub(super) struct ContextSavingsParams {
 pub(super) struct ExplainCompilationParams {
     /// The compile request to explain (compilation is deterministic, so
     /// re-submitting the request reproduces the exact decisions).
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub request: CompileRequest,
     /// The fragment whose decision to return. Looked up by matching
     /// `ContextDecision::fragment_id`, UNLESS `fragment_index` is also
@@ -114,7 +116,11 @@ pub(super) struct ExplainCompilationParams {
     /// lookup always returns the FIRST such decision (the deduplication
     /// survivor), never a dropped twin's. Absent (the default): behavior is
     /// unchanged, the decision is found by `fragment_id` alone.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub fragment_index: Option<usize>,
 }
 
@@ -151,6 +157,7 @@ pub(super) struct SaveWorkingContextParams {
     /// The distilled state to persist: goal, active constraints, verified
     /// facts, open hypotheses, decisions taken, exact evidence, and pending
     /// actions.
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub working: WorkingContext,
 }
 
@@ -231,6 +238,7 @@ pub(super) struct CompileTranscriptParams {
     pub path: Option<String>,
     /// Hard token ceiling for the assembled content, same as
     /// `compile_context`'s `token_budget`.
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub token_budget: u64,
     /// Project facet, recorded in provenance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -245,7 +253,11 @@ pub(super) struct CompileTranscriptParams {
     /// Tuning knobs for the transcript segmentation step itself (format,
     /// merge threshold, system-turn caching). `None` uses
     /// [`SegmentationPolicy::default`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub segmentation: Option<SegmentationPolicy>,
 }
 
@@ -328,7 +340,11 @@ pub(super) struct SuggestBudgetParams {
     /// Tokens to reserve for the response, subtracted from the model's
     /// window (default `0`) — mirrors
     /// [`CompilePolicy::response_reserve_tokens`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub reserve_tokens: Option<u64>,
 }
 
@@ -587,7 +603,8 @@ impl McpServer {
 
     #[tool(
         name = "save_working_context",
-        description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Serialized size is capped at 1 MiB. Returns the stored fact's id."
+        description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Serialized size is capped at 1 MiB. Returns the stored fact's id.",
+        input_schema = wire_safe_input_schema::<SaveWorkingContextParams>()
     )]
     async fn save_working_context(
         &self,

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -1197,3 +1197,34 @@ async fn test_compile_transcript_rejects_empty_file_same_as_empty_inline_transcr
     assert_eq!(inline_err.code, ErrorCode::INVALID_PARAMS);
     assert_eq!(path_err.message, inline_err.message);
 }
+
+/// Harness-proof schema contract for `save_working_context` (observed
+/// 2026-07-24: a real MCP harness sent `working` as a JSON-encoded string —
+/// `invalid type: string, expected struct WorkingContext` — after degrading
+/// a `$ref`-only property to "untyped"). The `working` property must carry
+/// a DIRECT `type: object` keyword, not only a `$ref`.
+#[test]
+fn test_save_working_context_input_schema_declares_object_working_directly() {
+    let tool = McpServer::save_working_context_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+    let working = &schema["properties"]["working"];
+    assert_eq!(
+        working["type"],
+        serde_json::json!("object"),
+        "`working` must advertise a direct `type: object` (a $ref-only \
+         schema gets stringified by real MCP harnesses); got: {working}"
+    );
+}
+
+/// Server-side tolerance half (same wire-contract class as issue #1468):
+/// a harness that DID stringify the `working` object must still be served.
+#[test]
+fn test_save_working_context_params_accept_stringified_working() {
+    let params: SaveWorkingContextParams = serde_json::from_value(serde_json::json!({
+        "project": "veles",
+        "session": "s1",
+        "working": "{\"goal\": \"resume the campaign\"}"
+    }))
+    .expect("a JSON-encoded `working` string must deserialize");
+    assert_eq!(params.working.goal.as_deref(), Some("resume the campaign"));
+}

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -30,16 +30,17 @@ pub(super) struct RememberParams {
     /// The fact to store in memory.
     pub(super) fact: String,
     /// Optional typed links from this fact to existing memories.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) links: Vec<Link>,
     /// Optional structured metadata for later filtering (e.g.
     /// `{"project": "veles", "author": "julien", "status": "open"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) metadata: Option<Metadata>,
     /// Optional time-to-live in seconds. When set, the fact expires (and stops
     /// being recalled) after this many seconds — a durable TTL that survives a
     /// restart. Omit for a permanent memory. Falls back to the server's
     /// `VELESDB_MEMORY_DEFAULT_TTL` when unset.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) ttl_seconds: Option<u64>,
 }
 
@@ -63,9 +64,11 @@ pub(super) struct RecallParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
     /// Maximum number of memories to return (default 10).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
 }
 
@@ -128,6 +131,7 @@ pub(super) struct RecallWhereParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
     /// Maximum number of memories to return (default 10).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Structured `ColumnStore` predicates (ranges/comparisons) combined with AND,
     /// e.g. a date window `[{"field":"ts","op":"ge","value":20230101},
@@ -137,7 +141,7 @@ pub(super) struct RecallWhereParams {
     /// as-is — a numeric `20230101` never matches a fact stored with
     /// `{"ts": "20230101"}` (a string). Store comparable values (dates,
     /// counters) NUMERICALLY at `remember` time so these filters match them.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filters: Vec<ColumnFilter>,
 }
 
@@ -150,16 +154,20 @@ pub(super) struct RecallFusedParams {
     /// Maximum number of memories to return (default 10). Multi-hop reasoning
     /// benefits from a larger budget (~32-64); simple and temporal recall
     /// saturate early, where a larger budget only adds tokens.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
     /// Graph hops walked from the top vector hit (default 2). Higher reaches
     /// further but adds noise; capped at the `why` hop ceiling.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) hops: Option<usize>,
     /// Weight added to a graph-reached fact's normalised vector score
     /// (default 0.15). Raise to trust the graph more, lower to trust vector
     /// similarity more.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) graph_boost: Option<f64>,
     /// Name of the metadata field holding each fact's date as a `YYYYMMDD`
     /// integer (e.g. `"ts"`, `"occurred_at"`). When set, the result adds a
@@ -270,6 +278,7 @@ pub(super) struct FeedbackParams {
     pub(super) id: u64,
     /// `true` if the memory was useful (reinforce it), `false` if it was noise
     /// (weaken it).
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub(super) success: bool,
 }
 
@@ -293,9 +302,11 @@ pub(super) struct WhyParams {
     /// The decision (or fact) to explain.
     pub(super) decision: String,
     /// How many hops of typed links to follow (default 2).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) max_hops: Option<usize>,
     /// Optional exact-match metadata filter to scope the seed (e.g.
     /// `{"project": "veles"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
 }
 
@@ -390,6 +401,7 @@ pub(super) struct RememberExtractedParams {
     /// Raw text to extract atomic facts from and store as a connected graph.
     pub(super) text: String,
     /// Optional structured metadata applied to every extracted fact.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) metadata: Option<Metadata>,
 }
 

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1126,3 +1126,56 @@ fn test_recall_where_description_documents_type_strict_comparisons() {
          (e.g. dates) numerically: {description}"
     );
 }
+
+/// Issue: real MCP client harnesses (observed 2026-07-24 with Claude Code)
+/// degrade a parameter whose advertised schema carries no DIRECT `type`
+/// keyword — `anyOf`-wrapped optionals and `$ref`-only structs both come out
+/// untyped on the client side, and the harness then serializes the argument
+/// as a JSON-encoded STRING (`limit: "6"`, `filter: "{\"project\":...}"`),
+/// which the server rejects. Same wire-contract class as issue #1468
+/// (u64 ids vs float-lossy clients): the schema must be harness-proof, not
+/// merely spec-correct.
+///
+/// This test locks the contract for every optional scalar/object parameter
+/// of the recall family: each property's schema must expose a direct
+/// `type` keyword.
+#[test]
+fn test_recall_fused_input_schema_types_every_parameter_directly() {
+    let tool = McpServer::recall_fused_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+    let properties = schema["properties"]
+        .as_object()
+        .expect("recall_fused input schema must have properties");
+    for (name, subschema) in properties {
+        assert!(
+            subschema.get("type").is_some(),
+            "recall_fused parameter `{name}` must advertise a direct `type` \
+             keyword (anyOf/$ref-only schemas get stringified by real MCP \
+             harnesses); got: {subschema}"
+        );
+    }
+}
+
+/// Server-side tolerance half of the harness-proof contract: a client that
+/// DID stringify a scalar or object argument (today's Claude Code harness
+/// does exactly that for schema-degraded parameters) must still be served.
+/// Mirrors the #1468 string-id acceptance.
+#[test]
+fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
+    let params: RecallFusedParams = serde_json::from_value(serde_json::json!({
+        "query": "q",
+        "limit": "6",
+        "hops": "2",
+        "graph_boost": "0.15",
+        "filter": "{\"project\": \"velesdb\"}"
+    }))
+    .expect("stringified scalar/object arguments must deserialize");
+    assert_eq!(params.limit, Some(6));
+    assert_eq!(params.hops, Some(2));
+    assert!((params.graph_boost.unwrap() - 0.15).abs() < f64::EPSILON);
+    let filter = params.filter.expect("filter must parse from a JSON string");
+    assert_eq!(
+        filter.get("project").and_then(|v| v.as_str()),
+        Some("velesdb")
+    );
+}

--- a/crates/velesdb-memory/src/mcp/wire.rs
+++ b/crates/velesdb-memory/src/mcp/wire.rs
@@ -1,0 +1,47 @@
+//! Lenient wire-side deserialization for MCP tool parameters.
+//!
+//! Real MCP client harnesses (observed 2026-07-24 with Claude Code) can
+//! serialize a non-string tool argument as a JSON-encoded STRING when their
+//! own view of the advertised schema has degraded to "untyped" — `limit: 6`
+//! arrives as `"6"`, `filter: {"project": "x"}` as `"{\"project\": \"x\"}"`,
+//! and `save_working_context`'s whole `working` object as one escaped JSON
+//! string. Rejecting those loses the call (and, for `save_working_context`,
+//! silently loses a session handoff).
+//!
+//! [`lenient`] is the server-side half of the harness-proof wire contract
+//! (the schema half is `crate::schema::inline_ref_only_properties`): accept
+//! the properly-typed JSON value first, and fall back to parsing a string
+//! argument AS JSON into the target type. Same defensive-interop class as
+//! the #1468 string-or-number id contract in `crate::context::wire`.
+//!
+//! Never applied to genuinely string-typed parameters — a real string must
+//! not be re-interpreted as JSON.
+
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer};
+
+/// Deserializes `T` from either its proper JSON representation or from a
+/// JSON-encoded string containing it. The non-string path is byte-for-byte
+/// the plain serde behaviour; the error of the direct interpretation is the
+/// one reported when the string fallback fails too, so a genuinely malformed
+/// argument keeps a precise message.
+pub(super) fn lenient<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    match raw {
+        serde_json::Value::String(text) => serde_json::from_str(&text).map_err(|err| {
+            DeError::custom(format!(
+                "argument arrived as a JSON-encoded string and could not be \
+                 parsed as the expected type: {err}"
+            ))
+        }),
+        value => serde_json::from_value(value).map_err(DeError::custom),
+    }
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/mcp/wire_tests.rs
+++ b/crates/velesdb-memory/src/mcp/wire_tests.rs
@@ -1,0 +1,60 @@
+//! Unit tests for the lenient MCP parameter deserializer.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Probe {
+    #[serde(default, deserialize_with = "super::lenient")]
+    limit: Option<usize>,
+    #[serde(default, deserialize_with = "super::lenient")]
+    flag: Option<bool>,
+    #[serde(default, deserialize_with = "super::lenient")]
+    map: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[test]
+fn test_lenient_passes_proper_types_through_unchanged() {
+    let probe: Probe = serde_json::from_value(serde_json::json!({
+        "limit": 6, "flag": true, "map": {"k": "v"}
+    }))
+    .expect("proper types must keep deserializing");
+    assert_eq!(probe.limit, Some(6));
+    assert_eq!(probe.flag, Some(true));
+    assert_eq!(
+        probe.map.unwrap().get("k").and_then(|v| v.as_str()),
+        Some("v")
+    );
+}
+
+#[test]
+fn test_lenient_parses_stringified_arguments() {
+    let probe: Probe = serde_json::from_value(serde_json::json!({
+        "limit": "6", "flag": "true", "map": "{\"k\": \"v\"}"
+    }))
+    .expect("stringified arguments must parse as JSON");
+    assert_eq!(probe.limit, Some(6));
+    assert_eq!(probe.flag, Some(true));
+    assert_eq!(
+        probe.map.unwrap().get("k").and_then(|v| v.as_str()),
+        Some("v")
+    );
+}
+
+#[test]
+fn test_lenient_missing_fields_stay_none() {
+    let probe: Probe =
+        serde_json::from_value(serde_json::json!({})).expect("missing fields default");
+    assert_eq!(probe.limit, None);
+    assert_eq!(probe.flag, None);
+    assert!(probe.map.is_none());
+}
+
+#[test]
+fn test_lenient_rejects_garbage_strings_with_a_precise_error() {
+    let err = serde_json::from_value::<Probe>(serde_json::json!({ "limit": "six" }))
+        .expect_err("a non-JSON string must still fail");
+    assert!(
+        err.to_string().contains("JSON-encoded string"),
+        "error must explain the string fallback: {err}"
+    );
+}

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -114,6 +114,72 @@ fn widen_id_schema(schema: &mut Value) {
     }
 }
 
+/// Inline every top-level property whose schema is a bare `$ref` (or a
+/// single-element `allOf` wrapping one) into the referenced `$defs` entry,
+/// so the property carries a DIRECT `type` keyword.
+///
+/// Real MCP client harnesses (observed 2026-07-24 with Claude Code) degrade
+/// a `$ref`-only parameter to "untyped" and then serialize the argument as a
+/// JSON-encoded string — `save_working_context`'s `working` object arrived
+/// as `"{\"goal\": ...}"` and failed with `invalid type: string, expected
+/// struct WorkingContext`. Same wire-contract class as the #1468 float-lossy
+/// id fix: the advertised schema must be harness-proof, not merely
+/// spec-correct. Sibling keywords on the property (e.g. `description`)
+/// override the inlined definition's; properties that already expose a
+/// `type` are left untouched. One level only — nested `$refs` inside the
+/// inlined definition are not chased (only top-level tool parameters are
+/// serialized one by one by a harness).
+///
+/// `mcp`-gated: the advertised tool schemas are its only consumer.
+#[cfg(feature = "mcp")]
+pub(crate) fn inline_ref_only_properties(map: &mut Map<String, Value>) {
+    let Some(Value::Object(defs)) = map.get("$defs").cloned() else {
+        return;
+    };
+    let Some(Value::Object(properties)) = map.get_mut("properties") else {
+        return;
+    };
+    for subschema in properties.values_mut() {
+        let Value::Object(prop) = subschema else {
+            continue;
+        };
+        if prop.contains_key("type") {
+            continue;
+        }
+        let Some(name) = ref_only_target(prop) else {
+            continue;
+        };
+        let Some(Value::Object(definition)) = defs.get(&name) else {
+            continue;
+        };
+        let mut merged = definition.clone();
+        for (key, value) in prop.iter() {
+            if key != "$ref" && key != "allOf" {
+                merged.insert(key.clone(), value.clone());
+            }
+        }
+        *prop = merged;
+    }
+}
+
+/// Resolves the `#/$defs/<Name>` target of a `$ref`-only property schema:
+/// either a direct `$ref` keyword or a single-element `allOf` wrapping one.
+#[cfg(feature = "mcp")]
+fn ref_only_target(prop: &Map<String, Value>) -> Option<String> {
+    let reference = match (prop.get("$ref"), prop.get("allOf")) {
+        (Some(Value::String(r)), _) => r.clone(),
+        (None, Some(Value::Array(items))) if items.len() == 1 => match &items[0] {
+            Value::Object(inner) => match inner.get("$ref") {
+                Some(Value::String(r)) => r.clone(),
+                _ => return None,
+            },
+            _ => return None,
+        },
+        _ => return None,
+    };
+    reference.strip_prefix("#/$defs/").map(str::to_owned)
+}
+
 fn is_rust_int_format(format: &str) -> bool {
     matches!(
         format,


### PR DESCRIPTION
Closes #1575

## Problem

Real MCP client harnesses (observed live 2026-07-24 with Claude Code) serialize non-string tool arguments as **JSON-encoded strings** once their view of the advertised schema degrades: `save_working_context`'s `working` object arrived as `"{\"goal\": ...}"` (→ `invalid type: string, expected struct WorkingContext`, silently losing session handoffs), and `recall_fused` rejected `limit: "6"` and stringified `filter` objects. Reproduced live against the running server. Same wire-contract class as the #1468 float-lossy id fix.

## Fix (two-sided)

- **Schema half** — `schema::inline_ref_only_properties`: every top-level parameter whose schema is a bare `$ref` (or single-element `allOf` wrapper) is inlined into its `$defs` entry so it advertises a direct `type` keyword. Wired into `wire_safe_input_schema`; `save_working_context` now uses it and `working` exposes `type: object`. Ground truth before the fix: `{"$ref":"#/$defs/WorkingContext","description":…}` with no `type`.
- **Wire half** — `mcp::wire::lenient`: accepts the properly-typed value first, falls back to parsing a JSON-encoded string argument; applied to every non-string tool parameter (limits, hops, graph_boost, filters, metadata, links, ttl, booleans, nested `request`/`working`/`segmentation` structs). Genuinely malformed strings keep a precise error naming the fallback.

## TDD

Red-first, all verified failing before the fix:
- `test_save_working_context_input_schema_declares_object_working_directly` (was `$ref`-only)
- `test_save_working_context_params_accept_stringified_working`
- `test_recall_fused_params_accept_stringified_scalars_and_objects`
- (`test_recall_fused_input_schema_types_every_parameter_directly` — already green, kept as a contract lock)

Plus 4 wire unit tests (pass-through, string fallback, defaults, error path).

## Validation

- `cargo test -p velesdb-memory --features mcp --lib`: **361 passed, 0 failed**
- `cargo clippy -p velesdb-memory --all-targets --features mcp,context -D warnings -D clippy::pedantic`: clean; `cargo fmt --check`: clean

## Release note

Ships on the velesdb-memory track (0.11.x) — candidate for a `velesdb-memory-v0.11.1` patch tag after merge; independent of the core 4.0.0 train but merged before the cut per the no-deferral policy.