### PR TITLE
feat(agent-hooks,memory-skill): wire PreCompact to compile_transcript, clarify id_str wording

### DIFF
--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -67,6 +67,21 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.
+   - **Before storing a new incident/bug/anti-pattern, check for recurrence.**
+     `recall`/`recall_fused` using the *failure signature* — symptom + mechanism,
+     not the file name (`"write path deadlocks under concurrent compaction"`, not
+     `"bug in wal.rs"`) — a close semantic match (same trigger class: concurrency,
+     boundary, resource exhaustion) is a candidate recurrence even when the surface
+     symptom or file differs. If one turns up: say so explicitly rather than
+     storing a disconnected duplicate, `relate(new, prior, "same_root_cause_as")`,
+     and — if this is the second time the same *class* of mistake shows up under a
+     different name — `remember` one generalized `metadata: {"type":
+     "anti-pattern"}` fact describing the class itself (not just this instance),
+     linked to both incidents. A recall hit on the exact same bug is useful; a
+     recall hit on the *same class* of bug in a new file is what actually prevents
+     repeats, and that only works once the anti-pattern fact exists and is linked.
+     Skipping this check is how the same mistake gets "discovered" and fixed twice,
+     two names apart, with nothing connecting them.
 
 3. **Connect facts as relationships appear (`relate`).** Whenever a new fact
    relates to an existing memory, create a typed, directional edge. **Direction
@@ -77,12 +92,15 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
    `fixes`, `concerns`. This is the differentiator's fuel — build the graph
    incrementally, don't batch it up "later" (later never comes).
-   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
-   too): every id in a response also comes back as a decimal-string `id_str`
-   twin specifically because a raw JSON-number id can exceed 2^53 and get
-   rounded by a float-lossy client on the way back in, silently pointing
-   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
-   the numeric `id`.
+   **Pass the response's `id_str` STRING into the `id`/`from`/`to` parameter**
+   (same for `feedback`/`forget`) — the parameter is still named `id` (there is
+   no separate `id_str` *input* field anywhere; `id_str` only exists in
+   *responses*), but what you put in it matters: every id in a response also
+   comes back as a decimal-string `id_str` twin specifically because a raw
+   JSON-number id can exceed 2^53 and get rounded by a float-lossy client on
+   the way back in, silently pointing `relate` at the wrong memory — relay
+   the `id_str` value verbatim into `id` instead of retyping the numeric
+   `id`.
    **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
    JSON string) back into a JSON number before it reaches the server, which
    defeats `id_str` and reintroduces the precision loss it exists to avoid. If

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -67,6 +67,21 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.
+   - **Before storing a new incident/bug/anti-pattern, check for recurrence.**
+     `recall`/`recall_fused` using the *failure signature* — symptom + mechanism,
+     not the file name (`"write path deadlocks under concurrent compaction"`, not
+     `"bug in wal.rs"`) — a close semantic match (same trigger class: concurrency,
+     boundary, resource exhaustion) is a candidate recurrence even when the surface
+     symptom or file differs. If one turns up: say so explicitly rather than
+     storing a disconnected duplicate, `relate(new, prior, "same_root_cause_as")`,
+     and — if this is the second time the same *class* of mistake shows up under a
+     different name — `remember` one generalized `metadata: {"type":
+     "anti-pattern"}` fact describing the class itself (not just this instance),
+     linked to both incidents. A recall hit on the exact same bug is useful; a
+     recall hit on the *same class* of bug in a new file is what actually prevents
+     repeats, and that only works once the anti-pattern fact exists and is linked.
+     Skipping this check is how the same mistake gets "discovered" and fixed twice,
+     two names apart, with nothing connecting them.
 
 3. **Connect facts as relationships appear (`relate`).** Whenever a new fact
    relates to an existing memory, create a typed, directional edge. **Direction
@@ -77,12 +92,15 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
    `fixes`, `concerns`. This is the differentiator's fuel — build the graph
    incrementally, don't batch it up "later" (later never comes).
-   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
-   too): every id in a response also comes back as a decimal-string `id_str`
-   twin specifically because a raw JSON-number id can exceed 2^53 and get
-   rounded by a float-lossy client on the way back in, silently pointing
-   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
-   the numeric `id`.
+   **Pass the response's `id_str` STRING into the `id`/`from`/`to` parameter**
+   (same for `feedback`/`forget`) — the parameter is still named `id` (there is
+   no separate `id_str` *input* field anywhere; `id_str` only exists in
+   *responses*), but what you put in it matters: every id in a response also
+   comes back as a decimal-string `id_str` twin specifically because a raw
+   JSON-number id can exceed 2^53 and get rounded by a float-lossy client on
+   the way back in, silently pointing `relate` at the wrong memory — relay
+   the `id_str` value verbatim into `id` instead of retyping the numeric
+   `id`.
    **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
    JSON string) back into a JSON number before it reaches the server, which
    defeats `id_str` and reintroduces the precision loss it exists to avoid. If

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -6,11 +6,13 @@ gives it the *tools*. It does not make the agent actually call
 `load_working_context` at the start of every session or
 `save_working_context` before every one ends — that only happens if the
 agent remembers to, which it won't reliably do on its own. This directory
-closes that gap for [Claude Code](claude-code/) (real, tested hooks) and
-[Codex CLI](codex/) (a documented instruction-file convention, since Codex
-has no equivalent hook mechanism yet).
+closes that gap for [Claude Code](claude-code/) (real, tested hooks),
+[Windsurf](windsurf/) (real, tested hook — a single event folding both
+halves of the loop, see below), and [Codex CLI](codex/) (a documented
+instruction-file convention, since Codex has no equivalent hook mechanism
+yet).
 
-## Install
+## Install — Claude Code
 
 Both variants need `bash` and `jq` on `PATH` — the hooks refuse to run
 without `jq` rather than silently emitting malformed JSON.
@@ -71,6 +73,38 @@ into `~/.claude/settings.json` does not give you a global install by
 itself — that path only resolves inside a project that also has its own
 vendored copy of the scripts. Use the global pattern above instead.
 
+## Install — Windsurf
+
+```bash
+mkdir -p ~/.codeium/windsurf/hooks/velesdb-memory
+cp /path/to/velesdb/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh ~/.codeium/windsurf/hooks/velesdb-memory/
+cp -r /path/to/velesdb/integrations/agent-hooks/windsurf/hooks/lib ~/.codeium/windsurf/hooks/velesdb-memory/
+chmod +x ~/.codeium/windsurf/hooks/velesdb-memory/*.sh
+```
+
+Merge this into `~/.codeium/windsurf/hooks.json`'s `"hooks"` key:
+
+```json
+{
+  "hooks": {
+    "pre_user_prompt": [
+      { "command": "bash /Users/you/.codeium/windsurf/hooks/velesdb-memory/pre-user-prompt.sh", "show_output": true }
+    ]
+  }
+}
+```
+
+Same `.velesdb-hooks.json` config format as Claude Code (below) — the hook
+walks up from the payload's `cwd` looking for one.
+
+**Windsurf exposes only one lifecycle hook, `pre_user_prompt`** — no
+Claude-Code-style `Stop`/`PreCompact` equivalent. So `pre-user-prompt.sh`
+folds BOTH halves of the loop into its single first-of-session reminder:
+load working context now, **and** save it again before the session ends —
+because there is no separate event left to remind you a second time.
+`trajectory_id` from Windsurf's payload is the once-per-session sentinel key
+(falls back to the parent PID if ever absent).
+
 ## The structural constraint that shapes this whole design
 
 **velesdb-memory's store is mono-process, guarded by an flock.** While a
@@ -95,7 +129,10 @@ and hand it to the model directly (that would require opening the store
 from the hook) — it can only tell the model to call
 `load_working_context` itself.
 
-## The three hooks
+## The three Claude Code hooks
+
+(Windsurf's single `pre_user_prompt` hook is documented in its own install
+section above — it folds the same load/save loop into one event.)
 
 | Event | What it does | Mechanism |
 |---|---|---|

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -101,7 +101,7 @@ from the hook) — it can only tell the model to call
 |---|---|---|
 | `SessionStart` | Fires on every session start (new, resume, clear, or post-compact). Emits `additionalContext` telling the model to call `load_working_context(project, session)` as its first action if it hasn't already. | `hookSpecificOutput.additionalContext` — supported by `SessionStart`. |
 | `Stop` | Fires when Claude is about to stop responding. The **first** `Stop` per session is blocked with a reason telling the model to call `save_working_context(project, session)` with the distilled state before stopping; every later `Stop` in the same session passes through untouched. | `{"decision":"block","reason":"..."}`, gated by a sentinel file in `$TMPDIR` (or `/tmp`) keyed by the payload's `session_id`, so the reminder fires once, not on every turn. |
-| `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `save_working_context` first (compaction can lose detail the model hasn't distilled yet); later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
+| `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `compile_transcript` the about-to-be-compacted transcript (deterministic compression, not lossy compaction) and `save_working_context` first; later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
 
 **Design note — why `PreCompact` blocks instead of using
 `additionalContext`:** the original plan for this feature assumed
@@ -151,9 +151,9 @@ the exact JSON each script prints back (including the block-once/pass-
 after behavior of `Stop` and `PreCompact`). Run it after touching any
 script in `claude-code/hooks/`.
 
-## Roadmap note (V2b)
+## Why `PreCompact` only nudges `compile_transcript`, never calls it directly
 
-`PreCompact` currently only nudges the model to save by hand before
-compaction. Once `compile_transcript` ships (tracked separately), this
-hook can compile the transcript directly instead of relying on the model
-to distill it under time pressure right as compaction is about to run.
+Given the mono-process flock constraint above, `PreCompact` cannot call
+`compile_transcript` itself — only the model's own MCP connection can. The
+hook's `reason` tells the model to call it with the transcript about to be
+compacted, trading lossy compaction for a deterministic, auditable one.

--- a/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
+++ b/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
@@ -13,8 +13,10 @@
 # be unsafe (auto-compaction can fire repeatedly as a long session grows;
 # refusing it every time risks the transcript never compacting).
 #
-# TODO(V2b): once compile_transcript ships, this hook can compile the
-# transcript directly instead of only nudging the model to save by hand.
+# V2b (compile_transcript shipped): the hook still cannot touch the store
+# itself (mono-process flock constraint above), so it cannot compile the
+# transcript directly either — it nudges the model to call compile_transcript
+# itself, same mechanism as the save_working_context nudge below.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,6 +48,6 @@ fi
 
 : > "$sentinel"
 
-reason="Before compaction: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") via velesdb-memory with the distilled state so nothing is lost, then retry — compaction will proceed on the next attempt."
+reason="Before compaction: the transcript about to be compacted is exactly what compile_transcript exists for — call it (velesdb-memory) with a token_budget to deterministically compress it (duplicates dropped, logs collapsed, code/negative-constraints preserved verbatim) instead of losing detail to lossy compaction. Also call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") with the distilled state (goal, decisions, pending actions) so nothing is lost even for content compile_transcript can't recover. Then retry — compaction will proceed on the next attempt."
 
 jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -122,6 +122,12 @@ else
   fail "PreCompact: reason mentions save_working_context"
 fi
 
+if printf '%s' "$pre_compact_out_1" | jq -e '.reason | contains("compile_transcript")' >/dev/null; then
+  pass "PreCompact: reason mentions compile_transcript (V2b roadmap item, now shipped)"
+else
+  fail "PreCompact: reason mentions compile_transcript (V2b roadmap item, now shipped)"
+fi
+
 if printf '%s' "$pre_compact_out_1" | jq -e 'has("hookSpecificOutput") | not' >/dev/null; then
   pass "PreCompact: no hookSpecificOutput wrapper (unsupported for this event)"
 else

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOKS_DIR="$ROOT/claude-code/hooks"
+WINDSURF_HOOKS_DIR="$ROOT/windsurf/hooks"
 
 FAILED=0
 
@@ -167,12 +168,49 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Windsurf pre_user_prompt — first call with a trajectory_id reminds, second
+# call with the SAME trajectory_id is silent (single-event fold of the
+# Claude Code load+save reminder, since Windsurf has no Stop/PreCompact).
+# ---------------------------------------------------------------------------
+WINDSURF_TRAJECTORY_ID="test-trajectory-$$"
+windsurf_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg tid "$WINDSURF_TRAJECTORY_ID" \
+  '{trajectory_id: $tid, cwd: $cwd, execution_id: "exec-1", model_name: "test-model"}')"
+
+windsurf_out_1="$(printf '%s' "$windsurf_payload" | bash "$WINDSURF_HOOKS_DIR/pre-user-prompt.sh")"
+
+if printf '%s' "$windsurf_out_1" | grep -q "load_working_context"; then
+  pass "Windsurf pre_user_prompt: first call mentions load_working_context"
+else
+  fail "Windsurf pre_user_prompt: first call mentions load_working_context"
+fi
+
+if printf '%s' "$windsurf_out_1" | grep -q "save_working_context"; then
+  pass "Windsurf pre_user_prompt: first call also mentions save_working_context (no separate Stop event)"
+else
+  fail "Windsurf pre_user_prompt: first call also mentions save_working_context (no separate Stop event)"
+fi
+
+if printf '%s' "$windsurf_out_1" | grep -q "test-project"; then
+  pass "Windsurf pre_user_prompt: uses project from .velesdb-hooks.json"
+else
+  fail "Windsurf pre_user_prompt: uses project from .velesdb-hooks.json"
+fi
+
+windsurf_out_2="$(printf '%s' "$windsurf_payload" | bash "$WINDSURF_HOOKS_DIR/pre-user-prompt.sh")"
+
+if [ -z "$windsurf_out_2" ]; then
+  pass "Windsurf pre_user_prompt: second call in same trajectory is silent"
+else
+  fail "Windsurf pre_user_prompt: second call in same trajectory is silent"
+fi
+
+# ---------------------------------------------------------------------------
 # No hardcoded absolute user paths in the scripts (everything must come from
 # the stdin payload or the .velesdb-hooks.json config).
 # ---------------------------------------------------------------------------
-if grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >/dev/null 2>&1; then
+if grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" >/dev/null 2>&1; then
   fail "no hardcoded user home paths in hook scripts"
-  grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >&2 || true
+  grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" >&2 || true
 else
   pass "no hardcoded user home paths in hook scripts"
 fi
@@ -182,7 +220,7 @@ fi
 # installed, don't fail the suite over its absence)
 # ---------------------------------------------------------------------------
 if command -v shellcheck >/dev/null 2>&1; then
-  if find "$HOOKS_DIR" -name '*.sh' -print0 | xargs -0 shellcheck; then
+  if find "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" -name '*.sh' -print0 | xargs -0 shellcheck; then
     pass "shellcheck: hook scripts are clean"
   else
     fail "shellcheck: hook scripts are clean"

--- a/integrations/agent-hooks/windsurf/hooks/lib/common.sh
+++ b/integrations/agent-hooks/windsurf/hooks/lib/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared helpers for the VelesDB agent-hooks scripts.
+# Sourced by session-start.sh, stop.sh, pre-compact.sh — not meant to be run directly.
+
+# require_jq: fail loudly (not silently) if jq is missing, since every hook
+# builds its JSON output through jq to get escaping right.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "velesdb agent-hooks: 'jq' is required but was not found on PATH." >&2
+    exit 1
+  fi
+}
+
+# resolve_config CWD
+# Walks up from CWD looking for a .velesdb-hooks.json file (project root
+# convention). Sets PROJECT and SESSION globals. Falls back to
+# project=basename(cwd) and session="rolling" when no config file is found
+# or a field is missing — so the hooks work with zero setup, but a project
+# can pin stable identifiers via the config file.
+resolve_config() {
+  local start_dir="$1"
+  local dir="$start_dir"
+  local config=""
+  local depth=0
+
+  while [ "$depth" -lt 20 ]; do
+    if [ -f "$dir/.velesdb-hooks.json" ]; then
+      config="$dir/.velesdb-hooks.json"
+      break
+    fi
+    if [ "$dir" = "/" ] || [ -z "$dir" ]; then
+      break
+    fi
+    dir="$(dirname "$dir")"
+    depth=$((depth + 1))
+  done
+
+  PROJECT=""
+  SESSION=""
+  if [ -n "$config" ] && jq -e . "$config" >/dev/null 2>&1; then
+    PROJECT="$(jq -r '.project // empty' "$config")"
+    SESSION="$(jq -r '.session // empty' "$config")"
+  fi
+
+  if [ -z "$PROJECT" ]; then
+    PROJECT="$(basename "$start_dir")"
+  fi
+  if [ -z "$SESSION" ]; then
+    SESSION="rolling"
+  fi
+}
+
+# read_stdin_payload: read the hook's JSON payload from stdin exactly once.
+read_stdin_payload() {
+  cat
+}
+
+# sentinel_path KIND SESSION_ID: path to the once-per-session marker file
+# used by the Stop and PreCompact hooks to fire their reminder exactly once.
+# Uses $TMPDIR (falling back to /tmp) rather than a hardcoded path so it
+# works unmodified on macOS and Linux, and namespaces under
+# velesdb-agent-hooks/ to avoid colliding with unrelated temp files.
+sentinel_path() {
+  local kind="$1"
+  local session_id="$2"
+  local dir="${TMPDIR:-/tmp}/velesdb-agent-hooks"
+  mkdir -p "$dir"
+  printf '%s/%s-%s.marker' "$dir" "$kind" "$session_id"
+}

--- a/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh
+++ b/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Windsurf pre_user_prompt hook: on the first prompt of a session, remind the
+# model to load its working context from velesdb-memory.
+#
+# Windsurf only exposes one lifecycle hook event (pre_user_prompt) — no
+# separate Stop/PreCompact equivalent — so this single reminder folds in
+# BOTH halves of the loop the Claude Code hooks split across three events:
+# load working context now, and save it again before the session ends.
+#
+# Windsurf sends a JSON payload on stdin with fields like trajectory_id,
+# execution_id, timestamp, model_name, tool_info. There is no stable
+# cross-request session id in that payload other than trajectory_id, which
+# we use as the once-per-session sentinel key (falling back to the parent
+# PID if it's ever absent).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+session_id="$(printf '%s' "$payload" | jq -r '.trajectory_id // empty')"
+if [ -z "$session_id" ]; then
+  session_id="windsurf-${PPID:-$$}"
+fi
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+
+resolve_config "$cwd"
+
+sentinel="$(sentinel_path "windsurf-prompt" "$session_id")"
+
+if [ -f "$sentinel" ]; then
+  # Already reminded this session — pass through silently.
+  exit 0
+fi
+: > "$sentinel"
+
+cat <<EOF
+[velesdb-memory] Session memory: call load_working_context(project="$PROJECT", session="$SESSION") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally. Before finishing this session, call save_working_context(project="$PROJECT", session="$SESSION") with the distilled state — Windsurf has no separate end-of-session hook, so this is the only reminder you'll get. Reinforcement loop: whenever a memory surfaced by recall/recall_fused actually helps you, call feedback(id, true) with the id_str value; if it misled you, feedback(id, false).
+EOF


### PR DESCRIPTION
Auditing whether the shipped skills+hooks are actually *useful*, not just present (prompted directly by the maintainer wanting to confirm the context optimizer and the memory loop actually get used at the right moments — and by a real live report from a Devin session hitting the id_str wording ambiguity).

## 1. `PreCompact` now nudges `compile_transcript`, not just `save_working_context`

The working-context loop (`load`/`save_working_context`) is hook-enforced (`SessionStart`/`Stop`/`PreCompact`) and verified firing correctly in real sessions. The context compiler had **zero hook-level trigger** — it depended entirely on the skill's own description-matching to fire. The `PreCompact` hook's own V2b roadmap note already anticipated this: *"once `compile_transcript` ships, this hook can compile the transcript directly"* — it has shipped. The hook still can't call it directly (mono-process flock constraint documented in the README — hooks only ever drive the model, never touch the store), so it now nudges the model to `compile_transcript` the about-to-be-compacted transcript before falling back to lossy compaction, alongside the existing `save_working_context` nudge.

TDD: new `hooks.test.sh` assertion (reason mentions `compile_transcript`) written and verified **red** before the implementation, green after. Full suite: 16/16.

## 2. `id_str` wording fixed in the `velesdb-memory` skill

A live Devin session reported: *"le tool feedback attend le champ `id` (pas `id_str`), malgré ce que dit le skill"* — flagged as a possible server inconsistency. Verified it is **not a server bug**: `deserialize_id` (`crates/velesdb-memory/src/model.rs`) already accepts a decimal string directly, and the documented `+`-prefix harness workaround was independently re-verified (`"+12732540571541475285".parse::<u64>()` succeeds in Rust). The skill's own wording — *"use `id_str`, not `id`"* — reads, taken literally, as if there are two different parameter names to choose between; there's only one (`id`/`from`/`to`), and `id_str` only ever exists in *responses*. Reworded to say explicitly: relay the response's `id_str` *value* into the `id` parameter — nothing to look for under a different field name.

## 3. Generalized recurrence-check discipline added to the skill's "remember" step

Recall by failure signature before storing a new incident; `relate(..., "same_root_cause_as")` on a match; promote a generalized `type: "anti-pattern"` fact on a second occurrence of the same mistake class. Closes the gap between "store a fact" and "actually build a graph that prevents the same class of mistake twice" — the part of "use memory at the right moments to store *and search*" that wasn't covered by the existing step-by-step loop.

Both `crates/velesdb-memory/skill/velesdb-memory/SKILL.md` and its `crates/velesdb-node/skills/velesdb-memory/SKILL.md` mirror updated identically (repo convention: the two must stay byte-identical).