### PR TITLE
feat(memory): guided Claude Desktop onboarding — auto-wired mcp-remote bridge with strict TLS

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -15,14 +15,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`~/.config/devin/config.json`) alongside Claude Code, Claude Desktop and
   Windsurf; documented in the README's stdio and HTTP-transport client
   sections.
+- Both installers now wire **Claude Desktop** automatically (macOS and
+  Windows): an `mcp-remote` stdio→HTTPS bridge entry is written into
+  `claude_desktop_config.json` (non-destructive merge, timestamped backup)
+  with `NODE_EXTRA_CA_CERTS` pointing at the daemon's local CA, so the bridge
+  verifies TLS strictly — no manual proxy setup, no
+  `NODE_TLS_REJECT_UNAUTHORIZED=0`. The exact TLS path the bridge will use is
+  probed (Node HTTPS request to `/health` with `NODE_EXTRA_CA_CERTS`) before
+  the entry is written; absolute command paths are resolved so Desktop's
+  shell-less, minimal-`PATH` spawn works. Without Node.js the installers fall
+  back to printing the Settings → Connectors instructions. Documented in the
+  README's new "Claude Desktop (macOS / Windows)" section (happy path,
+  troubleshooting, CA-trust removal).
+- `--wire-only` (`.sh`) / `-WireOnly` (`.ps1`): re-verify CA trust and
+  re-wire all clients against an already-installed daemon — no build, no
+  daemon restart, no interactive prompts.
 
 ### Fixed
 
 - The installer no longer writes a `type:"http"` entry into
   `claude_desktop_config.json` — confirmed Desktop's config file never reads
-  that shape (silently ignored). It now prints the Settings → Connectors →
-  Add custom connector instructions instead, matching what the README already
-  documented.
+  that shape (silently ignored). Superseded in this same release by the
+  `mcp-remote` bridge entry above, which Desktop's config file *does* read.
+- The CA-trust step on both platforms now **verifies** after trusting instead
+  of assuming: a strict HTTPS request to the daemon (no `--cacert`, i.e.
+  against the OS trust store) must succeed, and a trust command that exits 0
+  without actually taking effect is reported with the exact command to re-run
+  by hand. (Follows up the idempotency ground-truth check from #1537.)
 
 ### Changed
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -575,30 +575,112 @@ claude mcp add --transport http velesdb-memory https://127.0.0.1:18090/mcp
 } } }
 ```
 
-**Claude Desktop** — a different mechanism than every other client above.
+### Claude Desktop (macOS / Windows)
 
-Desktop's local config file (`claude_desktop_config.json`) only recognizes
-stdio (`command`) entries — a `url`/`type: "http"` block there is silently
-ignored (confirmed: it does not even try to connect). Use Desktop's own UI
-instead: **Settings → Connectors → Add custom connector**, paste the daemon
-URL directly:
+Claude Desktop is a different mechanism than every other client above, twice
+over:
 
+- its local config file (`claude_desktop_config.json`) only recognizes stdio
+  (`command`) entries — a `url`/`type: "http"` block there is silently
+  ignored (confirmed: it does not even try to connect);
+- its **Settings → Connectors → Add custom connector** UI accepts an
+  `https://` URL, but verifies TLS through its own Chromium/Node stack, which
+  does **not** reliably consult the OS keychain/certificate store — so even
+  after the CA-trust step above, the UI path can still refuse the daemon's
+  certificate.
+
+The installers therefore wire Desktop through a **stdio→HTTPS bridge**:
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (needs Node.js),
+spawned by Desktop over stdio, connecting to the daemon over HTTPS with
+`NODE_EXTRA_CA_CERTS` pointed at the daemon's CA so TLS is verified
+*strictly* (never `NODE_TLS_REJECT_UNAUTHORIZED=0`, which disables
+verification entirely). The bridge is a plain HTTPS client of the daemon —
+it never opens the store itself, so there is no `flock` conflict.
+
+**Happy path** — run the installer, restart Desktop, done:
+
+```bash
+# macOS
+./scripts/install-memory-daemon.sh
 ```
-https://127.0.0.1:18090/mcp
+
+```powershell
+# Windows
+pwsh -File scripts/install-memory-daemon.ps1
 ```
 
-No API key/OAuth secret needed — the daemon binds to loopback only. This
-requires HTTPS specifically (Desktop's connector dialog rejects a plain
-`http://` URL outright, even for `127.0.0.1`), which is exactly what this
-daemon serves by default — see "trusting the local CA" earlier in this
-section if the connection fails with a certificate warning.
+then quit Claude Desktop **fully** (macOS: menu bar → Quit; Windows: system
+tray → Quit — closing the window is not enough) and relaunch it:
+**velesdb-memory** appears under **Settings → Developer** as "running". The
+installer verifies the whole TLS path before writing the entry (a Node probe
+against `/health` with `NODE_EXTRA_CA_CERTS` — exactly what the bridge will
+do) and merges into the existing config non-destructively, with a
+timestamped backup. Re-running is idempotent; to re-wire without rebuilding
+anything (e.g. after installing Node later), pass `--wire-only` / `-WireOnly`.
 
-If you'd rather not use the Connectors UI, the stdio fallback still works —
-same block as every other client above, but point `VELESDB_MEMORY_PATH` at a
-**different** directory than the daemon's store: pointed at the same one, the
-fallback process and the daemon would fight over the same `flock`,
-reproducing the exact `DatabaseLocked` problem this section exists to avoid.
-This gives Desktop its own separate memory, not shared with the daemon.
+The generated entry looks like this (macOS shown; Windows is the same shape
+with `mcp-remote.cmd`/`npx.cmd` and `%USERPROFILE%` paths — the installer
+resolves **absolute** paths because Desktop spawns the command without a
+shell and, on macOS, with launchd's minimal `PATH` that contains neither
+Homebrew nor nvm):
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "command": "/opt/homebrew/bin/mcp-remote",
+  "args": ["https://127.0.0.1:18090/mcp"],
+  "env": {
+    "NODE_EXTRA_CA_CERTS": "/Users/you/.velesdb-memory-tls/ca-cert.pem",
+    "PATH": "/opt/homebrew/bin:/usr/bin:/bin"
+  }
+} } }
+```
+
+(without a global `mcp-remote`, the installer writes
+`npx -y mcp-remote <url>` instead — same result, fetched on first launch.)
+
+**Troubleshooting**
+
+- *Certificate refused / bridge disconnected*: check the daemon answers —
+  `curl --cacert ~/.velesdb-memory-tls/ca-cert.pem https://127.0.0.1:18090/health`
+  (Windows: `curl.exe --cacert "$env:USERPROFILE\.velesdb-memory-tls\ca-cert.pem" https://127.0.0.1:18090/health`)
+  — then confirm the config entry's `NODE_EXTRA_CA_CERTS` path exists.
+  Re-run the installer with `--wire-only` / `-WireOnly` to re-verify and
+  re-write the entry. Never "fix" a certificate error with
+  `NODE_TLS_REJECT_UNAUTHORIZED=0` — that turns TLS verification off.
+- *Port already in use*: the installer refuses to grab a port another process
+  holds — re-run everything with `--port=<other>` / `-Port <other>` (the
+  Desktop entry is rewritten to match).
+- *No Node.js on the machine*: the bridge can't run — install Node (macOS:
+  `brew install node`; Windows: https://nodejs.org) and re-run with
+  `--wire-only` / `-WireOnly`. Until then the installer prints the UI
+  alternative: **Settings → Connectors → Add custom connector**, paste
+  `https://127.0.0.1:18090/mcp` (no API key — loopback only; requires the
+  CA-trust step to have succeeded, and Desktop's own TLS stack may still
+  refuse a local CA — which is why the bridge is the default).
+- *`Storage(DatabaseLocked)`*: something is opening the store directly
+  alongside the daemon — the bridge never does this; look for a leftover
+  stdio entry pointing `VELESDB_MEMORY_PATH` at the daemon's store.
+
+**Removing the CA trust** (the uninstallers never touch it — "never delete
+local state"):
+
+```bash
+# macOS — remove the trust-settings record, then the certificate itself
+security remove-trusted-cert ~/.velesdb-memory-tls/ca-cert.pem
+security delete-certificate -c "VelesDB Memory Local CA" ~/Library/Keychains/login.keychain-db
+```
+
+```powershell
+# Windows — user store only, mirroring how it was added
+certutil -delstore -user Root "VelesDB Memory Local CA"
+```
+
+If you'd rather not share memory with the daemon at all, the plain stdio
+config still works — same block as every other client above, but point
+`VELESDB_MEMORY_PATH` at a **different** directory than the daemon's store:
+pointed at the same one, the stdio process and the daemon would fight over
+the same `flock`, reproducing the exact `DatabaseLocked` problem this
+section exists to avoid. This gives Desktop its own separate memory.
 
 **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
 
@@ -622,6 +704,7 @@ macOS: building with the right features, running the daemon (as a `launchd`
 agent), trusting the local CA in your login keychain, and wiring Claude Code /
 Claude Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
 `--port`, `--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
+`--wire-only`,
 `--from-release`, `--uninstall`, …).
 
 ### Windows
@@ -629,7 +712,7 @@ Claude Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
 `scripts/install-memory-daemon.ps1` (`pwsh -File scripts/install-memory-daemon.ps1`,
 PowerShell 7+ on Windows 10/11) is the same automation with the same flags
 (PowerShell-cased: `-Embedder`, `-Port`, `-Store`, `-TlsDir`, `-Ttl`,
-`-SkipClient`, `-SkipCaTrust`, `-FromRelease`, `-Uninstall`, …), adapted to
+`-SkipClient`, `-SkipCaTrust`, `-WireOnly`, `-FromRelease`, `-Uninstall`, …), adapted to
 Windows in three places:
 
 - **Daemon**: a per-user **Scheduled Task** (`\VelesDB\MemoryDaemon`,
@@ -643,8 +726,10 @@ Windows in three places:
   the login keychain — also no admin rights needed (see "The local CA" above
   for the exact command).
 - **Client config paths**: Claude Desktop
-  `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
-  written by the installer, same as macOS), Windsurf
+  `%APPDATA%\Claude\claude_desktop_config.json` (wired with the same
+  `mcp-remote` stdio→HTTPS bridge as macOS — see "Claude Desktop
+  (macOS / Windows)" above; `.cmd` shims resolved explicitly because Desktop
+  spawns the command without a shell), Windsurf
   `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
   `%APPDATA%\devin\config.json`.
 

--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -21,8 +21,11 @@
 #     thumbprint before importing, same spirit as the macOS strict-curl
 #     ground-truth check.
 #   - Client config paths follow Windows conventions: Claude Desktop
-#     `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
-#     written here, same as macOS), Windsurf
+#     `%APPDATA%\Claude\claude_desktop_config.json` (stdio-only, so the
+#     installer writes an mcp-remote stdio→HTTPS bridge entry there with
+#     NODE_EXTRA_CA_CERTS — same mechanism as macOS; `.cmd` shims are
+#     resolved explicitly because Desktop spawns the command without a
+#     shell, and a bare/`.ps1` resolution would fail), Windsurf
 #     `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
 #     `%APPDATA%\devin\config.json` (documented at
 #     https://cli.devin.ai/docs/reference/configuration/config-file — Devin's
@@ -50,6 +53,8 @@
 #   -Yes                      Assume yes to interactive prompts (e.g. `ollama pull`)
 #   -SkipClient <name>        Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   -SkipCaTrust              Skip trusting the local CA in the CurrentUser\Root store
+#   -WireOnly                 Skip build/daemon setup: only (re-)verify CA trust and re-wire the
+#                             clients against an already-installed daemon (no prompts, fast)
 #   -ForceRestart             Re-register/restart the scheduled task even if already running
 #   -FromRelease              Install the prebuilt daemon binary from a GitHub Release archive
 #                             instead of building with cargo (see -FromReleaseTag). PowerShell
@@ -93,6 +98,8 @@ param(
     [string[]]$SkipClient = @(),
 
     [switch]$SkipCaTrust,
+
+    [switch]$WireOnly,
 
     [switch]$ForceRestart,
 
@@ -153,7 +160,7 @@ function Write-ErrorMsg { param([string]$Message) Write-Host $Message -Foregroun
 function Show-Usage {
     # Reprint the flag block from this file's own header — keeps `-Help`
     # honest (it can never drift from the comment a reader actually sees).
-    $lines = Get-Content -Path $PSCommandPath -TotalCount 70
+    $lines = Get-Content -Path $PSCommandPath -TotalCount 74
     ($lines | Select-Object -Skip 1) | ForEach-Object {
         if ($_ -match '^# ?(.*)$') { Write-Host $Matches[1] } else { Write-Host '' }
     }
@@ -570,7 +577,28 @@ function Enable-LocalCaTrust {
     # rights needed, and behaves consistently across PowerShell versions.
     $ok = Invoke-WithTimeout -Seconds 60 -FilePath 'certutil.exe' -ArgumentList @('-addstore', '-user', 'Root', "`"$CaCertPath`"")
     if ($ok) {
-        Write-Success 'Local CA trusted in Cert:\CurrentUser\Root.'
+        # VERIFY, don't assume: certutil exiting 0 is not proof a strict TLS
+        # client now accepts the daemon's certificate. Ground-truth it the
+        # same way the idempotency check above does — curl WITHOUT --cacert,
+        # i.e. against the user/system trust store.
+        if ($curl) {
+            & $curl.Source -fsS --max-time 2 "https://127.0.0.1:$Port/health" *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success 'Local CA trusted AND verified: a strict HTTPS request to the daemon now succeeds.'
+            } else {
+                & $curl.Source -fsS --max-time 2 --cacert $CaCertPath "https://127.0.0.1:$Port/health" *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Warn '   certutil reported success, but a strict HTTPS request to the daemon still fails'
+                    Write-Warn '   certificate verification. Re-run this by hand and approve any security dialog:'
+                    Write-Host "     certutil -addstore -user Root `"$CaCertPath`""
+                } else {
+                    Write-Warn "   CA imported, but the daemon is not answering /health right now, so the end-to-end"
+                    Write-Warn "   verification could not run — check $LogsDir\daemon.err.log"
+                }
+            }
+        } else {
+            Write-Success 'Local CA imported into Cert:\CurrentUser\Root (curl.exe not found — could not verify end-to-end).'
+        }
     } else {
         Write-Warn '   Could not confirm the CA trust automatically (no response within 60s, or the'
         Write-Warn '   command failed). The daemon is still up and serving HTTPS — this only affects'
@@ -605,24 +633,103 @@ function Set-ClaudeCodeClient {
 
 # Claude Desktop is a DIFFERENT mechanism than every other client here:
 # claude_desktop_config.json never reads a url/type:"http" entry (confirmed on
-# macOS, same binary/config format on Windows) — the only way to wire Desktop
-# to the daemon is its own UI. This prints that instruction instead of
-# touching the config file, same as the shell script.
+# macOS, same binary/config format on Windows), and Desktop's "Add custom
+# connector" UI verifies TLS through Chromium/Node — which does not reliably
+# consult the OS certificate store — so even a trusted local CA can leave the
+# UI path rejecting the daemon's certificate. The reliable, zero-UI-steps
+# path (same as the shell script) is a stdio→HTTPS bridge: an `mcp-remote`
+# entry in the config file, with NODE_EXTRA_CA_CERTS pointing at the daemon's
+# CA so the bridge verifies TLS strictly (never NODE_TLS_REJECT_UNAUTHORIZED=0
+# — that disables verification entirely). The bridge is a plain HTTPS client
+# of the daemon: it never opens the store itself, so no lock conflict.
+# `.cmd` shims are resolved explicitly (mcp-remote.cmd / npx.cmd, absolute
+# paths): Desktop spawns the command without a shell, so a bare name or a
+# `.ps1` shim would fail to launch.
 function Set-ClaudeDesktopClient {
     if (Test-ShouldSkip 'claude-desktop') {
         Write-Warn 'Skipping Claude Desktop (-SkipClient).'
         return
     }
-    Write-Host ''
-    Write-Info 'Claude Desktop — different mechanism than every other client here:'
-    Write-Warn "   its config file ($DesktopConfig) does not support HTTP (a url/type:`"http`" entry"
-    Write-Warn '   there is silently ignored). Add it yourself, once, via the UI instead:'
-    Write-Warn '   Settings -> Connectors -> Add custom connector, then paste:'
-    Write-Host "     https://127.0.0.1:$Port/mcp"
-    Write-Warn '   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.'
-    Write-Warn '   Prefer not to use the Connectors UI? A stdio fallback still works — see the README''s'
-    Write-Warn "   `"Configure your client`" section (use a DIFFERENT VELESDB_MEMORY_PATH than $script:Store,"
-    Write-Warn '   or the fallback process and the daemon will fight over the same lock).'
+
+    $configDir = Split-Path -Path $DesktopConfig -Parent
+    if (-not (Test-Path $configDir)) {
+        Write-Warn "Claude Desktop not detected (no $configDir) — skipping."
+        return
+    }
+
+    $caCert = "$script:TlsDir\ca-cert.pem"
+    $url = "https://127.0.0.1:$Port/mcp"
+
+    # Resolve the bridge: a globally-installed mcp-remote wins (no npx
+    # startup cost); otherwise npx fetches/caches it on first launch.
+    $bridgeCmd = $null
+    $bridgeArgs = @()
+    $mcpRemote = Get-Command 'mcp-remote.cmd' -ErrorAction SilentlyContinue
+    $npx = Get-Command 'npx.cmd' -ErrorAction SilentlyContinue
+    $node = Get-Command 'node.exe' -ErrorAction SilentlyContinue
+    if ($mcpRemote) {
+        $bridgeCmd = $mcpRemote.Source
+        $bridgeArgs = @($url)
+    } elseif ($npx) {
+        $bridgeCmd = $npx.Source
+        $bridgeArgs = @('-y', 'mcp-remote', $url)
+    }
+
+    if (-not $bridgeCmd -or -not $node) {
+        Write-Host ''
+        Write-Warn 'Claude Desktop needs a stdio->HTTPS bridge (mcp-remote), which needs Node.js —'
+        Write-Warn "   'mcp-remote.cmd'/'npx.cmd'/'node.exe' not found on PATH. Two ways to finish:"
+        Write-Warn '   a) install Node.js (https://nodejs.org) and re-run: pwsh -File scripts/install-memory-daemon.ps1 -WireOnly'
+        Write-Warn '   b) or use Desktop''s UI: Settings -> Connectors -> Add custom connector, paste:'
+        Write-Host "        $url"
+        Write-Warn '      (no API key needed — but this path requires the CA-trust step above to have'
+        Write-Warn '      succeeded, and Desktop''s own TLS stack may still refuse a local CA).'
+        return
+    }
+
+    # VERIFY the exact TLS path the bridge will use BEFORE writing any
+    # config: Node does not consult the Windows certificate store by default,
+    # so the CA-trust step above proves nothing for the bridge —
+    # NODE_EXTRA_CA_CERTS is what makes Node accept this CA, and this probe
+    # exercises precisely that.
+    if (Test-Path $caCert) {
+        $previousCa = $env:NODE_EXTRA_CA_CERTS
+        $env:NODE_EXTRA_CA_CERTS = $caCert
+        & $node.Source -e 'require("https").get(process.argv[1],(r)=>process.exit(r.statusCode===200?0:1)).on("error",()=>process.exit(1));setTimeout(()=>process.exit(1),8000);' "https://127.0.0.1:$Port/health" *> $null
+        $nodeOk = ($LASTEXITCODE -eq 0)
+        $env:NODE_EXTRA_CA_CERTS = $previousCa
+        if ($nodeOk) {
+            Write-Success 'Node accepts the daemon''s certificate via NODE_EXTRA_CA_CERTS — the Desktop bridge will verify TLS strictly.'
+        } else {
+            Write-Warn "Node could not fetch https://127.0.0.1:$Port/health with NODE_EXTRA_CA_CERTS=$caCert."
+            Write-Warn '   Writing the Claude Desktop entry anyway — if Desktop shows velesdb-memory as'
+            Write-Warn "   disconnected, check $LogsDir\daemon.err.log and re-run with -WireOnly."
+        }
+    } else {
+        Write-Warn "No CA certificate at $caCert yet — the Desktop bridge entry is written but can only"
+        Write-Warn '   be verified once the daemon has started and generated it (re-run with -WireOnly).'
+    }
+
+    $entry = [PSCustomObject]@{
+        command = $bridgeCmd
+        args    = [string[]]$bridgeArgs
+        env     = [PSCustomObject]@{ NODE_EXTRA_CA_CERTS = $caCert }
+    }
+
+    Set-JsonClient -Name 'claude-desktop' -ConfigPath $DesktopConfig -RequireExistingDir $true -Mutator {
+        param($json)
+        if (-not $json.PSObject.Properties['mcpServers']) {
+            $json | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue ([PSCustomObject]@{})
+        }
+        if ($json.mcpServers.PSObject.Properties['velesdb-memory']) {
+            $json.mcpServers.'velesdb-memory' = $entry
+        } else {
+            $json.mcpServers | Add-Member -NotePropertyName 'velesdb-memory' -NotePropertyValue $entry
+        }
+        $json
+    }.GetNewClosure()
+    Write-Warn '   Restart Claude Desktop fully (system tray -> Quit, not just closing the window) — then'
+    Write-Warn '   velesdb-memory appears in Settings -> Developer as "running".'
 }
 
 # Set-JsonClient NAME CONFIG_PATH MUTATOR REQUIRE_EXISTING_DIR
@@ -787,6 +894,38 @@ function Show-Summary {
 function Main {
     if ($Uninstall) {
         Invoke-Uninstall
+        exit 0
+    }
+
+    # -WireOnly: (re-)verify CA trust and re-wire every client against an
+    # ALREADY-installed daemon — no cargo build, no task re-registration, no
+    # interactive prompts. Both the "fix the wiring / Node got installed
+    # later" fast path for users and the testable entry point for this
+    # script's client-wiring logic (idempotent by construction: every wiring
+    # step backs up and merges, never overwrites).
+    if ($WireOnly) {
+        # Show-Summary reads this under Set-StrictMode; Set-Daemon (which
+        # normally sets it) is deliberately skipped on this path.
+        $script:DaemonAlreadyRunning = $true
+        $caCert = "$script:TlsDir\ca-cert.pem"
+        $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+        $daemonUp = $false
+        if ($curl -and (Test-Path $caCert)) {
+            & $curl.Source -fsS --max-time 2 --cacert $caCert "https://127.0.0.1:$Port/health" *> $null
+            $daemonUp = ($LASTEXITCODE -eq 0)
+        }
+        if (-not $daemonUp) {
+            Write-Warn "No daemon answering on https://127.0.0.1:$Port/health — -WireOnly only re-wires"
+            Write-Warn '   clients; run the full installer (without -WireOnly) if the daemon was never set up.'
+        }
+        Enable-LocalCaTrust -CaCertPath $caCert
+        Set-ClaudeCodeClient
+        Set-ClaudeDesktopClient
+        Set-WindsurfClient
+        Set-DevinClient
+        $script:Embedder = '(unchanged — -WireOnly)'
+        $script:Ttl = '(unchanged — -WireOnly)'
+        Show-Summary
         exit 0
     }
 

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -38,6 +38,8 @@
 #   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
 #   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   --skip-ca-trust          Skip trusting the local CA in the login keychain
+#   --wire-only              Skip build/daemon setup: only (re-)verify CA trust and re-wire the
+#                            clients against an already-installed daemon (no prompts, fast)
 #   --force-restart          Reload the daemon even if already running
 #   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http) from a
 #                            GitHub Release archive instead of `cargo install` (default TAG: the
@@ -90,6 +92,7 @@ FORCE_RESTART=0
 UNINSTALL=0
 SKIP_CLIENTS=""
 SKIP_CA_TRUST=0
+WIRE_ONLY=0
 FROM_RELEASE=0
 FROM_RELEASE_TAG=""
 SKIP_CHECKSUM=0
@@ -103,7 +106,7 @@ DEVIN_CONFIG="$HOME/.config/devin/config.json"
 RELEASE_REPO="cyberlife-coder/VelesDB"
 
 print_usage() {
-  sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -119,6 +122,7 @@ for arg in "$@"; do
     --yes) ASSUME_YES=1 ;;
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
     --skip-ca-trust) SKIP_CA_TRUST=1 ;;
+    --wire-only) WIRE_ONLY=1 ;;
     --force-restart) FORCE_RESTART=1 ;;
     --from-release) FROM_RELEASE=1 ;;
     --from-release=*) FROM_RELEASE=1; FROM_RELEASE_TAG="${arg#*=}" ;;
@@ -613,7 +617,23 @@ trust_local_ca() {
   echo -e "${YELLOW}   here or by hand later.${NC}"
 
   if run_with_timeout 60 "${trust_cmd[@]}"; then
-    echo -e "${GREEN}✅ Local CA trusted in your login keychain.${NC}"
+    # VERIFY, don't assume: `add-trusted-cert` exiting 0 is not proof a
+    # strict TLS client will now accept the daemon's certificate (trust
+    # settings can land in an unexpected domain/keychain). Ground-truth it
+    # the same way the idempotency check above does — a curl WITHOUT
+    # --cacert, i.e. against the system trust store.
+    if curl -fsS --max-time 2 "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${GREEN}✅ Local CA trusted AND verified: a strict HTTPS request to the daemon now succeeds.${NC}"
+    elif curl -fsS --max-time 2 --cacert "$ca_cert" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      # Daemon reachable with --cacert but not without it → the trust
+      # settings did NOT take effect, despite add-trusted-cert exiting 0.
+      echo -e "${YELLOW}⚠️  add-trusted-cert reported success, but a strict HTTPS request to the daemon still${NC}"
+      echo -e "${YELLOW}   fails certificate verification. Re-run this by hand and approve any system prompt:${NC}"
+      echo "     ${trust_cmd[*]}"
+    else
+      echo -e "${YELLOW}⚠️  CA trust was recorded, but the daemon is not answering /health right now, so the${NC}"
+      echo -e "${YELLOW}   end-to-end verification could not run — check $HOME/Library/Logs/velesdb-memory/daemon.err.log${NC}"
+    fi
   else
     echo -e "${YELLOW}⚠️  Could not confirm the CA trust automatically (no response to the system prompt within${NC}"
     echo -e "${YELLOW}   60s, or the command failed). The daemon is still up and serving HTTPS — this only${NC}"
@@ -645,12 +665,16 @@ wire_claude_code() {
   fi
 }
 
-# wire_json_client NAME CONFIG_PATH JQ_FILTER REQUIRE_EXISTING_DIR
+# wire_json_client NAME CONFIG_PATH JQ_FILTER REQUIRE_EXISTING_DIR [JQ_ARGS...]
 # REQUIRE_EXISTING_DIR=1 skips (rather than creating) the client's config
-# directory when absent — used for Claude Desktop, whose directory only
-# exists if the app itself is installed; Windsurf's is created if missing.
+# directory when absent — used for Claude Desktop and Devin, whose directories
+# only exist if the app itself is installed; Windsurf's is created if missing.
+# Any extra arguments are passed straight to jq (e.g. --argjson entry '...'),
+# so a caller can build a value safely with jq -n instead of string-splicing
+# shell variables into the filter.
 wire_json_client() {
   local name="$1" config_path="$2" jq_filter="$3" require_existing_dir="$4"
+  shift 4
   if should_skip "$name"; then
     echo -e "${YELLOW}⏭  Skipping $name (--skip-client).${NC}"
     return 0
@@ -680,7 +704,7 @@ wire_json_client() {
 
   local tmp
   tmp="$(mktemp)"
-  if jq "$jq_filter" "$config_path" > "$tmp"; then
+  if jq "$@" "$jq_filter" "$config_path" > "$tmp"; then
     mv "$tmp" "$config_path"
     echo -e "${GREEN}✅ $name wired → $config_path${NC}"
   else
@@ -690,26 +714,98 @@ wire_json_client() {
 }
 
 # Claude Desktop is a DIFFERENT mechanism than every other client here:
-# claude_desktop_config.json (the file every other JSON client uses) never
-# reads a url/type:"http" entry — confirmed it does not even try to connect —
-# so writing one there (as this script used to) silently does nothing. The
-# only way to wire Desktop to the daemon is its own UI. This function prints
-# that instruction instead of touching the config file.
+# claude_desktop_config.json never reads a url/type:"http" entry (confirmed:
+# it does not even try to connect), and Desktop's "Add custom connector" UI
+# verifies TLS through Chromium/Node — which does NOT reliably consult the
+# macOS keychain — so even a keychain-trusted local CA can leave the UI path
+# rejecting the daemon's certificate. The reliable, zero-UI-steps path is a
+# stdio→HTTPS bridge: an `mcp-remote` entry in the config file, with
+# NODE_EXTRA_CA_CERTS pointing at the daemon's CA so the bridge verifies TLS
+# strictly (never NODE_TLS_REJECT_UNAUTHORIZED=0 — that disables verification
+# entirely). The bridge is a plain HTTPS client of the daemon: it never opens
+# the store itself, so there is no flock conflict.
 wire_claude_desktop() {
   if should_skip "claude-desktop"; then
     echo -e "${YELLOW}⏭  Skipping Claude Desktop (--skip-client).${NC}"
     return 0
   fi
-  echo ""
-  echo -e "${BLUE}🖥  Claude Desktop — different mechanism than every other client here:${NC}"
-  echo -e "${YELLOW}   its config file does not support HTTP (a url/type:\"http\" entry there is silently${NC}"
-  echo -e "${YELLOW}   ignored). Add it yourself, once, via the UI instead:${NC}"
-  echo -e "${YELLOW}   Settings → Connectors → Add custom connector, then paste:${NC}"
-  echo "     https://127.0.0.1:$PORT/mcp"
-  echo -e "${YELLOW}   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.${NC}"
-  echo -e "${YELLOW}   Prefer not to use the Connectors UI? A stdio fallback still works — see the README's${NC}"
-  echo -e "${YELLOW}   \"Configure your client\" section (use a DIFFERENT VELESDB_MEMORY_PATH than $STORE,${NC}"
-  echo -e "${YELLOW}   or the fallback process and the daemon will fight over the same flock).${NC}"
+
+  local config_dir
+  config_dir="$(dirname "$DESKTOP_CONFIG")"
+  if [ ! -d "$config_dir" ]; then
+    echo -e "${YELLOW}⏭  Claude Desktop not detected (no $config_dir) — skipping.${NC}"
+    return 0
+  fi
+
+  local ca_cert="$TLS_DIR/ca-cert.pem"
+  local url="https://127.0.0.1:$PORT/mcp"
+
+  # Resolve the bridge command. A globally-installed mcp-remote wins (no npx
+  # startup cost); otherwise npx fetches/caches it on first launch. Absolute
+  # paths on purpose: Desktop launched from Finder/Dock inherits launchd's
+  # minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which contains neither
+  # Homebrew nor nvm — a bare "npx" there fails with ENOENT. Same reason the
+  # entry's env carries an explicit PATH: both mcp-remote and npx are
+  # `#!/usr/bin/env node` scripts, so node's directory must be reachable too.
+  local bridge_cmd="" node_bin=""
+  local -a bridge_args=()
+  if command -v mcp-remote >/dev/null 2>&1; then
+    bridge_cmd="$(command -v mcp-remote)"
+    bridge_args=("$url")
+  elif command -v npx >/dev/null 2>&1; then
+    bridge_cmd="$(command -v npx)"
+    bridge_args=("-y" "mcp-remote" "$url")
+  fi
+  node_bin="$(command -v node 2>/dev/null || true)"
+
+  if [ -z "$bridge_cmd" ] || [ -z "$node_bin" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  Claude Desktop needs a stdio→HTTPS bridge (mcp-remote), which needs Node.js —${NC}"
+    echo -e "${YELLOW}   'mcp-remote'/'npx'/'node' not found on PATH. Two ways to finish:${NC}"
+    echo -e "${YELLOW}   a) install Node.js (e.g. \`brew install node\`) and re-run: $0 --wire-only${NC}"
+    echo -e "${YELLOW}   b) or use Desktop's UI: Settings → Connectors → Add custom connector, paste:${NC}"
+    echo "        $url"
+    echo -e "${YELLOW}      (no API key needed — but this path requires the CA-trust step above to have${NC}"
+    echo -e "${YELLOW}      succeeded, and Desktop's own TLS stack may still refuse a local CA).${NC}"
+    return 0
+  fi
+
+  # VERIFY the exact TLS path the bridge will use BEFORE writing any config:
+  # Node does not consult the macOS keychain, so the keychain-trust step
+  # above proves nothing for the bridge — NODE_EXTRA_CA_CERTS is what makes
+  # Node accept this CA, and this probe exercises precisely that.
+  if [ -f "$ca_cert" ]; then
+    if run_with_timeout 10 env NODE_EXTRA_CA_CERTS="$ca_cert" "$node_bin" -e '
+        require("https").get(process.argv[1], (r) => process.exit(r.statusCode === 200 ? 0 : 1))
+          .on("error", () => process.exit(1));
+        setTimeout(() => process.exit(1), 8000);
+      ' "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${GREEN}✅ Node accepts the daemon's certificate via NODE_EXTRA_CA_CERTS — the Desktop bridge will verify TLS strictly.${NC}"
+    else
+      echo -e "${YELLOW}⚠️  Node could not fetch https://127.0.0.1:$PORT/health with NODE_EXTRA_CA_CERTS=$ca_cert.${NC}"
+      echo -e "${YELLOW}   Writing the Claude Desktop entry anyway — if Desktop shows velesdb-memory as${NC}"
+      echo -e "${YELLOW}   disconnected, check $HOME/Library/Logs/velesdb-memory/daemon.err.log and re-run with --wire-only.${NC}"
+    fi
+  else
+    echo -e "${YELLOW}⚠️  No CA certificate at $ca_cert yet — the Desktop bridge entry is written but can only${NC}"
+    echo -e "${YELLOW}   be verified once the daemon has started and generated it (re-run with --wire-only).${NC}"
+  fi
+
+  require_jq
+  local entry
+  entry="$(jq -n \
+    --arg cmd "$bridge_cmd" \
+    --arg ca "$ca_cert" \
+    --arg path "$(dirname "$node_bin"):/usr/bin:/bin" \
+    --args \
+    '{command: $cmd, args: $ARGS.positional, env: {NODE_EXTRA_CA_CERTS: $ca, PATH: $path}}' \
+    "${bridge_args[@]}")"
+
+  wire_json_client "claude-desktop" "$DESKTOP_CONFIG" \
+    '.mcpServers["velesdb-memory"] = $entry' 1 \
+    --argjson entry "$entry"
+  echo -e "${YELLOW}   Restart Claude Desktop fully (menu bar → Quit, not just closing the window) — then${NC}"
+  echo -e "${YELLOW}   velesdb-memory appears in Settings → Developer as \"running\".${NC}"
 }
 
 wire_windsurf() {
@@ -794,6 +890,29 @@ print_summary() {
 main() {
   if [ "$UNINSTALL" = "1" ]; then
     do_uninstall
+    exit 0
+  fi
+
+  # --wire-only: (re-)verify CA trust and re-wire every client against an
+  # ALREADY-installed daemon — no cargo build, no daemon restart, no
+  # interactive prompts. This is both the "my client config broke / Node got
+  # installed later, fix the wiring" fast path for users and the testable
+  # entry point for this script's client-wiring logic (idempotent by
+  # construction: every wiring step backs up and merges, never overwrites).
+  if [ "$WIRE_ONLY" = "1" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then DAEMON_SUPPORTED=1; else DAEMON_SUPPORTED=0; fi
+    if ! curl -fsS --max-time 2 --cacert "$TLS_DIR/ca-cert.pem" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${YELLOW}⚠️  No daemon answering on https://127.0.0.1:$PORT/health — --wire-only only re-wires${NC}"
+      echo -e "${YELLOW}   clients; run the full installer (without --wire-only) if the daemon was never set up.${NC}"
+    fi
+    trust_local_ca "$TLS_DIR/ca-cert.pem"
+    wire_claude_code
+    wire_claude_desktop
+    wire_windsurf
+    wire_devin
+    EMBEDDER="(unchanged — --wire-only)"
+    TTL="(unchanged — --wire-only)"
+    print_summary
     exit 0
   fi
 


### PR DESCRIPTION
Refs #1537

## Problem (field report)

Wiring the velesdb-memory HTTPS daemon into **Claude Desktop** required manual hacks: Desktop's custom-connector UI validates TLS through its own Chromium/Node stack, which does NOT consult the OS keychain — so even a trusted local CA gets rejected, and the observed workaround was an `mcp-remote` entry with `NODE_TLS_REJECT_UNAUTHORIZED=0` (TLS verification disabled). Unacceptable for an end user.

## Fix

Both installers (`install-memory-daemon.sh` / `.ps1`) now wire Claude Desktop automatically:

- **stdio bridge, strict TLS**: a `claude_desktop_config.json` entry (non-destructive JSON merge + backup) running `mcp-remote` (global install or `npx -y` fallback) with absolute paths (Desktop spawns without a shell/launchd PATH) and `NODE_EXTRA_CA_CERTS` pointing at the daemon's CA — TLS verified strictly, never `NODE_TLS_REJECT_UNAUTHORIZED=0`. A Node TLS probe against `/health` runs BEFORE writing the entry.
- **Post-trust verification**: `trust_local_ca` now verifies the trust actually took (strict curl without `--cacert`) with actionable diagnostics; Windows mirrors via user-store `certutil` + post-import check.
- **`--wire-only` / `-WireOnly`**: re-trust + re-wire every client without rebuild/restart.
- **Docs**: new "Claude Desktop (macOS / Windows)" section in the crate README — copy-paste happy path, troubleshooting (cert refused, port busy, Node absent, DatabaseLocked), clean CA uninstall. Crate CHANGELOG updated (memory track).

## Verified on macOS (this machine, for real)

- `--wire-only` full run: entry written (backup created, rest of config intact), Node TLS probe green, idempotent (second run → byte-identical entry).
- **End-to-end proof**: the bridge relaunched under `env -i` with exactly the written entry completed a full MCP `initialize` handshake against the live daemon (`serverInfo: velesdb-memory 0.11.0`) with strict TLS. The insecure workaround entry was replaced by the clean one.
- shellcheck + `bash -n` clean; PowerShell AST parse + `-Help` render clean.

## Not tested locally

Windows runtime behaviour (`certutil`, Scheduled Task, `-WireOnly`, `.cmd` shims) — parse/help validated only; needs a Windows smoke before the memory-track release.