### PR TITLE
chore(release): bump velesdb-memory/velesdb-node to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "axum",
  "criterion",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] — 2026-07-24
+
+Patch: fixes the MCP wire-contract bug (harness-stringified parameters) plus
+the Claude Desktop onboarding automation — no new memory-shape/API change.
+
 ### Added
 
 - `scripts/install-memory-daemon.sh` now wires **Devin CLI**
@@ -33,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP tool parameters are now harness-proof on both wire directions**
+  (issue #1575). Real MCP client harnesses were observed serializing
+  non-string arguments as JSON-encoded strings once their view of the
+  advertised schema degraded — `save_working_context`'s `working` object
+  arrived as `"{\"goal\": ...}"` and failed with `invalid type: string,
+  expected struct WorkingContext`, silently losing session handoffs;
+  `recall_fused` rejected `limit: "6"` and stringified `filter` objects
+  the same way. Same defensive-interop class as the #1468 string-id
+  contract. Two-sided fix: (1) `$ref`-only top-level parameter schemas
+  are now inlined so every parameter advertises a direct `type` keyword
+  (`working` exposes `type: object`); (2) a lenient deserializer on every
+  non-string tool parameter accepts the properly-typed value first and
+  falls back to parsing a JSON-encoded string, with a precise error when
+  neither form fits.
 - The installer no longer writes a `type:"http"` entry into
   `claude_desktop_config.json` — confirmed Desktop's config file never reads
   that shape (silently ignored). Superseded in this same release by the

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,31 +17,30 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
-> **Release 0.11.0** — multi-client memory: a single local `velesdb-memory
-> --http` daemon (see "HTTP transport (multi-client)" below) now lets Claude
-> Code, Claude Desktop, and Windsurf share the *same* memory instead of one
-> client at a time, and serves **HTTPS by default** with a natively-generated
-> local CA (no external `mkcert`/proxy) — some MCP clients refuse a
-> non-`https://` URL even for `127.0.0.1`. `scripts/install-memory-daemon.sh`
-> automates the whole setup, including trusting the CA. Every `remember` now
-> auto-stamps a `_veles_date` field (`YYYYMMDD`, never overwritten if you set
-> it yourself), so `recall_fused`'s `date_field` works with zero setup — this
-> is the metadata-shape change that makes this a **minor**, not patch,
-> release (a fact stored with no caller metadata no longer round-trips as
-> `metadata: None`). Also fixes two independent deadlocks under concurrent
-> `remember`/`recall` load found while building the daemon (rayon pool
-> exhaustion + a lock-ordering inversion) — real risk for any consumer, not
-> just the new HTTP transport, since both bugs lived in the shared storage
-> layer. Published to the registries by the `velesdb-memory-v0.11.0`
-> tag, so the links below may briefly lag right after merge. `velesdb-memory`
-> ships on [crates.io](https://crates.io/crates/velesdb-memory) and on the
+> **Release 0.11.1** (patch) — **MCP tool parameters are now harness-proof on
+> both wire directions.** Real MCP client harnesses were observed serializing
+> non-string arguments as JSON-encoded strings once their view of the
+> advertised schema degraded — `save_working_context`'s `working` object
+> arrived as an escaped JSON string and failed outright, silently losing
+> session handoffs; `recall_fused` rejected a stringified `limit`/`filter`
+> the same way. Fixed on both sides: every top-level parameter now
+> advertises a direct `type` in its schema, and a lenient deserializer
+> accepts a JSON-encoded string fallback on every non-string parameter. Also
+> in this release: Claude Desktop wiring is now fully automated on both
+> installers (an `mcp-remote` stdio→HTTPS bridge entry written into
+> `claude_desktop_config.json`, TLS verified strictly via
+> `NODE_EXTRA_CA_CERTS` — no manual proxy, no `NODE_TLS_REJECT_UNAUTHORIZED=0`)
+> and CA-trust is verified after trusting instead of assumed. Published to
+> the registries by the `velesdb-memory-v0.11.1` tag, so the links below may
+> briefly lag right after merge. `velesdb-memory` ships on
+> [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.11.0**
-> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.11.1**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **4.0.0**
 > (memory API only — the context compiler is merged on `develop` but **the
-> published 3.12.0 wheel predates it**; it ships with the next PyPI release,
+> published 4.0.0 wheel predates it**; it ships with a future PyPI release,
 > until then Python agents reach it through the MCP server).
 > **`cargo install velesdb-memory` installs the latest published release.**
 

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.0"
+version = "0.11.1"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Patch release for velesdb-memory's independent version track.

## Why now

#1576 (MCP wire-contract fix — harness-stringified `save_working_context`/`recall_fused` parameters) and #1577 (Claude Desktop onboarding automation) both landed on `develop`/`main` as part of the 4.0.0 workspace release, but `velesdb-memory` is versioned and released independently on its own `velesdb-memory-vX.Y.Z` tag — those fixes never got cut as their own release. Discovered live: the maintainer's own locally-running daemon was still on the pre-fix 0.11.0 binary and `save_working_context` was failing exactly as described, until rebuilt from `main`.

## What's in this bump

- Backfilled the #1576 CHANGELOG entry (was only documented in the root workspace CHANGELOG, missing from `crates/velesdb-memory/CHANGELOG.md` entirely).
- Cut `[0.11.1] — 2026-07-24`.
- Bumped both `Cargo.toml`s, npm `package.json`/`package-lock.json`, `server.json` (root + registry package version), `Cargo.lock`, and rewrote the README release banner for this release's actual content (not a version-number swap of the 0.11.0 banner).

## Validation

- `scripts/check-version-sync.py`: all versions match
- `cargo test -p velesdb-memory --features http,mcp,context --lib`: 370 passed, 0 failed

After merge: tag `velesdb-memory-v0.11.1` on the merge commit (once `develop`'s CI is green) to trigger `release-memory.yml` + `release-mcpb.yml`.