### PR TITLE
chore(release): prepare 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] — 2026-07-24
+
 ### Security
 
 - **`velesdb-memory`**: metadata is now size-capped. Caller-supplied
@@ -6767,7 +6769,8 @@ still genuinely pending is:
 > product), not part of the open-source Community roadmap — see the
 > "Scope & boundaries" section of the README.
 
-[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/cyberlife-coder/VelesDB/compare/v3.12.0...v4.0.0
 [1.16.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.16.0
 [1.15.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.15.0
 [1.14.4]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6818,7 +6818,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.12.0"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.12.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "4.0.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.12.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v4.0.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.12.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -661,7 +661,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.12.0"}
+{"status": "ok", "version": "4.0.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -675,13 +675,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.12.0"}
+{"status": "ready", "version": "4.0.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.12.0"}
+{"status": "not_ready", "version": "4.0.0"}
 ```
 
 ### Kubernetes Example

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.12.0"
+version = "4.0.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.12.0",
+    version="4.0.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 15, 2026 (VelesDB v3.12.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 24, 2026 (VelesDB v4.0.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-15 (VelesDB v3.12.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-24 (VelesDB v4.0.0)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.12.0 — 2026-06-12*
+*Version 4.0.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.12.0
+# velesdb 4.0.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.12.0              │
+│ Version             │ 4.0.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.12.0 - Interactive REPL
+VelesDB v4.0.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.12.0 — May 2026*
+*Version 4.0.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.12.0
+# Version: 4.0.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.12.0 -- May 2026*
+*Version 4.0.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.12.0/velesdb-3.12.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.0.0/velesdb-4.0.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.12.0-amd64.deb
+sudo dpkg -i velesdb-4.0.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.12.0
+docker pull ghcr.io/cyberlife-coder/velesdb:4.0.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.12.0
+  ghcr.io/cyberlife-coder/velesdb:4.0.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.12.0 -- 2026-06-12*
+*Version 4.0.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.12.0"
+    "version": "4.0.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.12.0
+  version: 4.0.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.12.0
+# VelesDB Architecture Diagrams — v4.0.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-23 (v3.12.0; velesdb-memory 0.11.0)
+Last updated: 2026-07-24 (v4.0.0; velesdb-memory 0.11.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.12.0
+> **VelesDB version:** 4.0.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-15 (VelesDB v3.12.0)
+> Last updated: 2026-07-24 (VelesDB v4.0.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.12.0"
+version = "4.0.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=4.0.0",
-    "velesdb-common>=4.0.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=4.0.0",
-    "velesdb-common>=4.0.0",
+    "velesdb>=3.8.0",
+    "velesdb-common>=3.8.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.12.0
+cargo add --quiet velesdb-core@4.0.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.12.0
+cargo install --quiet --locked velesdb-server@4.0.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v3.12.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v4.0.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.12.0",
+      "version": "4.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Release-prep for the **4.0.0 major** — the no-deferral campaign is fully merged (issues #1549, #1555, #1556, #1470/#1493, #1575 all closed; zero open issues, zero other open PRs besides #1577 which ships on the memory track).

## Contents

- `scripts/bump_version.py 4.0.0 2026-07-24` — 62 locations (workspace crates, pyprojects, package.json/locks, doc snippets, CLI/REPL examples); memory/node keep their own 0.11.x track.
- `Cargo.lock` refreshed; OpenAPI snapshots regenerated at 4.0.0.
- CHANGELOG: `[Unreleased]` cut as `[4.0.0] — 2026-07-24` (the #1576 memory fix entry folded in by rebase), fresh empty `[Unreleased]`, compare links updated.
- Dependency floors: langchain/llamaindex `velesdb>=4.0.0` / `velesdb-common>=4.0.0` (both call the new `open_native_graph(..., config=...)`).
- `check-version-sync.py`: all versions match.

## Major-version rationale (BREAKING, all documented in the 4.0.0 section)

- `AnyCollection::into_vector_facade` removed (train R1, announced in 3.12.0 notes)
- Strict/schemaless missing-endpoint error unified (`NodeNotFound`/404, #1470)
- WASM `weighted` fusion default weights now canonical 0.6/0.3/0.1 (#1545)

## After merge

`develop` → `main` sync PR, wait for green `CI Success` on main, then tag `v4.0.0` **on explicit maintainer go** (REL-06: never tag before main CI is green).