### PR TITLE
docs(memory,node): fix stale skill example, document skill-refresh step

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -429,6 +429,11 @@ curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/vele
   | tar -xz -C ~/.claude/skills/
 ```
 
+**Keep skills fresh:** the `cp`/`curl` above is a snapshot, not a live link — a
+skill installed once does not update itself when a new release changes it.
+Re-run the same command after every upgrade (safe to repeat: it just
+overwrites the local copy).
+
 **Skills teach an agent what to do; they don't make it remember to do it.**
 [`integrations/agent-hooks/`](https://github.com/cyberlife-coder/VelesDB/tree/develop/integrations/agent-hooks)
 closes that gap for Claude Code with real `SessionStart`/`Stop`/`PreCompact`
@@ -801,6 +806,11 @@ archive root — so a one-liner installs them straight from the release:
 curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz \
   | tar -xz -C ~/.claude/skills/
 ```
+
+**Keep skills fresh:** the `cp`/`curl` above is a snapshot, not a live link — a
+skill installed once does not update itself when a new release changes it.
+Re-run the same command after every upgrade (safe to repeat: it just
+overwrites the local copy).
 
 **Skills teach an agent what to do; they don't make it remember to do it.**
 [`integrations/agent-hooks/`](https://github.com/cyberlife-coder/VelesDB/tree/develop/integrations/agent-hooks)

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -110,7 +110,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
 An incident postmortem finds the payment provider's 30 s timeout let a stalled
 request pile up and take down checkout. The team drops it to 8 s.
 - `remember("Payment provider timeout set to 8s", metadata={type:"decision",
-  area:"payments", date:"2026-07-11"})` → returns id `D`.
+  area:"payments"})` → returns id `D`. No need to set a date — `_veles_date`
+  auto-stamps today's date as a numeric `YYYYMMDD`, as covered above.
 - `remember("Incident 2026-07-10: 30s payment timeout stalled checkout under load",
   metadata={type:"incident", area:"payments"})` → id `I`.
 - `relate(D, I, "caused_by")` and `relate(D, <config-PR fact>, "decided_in")`.

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -72,6 +72,10 @@ reinforce). Install it the same way as the context-optimizer skill below:
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory ~/.claude/skills/
 ```
 
+**Keep it fresh:** this `cp` is a snapshot, not a live link — re-run it after
+every `npm update` so the installed skill picks up doc/behavior changes from
+the new package version (safe to repeat: it just overwrites the local copy).
+
 ### Auto-extraction (`rememberExtracted`)
 
 ```js
@@ -122,6 +126,9 @@ Install the skill into your agent's skills directory:
 ```bash
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
 ```
+
+**Keep it fresh:** re-run this after every `npm update` for the same reason
+as the `velesdb-memory` skill above.
 
 #### Media fragments (`retrieveContextSource`)
 

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -110,7 +110,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
 An incident postmortem finds the payment provider's 30 s timeout let a stalled
 request pile up and take down checkout. The team drops it to 8 s.
 - `remember("Payment provider timeout set to 8s", metadata={type:"decision",
-  area:"payments", date:"2026-07-11"})` → returns id `D`.
+  area:"payments"})` → returns id `D`. No need to set a date — `_veles_date`
+  auto-stamps today's date as a numeric `YYYYMMDD`, as covered above.
 - `remember("Incident 2026-07-10: 30s payment timeout stalled checkout under load",
   metadata={type:"incident", area:"payments"})` → id `I`.
 - `relate(D, I, "caused_by")` and `relate(D, <config-PR fact>, "decided_in")`.


### PR DESCRIPTION
Found while auditing the maintainer's own installed skills against the repo source (post-4.0.0): the local `~/.claude/skills/velesdb-memory` was stale (pre-#1541) and its worked example contradicted the skill's own guidance.

## Content bug

The "Incident → decision" scenario still passed a string date (`date:"2026-07-11"`) to `remember()`, directly contradicting the numeric `_veles_date` auto-stamp guidance two paragraphs above it — a leftover from before #1541 shipped that feature. Fixed to match; also re-synced `crates/velesdb-node/skills/velesdb-memory/SKILL.md`, which had drifted from the crate's canonical copy (repo convention: the two must stay identical).

## Documentation gap

Both README "install the skill" snippets are one-shot copies (`cp`/`curl`) with **no update mechanism documented** — a skill installed once silently goes stale on the next release, exactly what happened here. Added a one-line "re-run after every upgrade" note at each of the 4 install snippets (2 in `crates/velesdb-memory/README.md`, 2 in `crates/velesdb-node/README.md`).

No code changes; docs/skill content only.