### PR TITLE
release: sync develop into main for 4.0.0

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,14 +8,16 @@
 # Pour activer: git config core.hooksPath .githooks
 #
 # NOTE SIGPIPE (exit 141): git ouvre la connexion au remote AVANT de lancer ce
-# hook et envoie le pack APRÈS sur la même connexion SSH. La validation
-# complète (~15 min) dépasse le timeout d'inactivité de la connexion, qui meurt
-# pendant les checks — git écrit alors dans un pipe fermé et sort en 141 sans
-# message, après "PASSED". Contre-mesures ici:
+# hook et envoie le pack APRÈS sur la même connexion. Si cette connexion SSH
+# meurt pendant la validation complète (~15 min), git écrit dans un pipe fermé
+# et sort en 141 sans message, après "PASSED" — le transfert n'a jamais lieu.
+# Contre-mesures ici:
 #   - stdin (liste des refs) est drainé AVANT les checks, et les sous-processus
 #     cargo reçoivent </dev/null pour ne pas consommer le pipe de git;
-#   - des keepalives SSH doivent maintenir la connexion pendant les checks:
-#     git config core.sshCommand "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=60"
+#   - pousser en HTTPS rend la coupure sans effet (advertisement et envoi du
+#     pack sont deux requêtes indépendantes, la connexion est rétablie):
+#     git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+#     git config credential.helper '!gh auth git-credential'
 # =============================================================================
 
 set -e

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,6 +6,16 @@
 # Ce hook s'exécute AVANT chaque git push.
 #
 # Pour activer: git config core.hooksPath .githooks
+#
+# NOTE SIGPIPE (exit 141): git ouvre la connexion au remote AVANT de lancer ce
+# hook et envoie le pack APRÈS sur la même connexion SSH. La validation
+# complète (~15 min) dépasse le timeout d'inactivité de la connexion, qui meurt
+# pendant les checks — git écrit alors dans un pipe fermé et sort en 141 sans
+# message, après "PASSED". Contre-mesures ici:
+#   - stdin (liste des refs) est drainé AVANT les checks, et les sous-processus
+#     cargo reçoivent </dev/null pour ne pas consommer le pipe de git;
+#   - des keepalives SSH doivent maintenir la connexion pendant les checks:
+#     git config core.sshCommand "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=60"
 # =============================================================================
 
 set -e
@@ -23,42 +33,52 @@ echo "  VelesDB-Core Pre-push Validation"
 echo "═══════════════════════════════════════════════════════════════════"
 echo -e "${NC}"
 
-# Détection de la branche cible
-while read local_ref local_sha remote_ref remote_sha; do
-    if [[ "$remote_ref" == *"main"* ]] || [[ "$remote_ref" == *"develop"* ]]; then
-        echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
-        echo -e "${YELLOW}   Running full CI validation...${NC}"
-        
-        # 1. Formatting
-        echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
-        if ! cargo fmt --all -- --check; then
-            echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Formatting OK${NC}"
-        
-        # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
-        if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings; then
-            echo -e "${RED}❌ Clippy found issues${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Clippy OK${NC}"
-        
-        # 3. Tests (exclude velesdb-python due to PyO3 env issues)
-        echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
-        if ! cargo test --workspace --exclude velesdb-python; then
-            echo -e "${RED}❌ Tests failed${NC}"
-            exit 1
-        fi
-        echo -e "${GREEN}✅ Tests OK${NC}"
-        
-        # 4. Security (non-blocking)
-        echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
-        cargo deny check 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
-        
-        echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
-    fi
+# Drainer TOUT stdin d'abord: git écrit "local_ref local_sha remote_ref
+# remote_sha" par ref poussée. Lire avant les checks garantit que le pipe est
+# consommé même si un check échoue (set -e) ou lit stdin.
+protected_push=false
+# shellcheck disable=SC2034 # local_ref/local_sha/remote_sha documentent le format
+while read -r local_ref local_sha remote_ref remote_sha; do
+    case "$remote_ref" in
+        refs/heads/main|refs/heads/develop)
+            protected_push=true
+            echo -e "${YELLOW}⚠️  Pushing to protected branch: ${remote_ref}${NC}"
+            ;;
+    esac
 done
+
+if [[ "$protected_push" == true ]]; then
+    echo -e "${YELLOW}   Running full CI validation...${NC}"
+
+    # 1. Formatting
+    echo -e "\n${YELLOW}📐 Check 1/4: Formatting...${NC}"
+    if ! cargo fmt --all -- --check </dev/null; then
+        echo -e "${RED}❌ Formatting failed. Run 'cargo fmt --all'${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Formatting OK${NC}"
+
+    # 2. Clippy (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}📎 Check 2/4: Clippy...${NC}"
+    if ! cargo clippy --workspace --exclude velesdb-python --all-targets -- -D warnings </dev/null; then
+        echo -e "${RED}❌ Clippy found issues${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Clippy OK${NC}"
+
+    # 3. Tests (exclude velesdb-python due to PyO3 env issues)
+    echo -e "\n${YELLOW}🧪 Check 3/4: Tests...${NC}"
+    if ! cargo test --workspace --exclude velesdb-python </dev/null; then
+        echo -e "${RED}❌ Tests failed${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✅ Tests OK${NC}"
+
+    # 4. Security (non-blocking)
+    echo -e "\n${YELLOW}🛡️ Check 4/4: Security audit...${NC}"
+    cargo deny check </dev/null 2>/dev/null || echo -e "${YELLOW}⚠️  Security audit warnings (non-blocking)${NC}"
+
+    echo -e "\n${GREEN}🎉 Pre-push validation PASSED!${NC}\n"
+fi
 
 exit 0

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -154,7 +154,7 @@ jobs:
           echo "Built ${ASSET}"
 
       - name: Upload bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mcpb-${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download all bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: bundles
           merge-multiple: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-core`**: `Database::execute_aggregate` now applies the
+  statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
+  the WASM aggregate pipeline (executor-conformance divergence D006). As in
+  WASM, there is no default cap: a LIMIT-less GROUP BY still returns every
+  group. Conformance fixture gains case G005 locking the behaviour on both
+  engines. (issue #1556)
 - **`scripts/check-promise-contract.py`**: the promise-contract guardrail
   only ever checked that a claim's `must_contain` substring was still
   present in the file it points at — it never executed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -497,6 +497,25 @@ account).
   the result needs a touch.
   [EPIC-P-071/US-004]
 
+- **BREAKING (Rust core API) — missing graph-edge endpoint is now
+  `Error::NodeNotFound` in strict-schema mode too**, unifying it with the
+  existing schemaless behavior. The #1442 fix (`add_edge`/`add_edges_batch`
+  reject an edge whose `source` or `target` has no stored node payload)
+  intentionally kept two variants depending on schema mode: schemaless
+  returned `Error::NodeNotFound` (`VELES-022`, REST `404`), while strict
+  mode overloaded the pre-existing `Error::SchemaValidation` (`VELES-017`,
+  REST `400`) to also mean "endpoint doesn't exist at all". Both modes now
+  return `NodeNotFound` for a genuinely missing endpoint;
+  `SchemaValidation` in strict mode is reserved for actual schema-shape
+  violations (undeclared node type, undeclared edge type, endpoint type
+  mismatch, or a node with no `_labels`). *Migration*: code in strict-schema
+  collections matching on `Error::SchemaValidation`/`VELES-017`/HTTP `400`
+  to detect a missing edge endpoint must match on `Error::NodeNotFound`/
+  `VELES-022`/HTTP `404` instead — REST, the Python/Node/WASM/TS bindings,
+  and the `velesdb-memory` wedge already map both variants generically by
+  error code, so no adapter code changed, only which variant strict mode
+  now returns for this one case. (#1470)
+
 ### Fixed
 
 - **Benchmark online mode**: the CLI runner now uses the CLI-enforced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] — 2026-07-24
+
 ### Security
 
 - **`velesdb-memory`**: metadata is now size-capped. Caller-supplied
@@ -6767,7 +6769,8 @@ still genuinely pending is:
 > product), not part of the open-source Community roadmap — see the
 > "Scope & boundaries" section of the README.
 
-[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v1.16.0...HEAD
+[Unreleased]: https://github.com/cyberlife-coder/VelesDB/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/cyberlife-coder/VelesDB/compare/v3.12.0...v4.0.0
 [1.16.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.16.0
 [1.15.0]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.15.0
 [1.14.4]: https://github.com/cyberlife-coder/VelesDB/releases/tag/v1.14.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`VelesConfig` on every remaining surface (issue #1549)** — after the
+  server/CLI wiring (#1565), the four surfaces that could still only open
+  the engine on core defaults now accept an explicit engine configuration,
+  all built on the same engine-only TOML loaders
+  (`load_from_path_engine_only` / `from_toml_engine_only`) with fail-fast
+  validation and the typed `ConfigError` preserved:
+  - **`tauri-plugin-velesdb`**: new plugin `Builder` with
+    `with_config(VelesConfig)` / `with_config_path(path)` (fail-fast at
+    build time), threading through the four observer×config open
+    combinations; `VelesConfig` re-exported for hosts; typed
+    `Error::ConfigLoad` variant.
+  - **`velesdb-mobile`**: `open_with_config(_toml)` and
+    `open_with_observer_and_config(_toml)` UniFFI constructors (TOML file
+    path or embedded TOML string — the string variant suits mobile asset
+    pipelines); `ConfigError` surfaced through the flat UniFFI error as
+    `VELES-009` with the full message.
+  - **`velesdb-python`**: `VelesConfigOptions` now covers the full engine
+    surface — new `SearchConfigOptions`, `HnswConfigOptions`,
+    `StorageOptions` and `QuantizationOptions` sections alongside the
+    existing `limits`, plus `VelesConfigOptions.from_toml(str)` /
+    `from_toml_path(path)`. Invalid values raise at construction or at
+    `Database(path, config=...)` open, never silently. `wal_batch` stays
+    intentionally unexposed (velesdb-premium Enterprise feature). Stubs,
+    pure-python adapter and README updated.
+  - **`langchain-velesdb` / `llamaindex-velesdb`**: every store/memory
+    entry point that creates a `Database` accepts an optional
+    `config: velesdb.VelesConfigOptions` pass-through (vector stores,
+    chat/semantic/episodic/procedural memories, native `GraphLoader`),
+    and the shared `velesdb_common.graph.open_native_graph` helper
+    forwards it too. Omitting `config` is bit-for-bit the previous
+    behaviour.
 - **`velesdb-cli`**: new `graph doctor <collection> [--purge|--stub]`
   subcommand to audit and repair legacy phantom edges -- edges present in
   a graph collection's edge store whose `source` or `target` node has no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-wasm`**: the VelesQL JOIN executor no longer depends on which
+  side of the `ON` condition names the joined table. `ON joined.col =
+  base.col` used to match nothing (NULL joined columns on every row);
+  `equality_keys` now orients the condition like core's
+  `normalize_join_condition`. Conformance join case J005 locks both engines
+  (was executor-conformance divergence D002). (issue #1555)
 - **`velesdb-core`**: `Database::execute_aggregate` now applies the
   statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
   the WASM aggregate pipeline (executor-conformance divergence D006). As in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`velesdb-memory` (MCP)**: tool parameters are now harness-proof on both
+  wire directions. Real MCP client harnesses were observed serializing
+  non-string arguments as JSON-encoded strings once their view of the
+  advertised schema degraded — `save_working_context`'s `working` object
+  arrived as `"{\"goal\": ...}"` and the call failed with `invalid type:
+  string, expected struct WorkingContext`, silently losing session
+  handoffs; `recall_fused` rejected `limit: "6"` and stringified `filter`
+  objects the same way. Two-sided fix, same defensive-interop class as the
+  #1468 string-id contract: (1) `$ref`-only top-level parameter schemas are
+  now inlined so every parameter advertises a direct `type` keyword
+  (`working` exposes `type: object`); (2) a lenient deserializer on every
+  non-string tool parameter accepts the properly-typed value first and
+  falls back to parsing a JSON-encoded string, with a precise error when
+  neither form fits.
 - **`velesdb-wasm`**: the VelesQL JOIN executor no longer depends on which
   side of the `ON` condition names the joined table. `ON joined.col =
   base.col` used to match nothing (NULL joined columns on every row);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,17 @@ Or use the local CI script: `.\scripts\local-ci.ps1` (Full) or `.\scripts\local-
 
 Git hooks are provided in `.githooks/` — activate with: `git config core.hooksPath .githooks`
 
+> **Note (SSH pushes):** the pre-push hook runs the full validation (~15 min) while
+> git already holds the connection to GitHub open; if that SSH connection dies in
+> the meantime, `git push` exits 141 (SIGPIPE) with no error message right after
+> the validation passes. Pushing over HTTPS is immune (the ref advertisement and
+> the pack upload are independent requests):
+>
+> ```
+> git config remote.origin.pushurl https://github.com/cyberlife-coder/VelesDB.git
+> git config credential.helper '!gh auth git-credential'
+> ```
+
 ## Development Setup
 
 ### Prerequisites

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6818,7 +6818,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "3.12.0"
+version = "4.0.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.12.0"
+version = "4.0.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "3.12.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "4.0.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v3.12.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v4.0.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="3.12.0"
+LABEL version="4.0.0"
 
 WORKDIR /app
 

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -159,13 +159,19 @@
       "id": "J002",
       "query": "SELECT * FROM orders LEFT JOIN customers ON orders.customer_id = customers.id ORDER BY orders.id ASC",
       "expect_ids": [1, 2, 3, 4],
-      "note": "issue #1544: LEFT JOIN keeps the unmatched left row (id=4) with NULL joined columns. Written base-table-first (orders.customer_id = customers.id) — see documented_divergences D002 for why the reversed condition order is deliberately NOT used here"
+      "note": "issue #1544: LEFT JOIN keeps the unmatched left row (id=4) with NULL joined columns. Written base-table-first (orders.customer_id = customers.id); the reversed order is exercised by J005 (issue #1555)"
     },
     {
       "id": "J003",
       "query": "SELECT * FROM orders JOIN customers ON orders.customer_id = customers.id WHERE customers.name = 'Alice' ORDER BY orders.id ASC",
       "expect_ids": [1, 3],
       "note": "issue #1544: JOIN combined with a WHERE predicate on a joined-table column"
+    },
+    {
+      "id": "J005",
+      "query": "SELECT * FROM orders JOIN customers ON customers.id = orders.customer_id ORDER BY orders.id ASC",
+      "expect_ids": [1, 2, 3],
+      "note": "issue #1555: identical to J001 but with the ON condition written joined-table-first — both engines must orient the condition by which side names the joined table (was documented_divergences D002)"
     },
     {
       "id": "J004",
@@ -273,10 +279,10 @@
     {
       "id": "D002",
       "area": "JOIN condition side order (WASM only)",
-      "core_behavior": "normalize_join_condition (query_join.rs) accepts ON in either order — `base.col = joined.col` and `joined.col = base.col` both resolve to the same match",
-      "wasm_behavior": "equality_keys/key_of (velesql_join.rs) does not normalize side order: `ON joined.col = base.col` looks up the joined-table-qualified key on the yet-unjoined base row (which never has it), so EVERY row silently comes back with NULL joined columns instead of matching — verified empirically with `LEFT JOIN customers ON customers.id = orders.customer_id` (all 4 rows got customers:null) vs the working `ON orders.customer_id = customers.id` (rows 1-3 matched, row 4 null)",
-      "status": "tracked as a real WASM gap, not fixed here (out of scope per issue #1544 — coverage of existing behaviour, not new WASM support). fixture J001/J002 are written in the working (base-table-first) order so the conformance suite stays green; the reversed order is intentionally not exercised as a passing case",
-      "evidence": "crates/velesdb-wasm/src/velesql_join.rs: equality_keys()/key_of()"
+      "core_behavior": "normalize_join_condition (search/query/join.rs) accepts ON in either order — `base.col = joined.col` and `joined.col = base.col` both resolve to the same match",
+      "wasm_behavior": "RESOLVED (issue #1555): equality_keys (velesql_join.rs) now orients the condition by which side targets the join alias (or raw table name), mirroring core; both orders resolve identically",
+      "status": "resolved by issue #1555 — join case J005 exercises the joined-table-first order on both engines; the former regression-lock canary test is now a parity lock (test_wasm_join_condition_side_order_parity_1555)",
+      "evidence": "crates/velesdb-wasm/src/velesql_join.rs: equality_keys() orientation; crates/velesdb-core/src/collection/search/query/join.rs: normalize_join_condition()"
     },
     {
       "id": "D003",

--- a/conformance/velesql_executor_cases.json
+++ b/conformance/velesql_executor_cases.json
@@ -208,7 +208,15 @@
         { "category": "tech", "n": 3, "total_year": 6065.0 },
         { "category": "other", "n": 2, "total_year": 4040.0 }
       ],
-      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT is deliberately not exercised here — see documented_divergences D006"
+      "note": "issue #1544: multiple aggregates per group and ORDER BY an aggregate column plus the group key. LIMIT on grouped rows is exercised by G005"
+    },
+    {
+      "id": "G005",
+      "query": "SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1",
+      "expect_groups": [
+        { "category": "tech", "n": 3, "total_year": 6065.0 }
+      ],
+      "note": "issue #1556: LIMIT applies to the ordered group rows in both engines (was documented_divergences D006 — core returned every group)"
     }
   ],
   "setops_cases": [
@@ -297,10 +305,10 @@
     {
       "id": "D006",
       "area": "LIMIT on GROUP BY aggregate results",
-      "core_behavior": "Database::execute_aggregate / Collection::execute_grouped_aggregate never reads stmt.limit — every group is returned regardless of a trailing LIMIT clause, verified empirically with 'SELECT category, COUNT(*) AS n, SUM(year) AS total_year FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1', which returned BOTH groups",
-      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; the identical query returned only 1 row (the 'tech' group)",
-      "status": "tracked as a real core gap, not fixed here (out of scope for issue #1544 — coverage of existing behaviour, not a new feature). aggregate_cases G001-G004 deliberately do not exercise LIMIT so the fixture's shared expect_groups is correct for both engines",
-      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: execute_grouped_aggregate/build_grouped_results (no limit/truncate call); crates/velesdb-wasm/src/velesql_aggregate.rs applies the standard SELECT finalize path which includes LIMIT"
+      "core_behavior": "RESOLVED (issue #1556): build_grouped_results now applies OFFSET/LIMIT after ORDER BY, with no default cap — a LIMIT-less GROUP BY still returns every group",
+      "wasm_behavior": "the WASM aggregate pipeline applies LIMIT to the grouped row set the same as a plain SELECT; both engines now agree",
+      "status": "resolved by issue #1556 — aggregate case G005 exercises LIMIT on grouped rows and is asserted by both engines; unit coverage in crates/velesdb-core/tests/velesql_group_by_limit.rs",
+      "evidence": "crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs: build_grouped_results applies skip(offset)/take(limit) after sort; crates/velesdb-wasm/src/velesql_select.rs: finalize_aggregated routes through apply_limit_offset with u64::MAX default"
     }
   ]
 }

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/tauri-plugin-velesdb/src/error.rs
+++ b/crates/tauri-plugin-velesdb/src/error.rs
@@ -31,6 +31,21 @@ pub enum Error {
     #[error("Invalid configuration: {0}")]
     InvalidConfig(String),
 
+    /// An explicit engine config file could not be loaded (issue #1549).
+    ///
+    /// Raised by `Builder::with_config_path` when the TOML file is missing,
+    /// unparsable, or fails engine validation. The typed core
+    /// [`velesdb_core::config::ConfigError`] is preserved as the source so
+    /// hosts can match on the exact failure.
+    #[error("Failed to load VelesDB config from {path}: {source}")]
+    ConfigLoad {
+        /// The config file path that failed to load.
+        path: String,
+        /// The typed core configuration error.
+        #[source]
+        source: velesdb_core::config::ConfigError,
+    },
+
     /// Serialization error.
     #[error("Serialization error: {0}")]
     Serialization(String),
@@ -56,7 +71,7 @@ impl From<Error> for CommandError {
             Error::CollectionNotFound(_) => "VELES-002",
             Error::NotFound(_) => "NOT_FOUND",
             Error::DimensionMismatch { .. } => "DIMENSION_MISMATCH",
-            Error::InvalidConfig(_) => "INVALID_CONFIG",
+            Error::InvalidConfig(_) | Error::ConfigLoad { .. } => "INVALID_CONFIG",
             Error::Serialization(_) => "SERIALIZATION_ERROR",
             Error::Io(_) => "VELES-011",
         };

--- a/crates/tauri-plugin-velesdb/src/lib.rs
+++ b/crates/tauri-plugin-velesdb/src/lib.rs
@@ -58,10 +58,10 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::module_name_repetitions)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tauri::{
-    plugin::{Builder, TauriPlugin},
+    plugin::{Builder as TauriPluginBuilder, TauriPlugin},
     Manager, Runtime,
 };
 
@@ -81,6 +81,7 @@ pub mod types_graph;
 
 pub use error::{CommandError, Error, Result};
 pub use state::VelesDbState;
+pub use velesdb_core::config::VelesConfig;
 
 /// Initializes the `VelesDB` plugin with the default settings.
 ///
@@ -137,102 +138,214 @@ macro_rules! velesdb_invoke_handler {
 ///     .expect("error while running tauri application");
 /// ```
 #[must_use]
-// The body is a flat command-registration list (trivial cyclomatic complexity);
-// the line count grows linearly with the number of exposed commands.
-#[allow(clippy::too_many_lines)]
 pub fn init_with_path<R: Runtime, P: AsRef<Path>>(path: P) -> TauriPlugin<R> {
-    let db_path = path.as_ref().to_path_buf();
+    Builder::new(path).build()
+}
 
-    let builder = Builder::new("velesdb").invoke_handler(velesdb_invoke_handler!(
-        common: [
-            commands::create_collection,
-            commands::create_metadata_collection,
-            commands::delete_collection,
-            commands::list_collections,
-            commands::get_collection,
-            commands::upsert,
-            commands::upsert_metadata,
-            commands::get_points,
-            commands::delete_points,
-            commands::search,
-            commands::search_ids,
-            commands::batch_search,
-            commands::text_search,
-            commands::hybrid_search,
-            commands::multi_query_search,
-            commands_query::query,
-            commands::is_empty,
-            commands::flush,
-            commands::compact_storage,
-            commands::update_guardrails,
-            commands::get_guardrails,
-            commands::scroll_collection,
-            // Sparse vector commands
-            commands_sparse::sparse_search,
-            commands_sparse::hybrid_sparse_search,
-            commands_sparse::sparse_upsert,
-            // PQ training command
-            commands::train_pq,
-            // AgentMemory commands (EPIC-016 US-003)
-            commands_memory::semantic_store,
-            commands_memory::semantic_store_with_ttl,
-            commands_memory::semantic_query,
-            commands_memory::semantic_delete,
-            commands_memory::semantic_dimension,
-            commands_memory::semantic_serialize,
-            commands_memory::semantic_deserialize,
-            commands_memory::episodic_record,
-            commands_memory::episodic_recent,
-            commands_memory::episodic_recall_similar,
-            commands_memory::episodic_older_than,
-            commands_memory::episodic_delete,
-            commands_memory::episodic_serialize,
-            commands_memory::episodic_deserialize,
-            commands_memory::procedural_learn,
-            commands_memory::procedural_recall,
-            commands_memory::procedural_reinforce,
-            commands_memory::procedural_list_all,
-            commands_memory::procedural_delete,
-            commands_memory::procedural_serialize,
-            commands_memory::procedural_deserialize,
-            // AgentMemory TTL / eviction / snapshot-versioning / VelesQL parity
-            commands_memory::memory_set_ttl,
-            commands_memory::memory_auto_expire,
-            commands_memory::memory_evict_low_confidence,
-            commands_memory::memory_snapshot,
-            commands_memory::memory_load_latest_snapshot,
-            commands_memory::memory_load_snapshot_version,
-            commands_memory::memory_list_snapshot_versions,
-            commands_memory::memory_query_semantic,
-            commands_memory::memory_query_episodic,
-            commands_memory::memory_query_procedural,
-            // Knowledge Graph commands (EPIC-015 US-001)
-            commands_graph::create_graph_collection,
-            commands_graph::add_edge,
-            commands_graph::add_edges_batch,
-            commands_graph::get_edges,
-            commands_graph::traverse_graph,
-            commands_graph::get_node_degree,
-            commands_graph::traverse_graph_parallel,
-            // Secondary Index commands
-            commands_index::create_index,
-            commands_index::drop_index,
-            commands_index::list_indexes,
-        ],
-        persistence_only: [
-            commands::stream_insert,
-            commands::enable_streaming,
-        ],
-    ));
-    builder
-        .setup(move |app, _api| {
-            let observer = std::sync::Arc::new(observer::TauriObserver::new(app.clone()));
-            let state = VelesDbState::new_with_observer(db_path.clone(), observer);
-            app.manage(state);
-            tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
-            Ok(())
-        })
-        .build()
+/// Builder for the `VelesDB` plugin (issue #1549).
+///
+/// Lets the host application supply an explicit engine
+/// [`VelesConfig`] — either as a value ([`Builder::with_config`]) or loaded
+/// from a TOML file ([`Builder::with_config_path`]) — before building the
+/// plugin. Without a config, the database opens with core defaults, exactly
+/// like [`init_with_path`] always did.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let plugin = tauri_plugin_velesdb::Builder::new("./my_data")
+///     .with_config_path("./velesdb.toml")?  // fail-fast if missing/invalid
+///     .build();
+/// tauri::Builder::default()
+///     .plugin(plugin)
+///     .run(tauri::generate_context!())
+///     .expect("error while running tauri application");
+/// ```
+#[derive(Debug)]
+pub struct Builder {
+    path: PathBuf,
+    config: Option<VelesConfig>,
+}
+
+impl Builder {
+    /// Creates a builder for a plugin persisting under `path`.
+    #[must_use]
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+            config: None,
+        }
+    }
+
+    /// Supplies an explicit engine [`VelesConfig`] value.
+    ///
+    /// The database is opened with
+    /// [`velesdb_core::Database::open_with_observer_and_config`], so every
+    /// config-honouring subsystem (HNSW defaults, WAL batching, runtime
+    /// limits, search quality) reads from this instance instead of core
+    /// defaults. Note that the core re-validates the config when the
+    /// database is opened, so an out-of-range value fails the first open.
+    #[must_use]
+    pub fn with_config(mut self, config: VelesConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Loads an engine [`VelesConfig`] from a TOML file, fail-fast.
+    ///
+    /// Only the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+    /// `[quantization]`/`[wal_batch]`) are read (via
+    /// [`VelesConfig::load_from_path_engine_only`]); any other top-level
+    /// table — e.g. a `[server]` section owned by `velesdb-server` in a
+    /// shared config file — is ignored rather than being parsed into
+    /// `VelesConfig`'s own unrelated same-named fields and spuriously
+    /// rejected. `VELESDB_*` environment variables still layer on top of
+    /// the filtered file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigLoad`] immediately — never a silent fallback
+    /// to defaults — if the file is missing, is not valid TOML, or fails
+    /// engine validation. The typed
+    /// [`velesdb_core::config::ConfigError`] is preserved as the source.
+    pub fn with_config_path<P: AsRef<Path>>(mut self, config_path: P) -> Result<Self> {
+        let config_path = config_path.as_ref();
+        if !config_path.exists() {
+            return Err(Error::ConfigLoad {
+                path: config_path.display().to_string(),
+                source: velesdb_core::config::ConfigError::FileNotFound(
+                    config_path.display().to_string(),
+                ),
+            });
+        }
+        let config = VelesConfig::load_from_path_engine_only(config_path).map_err(|source| {
+            Error::ConfigLoad {
+                path: config_path.display().to_string(),
+                source,
+            }
+        })?;
+        self.config = Some(config);
+        Ok(self)
+    }
+
+    /// Returns the engine config recorded so far, if any.
+    #[must_use]
+    pub fn config(&self) -> Option<&VelesConfig> {
+        self.config.as_ref()
+    }
+
+    /// Builds the Tauri plugin, registering every `VelesDB` command and
+    /// managing a [`VelesDbState`] that opens the database with the
+    /// recorded config (or core defaults when none was supplied).
+    #[must_use]
+    // The body is a flat command-registration list (trivial cyclomatic
+    // complexity); the line count grows linearly with the number of
+    // exposed commands.
+    #[allow(clippy::too_many_lines)]
+    pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+        let Self {
+            path: db_path,
+            config,
+        } = self;
+
+        let builder = TauriPluginBuilder::new("velesdb").invoke_handler(velesdb_invoke_handler!(
+            common: [
+                commands::create_collection,
+                commands::create_metadata_collection,
+                commands::delete_collection,
+                commands::list_collections,
+                commands::get_collection,
+                commands::upsert,
+                commands::upsert_metadata,
+                commands::get_points,
+                commands::delete_points,
+                commands::search,
+                commands::search_ids,
+                commands::batch_search,
+                commands::text_search,
+                commands::hybrid_search,
+                commands::multi_query_search,
+                commands_query::query,
+                commands::is_empty,
+                commands::flush,
+                commands::compact_storage,
+                commands::update_guardrails,
+                commands::get_guardrails,
+                commands::scroll_collection,
+                // Sparse vector commands
+                commands_sparse::sparse_search,
+                commands_sparse::hybrid_sparse_search,
+                commands_sparse::sparse_upsert,
+                // PQ training command
+                commands::train_pq,
+                // AgentMemory commands (EPIC-016 US-003)
+                commands_memory::semantic_store,
+                commands_memory::semantic_store_with_ttl,
+                commands_memory::semantic_query,
+                commands_memory::semantic_delete,
+                commands_memory::semantic_dimension,
+                commands_memory::semantic_serialize,
+                commands_memory::semantic_deserialize,
+                commands_memory::episodic_record,
+                commands_memory::episodic_recent,
+                commands_memory::episodic_recall_similar,
+                commands_memory::episodic_older_than,
+                commands_memory::episodic_delete,
+                commands_memory::episodic_serialize,
+                commands_memory::episodic_deserialize,
+                commands_memory::procedural_learn,
+                commands_memory::procedural_recall,
+                commands_memory::procedural_reinforce,
+                commands_memory::procedural_list_all,
+                commands_memory::procedural_delete,
+                commands_memory::procedural_serialize,
+                commands_memory::procedural_deserialize,
+                // AgentMemory TTL / eviction / snapshot-versioning / VelesQL parity
+                commands_memory::memory_set_ttl,
+                commands_memory::memory_auto_expire,
+                commands_memory::memory_evict_low_confidence,
+                commands_memory::memory_snapshot,
+                commands_memory::memory_load_latest_snapshot,
+                commands_memory::memory_load_snapshot_version,
+                commands_memory::memory_list_snapshot_versions,
+                commands_memory::memory_query_semantic,
+                commands_memory::memory_query_episodic,
+                commands_memory::memory_query_procedural,
+                // Knowledge Graph commands (EPIC-015 US-001)
+                commands_graph::create_graph_collection,
+                commands_graph::add_edge,
+                commands_graph::add_edges_batch,
+                commands_graph::get_edges,
+                commands_graph::traverse_graph,
+                commands_graph::get_node_degree,
+                commands_graph::traverse_graph_parallel,
+                // Secondary Index commands
+                commands_index::create_index,
+                commands_index::drop_index,
+                commands_index::list_indexes,
+            ],
+            persistence_only: [
+                commands::stream_insert,
+                commands::enable_streaming,
+            ],
+        ));
+        builder
+            .setup(move |app, _api| {
+                let observer = std::sync::Arc::new(observer::TauriObserver::new(app.clone()));
+                let state = match config {
+                    Some(config) => VelesDbState::new_with_observer_and_config(
+                        db_path.clone(),
+                        observer,
+                        config,
+                    ),
+                    None => VelesDbState::new_with_observer(db_path.clone(), observer),
+                };
+                app.manage(state);
+                tracing::info!("VelesDB plugin initialized with path: {:?}", db_path);
+                Ok(())
+            })
+            .build()
+    }
 }
 
 /// Alias for `init()` for backward compatibility.

--- a/crates/tauri-plugin-velesdb/src/state.rs
+++ b/crates/tauri-plugin-velesdb/src/state.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 use velesdb_core::agent::AgentMemory;
+use velesdb_core::config::VelesConfig;
 use velesdb_core::{Database, DatabaseObserver};
 
 use crate::error::{Error, Result};
@@ -40,6 +41,12 @@ pub struct VelesDbState {
     /// Set by the plugin at setup so collection create/delete events reach the
     /// frontend regardless of the entry path. `None` falls back to a plain open.
     observer: Option<Arc<dyn DatabaseObserver>>,
+    /// Optional explicit engine [`VelesConfig`] applied when the database is
+    /// opened (issue #1549).
+    ///
+    /// `None` preserves the historical behaviour: the database opens with
+    /// core defaults, exactly as before config wiring existed.
+    config: Option<VelesConfig>,
 }
 
 impl VelesDbState {
@@ -54,22 +61,49 @@ impl VelesDbState {
     /// A new `VelesDbState` instance (database not yet opened).
     #[must_use]
     pub fn new(path: PathBuf) -> Self {
-        Self::with_observer(path, None)
+        Self::with_parts(path, None, None)
     }
 
     /// Creates a new plugin state that injects `observer` into the database when
     /// it is opened, so collection lifecycle events are forwarded to Tauri.
     #[must_use]
     pub fn new_with_observer(path: PathBuf, observer: Arc<dyn DatabaseObserver>) -> Self {
-        Self::with_observer(path, Some(observer))
+        Self::with_parts(path, Some(observer), None)
     }
 
-    fn with_observer(path: PathBuf, observer: Option<Arc<dyn DatabaseObserver>>) -> Self {
+    /// Creates a new plugin state that opens the database with an explicit
+    /// engine [`VelesConfig`] instead of core defaults (issue #1549).
+    #[must_use]
+    pub fn new_with_config(path: PathBuf, config: VelesConfig) -> Self {
+        Self::with_parts(path, None, Some(config))
+    }
+
+    /// Creates a new plugin state with both a lifecycle `observer` and an
+    /// explicit engine [`VelesConfig`] (issue #1549).
+    ///
+    /// The database is opened via
+    /// [`Database::open_with_observer_and_config`], so lifecycle events reach
+    /// Tauri *and* the engine honours the supplied config.
+    #[must_use]
+    pub fn new_with_observer_and_config(
+        path: PathBuf,
+        observer: Arc<dyn DatabaseObserver>,
+        config: VelesConfig,
+    ) -> Self {
+        Self::with_parts(path, Some(observer), Some(config))
+    }
+
+    fn with_parts(
+        path: PathBuf,
+        observer: Option<Arc<dyn DatabaseObserver>>,
+        config: Option<VelesConfig>,
+    ) -> Self {
         Self {
             db: Arc::new(RwLock::new(None)),
             memory: Arc::new(RwLock::new(None)),
             path,
             observer,
+            config,
         }
     }
 
@@ -81,9 +115,17 @@ impl VelesDbState {
     pub fn open(&self) -> Result<()> {
         let mut db_guard = self.db.write();
         if db_guard.is_none() {
-            let db = match &self.observer {
-                Some(observer) => Database::open_with_observer(&self.path, Arc::clone(observer))?,
-                None => Database::open(&self.path)?,
+            let db = match (&self.observer, &self.config) {
+                (Some(observer), Some(config)) => Database::open_with_observer_and_config(
+                    &self.path,
+                    Arc::clone(observer),
+                    config.clone(),
+                )?,
+                (Some(observer), None) => {
+                    Database::open_with_observer(&self.path, Arc::clone(observer))?
+                }
+                (None, Some(config)) => Database::open_with_config(&self.path, config.clone())?,
+                (None, None) => Database::open(&self.path)?,
             };
             *db_guard = Some(Arc::new(db));
             tracing::info!("VelesDB opened at {:?}", self.path);

--- a/crates/tauri-plugin-velesdb/tests/config_wiring.rs
+++ b/crates/tauri-plugin-velesdb/tests/config_wiring.rs
@@ -1,0 +1,240 @@
+//! Integration coverage for the engine `VelesConfig` wiring (issue #1549).
+//!
+//! Mirrors the server/CLI pattern from PR #1565: an explicit engine config
+//! (given as a value or loaded engine-only from a TOML path) must reach
+//! `Database::open_with_config` / `open_with_observer_and_config`, a missing
+//! or invalid config path must fail fast with an actionable error (never a
+//! silent fallback to defaults), and the no-config behaviour must stay
+//! byte-for-byte identical to before.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tauri::test::{mock_builder, mock_context, noop_assets};
+use tauri::Manager;
+use tauri_plugin_velesdb::{Builder, VelesDbState};
+use velesdb_core::config::VelesConfig;
+
+/// Engine config with `limits.max_collections = 1`, built through the same
+/// engine-only parser the path loader uses.
+fn one_collection_config() -> VelesConfig {
+    VelesConfig::from_toml_engine_only("[limits]\nmax_collections = 1\n")
+        .expect("test: valid engine-only config")
+}
+
+/// Proves a config is *enforced* by the opened database, not just stored:
+/// the first collection fits under `max_collections = 1`, the second must be
+/// refused by the engine.
+fn assert_limit_of_one_enforced(state: &VelesDbState) {
+    state
+        .with_db(|db| {
+            assert_eq!(db.config().limits.max_collections, 1);
+            db.create_metadata_collection("first")?;
+            Ok(())
+        })
+        .expect("test: first collection under the limit should succeed");
+
+    let err = state
+        .with_db(|db| {
+            db.create_metadata_collection("second")?;
+            Ok(())
+        })
+        .expect_err("test: second collection should be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "unexpected error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (a) explicit config honoured
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_state_open_honours_explicit_config() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let state = VelesDbState::new_with_config(dir.path().to_path_buf(), one_collection_config());
+
+    // Act + Assert
+    assert_limit_of_one_enforced(&state);
+}
+
+#[test]
+fn test_state_open_honours_config_alongside_observer() {
+    #[derive(Default)]
+    struct CountingObserver {
+        created: AtomicUsize,
+    }
+    impl velesdb_core::DatabaseObserver for CountingObserver {
+        fn on_collection_created(
+            &self,
+            _name: &str,
+            _kind: &velesdb_core::collection::CollectionType,
+        ) {
+            self.created.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let observer = Arc::new(CountingObserver::default());
+    let state = VelesDbState::new_with_observer_and_config(
+        dir.path().to_path_buf(),
+        observer.clone(),
+        one_collection_config(),
+    );
+
+    // Act + Assert - the config is enforced...
+    assert_limit_of_one_enforced(&state);
+
+    // ...and the observer still received the successful create.
+    assert_eq!(observer.created.load(Ordering::SeqCst), 1);
+}
+
+/// End-to-end through the plugin builder: a config passed to
+/// `Builder::with_config` must reach the managed state and the opened engine.
+#[test]
+fn test_plugin_builder_with_config_reaches_managed_state() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let app = mock_builder()
+        .plugin(
+            Builder::new(dir.path())
+                .with_config(one_collection_config())
+                .build(),
+        )
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+
+    // Act + Assert
+    let state = app.state::<VelesDbState>();
+    assert_limit_of_one_enforced(&state);
+}
+
+// ---------------------------------------------------------------------------
+// (b) invalid / missing config path -> fail-fast, actionable, typed source
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_with_config_path_missing_file_fails_fast() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let missing = dir.path().join("does-not-exist.toml");
+
+    // Act
+    let err = Builder::new(dir.path())
+        .with_config_path(&missing)
+        .expect_err("test: a missing explicit config path must be an immediate error");
+
+    // Assert - actionable: the message names the offending path.
+    assert!(
+        err.to_string().contains("does-not-exist.toml"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_with_config_path_invalid_value_fails_fast_with_typed_source() {
+    // Arrange - parses fine, fails engine validation (max_collections = 0).
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let config_path = dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 0\n").expect("test: write config");
+
+    // Act
+    let err = Builder::new(dir.path())
+        .with_config_path(&config_path)
+        .expect_err("test: an invalid engine value must be an immediate error");
+
+    // Assert - the typed core ConfigError is preserved as the error source.
+    let source = std::error::Error::source(&err).expect("test: error must expose a source");
+    assert!(
+        source
+            .downcast_ref::<velesdb_core::config::ConfigError>()
+            .is_some(),
+        "source must be velesdb_core::config::ConfigError, got: {source}"
+    );
+}
+
+/// Engine-only semantics: a TOML shared with `velesdb-server` may carry a
+/// `[server]` table (its HTTP transport) whose values would be rejected by
+/// `VelesConfig`'s own unrelated `server` validation. The plugin loader must
+/// ignore non-engine sections instead of failing on them.
+#[test]
+fn test_with_config_path_ignores_non_engine_sections() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let config_path = dir.path().join("velesdb.toml");
+    std::fs::write(
+        &config_path,
+        "[server]\nport = 443\n\n[limits]\nmax_collections = 1\n",
+    )
+    .expect("test: write config");
+
+    // Act
+    let builder = Builder::new(dir.path())
+        .with_config_path(&config_path)
+        .expect("test: shell-owned [server] section must not block the plugin");
+
+    // Assert - the engine section was loaded...
+    assert_eq!(
+        builder
+            .config()
+            .expect("test: config must be loaded")
+            .limits
+            .max_collections,
+        1
+    );
+
+    // ...and it is enforced end-to-end through the built plugin.
+    let app = mock_builder()
+        .plugin(builder.build())
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+    let state = app.state::<VelesDbState>();
+    assert_limit_of_one_enforced(&state);
+}
+
+// ---------------------------------------------------------------------------
+// (c) no config -> behaviour unchanged (core defaults)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_no_config_opens_with_core_defaults() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let state = VelesDbState::new(dir.path().to_path_buf());
+
+    // Act + Assert
+    state
+        .with_db(|db| {
+            assert_eq!(
+                db.config().limits.max_collections,
+                velesdb_core::config::LimitsConfig::default().max_collections
+            );
+            Ok(())
+        })
+        .expect("test: open without config");
+}
+
+#[test]
+fn test_builder_without_config_opens_with_core_defaults() {
+    // Arrange
+    let dir = tempfile::tempdir().expect("test: temp dir");
+    let app = mock_builder()
+        .plugin(Builder::new(dir.path()).build())
+        .build(mock_context(noop_assets()))
+        .expect("test: build mock app with plugin");
+
+    // Act + Assert
+    let state = app.state::<VelesDbState>();
+    state
+        .with_db(|db| {
+            assert_eq!(
+                db.config().limits.max_collections,
+                velesdb_core::config::LimitsConfig::default().max_collections
+            );
+            Ok(())
+        })
+        .expect("test: open without config");
+}

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -30,11 +30,14 @@ impl Collection {
     /// # Errors
     ///
     /// Returns `Error::EdgeExists` if an edge with the same ID already exists.
-    /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
-    /// (strict schema) if `source` or `target` has no stored node payload —
-    /// an edge to a node that was never created would otherwise be invisible
-    /// to `all_node_ids()` and MATCH (issue #1442), since both derive their
-    /// node set from the payload store, not the edge store.
+    /// Returns `Error::NodeNotFound` if `source` or `target` has no stored
+    /// node payload, in both schema modes (issue #1470) — an edge to a node
+    /// that was never created would otherwise be invisible to
+    /// `all_node_ids()` and MATCH (issue #1442), since both derive their
+    /// node set from the payload store, not the edge store. In strict mode,
+    /// `Error::SchemaValidation` is still returned for actual schema-shape
+    /// violations (undeclared node type, undeclared edge type, endpoint
+    /// type mismatch) once both endpoints are confirmed to exist.
     ///
     /// # Example
     ///
@@ -290,14 +293,15 @@ impl Collection {
     ///
     /// # Errors
     ///
-    /// Returns `Error::NodeNotFound` (schemaless) or `Error::SchemaValidation`
-    /// (strict mode: missing endpoint, no `_labels`, or an edge-type
-    /// constraint violation). This divergence is deliberate and documented,
-    /// not an oversight: `SchemaValidation` is part of the strict-schema
-    /// contract already published, so folding the missing-endpoint case
-    /// into `NodeNotFound` there would be a breaking change. Tracked for
-    /// the next major version in
-    /// <https://github.com/cyberlife-coder/VelesDB/issues/1470>.
+    /// Returns `Error::NodeNotFound` when `source` or `target` has no stored
+    /// payload, in both schema modes (issue #1470 — unified with the
+    /// schemaless-only behavior described above; strict mode used to
+    /// overload `Error::SchemaValidation` for this case, see the CHANGELOG
+    /// entry for the next major version and issue #1442 for why it
+    /// originally diverged). Returns `Error::SchemaValidation` in strict
+    /// mode for an actual schema-shape violation once both endpoints are
+    /// confirmed to exist: no `_labels` on an endpoint, or an edge-type /
+    /// endpoint-type constraint violation.
     fn validate_edge_referential_integrity(
         payload: &LogPayloadStorage,
         schema: Option<&GraphSchema>,
@@ -320,14 +324,16 @@ impl Collection {
     ///
     /// # Errors
     ///
-    /// Returns `Error::SchemaValidation` if the node has no stored payload
-    /// (referential integrity violation) or the payload declares no `_labels`.
+    /// Returns `Error::NodeNotFound` if the node has no stored payload — a
+    /// genuinely missing endpoint, unified with the schemaless-mode contract
+    /// (issue #1470; previously `Error::SchemaValidation`, see the CHANGELOG
+    /// entry for the next major version). Returns `Error::SchemaValidation`
+    /// if the node exists but its payload declares no `_labels` — an actual
+    /// schema-shape violation, not a missing endpoint.
     fn endpoint_node_type(payload: &LogPayloadStorage, node_id: u64) -> Result<String> {
         let stored = payload.retrieve(node_id)?;
         let Some(stored) = stored else {
-            return Err(Error::SchemaValidation(format!(
-                "edge references non-existent node {node_id}"
-            )));
+            return Err(Error::NodeNotFound(node_id));
         };
         extract_labels(&stored)
             .into_iter()

--- a/crates/velesdb-core/src/collection/core/graph_api_tests.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api_tests.rs
@@ -906,11 +906,27 @@ mod tests {
         }
     }
 
+    /// Asserts the error is `NodeNotFound(expected_id)` — the unified
+    /// missing-endpoint contract (issue #1470): a genuinely missing endpoint
+    /// is `NodeNotFound` in both schema modes, `SchemaValidation` being
+    /// reserved for actual schema-shape violations (undeclared type, edge
+    /// type / endpoint type mismatch).
+    fn assert_node_not_found(result: crate::error::Result<()>, expected_id: u64) {
+        match result {
+            Err(crate::error::Error::NodeNotFound(id)) => assert_eq!(id, expected_id),
+            other => panic!("expected NodeNotFound({expected_id}), got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_strict_mode_rejects_dangling_edge() {
+        // Issue #1470: a genuinely missing endpoint is NodeNotFound in
+        // strict mode too, not SchemaValidation — that variant is reserved
+        // for actual schema-shape violations (see the other
+        // test_strict_mode_rejects_* below, which are unaffected).
         let (collection, _temp) = create_strict_graph_collection();
         // No node payloads stored: endpoints do not exist.
-        assert_schema_violation(collection.add_edge(make_edge(1, 100, 200, "KNOWS")));
+        assert_node_not_found(collection.add_edge(make_edge(1, 100, 200, "KNOWS")), 100);
         assert_eq!(collection.edge_count(), 0, "no partial write on rejection");
     }
 
@@ -1016,6 +1032,8 @@ mod tests {
 
     #[test]
     fn test_strict_mode_batch_rejects_dangling_edge() {
+        // Issue #1470: same unification as test_strict_mode_rejects_dangling_edge,
+        // for the batch path.
         let (collection, _temp) = create_strict_graph_collection();
         store_typed_node(&collection, 100, "Person");
         store_typed_node(&collection, 200, "Person");
@@ -1024,7 +1042,7 @@ mod tests {
             make_edge(1, 100, 200, "KNOWS"),
             make_edge(2, 300, 400, "KNOWS"),
         ];
-        assert_schema_violation(collection.add_edges_batch(batch).map(|_| ()));
+        assert_node_not_found(collection.add_edges_batch(batch).map(|_| ()), 300);
         // Whole batch rejected before any mutation — no partial write.
         assert_eq!(
             collection.edge_count(),

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -44,6 +44,8 @@ impl Collection {
             group_by_columns,
             having,
             stmt.order_by.as_deref(),
+            stmt.limit,
+            stmt.offset,
         );
 
         Ok(serde_json::Value::Array(results))
@@ -179,13 +181,19 @@ impl Collection {
         Ok(())
     }
 
-    /// Builds the result array from grouped aggregators, applying HAVING and ORDER BY.
+    /// Builds the result array from grouped aggregators, applying HAVING,
+    /// ORDER BY, then OFFSET/LIMIT (issue #1556). Unlike plain SELECT there is
+    /// no default cap: a LIMIT-less GROUP BY returns every group, matching the
+    /// WASM aggregate pipeline.
+    #[allow(clippy::too_many_arguments)]
     fn build_grouped_results(
         groups: HashMap<GroupKey, Aggregator>,
         aggregations: &[AggregateFunction],
         group_by_columns: &[String],
         having: Option<&HavingClause>,
         order_by: Option<&[crate::velesql::SelectOrderBy]>,
+        limit: Option<u64>,
+        offset: Option<u64>,
     ) -> Vec<serde_json::Value> {
         let mut results = Vec::new();
 
@@ -213,6 +221,12 @@ impl Collection {
 
         if let Some(order_by) = order_by {
             Self::sort_aggregation_results(&mut results, order_by);
+        }
+
+        let skip = usize::try_from(offset.unwrap_or(0)).unwrap_or(usize::MAX);
+        let take = limit.map_or(usize::MAX, |l| usize::try_from(l).unwrap_or(usize::MAX));
+        if skip > 0 || take < results.len() {
+            results = results.into_iter().skip(skip).take(take).collect();
         }
 
         results

--- a/crates/velesdb-core/tests/velesql_group_by_limit.rs
+++ b/crates/velesdb-core/tests/velesql_group_by_limit.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "persistence")]
+//! Reproducer for issue #1556: `Database::execute_aggregate` must apply the
+//! statement's `OFFSET`/`LIMIT` to GROUP BY results after ORDER BY, matching
+//! the WASM aggregate pipeline (`finalize_aggregated` routes group rows
+//! through `apply_limit_offset` with no default cap — a LIMIT-less GROUP BY
+//! still returns every group).
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use velesdb_core::velesql::Parser;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+/// Three groups by construction: tech (3 rows), other (2 rows), misc (1 row).
+fn open_grouped_db() -> (TempDir, Database) {
+    let dir = TempDir::new().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open db");
+    db.create_collection("docs", 2, DistanceMetric::Cosine)
+        .expect("create collection");
+    let collection = db.get_vector_collection("docs").expect("get collection");
+    let rows = [
+        (1, "tech", 2020),
+        (2, "tech", 2021),
+        (3, "tech", 2024),
+        (4, "other", 2019),
+        (5, "other", 2021),
+        (6, "misc", 2022),
+    ];
+    let points: Vec<Point> = rows
+        .iter()
+        .map(|(id, category, year)| {
+            Point::new(
+                *id,
+                vec![0.1, 0.2],
+                Some(json!({ "category": category, "year": year })),
+            )
+        })
+        .collect();
+    collection.upsert(points).expect("upsert");
+    (dir, db)
+}
+
+fn run_aggregate(db: &Database, sql: &str) -> Vec<Value> {
+    let query = Parser::parse(sql).expect("parse");
+    let result = db
+        .execute_aggregate(&query, &HashMap::new())
+        .expect("execute_aggregate");
+    result.as_array().expect("array result").clone()
+}
+
+#[test]
+fn group_by_limit_truncates_ordered_groups() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1",
+    );
+    assert_eq!(
+        groups,
+        vec![json!({ "category": "tech", "n": 3 })],
+        "LIMIT 1 must keep only the first group after ORDER BY"
+    );
+}
+
+#[test]
+fn group_by_offset_skips_leading_groups() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC LIMIT 1 OFFSET 1",
+    );
+    assert_eq!(
+        groups,
+        vec![json!({ "category": "other", "n": 2 })],
+        "OFFSET must skip already-ordered groups before LIMIT applies"
+    );
+}
+
+#[test]
+fn group_by_offset_only_drops_prefix_without_capping() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC OFFSET 1",
+    );
+    assert_eq!(
+        groups,
+        vec![
+            json!({ "category": "other", "n": 2 }),
+            json!({ "category": "misc", "n": 1 })
+        ],
+        "OFFSET without LIMIT must return every remaining group"
+    );
+}
+
+#[test]
+fn group_by_without_limit_returns_every_group() {
+    let (_dir, db) = open_grouped_db();
+    let groups = run_aggregate(
+        &db,
+        "SELECT category, COUNT(*) AS n FROM docs GROUP BY category ORDER BY n DESC, category ASC",
+    );
+    assert_eq!(
+        groups.len(),
+        3,
+        "a LIMIT-less GROUP BY must not be capped by any default SELECT limit"
+    );
+}

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -15,14 +15,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`~/.config/devin/config.json`) alongside Claude Code, Claude Desktop and
   Windsurf; documented in the README's stdio and HTTP-transport client
   sections.
+- Both installers now wire **Claude Desktop** automatically (macOS and
+  Windows): an `mcp-remote` stdio→HTTPS bridge entry is written into
+  `claude_desktop_config.json` (non-destructive merge, timestamped backup)
+  with `NODE_EXTRA_CA_CERTS` pointing at the daemon's local CA, so the bridge
+  verifies TLS strictly — no manual proxy setup, no
+  `NODE_TLS_REJECT_UNAUTHORIZED=0`. The exact TLS path the bridge will use is
+  probed (Node HTTPS request to `/health` with `NODE_EXTRA_CA_CERTS`) before
+  the entry is written; absolute command paths are resolved so Desktop's
+  shell-less, minimal-`PATH` spawn works. Without Node.js the installers fall
+  back to printing the Settings → Connectors instructions. Documented in the
+  README's new "Claude Desktop (macOS / Windows)" section (happy path,
+  troubleshooting, CA-trust removal).
+- `--wire-only` (`.sh`) / `-WireOnly` (`.ps1`): re-verify CA trust and
+  re-wire all clients against an already-installed daemon — no build, no
+  daemon restart, no interactive prompts.
 
 ### Fixed
 
 - The installer no longer writes a `type:"http"` entry into
   `claude_desktop_config.json` — confirmed Desktop's config file never reads
-  that shape (silently ignored). It now prints the Settings → Connectors →
-  Add custom connector instructions instead, matching what the README already
-  documented.
+  that shape (silently ignored). Superseded in this same release by the
+  `mcp-remote` bridge entry above, which Desktop's config file *does* read.
+- The CA-trust step on both platforms now **verifies** after trusting instead
+  of assuming: a strict HTTPS request to the daemon (no `--cacert`, i.e.
+  against the OS trust store) must succeed, and a trust command that exits 0
+  without actually taking effect is reported with the exact command to re-run
+  by hand. (Follows up the idempotency ground-truth check from #1537.)
 
 ### Changed
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -575,30 +575,112 @@ claude mcp add --transport http velesdb-memory https://127.0.0.1:18090/mcp
 } } }
 ```
 
-**Claude Desktop** — a different mechanism than every other client above.
+### Claude Desktop (macOS / Windows)
 
-Desktop's local config file (`claude_desktop_config.json`) only recognizes
-stdio (`command`) entries — a `url`/`type: "http"` block there is silently
-ignored (confirmed: it does not even try to connect). Use Desktop's own UI
-instead: **Settings → Connectors → Add custom connector**, paste the daemon
-URL directly:
+Claude Desktop is a different mechanism than every other client above, twice
+over:
 
+- its local config file (`claude_desktop_config.json`) only recognizes stdio
+  (`command`) entries — a `url`/`type: "http"` block there is silently
+  ignored (confirmed: it does not even try to connect);
+- its **Settings → Connectors → Add custom connector** UI accepts an
+  `https://` URL, but verifies TLS through its own Chromium/Node stack, which
+  does **not** reliably consult the OS keychain/certificate store — so even
+  after the CA-trust step above, the UI path can still refuse the daemon's
+  certificate.
+
+The installers therefore wire Desktop through a **stdio→HTTPS bridge**:
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (needs Node.js),
+spawned by Desktop over stdio, connecting to the daemon over HTTPS with
+`NODE_EXTRA_CA_CERTS` pointed at the daemon's CA so TLS is verified
+*strictly* (never `NODE_TLS_REJECT_UNAUTHORIZED=0`, which disables
+verification entirely). The bridge is a plain HTTPS client of the daemon —
+it never opens the store itself, so there is no `flock` conflict.
+
+**Happy path** — run the installer, restart Desktop, done:
+
+```bash
+# macOS
+./scripts/install-memory-daemon.sh
 ```
-https://127.0.0.1:18090/mcp
+
+```powershell
+# Windows
+pwsh -File scripts/install-memory-daemon.ps1
 ```
 
-No API key/OAuth secret needed — the daemon binds to loopback only. This
-requires HTTPS specifically (Desktop's connector dialog rejects a plain
-`http://` URL outright, even for `127.0.0.1`), which is exactly what this
-daemon serves by default — see "trusting the local CA" earlier in this
-section if the connection fails with a certificate warning.
+then quit Claude Desktop **fully** (macOS: menu bar → Quit; Windows: system
+tray → Quit — closing the window is not enough) and relaunch it:
+**velesdb-memory** appears under **Settings → Developer** as "running". The
+installer verifies the whole TLS path before writing the entry (a Node probe
+against `/health` with `NODE_EXTRA_CA_CERTS` — exactly what the bridge will
+do) and merges into the existing config non-destructively, with a
+timestamped backup. Re-running is idempotent; to re-wire without rebuilding
+anything (e.g. after installing Node later), pass `--wire-only` / `-WireOnly`.
 
-If you'd rather not use the Connectors UI, the stdio fallback still works —
-same block as every other client above, but point `VELESDB_MEMORY_PATH` at a
-**different** directory than the daemon's store: pointed at the same one, the
-fallback process and the daemon would fight over the same `flock`,
-reproducing the exact `DatabaseLocked` problem this section exists to avoid.
-This gives Desktop its own separate memory, not shared with the daemon.
+The generated entry looks like this (macOS shown; Windows is the same shape
+with `mcp-remote.cmd`/`npx.cmd` and `%USERPROFILE%` paths — the installer
+resolves **absolute** paths because Desktop spawns the command without a
+shell and, on macOS, with launchd's minimal `PATH` that contains neither
+Homebrew nor nvm):
+
+```json
+{ "mcpServers": { "velesdb-memory": {
+  "command": "/opt/homebrew/bin/mcp-remote",
+  "args": ["https://127.0.0.1:18090/mcp"],
+  "env": {
+    "NODE_EXTRA_CA_CERTS": "/Users/you/.velesdb-memory-tls/ca-cert.pem",
+    "PATH": "/opt/homebrew/bin:/usr/bin:/bin"
+  }
+} } }
+```
+
+(without a global `mcp-remote`, the installer writes
+`npx -y mcp-remote <url>` instead — same result, fetched on first launch.)
+
+**Troubleshooting**
+
+- *Certificate refused / bridge disconnected*: check the daemon answers —
+  `curl --cacert ~/.velesdb-memory-tls/ca-cert.pem https://127.0.0.1:18090/health`
+  (Windows: `curl.exe --cacert "$env:USERPROFILE\.velesdb-memory-tls\ca-cert.pem" https://127.0.0.1:18090/health`)
+  — then confirm the config entry's `NODE_EXTRA_CA_CERTS` path exists.
+  Re-run the installer with `--wire-only` / `-WireOnly` to re-verify and
+  re-write the entry. Never "fix" a certificate error with
+  `NODE_TLS_REJECT_UNAUTHORIZED=0` — that turns TLS verification off.
+- *Port already in use*: the installer refuses to grab a port another process
+  holds — re-run everything with `--port=<other>` / `-Port <other>` (the
+  Desktop entry is rewritten to match).
+- *No Node.js on the machine*: the bridge can't run — install Node (macOS:
+  `brew install node`; Windows: https://nodejs.org) and re-run with
+  `--wire-only` / `-WireOnly`. Until then the installer prints the UI
+  alternative: **Settings → Connectors → Add custom connector**, paste
+  `https://127.0.0.1:18090/mcp` (no API key — loopback only; requires the
+  CA-trust step to have succeeded, and Desktop's own TLS stack may still
+  refuse a local CA — which is why the bridge is the default).
+- *`Storage(DatabaseLocked)`*: something is opening the store directly
+  alongside the daemon — the bridge never does this; look for a leftover
+  stdio entry pointing `VELESDB_MEMORY_PATH` at the daemon's store.
+
+**Removing the CA trust** (the uninstallers never touch it — "never delete
+local state"):
+
+```bash
+# macOS — remove the trust-settings record, then the certificate itself
+security remove-trusted-cert ~/.velesdb-memory-tls/ca-cert.pem
+security delete-certificate -c "VelesDB Memory Local CA" ~/Library/Keychains/login.keychain-db
+```
+
+```powershell
+# Windows — user store only, mirroring how it was added
+certutil -delstore -user Root "VelesDB Memory Local CA"
+```
+
+If you'd rather not share memory with the daemon at all, the plain stdio
+config still works — same block as every other client above, but point
+`VELESDB_MEMORY_PATH` at a **different** directory than the daemon's store:
+pointed at the same one, the stdio process and the daemon would fight over
+the same `flock`, reproducing the exact `DatabaseLocked` problem this
+section exists to avoid. This gives Desktop its own separate memory.
 
 **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
 
@@ -622,6 +704,7 @@ macOS: building with the right features, running the daemon (as a `launchd`
 agent), trusting the local CA in your login keychain, and wiring Claude Code /
 Claude Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
 `--port`, `--store`, `--tls-dir`, `--ttl`, `--skip-client`, `--skip-ca-trust`,
+`--wire-only`,
 `--from-release`, `--uninstall`, …).
 
 ### Windows
@@ -629,7 +712,7 @@ Claude Desktop / Windsurf / Devin CLI — see `--help` for flags (`--embedder`,
 `scripts/install-memory-daemon.ps1` (`pwsh -File scripts/install-memory-daemon.ps1`,
 PowerShell 7+ on Windows 10/11) is the same automation with the same flags
 (PowerShell-cased: `-Embedder`, `-Port`, `-Store`, `-TlsDir`, `-Ttl`,
-`-SkipClient`, `-SkipCaTrust`, `-FromRelease`, `-Uninstall`, …), adapted to
+`-SkipClient`, `-SkipCaTrust`, `-WireOnly`, `-FromRelease`, `-Uninstall`, …), adapted to
 Windows in three places:
 
 - **Daemon**: a per-user **Scheduled Task** (`\VelesDB\MemoryDaemon`,
@@ -643,8 +726,10 @@ Windows in three places:
   the login keychain — also no admin rights needed (see "The local CA" above
   for the exact command).
 - **Client config paths**: Claude Desktop
-  `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
-  written by the installer, same as macOS), Windsurf
+  `%APPDATA%\Claude\claude_desktop_config.json` (wired with the same
+  `mcp-remote` stdio→HTTPS bridge as macOS — see "Claude Desktop
+  (macOS / Windows)" above; `.cmd` shims resolved explicitly because Desktop
+  spawns the command without a shell), Windsurf
   `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
   `%APPDATA%\devin\config.json`.
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -38,6 +38,7 @@ use crate::extract::DynExtractor;
 mod context_tools;
 
 mod dto;
+mod wire;
 use dto::{
     ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, RecallFusedParams,
     RecallFusedResult, RecallParams, RecallResult, RecallWhereParams, RelateParams, RelateResult,

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -81,6 +81,7 @@ fn wire_safe_input_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
     });
     let mut map = (*schema).clone();
     crate::schema::widen_id_properties(&mut map, &["id"]);
+    crate::schema::inline_ref_only_properties(&mut map);
     Arc::new(map)
 }
 
@@ -99,6 +100,7 @@ pub(super) struct ContextSavingsParams {
 pub(super) struct ExplainCompilationParams {
     /// The compile request to explain (compilation is deterministic, so
     /// re-submitting the request reproduces the exact decisions).
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub request: CompileRequest,
     /// The fragment whose decision to return. Looked up by matching
     /// `ContextDecision::fragment_id`, UNLESS `fragment_index` is also
@@ -114,7 +116,11 @@ pub(super) struct ExplainCompilationParams {
     /// lookup always returns the FIRST such decision (the deduplication
     /// survivor), never a dropped twin's. Absent (the default): behavior is
     /// unchanged, the decision is found by `fragment_id` alone.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub fragment_index: Option<usize>,
 }
 
@@ -151,6 +157,7 @@ pub(super) struct SaveWorkingContextParams {
     /// The distilled state to persist: goal, active constraints, verified
     /// facts, open hypotheses, decisions taken, exact evidence, and pending
     /// actions.
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub working: WorkingContext,
 }
 
@@ -231,6 +238,7 @@ pub(super) struct CompileTranscriptParams {
     pub path: Option<String>,
     /// Hard token ceiling for the assembled content, same as
     /// `compile_context`'s `token_budget`.
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub token_budget: u64,
     /// Project facet, recorded in provenance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -245,7 +253,11 @@ pub(super) struct CompileTranscriptParams {
     /// Tuning knobs for the transcript segmentation step itself (format,
     /// merge threshold, system-turn caching). `None` uses
     /// [`SegmentationPolicy::default`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub segmentation: Option<SegmentationPolicy>,
 }
 
@@ -328,7 +340,11 @@ pub(super) struct SuggestBudgetParams {
     /// Tokens to reserve for the response, subtracted from the model's
     /// window (default `0`) — mirrors
     /// [`CompilePolicy::response_reserve_tokens`].
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub reserve_tokens: Option<u64>,
 }
 
@@ -587,7 +603,8 @@ impl McpServer {
 
     #[tool(
         name = "save_working_context",
-        description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Serialized size is capped at 1 MiB. Returns the stored fact's id."
+        description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Serialized size is capped at 1 MiB. Returns the stored fact's id.",
+        input_schema = wire_safe_input_schema::<SaveWorkingContextParams>()
     )]
     async fn save_working_context(
         &self,

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -1197,3 +1197,34 @@ async fn test_compile_transcript_rejects_empty_file_same_as_empty_inline_transcr
     assert_eq!(inline_err.code, ErrorCode::INVALID_PARAMS);
     assert_eq!(path_err.message, inline_err.message);
 }
+
+/// Harness-proof schema contract for `save_working_context` (observed
+/// 2026-07-24: a real MCP harness sent `working` as a JSON-encoded string —
+/// `invalid type: string, expected struct WorkingContext` — after degrading
+/// a `$ref`-only property to "untyped"). The `working` property must carry
+/// a DIRECT `type: object` keyword, not only a `$ref`.
+#[test]
+fn test_save_working_context_input_schema_declares_object_working_directly() {
+    let tool = McpServer::save_working_context_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+    let working = &schema["properties"]["working"];
+    assert_eq!(
+        working["type"],
+        serde_json::json!("object"),
+        "`working` must advertise a direct `type: object` (a $ref-only \
+         schema gets stringified by real MCP harnesses); got: {working}"
+    );
+}
+
+/// Server-side tolerance half (same wire-contract class as issue #1468):
+/// a harness that DID stringify the `working` object must still be served.
+#[test]
+fn test_save_working_context_params_accept_stringified_working() {
+    let params: SaveWorkingContextParams = serde_json::from_value(serde_json::json!({
+        "project": "veles",
+        "session": "s1",
+        "working": "{\"goal\": \"resume the campaign\"}"
+    }))
+    .expect("a JSON-encoded `working` string must deserialize");
+    assert_eq!(params.working.goal.as_deref(), Some("resume the campaign"));
+}

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -30,16 +30,17 @@ pub(super) struct RememberParams {
     /// The fact to store in memory.
     pub(super) fact: String,
     /// Optional typed links from this fact to existing memories.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) links: Vec<Link>,
     /// Optional structured metadata for later filtering (e.g.
     /// `{"project": "veles", "author": "julien", "status": "open"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) metadata: Option<Metadata>,
     /// Optional time-to-live in seconds. When set, the fact expires (and stops
     /// being recalled) after this many seconds — a durable TTL that survives a
     /// restart. Omit for a permanent memory. Falls back to the server's
     /// `VELESDB_MEMORY_DEFAULT_TTL` when unset.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) ttl_seconds: Option<u64>,
 }
 
@@ -63,9 +64,11 @@ pub(super) struct RecallParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
     /// Maximum number of memories to return (default 10).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
 }
 
@@ -128,6 +131,7 @@ pub(super) struct RecallWhereParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
     /// Maximum number of memories to return (default 10).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Structured `ColumnStore` predicates (ranges/comparisons) combined with AND,
     /// e.g. a date window `[{"field":"ts","op":"ge","value":20230101},
@@ -137,7 +141,7 @@ pub(super) struct RecallWhereParams {
     /// as-is — a numeric `20230101` never matches a fact stored with
     /// `{"ts": "20230101"}` (a string). Store comparable values (dates,
     /// counters) NUMERICALLY at `remember` time so these filters match them.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filters: Vec<ColumnFilter>,
 }
 
@@ -150,16 +154,20 @@ pub(super) struct RecallFusedParams {
     /// Maximum number of memories to return (default 10). Multi-hop reasoning
     /// benefits from a larger budget (~32-64); simple and temporal recall
     /// saturate early, where a larger budget only adds tokens.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
     /// Graph hops walked from the top vector hit (default 2). Higher reaches
     /// further but adds noise; capped at the `why` hop ceiling.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) hops: Option<usize>,
     /// Weight added to a graph-reached fact's normalised vector score
     /// (default 0.15). Raise to trust the graph more, lower to trust vector
     /// similarity more.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) graph_boost: Option<f64>,
     /// Name of the metadata field holding each fact's date as a `YYYYMMDD`
     /// integer (e.g. `"ts"`, `"occurred_at"`). When set, the result adds a
@@ -270,6 +278,7 @@ pub(super) struct FeedbackParams {
     pub(super) id: u64,
     /// `true` if the memory was useful (reinforce it), `false` if it was noise
     /// (weaken it).
+    #[serde(deserialize_with = "super::wire::lenient")]
     pub(super) success: bool,
 }
 
@@ -293,9 +302,11 @@ pub(super) struct WhyParams {
     /// The decision (or fact) to explain.
     pub(super) decision: String,
     /// How many hops of typed links to follow (default 2).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) max_hops: Option<usize>,
     /// Optional exact-match metadata filter to scope the seed (e.g.
     /// `{"project": "veles"}`).
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) filter: Option<Metadata>,
 }
 
@@ -390,6 +401,7 @@ pub(super) struct RememberExtractedParams {
     /// Raw text to extract atomic facts from and store as a connected graph.
     pub(super) text: String,
     /// Optional structured metadata applied to every extracted fact.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) metadata: Option<Metadata>,
 }
 

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1126,3 +1126,56 @@ fn test_recall_where_description_documents_type_strict_comparisons() {
          (e.g. dates) numerically: {description}"
     );
 }
+
+/// Issue: real MCP client harnesses (observed 2026-07-24 with Claude Code)
+/// degrade a parameter whose advertised schema carries no DIRECT `type`
+/// keyword — `anyOf`-wrapped optionals and `$ref`-only structs both come out
+/// untyped on the client side, and the harness then serializes the argument
+/// as a JSON-encoded STRING (`limit: "6"`, `filter: "{\"project\":...}"`),
+/// which the server rejects. Same wire-contract class as issue #1468
+/// (u64 ids vs float-lossy clients): the schema must be harness-proof, not
+/// merely spec-correct.
+///
+/// This test locks the contract for every optional scalar/object parameter
+/// of the recall family: each property's schema must expose a direct
+/// `type` keyword.
+#[test]
+fn test_recall_fused_input_schema_types_every_parameter_directly() {
+    let tool = McpServer::recall_fused_tool_attr();
+    let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+    let properties = schema["properties"]
+        .as_object()
+        .expect("recall_fused input schema must have properties");
+    for (name, subschema) in properties {
+        assert!(
+            subschema.get("type").is_some(),
+            "recall_fused parameter `{name}` must advertise a direct `type` \
+             keyword (anyOf/$ref-only schemas get stringified by real MCP \
+             harnesses); got: {subschema}"
+        );
+    }
+}
+
+/// Server-side tolerance half of the harness-proof contract: a client that
+/// DID stringify a scalar or object argument (today's Claude Code harness
+/// does exactly that for schema-degraded parameters) must still be served.
+/// Mirrors the #1468 string-id acceptance.
+#[test]
+fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
+    let params: RecallFusedParams = serde_json::from_value(serde_json::json!({
+        "query": "q",
+        "limit": "6",
+        "hops": "2",
+        "graph_boost": "0.15",
+        "filter": "{\"project\": \"velesdb\"}"
+    }))
+    .expect("stringified scalar/object arguments must deserialize");
+    assert_eq!(params.limit, Some(6));
+    assert_eq!(params.hops, Some(2));
+    assert!((params.graph_boost.unwrap() - 0.15).abs() < f64::EPSILON);
+    let filter = params.filter.expect("filter must parse from a JSON string");
+    assert_eq!(
+        filter.get("project").and_then(|v| v.as_str()),
+        Some("velesdb")
+    );
+}

--- a/crates/velesdb-memory/src/mcp/wire.rs
+++ b/crates/velesdb-memory/src/mcp/wire.rs
@@ -1,0 +1,47 @@
+//! Lenient wire-side deserialization for MCP tool parameters.
+//!
+//! Real MCP client harnesses (observed 2026-07-24 with Claude Code) can
+//! serialize a non-string tool argument as a JSON-encoded STRING when their
+//! own view of the advertised schema has degraded to "untyped" — `limit: 6`
+//! arrives as `"6"`, `filter: {"project": "x"}` as `"{\"project\": \"x\"}"`,
+//! and `save_working_context`'s whole `working` object as one escaped JSON
+//! string. Rejecting those loses the call (and, for `save_working_context`,
+//! silently loses a session handoff).
+//!
+//! [`lenient`] is the server-side half of the harness-proof wire contract
+//! (the schema half is `crate::schema::inline_ref_only_properties`): accept
+//! the properly-typed JSON value first, and fall back to parsing a string
+//! argument AS JSON into the target type. Same defensive-interop class as
+//! the #1468 string-or-number id contract in `crate::context::wire`.
+//!
+//! Never applied to genuinely string-typed parameters — a real string must
+//! not be re-interpreted as JSON.
+
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer};
+
+/// Deserializes `T` from either its proper JSON representation or from a
+/// JSON-encoded string containing it. The non-string path is byte-for-byte
+/// the plain serde behaviour; the error of the direct interpretation is the
+/// one reported when the string fallback fails too, so a genuinely malformed
+/// argument keeps a precise message.
+pub(super) fn lenient<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    match raw {
+        serde_json::Value::String(text) => serde_json::from_str(&text).map_err(|err| {
+            DeError::custom(format!(
+                "argument arrived as a JSON-encoded string and could not be \
+                 parsed as the expected type: {err}"
+            ))
+        }),
+        value => serde_json::from_value(value).map_err(DeError::custom),
+    }
+}
+
+#[cfg(test)]
+#[path = "wire_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/mcp/wire_tests.rs
+++ b/crates/velesdb-memory/src/mcp/wire_tests.rs
@@ -1,0 +1,60 @@
+//! Unit tests for the lenient MCP parameter deserializer.
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Probe {
+    #[serde(default, deserialize_with = "super::lenient")]
+    limit: Option<usize>,
+    #[serde(default, deserialize_with = "super::lenient")]
+    flag: Option<bool>,
+    #[serde(default, deserialize_with = "super::lenient")]
+    map: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+#[test]
+fn test_lenient_passes_proper_types_through_unchanged() {
+    let probe: Probe = serde_json::from_value(serde_json::json!({
+        "limit": 6, "flag": true, "map": {"k": "v"}
+    }))
+    .expect("proper types must keep deserializing");
+    assert_eq!(probe.limit, Some(6));
+    assert_eq!(probe.flag, Some(true));
+    assert_eq!(
+        probe.map.unwrap().get("k").and_then(|v| v.as_str()),
+        Some("v")
+    );
+}
+
+#[test]
+fn test_lenient_parses_stringified_arguments() {
+    let probe: Probe = serde_json::from_value(serde_json::json!({
+        "limit": "6", "flag": "true", "map": "{\"k\": \"v\"}"
+    }))
+    .expect("stringified arguments must parse as JSON");
+    assert_eq!(probe.limit, Some(6));
+    assert_eq!(probe.flag, Some(true));
+    assert_eq!(
+        probe.map.unwrap().get("k").and_then(|v| v.as_str()),
+        Some("v")
+    );
+}
+
+#[test]
+fn test_lenient_missing_fields_stay_none() {
+    let probe: Probe =
+        serde_json::from_value(serde_json::json!({})).expect("missing fields default");
+    assert_eq!(probe.limit, None);
+    assert_eq!(probe.flag, None);
+    assert!(probe.map.is_none());
+}
+
+#[test]
+fn test_lenient_rejects_garbage_strings_with_a_precise_error() {
+    let err = serde_json::from_value::<Probe>(serde_json::json!({ "limit": "six" }))
+        .expect_err("a non-JSON string must still fail");
+    assert!(
+        err.to_string().contains("JSON-encoded string"),
+        "error must explain the string fallback: {err}"
+    );
+}

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -114,6 +114,72 @@ fn widen_id_schema(schema: &mut Value) {
     }
 }
 
+/// Inline every top-level property whose schema is a bare `$ref` (or a
+/// single-element `allOf` wrapping one) into the referenced `$defs` entry,
+/// so the property carries a DIRECT `type` keyword.
+///
+/// Real MCP client harnesses (observed 2026-07-24 with Claude Code) degrade
+/// a `$ref`-only parameter to "untyped" and then serialize the argument as a
+/// JSON-encoded string — `save_working_context`'s `working` object arrived
+/// as `"{\"goal\": ...}"` and failed with `invalid type: string, expected
+/// struct WorkingContext`. Same wire-contract class as the #1468 float-lossy
+/// id fix: the advertised schema must be harness-proof, not merely
+/// spec-correct. Sibling keywords on the property (e.g. `description`)
+/// override the inlined definition's; properties that already expose a
+/// `type` are left untouched. One level only — nested `$refs` inside the
+/// inlined definition are not chased (only top-level tool parameters are
+/// serialized one by one by a harness).
+///
+/// `mcp`-gated: the advertised tool schemas are its only consumer.
+#[cfg(feature = "mcp")]
+pub(crate) fn inline_ref_only_properties(map: &mut Map<String, Value>) {
+    let Some(Value::Object(defs)) = map.get("$defs").cloned() else {
+        return;
+    };
+    let Some(Value::Object(properties)) = map.get_mut("properties") else {
+        return;
+    };
+    for subschema in properties.values_mut() {
+        let Value::Object(prop) = subschema else {
+            continue;
+        };
+        if prop.contains_key("type") {
+            continue;
+        }
+        let Some(name) = ref_only_target(prop) else {
+            continue;
+        };
+        let Some(Value::Object(definition)) = defs.get(&name) else {
+            continue;
+        };
+        let mut merged = definition.clone();
+        for (key, value) in prop.iter() {
+            if key != "$ref" && key != "allOf" {
+                merged.insert(key.clone(), value.clone());
+            }
+        }
+        *prop = merged;
+    }
+}
+
+/// Resolves the `#/$defs/<Name>` target of a `$ref`-only property schema:
+/// either a direct `$ref` keyword or a single-element `allOf` wrapping one.
+#[cfg(feature = "mcp")]
+fn ref_only_target(prop: &Map<String, Value>) -> Option<String> {
+    let reference = match (prop.get("$ref"), prop.get("allOf")) {
+        (Some(Value::String(r)), _) => r.clone(),
+        (None, Some(Value::Array(items))) if items.len() == 1 => match &items[0] {
+            Value::Object(inner) => match inner.get("$ref") {
+                Some(Value::String(r)) => r.clone(),
+                _ => return None,
+            },
+            _ => return None,
+        },
+        _ => return None,
+    };
+    reference.strip_prefix("#/$defs/").map(str::to_owned)
+}
+
 fn is_rust_int_format(format: &str) -> bool {
     matches!(
         format,

--- a/crates/velesdb-mobile/src/lib.rs
+++ b/crates/velesdb-mobile/src/lib.rs
@@ -88,6 +88,39 @@ use velesdb_core::SearchQuality as CoreSearchQuality;
 // NOTE: VelesCollection moved to collection.rs (NLOC/CC resolution)
 
 // ============================================================================
+// Engine config loading (issue #1549, mobile surface)
+// ============================================================================
+
+/// Maps a [`velesdb_core::config::ConfigError`] to the FFI [`VelesError`].
+///
+/// UniFFI errors are flat records (no `#[source]` chain survives the FFI
+/// boundary), so the `ConfigError` is preserved the closest way the surface
+/// allows: routed through [`velesdb_core::Error::Config`] so the mobile error
+/// carries the canonical `VELES-009` taxonomy code, core's recoverability
+/// flag, and the full underlying `ConfigError` message.
+fn config_error(err: velesdb_core::config::ConfigError) -> VelesError {
+    velesdb_core::Error::Config(err.to_string()).into()
+}
+
+/// Loads a [`velesdb_core::config::VelesConfig`] from a TOML file, engine
+/// sections only. Fail-fast: a missing/unreadable/invalid file is an
+/// immediate typed error, never a silent fallback to defaults.
+fn load_engine_config_from_path(
+    config_path: &str,
+) -> Result<velesdb_core::config::VelesConfig, VelesError> {
+    velesdb_core::config::VelesConfig::load_from_path_engine_only(config_path).map_err(config_error)
+}
+
+/// Parses a [`velesdb_core::config::VelesConfig`] from an in-memory TOML
+/// string, engine sections only. Same fail-fast semantics as
+/// [`load_engine_config_from_path`].
+fn load_engine_config_from_toml(
+    config_toml: &str,
+) -> Result<velesdb_core::config::VelesConfig, VelesError> {
+    velesdb_core::config::VelesConfig::from_toml_engine_only(config_toml).map_err(config_error)
+}
+
+// ============================================================================
 // Database
 // ============================================================================
 
@@ -148,6 +181,136 @@ impl VelesDatabase {
     ) -> Result<Arc<Self>, VelesError> {
         let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
         let db = CoreDatabase::open_with_observer(&path, core_observer)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database configured from a TOML file on disk.
+    ///
+    /// The file is parsed with
+    /// [`VelesConfig::load_from_path_engine_only`](velesdb_core::config::VelesConfig::load_from_path_engine_only):
+    /// only the engine sections (`[search]`/`[hnsw]`/`[storage]`/`[limits]`/
+    /// `[quantization]`/`[wal_batch]`) are considered, any other top-level
+    /// table is dropped, and `VELESDB_*` environment variables still layer on
+    /// top of the filtered file. The database is then opened with
+    /// [`Database::open_with_config`](velesdb_core::Database::open_with_config),
+    /// so every subsystem honours the loaded values instead of core defaults.
+    ///
+    /// This is the mobile counterpart of the server/CLI `--config` wiring
+    /// (issue #1549). If the app ships its config as an in-memory string
+    /// (bundled asset, remote config), use
+    /// [`open_with_config_toml`](Self::open_with_config_toml) instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `config_path` - Path to an existing TOML configuration file
+    ///
+    /// # Errors
+    ///
+    /// Fails fast — never falls back to defaults silently — if the config
+    /// file is missing, unreadable, not valid TOML, or fails validation
+    /// (typed as a `VELES-009` configuration error), or if the database path
+    /// is invalid or cannot be accessed.
+    #[uniffi::constructor]
+    pub fn open_with_config(path: String, config_path: String) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_path(&config_path)?;
+        let db = CoreDatabase::open_with_config(&path, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database configured from an in-memory TOML string.
+    ///
+    /// Same semantics as [`open_with_config`](Self::open_with_config) but the
+    /// TOML is passed directly (parsed with
+    /// [`VelesConfig::from_toml_engine_only`](velesdb_core::config::VelesConfig::from_toml_engine_only),
+    /// no environment-variable layer) — the most portable option on mobile,
+    /// where config often lives in a bundled asset or remote-config payload
+    /// rather than a standalone file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `config_toml` - TOML configuration string (engine sections only)
+    ///
+    /// # Errors
+    ///
+    /// Fails fast — never falls back to defaults silently — if `config_toml`
+    /// is not valid TOML or fails validation (typed as a `VELES-009`
+    /// configuration error), or if the database path is invalid or cannot be
+    /// accessed.
+    #[uniffi::constructor]
+    pub fn open_with_config_toml(
+        path: String,
+        config_toml: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_toml(&config_toml)?;
+        let db = CoreDatabase::open_with_config(&path, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database with both a read-path [`MobileObserver`]
+    /// and a TOML configuration file.
+    ///
+    /// Combines [`open_with_observer`](Self::open_with_observer) (read gate)
+    /// and [`open_with_config`](Self::open_with_config) (engine config) on a
+    /// single handle via
+    /// [`Database::open_with_observer_and_config`](velesdb_core::Database::open_with_observer_and_config).
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `observer` - A Kotlin/Swift implementation of [`MobileObserver`]
+    /// * `config_path` - Path to an existing TOML configuration file
+    ///
+    /// # Errors
+    ///
+    /// Same fail-fast semantics as [`open_with_config`](Self::open_with_config).
+    #[uniffi::constructor]
+    pub fn open_with_observer_and_config(
+        path: String,
+        observer: Arc<dyn MobileObserver>,
+        config_path: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_path(&config_path)?;
+        let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
+        let db = CoreDatabase::open_with_observer_and_config(&path, core_observer, config)?;
+        Ok(Arc::new(Self {
+            inner: Arc::new(db),
+        }))
+    }
+
+    /// Opens or creates a database with both a read-path [`MobileObserver`]
+    /// and an in-memory TOML configuration string.
+    ///
+    /// Combines [`open_with_observer`](Self::open_with_observer) (read gate)
+    /// and [`open_with_config_toml`](Self::open_with_config_toml) (engine
+    /// config) on a single handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the database directory (will be created if needed)
+    /// * `observer` - A Kotlin/Swift implementation of [`MobileObserver`]
+    /// * `config_toml` - TOML configuration string (engine sections only)
+    ///
+    /// # Errors
+    ///
+    /// Same fail-fast semantics as
+    /// [`open_with_config_toml`](Self::open_with_config_toml).
+    #[uniffi::constructor]
+    pub fn open_with_observer_and_config_toml(
+        path: String,
+        observer: Arc<dyn MobileObserver>,
+        config_toml: String,
+    ) -> Result<Arc<Self>, VelesError> {
+        let config = load_engine_config_from_toml(&config_toml)?;
+        let core_observer: Arc<dyn DatabaseObserver> = Arc::new(ForeignObserver::new(observer));
+        let db = CoreDatabase::open_with_observer_and_config(&path, core_observer, config)?;
         Ok(Arc::new(Self {
             inner: Arc::new(db),
         }))

--- a/crates/velesdb-mobile/src/lib_tests.rs
+++ b/crates/velesdb-mobile/src/lib_tests.rs
@@ -1391,3 +1391,217 @@ fn test_open_without_observer_reads_unchanged() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, 7);
 }
+
+// =========================================================================
+// Config-aware constructor tests (issue #1549, mobile surface)
+// =========================================================================
+//
+// Before these constructors existed, `VelesDatabase` could only be opened
+// through `open` / `open_with_observer`, which always run the core engine on
+// default `VelesConfig` values — a TOML engine config (`[search]`/`[hnsw]`/
+// `[storage]`/`[limits]`/`[quantization]`/`[wal_batch]`) had no way in.
+// These tests prove the config is *enforced* by the engine (not merely
+// parsed), that invalid input fails fast with a typed error, and that the
+// pre-existing constructors keep their default behaviour.
+
+/// The core proof required by issue #1549: a `limits.max_collections` cap in
+/// the TOML string must be enforced by the opened database. First collection
+/// succeeds (within the cap), second is refused by the engine.
+#[test]
+fn test_open_with_config_toml_limit_is_enforced() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db =
+        VelesDatabase::open_with_config_toml(path, "[limits]\nmax_collections = 1\n".to_string())
+            .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {err}"
+    );
+}
+
+/// Same proof through the file-path variant (`load_from_path_engine_only`).
+#[test]
+fn test_open_with_config_path_limit_is_enforced() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = TempDir::new().unwrap();
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 1\n").unwrap();
+
+    let db = VelesDatabase::open_with_config(
+        tmp.path().to_str().unwrap().to_string(),
+        config_path.to_str().unwrap().to_string(),
+    )
+    .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(
+        err.to_string().contains("max_collections"),
+        "expected the limit error to mention max_collections, got: {err}"
+    );
+}
+
+/// Fail-fast: a syntactically invalid TOML string must abort the open with a
+/// typed config error (core taxonomy code VELES-009), never fall back to
+/// defaults silently.
+#[test]
+fn test_open_with_config_toml_invalid_toml_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let Err(err) = VelesDatabase::open_with_config_toml(path, "not [[[ toml".to_string()) else {
+        panic!("invalid TOML must fail fast");
+    };
+    let VelesError::Database { code, message, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(
+        code, "VELES-009",
+        "config errors carry the core config code"
+    );
+    assert!(
+        message.contains("parse") || message.contains("Parse"),
+        "message should surface the underlying ConfigError, got: {message}"
+    );
+}
+
+/// Fail-fast: a TOML value rejected by `VelesConfig::validate` (here
+/// `limits.max_collections = 0`, outside `[1, cap]`) must abort the open.
+#[test]
+fn test_open_with_config_toml_invalid_value_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let Err(err) =
+        VelesDatabase::open_with_config_toml(path, "[limits]\nmax_collections = 0\n".to_string())
+    else {
+        panic!("out-of-range value must fail validation");
+    };
+    let VelesError::Database { code, message, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(code, "VELES-009");
+    assert!(
+        message.contains("max_collections"),
+        "message should name the offending key, got: {message}"
+    );
+}
+
+/// Fail-fast: a config path that does not exist must abort the open with a
+/// typed config error — never open on silent defaults.
+#[test]
+fn test_open_with_config_path_missing_file_fails_fast() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+    let missing = tmp.path().join("does-not-exist.toml");
+
+    let Err(err) = VelesDatabase::open_with_config(path, missing.to_str().unwrap().to_string())
+    else {
+        panic!("missing config file must fail fast");
+    };
+    let VelesError::Database { code, .. } = &err else {
+        panic!("expected VelesError::Database, got {err:?}");
+    };
+    assert_eq!(code, "VELES-009");
+}
+
+/// Observer + config: the TOML limit must be enforced AND the observer read
+/// gate must be active on the same handle.
+#[test]
+fn test_open_with_observer_and_config_toml_wires_both() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open_with_observer_and_config_toml(
+        path,
+        std::sync::Arc::new(DenyAllObserver),
+        "[limits]\nmax_collections = 1\n".to_string(),
+    )
+    .unwrap();
+
+    // Config wired: cap of 1 enforced.
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    let err = db
+        .create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .expect_err("second collection must be refused by the configured limit");
+    assert!(err.to_string().contains("max_collections"));
+
+    // Observer wired: reads are denied by the gate (writes are not gated).
+    let col = db.get_collection("first".to_string()).unwrap().unwrap();
+    col.upsert(VelesPoint {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: None,
+    })
+    .unwrap();
+    let err = col
+        .search(vec![1.0, 0.0, 0.0, 0.0], 1)
+        .expect_err("deny-all observer must block the read");
+    assert!(
+        err.to_string().contains("test policy"),
+        "expected the observer's deny reason, got: {err}"
+    );
+}
+
+/// Observer + config through the file-path variant.
+#[test]
+fn test_open_with_observer_and_config_path_wires_both() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = TempDir::new().unwrap();
+    let config_path = config_dir.path().join("velesdb.toml");
+    std::fs::write(&config_path, "[limits]\nmax_collections = 1\n").unwrap();
+
+    let db = VelesDatabase::open_with_observer_and_config(
+        tmp.path().to_str().unwrap().to_string(),
+        std::sync::Arc::new(DenyAllObserver),
+        config_path.to_str().unwrap().to_string(),
+    )
+    .unwrap();
+
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    assert!(
+        db.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+            .is_err(),
+        "cap of 1 must be enforced"
+    );
+}
+
+/// Regression guard: the pre-existing constructors keep running on core
+/// defaults (`limits.max_collections = 1000`) — adding the config-aware
+/// constructors must not change `open` / `open_with_observer` behaviour.
+#[test]
+fn test_open_without_config_keeps_default_limits() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().to_str().unwrap().to_string();
+
+    let db = VelesDatabase::open(path).unwrap();
+    // Well above a cap of 1: proves no stray config is applied.
+    db.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    db.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+
+    let tmp2 = TempDir::new().unwrap();
+    let db2 = VelesDatabase::open_with_observer(
+        tmp2.path().to_str().unwrap().to_string(),
+        std::sync::Arc::new(RecordingObserver::default()),
+    )
+    .unwrap();
+    db2.create_collection("first".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+    db2.create_collection("second".to_string(), 4, DistanceMetric::Cosine)
+        .unwrap();
+}

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -217,6 +217,35 @@ for result in results:
 > `sparse_index_name` and `include_vectors`, plus a fluent builder
 > (`SearchOptions().with_vector(v).with_top_k(10)`).
 
+### Engine configuration (`VelesConfigOptions`)
+
+`Database(path, config=...)` accepts a typed `VelesConfigOptions` covering
+every engine section of the core `VelesConfig`: `limits`, `search`, `hnsw`,
+`storage` and `quantization`. Build it in code or load it from a
+`velesdb.toml` (engine-only semantics: a shell-owned `[server]`/`[logging]`
+table in a shared file is ignored):
+
+```python
+from velesdb import (
+    Database, VelesConfigOptions, LimitsOptions, SearchConfigOptions,
+)
+
+# In code:
+cfg = VelesConfigOptions(
+    limits=LimitsOptions(max_collections=50),
+    search=SearchConfigOptions(default_mode="accurate", max_results=100),
+)
+db = Database("./tenant1", config=cfg)
+
+# Or from TOML (fail-fast: invalid TOML/values raise ValueError,
+# a missing file raises FileNotFoundError):
+cfg = VelesConfigOptions.from_toml_path("./velesdb.toml")
+db = Database("./tenant1", config=cfg)
+```
+
+`wal_batch` is intentionally not exposed — the concurrent WAL writer is a
+VelesDB Enterprise feature (see `docs/guides/WRITE_CONCURRENCY.md`).
+
 ### End-to-End: Text to Search Results (RAG Pipeline)
 
 VelesDB stores and searches vectors — it does not generate embeddings. Use any embedding model to convert text to vectors first.

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-3.12.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-python/python/velesdb/__init__.py
+++ b/crates/velesdb-python/python/velesdb/__init__.py
@@ -27,6 +27,7 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     EdgeExistsError,
     FusionStrategy,
     GraphStore as _RawGraphStore,
+    HnswConfigOptions,
     HnswOptions,
     LimitsOptions,
     MemoryService,
@@ -36,9 +37,12 @@ from velesdb.velesdb import (  # type: ignore[attr-defined]
     GraphSchema as PyGraphSchema,
     PyProceduralMemory,
     PySemanticMemory,
+    QuantizationOptions,
+    SearchConfigOptions,
     SearchOptions,
     SearchResult,
     STORAGE_MODES,
+    StorageOptions,
     StreamingConfig,
     StreamingIngestConfig,
     TraversalResult,
@@ -918,6 +922,16 @@ __all__ = [
     "LimitsOptions",
     "AutoReindexOptions",
     "VelesConfigOptions",
+    # Engine config sections (issue #1549). Each maps 1:1 to a `[section]`
+    # of the core `VelesConfig` TOML; attach them to `VelesConfigOptions`
+    # or load a whole file via `VelesConfigOptions.from_toml_path`.
+    # `wal_batch` is intentionally absent (velesdb-premium Enterprise —
+    # docs/guides/WRITE_CONCURRENCY.md); `server`/`logging` configure
+    # hosting shells, not the embedded engine.
+    "SearchConfigOptions",
+    "HnswConfigOptions",
+    "StorageOptions",
+    "QuantizationOptions",
     # Canonical enum name sets, single-sourced from velesdb-core (tuples of str).
     "CONDITION_TYPES",
     "DISTANCE_METRICS",

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2803,14 +2803,144 @@ class AutoReindexOptions:
         ...
 
 
+class SearchConfigOptions:
+    """Global search defaults mapped to core `SearchConfig` (`[search]`).
+
+    Distinct from the per-query :class:`SearchOptions`. Unspecified
+    fields fall back to the engine defaults (default_mode="balanced",
+    max_results=1000, query_timeout_ms=30000).
+    """
+
+    default_mode: Optional[str]
+    ef_search: Optional[int]
+    max_results: Optional[int]
+    query_timeout_ms: Optional[int]
+
+    def __init__(
+        self,
+        default_mode: Optional[str] = None,
+        ef_search: Optional[int] = None,
+        max_results: Optional[int] = None,
+        query_timeout_ms: Optional[int] = None,
+    ) -> None: ...
+
+
+class HnswConfigOptions:
+    """Database-wide HNSW defaults mapped to core `HnswConfig` (`[hnsw]`).
+
+    Distinct from the per-collection :class:`HnswOptions`. `None` fields
+    fall back to the engine defaults (m/ef_construction auto by
+    dimension, max_layers=0 = auto).
+    """
+
+    m: Optional[int]
+    ef_construction: Optional[int]
+    max_layers: Optional[int]
+
+    def __init__(
+        self,
+        m: Optional[int] = None,
+        ef_construction: Optional[int] = None,
+        max_layers: Optional[int] = None,
+    ) -> None: ...
+
+
+class StorageOptions:
+    """Storage engine settings mapped to core `StorageConfig` (`[storage]`).
+
+    Unspecified fields fall back to the engine defaults
+    (data_dir="./velesdb_data", storage_mode="mmap", mmap_cache_mb=1024,
+    vector_alignment=64).
+    """
+
+    data_dir: Optional[str]
+    storage_mode: Optional[str]
+    mmap_cache_mb: Optional[int]
+    vector_alignment: Optional[int]
+
+    def __init__(
+        self,
+        data_dir: Optional[str] = None,
+        storage_mode: Optional[str] = None,
+        mmap_cache_mb: Optional[int] = None,
+        vector_alignment: Optional[int] = None,
+    ) -> None: ...
+
+
+class QuantizationOptions:
+    """Quantization settings mapped to core `QuantizationConfig`
+    (`[quantization]`).
+
+    `mode` is one of "none", "sq8", "binary", "pq", "rabitq". The `pq_*`
+    fields are only valid with mode="pq" (where `pq_m` is required);
+    combining them with any other mode raises `ValueError`.
+    """
+
+    mode: Optional[str]
+    pq_m: Optional[int]
+    pq_k: Optional[int]
+    pq_opq_enabled: Optional[bool]
+    pq_oversampling: Optional[int]
+    rerank_enabled: Optional[bool]
+    rerank_multiplier: Optional[int]
+    auto_quantization: Optional[bool]
+    auto_quantization_threshold: Optional[int]
+
+    def __init__(
+        self,
+        mode: Optional[str] = None,
+        pq_m: Optional[int] = None,
+        pq_k: Optional[int] = None,
+        pq_opq_enabled: Optional[bool] = None,
+        pq_oversampling: Optional[int] = None,
+        rerank_enabled: Optional[bool] = None,
+        rerank_multiplier: Optional[int] = None,
+        auto_quantization: Optional[bool] = None,
+        auto_quantization_threshold: Optional[int] = None,
+    ) -> None: ...
+
+
 class VelesConfigOptions:
     """Global database-level configuration mapped to core `VelesConfig`.
 
-    Currently exposes the `limits` sub-section only. Other sub-sections
-    (search, hnsw, storage) are left at their engine defaults — user
-    tuning is done per-collection via :class:`HnswOptions`.
+    Exposes every engine section: `limits`, `search`, `hnsw`, `storage`
+    and `quantization`. Unset sections stay at their engine defaults.
+    Load a TOML file with :meth:`from_toml_path` / :meth:`from_toml`
+    (engine-only semantics: a shell-owned `[server]`/`[logging]` table
+    is ignored). `wal_batch` is intentionally not exposed — the
+    concurrent WAL writer is a velesdb-premium Enterprise feature
+    (docs/guides/WRITE_CONCURRENCY.md).
     """
 
     limits: Optional[LimitsOptions]
+    search: Optional[SearchConfigOptions]
+    hnsw: Optional[HnswConfigOptions]
+    storage: Optional[StorageOptions]
+    quantization: Optional[QuantizationOptions]
 
-    def __init__(self, limits: Optional[LimitsOptions] = None) -> None: ...
+    def __init__(
+        self,
+        limits: Optional[LimitsOptions] = None,
+        search: Optional[SearchConfigOptions] = None,
+        hnsw: Optional[HnswConfigOptions] = None,
+        storage: Optional[StorageOptions] = None,
+        quantization: Optional[QuantizationOptions] = None,
+    ) -> None: ...
+
+    @staticmethod
+    def from_toml(toml_str: str) -> "VelesConfigOptions":
+        """Load engine configuration from an in-memory TOML string.
+
+        Fail-fast: invalid TOML or an out-of-range value raises
+        `ValueError` with the typed core message.
+        """
+        ...
+
+    @staticmethod
+    def from_toml_path(path: str) -> "VelesConfigOptions":
+        """Load engine configuration from a TOML file path.
+
+        Fail-fast: a missing file raises `FileNotFoundError`; invalid
+        TOML or an out-of-range value raises `ValueError`.
+        """
+        ...

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -226,7 +226,7 @@ impl Database {
         // `'static` open closure; building the `PyObserver` stays off-GIL.
         let path_buf = PathBuf::from(path);
         let path_clone = path_buf.clone();
-        let core_config = config.map(|cfg| cfg.to_core());
+        let core_config = config.map(|cfg| cfg.to_core()).transpose()?;
         let core_observer: Option<Arc<dyn DatabaseObserver>> = observer
             .map(|cb| Arc::new(PyObserver::new(cb, observer_strict)) as Arc<dyn DatabaseObserver>);
         let db = py

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -53,7 +53,10 @@ pub use fusion::FusionStrategy;
 pub use graph::{dict_to_edge, dict_to_node, edge_to_dict, node_to_dict, traversal_to_dict};
 pub use graph_collection::{PyGraphCollection, PyGraphSchema};
 pub use graph_store::{GraphStore, StreamingConfig, TraversalResult};
-pub use options::{AutoReindexOptions, HnswOptions, LimitsOptions, VelesConfigOptions};
+pub use options::{
+    AutoReindexOptions, HnswConfigOptions, HnswOptions, LimitsOptions, QuantizationOptions,
+    SearchConfigOptions, StorageOptions, VelesConfigOptions,
+};
 pub use streaming_config::StreamingIngestConfig;
 
 use pyo3::prelude::*;

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -5,26 +5,56 @@
 //! explicit `#[pyclass]` dataclasses that map 1:1 to the core config
 //! structs.
 //!
-//! Four options types:
+//! Options types:
 //! - [`HnswOptions`] — per-collection HNSW parameters (maps to
 //!   [`velesdb_core::index::hnsw::HnswParams`])
 //! - [`LimitsOptions`] — global tenant-wide limits (maps to
 //!   [`velesdb_core::config::LimitsConfig`])
 //! - [`AutoReindexOptions`] — per-collection auto-reindex policy (maps
 //!   to [`velesdb_core::collection::auto_reindex::AutoReindexConfig`])
+//! - [`SearchConfigOptions`] / [`HnswConfigOptions`] /
+//!   [`StorageOptions`] / [`QuantizationOptions`] — engine config
+//!   sections (issue #1549; map to the same-named
+//!   `velesdb_core::config` sections)
 //! - [`VelesConfigOptions`] — global database-level configuration
-//!   wrapper (maps to [`velesdb_core::config::VelesConfig`])
+//!   wrapper (maps to [`velesdb_core::config::VelesConfig`]), with TOML
+//!   loading via `from_toml` / `from_toml_path`
 //!
 //! `WalBatchOptions` is intentionally **not** exposed: the concurrent
 //! WAL writer is a velesdb-premium Enterprise feature (see Commit 8
 //! `docs/CORE_WIRING_DEBT.md` and `docs/guides/WRITE_CONCURRENCY.md`).
 
 use pyo3::prelude::*;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use velesdb_core::collection::auto_reindex::AutoReindexConfig as CoreAutoReindexConfig;
-use velesdb_core::config::{LimitsConfig as CoreLimitsConfig, VelesConfig as CoreVelesConfig};
+use velesdb_core::config::{
+    ConfigError, HnswConfig as CoreHnswConfig, LimitsConfig as CoreLimitsConfig,
+    QuantizationConfig as CoreQuantizationConfig, QuantizationType,
+    SearchConfig as CoreSearchConfig, SearchMode, StorageConfig as CoreStorageConfig,
+    VelesConfig as CoreVelesConfig,
+};
 use velesdb_core::index::hnsw::HnswParams;
+
+/// Maps a typed core [`ConfigError`] onto the closest Python exception.
+///
+/// - missing file → `FileNotFoundError`
+/// - other IO failures → `OSError`
+/// - parse/validation failures → `ValueError` carrying the typed message
+///   (`Invalid configuration value for 'limits.max_collections': ...`)
+///
+/// Never falls back to a default configuration: every loader error is
+/// surfaced fail-fast to the Python caller.
+fn config_err_to_py(err: ConfigError) -> PyErr {
+    match err {
+        ConfigError::IoError(io) if io.kind() == std::io::ErrorKind::NotFound => {
+            pyo3::exceptions::PyFileNotFoundError::new_err(io.to_string())
+        }
+        ConfigError::IoError(io) => pyo3::exceptions::PyOSError::new_err(io.to_string()),
+        other => pyo3::exceptions::PyValueError::new_err(other.to_string()),
+    }
+}
 
 // ---------------------------------------------------------------------------
 // HnswOptions
@@ -303,6 +333,19 @@ impl LimitsOptions {
             .unwrap_or(cfg.max_perfect_mode_vectors);
         cfg
     }
+
+    /// Builds a fully-populated options object from a core config section
+    /// (every field `Some`), so a TOML-loaded config round-trips
+    /// losslessly through [`Self::to_core`].
+    fn from_core(core: &CoreLimitsConfig) -> Self {
+        Self {
+            max_collections: Some(core.max_collections),
+            max_dimensions: Some(core.max_dimensions),
+            max_vectors_per_collection: Some(core.max_vectors_per_collection),
+            max_payload_size: Some(core.max_payload_size),
+            max_perfect_mode_vectors: Some(core.max_perfect_mode_vectors),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -428,47 +471,633 @@ impl AutoReindexOptions {
 }
 
 // ---------------------------------------------------------------------------
+// SearchConfigOptions
+// ---------------------------------------------------------------------------
+
+/// Valid values for `SearchConfigOptions.default_mode`, mirroring the
+/// serde `snake_case` names of [`SearchMode`].
+const SEARCH_MODES: &[&str] = &["fast", "balanced", "accurate", "perfect"];
+
+/// Parses a Python-side mode string into a core [`SearchMode`].
+fn parse_search_mode(mode: &str) -> PyResult<SearchMode> {
+    match mode {
+        "fast" => Ok(SearchMode::Fast),
+        "balanced" => Ok(SearchMode::Balanced),
+        "accurate" => Ok(SearchMode::Accurate),
+        "perfect" => Ok(SearchMode::Perfect),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "invalid search.default_mode '{other}' (expected one of: {SEARCH_MODES:?})"
+        ))),
+    }
+}
+
+/// Renders a core [`SearchMode`] as its Python-side mode string.
+///
+/// Fallible: [`SearchMode`] is `#[non_exhaustive]`, so a future core
+/// variant unknown to this binding is rejected loudly instead of being
+/// silently re-mapped.
+fn search_mode_str(mode: SearchMode) -> PyResult<&'static str> {
+    match mode {
+        SearchMode::Fast => Ok("fast"),
+        SearchMode::Balanced => Ok("balanced"),
+        SearchMode::Accurate => Ok("accurate"),
+        SearchMode::Perfect => Ok("perfect"),
+        other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "unsupported search mode in configuration: {other:?}"
+        ))),
+    }
+}
+
+/// Global search defaults mapped to
+/// [`velesdb_core::config::SearchConfig`] (the `[search]` TOML section).
+///
+/// All fields are optional — unspecified fields fall back to the engine
+/// defaults (`default_mode="balanced"`, `max_results=1000`,
+/// `query_timeout_ms=30000`). Distinct from the per-query
+/// `SearchOptions` class, which tunes a single search call.
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct SearchConfigOptions {
+    /// Default search mode: `"fast"`, `"balanced"`, `"accurate"` or
+    /// `"perfect"`. Default: `"balanced"`.
+    #[pyo3(get, set)]
+    pub default_mode: Option<String>,
+    /// Override `ef_search` (if set, overrides the mode). Range [16, 4096].
+    #[pyo3(get, set)]
+    pub ef_search: Option<usize>,
+    /// Maximum results per query. Default: 1000.
+    #[pyo3(get, set)]
+    pub max_results: Option<usize>,
+    /// Query timeout in milliseconds (0 disables). Default: 30000.
+    #[pyo3(get, set)]
+    pub query_timeout_ms: Option<u64>,
+}
+
+#[pymethods]
+impl SearchConfigOptions {
+    #[new]
+    #[pyo3(signature = (
+        default_mode = None,
+        ef_search = None,
+        max_results = None,
+        query_timeout_ms = None,
+    ))]
+    fn new(
+        default_mode: Option<String>,
+        ef_search: Option<usize>,
+        max_results: Option<usize>,
+        query_timeout_ms: Option<u64>,
+    ) -> Self {
+        Self {
+            default_mode,
+            ef_search,
+            max_results,
+            query_timeout_ms,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "SearchConfigOptions(default_mode={:?}, ef_search={:?}, max_results={:?}, query_timeout_ms={:?})",
+            self.default_mode, self.ef_search, self.max_results, self.query_timeout_ms,
+        )
+    }
+}
+
+impl SearchConfigOptions {
+    /// Materializes into the core section, rejecting an unknown
+    /// `default_mode` string with a `ValueError`.
+    pub(crate) fn to_core(&self) -> PyResult<CoreSearchConfig> {
+        let mut cfg = CoreSearchConfig::default();
+        if let Some(ref mode) = self.default_mode {
+            cfg.default_mode = parse_search_mode(mode)?;
+        }
+        if self.ef_search.is_some() {
+            cfg.ef_search = self.ef_search;
+        }
+        cfg.max_results = self.max_results.unwrap_or(cfg.max_results);
+        cfg.query_timeout_ms = self.query_timeout_ms.unwrap_or(cfg.query_timeout_ms);
+        Ok(cfg)
+    }
+
+    /// Builds a fully-populated options object from a core section
+    /// (see [`LimitsOptions::from_core`]). `ef_search` stays `None` when
+    /// the core leaves it unset (mode-driven), preserving the override
+    /// semantics on round-trip. Fallible because [`SearchMode`] is
+    /// `#[non_exhaustive]` (see [`search_mode_str`]).
+    fn from_core(core: &CoreSearchConfig) -> PyResult<Self> {
+        Ok(Self {
+            default_mode: Some(search_mode_str(core.default_mode)?.to_string()),
+            ef_search: core.ef_search,
+            max_results: Some(core.max_results),
+            query_timeout_ms: Some(core.query_timeout_ms),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HnswConfigOptions
+// ---------------------------------------------------------------------------
+
+/// Global HNSW index defaults mapped to
+/// [`velesdb_core::config::HnswConfig`] (the `[hnsw]` TOML section).
+///
+/// Distinct from the per-collection [`HnswOptions`] passed to
+/// `Database.create_collection` — this section sets the database-wide
+/// defaults instead. `None` fields fall back to the engine defaults
+/// (`m`/`ef_construction` auto by dimension, `max_layers=0` = auto).
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct HnswConfigOptions {
+    /// Connections per node (M parameter), range [4, 128].
+    /// `None` = auto based on dimension.
+    #[pyo3(get, set)]
+    pub m: Option<usize>,
+    /// Candidate pool size during construction, range [100, 2000].
+    /// `None` = auto based on dimension.
+    #[pyo3(get, set)]
+    pub ef_construction: Option<usize>,
+    /// Maximum number of layers (0 = auto). Default: 0.
+    #[pyo3(get, set)]
+    pub max_layers: Option<usize>,
+}
+
+#[pymethods]
+impl HnswConfigOptions {
+    #[new]
+    #[pyo3(signature = (m = None, ef_construction = None, max_layers = None))]
+    fn new(m: Option<usize>, ef_construction: Option<usize>, max_layers: Option<usize>) -> Self {
+        Self {
+            m,
+            ef_construction,
+            max_layers,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "HnswConfigOptions(m={:?}, ef_construction={:?}, max_layers={:?})",
+            self.m, self.ef_construction, self.max_layers,
+        )
+    }
+}
+
+impl HnswConfigOptions {
+    pub(crate) fn to_core(&self) -> CoreHnswConfig {
+        let mut cfg = CoreHnswConfig::default();
+        if self.m.is_some() {
+            cfg.m = self.m;
+        }
+        if self.ef_construction.is_some() {
+            cfg.ef_construction = self.ef_construction;
+        }
+        cfg.max_layers = self.max_layers.unwrap_or(cfg.max_layers);
+        cfg
+    }
+
+    /// Builds an options object from a core section. `m`/`ef_construction`
+    /// stay `None` when the core leaves them auto, preserving auto-tuning
+    /// semantics on round-trip.
+    fn from_core(core: &CoreHnswConfig) -> Self {
+        Self {
+            m: core.m,
+            ef_construction: core.ef_construction,
+            max_layers: Some(core.max_layers),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StorageOptions
+// ---------------------------------------------------------------------------
+
+/// Storage engine settings mapped to
+/// [`velesdb_core::config::StorageConfig`] (the `[storage]` TOML section).
+///
+/// All fields are optional — unspecified fields fall back to the engine
+/// defaults (`data_dir="./velesdb_data"`, `storage_mode="mmap"`,
+/// `mmap_cache_mb=1024`, `vector_alignment=64`).
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct StorageOptions {
+    /// Data directory path. Default: `"./velesdb_data"`.
+    #[pyo3(get, set)]
+    pub data_dir: Option<String>,
+    /// Storage mode: `"mmap"` or `"memory"`. Default: `"mmap"`.
+    #[pyo3(get, set)]
+    pub storage_mode: Option<String>,
+    /// Mmap cache size in megabytes. Default: 1024.
+    #[pyo3(get, set)]
+    pub mmap_cache_mb: Option<usize>,
+    /// Vector alignment in bytes. Default: 64.
+    #[pyo3(get, set)]
+    pub vector_alignment: Option<usize>,
+}
+
+#[pymethods]
+impl StorageOptions {
+    #[new]
+    #[pyo3(signature = (
+        data_dir = None,
+        storage_mode = None,
+        mmap_cache_mb = None,
+        vector_alignment = None,
+    ))]
+    fn new(
+        data_dir: Option<String>,
+        storage_mode: Option<String>,
+        mmap_cache_mb: Option<usize>,
+        vector_alignment: Option<usize>,
+    ) -> Self {
+        Self {
+            data_dir,
+            storage_mode,
+            mmap_cache_mb,
+            vector_alignment,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "StorageOptions(data_dir={:?}, storage_mode={:?}, mmap_cache_mb={:?}, vector_alignment={:?})",
+            self.data_dir, self.storage_mode, self.mmap_cache_mb, self.vector_alignment,
+        )
+    }
+}
+
+impl StorageOptions {
+    pub(crate) fn to_core(&self) -> CoreStorageConfig {
+        let mut cfg = CoreStorageConfig::default();
+        if let Some(ref data_dir) = self.data_dir {
+            cfg.data_dir.clone_from(data_dir);
+        }
+        if let Some(ref storage_mode) = self.storage_mode {
+            cfg.storage_mode.clone_from(storage_mode);
+        }
+        cfg.mmap_cache_mb = self.mmap_cache_mb.unwrap_or(cfg.mmap_cache_mb);
+        cfg.vector_alignment = self.vector_alignment.unwrap_or(cfg.vector_alignment);
+        cfg
+    }
+
+    /// Builds a fully-populated options object from a core section
+    /// (see [`LimitsOptions::from_core`]).
+    fn from_core(core: &CoreStorageConfig) -> Self {
+        Self {
+            data_dir: Some(core.data_dir.clone()),
+            storage_mode: Some(core.storage_mode.clone()),
+            mmap_cache_mb: Some(core.mmap_cache_mb),
+            vector_alignment: Some(core.vector_alignment),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationOptions
+// ---------------------------------------------------------------------------
+
+/// Valid values for `QuantizationOptions.mode`, mirroring the serde tags
+/// of [`QuantizationType`].
+const QUANTIZATION_MODES: &[&str] = &["none", "sq8", "binary", "pq", "rabitq"];
+
+/// Quantization settings mapped to
+/// [`velesdb_core::config::QuantizationConfig`] (the `[quantization]`
+/// TOML section).
+///
+/// `mode` selects the algorithm (`"none"`, `"sq8"`, `"binary"`, `"pq"`,
+/// `"rabitq"`). The `pq_*` fields configure Product Quantization and are
+/// only valid with `mode="pq"` (where `pq_m` is required); combining
+/// them with any other mode raises `ValueError` — they are never
+/// silently dropped.
+#[pyclass(module = "velesdb", from_py_object)]
+#[derive(Clone, Debug, Default)]
+pub struct QuantizationOptions {
+    /// Quantization mode. Default: `"none"`.
+    #[pyo3(get, set)]
+    pub mode: Option<String>,
+    /// PQ: number of subspaces (dimension must be divisible by it).
+    /// Required when `mode="pq"`.
+    #[pyo3(get, set)]
+    pub pq_m: Option<usize>,
+    /// PQ: codebook size per subspace. Default: 256.
+    #[pyo3(get, set)]
+    pub pq_k: Option<usize>,
+    /// PQ: enable Optimized Product Quantization (OPQ) rotation.
+    /// Default: `False`.
+    #[pyo3(get, set)]
+    pub pq_opq_enabled: Option<bool>,
+    /// PQ: oversampling factor for training. Default: 4.
+    #[pyo3(get, set)]
+    pub pq_oversampling: Option<u32>,
+    /// Enable reranking after quantized search. Default: `True`.
+    #[pyo3(get, set)]
+    pub rerank_enabled: Option<bool>,
+    /// Reranking multiplier for candidates. Default: 2.
+    #[pyo3(get, set)]
+    pub rerank_multiplier: Option<usize>,
+    /// Auto-enable quantization for large collections. Default: `True`.
+    #[pyo3(get, set)]
+    pub auto_quantization: Option<bool>,
+    /// Vector-count threshold for auto-quantization. Default: 10000.
+    #[pyo3(get, set)]
+    pub auto_quantization_threshold: Option<usize>,
+}
+
+#[pymethods]
+impl QuantizationOptions {
+    #[new]
+    #[pyo3(signature = (
+        mode = None,
+        pq_m = None,
+        pq_k = None,
+        pq_opq_enabled = None,
+        pq_oversampling = None,
+        rerank_enabled = None,
+        rerank_multiplier = None,
+        auto_quantization = None,
+        auto_quantization_threshold = None,
+    ))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        mode: Option<String>,
+        pq_m: Option<usize>,
+        pq_k: Option<usize>,
+        pq_opq_enabled: Option<bool>,
+        pq_oversampling: Option<u32>,
+        rerank_enabled: Option<bool>,
+        rerank_multiplier: Option<usize>,
+        auto_quantization: Option<bool>,
+        auto_quantization_threshold: Option<usize>,
+    ) -> Self {
+        Self {
+            mode,
+            pq_m,
+            pq_k,
+            pq_opq_enabled,
+            pq_oversampling,
+            rerank_enabled,
+            rerank_multiplier,
+            auto_quantization,
+            auto_quantization_threshold,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "QuantizationOptions(mode={:?}, pq_m={:?}, pq_k={:?}, pq_opq_enabled={:?}, pq_oversampling={:?}, rerank_enabled={:?}, rerank_multiplier={:?}, auto_quantization={:?}, auto_quantization_threshold={:?})",
+            self.mode,
+            self.pq_m,
+            self.pq_k,
+            self.pq_opq_enabled,
+            self.pq_oversampling,
+            self.rerank_enabled,
+            self.rerank_multiplier,
+            self.auto_quantization,
+            self.auto_quantization_threshold,
+        )
+    }
+}
+
+impl QuantizationOptions {
+    /// Returns `true` when any `pq_*` field is set.
+    fn has_pq_fields(&self) -> bool {
+        self.pq_m.is_some()
+            || self.pq_k.is_some()
+            || self.pq_opq_enabled.is_some()
+            || self.pq_oversampling.is_some()
+    }
+
+    /// Materializes the `mode` string (plus `pq_*` fields) into a core
+    /// [`QuantizationType`], failing fast on every inconsistent combination.
+    fn mode_to_core(&self) -> PyResult<QuantizationType> {
+        let mode = self.mode.as_deref().unwrap_or("none");
+        if mode != "pq" && self.has_pq_fields() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "quantization pq_m/pq_k/pq_opq_enabled/pq_oversampling require mode='pq' (got mode={mode:?})"
+            )));
+        }
+        match mode {
+            "none" => Ok(QuantizationType::None),
+            "sq8" => Ok(QuantizationType::SQ8),
+            "binary" => Ok(QuantizationType::Binary),
+            "rabitq" => Ok(QuantizationType::RaBitQ),
+            "pq" => {
+                let m = self.pq_m.ok_or_else(|| {
+                    pyo3::exceptions::PyValueError::new_err(
+                        "quantization mode='pq' requires pq_m (number of subspaces)",
+                    )
+                })?;
+                Ok(QuantizationType::PQ {
+                    m,
+                    k: self.pq_k.unwrap_or(256),
+                    opq_enabled: self.pq_opq_enabled.unwrap_or(false),
+                    oversampling: self.pq_oversampling.or(Some(4)),
+                })
+            }
+            other => Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "invalid quantization.mode '{other}' (expected one of: {QUANTIZATION_MODES:?})"
+            ))),
+        }
+    }
+
+    pub(crate) fn to_core(&self) -> PyResult<CoreQuantizationConfig> {
+        let mut cfg = CoreQuantizationConfig::default();
+        cfg.mode = self.mode_to_core()?;
+        cfg.rerank_enabled = self.rerank_enabled.unwrap_or(cfg.rerank_enabled);
+        cfg.rerank_multiplier = self.rerank_multiplier.unwrap_or(cfg.rerank_multiplier);
+        cfg.auto_quantization = self.auto_quantization.unwrap_or(cfg.auto_quantization);
+        cfg.auto_quantization_threshold = self
+            .auto_quantization_threshold
+            .unwrap_or(cfg.auto_quantization_threshold);
+        Ok(cfg)
+    }
+
+    /// Builds a fully-populated options object from a core section.
+    ///
+    /// Fallible: [`QuantizationType`] is `#[non_exhaustive]`, so a future
+    /// core variant unknown to this binding is rejected loudly instead of
+    /// being silently re-mapped.
+    fn from_core(core: &CoreQuantizationConfig) -> PyResult<Self> {
+        let (mode, pq_m, pq_k, pq_opq_enabled, pq_oversampling) = match &core.mode {
+            QuantizationType::None => ("none", None, None, None, None),
+            QuantizationType::SQ8 => ("sq8", None, None, None, None),
+            QuantizationType::Binary => ("binary", None, None, None, None),
+            QuantizationType::RaBitQ => ("rabitq", None, None, None, None),
+            QuantizationType::PQ {
+                m,
+                k,
+                opq_enabled,
+                oversampling,
+            } => ("pq", Some(*m), Some(*k), Some(*opq_enabled), *oversampling),
+            other => {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "unsupported quantization mode in configuration: {other:?}"
+                )));
+            }
+        };
+        Ok(Self {
+            mode: Some(mode.to_string()),
+            pq_m,
+            pq_k,
+            pq_opq_enabled,
+            pq_oversampling,
+            rerank_enabled: Some(core.rerank_enabled),
+            rerank_multiplier: Some(core.rerank_multiplier),
+            auto_quantization: Some(core.auto_quantization),
+            auto_quantization_threshold: Some(core.auto_quantization_threshold),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // VelesConfigOptions
 // ---------------------------------------------------------------------------
 
 /// Global database-level configuration exposed to Python.
 ///
-/// Maps to [`velesdb_core::config::VelesConfig`]. Currently exposes
-/// the `limits` sub-section. Other sub-sections (search, hnsw,
-/// storage, wal_batch) are left at their engine defaults — user-level
-/// tuning is done per-collection via [`HnswOptions`].
+/// Maps to [`velesdb_core::config::VelesConfig`], covering every *engine*
+/// section: `limits` ([`LimitsOptions`]), `search`
+/// ([`SearchConfigOptions`]), `hnsw` ([`HnswConfigOptions`]), `storage`
+/// ([`StorageOptions`]) and `quantization` ([`QuantizationOptions`]).
+/// Unset sections stay at their engine defaults.
+///
+/// Load from TOML with [`VelesConfigOptions::from_toml`] /
+/// [`VelesConfigOptions::from_toml_path`] (engine-only semantics — a
+/// shell-owned `[server]`/`[logging]` table in a shared file is ignored,
+/// mirroring `VelesConfig::from_toml_engine_only`).
 ///
 /// `wal_batch` is intentionally not exposed: the concurrent WAL
 /// writer is a velesdb-premium Enterprise feature. See
-/// `docs/guides/WRITE_CONCURRENCY.md`.
+/// `docs/guides/WRITE_CONCURRENCY.md`. A `[wal_batch]` TOML section is
+/// accepted by the loaders (it is a valid engine section for the
+/// server/CLI) but is not surfaced on — nor applied by — this embedded
+/// options type.
+///
+/// `server`/`logging` are likewise not exposed: they configure hosting
+/// shells, not the embedded engine surface.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct VelesConfigOptions {
     /// Tenant-wide guard-rail limits.
     #[pyo3(get, set)]
     pub limits: Option<LimitsOptions>,
+    /// Global search defaults (`[search]`).
+    #[pyo3(get, set)]
+    pub search: Option<SearchConfigOptions>,
+    /// Database-wide HNSW defaults (`[hnsw]`).
+    #[pyo3(get, set)]
+    pub hnsw: Option<HnswConfigOptions>,
+    /// Storage engine settings (`[storage]`).
+    #[pyo3(get, set)]
+    pub storage: Option<StorageOptions>,
+    /// Quantization settings (`[quantization]`).
+    #[pyo3(get, set)]
+    pub quantization: Option<QuantizationOptions>,
 }
 
 #[pymethods]
 impl VelesConfigOptions {
     #[new]
-    #[pyo3(signature = (limits = None))]
-    fn new(limits: Option<LimitsOptions>) -> Self {
-        Self { limits }
+    #[pyo3(signature = (
+        limits = None,
+        search = None,
+        hnsw = None,
+        storage = None,
+        quantization = None,
+    ))]
+    fn new(
+        limits: Option<LimitsOptions>,
+        search: Option<SearchConfigOptions>,
+        hnsw: Option<HnswConfigOptions>,
+        storage: Option<StorageOptions>,
+        quantization: Option<QuantizationOptions>,
+    ) -> Self {
+        Self {
+            limits,
+            search,
+            hnsw,
+            storage,
+            quantization,
+        }
+    }
+
+    /// Loads engine configuration from an in-memory TOML string.
+    ///
+    /// Wraps [`CoreVelesConfig::from_toml_engine_only`]: only the engine
+    /// sections are considered (a shell-owned `[server]`/`[logging]`
+    /// table is dropped before parsing), and the loaded config is
+    /// validated. Fail-fast: invalid TOML or an out-of-range value
+    /// raises `ValueError` carrying the typed core message — there is no
+    /// silent fallback to defaults.
+    ///
+    /// Every returned section is fully populated (engine defaults for
+    /// keys the TOML does not set).
+    #[staticmethod]
+    fn from_toml(toml_str: &str) -> PyResult<Self> {
+        let core = CoreVelesConfig::from_toml_engine_only(toml_str).map_err(config_err_to_py)?;
+        Self::from_core(&core)
+    }
+
+    /// Loads engine configuration from a TOML file path.
+    ///
+    /// Wraps [`CoreVelesConfig::load_from_path_engine_only`]: engine-only
+    /// section filtering plus validation, with `VELESDB_*` environment
+    /// variables layered on top of the file (mirroring the server/CLI
+    /// `--config` semantics from PR #1565). Fail-fast: a missing file
+    /// raises `FileNotFoundError`; invalid TOML or an out-of-range value
+    /// raises `ValueError` with the typed core message.
+    #[staticmethod]
+    fn from_toml_path(path: PathBuf) -> PyResult<Self> {
+        let core = CoreVelesConfig::load_from_path_engine_only(&path).map_err(config_err_to_py)?;
+        Self::from_core(&core)
     }
 
     fn __repr__(&self) -> String {
-        format!("VelesConfigOptions(limits={:?})", self.limits)
+        format!(
+            "VelesConfigOptions(limits={:?}, search={:?}, hnsw={:?}, storage={:?}, quantization={:?})",
+            self.limits, self.search, self.hnsw, self.storage, self.quantization,
+        )
     }
 }
 
 impl VelesConfigOptions {
-    pub(crate) fn to_core(&self) -> CoreVelesConfig {
+    /// Assembles the full core config and validates it, so an invalid
+    /// value fails fast as `ValueError` at `Database(..., config=...)`
+    /// time (in addition to the core-side validation in
+    /// `Database::open_with_config`).
+    pub(crate) fn to_core(&self) -> PyResult<CoreVelesConfig> {
         let mut core = CoreVelesConfig::default();
         if let Some(ref limits) = self.limits {
             core.limits = limits.to_core();
         }
-        core
+        if let Some(ref search) = self.search {
+            core.search = search.to_core()?;
+        }
+        if let Some(ref hnsw) = self.hnsw {
+            core.hnsw = hnsw.to_core();
+        }
+        if let Some(ref storage) = self.storage {
+            core.storage = storage.to_core();
+        }
+        if let Some(ref quantization) = self.quantization {
+            core.quantization = quantization.to_core()?;
+        }
+        core.validate().map_err(config_err_to_py)?;
+        Ok(core)
+    }
+
+    /// Builds a fully-populated options object from a validated core
+    /// config (every exposed section `Some`, every field set), so
+    /// [`Self::to_core`] round-trips the loaded values losslessly.
+    /// `wal_batch`/`server`/`logging` are intentionally not carried over
+    /// (see the type-level docs).
+    fn from_core(core: &CoreVelesConfig) -> PyResult<Self> {
+        Ok(Self {
+            limits: Some(LimitsOptions::from_core(&core.limits)),
+            search: Some(SearchConfigOptions::from_core(&core.search)?),
+            hnsw: Some(HnswConfigOptions::from_core(&core.hnsw)),
+            storage: Some(StorageOptions::from_core(&core.storage)),
+            quantization: Some(QuantizationOptions::from_core(&core.quantization)?),
+        })
     }
 }
 
@@ -481,6 +1110,205 @@ pub fn register_options(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<HnswOptions>()?;
     m.add_class::<LimitsOptions>()?;
     m.add_class::<AutoReindexOptions>()?;
+    m.add_class::<SearchConfigOptions>()?;
+    m.add_class::<HnswConfigOptions>()?;
+    m.add_class::<StorageOptions>()?;
+    m.add_class::<QuantizationOptions>()?;
     m.add_class::<VelesConfigOptions>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that stringify a `PyErr` need a live interpreter (error
+    /// formatting goes through the Python C-API). Idempotent.
+    fn init_python() {
+        Python::initialize();
+    }
+
+    // -- Section mapping: non-default values must propagate to core ------
+
+    #[test]
+    fn search_config_options_to_core_propagates_non_defaults() {
+        let opts = SearchConfigOptions {
+            default_mode: Some("accurate".to_string()),
+            ef_search: Some(256),
+            max_results: Some(42),
+            query_timeout_ms: Some(5_000),
+        };
+        let core = opts.to_core().expect("valid section");
+        assert!(matches!(core.default_mode, SearchMode::Accurate));
+        assert_eq!(core.ef_search, Some(256));
+        assert_eq!(core.max_results, 42);
+        assert_eq!(core.query_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn search_config_options_unset_fields_keep_engine_defaults() {
+        let core = SearchConfigOptions::default()
+            .to_core()
+            .expect("empty section is valid");
+        let defaults = CoreSearchConfig::default();
+        assert_eq!(core.max_results, defaults.max_results);
+        assert_eq!(core.ef_search, defaults.ef_search);
+        assert_eq!(core.query_timeout_ms, defaults.query_timeout_ms);
+    }
+
+    #[test]
+    fn search_config_options_rejects_unknown_mode() {
+        let opts = SearchConfigOptions {
+            default_mode: Some("warp".to_string()),
+            ..SearchConfigOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("unknown mode must fail");
+        assert!(err.to_string().contains("default_mode"));
+    }
+
+    #[test]
+    fn hnsw_config_options_to_core_propagates_non_defaults() {
+        let opts = HnswConfigOptions {
+            m: Some(32),
+            ef_construction: Some(400),
+            max_layers: Some(8),
+        };
+        let core = opts.to_core();
+        assert_eq!(core.m, Some(32));
+        assert_eq!(core.ef_construction, Some(400));
+        assert_eq!(core.max_layers, 8);
+    }
+
+    #[test]
+    fn storage_options_to_core_propagates_non_defaults() {
+        let opts = StorageOptions {
+            data_dir: Some("./custom".to_string()),
+            storage_mode: Some("memory".to_string()),
+            mmap_cache_mb: Some(256),
+            vector_alignment: Some(32),
+        };
+        let core = opts.to_core();
+        assert_eq!(core.data_dir, "./custom");
+        assert_eq!(core.storage_mode, "memory");
+        assert_eq!(core.mmap_cache_mb, 256);
+        assert_eq!(core.vector_alignment, 32);
+    }
+
+    #[test]
+    fn quantization_options_to_core_propagates_pq_mode() {
+        let opts = QuantizationOptions {
+            mode: Some("pq".to_string()),
+            pq_m: Some(8),
+            pq_k: Some(128),
+            pq_opq_enabled: Some(true),
+            rerank_enabled: Some(false),
+            rerank_multiplier: Some(3),
+            ..QuantizationOptions::default()
+        };
+        let core = opts.to_core().expect("valid pq section");
+        match core.mode {
+            QuantizationType::PQ {
+                m,
+                k,
+                opq_enabled,
+                oversampling,
+            } => {
+                assert_eq!(m, 8);
+                assert_eq!(k, 128);
+                assert!(opq_enabled);
+                assert_eq!(oversampling, Some(4), "unset oversampling → core default");
+            }
+            other => panic!("expected PQ mode, got {other:?}"),
+        }
+        assert!(!core.rerank_enabled);
+        assert_eq!(core.rerank_multiplier, 3);
+    }
+
+    #[test]
+    fn quantization_options_pq_without_m_fails() {
+        let opts = QuantizationOptions {
+            mode: Some("pq".to_string()),
+            ..QuantizationOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("pq without pq_m must fail");
+        assert!(err.to_string().contains("pq_m"));
+    }
+
+    #[test]
+    fn quantization_options_pq_fields_without_pq_mode_fail() {
+        let opts = QuantizationOptions {
+            mode: Some("sq8".to_string()),
+            pq_m: Some(8),
+            ..QuantizationOptions::default()
+        };
+        init_python();
+        let err = opts
+            .to_core()
+            .expect_err("pq fields with mode='sq8' must fail, not be dropped");
+        assert!(err.to_string().contains("pq_"));
+    }
+
+    // -- Whole-config assembly + validation ------------------------------
+
+    #[test]
+    fn veles_config_options_to_core_applies_every_section() {
+        let opts = VelesConfigOptions {
+            limits: Some(LimitsOptions {
+                max_collections: Some(5),
+                ..LimitsOptions::default()
+            }),
+            search: Some(SearchConfigOptions {
+                max_results: Some(42),
+                ..SearchConfigOptions::default()
+            }),
+            hnsw: Some(HnswConfigOptions {
+                m: Some(32),
+                ..HnswConfigOptions::default()
+            }),
+            storage: Some(StorageOptions {
+                mmap_cache_mb: Some(256),
+                ..StorageOptions::default()
+            }),
+            quantization: Some(QuantizationOptions {
+                mode: Some("sq8".to_string()),
+                ..QuantizationOptions::default()
+            }),
+        };
+        let core = opts.to_core().expect("valid full config");
+        assert_eq!(core.limits.max_collections, 5);
+        assert_eq!(core.search.max_results, 42);
+        assert_eq!(core.hnsw.m, Some(32));
+        assert_eq!(core.storage.mmap_cache_mb, 256);
+        assert!(matches!(core.quantization.mode, QuantizationType::SQ8));
+    }
+
+    #[test]
+    fn veles_config_options_to_core_validates_fail_fast() {
+        let opts = VelesConfigOptions {
+            search: Some(SearchConfigOptions {
+                max_results: Some(0),
+                ..SearchConfigOptions::default()
+            }),
+            ..VelesConfigOptions::default()
+        };
+        init_python();
+        let err = opts.to_core().expect_err("max_results=0 must fail");
+        assert!(err.to_string().contains("search.max_results"));
+    }
+
+    // -- TOML round-trip --------------------------------------------------
+
+    #[test]
+    fn from_core_round_trips_through_to_core() {
+        let toml = "[limits]\nmax_collections = 7\n\n[search]\nmax_results = 42\n";
+        let core = CoreVelesConfig::from_toml_engine_only(toml).expect("valid toml");
+        let opts = VelesConfigOptions::from_core(&core).expect("mappable config");
+        let back = opts.to_core().expect("round-trip stays valid");
+        assert_eq!(back.limits.max_collections, 7);
+        assert_eq!(back.search.max_results, 42);
+        // Untouched engine defaults survive the round-trip:
+        assert_eq!(back.storage.storage_mode, "mmap");
+    }
 }

--- a/crates/velesdb-python/tests/test_config_sections.py
+++ b/crates/velesdb-python/tests/test_config_sections.py
@@ -1,0 +1,384 @@
+"""BDD tests for issue #1549 — full engine `VelesConfig` coverage in Python.
+
+`VelesConfigOptions` historically exposed only the `limits` section. This
+suite covers the extension to the remaining *engine* sections
+(`search`, `hnsw`, `storage`, `quantization`) plus TOML loading via
+`VelesConfigOptions.from_toml` / `from_toml_path` (engine-only semantics,
+mirroring `VelesConfig::from_toml_engine_only` /
+`load_from_path_engine_only` from PR #1565).
+
+Scope guards:
+- `wal_batch` stays NOT exposed (velesdb-premium Enterprise feature —
+  see docs/guides/WRITE_CONCURRENCY.md).
+- `server` / `logging` are out of scope for the embedded surface; a TOML
+  shared with a hosting shell must still load (engine-only filtering).
+
+Test categories:
+- Nominal (>= 60%): section construction + TOML happy paths + round-trip
+  through `Database(path, config=...)`
+- Edge (~20%): defaults pass-through, engine-only section filtering
+- Negative (>= 20%): invalid TOML, invalid values, wal_batch guardrails
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import velesdb
+from velesdb import (
+    Database,
+    HnswConfigOptions,
+    LimitsOptions,
+    QuantizationOptions,
+    SearchConfigOptions,
+    StorageOptions,
+    VelesConfigOptions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db_path():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d) / "db"
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+# ---------------------------------------------------------------------------
+# Section dataclasses — nominal construction
+# ---------------------------------------------------------------------------
+
+
+def test_search_config_options_default_is_all_none():
+    opts = SearchConfigOptions()
+    assert opts.default_mode is None
+    assert opts.ef_search is None
+    assert opts.max_results is None
+    assert opts.query_timeout_ms is None
+
+
+def test_search_config_options_explicit_fields():
+    opts = SearchConfigOptions(
+        default_mode="accurate", ef_search=256, max_results=42, query_timeout_ms=5_000
+    )
+    assert opts.default_mode == "accurate"
+    assert opts.ef_search == 256
+    assert opts.max_results == 42
+    assert opts.query_timeout_ms == 5_000
+
+
+def test_hnsw_config_options_default_is_all_none():
+    opts = HnswConfigOptions()
+    assert opts.m is None
+    assert opts.ef_construction is None
+    assert opts.max_layers is None
+
+
+def test_hnsw_config_options_explicit_fields():
+    opts = HnswConfigOptions(m=32, ef_construction=400, max_layers=8)
+    assert opts.m == 32
+    assert opts.ef_construction == 400
+    assert opts.max_layers == 8
+
+
+def test_storage_options_default_is_all_none():
+    opts = StorageOptions()
+    assert opts.data_dir is None
+    assert opts.storage_mode is None
+    assert opts.mmap_cache_mb is None
+    assert opts.vector_alignment is None
+
+
+def test_storage_options_explicit_fields():
+    opts = StorageOptions(
+        data_dir="./data", storage_mode="memory", mmap_cache_mb=256, vector_alignment=32
+    )
+    assert opts.data_dir == "./data"
+    assert opts.storage_mode == "memory"
+    assert opts.mmap_cache_mb == 256
+    assert opts.vector_alignment == 32
+
+
+def test_quantization_options_default_is_all_none():
+    opts = QuantizationOptions()
+    assert opts.mode is None
+    assert opts.pq_m is None
+    assert opts.pq_k is None
+    assert opts.pq_opq_enabled is None
+    assert opts.pq_oversampling is None
+    assert opts.rerank_enabled is None
+    assert opts.rerank_multiplier is None
+    assert opts.auto_quantization is None
+    assert opts.auto_quantization_threshold is None
+
+
+def test_quantization_options_explicit_sq8():
+    opts = QuantizationOptions(mode="sq8", rerank_enabled=False, rerank_multiplier=3)
+    assert opts.mode == "sq8"
+    assert opts.rerank_enabled is False
+    assert opts.rerank_multiplier == 3
+
+
+def test_quantization_options_explicit_pq():
+    opts = QuantizationOptions(mode="pq", pq_m=8, pq_k=128, pq_opq_enabled=True)
+    assert opts.mode == "pq"
+    assert opts.pq_m == 8
+    assert opts.pq_k == 128
+    assert opts.pq_opq_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# VelesConfigOptions — new section kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_veles_config_options_accepts_all_engine_sections():
+    cfg = VelesConfigOptions(
+        limits=LimitsOptions(max_collections=10),
+        search=SearchConfigOptions(max_results=100),
+        hnsw=HnswConfigOptions(m=16),
+        storage=StorageOptions(mmap_cache_mb=128),
+        quantization=QuantizationOptions(mode="sq8"),
+    )
+    assert cfg.limits.max_collections == 10
+    assert cfg.search.max_results == 100
+    assert cfg.hnsw.m == 16
+    assert cfg.storage.mmap_cache_mb == 128
+    assert cfg.quantization.mode == "sq8"
+
+
+def test_veles_config_options_sections_default_to_none():
+    cfg = VelesConfigOptions()
+    assert cfg.limits is None
+    assert cfg.search is None
+    assert cfg.hnsw is None
+    assert cfg.storage is None
+    assert cfg.quantization is None
+
+
+def test_new_section_classes_are_exported_from_top_level():
+    for name in (
+        "SearchConfigOptions",
+        "HnswConfigOptions",
+        "StorageOptions",
+        "QuantizationOptions",
+    ):
+        assert name in velesdb.__all__, f"{name} missing from velesdb.__all__"
+
+
+# ---------------------------------------------------------------------------
+# Sections are actually applied at Database open time
+# ---------------------------------------------------------------------------
+
+
+def test_database_open_applies_search_section(tmp_db_path):
+    """An out-of-range `search.max_results` must be rejected at open —
+    proof the section reaches the core engine config (not dropped)."""
+    cfg = VelesConfigOptions(search=SearchConfigOptions(max_results=0))
+    with pytest.raises(ValueError, match="search.max_results"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_applies_hnsw_section(tmp_db_path):
+    cfg = VelesConfigOptions(hnsw=HnswConfigOptions(m=2))  # < 4 → invalid
+    with pytest.raises(ValueError, match="hnsw.m"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_applies_storage_section(tmp_db_path):
+    cfg = VelesConfigOptions(storage=StorageOptions(storage_mode="floppy"))
+    with pytest.raises(ValueError, match="storage.storage_mode"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_invalid_search_mode(tmp_db_path):
+    cfg = VelesConfigOptions(search=SearchConfigOptions(default_mode="warp"))
+    with pytest.raises(ValueError, match="default_mode"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_pq_without_m(tmp_db_path):
+    cfg = VelesConfigOptions(quantization=QuantizationOptions(mode="pq"))
+    with pytest.raises(ValueError, match="pq_m"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_rejects_pq_fields_without_pq_mode(tmp_db_path):
+    """pq_* fields with a non-pq mode must fail fast, never be silently
+    dropped."""
+    cfg = VelesConfigOptions(quantization=QuantizationOptions(mode="sq8", pq_m=8))
+    with pytest.raises(ValueError, match="pq_"):
+        Database(str(tmp_db_path), config=cfg)
+
+
+def test_database_open_with_valid_full_config_works(tmp_db_path):
+    cfg = VelesConfigOptions(
+        limits=LimitsOptions(max_collections=3),
+        search=SearchConfigOptions(default_mode="fast", max_results=50),
+        hnsw=HnswConfigOptions(m=16, ef_construction=200),
+        storage=StorageOptions(storage_mode="mmap", mmap_cache_mb=64),
+        quantization=QuantizationOptions(mode="none"),
+    )
+    db = Database(str(tmp_db_path), config=cfg)
+    db.create_collection("ok", dimension=4)
+    assert db.list_collections() == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# TOML loading — nominal
+# ---------------------------------------------------------------------------
+
+FULL_TOML = """
+[search]
+default_mode = "accurate"
+ef_search = 256
+max_results = 42
+query_timeout_ms = 5000
+
+[hnsw]
+m = 32
+ef_construction = 400
+max_layers = 8
+
+[storage]
+data_dir = "./custom_data"
+storage_mode = "memory"
+mmap_cache_mb = 256
+vector_alignment = 32
+
+[limits]
+max_collections = 5
+max_dimensions = 512
+
+[quantization]
+rerank_enabled = false
+rerank_multiplier = 3
+auto_quantization = false
+auto_quantization_threshold = 50000
+"""
+
+
+def test_from_toml_happy_path_populates_every_section():
+    cfg = VelesConfigOptions.from_toml(FULL_TOML)
+    assert cfg.search.default_mode == "accurate"
+    assert cfg.search.ef_search == 256
+    assert cfg.search.max_results == 42
+    assert cfg.search.query_timeout_ms == 5000
+    assert cfg.hnsw.m == 32
+    assert cfg.hnsw.ef_construction == 400
+    assert cfg.hnsw.max_layers == 8
+    assert cfg.storage.data_dir == "./custom_data"
+    assert cfg.storage.storage_mode == "memory"
+    assert cfg.storage.mmap_cache_mb == 256
+    assert cfg.storage.vector_alignment == 32
+    assert cfg.limits.max_collections == 5
+    assert cfg.limits.max_dimensions == 512
+    assert cfg.quantization.rerank_enabled is False
+    assert cfg.quantization.rerank_multiplier == 3
+    assert cfg.quantization.auto_quantization is False
+    assert cfg.quantization.auto_quantization_threshold == 50000
+
+
+def test_from_toml_unset_sections_carry_engine_defaults():
+    """A TOML with only [limits] still yields fully-populated sections
+    (engine defaults), so `to_core` round-trips losslessly."""
+    cfg = VelesConfigOptions.from_toml("[limits]\nmax_collections = 7\n")
+    assert cfg.limits.max_collections == 7
+    # Engine defaults surfaced, not None:
+    assert cfg.search.max_results == 1000
+    assert cfg.search.default_mode == "balanced"
+    assert cfg.storage.storage_mode == "mmap"
+    assert cfg.quantization.mode == "none"
+
+
+def test_from_toml_pq_mode_round_trips():
+    cfg = VelesConfigOptions.from_toml(
+        '[quantization]\nmode = { type = "pq", m = 8 }\n'
+    )
+    assert cfg.quantization.mode == "pq"
+    assert cfg.quantization.pq_m == 8
+    assert cfg.quantization.pq_k == 256  # core default k
+
+
+def test_from_toml_path_happy_path(tmp_dir):
+    path = tmp_dir / "velesdb.toml"
+    path.write_text(FULL_TOML)
+    cfg = VelesConfigOptions.from_toml_path(str(path))
+    assert cfg.limits.max_collections == 5
+    assert cfg.search.default_mode == "accurate"
+
+
+def test_from_toml_config_is_applied_by_database(tmp_db_path):
+    """End-to-end: a TOML-limit of 1 collection must be enforced by a
+    Database opened with the loaded config."""
+    cfg = VelesConfigOptions.from_toml("[limits]\nmax_collections = 1\n")
+    db = Database(str(tmp_db_path), config=cfg)
+    db.create_collection("a", dimension=4)
+    with pytest.raises(Exception):
+        db.create_collection("b", dimension=4)
+
+
+def test_from_toml_ignores_shell_owned_server_section():
+    """Engine-only semantics (PR #1565): a shell-owned [server] table with
+    a low bind port must not leak into the engine config nor fail
+    validation; the genuine engine sections still apply."""
+    cfg = VelesConfigOptions.from_toml(
+        "[server]\nport = 443\n\n[limits]\nmax_collections = 5\n"
+    )
+    assert cfg.limits.max_collections == 5
+
+
+# ---------------------------------------------------------------------------
+# TOML loading — negative (fail-fast, typed messages)
+# ---------------------------------------------------------------------------
+
+
+def test_from_toml_invalid_syntax_raises_value_error():
+    with pytest.raises(ValueError):
+        VelesConfigOptions.from_toml("this is [not valid toml")
+
+
+def test_from_toml_invalid_value_carries_typed_config_error():
+    """`limits.max_collections = 0` must surface the core ConfigError
+    message (key + range), never fall back to defaults silently."""
+    with pytest.raises(ValueError, match="limits.max_collections"):
+        VelesConfigOptions.from_toml("[limits]\nmax_collections = 0\n")
+
+
+def test_from_toml_path_missing_file_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        VelesConfigOptions.from_toml_path("/nonexistent/velesdb.toml")
+
+
+# ---------------------------------------------------------------------------
+# wal_batch stays unexposed (velesdb-premium Enterprise feature)
+# ---------------------------------------------------------------------------
+
+
+def test_veles_config_options_rejects_wal_batch_kwarg():
+    with pytest.raises(TypeError):
+        VelesConfigOptions(wal_batch={"enabled": True})  # type: ignore[call-arg]
+
+
+def test_veles_config_options_has_no_wal_batch_attribute():
+    assert not hasattr(VelesConfigOptions(), "wal_batch")
+
+
+def test_from_toml_does_not_surface_wal_batch_section():
+    """[wal_batch] in a TOML is valid engine input for the server/CLI, but
+    the embedded Python surface does not expose it (Enterprise-only —
+    docs/guides/WRITE_CONCURRENCY.md)."""
+    cfg = VelesConfigOptions.from_toml("[wal_batch]\nenabled = true\n")
+    assert not hasattr(cfg, "wal_batch")

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -661,7 +661,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "3.12.0"}
+{"status": "ok", "version": "4.0.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -675,13 +675,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "3.12.0"}
+{"status": "ready", "version": "4.0.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "3.12.0"}
+{"status": "not_ready", "version": "4.0.0"}
 ```
 
 ### Kubernetes Example

--- a/crates/velesdb-wasm/CHANGELOG.md
+++ b/crates/velesdb-wasm/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-sourcing; output is unchanged. (Issue #1545.)
 
 ### Fixed
+- **JOIN `ON` condition side order (#1555)**: `ON joined.col = base.col`
+  silently matched nothing (every row came back with NULL joined columns)
+  because the join key resolution read the two sides of the condition
+  positionally. `equality_keys` now orients the condition by which side
+  names the joined table (alias or raw table name), mirroring
+  `velesdb-core`'s `normalize_join_condition` — both `ON` orders resolve
+  identically. Conformance case J005 locks the parity on both engines.
 - **SQ8 quantization parity with `velesdb-core` (#1543)**: the WASM SQ8
   encode/decode paths (`store_insert::encode_sq8`, `store_get::decode_sq8`,
   `vector_ops::ScratchBuffer::decode_sq8`) used an ad hoc `1e-10`

--- a/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
+++ b/crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs
@@ -342,22 +342,14 @@ fn test_wasm_velesql_executor_match_cases() {
     }
 }
 
-/// Documents a real, currently-existing WASM JOIN gap
-/// (`documented_divergences` D002 in the fixture): `ON <base>.<col> =
-/// <joined>.<col>` matches correctly, but the reversed condition order
-/// (`ON <joined>.<col> = <base>.<col>`) fails to match ANY row and every
-/// joined column comes back NULL, because `equality_keys`/`key_of`
-/// (`velesql_join.rs`) does not normalize which side names the base vs.
-/// joined table the way core's `normalize_join_condition` does.
-///
-/// This is a **regression-lock for the current (buggy) behaviour**, not a
-/// desired outcome: fixing the underlying normalization is out of scope for
-/// issue #1544 (coverage of existing behaviour, not new WASM support). If
-/// this test starts failing because someone *fixed* the normalization, that
-/// is good news — update this test and `documented_divergences` D002 in
-/// `conformance/velesql_executor_cases.json` to match.
+/// Parity lock for issue #1555 (formerly `documented_divergences` D002):
+/// the ON condition must match regardless of which side names the joined
+/// table. `equality_keys` (`velesql_join.rs`) now orients the condition by
+/// which `ColumnRef` targets the join alias, mirroring core's
+/// `normalize_join_condition`, so `ON <joined>.<col> = <base>.<col>`
+/// resolves identically to `ON <base>.<col> = <joined>.<col>`.
 #[test]
-fn test_wasm_join_condition_side_order_gap_d002() {
+fn test_wasm_join_condition_side_order_parity_1555() {
     let mut db = DatabaseInner::new();
     db.create_collection("customers", 2, "cosine")
         .expect("test: create customers");
@@ -391,7 +383,8 @@ fn test_wasm_join_condition_side_order_gap_d002() {
         "base-table-first ON order should match and enrich the row with the customer name"
     );
 
-    // Reversed order: joined-table-first. Currently fails to match (D002).
+    // Reversed order: joined-table-first. Must match exactly like the
+    // base-table-first form (issue #1555).
     let reversed = execute(
         &mut db,
         "SELECT * FROM orders LEFT JOIN customers ON customers.id = orders.customer_id",
@@ -400,10 +393,9 @@ fn test_wasm_join_condition_side_order_gap_d002() {
     .expect("test: reversed-order join");
     let reversed_row: Value =
         serde_json::from_str(&reversed.rows_ref()[0].data_json()).expect("test: parse row");
-    assert!(
-        reversed_row.get("name").is_none() || reversed_row.get("name") == Some(&Value::Null),
-        "documented WASM gap D002: joined-table-first ON order currently does NOT match \
-         (customer name should be absent/null); if this assertion now fails, the underlying \
-         bug was fixed — update documented_divergences D002 accordingly"
+    assert_eq!(
+        reversed_row.get("name").and_then(Value::as_str),
+        Some("Alice"),
+        "joined-table-first ON order must resolve identically to base-table-first (issue #1555)"
     );
 }

--- a/crates/velesdb-wasm/src/velesql_join.rs
+++ b/crates/velesdb-wasm/src/velesql_join.rs
@@ -191,7 +191,23 @@ fn reject_unsupported_join(join: &JoinClause) -> Result<(), String> {
 /// "alias.column on right side".
 fn equality_keys(join: &JoinClause, alias: &str) -> Result<(String, String), String> {
     if let Some(cond) = &join.condition {
-        return Ok((key_of(&cond.left, alias), key_of(&cond.right, alias)));
+        // Orient the condition by which side targets the joined table, the
+        // same way core's `normalize_join_condition` does (issue #1555):
+        // the base-side ref is looked up on the accumulated row, the
+        // join-side ref on the scanned right row — regardless of which side
+        // of `ON` named which table. The joined table is addressable by its
+        // alias or by its raw table name even when aliased.
+        let is_join_side = |r: &velesdb_core::velesql::ColumnRef| {
+            r.table
+                .as_deref()
+                .is_some_and(|t| t == alias || t == join.table)
+        };
+        let (base_ref, join_ref) = if !is_join_side(&cond.left) || is_join_side(&cond.right) {
+            (&cond.left, &cond.right)
+        } else {
+            (&cond.right, &cond.left)
+        };
+        return Ok((key_of(base_ref, alias), key_of(join_ref, alias)));
     }
     if let Some(cols) = &join.using_columns {
         if let Some(first) = cols.first() {

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "3.12.0"
+version = "4.0.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="3.12.0",
+    version="4.0.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 15, 2026 (VelesDB v3.12.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 24, 2026 (VelesDB v4.0.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-15 (VelesDB v3.12.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-24 (VelesDB v4.0.0)
 
 ---
 

--- a/docs/contributing/PROJECT_STRUCTURE.md
+++ b/docs/contributing/PROJECT_STRUCTURE.md
@@ -243,6 +243,10 @@ Runs automatically before each `git commit`:
 
 Activate with: `git config core.hooksPath .githooks`
 
+When pushing over SSH, also configure an HTTPS push URL so the long pre-push
+validation cannot kill the connection before the transfer (see CONTRIBUTING.md,
+"Note (SSH pushes)").
+
 ---
 
 ## Relationship with VelesDB-Premium

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 3.12.0 — 2026-06-12*
+*Version 4.0.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 3.12.0
+# velesdb 4.0.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 3.12.0              │
+│ Version             │ 4.0.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v3.12.0 - Interactive REPL
+VelesDB v4.0.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 3.12.0 — May 2026*
+*Version 4.0.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 3.12.0
+# Version: 4.0.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 3.12.0 -- May 2026*
+*Version 4.0.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v3.12.0/velesdb-3.12.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.0.0/velesdb-4.0.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-3.12.0-amd64.deb
+sudo dpkg -i velesdb-4.0.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:3.12.0
+docker pull ghcr.io/cyberlife-coder/velesdb:4.0.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:3.12.0
+  ghcr.io/cyberlife-coder/velesdb:4.0.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 3.12.0 -- 2026-06-12*
+*Version 4.0.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "3.12.0"
+    "version": "4.0.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 3.12.0
+  version: 4.0.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v3.12.0
+# VelesDB Architecture Diagrams — v4.0.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-23 (v3.12.0; velesdb-memory 0.11.0)
+Last updated: 2026-07-24 (v4.0.0; velesdb-memory 0.11.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -422,10 +422,12 @@ scalar-expression ones below, which use the same single-collection dataset):
 - `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
   WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
   (col)`.
-- `aggregate_cases` G001–G004: `GROUP BY` / `HAVING` / `COUNT` / `SUM`,
-  checked via `Database::execute_aggregate` on core (not `execute_query`,
-  which only groups when combined with vector `NEAR` search) and via the
-  default SELECT pipeline on WASM.
+- `aggregate_cases` G001–G005: `GROUP BY` / `HAVING` / `COUNT` / `SUM` /
+  `LIMIT`, checked via `Database::execute_aggregate` on core (not
+  `execute_query`, which only groups when combined with vector `NEAR`
+  search) and via the default SELECT pipeline on WASM. G005 (issue #1556)
+  locks `LIMIT` truncation on grouped results — formerly D006 below, now
+  resolved on both engines.
 - `setops_cases` S001–S004: `UNION` / `INTERSECT` / `EXCEPT`, compared as a
   **sorted set of ids**, not an ordered list (see D003 below).
 - `match_cases` M001–M002: 1- and 2-hop `MATCH`, with per-executor query text
@@ -461,9 +463,12 @@ silently relied upon:
 - **D005** — cross-reference to the pre-existing `relative_score`/`rsf`
   multi-query fusion ranking divergence, already tracked in
   `docs/reference/ECOSYSTEM_PARITY.md`.
-- **D006** — `Database::execute_aggregate` never applies `LIMIT` to the group
-  array on core (every group comes back regardless); WASM's aggregate
-  pipeline does apply `LIMIT`. Tracked, not fixed — out of scope for #1544.
+- ~~D006~~ — **fixed 2026-07-24** (issue #1556):
+  `Collection::build_grouped_results` now applies `OFFSET`/`LIMIT` to grouped
+  results after `ORDER BY`, matching the WASM aggregate pipeline (no default
+  cap — a LIMIT-less `GROUP BY` still returns every group). Locked by
+  `aggregate_cases` G005 above and
+  `crates/velesdb-core/tests/velesql_group_by_limit.rs`.
 
 ### Large production files vs the NLOC/complexity gate (audit F-5.13)
 

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -419,9 +419,9 @@ scalar-expression ones below, which use the same single-collection dataset):
 - `cases` X011–X014: WHERE-expression evaluation (`BETWEEN`, parenthesized
   `AND`/`OR`, `NOT`, `IN`) — safe for CLI's strict-order comparison, so these
   run on all three executors.
-- `join_cases` J001–J004: `JOIN ... ON` (both condition-side orders on core;
-  WASM only accepts base-table-first — see D002 below) and `JOIN ... USING
-  (col)`.
+- `join_cases` J001–J005: `JOIN ... ON` (both condition-side orders on both
+  engines — J005 locks the joined-table-first order, issue #1555) and
+  `JOIN ... USING (col)`.
 - `aggregate_cases` G001–G005: `GROUP BY` / `HAVING` / `COUNT` / `SUM` /
   `LIMIT`, checked via `Database::execute_aggregate` on core (not
   `execute_query`, which only groups when combined with vector `NEAR`
@@ -441,14 +441,13 @@ silently relied upon:
 - **D001** — unaliased aggregate output field names differ (`"count"` /
   `"sum_year"` on core vs `"count(*)"` / `"sum(year)"` on WASM); sidestepped
   in the fixture by always using an explicit `AS` alias.
-- **D002** — WASM's `JOIN ... ON` does not normalize condition side order the
-  way core does: `ON base.col = joined.col` matches, but the reversed
-  `ON joined.col = base.col` silently returns every row with NULL joined
-  columns instead of matching. Locked as a regression test
-  (`test_wasm_join_condition_side_order_gap_d002` in
-  `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs`) rather than
-  fixed — out of scope for #1544 (coverage of existing behaviour, not new
-  WASM support).
+- ~~D002~~ — **fixed 2026-07-24** (issue #1555): WASM's `equality_keys` now
+  orients the `ON` condition by which side names the joined table (alias or
+  raw table name), mirroring core's `normalize_join_condition` — both
+  condition-side orders resolve identically. Locked by `join_cases` J005
+  above and the parity test
+  (`test_wasm_join_condition_side_order_parity_1555` in
+  `crates/velesdb-wasm/src/velesql_executor_conformance_tests.rs`).
 - **D003** — `UNION`/`INTERSECT`/`EXCEPT` row order for non-ranked (score 0.0)
   branches is implementation-defined on both sides (core re-sorts by score
   with an unstable tie-break that was observed to differ between two runs of

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 3.12.0
+> **VelesDB version:** 4.0.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-15 (VelesDB v3.12.0)
+> Last updated: 2026-07-24 (VelesDB v4.0.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "3.12.0"
+  "version": "4.0.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@3.12.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "3.12.0"
+version = "4.0.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/common/src/velesdb_common/graph.py
+++ b/integrations/common/src/velesdb_common/graph.py
@@ -76,7 +76,9 @@ def is_timeout_exception(exc: Exception) -> bool:
     return isinstance(exc, TimeoutError)
 
 
-def open_native_graph(db_path: str, collection_name: str) -> Any:
+def open_native_graph(
+    db_path: str, collection_name: str, config: Any = None
+) -> Any:
     """Open a native VelesDB graph collection.
 
     Shared implementation for both integrations.
@@ -91,6 +93,10 @@ def open_native_graph(db_path: str, collection_name: str) -> Any:
     Args:
         db_path: Filesystem path to the VelesDB database directory.
         collection_name: Name of the graph collection to open.
+        config: Optional ``velesdb.VelesConfigOptions`` engine
+            configuration, forwarded verbatim to ``velesdb.Database`` at
+            open time.  ``None`` (default) opens the database exactly as
+            before.
 
     Returns:
         PyGraphCollection instance.
@@ -107,7 +113,10 @@ def open_native_graph(db_path: str, collection_name: str) -> Any:
             "Install it with: pip install velesdb"
         ) from exc
 
-    db = velesdb.Database(db_path)
+    if config is not None:
+        db = velesdb.Database(db_path, config=config)
+    else:
+        db = velesdb.Database(db_path)
     graph = db.get_graph_collection(collection_name)
     if graph is None:
         raise ValueError(

--- a/integrations/common/tests/test_graph.py
+++ b/integrations/common/tests/test_graph.py
@@ -1,6 +1,9 @@
+import pytest
+
 from velesdb_common.graph import (
     build_graph_rest_payload,
     is_timeout_exception,
+    open_native_graph,
 )
 
 
@@ -36,3 +39,39 @@ def test_is_timeout_exception_with_timeout():
 def test_is_timeout_exception_with_other():
     exc = ValueError("Some error")
     assert is_timeout_exception(exc) is False
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls = []
+
+    def __init__(self, *args, **kwargs):
+        type(self).calls.append((args, kwargs))
+
+    def get_graph_collection(self, name):
+        return object()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    velesdb = pytest.importorskip("velesdb")
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+def test_open_native_graph_forwards_config(tmp_path, recording_db):
+    """Issue #1549: a provided config is forwarded verbatim to Database."""
+    config = object()  # opaque pass-through payload
+    graph = open_native_graph(str(tmp_path), "kg", config=config)
+    assert graph is not None
+    assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+
+def test_open_native_graph_no_config_call_unchanged(tmp_path, recording_db):
+    """Without config the historical Database(path) call is preserved."""
+    graph = open_native_graph(str(tmp_path), "kg")
+    assert graph is not None
+    assert recording_db.calls == [((str(tmp_path),), {})]

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/langchain/src/langchain_velesdb/_common.py
+++ b/integrations/langchain/src/langchain_velesdb/_common.py
@@ -22,10 +22,32 @@ from velesdb_common.graph import (  # noqa: F401
 __all__ = [
     "make_initial_id_counter", "build_graph_rest_payload",
     "is_timeout_exception", "open_native_graph", "parse_graph_traverse_response",
-    "payload_to_doc_parts", "validate_queries_batch",
+    "payload_to_doc_parts", "validate_queries_batch", "open_database",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def open_database(path: str, config: Any = None) -> Any:
+    """Open a :class:`velesdb.Database`, forwarding ``config`` only when set.
+
+    ``config`` is an opaque pass-through of ``velesdb.VelesConfigOptions``:
+    whatever the caller provides is handed to the binding verbatim.  When
+    ``config`` is ``None`` the call is identical to the historical
+    ``velesdb.Database(path)`` so default behaviour never changes.
+
+    Args:
+        path: Filesystem path to the VelesDB database directory.
+        config: Optional ``velesdb.VelesConfigOptions`` applied at open time.
+
+    Returns:
+        An open ``velesdb.Database`` handle.
+    """
+    import velesdb
+
+    if config is not None:
+        return velesdb.Database(path, config=config)
+    return velesdb.Database(path)
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/langchain/src/langchain_velesdb/graph_retriever.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_retriever.py
@@ -222,6 +222,11 @@ class GraphRetriever(BaseRetriever):
                 "'_db_path' / '_path' attribute."
             )
         config = getattr(self.vector_store, "_config", None)
+        if config is None:
+            # Keep the pre-config call shape so a velesdb-common that
+            # predates open_native_graph's ``config`` parameter (floor
+            # 3.8.0) stays compatible when the feature is unused.
+            return open_native_graph(resolved_path, self.graph_collection_name)
         return open_native_graph(
             resolved_path, self.graph_collection_name, config=config
         )

--- a/integrations/langchain/src/langchain_velesdb/graph_retriever.py
+++ b/integrations/langchain/src/langchain_velesdb/graph_retriever.py
@@ -209,14 +209,22 @@ class GraphRetriever(BaseRetriever):
         return graph
 
     def _open_graph_from_path(self) -> Any:
-        """Open graph collection by resolving db_path (fallback path)."""
+        """Open graph collection by resolving db_path (fallback path).
+
+        Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+        when present — the same source ``_get_db()`` uses — so the graph
+        database is opened with the same engine configuration.
+        """
         resolved_path = self.db_path or _infer_db_path(self.vector_store)
         if resolved_path is None:
             raise ValueError(
                 "Native mode requires 'db_path' or a vector store with a "
                 "'_db_path' / '_path' attribute."
             )
-        return open_native_graph(resolved_path, self.graph_collection_name)
+        config = getattr(self.vector_store, "_config", None)
+        return open_native_graph(
+            resolved_path, self.graph_collection_name, config=config
+        )
 
     def _get_relevant_documents(
         self,

--- a/integrations/langchain/src/langchain_velesdb/memory.py
+++ b/integrations/langchain/src/langchain_velesdb/memory.py
@@ -18,7 +18,10 @@ import json
 from typing import Any, Dict, List, Optional, Union
 import time
 
-from langchain_velesdb._common import make_initial_id_counter
+from langchain_velesdb._common import (
+    make_initial_id_counter,
+    open_database as _open_database,
+)
 from velesdb_common.memory import (
     chronological,
     format_procedural_results,
@@ -90,6 +93,9 @@ class VelesDBChatMemory(BaseChatMemory):
         human_prefix: Prefix for human messages (default: "Human")
         ai_prefix: Prefix for AI messages (default: "AI")
         return_messages: Return messages as objects vs string (default: False)
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBChatMemory(path="./chat_data")
@@ -126,10 +132,11 @@ class VelesDBChatMemory(BaseChatMemory):
         dimension: int = 384,
         window: int = 20,
         embedding: Optional[Any] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
         **kwargs,
     ):
         super().__init__(path=path, dimension=dimension, window=window, **kwargs)
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._embedding = embedding
         self._message_counter = make_initial_id_counter()
@@ -234,6 +241,9 @@ class VelesDBSemanticMemory:
         path: Path to VelesDB database directory
         dimension: Embedding dimension (must match your embeddings)
         embedding: LangChain Embeddings instance for encoding
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> from langchain_openai import OpenAIEmbeddings
@@ -245,7 +255,13 @@ class VelesDBSemanticMemory:
         >>> facts = memory.query("What is the capital of France?", k=3)
     """
 
-    def __init__(self, path: str, embedding: Any, dimension: Optional[int] = None):
+    def __init__(
+        self,
+        path: str,
+        embedding: Any,
+        dimension: Optional[int] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
+    ):
         self.path = path
         self.embedding = embedding
 
@@ -255,7 +271,7 @@ class VelesDBSemanticMemory:
             dimension = len(sample)
 
         self.dimension = dimension
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._fact_counter = make_initial_id_counter()
 
@@ -331,6 +347,9 @@ class VelesDBProceduralMemory:
             ``pattern`` string passed to :meth:`recall`.  Required for
             text-based recall; omit if you will always supply a raw
             embedding vector directly.
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> from langchain_velesdb import VelesDBProceduralMemory
@@ -350,9 +369,10 @@ class VelesDBProceduralMemory:
         path: str,
         dimension: int = 384,
         embeddings: Optional[Any] = None,
+        config: Optional["velesdb.VelesConfigOptions"] = None,
     ) -> None:
         self.path = path
-        self._db = velesdb.Database(path)
+        self._db = _open_database(path, config)
         self._memory = self._db.agent_memory(dimension=dimension)
         self._procedural = self._memory.procedural
         self._embeddings = embeddings

--- a/integrations/langchain/src/langchain_velesdb/vectorstore.py
+++ b/integrations/langchain/src/langchain_velesdb/vectorstore.py
@@ -38,7 +38,10 @@ from langchain_velesdb.security import (
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
-from langchain_velesdb._common import payload_to_doc_parts
+from langchain_velesdb._common import (
+    open_database as _open_database,
+    payload_to_doc_parts,
+)
 from langchain_velesdb.point_builder import build_point as _build_point, flush_stream_batches as _flush_stream_batches
 from langchain_velesdb.search_ops import SearchOpsMixin
 from langchain_velesdb.graph_ops import GraphOpsMixin
@@ -86,6 +89,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         metric: str = "cosine",
         storage_mode: str = "full",
         search_quality: Optional[str] = None,
+        config: Optional[velesdb.VelesConfigOptions] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -117,6 +121,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
                 ``"adaptive:MIN:MAX"``. ``None`` uses the built-in search.
                 Per-call override: pass ``search_quality=`` to
                 :meth:`similarity_search_with_score`.
+            config: Optional :class:`velesdb.VelesConfigOptions` engine
+                configuration, forwarded verbatim to ``velesdb.Database``
+                when the connection is opened. ``None`` (default) keeps the
+                engine defaults — the database is opened exactly as before.
             **kwargs: Additional arguments passed to the database.
 
         Raises:
@@ -139,6 +147,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             self._search_quality = validate_search_quality(search_quality)
 
         self._embedding = embedding
+        self._config = config
         self._db: Optional[velesdb.Database] = None
         self._collection: Optional[velesdb.Collection] = None
 
@@ -155,7 +164,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     def _get_db(self) -> velesdb.Database:
         """Get or create the database connection."""
         if self._db is None:
-            self._db = velesdb.Database(self._path)
+            self._db = _open_database(self._path, self._config)
         return self._db
 
     def _get_collection(self, dimension: int) -> velesdb.Collection:
@@ -327,7 +336,9 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             path: Path to database directory.
             collection_name: Name of the collection.
             metric: Distance metric.
-            **kwargs: Additional arguments.
+            **kwargs: Additional constructor arguments (e.g. ``config=``
+                for a :class:`velesdb.VelesConfigOptions` engine
+                configuration), forwarded to :meth:`__init__`.
 
         Returns:
             VelesDBVectorStore instance with texts added.

--- a/integrations/langchain/tests/test_config_passthrough.py
+++ b/integrations/langchain/tests/test_config_passthrough.py
@@ -1,0 +1,170 @@
+"""Tests for VelesConfigOptions pass-through to velesdb.Database.
+
+Covers issue #1549: every entry point that opens a ``velesdb.Database``
+must accept an optional ``config`` and forward it verbatim, while the
+no-config path must keep calling ``velesdb.Database(path)`` exactly as
+before.
+
+Run with: pytest tests/test_config_passthrough.py -v
+"""
+
+from typing import Any, List, Tuple
+
+import pytest
+
+try:
+    import velesdb
+    from langchain_velesdb import VelesDBVectorStore
+    from langchain_velesdb.graph_retriever import GraphRetriever
+    from langchain_velesdb.memory import (
+        VelesDBChatMemory,
+        VelesDBProceduralMemory,
+        VelesDBSemanticMemory,
+    )
+    from langchain_core.embeddings import Embeddings
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+class FakeEmbeddings(Embeddings):
+    """Deterministic embeddings for testing."""
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        return [[0.1, 0.2, 0.3, 0.4] for _ in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        return [0.1, 0.2, 0.3, 0.4]
+
+
+class _FakeAgentMemory:
+    """Minimal stand-in for the agent memory service."""
+
+    def __init__(self) -> None:
+        self.episodic = object()
+        self.semantic = object()
+        self.procedural = object()
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls: List[Tuple[tuple, dict]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).calls.append((args, kwargs))
+
+    def agent_memory(self, dimension: int = 384) -> _FakeAgentMemory:
+        return _FakeAgentMemory()
+
+    def get_graph_collection(self, name: str) -> Any:
+        return object()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+@pytest.fixture
+def config() -> Any:
+    """A real VelesConfigOptions instance (opaque pass-through payload)."""
+    return velesdb.VelesConfigOptions()
+
+
+class TestVectorStoreConfigPassthrough:
+    """VelesDBVectorStore forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=str(tmp_path),
+            config=config,
+        )
+        store._get_db()
+        assert recording_db.calls == [((store._path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(
+            embedding=FakeEmbeddings(),
+            path=str(tmp_path),
+        )
+        store._get_db()
+        assert recording_db.calls == [((store._path,), {})]
+
+
+class TestChatMemoryConfigPassthrough:
+    """VelesDBChatMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBChatMemory(path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBChatMemory(path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestSemanticMemoryConfigPassthrough:
+    """VelesDBSemanticMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBSemanticMemory(
+            path=str(tmp_path),
+            embedding=FakeEmbeddings(),
+            dimension=4,
+            config=config,
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBSemanticMemory(
+            path=str(tmp_path),
+            embedding=FakeEmbeddings(),
+            dimension=4,
+        )
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class _StoreWithoutGetDb:
+    """Fake vector store lacking _get_db, forcing the open_native_graph path."""
+
+    def __init__(self, path: str, config: Any = None) -> None:
+        self._path = path
+        self._config = config
+
+
+class TestGraphRetrieverConfigPassthrough:
+    """GraphRetriever's path fallback forwards the store's config."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = _StoreWithoutGetDb(str(tmp_path), config=config)
+        GraphRetriever(
+            vector_store=store,
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = _StoreWithoutGetDb(str(tmp_path))
+        GraphRetriever(
+            vector_store=store,
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestProceduralMemoryConfigPassthrough:
+    """VelesDBProceduralMemory forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        VelesDBProceduralMemory(path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        VelesDBProceduralMemory(path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]

--- a/integrations/langchain/tests/test_config_passthrough.py
+++ b/integrations/langchain/tests/test_config_passthrough.py
@@ -168,3 +168,26 @@ class TestProceduralMemoryConfigPassthrough:
     def test_no_config_call_unchanged(self, tmp_path, recording_db):
         VelesDBProceduralMemory(path=str(tmp_path))
         assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestGraphRetrieverOldCommonCompat:
+    """The path fallback must stay callable against a velesdb-common that
+    predates ``open_native_graph``'s ``config`` parameter (floor 3.8.0):
+    when the store carries no config, the kwarg must not be passed at all."""
+
+    def test_no_config_works_with_old_common_signature(self, tmp_path, monkeypatch):
+        import langchain_velesdb.graph_retriever as gr
+
+        calls = []
+
+        def old_signature(db_path, collection_name):
+            calls.append((db_path, collection_name))
+            return object()
+
+        monkeypatch.setattr(gr, "open_native_graph", old_signature)
+        GraphRetriever(
+            vector_store=_StoreWithoutGetDb(str(tmp_path)),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert calls == [(str(tmp_path), "kg")]

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "3.12.0"
+version = "4.0.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "3.12.0"
+__version__ = "4.0.0"

--- a/integrations/llamaindex/src/llamaindex_velesdb/_common.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/_common.py
@@ -5,6 +5,8 @@ Not part of the public API — import from the top-level package instead.
 
 from __future__ import annotations
 
+from typing import Any
+
 # Re-export shared helpers so existing intra-package imports keep working.
 from velesdb_common.ids import make_initial_id_counter  # noqa: F401
 from velesdb_common.graph import (  # noqa: F401
@@ -17,4 +19,27 @@ from velesdb_common.graph import (  # noqa: F401
 __all__ = [
     "make_initial_id_counter", "build_graph_rest_payload",
     "is_timeout_exception", "open_native_graph", "parse_graph_traverse_response",
+    "open_database",
 ]
+
+
+def open_database(path: str, config: Any = None) -> Any:
+    """Open a :class:`velesdb.Database`, forwarding ``config`` only when set.
+
+    ``config`` is an opaque pass-through of ``velesdb.VelesConfigOptions``:
+    whatever the caller provides is handed to the binding verbatim.  When
+    ``config`` is ``None`` the call is identical to the historical
+    ``velesdb.Database(path)`` so default behaviour never changes.
+
+    Args:
+        path: Filesystem path to the VelesDB database directory.
+        config: Optional ``velesdb.VelesConfigOptions`` applied at open time.
+
+    Returns:
+        An open ``velesdb.Database`` handle.
+    """
+    import velesdb
+
+    if config is not None:
+        return velesdb.Database(path, config=config)
+    return velesdb.Database(path)

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_loader.py
@@ -24,6 +24,8 @@ import logging
 
 from velesdb_common.ids import stable_hash_id
 
+from llamaindex_velesdb._common import open_database as _open_database
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -42,6 +44,10 @@ def _generate_id(name: str, entity_type: str) -> int:
 def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]:
     """Open a native graph collection from the vector store's database path.
 
+    Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+    when present, so the graph database is opened with the same engine
+    configuration as the vector store.
+
     Args:
         vector_store: VelesDBVectorStore instance.
         collection_name: Name of the graph collection.
@@ -50,7 +56,7 @@ def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]
         PyGraphCollection instance, or None if unavailable.
     """
     db_path: Optional[str] = None
-    for attr in ("_db_path", "_path", "_data_path"):
+    for attr in ("_db_path", "_path", "path", "_data_path"):
         candidate = getattr(vector_store, attr, None)
         if candidate is not None:
             db_path = str(candidate)
@@ -59,13 +65,14 @@ def _open_native_graph(vector_store: Any, collection_name: str) -> Optional[Any]
     if db_path is None:
         logger.debug(
             "Cannot open native graph collection: vector store has no "
-            "_db_path / _path attribute."
+            "_db_path / _path / path attribute."
         )
         return None
 
+    config = getattr(vector_store, "_config", None)
+
     try:
-        import velesdb  # type: ignore[import]
-        db = velesdb.Database(db_path)
+        db = _open_database(db_path, config)
         graph = db.get_graph_collection(collection_name)
         if graph is None:
             logger.debug(

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
@@ -231,14 +231,24 @@ class GraphRetriever(BaseRetriever):
     def _open_graph_from_path(
         self, db_path: Optional[str], collection_name: str
     ) -> Any:
-        """Open graph collection by resolving db_path (fallback path)."""
+        """Open graph collection by resolving db_path (fallback path).
+
+        Reuses the vector store's ``_config`` (``velesdb.VelesConfigOptions``)
+        when present — the same source ``_get_db()`` uses — so the graph
+        database is opened with the same engine configuration.
+        """
         resolved_path = db_path or _infer_db_path(self._index)
         if resolved_path is None:
             raise ValueError(
                 "Native mode requires 'db_path' or an index whose vector store "
                 "exposes a '_db_path' / '_path' attribute."
             )
-        return open_native_graph(resolved_path, collection_name)
+        try:
+            vs = self._index._vector_store
+        except AttributeError:
+            vs = None
+        config = getattr(vs, "_config", None)
+        return open_native_graph(resolved_path, collection_name, config=config)
 
     def _infer_collection_name(self) -> str:
         """Try to infer collection name from the index's vector store."""

--- a/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/graph_retriever.py
@@ -248,6 +248,11 @@ class GraphRetriever(BaseRetriever):
         except AttributeError:
             vs = None
         config = getattr(vs, "_config", None)
+        if config is None:
+            # Keep the pre-config call shape so a velesdb-common that
+            # predates open_native_graph's ``config`` parameter (floor
+            # 3.8.0) stays compatible when the feature is unused.
+            return open_native_graph(resolved_path, collection_name)
         return open_native_graph(resolved_path, collection_name, config=config)
 
     def _infer_collection_name(self) -> str:

--- a/integrations/llamaindex/src/llamaindex_velesdb/memory.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/memory.py
@@ -19,7 +19,10 @@ from typing import Any, Dict, List, Optional, Union
 
 import velesdb
 
-from llamaindex_velesdb._common import make_initial_id_counter
+from llamaindex_velesdb._common import (
+    make_initial_id_counter,
+    open_database as _open_database,
+)
 from velesdb_common.memory import (
     chronological,
     format_procedural_results,
@@ -38,10 +41,15 @@ class _VelesDBMemoryBase:
     ``db_path`` validation and ``agent_memory`` setup in every ``__init__``.
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
         if not db_path:
             raise ValueError("db_path must not be empty")
-        self._db = velesdb.Database(db_path)
+        self._db = _open_database(db_path, config)
         self._dimension = dimension
         self._memory = self._db.agent_memory(dimension=dimension)
 
@@ -55,6 +63,9 @@ class VelesDBSemanticMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBSemanticMemory(db_path="./data", dimension=768)
@@ -127,6 +138,9 @@ class VelesDBEpisodicMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBEpisodicMemory(db_path="./data")
@@ -134,8 +148,13 @@ class VelesDBEpisodicMemory(_VelesDBMemoryBase):
         >>> recent = memory.recall(query_embedding, top_k=5)
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
-        super().__init__(db_path, dimension)
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
+        super().__init__(db_path, dimension, config)
         self._event_counter = make_initial_id_counter()
 
     def record_event(
@@ -252,6 +271,9 @@ class VelesDBChatMemory(_VelesDBMemoryBase):
         dimension: Embedding dimension of the underlying store (default: 384).
         human_prefix: Prefix used for human turns in the string view.
         ai_prefix: Prefix used for AI turns in the string view.
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBChatMemory(db_path="./chat")
@@ -266,8 +288,9 @@ class VelesDBChatMemory(_VelesDBMemoryBase):
         dimension: int = 384,
         human_prefix: str = "Human",
         ai_prefix: str = "AI",
+        config: Optional[velesdb.VelesConfigOptions] = None,
     ) -> None:
-        super().__init__(db_path, dimension)
+        super().__init__(db_path, dimension, config)
         self._human_prefix = human_prefix
         self._ai_prefix = ai_prefix
         self._message_counter = make_initial_id_counter()
@@ -372,6 +395,9 @@ class VelesDBProceduralMemory(_VelesDBMemoryBase):
     Args:
         db_path: Path to VelesDB database directory.
         dimension: Embedding dimension (default: 384).
+        config: Optional :class:`velesdb.VelesConfigOptions` engine
+            configuration, forwarded verbatim to ``velesdb.Database``.
+            ``None`` (default) opens the database exactly as before.
 
     Example:
         >>> memory = VelesDBProceduralMemory(db_path="./data", dimension=384)
@@ -381,8 +407,13 @@ class VelesDBProceduralMemory(_VelesDBMemoryBase):
         >>> memory.reinforce("deploy_app", success=True)
     """
 
-    def __init__(self, db_path: str, dimension: int = 384) -> None:
-        super().__init__(db_path, dimension)
+    def __init__(
+        self,
+        db_path: str,
+        dimension: int = 384,
+        config: Optional[velesdb.VelesConfigOptions] = None,
+    ) -> None:
+        super().__init__(db_path, dimension, config)
         self._name_to_id: Dict[str, int] = {}
         self._id_counter = make_initial_id_counter()
 

--- a/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/vectorstore.py
@@ -32,6 +32,7 @@ from llamaindex_velesdb.security import (
 )
 from velesdb_common.collection_admin import CollectionAdminMixin
 from velesdb_common.ids import stable_hash_id as _stable_hash_id
+from llamaindex_velesdb._common import open_database as _open_database
 from llamaindex_velesdb.filter_ops import metadata_filters_to_core_filter
 from llamaindex_velesdb.node_builder import (
     validate_all_embeddings as _validate_all_embeddings,
@@ -121,6 +122,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     _collection: Optional[velesdb.Collection] = PrivateAttr(default=None)
     _dimension: Optional[int] = PrivateAttr(default=None)
     _search_quality: Optional[str] = PrivateAttr(default=None)
+    _config: Optional[velesdb.VelesConfigOptions] = PrivateAttr(default=None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -131,6 +133,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
         metric: str = "cosine",
         storage_mode: str = "full",
         search_quality: Optional[str] = None,
+        config: Optional[velesdb.VelesConfigOptions] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize VelesDB vector store.
@@ -160,6 +163,10 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
                 ``"autotune"``, ``"custom:N"``, ``"adaptive:MIN:MAX"``.
                 ``None`` uses the built-in search. Per-call override:
                 pass ``search_quality=`` to :meth:`query`.
+            config: Optional :class:`velesdb.VelesConfigOptions` engine
+                configuration, forwarded verbatim to ``velesdb.Database``
+                when the connection is opened. ``None`` (default) keeps the
+                engine defaults — the database is opened exactly as before.
             **kwargs: Additional arguments.
 
         Raises:
@@ -191,6 +198,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
             **kwargs,
         )
         self._search_quality = validated_quality
+        self._config = config
 
     # ------------------------------------------------------------------
     # Static / class helpers
@@ -256,7 +264,7 @@ class VelesDBVectorStore(CollectionAdminMixin, SearchOpsMixin, GraphOpsMixin, Sc
     def _get_db(self) -> velesdb.Database:
         """Get or create the database connection."""
         if self._db is None:
-            self._db = velesdb.Database(self.path)
+            self._db = _open_database(self.path, self._config)
         return self._db
 
     def _get_collection(self, dimension: int) -> velesdb.Collection:

--- a/integrations/llamaindex/tests/test_config_passthrough.py
+++ b/integrations/llamaindex/tests/test_config_passthrough.py
@@ -162,3 +162,26 @@ class TestGraphLoaderConfigPassthrough:
         recording_db.calls = []
         GraphLoader(store, graph_collection_name="kg")
         assert recording_db.calls == [((store.path,), {})]
+
+
+class TestGraphRetrieverOldCommonCompat:
+    """The path fallback must stay callable against a velesdb-common that
+    predates ``open_native_graph``'s ``config`` parameter (floor 3.8.0):
+    when the store carries no config, the kwarg must not be passed at all."""
+
+    def test_no_config_works_with_old_common_signature(self, tmp_path, monkeypatch):
+        import llamaindex_velesdb.graph_retriever as gr
+
+        calls = []
+
+        def old_signature(db_path, collection_name):
+            calls.append((db_path, collection_name))
+            return object()
+
+        monkeypatch.setattr(gr, "open_native_graph", old_signature)
+        GraphRetriever(
+            index=_FakeIndex(_StoreWithoutGetDb(str(tmp_path))),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert calls == [(str(tmp_path), "kg")]

--- a/integrations/llamaindex/tests/test_config_passthrough.py
+++ b/integrations/llamaindex/tests/test_config_passthrough.py
@@ -1,0 +1,164 @@
+"""Tests for VelesConfigOptions pass-through to velesdb.Database.
+
+Covers issue #1549: every entry point that opens a ``velesdb.Database``
+must accept an optional ``config`` and forward it verbatim, while the
+no-config path must keep calling ``velesdb.Database(path)`` exactly as
+before.
+
+Run with: pytest tests/test_config_passthrough.py -v
+"""
+
+from typing import Any, List, Tuple
+
+import pytest
+
+try:
+    import velesdb
+    from llamaindex_velesdb import VelesDBVectorStore
+    from llamaindex_velesdb.graph_loader import GraphLoader
+    from llamaindex_velesdb.graph_retriever import GraphRetriever
+    from llamaindex_velesdb.memory import (
+        VelesDBChatMemory,
+        VelesDBEpisodicMemory,
+        VelesDBProceduralMemory,
+        VelesDBSemanticMemory,
+    )
+except ImportError:
+    pytest.skip("Dependencies not installed", allow_module_level=True)
+
+
+class _FakeAgentMemory:
+    """Minimal stand-in for the agent memory service."""
+
+    def __init__(self) -> None:
+        self.episodic = object()
+        self.semantic = object()
+        self.procedural = object()
+
+
+class _RecordingDatabase:
+    """Recording fake for ``velesdb.Database`` capturing constructor calls."""
+
+    calls: List[Tuple[tuple, dict]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).calls.append((args, kwargs))
+
+    def agent_memory(self, dimension: int = 384) -> _FakeAgentMemory:
+        return _FakeAgentMemory()
+
+    def get_graph_collection(self, name: str) -> Any:
+        return object()
+
+
+@pytest.fixture
+def recording_db(monkeypatch):
+    """Patch velesdb.Database with a recording fake and reset its call log."""
+    _RecordingDatabase.calls = []
+    monkeypatch.setattr(velesdb, "Database", _RecordingDatabase)
+    return _RecordingDatabase
+
+
+@pytest.fixture
+def config() -> Any:
+    """A real VelesConfigOptions instance (opaque pass-through payload)."""
+    return velesdb.VelesConfigOptions()
+
+
+class TestVectorStoreConfigPassthrough:
+    """VelesDBVectorStore forwards config to velesdb.Database."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(path=str(tmp_path), config=config)
+        store._get_db()
+        assert recording_db.calls == [((store.path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(path=str(tmp_path))
+        store._get_db()
+        assert recording_db.calls == [((store.path,), {})]
+
+
+class TestMemoryConfigPassthrough:
+    """All four memory classes forward config to velesdb.Database."""
+
+    @pytest.mark.parametrize(
+        "memory_cls",
+        [
+            VelesDBSemanticMemory,
+            VelesDBEpisodicMemory,
+            VelesDBChatMemory,
+            VelesDBProceduralMemory,
+        ],
+    )
+    def test_config_forwarded_to_database(
+        self, tmp_path, recording_db, config, memory_cls
+    ):
+        memory_cls(db_path=str(tmp_path), config=config)
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    @pytest.mark.parametrize(
+        "memory_cls",
+        [
+            VelesDBSemanticMemory,
+            VelesDBEpisodicMemory,
+            VelesDBChatMemory,
+            VelesDBProceduralMemory,
+        ],
+    )
+    def test_no_config_call_unchanged(self, tmp_path, recording_db, memory_cls):
+        memory_cls(db_path=str(tmp_path))
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class _StoreWithoutGetDb:
+    """Fake vector store lacking _get_db, forcing the open_native_graph path."""
+
+    def __init__(self, path: str, config: Any = None) -> None:
+        self._path = path
+        self._config = config
+
+
+class _FakeIndex:
+    """Fake VectorStoreIndex exposing only a vector store."""
+
+    def __init__(self, vector_store: Any) -> None:
+        self._vector_store = vector_store
+
+
+class TestGraphRetrieverConfigPassthrough:
+    """GraphRetriever's path fallback forwards the store's config."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = _StoreWithoutGetDb(str(tmp_path), config=config)
+        GraphRetriever(
+            index=_FakeIndex(store),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = _StoreWithoutGetDb(str(tmp_path))
+        GraphRetriever(
+            index=_FakeIndex(store),
+            mode="native",
+            graph_collection_name="kg",
+        )
+        assert recording_db.calls == [((str(tmp_path),), {})]
+
+
+class TestGraphLoaderConfigPassthrough:
+    """GraphLoader reuses the vector store's config for the native graph DB."""
+
+    def test_config_forwarded_to_database(self, tmp_path, recording_db, config):
+        store = VelesDBVectorStore(path=str(tmp_path), config=config)
+        recording_db.calls = []
+        GraphLoader(store, graph_collection_name="kg")
+        assert recording_db.calls == [((store.path,), {"config": config})]
+
+    def test_no_config_call_unchanged(self, tmp_path, recording_db):
+        store = VelesDBVectorStore(path=str(tmp_path))
+        recording_db.calls = []
+        GraphLoader(store, graph_collection_name="kg")
+        assert recording_db.calls == [((store.path,), {})]

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@3.12.0
+cargo add --quiet velesdb-core@4.0.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@3.12.0
+cargo install --quiet --locked velesdb-server@4.0.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -21,8 +21,11 @@
 #     thumbprint before importing, same spirit as the macOS strict-curl
 #     ground-truth check.
 #   - Client config paths follow Windows conventions: Claude Desktop
-#     `%APPDATA%\Claude\claude_desktop_config.json` (still stdio-only — never
-#     written here, same as macOS), Windsurf
+#     `%APPDATA%\Claude\claude_desktop_config.json` (stdio-only, so the
+#     installer writes an mcp-remote stdio→HTTPS bridge entry there with
+#     NODE_EXTRA_CA_CERTS — same mechanism as macOS; `.cmd` shims are
+#     resolved explicitly because Desktop spawns the command without a
+#     shell, and a bare/`.ps1` resolution would fail), Windsurf
 #     `%USERPROFILE%\.codeium\windsurf\mcp_config.json`, Devin CLI
 #     `%APPDATA%\devin\config.json` (documented at
 #     https://cli.devin.ai/docs/reference/configuration/config-file — Devin's
@@ -50,6 +53,8 @@
 #   -Yes                      Assume yes to interactive prompts (e.g. `ollama pull`)
 #   -SkipClient <name>        Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   -SkipCaTrust              Skip trusting the local CA in the CurrentUser\Root store
+#   -WireOnly                 Skip build/daemon setup: only (re-)verify CA trust and re-wire the
+#                             clients against an already-installed daemon (no prompts, fast)
 #   -ForceRestart             Re-register/restart the scheduled task even if already running
 #   -FromRelease              Install the prebuilt daemon binary from a GitHub Release archive
 #                             instead of building with cargo (see -FromReleaseTag). PowerShell
@@ -93,6 +98,8 @@ param(
     [string[]]$SkipClient = @(),
 
     [switch]$SkipCaTrust,
+
+    [switch]$WireOnly,
 
     [switch]$ForceRestart,
 
@@ -153,7 +160,7 @@ function Write-ErrorMsg { param([string]$Message) Write-Host $Message -Foregroun
 function Show-Usage {
     # Reprint the flag block from this file's own header — keeps `-Help`
     # honest (it can never drift from the comment a reader actually sees).
-    $lines = Get-Content -Path $PSCommandPath -TotalCount 70
+    $lines = Get-Content -Path $PSCommandPath -TotalCount 74
     ($lines | Select-Object -Skip 1) | ForEach-Object {
         if ($_ -match '^# ?(.*)$') { Write-Host $Matches[1] } else { Write-Host '' }
     }
@@ -570,7 +577,28 @@ function Enable-LocalCaTrust {
     # rights needed, and behaves consistently across PowerShell versions.
     $ok = Invoke-WithTimeout -Seconds 60 -FilePath 'certutil.exe' -ArgumentList @('-addstore', '-user', 'Root', "`"$CaCertPath`"")
     if ($ok) {
-        Write-Success 'Local CA trusted in Cert:\CurrentUser\Root.'
+        # VERIFY, don't assume: certutil exiting 0 is not proof a strict TLS
+        # client now accepts the daemon's certificate. Ground-truth it the
+        # same way the idempotency check above does — curl WITHOUT --cacert,
+        # i.e. against the user/system trust store.
+        if ($curl) {
+            & $curl.Source -fsS --max-time 2 "https://127.0.0.1:$Port/health" *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success 'Local CA trusted AND verified: a strict HTTPS request to the daemon now succeeds.'
+            } else {
+                & $curl.Source -fsS --max-time 2 --cacert $CaCertPath "https://127.0.0.1:$Port/health" *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Warn '   certutil reported success, but a strict HTTPS request to the daemon still fails'
+                    Write-Warn '   certificate verification. Re-run this by hand and approve any security dialog:'
+                    Write-Host "     certutil -addstore -user Root `"$CaCertPath`""
+                } else {
+                    Write-Warn "   CA imported, but the daemon is not answering /health right now, so the end-to-end"
+                    Write-Warn "   verification could not run — check $LogsDir\daemon.err.log"
+                }
+            }
+        } else {
+            Write-Success 'Local CA imported into Cert:\CurrentUser\Root (curl.exe not found — could not verify end-to-end).'
+        }
     } else {
         Write-Warn '   Could not confirm the CA trust automatically (no response within 60s, or the'
         Write-Warn '   command failed). The daemon is still up and serving HTTPS — this only affects'
@@ -605,24 +633,103 @@ function Set-ClaudeCodeClient {
 
 # Claude Desktop is a DIFFERENT mechanism than every other client here:
 # claude_desktop_config.json never reads a url/type:"http" entry (confirmed on
-# macOS, same binary/config format on Windows) — the only way to wire Desktop
-# to the daemon is its own UI. This prints that instruction instead of
-# touching the config file, same as the shell script.
+# macOS, same binary/config format on Windows), and Desktop's "Add custom
+# connector" UI verifies TLS through Chromium/Node — which does not reliably
+# consult the OS certificate store — so even a trusted local CA can leave the
+# UI path rejecting the daemon's certificate. The reliable, zero-UI-steps
+# path (same as the shell script) is a stdio→HTTPS bridge: an `mcp-remote`
+# entry in the config file, with NODE_EXTRA_CA_CERTS pointing at the daemon's
+# CA so the bridge verifies TLS strictly (never NODE_TLS_REJECT_UNAUTHORIZED=0
+# — that disables verification entirely). The bridge is a plain HTTPS client
+# of the daemon: it never opens the store itself, so no lock conflict.
+# `.cmd` shims are resolved explicitly (mcp-remote.cmd / npx.cmd, absolute
+# paths): Desktop spawns the command without a shell, so a bare name or a
+# `.ps1` shim would fail to launch.
 function Set-ClaudeDesktopClient {
     if (Test-ShouldSkip 'claude-desktop') {
         Write-Warn 'Skipping Claude Desktop (-SkipClient).'
         return
     }
-    Write-Host ''
-    Write-Info 'Claude Desktop — different mechanism than every other client here:'
-    Write-Warn "   its config file ($DesktopConfig) does not support HTTP (a url/type:`"http`" entry"
-    Write-Warn '   there is silently ignored). Add it yourself, once, via the UI instead:'
-    Write-Warn '   Settings -> Connectors -> Add custom connector, then paste:'
-    Write-Host "     https://127.0.0.1:$Port/mcp"
-    Write-Warn '   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.'
-    Write-Warn '   Prefer not to use the Connectors UI? A stdio fallback still works — see the README''s'
-    Write-Warn "   `"Configure your client`" section (use a DIFFERENT VELESDB_MEMORY_PATH than $script:Store,"
-    Write-Warn '   or the fallback process and the daemon will fight over the same lock).'
+
+    $configDir = Split-Path -Path $DesktopConfig -Parent
+    if (-not (Test-Path $configDir)) {
+        Write-Warn "Claude Desktop not detected (no $configDir) — skipping."
+        return
+    }
+
+    $caCert = "$script:TlsDir\ca-cert.pem"
+    $url = "https://127.0.0.1:$Port/mcp"
+
+    # Resolve the bridge: a globally-installed mcp-remote wins (no npx
+    # startup cost); otherwise npx fetches/caches it on first launch.
+    $bridgeCmd = $null
+    $bridgeArgs = @()
+    $mcpRemote = Get-Command 'mcp-remote.cmd' -ErrorAction SilentlyContinue
+    $npx = Get-Command 'npx.cmd' -ErrorAction SilentlyContinue
+    $node = Get-Command 'node.exe' -ErrorAction SilentlyContinue
+    if ($mcpRemote) {
+        $bridgeCmd = $mcpRemote.Source
+        $bridgeArgs = @($url)
+    } elseif ($npx) {
+        $bridgeCmd = $npx.Source
+        $bridgeArgs = @('-y', 'mcp-remote', $url)
+    }
+
+    if (-not $bridgeCmd -or -not $node) {
+        Write-Host ''
+        Write-Warn 'Claude Desktop needs a stdio->HTTPS bridge (mcp-remote), which needs Node.js —'
+        Write-Warn "   'mcp-remote.cmd'/'npx.cmd'/'node.exe' not found on PATH. Two ways to finish:"
+        Write-Warn '   a) install Node.js (https://nodejs.org) and re-run: pwsh -File scripts/install-memory-daemon.ps1 -WireOnly'
+        Write-Warn '   b) or use Desktop''s UI: Settings -> Connectors -> Add custom connector, paste:'
+        Write-Host "        $url"
+        Write-Warn '      (no API key needed — but this path requires the CA-trust step above to have'
+        Write-Warn '      succeeded, and Desktop''s own TLS stack may still refuse a local CA).'
+        return
+    }
+
+    # VERIFY the exact TLS path the bridge will use BEFORE writing any
+    # config: Node does not consult the Windows certificate store by default,
+    # so the CA-trust step above proves nothing for the bridge —
+    # NODE_EXTRA_CA_CERTS is what makes Node accept this CA, and this probe
+    # exercises precisely that.
+    if (Test-Path $caCert) {
+        $previousCa = $env:NODE_EXTRA_CA_CERTS
+        $env:NODE_EXTRA_CA_CERTS = $caCert
+        & $node.Source -e 'require("https").get(process.argv[1],(r)=>process.exit(r.statusCode===200?0:1)).on("error",()=>process.exit(1));setTimeout(()=>process.exit(1),8000);' "https://127.0.0.1:$Port/health" *> $null
+        $nodeOk = ($LASTEXITCODE -eq 0)
+        $env:NODE_EXTRA_CA_CERTS = $previousCa
+        if ($nodeOk) {
+            Write-Success 'Node accepts the daemon''s certificate via NODE_EXTRA_CA_CERTS — the Desktop bridge will verify TLS strictly.'
+        } else {
+            Write-Warn "Node could not fetch https://127.0.0.1:$Port/health with NODE_EXTRA_CA_CERTS=$caCert."
+            Write-Warn '   Writing the Claude Desktop entry anyway — if Desktop shows velesdb-memory as'
+            Write-Warn "   disconnected, check $LogsDir\daemon.err.log and re-run with -WireOnly."
+        }
+    } else {
+        Write-Warn "No CA certificate at $caCert yet — the Desktop bridge entry is written but can only"
+        Write-Warn '   be verified once the daemon has started and generated it (re-run with -WireOnly).'
+    }
+
+    $entry = [PSCustomObject]@{
+        command = $bridgeCmd
+        args    = [string[]]$bridgeArgs
+        env     = [PSCustomObject]@{ NODE_EXTRA_CA_CERTS = $caCert }
+    }
+
+    Set-JsonClient -Name 'claude-desktop' -ConfigPath $DesktopConfig -RequireExistingDir $true -Mutator {
+        param($json)
+        if (-not $json.PSObject.Properties['mcpServers']) {
+            $json | Add-Member -NotePropertyName 'mcpServers' -NotePropertyValue ([PSCustomObject]@{})
+        }
+        if ($json.mcpServers.PSObject.Properties['velesdb-memory']) {
+            $json.mcpServers.'velesdb-memory' = $entry
+        } else {
+            $json.mcpServers | Add-Member -NotePropertyName 'velesdb-memory' -NotePropertyValue $entry
+        }
+        $json
+    }.GetNewClosure()
+    Write-Warn '   Restart Claude Desktop fully (system tray -> Quit, not just closing the window) — then'
+    Write-Warn '   velesdb-memory appears in Settings -> Developer as "running".'
 }
 
 # Set-JsonClient NAME CONFIG_PATH MUTATOR REQUIRE_EXISTING_DIR
@@ -787,6 +894,38 @@ function Show-Summary {
 function Main {
     if ($Uninstall) {
         Invoke-Uninstall
+        exit 0
+    }
+
+    # -WireOnly: (re-)verify CA trust and re-wire every client against an
+    # ALREADY-installed daemon — no cargo build, no task re-registration, no
+    # interactive prompts. Both the "fix the wiring / Node got installed
+    # later" fast path for users and the testable entry point for this
+    # script's client-wiring logic (idempotent by construction: every wiring
+    # step backs up and merges, never overwrites).
+    if ($WireOnly) {
+        # Show-Summary reads this under Set-StrictMode; Set-Daemon (which
+        # normally sets it) is deliberately skipped on this path.
+        $script:DaemonAlreadyRunning = $true
+        $caCert = "$script:TlsDir\ca-cert.pem"
+        $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
+        $daemonUp = $false
+        if ($curl -and (Test-Path $caCert)) {
+            & $curl.Source -fsS --max-time 2 --cacert $caCert "https://127.0.0.1:$Port/health" *> $null
+            $daemonUp = ($LASTEXITCODE -eq 0)
+        }
+        if (-not $daemonUp) {
+            Write-Warn "No daemon answering on https://127.0.0.1:$Port/health — -WireOnly only re-wires"
+            Write-Warn '   clients; run the full installer (without -WireOnly) if the daemon was never set up.'
+        }
+        Enable-LocalCaTrust -CaCertPath $caCert
+        Set-ClaudeCodeClient
+        Set-ClaudeDesktopClient
+        Set-WindsurfClient
+        Set-DevinClient
+        $script:Embedder = '(unchanged — -WireOnly)'
+        $script:Ttl = '(unchanged — -WireOnly)'
+        Show-Summary
         exit 0
     }
 

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -38,6 +38,8 @@
 #   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
 #   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
 #   --skip-ca-trust          Skip trusting the local CA in the login keychain
+#   --wire-only              Skip build/daemon setup: only (re-)verify CA trust and re-wire the
+#                            clients against an already-installed daemon (no prompts, fast)
 #   --force-restart          Reload the daemon even if already running
 #   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http) from a
 #                            GitHub Release archive instead of `cargo install` (default TAG: the
@@ -90,6 +92,7 @@ FORCE_RESTART=0
 UNINSTALL=0
 SKIP_CLIENTS=""
 SKIP_CA_TRUST=0
+WIRE_ONLY=0
 FROM_RELEASE=0
 FROM_RELEASE_TAG=""
 SKIP_CHECKSUM=0
@@ -103,7 +106,7 @@ DEVIN_CONFIG="$HOME/.config/devin/config.json"
 RELEASE_REPO="cyberlife-coder/VelesDB"
 
 print_usage() {
-  sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -119,6 +122,7 @@ for arg in "$@"; do
     --yes) ASSUME_YES=1 ;;
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
     --skip-ca-trust) SKIP_CA_TRUST=1 ;;
+    --wire-only) WIRE_ONLY=1 ;;
     --force-restart) FORCE_RESTART=1 ;;
     --from-release) FROM_RELEASE=1 ;;
     --from-release=*) FROM_RELEASE=1; FROM_RELEASE_TAG="${arg#*=}" ;;
@@ -613,7 +617,23 @@ trust_local_ca() {
   echo -e "${YELLOW}   here or by hand later.${NC}"
 
   if run_with_timeout 60 "${trust_cmd[@]}"; then
-    echo -e "${GREEN}✅ Local CA trusted in your login keychain.${NC}"
+    # VERIFY, don't assume: `add-trusted-cert` exiting 0 is not proof a
+    # strict TLS client will now accept the daemon's certificate (trust
+    # settings can land in an unexpected domain/keychain). Ground-truth it
+    # the same way the idempotency check above does — a curl WITHOUT
+    # --cacert, i.e. against the system trust store.
+    if curl -fsS --max-time 2 "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${GREEN}✅ Local CA trusted AND verified: a strict HTTPS request to the daemon now succeeds.${NC}"
+    elif curl -fsS --max-time 2 --cacert "$ca_cert" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      # Daemon reachable with --cacert but not without it → the trust
+      # settings did NOT take effect, despite add-trusted-cert exiting 0.
+      echo -e "${YELLOW}⚠️  add-trusted-cert reported success, but a strict HTTPS request to the daemon still${NC}"
+      echo -e "${YELLOW}   fails certificate verification. Re-run this by hand and approve any system prompt:${NC}"
+      echo "     ${trust_cmd[*]}"
+    else
+      echo -e "${YELLOW}⚠️  CA trust was recorded, but the daemon is not answering /health right now, so the${NC}"
+      echo -e "${YELLOW}   end-to-end verification could not run — check $HOME/Library/Logs/velesdb-memory/daemon.err.log${NC}"
+    fi
   else
     echo -e "${YELLOW}⚠️  Could not confirm the CA trust automatically (no response to the system prompt within${NC}"
     echo -e "${YELLOW}   60s, or the command failed). The daemon is still up and serving HTTPS — this only${NC}"
@@ -645,12 +665,16 @@ wire_claude_code() {
   fi
 }
 
-# wire_json_client NAME CONFIG_PATH JQ_FILTER REQUIRE_EXISTING_DIR
+# wire_json_client NAME CONFIG_PATH JQ_FILTER REQUIRE_EXISTING_DIR [JQ_ARGS...]
 # REQUIRE_EXISTING_DIR=1 skips (rather than creating) the client's config
-# directory when absent — used for Claude Desktop, whose directory only
-# exists if the app itself is installed; Windsurf's is created if missing.
+# directory when absent — used for Claude Desktop and Devin, whose directories
+# only exist if the app itself is installed; Windsurf's is created if missing.
+# Any extra arguments are passed straight to jq (e.g. --argjson entry '...'),
+# so a caller can build a value safely with jq -n instead of string-splicing
+# shell variables into the filter.
 wire_json_client() {
   local name="$1" config_path="$2" jq_filter="$3" require_existing_dir="$4"
+  shift 4
   if should_skip "$name"; then
     echo -e "${YELLOW}⏭  Skipping $name (--skip-client).${NC}"
     return 0
@@ -680,7 +704,7 @@ wire_json_client() {
 
   local tmp
   tmp="$(mktemp)"
-  if jq "$jq_filter" "$config_path" > "$tmp"; then
+  if jq "$@" "$jq_filter" "$config_path" > "$tmp"; then
     mv "$tmp" "$config_path"
     echo -e "${GREEN}✅ $name wired → $config_path${NC}"
   else
@@ -690,26 +714,98 @@ wire_json_client() {
 }
 
 # Claude Desktop is a DIFFERENT mechanism than every other client here:
-# claude_desktop_config.json (the file every other JSON client uses) never
-# reads a url/type:"http" entry — confirmed it does not even try to connect —
-# so writing one there (as this script used to) silently does nothing. The
-# only way to wire Desktop to the daemon is its own UI. This function prints
-# that instruction instead of touching the config file.
+# claude_desktop_config.json never reads a url/type:"http" entry (confirmed:
+# it does not even try to connect), and Desktop's "Add custom connector" UI
+# verifies TLS through Chromium/Node — which does NOT reliably consult the
+# macOS keychain — so even a keychain-trusted local CA can leave the UI path
+# rejecting the daemon's certificate. The reliable, zero-UI-steps path is a
+# stdio→HTTPS bridge: an `mcp-remote` entry in the config file, with
+# NODE_EXTRA_CA_CERTS pointing at the daemon's CA so the bridge verifies TLS
+# strictly (never NODE_TLS_REJECT_UNAUTHORIZED=0 — that disables verification
+# entirely). The bridge is a plain HTTPS client of the daemon: it never opens
+# the store itself, so there is no flock conflict.
 wire_claude_desktop() {
   if should_skip "claude-desktop"; then
     echo -e "${YELLOW}⏭  Skipping Claude Desktop (--skip-client).${NC}"
     return 0
   fi
-  echo ""
-  echo -e "${BLUE}🖥  Claude Desktop — different mechanism than every other client here:${NC}"
-  echo -e "${YELLOW}   its config file does not support HTTP (a url/type:\"http\" entry there is silently${NC}"
-  echo -e "${YELLOW}   ignored). Add it yourself, once, via the UI instead:${NC}"
-  echo -e "${YELLOW}   Settings → Connectors → Add custom connector, then paste:${NC}"
-  echo "     https://127.0.0.1:$PORT/mcp"
-  echo -e "${YELLOW}   No API key needed (loopback only) — requires the CA-trust step above to have succeeded.${NC}"
-  echo -e "${YELLOW}   Prefer not to use the Connectors UI? A stdio fallback still works — see the README's${NC}"
-  echo -e "${YELLOW}   \"Configure your client\" section (use a DIFFERENT VELESDB_MEMORY_PATH than $STORE,${NC}"
-  echo -e "${YELLOW}   or the fallback process and the daemon will fight over the same flock).${NC}"
+
+  local config_dir
+  config_dir="$(dirname "$DESKTOP_CONFIG")"
+  if [ ! -d "$config_dir" ]; then
+    echo -e "${YELLOW}⏭  Claude Desktop not detected (no $config_dir) — skipping.${NC}"
+    return 0
+  fi
+
+  local ca_cert="$TLS_DIR/ca-cert.pem"
+  local url="https://127.0.0.1:$PORT/mcp"
+
+  # Resolve the bridge command. A globally-installed mcp-remote wins (no npx
+  # startup cost); otherwise npx fetches/caches it on first launch. Absolute
+  # paths on purpose: Desktop launched from Finder/Dock inherits launchd's
+  # minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin), which contains neither
+  # Homebrew nor nvm — a bare "npx" there fails with ENOENT. Same reason the
+  # entry's env carries an explicit PATH: both mcp-remote and npx are
+  # `#!/usr/bin/env node` scripts, so node's directory must be reachable too.
+  local bridge_cmd="" node_bin=""
+  local -a bridge_args=()
+  if command -v mcp-remote >/dev/null 2>&1; then
+    bridge_cmd="$(command -v mcp-remote)"
+    bridge_args=("$url")
+  elif command -v npx >/dev/null 2>&1; then
+    bridge_cmd="$(command -v npx)"
+    bridge_args=("-y" "mcp-remote" "$url")
+  fi
+  node_bin="$(command -v node 2>/dev/null || true)"
+
+  if [ -z "$bridge_cmd" ] || [ -z "$node_bin" ]; then
+    echo ""
+    echo -e "${YELLOW}⚠️  Claude Desktop needs a stdio→HTTPS bridge (mcp-remote), which needs Node.js —${NC}"
+    echo -e "${YELLOW}   'mcp-remote'/'npx'/'node' not found on PATH. Two ways to finish:${NC}"
+    echo -e "${YELLOW}   a) install Node.js (e.g. \`brew install node\`) and re-run: $0 --wire-only${NC}"
+    echo -e "${YELLOW}   b) or use Desktop's UI: Settings → Connectors → Add custom connector, paste:${NC}"
+    echo "        $url"
+    echo -e "${YELLOW}      (no API key needed — but this path requires the CA-trust step above to have${NC}"
+    echo -e "${YELLOW}      succeeded, and Desktop's own TLS stack may still refuse a local CA).${NC}"
+    return 0
+  fi
+
+  # VERIFY the exact TLS path the bridge will use BEFORE writing any config:
+  # Node does not consult the macOS keychain, so the keychain-trust step
+  # above proves nothing for the bridge — NODE_EXTRA_CA_CERTS is what makes
+  # Node accept this CA, and this probe exercises precisely that.
+  if [ -f "$ca_cert" ]; then
+    if run_with_timeout 10 env NODE_EXTRA_CA_CERTS="$ca_cert" "$node_bin" -e '
+        require("https").get(process.argv[1], (r) => process.exit(r.statusCode === 200 ? 0 : 1))
+          .on("error", () => process.exit(1));
+        setTimeout(() => process.exit(1), 8000);
+      ' "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${GREEN}✅ Node accepts the daemon's certificate via NODE_EXTRA_CA_CERTS — the Desktop bridge will verify TLS strictly.${NC}"
+    else
+      echo -e "${YELLOW}⚠️  Node could not fetch https://127.0.0.1:$PORT/health with NODE_EXTRA_CA_CERTS=$ca_cert.${NC}"
+      echo -e "${YELLOW}   Writing the Claude Desktop entry anyway — if Desktop shows velesdb-memory as${NC}"
+      echo -e "${YELLOW}   disconnected, check $HOME/Library/Logs/velesdb-memory/daemon.err.log and re-run with --wire-only.${NC}"
+    fi
+  else
+    echo -e "${YELLOW}⚠️  No CA certificate at $ca_cert yet — the Desktop bridge entry is written but can only${NC}"
+    echo -e "${YELLOW}   be verified once the daemon has started and generated it (re-run with --wire-only).${NC}"
+  fi
+
+  require_jq
+  local entry
+  entry="$(jq -n \
+    --arg cmd "$bridge_cmd" \
+    --arg ca "$ca_cert" \
+    --arg path "$(dirname "$node_bin"):/usr/bin:/bin" \
+    --args \
+    '{command: $cmd, args: $ARGS.positional, env: {NODE_EXTRA_CA_CERTS: $ca, PATH: $path}}' \
+    "${bridge_args[@]}")"
+
+  wire_json_client "claude-desktop" "$DESKTOP_CONFIG" \
+    '.mcpServers["velesdb-memory"] = $entry' 1 \
+    --argjson entry "$entry"
+  echo -e "${YELLOW}   Restart Claude Desktop fully (menu bar → Quit, not just closing the window) — then${NC}"
+  echo -e "${YELLOW}   velesdb-memory appears in Settings → Developer as \"running\".${NC}"
 }
 
 wire_windsurf() {
@@ -794,6 +890,29 @@ print_summary() {
 main() {
   if [ "$UNINSTALL" = "1" ]; then
     do_uninstall
+    exit 0
+  fi
+
+  # --wire-only: (re-)verify CA trust and re-wire every client against an
+  # ALREADY-installed daemon — no cargo build, no daemon restart, no
+  # interactive prompts. This is both the "my client config broke / Node got
+  # installed later, fix the wiring" fast path for users and the testable
+  # entry point for this script's client-wiring logic (idempotent by
+  # construction: every wiring step backs up and merges, never overwrites).
+  if [ "$WIRE_ONLY" = "1" ]; then
+    if [ "$(uname -s)" = "Darwin" ]; then DAEMON_SUPPORTED=1; else DAEMON_SUPPORTED=0; fi
+    if ! curl -fsS --max-time 2 --cacert "$TLS_DIR/ca-cert.pem" "https://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+      echo -e "${YELLOW}⚠️  No daemon answering on https://127.0.0.1:$PORT/health — --wire-only only re-wires${NC}"
+      echo -e "${YELLOW}   clients; run the full installer (without --wire-only) if the daemon was never set up.${NC}"
+    fi
+    trust_local_ca "$TLS_DIR/ca-cert.pem"
+    wire_claude_code
+    wire_claude_desktop
+    wire_windsurf
+    wire_devin
+    EMBEDDER="(unchanged — --wire-only)"
+    TTL="(unchanged — --wire-only)"
+    print_summary
     exit 0
   fi
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v3.12.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v4.0.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "3.12.0",
+      "version": "4.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "3.12.0",
+  "version": "4.0.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Synchronizes `develop` into `main` for the **v4.0.0 major release**. The no-deferral pre-major campaign is fully merged: #1549 (VelesConfig on every surface), #1555/#1556 (executor conformance fixes, divergences D002/D006 resolved), #1470/#1493 (unified missing-endpoint error — breaking, window opened), #1575/#1576 (harness-proof MCP wire contract), #1577 (guided Claude Desktop onboarding), plus the hook/transport fixes (#1567/#1574) and the 4.0.0 prep itself (#1578: version bump 62 locations, OpenAPI snapshots, dated CHANGELOG).

After merge: wait for a green `CI Success` on the main merge commit, then tag `v4.0.0` **on explicit maintainer go only** (REL-06). Post-publication follow-up documented: bump langchain/llamaindex floors to `velesdb>=4.0.0` / `velesdb-common>=4.0.0`.