### PR TITLE
feat(memory,agent-hooks): compress oversized tool results at PostToolUse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`velesdb-memory`**: `velesdb-memory compile-stdin --budget N [--query …]`
+  — compile text read on stdin with the deterministic context compiler and
+  print `{content, tokens_in, tokens_out, tokens_saved, risk}` as JSON. It
+  short-circuits in `main` *before* the store is opened, exactly like
+  `--version`, so it takes no `flock` and can run in a second process while
+  a session's own MCP server holds the store. A budget too small to fit any
+  fragment is a hard error rather than an empty success: an empty
+  compilation is worse than none for a caller that substitutes the result.
+- **agent-hooks**: a fourth Claude Code hook, `PostToolUse`
+  (`integrations/agent-hooks/claude-code/hooks/post-tool-use.sh`). It is the
+  only hook whose output can *replace* what the model sees
+  (`hookSpecificOutput.updatedToolOutput`), so it compresses oversized tool
+  results before they enter the transcript — where the other three hooks can
+  only nudge the model to call a tool itself. Allowlisted tools only
+  (`Bash,Grep,WebFetch` by default; `Read`/`Edit` are excluded by design),
+  above a size threshold, with the untouched original archived and its path
+  quoted in the replacement, a pure-bash watchdog (`timeout` is absent from
+  a stock macOS) bounding the call, and an identity fallback on every
+  failure path — including a `velesdb-memory` too old to know the
+  subcommand, which would otherwise treat the piped stdin as MCP traffic.
+
 ## [4.0.0] — 2026-07-24
 
 ### Security

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -731,15 +731,18 @@ mod compile_stdin_tests {
     };
 
     /// A tool-output-shaped corpus: repetitive log lines, the exact case a
-    /// PostToolUse hook has to shrink.
+    /// `PostToolUse` hook has to shrink.
     fn noisy_tool_output() -> String {
+        use std::fmt::Write as _;
+
         let mut text = String::new();
         for i in 0..120 {
-            text.push_str(&format!(
-                "[2026-07-25T01:0{}:00Z] INFO  worker: processing batch {} of 120 — retry=0 status=ok\n",
+            let _ = writeln!(
+                text,
+                "[2026-07-25T01:0{}:00Z] INFO  worker: processing batch {} of 120 — retry=0 status=ok",
                 i % 10,
                 i
-            ));
+            );
         }
         text
     }
@@ -781,7 +784,7 @@ mod compile_stdin_tests {
 
     /// A budget too small to fit even one fragment makes the compiler
     /// externalize everything and emit an EMPTY context. Returning that as a
-    /// success is a trap: `compile-stdin`'s caller (a PostToolUse hook) would
+    /// success is a trap: `compile-stdin`'s caller (a `PostToolUse` hook) would
     /// swap a real tool result for an empty string. Fail loudly instead, so
     /// the caller falls back to the untouched output.
     #[test]

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -613,6 +613,25 @@ struct CompileStdinOutput {
 /// # Errors
 /// A message naming the offending flag when it is unknown, when its value is
 /// missing, or when `--budget` is not a positive integer.
+/// Validate `--budget`'s value. Split out of [`parse_compile_stdin_args`] to
+/// keep that loop's branching within the repo's complexity ceiling.
+///
+/// # Errors
+/// When the value is absent, not an integer, or zero — a zero budget fits no
+/// fragment at all, so it can only ever produce the empty-compilation failure
+/// [`compile_stdin_json`] rejects anyway.
+#[cfg(feature = "context")]
+fn parse_compile_stdin_budget(value: Option<&String>) -> Result<u64, String> {
+    let raw = value.ok_or_else(|| "--budget requires a value".to_owned())?;
+    let parsed: u64 = raw
+        .parse()
+        .map_err(|_| format!("--budget expects a positive integer, got {raw:?}"))?;
+    if parsed == 0 {
+        return Err("--budget must be greater than 0".to_owned());
+    }
+    Ok(parsed)
+}
+
 #[cfg(feature = "context")]
 fn parse_compile_stdin_args(args: &[String]) -> Result<CompileStdinOptions, String> {
     let mut options = CompileStdinOptions::default();
@@ -622,14 +641,7 @@ fn parse_compile_stdin_args(args: &[String]) -> Result<CompileStdinOptions, Stri
         let value = args.get(index + 1);
         match flag {
             "--budget" => {
-                let raw = value.ok_or_else(|| "--budget requires a value".to_owned())?;
-                let parsed: u64 = raw
-                    .parse()
-                    .map_err(|_| format!("--budget expects a positive integer, got {raw:?}"))?;
-                if parsed == 0 {
-                    return Err("--budget must be greater than 0".to_owned());
-                }
-                options.token_budget = parsed;
+                options.token_budget = parse_compile_stdin_budget(value)?;
                 index += 2;
             }
             "--query" => {

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -50,6 +50,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    // Short-circuits for the same reason as `--version`: `compile-stdin` is
+    // the hook-facing surface (see `integrations/agent-hooks`). A PostToolUse
+    // hook runs SYNCHRONOUSLY after every tool call, in a process of its own,
+    // while the agent's own MCP server already holds the store's
+    // single-writer `flock` — so this path must never open the store. It
+    // doesn't have to: the compiler
+    // (`velesdb_memory::context::ContextCompiler::compile`) is pure — no
+    // store, no index, no clock — and the `context` feature is
+    // `persistence`-free by design.
+    if args.get(1).is_some_and(|arg| arg == "compile-stdin") {
+        return run_compile_stdin(&args[2..]);
+    }
+
     // Captured FIRST — before the (possibly seconds-long) embedder probe and
     // store open — so a client that exits during our own startup still
     // reparents us AFTER the baseline, and the watchdog sees the change. A
@@ -554,6 +567,291 @@ fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 #[cfg(not(feature = "ollama"))]
 fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
     Err("the 'ollama' embedder requires building with `--features ollama`".into())
+}
+
+/// Default token budget of `compile-stdin` when `--budget` is omitted.
+///
+/// Sized for the job the hook does: a tool result big enough to be worth
+/// compiling, compressed to something an agent can still read in full.
+const DEFAULT_COMPILE_STDIN_BUDGET: u64 = 2_000;
+
+/// Parsed `compile-stdin` invocation.
+#[cfg(feature = "context")]
+#[derive(Debug, PartialEq, Eq)]
+struct CompileStdinOptions {
+    token_budget: u64,
+    query: String,
+}
+
+#[cfg(feature = "context")]
+impl Default for CompileStdinOptions {
+    fn default() -> Self {
+        Self {
+            token_budget: DEFAULT_COMPILE_STDIN_BUDGET,
+            query: String::new(),
+        }
+    }
+}
+
+/// What `compile-stdin` writes to stdout: one JSON object, so a shell hook
+/// gets the compiled text AND the accounting from a single stream (`jq` is
+/// already a hard requirement of the hooks).
+#[cfg(feature = "context")]
+#[derive(serde::Serialize)]
+struct CompileStdinOutput {
+    content: String,
+    tokens_in: u64,
+    tokens_out: u64,
+    tokens_saved: u64,
+    risk: String,
+}
+
+/// Parse `compile-stdin`'s flags. Hand-rolled for the same reason as
+/// `--version`/`--http` above: two flags do not justify a `clap` dependency
+/// in the shipped binary.
+///
+/// # Errors
+/// A message naming the offending flag when it is unknown, when its value is
+/// missing, or when `--budget` is not a positive integer.
+#[cfg(feature = "context")]
+fn parse_compile_stdin_args(args: &[String]) -> Result<CompileStdinOptions, String> {
+    let mut options = CompileStdinOptions::default();
+    let mut index = 0;
+    while index < args.len() {
+        let flag = args[index].as_str();
+        let value = args.get(index + 1);
+        match flag {
+            "--budget" => {
+                let raw = value.ok_or_else(|| "--budget requires a value".to_owned())?;
+                let parsed: u64 = raw
+                    .parse()
+                    .map_err(|_| format!("--budget expects a positive integer, got {raw:?}"))?;
+                if parsed == 0 {
+                    return Err("--budget must be greater than 0".to_owned());
+                }
+                options.token_budget = parsed;
+                index += 2;
+            }
+            "--query" => {
+                options
+                    .query
+                    .clone_from(value.ok_or_else(|| "--query requires a value".to_owned())?);
+                index += 2;
+            }
+            other => return Err(format!("unknown compile-stdin flag {other:?}")),
+        }
+    }
+    Ok(options)
+}
+
+/// Compile `text` under `options` and render the JSON payload.
+///
+/// # Errors
+/// When `text` is empty, when segmentation hits a [`velesdb_memory::limits`]
+/// cap, or when the budget leaves no room for any context.
+#[cfg(feature = "context")]
+fn compile_stdin_json(
+    text: &str,
+    options: &CompileStdinOptions,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use velesdb_memory::context::{
+        segment_transcript, CompilePolicy, CompileRequest, ContextCompiler, SegmentationPolicy,
+    };
+
+    if text.trim().is_empty() {
+        return Err("compile-stdin received empty input on stdin".into());
+    }
+
+    let outcome = segment_transcript(text, &SegmentationPolicy::default())?;
+    let request = CompileRequest {
+        query: options.query.clone(),
+        fragments: outcome
+            .segments
+            .into_iter()
+            .map(|segment| segment.fragment)
+            .collect(),
+        project: None,
+        target_model: None,
+        token_budget: options.token_budget,
+        memory_scope: None,
+        policy: None,
+    };
+    let compiled = ContextCompiler::new(CompilePolicy::default()).compile(&request)?;
+
+    // The compiler externalizes rather than truncates: when no single
+    // fragment fits, everything moves behind a retrieval handle and the
+    // assembled content is empty. That is a legitimate compilation, but a
+    // useless one to return as a *replacement* for real content — surface it
+    // as an error so the caller keeps the original instead of shipping an
+    // empty string.
+    if compiled.content.is_empty() {
+        return Err(format!(
+            "a budget of {} tokens fits none of the {} input tokens — every fragment was \
+             externalized and the compiled context is empty; raise --budget",
+            options.token_budget, compiled.insights.tokens_in
+        )
+        .into());
+    }
+
+    let output = CompileStdinOutput {
+        content: compiled.content,
+        tokens_in: compiled.insights.tokens_in,
+        tokens_out: compiled.insights.tokens_out,
+        tokens_saved: compiled.insights.tokens_saved,
+        risk: format!("{:?}", compiled.risk).to_lowercase(),
+    };
+    Ok(serde_json::to_string(&output)?)
+}
+
+/// Read stdin, compile it, print the JSON payload.
+///
+/// # Errors
+/// Propagates flag-parsing, stdin-read, and compilation failures.
+#[cfg(feature = "context")]
+fn run_compile_stdin(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Read as _;
+
+    let options = parse_compile_stdin_args(args)?;
+    let mut text = String::new();
+    std::io::stdin().read_to_string(&mut text)?;
+    println!("{}", compile_stdin_json(&text, &options)?);
+    Ok(())
+}
+
+#[cfg(not(feature = "context"))]
+fn run_compile_stdin(_args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    Err("`compile-stdin` requires building with `--features context`".into())
+}
+
+#[cfg(all(test, feature = "context"))]
+mod compile_stdin_tests {
+    use super::{
+        compile_stdin_json, parse_compile_stdin_args, CompileStdinOptions,
+        DEFAULT_COMPILE_STDIN_BUDGET,
+    };
+
+    /// A tool-output-shaped corpus: repetitive log lines, the exact case a
+    /// PostToolUse hook has to shrink.
+    fn noisy_tool_output() -> String {
+        let mut text = String::new();
+        for i in 0..120 {
+            text.push_str(&format!(
+                "[2026-07-25T01:0{}:00Z] INFO  worker: processing batch {} of 120 — retry=0 status=ok\n",
+                i % 10,
+                i
+            ));
+        }
+        text
+    }
+
+    fn parse(value: &str) -> serde_json::Value {
+        serde_json::from_str(value).expect("compile-stdin must emit valid JSON")
+    }
+
+    #[test]
+    fn tight_budget_actually_shrinks_the_payload() {
+        let options = CompileStdinOptions {
+            token_budget: 1_500,
+            query: "what did the worker do".to_owned(),
+        };
+        let compiled = parse(&compile_stdin_json(&noisy_tool_output(), &options).unwrap());
+
+        let tokens_in = compiled["tokens_in"].as_u64().unwrap();
+        let tokens_out = compiled["tokens_out"].as_u64().unwrap();
+        assert!(tokens_in > 0, "tokens_in must be measured, got {tokens_in}");
+        assert!(
+            tokens_out < tokens_in,
+            "a 200-token budget over {tokens_in} tokens of logs must compress: got {tokens_out}"
+        );
+        assert_eq!(
+            compiled["tokens_saved"].as_u64().unwrap(),
+            tokens_in - tokens_out
+        );
+        let content = compiled["content"].as_str().unwrap();
+        assert!(
+            !content.is_empty(),
+            "an empty compilation is worse than no compilation — the caller would replace a \
+             real tool result with nothing"
+        );
+        assert!(
+            content.len() < noisy_tool_output().len(),
+            "the compiled content must be shorter than the raw tool output"
+        );
+    }
+
+    /// A budget too small to fit even one fragment makes the compiler
+    /// externalize everything and emit an EMPTY context. Returning that as a
+    /// success is a trap: `compile-stdin`'s caller (a PostToolUse hook) would
+    /// swap a real tool result for an empty string. Fail loudly instead, so
+    /// the caller falls back to the untouched output.
+    #[test]
+    fn budget_too_small_for_any_fragment_is_an_error() {
+        let options = CompileStdinOptions {
+            token_budget: 50,
+            query: String::new(),
+        };
+        let error = compile_stdin_json(&noisy_tool_output(), &options).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("budget"),
+            "the error must point at the budget, got {message}"
+        );
+    }
+
+    #[test]
+    fn compilation_is_byte_identical_across_runs() {
+        let options = CompileStdinOptions {
+            token_budget: 1_500,
+            query: "worker batches".to_owned(),
+        };
+        let first = compile_stdin_json(&noisy_tool_output(), &options).unwrap();
+        let second = compile_stdin_json(&noisy_tool_output(), &options).unwrap();
+        assert_eq!(first, second, "the compiler must be deterministic");
+    }
+
+    #[test]
+    fn empty_stdin_is_rejected() {
+        let error = compile_stdin_json("   \n\t ", &CompileStdinOptions::default()).unwrap_err();
+        assert!(
+            error.to_string().contains("empty"),
+            "the error must name the cause, got {error}"
+        );
+    }
+
+    #[test]
+    fn flags_default_and_override() {
+        assert_eq!(
+            parse_compile_stdin_args(&[]).unwrap(),
+            CompileStdinOptions {
+                token_budget: DEFAULT_COMPILE_STDIN_BUDGET,
+                query: String::new(),
+            }
+        );
+        let parsed = parse_compile_stdin_args(&[
+            "--budget".to_owned(),
+            "512".to_owned(),
+            "--query".to_owned(),
+            "why did it fail".to_owned(),
+        ])
+        .unwrap();
+        assert_eq!(parsed.token_budget, 512);
+        assert_eq!(parsed.query, "why did it fail");
+    }
+
+    #[test]
+    fn malformed_flags_are_rejected() {
+        for bad in [
+            vec!["--budget".to_owned()],
+            vec!["--budget".to_owned(), "zero".to_owned()],
+            vec!["--budget".to_owned(), "0".to_owned()],
+            vec!["--nope".to_owned()],
+        ] {
+            assert!(
+                parse_compile_stdin_args(&bad).is_err(),
+                "must reject {bad:?}"
+            );
+        }
+    }
 }
 
 #[cfg(all(test, feature = "http"))]

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -58,6 +58,26 @@ with steps 1-3.
 }}
 ```
 
+## Oversized tool results — usually not your job
+
+A tool result that blew up (a 300 KB build log, a wide `grep`, a fetched
+page) is the single biggest source of context bloat, and it is worth
+compressing *once*, at the moment it arrives — every later turn re-sends it
+otherwise. But you are usually not the one who should do it: the
+`PostToolUse` hook shipped in `integrations/agent-hooks/` compresses it
+before it ever reaches you, using `velesdb-memory compile-stdin` (the
+store-free CLI form of this compiler) and replacing the tool result in
+place. When that hook is installed you will see results ending in a
+`--- velesdb: compiled N tokens down to M …` footer quoting the path of the
+untouched original — `Read` that path when the compiled view is not enough.
+
+Compress a tool result *yourself* only when the hook is not installed, or
+when it deliberately skipped the tool (`Read`/`Edit` outputs are never
+compressed — the exact bytes are the point). In that case treat the output
+as a transcript and call `compile_transcript` on it. Never re-compress
+something that already carries the footer above: it has been compiled once
+already, and compiling a compilation only loses fidelity.
+
 ## Workflow (10 steps)
 
 1. **Scope the problem.** Identify what is about to be sent to the model:

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -42,10 +42,18 @@ be relative to for a global install):
     ],
     "PreCompact": [
       { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/pre-compact.sh" }] }
+    ],
+    "PostToolUse": [
+      { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/post-tool-use.sh" }] }
     ]
   }
 }
 ```
+
+`PostToolUse` additionally needs a `velesdb-memory` binary on `PATH` that
+knows the `compile-stdin` subcommand. Until you have one, the hook is
+inert — it detects the missing capability and passes every tool result
+through untouched, so installing it early costs nothing.
 
 Works with zero further setup (each project defaults to
 `project = basename(cwd)`, `session = "rolling"`) — drop a
@@ -129,7 +137,18 @@ and hand it to the model directly (that would require opening the store
 from the hook) — it can only tell the model to call
 `load_working_context` itself.
 
-## The three Claude Code hooks
+**The one thing the constraint does *not* forbid.** The lock guards the
+*store*, and it is taken at store-open time only (`Database::open`, keyed by
+the data directory). The deterministic context compiler is a different
+animal: `ContextCompiler::compile` is pure — no store, no index, no
+embeddings, no clock — and velesdb-memory's `context` feature is
+`persistence`-free by design. So a hook *can* compile text in a separate
+process, as long as that process never opens a store. That is precisely what
+`velesdb-memory compile-stdin` does: it short-circuits in `main` before the
+store open, the same way `--version` does. `PostToolUse` below is the one
+hook that uses it; the other three still only ever drive the model.
+
+## The four Claude Code hooks
 
 (Windsurf's single `pre_user_prompt` hook is documented in its own install
 section above — it folds the same load/save loop into one event.)
@@ -139,6 +158,41 @@ section above — it folds the same load/save loop into one event.)
 | `SessionStart` | Fires on every session start (new, resume, clear, or post-compact). Emits `additionalContext` telling the model to call `load_working_context(project, session)` as its first action if it hasn't already. | `hookSpecificOutput.additionalContext` — supported by `SessionStart`. |
 | `Stop` | Fires when Claude is about to stop responding. The **first** `Stop` per session is blocked with a reason telling the model to call `save_working_context(project, session)` with the distilled state before stopping; every later `Stop` in the same session passes through untouched. | `{"decision":"block","reason":"..."}`, gated by a sentinel file in `$TMPDIR` (or `/tmp`) keyed by the payload's `session_id`, so the reminder fires once, not on every turn. |
 | `PreCompact` | Fires before the transcript is compacted (manual or auto-triggered). The **first** `PreCompact` per session is blocked with a reason telling the model to `compile_transcript` the about-to-be-compacted transcript (deterministic compression, not lossy compaction) and `save_working_context` first; later ones pass through. | Same block-once-then-pass pattern as `Stop`, separate sentinel key. |
+| `PostToolUse` | Fires after every tool call. When an **allowlisted** tool returns more than the size threshold, the result is compiled through `velesdb-memory compile-stdin` and the compiled view replaces it. Everything else passes through untouched. | `hookSpecificOutput.updatedToolOutput` — the only hook output that replaces what the model sees, rather than advising it. |
+
+**Design note — the only hook that reduces the payload itself.** The other
+three can only ask the model to call a tool; whether the context actually
+shrinks is the model's decision. `PostToolUse` is different: its output
+schema replaces the tool result before it ever enters the transcript. A
+300 KB `Bash` result compiled here is 300 KB that never gets re-sent on
+every later turn — the compression is structural, not advisory.
+
+Because it runs on *every* tool call and *replaces* content, its safety
+rules are strict, and each is covered by `test/hooks.test.sh`:
+
+- **Nothing is deleted.** The untouched original is written under
+  `$TMPDIR/velesdb-agent-hooks/tool-output/` and its path is quoted in the
+  replacement, so the agent can `Read` it back — the out-of-store equivalent
+  of a retrieval handle.
+- **Identity fallback everywhere.** Missing `jq`, missing binary, a binary
+  too old to know `compile-stdin`, a compilation error, an empty compiled
+  result — each emits `{}` and leaves the tool result exactly as it was.
+- **Bounded.** A velesdb-memory released *before* `compile-stdin` ignores
+  the subcommand and starts the MCP server on the piped stdin. A pure-bash
+  watchdog (no `timeout`, absent from stock macOS) bounds the call, and a
+  cached capability probe tells old binaries from new ones without guessing
+  versions.
+- **Allowlist, not denylist.** Default `Bash,Grep,WebFetch`. `Read` and
+  `Edit` are deliberately excluded and must stay excluded: their value *is*
+  the exact bytes.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `VELESDB_HOOK_COMPRESS_TOOLS` | `Bash,Grep,WebFetch` | Comma-separated tool allowlist. |
+| `VELESDB_HOOK_MIN_BYTES` | `12000` | Below this, pass through — compiling would cost more than it saves. |
+| `VELESDB_HOOK_TOKEN_BUDGET` | `2000` | Token budget handed to `compile-stdin`. |
+| `VELESDB_MEMORY_BIN` | `velesdb-memory` on `PATH` | Binary to invoke. |
+| `VELESDB_HOOK_PROBE_TIMEOUT` | `10` | Seconds the capability probe may take. |
 
 **Design note — why `PreCompact` blocks instead of using
 `additionalContext`:** the original plan for this feature assumed

--- a/integrations/agent-hooks/claude-code/hooks/lib/common.sh
+++ b/integrations/agent-hooks/claude-code/hooks/lib/common.sh
@@ -55,6 +55,40 @@ read_stdin_payload() {
   cat
 }
 
+# run_with_watchdog SECONDS OUTFILE CMD...
+# Run CMD with stdout captured into OUTFILE, killing it after SECONDS.
+# Returns CMD's exit status, or 124 if it had to be killed.
+#
+# Why not `timeout`: it is GNU coreutils, absent from a stock macOS (where it
+# is `gtimeout`, if installed at all). A hook runs on every tool call and must
+# never hang the agent, so the watchdog is pure bash and always available.
+#
+# This matters most for post-tool-use.sh: a velesdb-memory binary predating
+# `compile-stdin` ignores the subcommand and starts the MCP *server* on the
+# stdin we just piped it. Without this bound, that is a hung hook.
+run_with_watchdog() {
+  local secs="$1"
+  local outfile="$2"
+  shift 2
+
+  "$@" >"$outfile" 2>/dev/null &
+  local pid=$!
+  local waited=0
+  local limit=$((secs * 10))
+
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$limit" ]; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  wait "$pid"
+}
+
 # sentinel_path KIND SESSION_ID: path to the once-per-session marker file
 # used by the Stop and PreCompact hooks to fire their reminder exactly once.
 # Uses $TMPDIR (falling back to /tmp) rather than a hardcoded path so it

--- a/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
+++ b/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# PostToolUse hook: shrink an oversized tool result BEFORE it enters the
+# agent's context, using the deterministic VelesDB context compiler.
+#
+# Why this hook is different from the other three. SessionStart, Stop and
+# PreCompact can only *nudge the model* — they hand it a reason string and
+# hope it calls the right tool. PostToolUse is the one event whose output
+# schema can REPLACE what the model sees
+# (`hookSpecificOutput.updatedToolOutput`), so it is the only place where
+# VelesDB can reduce the payload of every subsequent API call rather than
+# merely advising. A 300 KB `Bash` result compressed here is 300 KB that
+# never enters the transcript, and therefore never gets re-sent on every
+# later turn.
+#
+# It compiles in a SEPARATE PROCESS and never opens the store: the agent's
+# own velesdb-memory MCP server already holds the store's single-writer
+# `flock`, and this hook runs synchronously after every tool call. That is
+# exactly what `velesdb-memory compile-stdin` exists for — the compiler
+# (`ContextCompiler::compile`) is pure: no store, no index, no clock.
+#
+# Safety rules, in order of importance — a hook that runs on EVERY tool call
+# must never lose data and never hang:
+#   1. Nothing is deleted. The untouched original is written to a temp file
+#      and its path is quoted in the replacement, so the agent can `Read` it
+#      whenever the compiled view is not enough. This is the out-of-store
+#      equivalent of a retrieval handle.
+#   2. Identity fallback everywhere. Missing `jq`, missing or too-old binary,
+#      compilation error, empty compiled output, unreadable JSON — every one
+#      of them emits `{}` and leaves the tool result exactly as it was.
+#   3. Bounded. The compile call runs under a watchdog (see
+#      lib/common.sh run_with_watchdog); a binary predating `compile-stdin`
+#      would otherwise treat our piped stdin as MCP traffic and hang.
+#   4. Tool allowlist. Only tools whose output is prose/logs are compressed.
+#      `Read` and `Edit` are deliberately NEVER in it: the model needs file
+#      contents verbatim, byte for byte.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+# Identity fallback: emit an empty decision and leave the tool result alone.
+passthrough() {
+  echo '{}'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || passthrough
+
+payload="$(read_stdin_payload)"
+
+# A malformed payload is not something to fail loudly on: it would mean
+# every tool call in the session errors.
+printf '%s' "$payload" | jq -e . >/dev/null 2>&1 || passthrough
+
+tool_name="$(printf '%s' "$payload" | jq -r '.tool_name // empty')"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // "unknown-session"')"
+tool_use_id="$(printf '%s' "$payload" | jq -r '.tool_use_id // "unknown-call"')"
+
+# Tools whose output is prose or logs, and therefore compressible without
+# breaking the agent's reasoning. Override with a comma-separated list.
+# `Read`/`Edit` must never be added: their value IS the exact bytes.
+allowed="${VELESDB_HOOK_COMPRESS_TOOLS:-Bash,Grep,WebFetch}"
+case ",${allowed}," in
+  *",${tool_name},"*) ;;
+  *) passthrough ;;
+esac
+
+# `tool_response` is a string for some tools and an object for others (Bash
+# reports `{stdout, stderr, ...}`). Compile the text either way; the
+# replacement field is a string in both cases.
+text="$(printf '%s' "$payload" \
+  | jq -r 'if (.tool_response | type) == "string" then .tool_response else (.tool_response | tojson) end')"
+[ -n "$text" ] || passthrough
+
+# Below the threshold, compiling costs more (a process spawn on every tool
+# call) than the tokens it would save.
+min_bytes="${VELESDB_HOOK_MIN_BYTES:-12000}"
+original_bytes="$(printf '%s' "$text" | wc -c | tr -d ' ')"
+[ "$original_bytes" -ge "$min_bytes" ] || passthrough
+
+bin="${VELESDB_MEMORY_BIN:-velesdb-memory}"
+command -v "$bin" >/dev/null 2>&1 || passthrough
+
+# Capability probe, cached once per session per binary: a velesdb-memory
+# released before `compile-stdin` ignores the subcommand and starts the MCP
+# server instead. Probing with a tiny corpus under the watchdog tells the two
+# apart without any version guessing, and without risking a hang.
+probe_key="$(printf '%s' "$bin" | tr -c 'a-zA-Z0-9' '_')"
+probe_marker="$(sentinel_path "compile-stdin-${probe_key}" "$session_id")"
+if [ ! -f "$probe_marker" ]; then
+  probe_out="$(sentinel_path "compile-stdin-probe-out-${probe_key}" "$session_id")"
+  if printf 'probe corpus for the capability check\n' \
+    | run_with_watchdog "${VELESDB_HOOK_PROBE_TIMEOUT:-10}" "$probe_out" "$bin" compile-stdin --budget 4096 \
+    && jq -e 'has("content")' "$probe_out" >/dev/null 2>&1; then
+    echo "yes" > "$probe_marker"
+  else
+    echo "no" > "$probe_marker"
+  fi
+  rm -f "$probe_out"
+fi
+[ "$(cat "$probe_marker")" = "yes" ] || passthrough
+
+# Rule 1: the original survives, at a path the agent can read back.
+archive_dir="${TMPDIR:-/tmp}/velesdb-agent-hooks/tool-output"
+mkdir -p "$archive_dir"
+archive="${archive_dir}/${session_id}-${tool_use_id}.txt"
+printf '%s' "$text" > "$archive"
+
+budget="${VELESDB_HOOK_TOKEN_BUDGET:-2000}"
+compiled_file="$(sentinel_path "compile-stdin-result" "${session_id}-${tool_use_id}")"
+if ! printf '%s' "$text" \
+  | run_with_watchdog 20 "$compiled_file" "$bin" compile-stdin --budget "$budget" --query "$tool_name output"; then
+  rm -f "$compiled_file"
+  passthrough
+fi
+
+content="$(jq -r '.content // empty' "$compiled_file" 2>/dev/null || true)"
+tokens_in="$(jq -r '.tokens_in // 0' "$compiled_file" 2>/dev/null || echo 0)"
+tokens_out="$(jq -r '.tokens_out // 0' "$compiled_file" 2>/dev/null || echo 0)"
+tokens_saved="$(jq -r '.tokens_saved // 0' "$compiled_file" 2>/dev/null || echo 0)"
+rm -f "$compiled_file"
+
+# An empty compilation would replace a real result with nothing. compile-stdin
+# already refuses to emit one, but the hook does not take that on trust.
+[ -n "$content" ] || passthrough
+
+footer="$(printf '\n\n--- velesdb: compiled %s tokens down to %s (saved %s). Nothing was deleted — the untouched %s-byte original is at %s; Read it if this view is not enough. ---' \
+  "$tokens_in" "$tokens_out" "$tokens_saved" "$original_bytes" "$archive")"
+
+jq -n --arg out "${content}${footer}" \
+  '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $out}}'

--- a/integrations/agent-hooks/claude-code/settings-snippet.json
+++ b/integrations/agent-hooks/claude-code/settings-snippet.json
@@ -29,6 +29,16 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/velesdb-memory/post-tool-use.sh\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -205,6 +205,144 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# PostToolUse — the only hook that REPLACES what the model sees, so every
+# check below is really a data-loss check. Driven against fake
+# `velesdb-memory` binaries rather than a built one: the harness must stay
+# hermetic, and what is under test is the hook's decision logic, not the
+# compiler (that has its own Rust tests).
+# ---------------------------------------------------------------------------
+FAKE_BIN_DIR="$TMP_TEST_DIR/bin"
+mkdir -p "$FAKE_BIN_DIR"
+
+# Behaves like a compile-stdin-capable binary: consumes stdin, prints the
+# result JSON.
+cat > "$FAKE_BIN_DIR/fake-ok" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"content":"COMPILED SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"medium"}\n'
+FAKE
+
+# Behaves like a binary whose compilation failed (budget too small, bad input…).
+cat > "$FAKE_BIN_DIR/fake-fail" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+echo "compile-stdin: boom" >&2
+exit 1
+FAKE
+
+# Behaves like a velesdb-memory RELEASED BEFORE compile-stdin: it ignores the
+# subcommand and starts the MCP server, which sits on stdin forever. Without
+# the watchdog this is a hung agent, so this is the most important case here.
+cat > "$FAKE_BIN_DIR/fake-old" <<'FAKE'
+#!/usr/bin/env bash
+sleep 30
+FAKE
+
+chmod +x "$FAKE_BIN_DIR/fake-ok" "$FAKE_BIN_DIR/fake-fail" "$FAKE_BIN_DIR/fake-old"
+
+big_output="$(head -c 40000 < /dev/zero | tr '\0' 'x')"
+
+post_tool_payload() {
+  # $1 tool_name, $2 session suffix, $3 response text
+  jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID-$2" --arg tool "$1" --arg body "$3" \
+    '{session_id: $sid, cwd: $cwd, hook_event_name: "PostToolUse", tool_name: $tool,
+      tool_input: {command: "echo"}, tool_use_id: "toolu_test", tool_response: $body}'
+}
+
+# A tool NOT on the allowlist must be left strictly alone, however big it is.
+# Read is the case that matters: the model needs file bytes verbatim.
+read_out="$(post_tool_payload "Read" "read" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-ok" bash "$HOOKS_DIR/post-tool-use.sh")"
+if [ "$(printf '%s' "$read_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: Read is never compressed, whatever its size"
+else
+  fail "PostToolUse: Read is never compressed, whatever its size"
+fi
+
+# Below the size threshold, compiling costs more than it saves.
+small_out="$(post_tool_payload "Bash" "small" "tiny output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-ok" bash "$HOOKS_DIR/post-tool-use.sh")"
+if [ "$(printf '%s' "$small_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: output below the threshold is passed through untouched"
+else
+  fail "PostToolUse: output below the threshold is passed through untouched"
+fi
+
+# The nominal case: an allowlisted tool, over the threshold, capable binary.
+big_out="$(post_tool_payload "Bash" "big" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-ok" bash "$HOOKS_DIR/post-tool-use.sh")"
+
+if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"' >/dev/null; then
+  pass "PostToolUse: replaces the result with hookEventName PostToolUse"
+else
+  fail "PostToolUse: replaces the result with hookEventName PostToolUse"
+fi
+
+if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("COMPILED SUMMARY")' >/dev/null; then
+  pass "PostToolUse: updatedToolOutput carries the compiled content"
+else
+  fail "PostToolUse: updatedToolOutput carries the compiled content"
+fi
+
+# Rule 1 — nothing is deleted: the replacement must point at the untouched
+# original, and that file must actually hold it.
+archive_path="$(printf '%s' "$big_out" \
+  | jq -r '.hookSpecificOutput.updatedToolOutput' \
+  | sed -n 's/.*original is at \(.*\); Read it.*/\1/p')"
+if [ -n "$archive_path" ] && [ -f "$archive_path" ]; then
+  pass "PostToolUse: the replacement quotes a real path to the original"
+else
+  fail "PostToolUse: the replacement quotes a real path to the original"
+fi
+
+if [ -n "$archive_path" ] && [ -f "$archive_path" ] \
+  && [ "$(wc -c < "$archive_path" | tr -d ' ')" = "$(printf '%s' "$big_output" | wc -c | tr -d ' ')" ]; then
+  pass "PostToolUse: the archived original is byte-complete"
+else
+  fail "PostToolUse: the archived original is byte-complete"
+fi
+
+# A failing compilation must never cost the agent its tool result.
+fail_out="$(post_tool_payload "Bash" "failbin" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-fail" bash "$HOOKS_DIR/post-tool-use.sh")"
+if [ "$(printf '%s' "$fail_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: a failed compilation falls back to the untouched output"
+else
+  fail "PostToolUse: a failed compilation falls back to the untouched output"
+fi
+
+# No binary at all — the overwhelmingly common case before the release that
+# ships compile-stdin.
+missing_out="$(post_tool_payload "Bash" "nobin" "$big_output" \
+  | VELESDB_MEMORY_BIN="$TMP_TEST_DIR/definitely-not-installed" bash "$HOOKS_DIR/post-tool-use.sh")"
+if [ "$(printf '%s' "$missing_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: a missing velesdb-memory binary falls back cleanly"
+else
+  fail "PostToolUse: a missing velesdb-memory binary falls back cleanly"
+fi
+
+# The hang case: an older binary treats our piped stdin as MCP traffic. The
+# watchdog must bound it AND the hook must still answer.
+old_started="$(date +%s)"
+old_out="$(post_tool_payload "Bash" "oldbin" "$big_output" \
+  | VELESDB_HOOK_PROBE_TIMEOUT=2 VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-old" bash "$HOOKS_DIR/post-tool-use.sh")"
+old_elapsed=$(( $(date +%s) - old_started ))
+if [ "$(printf '%s' "$old_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: a pre-compile-stdin binary falls back instead of hanging"
+else
+  fail "PostToolUse: a pre-compile-stdin binary falls back instead of hanging"
+fi
+# Bound checked against the fake binary's own 30s sleep, NOT against the 2s
+# probe timeout: what is under test is "the watchdog cut it short", and a
+# tight wall-clock budget would just make this assertion fail on a loaded CI
+# runner (observed once, with a full cargo test suite running alongside).
+if [ "$old_elapsed" -lt 25 ]; then
+  pass "PostToolUse: the watchdog bounds the probe (${old_elapsed}s < the fake binary's 30s)"
+else
+  fail "PostToolUse: the watchdog bounds the probe (${old_elapsed}s < the fake binary's 30s)"
+fi
+
+# ---------------------------------------------------------------------------
 # No hardcoded absolute user paths in the scripts (everything must come from
 # the stdin payload or the .velesdb-hooks.json config).
 # ---------------------------------------------------------------------------

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -58,6 +58,26 @@ with steps 1-3.
 }}
 ```
 
+## Oversized tool results — usually not your job
+
+A tool result that blew up (a 300 KB build log, a wide `grep`, a fetched
+page) is the single biggest source of context bloat, and it is worth
+compressing *once*, at the moment it arrives — every later turn re-sends it
+otherwise. But you are usually not the one who should do it: the
+`PostToolUse` hook shipped in `integrations/agent-hooks/` compresses it
+before it ever reaches you, using `velesdb-memory compile-stdin` (the
+store-free CLI form of this compiler) and replacing the tool result in
+place. When that hook is installed you will see results ending in a
+`--- velesdb: compiled N tokens down to M …` footer quoting the path of the
+untouched original — `Read` that path when the compiled view is not enough.
+
+Compress a tool result *yourself* only when the hook is not installed, or
+when it deliberately skipped the tool (`Read`/`Edit` outputs are never
+compressed — the exact bytes are the point). In that case treat the output
+as a transcript and call `compile_transcript` on it. Never re-compress
+something that already carries the footer above: it has been compiled once
+already, and compiling a compilation only loses fidelity.
+
 ## Workflow (10 steps)
 
 1. **Scope the problem.** Identify what is about to be sent to the model:


### PR DESCRIPTION
## What

Adds the fourth Claude Code hook, `PostToolUse`, and the store-free CLI it needs.

The three shipped hooks can only **nudge** the model — they hand it a `reason` string and hope it calls the right tool. Nothing in the integration ever reduced the payload itself, which is why the docs had to say VelesDB does not shrink each API call. `PostToolUse` is the one event whose output schema **replaces** what the model sees (`hookSpecificOutput.updatedToolOutput`), so it closes that gap structurally: a 300 KB `Bash` result compiled once here is 300 KB that never enters the transcript, and therefore never gets re-sent on every later turn.

## The constraint, corrected

The README claimed hooks can never touch the store because of the single-writer `flock`. True for the *store* — but the flock is taken at store-open time only (`Database::open`, keyed by data dir), and `ContextCompiler::compile` is pure: no store, no index, no clock. The `context` feature is already `persistence`-free by design. So a hook *can* compile in a separate process, as long as that process never opens a store.

`velesdb-memory compile-stdin --budget N [--query ...]` does exactly that: it short-circuits in `main()` **before** the store open, the same way `--version` does, and prints `{content, tokens_in, tokens_out, tokens_saved, risk}`.

One behavioural decision worth reviewing: **a budget too small to fit any fragment is now an error, not an empty success.** The compiler externalizes rather than truncates, so a tight budget legitimately yields empty content — harmless for a reader, a data loss for a caller that *substitutes* the result. Found by strengthening the test after the first end-to-end run returned empty content at budget 200.

## Safety rules, each with a test

A hook that runs on every tool call and replaces content must never lose data and never hang:

- **Nothing is deleted.** The untouched original is archived under `$TMPDIR/velesdb-agent-hooks/tool-output/` and its path is quoted in the replacement — the out-of-store equivalent of a retrieval handle.
- **Identity fallback everywhere.** No `jq`, no binary, an old binary, a compile error, an empty result — each emits `{}` and leaves the tool result exactly as it was.
- **Bounded.** A `velesdb-memory` predating `compile-stdin` ignores the subcommand and starts the MCP server on the piped stdin. A pure-bash watchdog bounds it (`timeout` is GNU coreutils, absent from a stock macOS), and a cached capability probe tells old binaries from new ones without version guessing.
- **Allowlist, not denylist.** `Bash,Grep,WebFetch` by default. `Read`/`Edit` are excluded by design and must stay excluded — their value *is* the exact bytes.

## Verification

- **TDD:** the 6 Rust tests were written against a stub echoing its input, verified red (`tokens_in must be measured, got 0`), then green.
- `hooks.test.sh`: **30 assertions** (was 20), all green, shellcheck clean, suite run 5x for stability.
- **Mutation-checked** the allowlist assertion: explicitly allowing `Read` does compress, so the test has teeth.
- **End to end against the real binary:** a 10331-byte log became a 4374-byte replacement (4872 → 1928 tokens), original readable at the quoted path.

## Note for reviewers

Until a release ships a binary carrying `compile-stdin`, the hook is **inert** — it detects the missing capability and passes every tool result through untouched. Installing it early costs nothing.