### PR TITLE
chore(release): sync develop into main (installer VELES-004 fix + 0.11.1 bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "axum",
  "criterion",
@@ -6966,7 +6966,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] — 2026-07-24
+
+Patch: fixes the MCP wire-contract bug (harness-stringified parameters) plus
+the Claude Desktop onboarding automation — no new memory-shape/API change.
+
 ### Added
 
 - `scripts/install-memory-daemon.sh` now wires **Devin CLI**
@@ -33,6 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCP tool parameters are now harness-proof on both wire directions**
+  (issue #1575). Real MCP client harnesses were observed serializing
+  non-string arguments as JSON-encoded strings once their view of the
+  advertised schema degraded — `save_working_context`'s `working` object
+  arrived as `"{\"goal\": ...}"` and failed with `invalid type: string,
+  expected struct WorkingContext`, silently losing session handoffs;
+  `recall_fused` rejected `limit: "6"` and stringified `filter` objects
+  the same way. Same defensive-interop class as the #1468 string-id
+  contract. Two-sided fix: (1) `$ref`-only top-level parameter schemas
+  are now inlined so every parameter advertises a direct `type` keyword
+  (`working` exposes `type: object`); (2) a lenient deserializer on every
+  non-string tool parameter accepts the properly-typed value first and
+  falls back to parsing a JSON-encoded string, with a precise error when
+  neither form fits.
 - The installer no longer writes a `type:"http"` entry into
   `claude_desktop_config.json` — confirmed Desktop's config file never reads
   that shape (silently ignored). Superseded in this same release by the

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,31 +17,30 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
-> **Release 0.11.0** — multi-client memory: a single local `velesdb-memory
-> --http` daemon (see "HTTP transport (multi-client)" below) now lets Claude
-> Code, Claude Desktop, and Windsurf share the *same* memory instead of one
-> client at a time, and serves **HTTPS by default** with a natively-generated
-> local CA (no external `mkcert`/proxy) — some MCP clients refuse a
-> non-`https://` URL even for `127.0.0.1`. `scripts/install-memory-daemon.sh`
-> automates the whole setup, including trusting the CA. Every `remember` now
-> auto-stamps a `_veles_date` field (`YYYYMMDD`, never overwritten if you set
-> it yourself), so `recall_fused`'s `date_field` works with zero setup — this
-> is the metadata-shape change that makes this a **minor**, not patch,
-> release (a fact stored with no caller metadata no longer round-trips as
-> `metadata: None`). Also fixes two independent deadlocks under concurrent
-> `remember`/`recall` load found while building the daemon (rayon pool
-> exhaustion + a lock-ordering inversion) — real risk for any consumer, not
-> just the new HTTP transport, since both bugs lived in the shared storage
-> layer. Published to the registries by the `velesdb-memory-v0.11.0`
-> tag, so the links below may briefly lag right after merge. `velesdb-memory`
-> ships on [crates.io](https://crates.io/crates/velesdb-memory) and on the
+> **Release 0.11.1** (patch) — **MCP tool parameters are now harness-proof on
+> both wire directions.** Real MCP client harnesses were observed serializing
+> non-string arguments as JSON-encoded strings once their view of the
+> advertised schema degraded — `save_working_context`'s `working` object
+> arrived as an escaped JSON string and failed outright, silently losing
+> session handoffs; `recall_fused` rejected a stringified `limit`/`filter`
+> the same way. Fixed on both sides: every top-level parameter now
+> advertises a direct `type` in its schema, and a lenient deserializer
+> accepts a JSON-encoded string fallback on every non-string parameter. Also
+> in this release: Claude Desktop wiring is now fully automated on both
+> installers (an `mcp-remote` stdio→HTTPS bridge entry written into
+> `claude_desktop_config.json`, TLS verified strictly via
+> `NODE_EXTRA_CA_CERTS` — no manual proxy, no `NODE_TLS_REJECT_UNAUTHORIZED=0`)
+> and CA-trust is verified after trusting instead of assumed. Published to
+> the registries by the `velesdb-memory-v0.11.1` tag, so the links below may
+> briefly lag right after merge. `velesdb-memory` ships on
+> [crates.io](https://crates.io/crates/velesdb-memory) and on the
 > [official MCP registry](https://registry.modelcontextprotocol.io)
 > (`io.github.cyberlife-coder/velesdb-memory`, with **5 prebuilt `.mcpb` bundles**:
 > macOS arm64/x64, Linux arm64/x64, Windows x64). Bindings: Node
-> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.11.0**
-> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **3.12.0**
+> [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) **0.11.1**
+> and Python in [`velesdb`](https://pypi.org/project/velesdb/) **4.0.0**
 > (memory API only — the context compiler is merged on `develop` but **the
-> published 3.12.0 wheel predates it**; it ships with the next PyPI release,
+> published 4.0.0 wheel predates it**; it ships with a future PyPI release,
 > until then Python agents reach it through the MCP server).
 > **`cargo install velesdb-memory` installs the latest published release.**
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -429,6 +429,11 @@ curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/vele
   | tar -xz -C ~/.claude/skills/
 ```
 
+**Keep skills fresh:** the `cp`/`curl` above is a snapshot, not a live link — a
+skill installed once does not update itself when a new release changes it.
+Re-run the same command after every upgrade (safe to repeat: it just
+overwrites the local copy).
+
 **Skills teach an agent what to do; they don't make it remember to do it.**
 [`integrations/agent-hooks/`](https://github.com/cyberlife-coder/VelesDB/tree/develop/integrations/agent-hooks)
 closes that gap for Claude Code with real `SessionStart`/`Stop`/`PreCompact`
@@ -801,6 +806,11 @@ archive root — so a one-liner installs them straight from the release:
 curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz \
   | tar -xz -C ~/.claude/skills/
 ```
+
+**Keep skills fresh:** the `cp`/`curl` above is a snapshot, not a live link — a
+skill installed once does not update itself when a new release changes it.
+Re-run the same command after every upgrade (safe to repeat: it just
+overwrites the local copy).
 
 **Skills teach an agent what to do; they don't make it remember to do it.**
 [`integrations/agent-hooks/`](https://github.com/cyberlife-coder/VelesDB/tree/develop/integrations/agent-hooks)

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -110,7 +110,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
 An incident postmortem finds the payment provider's 30 s timeout let a stalled
 request pile up and take down checkout. The team drops it to 8 s.
 - `remember("Payment provider timeout set to 8s", metadata={type:"decision",
-  area:"payments", date:"2026-07-11"})` → returns id `D`.
+  area:"payments"})` → returns id `D`. No need to set a date — `_veles_date`
+  auto-stamps today's date as a numeric `YYYYMMDD`, as covered above.
 - `remember("Incident 2026-07-10: 30s payment timeout stalled checkout under load",
   metadata={type:"incident", area:"payments"})` → id `I`.
 - `relate(D, I, "caused_by")` and `relate(D, <config-PR fact>, "decided_in")`.

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -67,6 +67,21 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.
+   - **Before storing a new incident/bug/anti-pattern, check for recurrence.**
+     `recall`/`recall_fused` using the *failure signature* — symptom + mechanism,
+     not the file name (`"write path deadlocks under concurrent compaction"`, not
+     `"bug in wal.rs"`) — a close semantic match (same trigger class: concurrency,
+     boundary, resource exhaustion) is a candidate recurrence even when the surface
+     symptom or file differs. If one turns up: say so explicitly rather than
+     storing a disconnected duplicate, `relate(new, prior, "same_root_cause_as")`,
+     and — if this is the second time the same *class* of mistake shows up under a
+     different name — `remember` one generalized `metadata: {"type":
+     "anti-pattern"}` fact describing the class itself (not just this instance),
+     linked to both incidents. A recall hit on the exact same bug is useful; a
+     recall hit on the *same class* of bug in a new file is what actually prevents
+     repeats, and that only works once the anti-pattern fact exists and is linked.
+     Skipping this check is how the same mistake gets "discovered" and fixed twice,
+     two names apart, with nothing connecting them.
 
 3. **Connect facts as relationships appear (`relate`).** Whenever a new fact
    relates to an existing memory, create a typed, directional edge. **Direction
@@ -77,12 +92,15 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
    `fixes`, `concerns`. This is the differentiator's fuel — build the graph
    incrementally, don't batch it up "later" (later never comes).
-   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
-   too): every id in a response also comes back as a decimal-string `id_str`
-   twin specifically because a raw JSON-number id can exceed 2^53 and get
-   rounded by a float-lossy client on the way back in, silently pointing
-   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
-   the numeric `id`.
+   **Pass the response's `id_str` STRING into the `id`/`from`/`to` parameter**
+   (same for `feedback`/`forget`) — the parameter is still named `id` (there is
+   no separate `id_str` *input* field anywhere; `id_str` only exists in
+   *responses*), but what you put in it matters: every id in a response also
+   comes back as a decimal-string `id_str` twin specifically because a raw
+   JSON-number id can exceed 2^53 and get rounded by a float-lossy client on
+   the way back in, silently pointing `relate` at the wrong memory — relay
+   the `id_str` value verbatim into `id` instead of retyping the numeric
+   `id`.
    **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
    JSON string) back into a JSON number before it reaches the server, which
    defeats `id_str` and reintroduces the precision loss it exists to avoid. If

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.0"
+version = "0.11.1"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -72,6 +72,10 @@ reinforce). Install it the same way as the context-optimizer skill below:
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory ~/.claude/skills/
 ```
 
+**Keep it fresh:** this `cp` is a snapshot, not a live link — re-run it after
+every `npm update` so the installed skill picks up doc/behavior changes from
+the new package version (safe to repeat: it just overwrites the local copy).
+
 ### Auto-extraction (`rememberExtracted`)
 
 ```js
@@ -122,6 +126,9 @@ Install the skill into your agent's skills directory:
 ```bash
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
 ```
+
+**Keep it fresh:** re-run this after every `npm update` for the same reason
+as the `velesdb-memory` skill above.
 
 #### Media fragments (`retrieveContextSource`)
 

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -110,7 +110,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
 An incident postmortem finds the payment provider's 30 s timeout let a stalled
 request pile up and take down checkout. The team drops it to 8 s.
 - `remember("Payment provider timeout set to 8s", metadata={type:"decision",
-  area:"payments", date:"2026-07-11"})` → returns id `D`.
+  area:"payments"})` → returns id `D`. No need to set a date — `_veles_date`
+  auto-stamps today's date as a numeric `YYYYMMDD`, as covered above.
 - `remember("Incident 2026-07-10: 30s payment timeout stalled checkout under load",
   metadata={type:"incident", area:"payments"})` → id `I`.
 - `relate(D, I, "caused_by")` and `relate(D, <config-PR fact>, "decided_in")`.

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -67,6 +67,21 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    - **links** (the graph facet): connect the new fact to the artifacts it concerns
      — the PR, the ticket, the file, the prior decision it supersedes. **The graph
      is what makes `why` work.** A fact with no edges is invisible to `why`.
+   - **Before storing a new incident/bug/anti-pattern, check for recurrence.**
+     `recall`/`recall_fused` using the *failure signature* — symptom + mechanism,
+     not the file name (`"write path deadlocks under concurrent compaction"`, not
+     `"bug in wal.rs"`) — a close semantic match (same trigger class: concurrency,
+     boundary, resource exhaustion) is a candidate recurrence even when the surface
+     symptom or file differs. If one turns up: say so explicitly rather than
+     storing a disconnected duplicate, `relate(new, prior, "same_root_cause_as")`,
+     and — if this is the second time the same *class* of mistake shows up under a
+     different name — `remember` one generalized `metadata: {"type":
+     "anti-pattern"}` fact describing the class itself (not just this instance),
+     linked to both incidents. A recall hit on the exact same bug is useful; a
+     recall hit on the *same class* of bug in a new file is what actually prevents
+     repeats, and that only works once the anti-pattern fact exists and is linked.
+     Skipping this check is how the same mistake gets "discovered" and fixed twice,
+     two names apart, with nothing connecting them.
 
 3. **Connect facts as relationships appear (`relate`).** Whenever a new fact
    relates to an existing memory, create a typed, directional edge. **Direction
@@ -77,12 +92,15 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    labels: `caused_by`, `decided_in`, `supersedes`, `references`, `depends_on`,
    `fixes`, `concerns`. This is the differentiator's fuel — build the graph
    incrementally, don't batch it up "later" (later never comes).
-   **Use `id_str`, not `id`, for `from`/`to`** (and for `feedback`/`forget`'s id
-   too): every id in a response also comes back as a decimal-string `id_str`
-   twin specifically because a raw JSON-number id can exceed 2^53 and get
-   rounded by a float-lossy client on the way back in, silently pointing
-   `relate` at the wrong memory — relay `id_str` verbatim instead of retyping
-   the numeric `id`.
+   **Pass the response's `id_str` STRING into the `id`/`from`/`to` parameter**
+   (same for `feedback`/`forget`) — the parameter is still named `id` (there is
+   no separate `id_str` *input* field anywhere; `id_str` only exists in
+   *responses*), but what you put in it matters: every id in a response also
+   comes back as a decimal-string `id_str` twin specifically because a raw
+   JSON-number id can exceed 2^53 and get rounded by a float-lossy client on
+   the way back in, silently pointing `relate` at the wrong memory — relay
+   the `id_str` value verbatim into `id` instead of retyping the numeric
+   `id`.
    **Harness caveat**: some MCP harnesses coerce any all-digit scalar (even a
    JSON string) back into a JSON number before it reaches the server, which
    defeats `id_str` and reintroduces the precision loss it exists to avoid. If

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -6,11 +6,13 @@ gives it the *tools*. It does not make the agent actually call
 `load_working_context` at the start of every session or
 `save_working_context` before every one ends — that only happens if the
 agent remembers to, which it won't reliably do on its own. This directory
-closes that gap for [Claude Code](claude-code/) (real, tested hooks) and
-[Codex CLI](codex/) (a documented instruction-file convention, since Codex
-has no equivalent hook mechanism yet).
+closes that gap for [Claude Code](claude-code/) (real, tested hooks),
+[Windsurf](windsurf/) (real, tested hook — a single event folding both
+halves of the loop, see below), and [Codex CLI](codex/) (a documented
+instruction-file convention, since Codex has no equivalent hook mechanism
+yet).
 
-## Install
+## Install — Claude Code
 
 Both variants need `bash` and `jq` on `PATH` — the hooks refuse to run
 without `jq` rather than silently emitting malformed JSON.
@@ -71,6 +73,38 @@ into `~/.claude/settings.json` does not give you a global install by
 itself — that path only resolves inside a project that also has its own
 vendored copy of the scripts. Use the global pattern above instead.
 
+## Install — Windsurf
+
+```bash
+mkdir -p ~/.codeium/windsurf/hooks/velesdb-memory
+cp /path/to/velesdb/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh ~/.codeium/windsurf/hooks/velesdb-memory/
+cp -r /path/to/velesdb/integrations/agent-hooks/windsurf/hooks/lib ~/.codeium/windsurf/hooks/velesdb-memory/
+chmod +x ~/.codeium/windsurf/hooks/velesdb-memory/*.sh
+```
+
+Merge this into `~/.codeium/windsurf/hooks.json`'s `"hooks"` key:
+
+```json
+{
+  "hooks": {
+    "pre_user_prompt": [
+      { "command": "bash /Users/you/.codeium/windsurf/hooks/velesdb-memory/pre-user-prompt.sh", "show_output": true }
+    ]
+  }
+}
+```
+
+Same `.velesdb-hooks.json` config format as Claude Code (below) — the hook
+walks up from the payload's `cwd` looking for one.
+
+**Windsurf exposes only one lifecycle hook, `pre_user_prompt`** — no
+Claude-Code-style `Stop`/`PreCompact` equivalent. So `pre-user-prompt.sh`
+folds BOTH halves of the loop into its single first-of-session reminder:
+load working context now, **and** save it again before the session ends —
+because there is no separate event left to remind you a second time.
+`trajectory_id` from Windsurf's payload is the once-per-session sentinel key
+(falls back to the parent PID if ever absent).
+
 ## The structural constraint that shapes this whole design
 
 **velesdb-memory's store is mono-process, guarded by an flock.** While a
@@ -95,13 +129,16 @@ and hand it to the model directly (that would require opening the store
 from the hook) — it can only tell the model to call
 `load_working_context` itself.
 
-## The three hooks
+## The three Claude Code hooks
+
+(Windsurf's single `pre_user_prompt` hook is documented in its own install
+section above — it folds the same load/save loop into one event.)
 
 | Event | What it does | Mechanism |
 |---|---|---|
 | `SessionStart` | Fires on every session start (new, resume, clear, or post-compact). Emits `additionalContext` telling the model to call `load_working_context(project, session)` as its first action if it hasn't already. | `hookSpecificOutput.additionalContext` — supported by `SessionStart`. |
 | `Stop` | Fires when Claude is about to stop responding. The **first** `Stop` per session is blocked with a reason telling the model to call `save_working_context(project, session)` with the distilled state before stopping; every later `Stop` in the same session passes through untouched. | `{"decision":"block","reason":"..."}`, gated by a sentinel file in `$TMPDIR` (or `/tmp`) keyed by the payload's `session_id`, so the reminder fires once, not on every turn. |
-| `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `save_working_context` first (compaction can lose detail the model hasn't distilled yet); later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
+| `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `compile_transcript` the about-to-be-compacted transcript (deterministic compression, not lossy compaction) and `save_working_context` first; later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
 
 **Design note — why `PreCompact` blocks instead of using
 `additionalContext`:** the original plan for this feature assumed
@@ -151,9 +188,9 @@ the exact JSON each script prints back (including the block-once/pass-
 after behavior of `Stop` and `PreCompact`). Run it after touching any
 script in `claude-code/hooks/`.
 
-## Roadmap note (V2b)
+## Why `PreCompact` only nudges `compile_transcript`, never calls it directly
 
-`PreCompact` currently only nudges the model to save by hand before
-compaction. Once `compile_transcript` ships (tracked separately), this
-hook can compile the transcript directly instead of relying on the model
-to distill it under time pressure right as compaction is about to run.
+Given the mono-process flock constraint above, `PreCompact` cannot call
+`compile_transcript` itself — only the model's own MCP connection can. The
+hook's `reason` tells the model to call it with the transcript about to be
+compacted, trading lossy compaction for a deterministic, auditable one.

--- a/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
+++ b/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
@@ -13,8 +13,10 @@
 # be unsafe (auto-compaction can fire repeatedly as a long session grows;
 # refusing it every time risks the transcript never compacting).
 #
-# TODO(V2b): once compile_transcript ships, this hook can compile the
-# transcript directly instead of only nudging the model to save by hand.
+# V2b (compile_transcript shipped): the hook still cannot touch the store
+# itself (mono-process flock constraint above), so it cannot compile the
+# transcript directly either — it nudges the model to call compile_transcript
+# itself, same mechanism as the save_working_context nudge below.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,6 +48,6 @@ fi
 
 : > "$sentinel"
 
-reason="Before compaction: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") via velesdb-memory with the distilled state so nothing is lost, then retry — compaction will proceed on the next attempt."
+reason="Before compaction: the transcript about to be compacted is exactly what compile_transcript exists for — call it (velesdb-memory) with a token_budget to deterministically compress it (duplicates dropped, logs collapsed, code/negative-constraints preserved verbatim) instead of losing detail to lossy compaction. Also call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") with the distilled state (goal, decisions, pending actions) so nothing is lost even for content compile_transcript can't recover. Then retry — compaction will proceed on the next attempt."
 
 jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOOKS_DIR="$ROOT/claude-code/hooks"
+WINDSURF_HOOKS_DIR="$ROOT/windsurf/hooks"
 
 FAILED=0
 
@@ -122,6 +123,12 @@ else
   fail "PreCompact: reason mentions save_working_context"
 fi
 
+if printf '%s' "$pre_compact_out_1" | jq -e '.reason | contains("compile_transcript")' >/dev/null; then
+  pass "PreCompact: reason mentions compile_transcript (V2b roadmap item, now shipped)"
+else
+  fail "PreCompact: reason mentions compile_transcript (V2b roadmap item, now shipped)"
+fi
+
 if printf '%s' "$pre_compact_out_1" | jq -e 'has("hookSpecificOutput") | not' >/dev/null; then
   pass "PreCompact: no hookSpecificOutput wrapper (unsupported for this event)"
 else
@@ -161,12 +168,49 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Windsurf pre_user_prompt — first call with a trajectory_id reminds, second
+# call with the SAME trajectory_id is silent (single-event fold of the
+# Claude Code load+save reminder, since Windsurf has no Stop/PreCompact).
+# ---------------------------------------------------------------------------
+WINDSURF_TRAJECTORY_ID="test-trajectory-$$"
+windsurf_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg tid "$WINDSURF_TRAJECTORY_ID" \
+  '{trajectory_id: $tid, cwd: $cwd, execution_id: "exec-1", model_name: "test-model"}')"
+
+windsurf_out_1="$(printf '%s' "$windsurf_payload" | bash "$WINDSURF_HOOKS_DIR/pre-user-prompt.sh")"
+
+if printf '%s' "$windsurf_out_1" | grep -q "load_working_context"; then
+  pass "Windsurf pre_user_prompt: first call mentions load_working_context"
+else
+  fail "Windsurf pre_user_prompt: first call mentions load_working_context"
+fi
+
+if printf '%s' "$windsurf_out_1" | grep -q "save_working_context"; then
+  pass "Windsurf pre_user_prompt: first call also mentions save_working_context (no separate Stop event)"
+else
+  fail "Windsurf pre_user_prompt: first call also mentions save_working_context (no separate Stop event)"
+fi
+
+if printf '%s' "$windsurf_out_1" | grep -q "test-project"; then
+  pass "Windsurf pre_user_prompt: uses project from .velesdb-hooks.json"
+else
+  fail "Windsurf pre_user_prompt: uses project from .velesdb-hooks.json"
+fi
+
+windsurf_out_2="$(printf '%s' "$windsurf_payload" | bash "$WINDSURF_HOOKS_DIR/pre-user-prompt.sh")"
+
+if [ -z "$windsurf_out_2" ]; then
+  pass "Windsurf pre_user_prompt: second call in same trajectory is silent"
+else
+  fail "Windsurf pre_user_prompt: second call in same trajectory is silent"
+fi
+
+# ---------------------------------------------------------------------------
 # No hardcoded absolute user paths in the scripts (everything must come from
 # the stdin payload or the .velesdb-hooks.json config).
 # ---------------------------------------------------------------------------
-if grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >/dev/null 2>&1; then
+if grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" >/dev/null 2>&1; then
   fail "no hardcoded user home paths in hook scripts"
-  grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" >&2 || true
+  grep -rEn '/Users/[A-Za-z0-9_.-]+|/home/[A-Za-z0-9_.-]+' "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" >&2 || true
 else
   pass "no hardcoded user home paths in hook scripts"
 fi
@@ -176,7 +220,7 @@ fi
 # installed, don't fail the suite over its absence)
 # ---------------------------------------------------------------------------
 if command -v shellcheck >/dev/null 2>&1; then
-  if find "$HOOKS_DIR" -name '*.sh' -print0 | xargs -0 shellcheck; then
+  if find "$HOOKS_DIR" "$WINDSURF_HOOKS_DIR" -name '*.sh' -print0 | xargs -0 shellcheck; then
     pass "shellcheck: hook scripts are clean"
   else
     fail "shellcheck: hook scripts are clean"

--- a/integrations/agent-hooks/windsurf/hooks/lib/common.sh
+++ b/integrations/agent-hooks/windsurf/hooks/lib/common.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared helpers for the VelesDB agent-hooks scripts.
+# Sourced by session-start.sh, stop.sh, pre-compact.sh — not meant to be run directly.
+
+# require_jq: fail loudly (not silently) if jq is missing, since every hook
+# builds its JSON output through jq to get escaping right.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "velesdb agent-hooks: 'jq' is required but was not found on PATH." >&2
+    exit 1
+  fi
+}
+
+# resolve_config CWD
+# Walks up from CWD looking for a .velesdb-hooks.json file (project root
+# convention). Sets PROJECT and SESSION globals. Falls back to
+# project=basename(cwd) and session="rolling" when no config file is found
+# or a field is missing — so the hooks work with zero setup, but a project
+# can pin stable identifiers via the config file.
+resolve_config() {
+  local start_dir="$1"
+  local dir="$start_dir"
+  local config=""
+  local depth=0
+
+  while [ "$depth" -lt 20 ]; do
+    if [ -f "$dir/.velesdb-hooks.json" ]; then
+      config="$dir/.velesdb-hooks.json"
+      break
+    fi
+    if [ "$dir" = "/" ] || [ -z "$dir" ]; then
+      break
+    fi
+    dir="$(dirname "$dir")"
+    depth=$((depth + 1))
+  done
+
+  PROJECT=""
+  SESSION=""
+  if [ -n "$config" ] && jq -e . "$config" >/dev/null 2>&1; then
+    PROJECT="$(jq -r '.project // empty' "$config")"
+    SESSION="$(jq -r '.session // empty' "$config")"
+  fi
+
+  if [ -z "$PROJECT" ]; then
+    PROJECT="$(basename "$start_dir")"
+  fi
+  if [ -z "$SESSION" ]; then
+    SESSION="rolling"
+  fi
+}
+
+# read_stdin_payload: read the hook's JSON payload from stdin exactly once.
+read_stdin_payload() {
+  cat
+}
+
+# sentinel_path KIND SESSION_ID: path to the once-per-session marker file
+# used by the Stop and PreCompact hooks to fire their reminder exactly once.
+# Uses $TMPDIR (falling back to /tmp) rather than a hardcoded path so it
+# works unmodified on macOS and Linux, and namespaces under
+# velesdb-agent-hooks/ to avoid colliding with unrelated temp files.
+sentinel_path() {
+  local kind="$1"
+  local session_id="$2"
+  local dir="${TMPDIR:-/tmp}/velesdb-agent-hooks"
+  mkdir -p "$dir"
+  printf '%s/%s-%s.marker' "$dir" "$kind" "$session_id"
+}

--- a/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh
+++ b/integrations/agent-hooks/windsurf/hooks/pre-user-prompt.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Windsurf pre_user_prompt hook: on the first prompt of a session, remind the
+# model to load its working context from velesdb-memory.
+#
+# Windsurf only exposes one lifecycle hook event (pre_user_prompt) — no
+# separate Stop/PreCompact equivalent — so this single reminder folds in
+# BOTH halves of the loop the Claude Code hooks split across three events:
+# load working context now, and save it again before the session ends.
+#
+# Windsurf sends a JSON payload on stdin with fields like trajectory_id,
+# execution_id, timestamp, model_name, tool_info. There is no stable
+# cross-request session id in that payload other than trajectory_id, which
+# we use as the once-per-session sentinel key (falling back to the parent
+# PID if it's ever absent).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+session_id="$(printf '%s' "$payload" | jq -r '.trajectory_id // empty')"
+if [ -z "$session_id" ]; then
+  session_id="windsurf-${PPID:-$$}"
+fi
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+
+resolve_config "$cwd"
+
+sentinel="$(sentinel_path "windsurf-prompt" "$session_id")"
+
+if [ -f "$sentinel" ]; then
+  # Already reminded this session — pass through silently.
+  exit 0
+fi
+: > "$sentinel"
+
+cat <<EOF
+[velesdb-memory] Session memory: call load_working_context(project="$PROJECT", session="$SESSION") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally. Before finishing this session, call save_working_context(project="$PROJECT", session="$SESSION") with the distilled state — Windsurf has no separate end-of-session hook, so this is the only reminder you'll get. Reinforcement loop: whenever a memory surfaced by recall/recall_fused actually helps you, call feedback(id, true) with the id_str value; if it misled you, feedback(id, false).
+EOF

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=0.1.0,<2.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -30,8 +30,8 @@ classifiers = [
 
 dependencies = [
     "llama-index-core>=0.10.0,<1.0.0",
-    "velesdb>=3.8.0",
-    "velesdb-common>=3.8.0",
+    "velesdb>=4.0.0",
+    "velesdb-common>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -33,7 +33,9 @@
 #   --store=PATH             Store directory (default: $HOME/.velesdb-memory)
 #   --tls-dir=PATH           TLS material (CA + leaf cert) directory (default: $HOME/.velesdb-memory-tls)
 #   --ollama-url=URL         Ollama endpoint (default: http://localhost:11434)
-#   --ollama-model=MODEL     Ollama embedding model (default: all-minilm)
+#   --ollama-model=MODEL     Ollama embedding model (default: all-minilm; when unset it is
+#                            auto-matched to an existing store's dimension, and any model whose
+#                            dimension differs from that store is rejected — see VELES-004)
 #   --ttl=SECONDS            Default TTL for new facts (default: prompted, empty = permanent)
 #   --yes                    Assume yes to interactive prompts (e.g. `ollama pull`)
 #   --skip-client=NAME       Skip wiring a client (repeatable): claude-code|claude-desktop|windsurf|devin
@@ -85,6 +87,7 @@ STORE="$HOME/.velesdb-memory"
 TLS_DIR="$HOME/.velesdb-memory-tls"
 OLLAMA_URL="http://localhost:11434"
 OLLAMA_MODEL="all-minilm"
+OLLAMA_MODEL_SET=0
 TTL=""
 TTL_SET=0
 ASSUME_YES=0
@@ -106,7 +109,7 @@ DEVIN_CONFIG="$HOME/.config/devin/config.json"
 RELEASE_REPO="cyberlife-coder/VelesDB"
 
 print_usage() {
-  sed -n '2,55p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,58p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 # ---- 0. Parse flags ---------------------------------------------------
@@ -117,7 +120,7 @@ for arg in "$@"; do
     --store=*) STORE="${arg#*=}" ;;
     --tls-dir=*) TLS_DIR="${arg#*=}" ;;
     --ollama-url=*) OLLAMA_URL="${arg#*=}" ;;
-    --ollama-model=*) OLLAMA_MODEL="${arg#*=}" ;;
+    --ollama-model=*) OLLAMA_MODEL="${arg#*=}"; OLLAMA_MODEL_SET=1 ;;
     --ttl=*) TTL="${arg#*=}"; TTL_SET=1 ;;
     --yes) ASSUME_YES=1 ;;
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
@@ -221,6 +224,56 @@ normalize_model_tag() {
   esac
 }
 
+# ollama_has_model NAME: succeed iff NAME (normalized to :latest) is present in
+# the local Ollama tag list. Prefers the HTTP /api/tags endpoint so a custom
+# --ollama-url is honoured, and falls back to the `ollama` CLI if curl/jq can't
+# reach it.
+ollama_has_model() {
+  local want tags_file have
+  want="$(normalize_model_tag "$1")"
+  tags_file="$(mktemp)"
+  if curl -fsS --max-time 5 "$OLLAMA_URL/api/tags" >"$tags_file" 2>/dev/null; then
+    have="$(jq -r --arg want "$want" '[.models[]?.name | select(. == $want)] | length' "$tags_file" 2>/dev/null || echo 0)"
+    rm -f "$tags_file"
+    [ "${have:-0}" != "0" ]
+    return
+  fi
+  rm -f "$tags_file"
+  ollama list 2>/dev/null | awk 'NR>1{print $1}' | grep -qxF "$want"
+}
+
+# detect_store_dim: echo the embedding dimension the store at $STORE was built
+# at, or nothing if there is no store yet. Reads the per-collection config.json
+# that velesdb-memory writes (a plain file — no flock needed, so it is safe to
+# read while the daemon holds the store). The semantic collection is
+# authoritative; the others are consistent fallbacks.
+detect_store_dim() {
+  local c cfg d
+  for c in _semantic_memory _episodic_memory _procedural_memory; do
+    cfg="$STORE/$c/config.json"
+    if [ -f "$cfg" ]; then
+      d="$(jq -r '.dimension // empty' "$cfg" 2>/dev/null)"
+      if [ -n "$d" ] && [ "$d" != "null" ]; then
+        printf '%s' "$d"
+        return 0
+      fi
+    fi
+  done
+}
+
+# probe_model_dim MODEL: echo the real output dimension of MODEL by asking the
+# local Ollama server for one embedding and counting it. Empty on any failure
+# (server down, model not pulled, cold-load timeout) — callers must treat empty
+# as "could not verify", never as a dimension. The `type=="array"` guard keeps
+# an error response ({"error":...}, whose .embedding is null) from being counted
+# as dimension 0.
+probe_model_dim() {
+  local model="$1"
+  curl -fsS --max-time 30 "$OLLAMA_URL/api/embeddings" \
+    -d "$(jq -n --arg m "$model" '{model:$m, prompt:"x"}')" 2>/dev/null \
+    | jq -r 'if (.embedding|type)=="array" then (.embedding|length) else empty end' 2>/dev/null
+}
+
 setup_ollama() {
   [ "$EMBEDDER" = "ollama" ] || return 0
 
@@ -246,13 +299,43 @@ setup_ollama() {
     exit 1
   fi
 
-  require_jq
-  local wanted have
-  wanted="$(normalize_model_tag "$OLLAMA_MODEL")"
-  have="$(jq -r --arg want "$wanted" '[.models[]?.name | select(. == $want)] | length' "$tags_file" 2>/dev/null || echo 0)"
   rm -f "$tags_file"
+  require_jq
 
-  if [ "${have:-0}" = "0" ]; then
+  # ---- Embedding-dimension reconciliation (VELES-004 guard) -------------
+  # A store is created at the embedding dimension of the model that first
+  # wrote to it and can NEVER be read back by a model of a different
+  # dimension (a 1024-dim bge-m3 store is unreadable by 384-dim all-minilm,
+  # and the daemon fails at query time, not at launch). So: detect the
+  # existing store's dimension, auto-pick a matching model when the user did
+  # not force one, and hard-fail on any mismatch BEFORE the daemon is
+  # (re)launched against an incompatible store.
+  local store_dim
+  store_dim="$(detect_store_dim)"
+
+  if [ -n "$store_dim" ] && [ "$OLLAMA_MODEL_SET" != "1" ]; then
+    # Model left at its default but a store already exists — prefer a
+    # locally-present model whose *real* output dimension matches the store,
+    # rather than the compiled default that may not.
+    local picked="" cand
+    for cand in bge-m3 mxbai-embed-large all-minilm "$OLLAMA_MODEL"; do
+      if ollama_has_model "$cand" && [ "$(probe_model_dim "$cand")" = "$store_dim" ]; then
+        picked="$cand"; break
+      fi
+    done
+    if [ -n "$picked" ] && [ "$picked" != "$OLLAMA_MODEL" ]; then
+      echo -e "${BLUE}ℹ️  Store at $STORE is ${store_dim}-dim; auto-selecting installed model '$picked' (dimension matches).${NC}"
+      OLLAMA_MODEL="$picked"
+    elif [ -z "$picked" ] && [ "$store_dim" = "1024" ]; then
+      # Nothing installed matches a 1024-dim store — steer to bge-m3, the
+      # reference 1024-dim model, and let the pull step below fetch it.
+      echo -e "${YELLOW}ℹ️  Store at $STORE is 1024-dim but no matching model is installed; using 'bge-m3'.${NC}"
+      OLLAMA_MODEL="bge-m3"
+    fi
+  fi
+
+  # ---- Ensure the chosen model is pulled --------------------------------
+  if ! ollama_has_model "$OLLAMA_MODEL"; then
     if [ "$ASSUME_YES" = "1" ]; then
       echo -e "${YELLOW}📥 Pulling Ollama model '$OLLAMA_MODEL'...${NC}"
       ollama pull "$OLLAMA_MODEL"
@@ -270,6 +353,23 @@ setup_ollama() {
       echo -e "${RED}❌ Model '$OLLAMA_MODEL' not found locally. Run: ollama pull $OLLAMA_MODEL${NC}"
       exit 1
     fi
+  fi
+
+  # ---- Verify the model's real dimension against the store --------------
+  local model_dim
+  model_dim="$(probe_model_dim "$OLLAMA_MODEL")"
+  if [ -z "$model_dim" ]; then
+    echo -e "${YELLOW}⚠️  Could not probe '$OLLAMA_MODEL' embedding dimension via $OLLAMA_URL (model may still be loading); skipping the dimension cross-check.${NC}"
+  elif [ -n "$store_dim" ] && [ "$model_dim" != "$store_dim" ]; then
+    echo -e "${RED}❌ Embedding-dimension mismatch (VELES-004): the store at $STORE was built at ${store_dim} dimensions, but '$OLLAMA_MODEL' produces ${model_dim}.${NC}"
+    echo -e "${RED}   A store can only be read by a same-dimension model. Fix one of:${NC}"
+    echo -e "${RED}     • use a ${store_dim}-dim model  (bge-m3 and mxbai-embed-large both give 1024):  --ollama-model=bge-m3${NC}"
+    echo -e "${RED}     • or start a fresh store at this model's dimension:  --store=\$HOME/.velesdb-memory-${model_dim}${NC}"
+    exit 1
+  elif [ -z "$store_dim" ]; then
+    echo -e "${BLUE}ℹ️  No existing store at $STORE; it will be created at ${model_dim} dimensions (model '$OLLAMA_MODEL').${NC}"
+  else
+    echo -e "${GREEN}✅ Embedding dimension OK: '$OLLAMA_MODEL' → ${model_dim}, matches the store at $STORE.${NC}"
   fi
 }
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Sync `develop` → `main`. No package publish — brings the current develop tip
onto the canonical release branch.

Commits landing on main:

- `c4dd1173` fix(installer): reconcile Ollama embedder dimension with the store (VELES-004) (#1586)
- `8f98cd13` chore(integrations): raise dependency floors to the published 4.0.0 (#1583)
- `64dc1548` chore(release): bump velesdb-memory/velesdb-node to 0.11.1 (#1582)
- `9c6bcbc7` docs(memory,node): fix stale skill example, document skill-refresh step (#1581)

No new tag / no crates.io/npm/registry publish: the installer fix is script-only
(not part of the `velesdb-memory` crate artifact), and the 0.11.1 daemon archives
that back `--from-release` are unchanged.