### PR TITLE
chore(integrations): raise dependency floors to the published 4.0.0

### DIFF
--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Post-publication follow-up promised in #1578/#1579.

The floors were kept at \`>=3.8.0\` during release-prep because CI resolves \`velesdb\`/\`velesdb-common\` from PyPI, where 4.0.0 could not yet exist — a \`>=4.0.0\` floor was unsatisfiable pre-publication (this is exactly what broke the Python Integrations Check on #1578). Now that **v4.0.0 is live on PyPI** (verified directly: \`pip install \"velesdb>=4.0.0\" \"velesdb-common>=4.0.0\"\` resolves and imports cleanly), raise both integrations to the floor they actually need: \`langchain-velesdb\` and \`llamaindex-velesdb\` both call \`open_native_graph(..., config=...)\`, which only exists in the 4.0.0 \`velesdb-common\`.

The \`config is None\` call-shape guard added in #1579 is left in place — cheap, correct defensive code even with the floor now guaranteed.