### PR TITLE
fix(memory): bound the Ollama embedding request instead of waiting forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`velesdb-memory`**: the Ollama embedder issued its HTTP request through a
+  bare `ureq::post` with **no timeout at all**, so an Ollama that accepted the
+  connection and never answered (a stalled cold model load, a wedged server)
+  blocked the caller indefinitely. Because `remember` / `save_working_context`
+  embed *before* writing, that surfaced as an opaque MCP transport timeout on
+  the client with nothing in the server's own error path — observed live as
+  `MCP error -32001: Request timed out`. Requests now go through a
+  `ureq::Agent` bounded at 60 s, the same pattern `extract.rs` has used for its
+  own Ollama calls since it was written. Proven by a test that stands up a
+  socket which accepts and never replies: 30.0 s before, bounded after.
+
 ### Added
 
 - **`velesdb-memory`**: `velesdb-memory compile-stdin --budget N [--query …]`

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -112,6 +112,7 @@ pub struct OllamaEmbedder {
     base_url: String,
     model: String,
     dimension: usize,
+    agent: ureq::Agent,
 }
 
 #[cfg(feature = "ollama")]
@@ -125,7 +126,8 @@ impl OllamaEmbedder {
     pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Result<Self, EmbedError> {
         let base_url = base_url.into();
         let model = model.into();
-        let dimension = request_embedding(&base_url, &model, "dimension probe")?.len();
+        let agent = embed_agent(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS));
+        let dimension = request_embedding(&agent, &base_url, &model, "dimension probe")?.len();
         if dimension == 0 {
             return Err(EmbedError::Empty);
         }
@@ -133,6 +135,7 @@ impl OllamaEmbedder {
             base_url,
             model,
             dimension,
+            agent,
         })
     }
 }
@@ -144,7 +147,7 @@ impl Embedder for OllamaEmbedder {
     }
 
     fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
-        request_embedding(&self.base_url, &self.model, text)
+        request_embedding(&self.agent, &self.base_url, &self.model, text)
     }
 }
 
@@ -172,12 +175,41 @@ fn parse_embedding_response(body: &str) -> Result<Vec<f32>, EmbedError> {
     Ok(parsed.embedding)
 }
 
+/// Wall-clock ceiling for one embeddings request.
+///
+/// Generous enough for a COLD Ollama that has to load the model into memory
+/// on the first call (seconds, occasionally tens of seconds), but bounded —
+/// which the bare `ureq::post` used before was not. An unbounded wait here is
+/// not a slow call, it is a **hung caller**: `remember`/`save_working_context`
+/// embed before writing, so an Ollama that accepts the connection and never
+/// answers blocks the MCP tool call until the *client* gives up, surfacing as
+/// an opaque transport timeout with nothing in the server's own error path.
+/// Deliberately far below `extract.rs`'s 300 s: that ceiling covers text
+/// GENERATION, while an embedding that has not returned in a minute is not
+/// going to.
+#[cfg(feature = "ollama")]
+const EMBED_TIMEOUT_SECS: u64 = 60;
+
+/// Agent used for every embeddings request, with [`EMBED_TIMEOUT_SECS`]
+/// applied. Same pattern as [`crate::extract::OllamaExtractor`], which has
+/// bounded its own Ollama calls since it was written.
+#[cfg(feature = "ollama")]
+fn embed_agent(timeout: std::time::Duration) -> ureq::Agent {
+    ureq::AgentBuilder::new().timeout(timeout).build()
+}
+
 /// Perform one blocking embeddings request against a local Ollama.
 #[cfg(feature = "ollama")]
-fn request_embedding(base_url: &str, model: &str, text: &str) -> Result<Vec<f32>, EmbedError> {
+fn request_embedding(
+    agent: &ureq::Agent,
+    base_url: &str,
+    model: &str,
+    text: &str,
+) -> Result<Vec<f32>, EmbedError> {
     let url = format!("{base_url}/api/embeddings");
     let body = build_request_body(model, text);
-    let response = ureq::post(&url)
+    let response = agent
+        .post(&url)
         .set("Content-Type", "application/json")
         .send_string(&body)
         .map_err(|err| EmbedError::Backend(format!("ollama request failed: {err}")))?;
@@ -216,6 +248,54 @@ mod ollama_tests {
     fn rejects_a_malformed_response() {
         let parsed = parse_embedding_response(r#"{"oops":true}"#);
         assert!(matches!(parsed, Err(EmbedError::Backend(_))));
+    }
+
+    /// An Ollama that accepts the TCP connection and then never answers is
+    /// the failure this bound exists for: without it the embed call blocks
+    /// forever, and since `remember`/`save_working_context` embed before
+    /// writing, the MCP tool call hangs until the CLIENT times out — an
+    /// opaque transport error with nothing in the server's own error path.
+    /// Uses a 1 s agent so the test stays fast; the shipped ceiling is
+    /// `EMBED_TIMEOUT_SECS`.
+    #[test]
+    fn a_silent_ollama_is_bounded_instead_of_hanging_forever() {
+        use std::io::Read as _;
+        use std::net::TcpListener;
+        use std::time::{Duration, Instant};
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        // Accept, read the request, then hold the socket open and answer
+        // nothing at all — the exact shape of a stalled model load.
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut socket, _)) = listener.accept() {
+                let mut scratch = [0_u8; 1024];
+                let _ = socket.read(&mut scratch);
+                std::thread::sleep(Duration::from_secs(30));
+            }
+        });
+
+        let agent = embed_agent(Duration::from_secs(1));
+        let started = Instant::now();
+        let outcome = request_embedding(&agent, &format!("http://{addr}"), "all-minilm", "hello");
+        let elapsed = started.elapsed();
+
+        assert!(
+            matches!(outcome, Err(EmbedError::Backend(_))),
+            "a silent backend must surface as a Backend error, got {outcome:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "the request must be bounded by the agent timeout, took {elapsed:?}"
+        );
+        drop(handle);
+    }
+
+    #[test]
+    fn the_shipped_timeout_stays_bounded_and_usable() {
+        // Low enough that an MCP client is still waiting when it fires,
+        // high enough to survive a cold model load.
+        assert!((5..=120).contains(&EMBED_TIMEOUT_SECS));
     }
 
     #[test]


### PR DESCRIPTION
## The symptom

Observed live: an MCP call to `save_working_context` returned `MCP error -32001: Request timed out`, while reads against the same daemon were fine — and an identical retry minutes later, with the same 6 KB payload, succeeded. A transient hang, not a broken payload.

## The cause, read rather than guessed

`request_embedding` issued its HTTP request through a bare `ureq::post`, which carries **no overall timeout**. An Ollama that accepts the TCP connection and then never answers — a stalled cold model load, a wedged server — blocks the call indefinitely.

That matters more than "a slow embed" because `remember` and `save_working_context` embed **before** writing: the block is not a slow tool, it is a hung one. The server never reaches its own error path, so the failure surfaces on the client as an opaque transport timeout with nothing actionable in it.

A second hypothesis was ruled out: `all-minilm` caps at ~512 tokens and Ollama rejects a 7 280-byte prompt with `the input length exceeds the context length` — but it does so in **0.03 s**, and it would fail *every* time, not transiently. That is not what happened here.

## The fix

This crate already had the pattern: `extract.rs` builds a `ureq::Agent` with an explicit `.timeout(...)` for its own Ollama calls. The embedder now does the same.

`60 s`, deliberately far below `extract.rs`'s `300 s` — that ceiling covers text *generation*; an embedding that has not returned within a minute is not going to, and the MCP client stopped waiting long before. The agent is built once in `OllamaEmbedder::new` (and reused for the dimension probe) rather than per request.

## Verification

TDD, with a real red. The new test stands up a socket that accepts, reads the request, then holds the connection open answering nothing:

- **Before**: `the request must be bounded by the agent timeout, took 30.002119042s` — bounded only by the peer closing the socket, i.e. not bounded at all.
- **After**: green.

A second test pins the shipped ceiling inside a usable range, so a future edit cannot quietly restore an unbounded wait.

`cargo clippy -p velesdb-memory --all-targets --features ollama -- -D warnings -D clippy::pedantic` clean; full pre-push gate green.

## Note for reviewers

The 60 s value is a judgement call, not a measurement: high enough to survive a cold model load, low enough that the server returns an actionable error while the client is still waiting. If real cold loads here routinely exceed it, the constant is the single place to adjust — the range test only guards against going back to unbounded.