### PR TITLE
fix(integrations): only pass config kwarg to open_native_graph when set

### DIFF
--- a/integrations/langchain/src/langchain_velesdb/graph_retriever.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_retriever.py
@@ -222,6 +222,11 @@ class GraphRetriever(BaseRetriever):
                 "'_db_path' / '_path' attribute."
             )
         config = getattr(self.vector_store, "_config", None)
+        if config is None:
+            # Keep the pre-config call shape so a velesdb-common that
+            # predates open_native_graph's ``config`` parameter (floor
+            # 3.8.0) stays compatible when the feature is unused.
+            return open_native_graph(resolved_path, self.graph_collection_name)
         return open_native_graph(
             resolved_path, self.graph_collection_name, config=config
         )

--- a/integrations/langchain/tests/test_config_passthrough.py
+++ b/integrations/langchain/tests/test_config_passthrough.py
@@ -168,3 +168,26 @@ class TestProceduralMemoryConfigPassthrough:
     def test_no_config_call_unchanged(self, tmp_path, recording_db):
         VelesDBProceduralMemory(path=str(tmp_path))
         assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestGraphRetrieverOldCommonCompat:
+    """The path fallback must stay callable against a velesdb-common that
+    predates ``open_native_graph``'s ``config`` parameter (floor 3.8.0):
+    when the store carries no config, the kwarg must not be passed at all."""
+
+    def test_no_config_works_with_old_common_signature(self, tmp_path, monkeypatch):
+        import langchain_velesdb.graph_retriever as gr
+
+        calls = []
+
+        def old_signature(db_path, collection_name):
+            calls.append((db_path, collection_name))
+            return object()
+
+        monkeypatch.setattr(gr, "open_native_graph", old_signature)
+        GraphRetriever(
+            vector_store=_StoreWithoutGetDb(str(tmp_path)),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert calls == [(str(tmp_path), "kg")]

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
@@ -248,6 +248,11 @@ class GraphRetriever(BaseRetriever):
         except AttributeError:
             vs = None
         config = getattr(vs, "_config", None)
+        if config is None:
+            # Keep the pre-config call shape so a velesdb-common that
+            # predates open_native_graph's ``config`` parameter (floor
+            # 3.8.0) stays compatible when the feature is unused.
+            return open_native_graph(resolved_path, collection_name)
         return open_native_graph(resolved_path, collection_name, config=config)
 
     def _infer_collection_name(self) -> str:

--- a/integrations/llamaindex/tests/test_config_passthrough.py
+++ b/integrations/llamaindex/tests/test_config_passthrough.py
@@ -162,3 +162,26 @@ class TestGraphLoaderConfigPassthrough:
         recording_db.calls = []
         GraphLoader(store, graph_collection_name="kg")
         assert recording_db.calls == [((store.path,), {})]
+
+
+class TestGraphRetrieverOldCommonCompat:
+    """The path fallback must stay callable against a velesdb-common that
+    predates ``open_native_graph``'s ``config`` parameter (floor 3.8.0):
+    when the store carries no config, the kwarg must not be passed at all."""
+
+    def test_no_config_works_with_old_common_signature(self, tmp_path, monkeypatch):
+        import llamaindex_velesdb.graph_retriever as gr
+
+        calls = []
+
+        def old_signature(db_path, collection_name):
+            calls.append((db_path, collection_name))
+            return object()
+
+        monkeypatch.setattr(gr, "open_native_graph", old_signature)
+        GraphRetriever(
+            index=_FakeIndex(_StoreWithoutGetDb(str(tmp_path))),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert calls == [(str(tmp_path), "kg")]


### PR DESCRIPTION
Follow-through of #1549/#1573, unblocking the 4.0.0 release-prep (#1578).

## Problem

Both `graph_retriever` path-fallbacks called `open_native_graph(..., config=config)` **unconditionally**. Against a `velesdb-common` that predates the `config` parameter (the dependency floor stays `>=3.8.0` until 4.0.0 actually publishes — CI resolves velesdb from PyPI, so a `>=4.0.0` floor is unsatisfiable pre-publication, as the Python Integrations Check on #1578 proved), that kwarg raises `TypeError` even when `config` is `None` — i.e. for every user not using the new feature.

## Fix

`config is None` → exact pre-config call shape (works with any common ≥ 3.8.0); a real config still requires the co-released common and fails loudly otherwise. Floors move to `>=4.0.0` in the documented **post-publication** follow-up.

## TDD

One red-first test per package monkeypatching `open_native_graph` with the OLD (config-less) signature — `TypeError: unexpected keyword argument 'config'` before the guard, green after. Full suites: langchain **236**, llamaindex **241**, common **106** passed.