### PR TITLE
fix(core): scope allocation-ceiling adjustments to the calling thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`velesdb-core`**: the allocation backstop (#899) is no longer disturbed by
+  concurrent index loads. `with_min_alloc_byte_limit` — used by the persisted
+  HNSW load path to admit a file-backed vector payload — raised the
+  *process-global* ceiling for the duration of the load, which had two
+  consequences: while any load was in flight the backstop was effectively lifted
+  for every other thread, and two overlapping loads clobbered each other's saved
+  ceiling (the inner scope saved the outer scope's temporary value and
+  republished it on exit), leaving the process-wide ceiling permanently wrong
+  after both loads had finished. Scoped adjustments are now thread-local via the
+  new `alloc_guard::with_alloc_byte_limit`, so a ceiling installed for one
+  operation is invisible to unrelated threads and overlapping scopes nest
+  correctly. `set_alloc_byte_limit` is unchanged: it remains the process-wide
+  operator policy and still bounds allocations on worker threads.
+
 ### Added
 
+- **`velesdb-core`**: `alloc_guard::with_alloc_byte_limit(limit, f)` — runs `f`
+  with the per-allocation ceiling pinned on the current thread only, restoring
+  the previous value on exit (including on panic). Scoped counterpart to
+  `set_alloc_byte_limit` for hardening or relaxing a single operation.
 - **`velesdb-memory`**: `velesdb-memory compile-stdin --budget N [--query …]`
   — compile text read on stdin with the deterministic context compiler and
   print `{content, tokens_in, tokens_out, tokens_saved, risk}` as JSON. It
@@ -29,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a stock macOS) bounding the call, and an identity fallback on every
   failure path — including a `velesdb-memory` too old to know the
   subcommand, which would otherwise treat the piped stdin as MCP traffic.
+
 
 ## [4.0.0] — 2026-07-24
 

--- a/crates/velesdb-core/src/alloc_guard.rs
+++ b/crates/velesdb-core/src/alloc_guard.rs
@@ -22,6 +22,7 @@
 //! ```
 
 use std::alloc::{alloc, alloc_zeroed, dealloc, Layout};
+use std::cell::Cell;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -69,15 +70,42 @@ pub const DEFAULT_ALLOC_BYTE_LIMIT: usize = usize::MAX;
 
 /// Process-wide per-allocation byte ceiling, initialized to
 /// [`DEFAULT_ALLOC_BYTE_LIMIT`]. See [`set_alloc_byte_limit`].
+///
+/// This is the *operator policy* layer: it is deliberately global so a limit
+/// configured once at startup also governs allocations made on worker threads
+/// (rayon index builds, tokio blocking pool). Short-lived, operation-scoped
+/// adjustments must NOT be made here — see [`with_alloc_byte_limit`].
 static ALLOC_BYTE_LIMIT: AtomicUsize = AtomicUsize::new(DEFAULT_ALLOC_BYTE_LIMIT);
 
-/// Overrides the per-allocation byte ceiling enforced by [`AllocGuard`].
+thread_local! {
+    /// Per-thread override of [`ALLOC_BYTE_LIMIT`], set only for the dynamic
+    /// extent of [`with_alloc_byte_limit`] / [`with_min_alloc_byte_limit`].
+    ///
+    /// Scoped adjustments live here rather than in the global so that a ceiling
+    /// raised (or pinned low) for *one* operation is invisible to every other
+    /// thread. Mutating the global for a scoped adjustment is unsound under
+    /// concurrency: two overlapping scopes each save the ceiling they happen to
+    /// observe and restore it on exit, so the inner scope saves the outer
+    /// scope's temporary value and republishes it after the outer scope has
+    /// already restored — a lost update that leaves the process-wide backstop
+    /// permanently wrong. It also leaves a window in which unrelated threads are
+    /// judged against another operation's ceiling.
+    static THREAD_ALLOC_BYTE_LIMIT: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// Overrides the **process-wide** per-allocation byte ceiling enforced by
+/// [`AllocGuard`].
 ///
 /// Use to raise the limit for genuinely huge single-buffer workloads, or lower
 /// it to harden against pathological sizes. Affects all subsequent allocations
 /// through [`AllocGuard::new`] / [`AllocGuard::new_zeroed`] and
-/// [`check_alloc_bound`]. Passing `0` is treated as "no override" and restores
-/// the default ceiling.
+/// [`check_alloc_bound`], **on every thread**. Passing `0` is treated as "no
+/// override" and restores the default ceiling.
+///
+/// This is intended for process-level configuration (startup / operator
+/// policy). For a ceiling that applies only to one operation, use
+/// [`with_alloc_byte_limit`] — a scoped, thread-local override that takes
+/// precedence over this value on the thread that installs it.
 pub fn set_alloc_byte_limit(limit_bytes: usize) {
     let effective = if limit_bytes == 0 {
         DEFAULT_ALLOC_BYTE_LIMIT
@@ -87,10 +115,40 @@ pub fn set_alloc_byte_limit(limit_bytes: usize) {
     ALLOC_BYTE_LIMIT.store(effective, Ordering::Relaxed);
 }
 
-/// Returns the current per-allocation byte ceiling.
+/// Returns the per-allocation byte ceiling in force **on the current thread**:
+/// the innermost [`with_alloc_byte_limit`] scope if one is active, otherwise the
+/// process-wide value set by [`set_alloc_byte_limit`].
 #[must_use]
 pub fn alloc_byte_limit() -> usize {
-    ALLOC_BYTE_LIMIT.load(Ordering::Relaxed)
+    THREAD_ALLOC_BYTE_LIMIT
+        .try_with(Cell::get)
+        .unwrap_or(None)
+        .unwrap_or_else(|| ALLOC_BYTE_LIMIT.load(Ordering::Relaxed))
+}
+
+/// Runs `f` with the per-allocation ceiling pinned to `limit_bytes` **on the
+/// current thread only**, restoring the previous state afterward (even on
+/// panic).
+///
+/// Scoped counterpart to [`set_alloc_byte_limit`]: use it to harden (or relax) a
+/// single operation without publishing that ceiling to unrelated threads. Nests
+/// correctly — an inner scope restores the outer scope's ceiling, not the global
+/// one. Passing `0` pins the scope to [`DEFAULT_ALLOC_BYTE_LIMIT`], matching
+/// [`set_alloc_byte_limit`]'s "no override" convention.
+pub fn with_alloc_byte_limit<T>(limit_bytes: usize, f: impl FnOnce() -> T) -> T {
+    let effective = if limit_bytes == 0 {
+        DEFAULT_ALLOC_BYTE_LIMIT
+    } else {
+        limit_bytes
+    };
+    // RAII restore so a panic inside `f` cannot leak the scoped ceiling.
+    // `try_with` so an override installed during thread-local teardown degrades
+    // to "no scope" rather than panicking.
+    let previous = THREAD_ALLOC_BYTE_LIMIT
+        .try_with(|scoped| scoped.replace(Some(effective)))
+        .unwrap_or(None);
+    let _restore = ScopedLimitRestore(previous);
+    f()
 }
 
 /// Runs `f` with the per-allocation ceiling raised to **at least** `min_bytes`,
@@ -107,24 +165,28 @@ pub fn alloc_byte_limit() -> usize {
 ///
 /// If the current ceiling already covers `min_bytes`, this is a transparent
 /// pass-through with no mutation.
+///
+/// The raise is **thread-local** (see [`with_alloc_byte_limit`]): a load in
+/// flight must not lift the backstop for allocations happening concurrently on
+/// unrelated threads, and two concurrent loads must not clobber each other's
+/// saved ceiling. The allocations this scope exists to admit are performed
+/// synchronously by `f` on the calling thread.
 pub fn with_min_alloc_byte_limit<T>(min_bytes: usize, f: impl FnOnce() -> T) -> T {
-    let previous = alloc_byte_limit();
-    if min_bytes <= previous {
+    if min_bytes <= alloc_byte_limit() {
         return f();
     }
-    // RAII restore so a panic inside `f` cannot leave the ceiling raised.
-    let _restore = LimitRestore(previous);
-    ALLOC_BYTE_LIMIT.store(min_bytes, Ordering::Relaxed);
-    f()
+    with_alloc_byte_limit(min_bytes, f)
 }
 
-/// RAII helper that restores [`ALLOC_BYTE_LIMIT`] to a saved value on drop,
-/// including during unwinding. Used by [`with_min_alloc_byte_limit`].
-struct LimitRestore(usize);
+/// RAII helper that restores [`THREAD_ALLOC_BYTE_LIMIT`] to a saved value on
+/// drop, including during unwinding. Used by [`with_alloc_byte_limit`].
+struct ScopedLimitRestore(Option<usize>);
 
-impl Drop for LimitRestore {
+impl Drop for ScopedLimitRestore {
     fn drop(&mut self) {
-        ALLOC_BYTE_LIMIT.store(self.0, Ordering::Relaxed);
+        // `try_with` (not `set`) so a drop running during thread-local teardown
+        // degrades to a no-op instead of panicking.
+        let _ = THREAD_ALLOC_BYTE_LIMIT.try_with(|scoped| scoped.set(self.0));
     }
 }
 

--- a/crates/velesdb-core/src/alloc_guard_tests.rs
+++ b/crates/velesdb-core/src/alloc_guard_tests.rs
@@ -131,9 +131,21 @@ fn test_alloc_guard_panic_safety() {
 // =========================================================================
 // #899 — Allocation-bound regression tests
 //
-// Tests that read or mutate the process-global `ALLOC_BYTE_LIMIT` are marked
-// `#[serial]` so they cannot observe or corrupt each other's view of the
-// global; each one also saves and restores the limit it changes.
+// Tests here may only ever *raise* the process-global `ALLOC_BYTE_LIMIT` back
+// to its default (`set_alloc_byte_limit(0)`); they must NEVER pin it to a low
+// value.
+//
+// `#[serial]` is not sufficient protection: it only excludes other `#[serial]`
+// tests, while the thousands of unannotated tests in this binary keep running
+// in parallel against whatever ceiling is installed. A low global ceiling
+// therefore fails unrelated tests at random with an `AllocationFailed` naming a
+// limit they never configured (observed 2026-07-25). `#[serial]` is kept below
+// only so these tests do not race each other's *reads* of the global.
+//
+// - Need a low ceiling for one operation? Use `with_alloc_byte_limit`
+//   (thread-local, scoped, invisible to other threads).
+// - Need to verify the process-global setter itself? It lives in its own test
+//   binary: `tests/alloc_guard_global_limit.rs`.
 // =========================================================================
 
 /// The default ceiling is the high 1 TiB backstop — not a 16 GiB workload cap.
@@ -183,24 +195,9 @@ fn test_check_alloc_bound() {
     set_alloc_byte_limit(saved);
 }
 
-/// The ceiling is configurable; `0` restores the default.
-#[test]
-#[serial]
-fn test_set_alloc_byte_limit_roundtrip() {
-    let original = alloc_byte_limit();
-
-    set_alloc_byte_limit(8192);
-    assert_eq!(alloc_byte_limit(), 8192);
-    assert!(AllocGuard::new(Layout::from_size_align(16384, 8).unwrap()).is_none());
-    assert!(AllocGuard::new(Layout::from_size_align(4096, 8).unwrap()).is_some());
-
-    // `0` means "no override" → back to default.
-    set_alloc_byte_limit(0);
-    assert_eq!(alloc_byte_limit(), DEFAULT_ALLOC_BYTE_LIMIT);
-
-    // Restore whatever the harness started with.
-    set_alloc_byte_limit(original);
-}
+// `test_set_alloc_byte_limit_roundtrip` moved to
+// `tests/alloc_guard_global_limit.rs`: it must pin the process-global ceiling to
+// 8192, which is unsafe in this binary (see the module note above).
 
 /// REGRESSION (#899 follow-up): a large-but-legitimate single-buffer size that
 /// the old 16 GiB cap would have falsely rejected is now accepted by the
@@ -228,26 +225,30 @@ fn test_large_legit_buffer_not_falsely_rejected() {
 /// the file-backed payload, so a realistic large `count` (above the old cap)
 /// reloads. `with_min_alloc_byte_limit` raises the ceiling to the file-backed
 /// size for the load scope, then restores it.
+///
+/// The low starting ceiling is pinned with `with_alloc_byte_limit` (thread-local)
+/// rather than `set_alloc_byte_limit` (process-global): pinning 4096 globally
+/// made every *other* test in this binary fail at random with an unrelated
+/// `AllocationFailed` while the window was open. `#[serial]` does not prevent
+/// that — it only excludes other `#[serial]` tests, and the thousands of
+/// unannotated tests keep running in parallel.
 #[test]
-#[serial]
 fn test_load_path_bound_allows_realistic_large_count() {
-    let saved = alloc_byte_limit();
     // Pin a deliberately low limit to prove the load path raises past it.
-    set_alloc_byte_limit(4096);
+    with_alloc_byte_limit(4096, || {
+        // ~30 GiB file-backed payload (8M vectors @768D *4 ≈ 24 GiB) — a legit
+        // persisted index. The load path must accept its own file-backed size.
+        let file_backed_bytes = 30usize * 1024 * 1024 * 1024;
+        let inner = with_min_alloc_byte_limit(file_backed_bytes, || {
+            // Inside the scope the ceiling covers the file-backed size.
+            assert!(check_alloc_bound(file_backed_bytes).is_ok());
+            alloc_byte_limit()
+        });
+        assert_eq!(inner, file_backed_bytes, "ceiling raised within load scope");
 
-    // ~30 GiB file-backed payload (8M vectors @768D *4 ≈ 24 GiB) — a legit
-    // persisted index. The load path must accept its own file-backed size.
-    let file_backed_bytes = 30usize * 1024 * 1024 * 1024;
-    let inner = with_min_alloc_byte_limit(file_backed_bytes, || {
-        // Inside the scope the ceiling covers the file-backed size.
-        assert!(check_alloc_bound(file_backed_bytes).is_ok());
-        alloc_byte_limit()
+        // Restored after the scope (no leak of the raised limit).
+        assert_eq!(alloc_byte_limit(), 4096);
     });
-    assert_eq!(inner, file_backed_bytes, "ceiling raised within load scope");
-
-    // Restored after the scope (no leak of the raised limit).
-    assert_eq!(alloc_byte_limit(), 4096);
-    set_alloc_byte_limit(saved);
 }
 
 /// `with_min_alloc_byte_limit` is a transparent pass-through when the current
@@ -267,22 +268,165 @@ fn test_with_min_alloc_byte_limit_passthrough() {
     set_alloc_byte_limit(saved);
 }
 
+// =========================================================================
+// Scoped-ceiling isolation — regression tests
+//
+// A scoped ceiling adjustment used to be written to the process-global
+// `ALLOC_BYTE_LIMIT`. Two independent defects followed, both reproduced
+// deterministically below with barriers rather than left to scheduling luck.
+// =========================================================================
+
+/// REGRESSION: a scoped raise must not lift the backstop for allocations
+/// happening concurrently on unrelated threads.
+///
+/// While a global raise was in flight, every other thread was judged against the
+/// raised ceiling — precisely the pathological sizes the #899 backstop exists to
+/// reject were admitted for the duration of any index load.
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn test_scoped_raise_is_not_visible_to_other_threads() {
+    const TWO_TIB: usize = 2 * 1024 * 1024 * 1024 * 1024;
+
+    let expected = alloc_byte_limit();
+    let observed = with_min_alloc_byte_limit(TWO_TIB, || {
+        // A raise on THIS thread is in force here...
+        assert_eq!(alloc_byte_limit(), TWO_TIB, "raise applies to this thread");
+        // ...but a concurrent thread must still see the unraised ceiling.
+        std::thread::spawn(|| (alloc_byte_limit(), check_alloc_bound(TWO_TIB).is_err()))
+            .join()
+            .expect("observer thread panicked")
+    });
+
+    assert_eq!(
+        observed.0, expected,
+        "scoped raise leaked to another thread: the allocation backstop was \
+         silently lifted process-wide for the duration of the scope"
+    );
+    assert!(
+        observed.1,
+        "an oversized allocation must still be rejected on threads outside the scope"
+    );
+}
+
+/// REGRESSION: overlapping scoped adjustments must not clobber each other.
+///
+/// With a single global cell, each scope saves the ceiling it happens to observe
+/// on entry and restores it on exit. When two scopes overlap, the inner one saves
+/// the outer one's temporary value and republishes it after the outer has already
+/// restored — a lost update that leaves the process-wide backstop permanently
+/// wrong (here: pinned at 2 TiB forever, long after both loads finished).
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn test_overlapping_scoped_raises_do_not_clobber() {
+    use std::sync::{Arc, Barrier};
+
+    const TWO_TIB: usize = 2 * 1024 * 1024 * 1024 * 1024;
+    const THREE_TIB: usize = 3 * 1024 * 1024 * 1024 * 1024;
+
+    let before = alloc_byte_limit();
+
+    // Force the exact interleaving: A enters, B enters, A exits, B exits.
+    let (entered_a, entered_b, exited_a) = (
+        Arc::new(Barrier::new(2)),
+        Arc::new(Barrier::new(2)),
+        Arc::new(Barrier::new(2)),
+    );
+
+    let (a1, b1, x1) = (
+        Arc::clone(&entered_a),
+        Arc::clone(&entered_b),
+        Arc::clone(&exited_a),
+    );
+    let thread_a = std::thread::spawn(move || {
+        with_min_alloc_byte_limit(TWO_TIB, || {
+            a1.wait(); // A is inside its scope
+            b1.wait(); // wait until B is inside its scope too
+        });
+        x1.wait(); // A has left its scope
+    });
+
+    let thread_b = std::thread::spawn(move || {
+        entered_a.wait(); // enter only once A is inside
+        with_min_alloc_byte_limit(THREE_TIB, || {
+            entered_b.wait(); // B is inside its scope
+            exited_a.wait(); // hold the scope open until A has left
+        });
+    });
+
+    thread_a.join().expect("thread A panicked");
+    thread_b.join().expect("thread B panicked");
+
+    assert_eq!(
+        alloc_byte_limit(),
+        before,
+        "overlapping scopes corrupted the ceiling: it must be exactly as it was \
+         before both scopes ran, not a value republished by a lost update"
+    );
+}
+
+/// REGRESSION (2026-07-25 flake): pinning a *low* ceiling for one operation must
+/// not make a legitimate allocation fail on another thread.
+///
+/// A low ceiling pinned globally by the `alloc_guard` tests made unrelated tests
+/// in the same binary fail at random with an `AllocationFailed` naming a limit
+/// they never configured (observed: a 1.6 MB agent-memory buffer rejected
+/// against a 4096-byte ceiling).
+#[test]
+fn test_low_scoped_ceiling_does_not_break_other_threads() {
+    // The exact allocation from the reported failure: a 4-dim collection with
+    // 100_000 capacity = 1_600_000 bytes.
+    const LEGITIMATE_BYTES: usize = 4 * 100_000 * std::mem::size_of::<f32>();
+
+    let admitted = with_alloc_byte_limit(4096, || {
+        assert!(
+            check_alloc_bound(LEGITIMATE_BYTES).is_err(),
+            "the pinned ceiling must still be enforced on the pinning thread"
+        );
+        std::thread::spawn(|| check_alloc_bound(LEGITIMATE_BYTES).is_ok())
+            .join()
+            .expect("observer thread panicked")
+    });
+
+    assert!(
+        admitted,
+        "a ceiling pinned low for one operation must not reject legitimate \
+         allocations on unrelated threads"
+    );
+}
+
+/// A scoped ceiling nests: the inner scope restores the outer scope's value, not
+/// the process-global one.
+#[test]
+fn test_scoped_alloc_byte_limit_nests() {
+    with_alloc_byte_limit(8192, || {
+        assert_eq!(alloc_byte_limit(), 8192);
+        with_alloc_byte_limit(4096, || {
+            assert_eq!(alloc_byte_limit(), 4096);
+        });
+        assert_eq!(
+            alloc_byte_limit(),
+            8192,
+            "inner scope restored the outer one"
+        );
+    });
+}
+
 /// `with_min_alloc_byte_limit` restores the previous ceiling even if the closure
 /// panics (RAII restore), so a panicking load cannot leak a raised limit.
 #[test]
-#[serial]
 fn test_with_min_alloc_byte_limit_restores_on_panic() {
     use std::panic;
-    let saved = alloc_byte_limit();
-    set_alloc_byte_limit(4096);
 
-    let huge = 30usize * 1024 * 1024 * 1024;
-    let result = panic::catch_unwind(|| {
-        with_min_alloc_byte_limit(huge, || {
-            panic!("simulated load failure");
+    // Thread-local pin (see `test_load_path_bound_allows_realistic_large_count`
+    // for why this must not be a global `set_alloc_byte_limit`).
+    with_alloc_byte_limit(4096, || {
+        let huge = 30usize * 1024 * 1024 * 1024;
+        let result = panic::catch_unwind(|| {
+            with_min_alloc_byte_limit(huge, || {
+                panic!("simulated load failure");
+            });
         });
+        assert!(result.is_err());
+        assert_eq!(alloc_byte_limit(), 4096, "ceiling restored after panic");
     });
-    assert!(result.is_err());
-    assert_eq!(alloc_byte_limit(), 4096, "ceiling restored after panic");
-    set_alloc_byte_limit(saved);
 }

--- a/crates/velesdb-core/src/lock_rank_tests.rs
+++ b/crates/velesdb-core/src/lock_rank_tests.rs
@@ -136,12 +136,56 @@ proptest! {
         let (lo, hi) = (x.min(y), x.max(y));
         let (low, high) = (rank(lo), rank(hi));
 
-        // Silence the panic hook so the expected violation is not noisy.
-        let prev_hook = std::panic::take_hook();
-        std::panic::set_hook(Box::new(|_| {}));
-        let outcome = std::panic::catch_unwind(|| assert_lock_order(high, low));
-        std::panic::set_hook(prev_hook);
+        // Silence the expected violation without muting the rest of the binary.
+        let outcome = with_panic_output_silenced(|| {
+            std::panic::catch_unwind(|| assert_lock_order(high, low))
+        });
 
         prop_assert!(outcome.is_err());
     }
+}
+
+/// Runs `f` with panic output from **this thread** suppressed.
+///
+/// `std::panic::set_hook` is process-global. The previous pattern here —
+/// install a no-op hook, run, restore — therefore swallowed the panic output of
+/// every test running concurrently in this binary for the duration of the
+/// window, and since it sits inside a proptest the window was reopened once per
+/// generated case. It never failed a test, but it could hide the diagnostics of
+/// an unrelated failure, which is exactly what one wants to read when a suite
+/// goes red.
+///
+/// The hook is instead installed once for the process and filters on a
+/// thread-local flag, so only the panic this test deliberately provokes is
+/// hidden and other threads keep printing normally.
+#[cfg(debug_assertions)]
+fn with_panic_output_silenced<T>(f: impl FnOnce() -> T) -> T {
+    use std::cell::Cell;
+    use std::sync::Once;
+
+    thread_local! {
+        static SILENCED: Cell<bool> = const { Cell::new(false) };
+    }
+    static INSTALL_HOOK: Once = Once::new();
+
+    /// Clears the flag on drop so an unwind cannot leave this thread muted.
+    struct Unsilence;
+    impl Drop for Unsilence {
+        fn drop(&mut self) {
+            SILENCED.with(|silenced| silenced.set(false));
+        }
+    }
+
+    INSTALL_HOOK.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if !SILENCED.with(Cell::get) {
+                previous(info);
+            }
+        }));
+    });
+
+    SILENCED.with(|silenced| silenced.set(true));
+    let _unsilence = Unsilence;
+    f()
 }

--- a/crates/velesdb-core/src/update_check/config.rs
+++ b/crates/velesdb-core/src/update_check/config.rs
@@ -83,21 +83,88 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
+    /// Restores an environment variable to its pre-test value on drop,
+    /// including while unwinding.
+    ///
+    /// The previous pattern set the variable, asserted, then removed it on the
+    /// last line. A failing assertion skipped that line and leaked the variable
+    /// to **every later test in this process** — `VELESDB_NO_UPDATE_CHECK` would
+    /// stay set and silently disable update checks for the rest of the run, so
+    /// one red test could mask a second one. The `remove_var`-first tests had the
+    /// mirror problem: they clobbered whatever the surrounding environment had
+    /// configured and never put it back.
+    ///
+    /// `#[serial(env)]` does not help with either: it orders these tests against
+    /// each other, not against a leak that outlives them.
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        /// Sets `key` to `value` for the lifetime of the guard.
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        /// Clears `key` for the lifetime of the guard.
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    /// The guard restores the variable even when the test body panics — the
+    /// property the old set/assert/remove ordering lacked.
+    ///
+    /// Uses a dedicated key so it needs no serialization: no other test reads
+    /// or writes it.
+    #[test]
+    fn test_env_var_guard_restores_on_unwind() {
+        const KEY: &str = "VELESDB_TEST_ENV_GUARD_PROBE";
+        std::env::set_var(KEY, "original");
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = EnvVarGuard::set(KEY, "overridden");
+            assert_eq!(std::env::var(KEY).as_deref(), Ok("overridden"));
+            panic!("simulated assertion failure");
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::env::var(KEY).as_deref(),
+            Ok("original"),
+            "a panicking test must not leak its environment override to the rest \
+             of the process"
+        );
+        std::env::remove_var(KEY);
+    }
+
     #[test]
     #[serial(env)]
     fn test_env_var_disables_update_check() {
-        std::env::set_var("VELESDB_NO_UPDATE_CHECK", "1");
+        let _no_check = EnvVarGuard::set("VELESDB_NO_UPDATE_CHECK", "1");
 
         let config = UpdateCheckConfig::default();
         assert!(!config.is_enabled());
-
-        std::env::remove_var("VELESDB_NO_UPDATE_CHECK");
     }
 
     #[test]
     #[serial(env)]
     fn test_env_var_overrides_config() {
-        std::env::set_var("VELESDB_NO_UPDATE_CHECK", "1");
+        let _no_check = EnvVarGuard::set("VELESDB_NO_UPDATE_CHECK", "1");
 
         let config = UpdateCheckConfig {
             enabled: true, // Config says yes
@@ -105,15 +172,13 @@ mod tests {
         };
 
         assert!(!config.is_enabled()); // But env says no
-
-        std::env::remove_var("VELESDB_NO_UPDATE_CHECK");
     }
 
     #[test]
     #[serial(env)]
     fn test_config_disabled() {
-        std::env::remove_var("VELESDB_NO_UPDATE_CHECK");
-        std::env::remove_var("VELESDB_UPDATE_CHECK");
+        let _no_check = EnvVarGuard::unset("VELESDB_NO_UPDATE_CHECK");
+        let _check = EnvVarGuard::unset("VELESDB_UPDATE_CHECK");
 
         let config = UpdateCheckConfig {
             enabled: false,
@@ -126,8 +191,8 @@ mod tests {
     #[test]
     #[serial(env)]
     fn test_default_enabled() {
-        std::env::remove_var("VELESDB_NO_UPDATE_CHECK");
-        std::env::remove_var("VELESDB_UPDATE_CHECK");
+        let _no_check = EnvVarGuard::unset("VELESDB_NO_UPDATE_CHECK");
+        let _check = EnvVarGuard::unset("VELESDB_UPDATE_CHECK");
 
         let config = UpdateCheckConfig::default();
         assert!(config.is_enabled());

--- a/crates/velesdb-core/tests/alloc_guard_global_limit.rs
+++ b/crates/velesdb-core/tests/alloc_guard_global_limit.rs
@@ -1,0 +1,72 @@
+//! Process-global allocation-ceiling tests (#899).
+//!
+//! # Why these live in their own test binary
+//!
+//! [`set_alloc_byte_limit`] configures a **process-global** ceiling: that is its
+//! contract, so a test that pins it to a small value necessarily lowers it for
+//! every thread in the process.
+//!
+//! Inside `--lib`, that is unsafe at any level of annotation. `#[serial]`
+//! (serial_test) only excludes other `#[serial]` tests; the thousands of
+//! unannotated tests in the same binary keep running in parallel and are judged
+//! against whatever ceiling happens to be installed. On 2026-07-25 this
+//! surfaced as a reproducible flake: with a 4096-byte ceiling pinned by
+//! `alloc_guard`, an unrelated agent-memory test failed on a legitimate
+//! 1_600_000-byte buffer with an `AllocationFailed` naming a limit it never
+//! configured. The test that failed varied run to run; only the full suite
+//! showed it, and each test passed in isolation.
+//!
+//! Process-global state needs *process* isolation. Cargo runs every integration
+//! test target as its own process, so these tests get a private global here and
+//! cannot perturb — or be perturbed by — the main suite. The scoped, thread-local
+//! counterpart (`with_alloc_byte_limit`) is exercised in the `--lib` tests, where
+//! it is safe by construction.
+
+use serial_test::serial;
+use std::alloc::Layout;
+use velesdb_core::alloc_guard::{
+    alloc_byte_limit, set_alloc_byte_limit, AllocGuard, DEFAULT_ALLOC_BYTE_LIMIT,
+};
+
+/// The ceiling is configurable process-wide; `0` restores the default.
+#[test]
+#[serial]
+fn test_set_alloc_byte_limit_roundtrip() {
+    let original = alloc_byte_limit();
+
+    set_alloc_byte_limit(8192);
+    assert_eq!(alloc_byte_limit(), 8192);
+    assert!(AllocGuard::new(Layout::from_size_align(16384, 8).unwrap()).is_none());
+    assert!(AllocGuard::new(Layout::from_size_align(4096, 8).unwrap()).is_some());
+
+    // `0` means "no override" → back to default.
+    set_alloc_byte_limit(0);
+    assert_eq!(alloc_byte_limit(), DEFAULT_ALLOC_BYTE_LIMIT);
+
+    // Restore whatever the harness started with.
+    set_alloc_byte_limit(original);
+}
+
+/// The global ceiling applies to **every** thread — that is the whole point of
+/// `set_alloc_byte_limit`, and what distinguishes it from the thread-local
+/// `with_alloc_byte_limit` scope.
+#[test]
+#[serial]
+fn test_global_limit_applies_to_worker_threads() {
+    let original = alloc_byte_limit();
+
+    set_alloc_byte_limit(8192);
+    let rejected_on_worker = std::thread::spawn(|| {
+        AllocGuard::new(Layout::from_size_align(16384, 8).unwrap()).is_none()
+    })
+    .join()
+    .expect("worker thread panicked");
+
+    set_alloc_byte_limit(original);
+
+    assert!(
+        rejected_on_worker,
+        "an operator-configured ceiling must bound allocations on worker threads \
+         (rayon index builds, tokio blocking pool), not just the caller's thread"
+    );
+}

--- a/crates/velesdb-core/tests/alloc_guard_global_limit.rs
+++ b/crates/velesdb-core/tests/alloc_guard_global_limit.rs
@@ -7,7 +7,7 @@
 //! every thread in the process.
 //!
 //! Inside `--lib`, that is unsafe at any level of annotation. `#[serial]`
-//! (serial_test) only excludes other `#[serial]` tests; the thousands of
+//! (`serial_test`) only excludes other `#[serial]` tests; the thousands of
 //! unannotated tests in the same binary keep running in parallel and are judged
 //! against whatever ceiling happens to be installed. On 2026-07-25 this
 //! surfaced as a reproducible flake: with a 4096-byte ceiling pinned by

--- a/crates/velesdb-core/tests/concurrency_lock_order.rs
+++ b/crates/velesdb-core/tests/concurrency_lock_order.rs
@@ -160,15 +160,52 @@ fn test_core_acquisition_path_is_strictly_ascending() {
 #[cfg(debug_assertions)]
 #[test]
 fn test_descending_acquisition_is_detected() {
-    let prev_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
-    let outcome = std::panic::catch_unwind(|| {
-        assert_lock_order(LockRank::NEIGHBORS, LockRank::GPU_VECTORS_SNAPSHOT);
+    let outcome = with_panic_output_silenced(|| {
+        std::panic::catch_unwind(|| {
+            assert_lock_order(LockRank::NEIGHBORS, LockRank::GPU_VECTORS_SNAPSHOT);
+        })
     });
-    std::panic::set_hook(prev_hook);
 
     assert!(
         outcome.is_err(),
         "descending acquisition must trip the lock-order assertion in debug builds"
     );
+}
+
+/// Runs `f` with panic output from **this thread** suppressed.
+///
+/// `std::panic::set_hook` is process-global, so installing a no-op hook for the
+/// duration of a `catch_unwind` also mutes the other tests running in parallel
+/// in this binary. Installing it once and filtering on a thread-local flag hides
+/// only the panic this test deliberately provokes.
+#[cfg(debug_assertions)]
+fn with_panic_output_silenced<T>(f: impl FnOnce() -> T) -> T {
+    use std::cell::Cell;
+    use std::sync::Once;
+
+    thread_local! {
+        static SILENCED: Cell<bool> = const { Cell::new(false) };
+    }
+    static INSTALL_HOOK: Once = Once::new();
+
+    /// Clears the flag on drop so an unwind cannot leave this thread muted.
+    struct Unsilence;
+    impl Drop for Unsilence {
+        fn drop(&mut self) {
+            SILENCED.with(|silenced| silenced.set(false));
+        }
+    }
+
+    INSTALL_HOOK.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if !SILENCED.with(Cell::get) {
+                previous(info);
+            }
+        }));
+    });
+
+    SILENCED.with(|silenced| silenced.set(true));
+    let _unsilence = Unsilence;
+    f()
 }


### PR DESCRIPTION
Reprise de #1592, dont la branche `claude/dazzling-wozniak-c53758` était rejetée par la règle de nommage Git Flow (`claude/*` n'est pas un préfixe autorisé à cibler `develop`). Contenu identique, plus deux corrections.

## Le défaut

`with_min_alloc_byte_limit` — utilisé par le chargement HNSW persisté pour admettre une charge vectorielle adossée à un fichier — élevait le plafond d'allocation **process-global** pendant toute la durée du chargement. Deux conséquences :

1. tant qu'un chargement était en cours, le garde-fou était de fait **levé pour tous les autres threads** ;
2. deux chargements simultanés écrasaient mutuellement leur valeur sauvegardée (la portée interne sauvait la valeur temporaire de la portée externe et la republiait en sortant), laissant le plafond **durablement faux après** la fin des deux chargements.

Les ajustements de portée sont désormais **thread-local** via `alloc_guard::with_alloc_byte_limit`. `set_alloc_byte_limit` est inchangé : il reste la politique opérateur process-wide.

## Comment il a été trouvé

Un test sans rapport, `agent::velesql_bridge_tests::tests::test_procedural_memory_confidence_filter`, échouait au hasard dans la suite complète avec `AllocationFailed("requested allocation of 1600000 bytes exceeds ceiling of 4096 bytes")`. Le plafond de 4096 venait de `alloc_guard_tests.rs`, dont les tests portent `#[serial]` — mais `#[serial]` n'exclut que les autres `#[serial]`, pas les milliers de tests non annotés du même binaire.

Ce n'était donc pas un défaut de tests : les tests révélaient un bug de production.

## Corrections ajoutées ici

- `doc_markdown` : backticks autour de `serial_test` (`alloc_guard_global_limit.rs:10`), exigé par `-D clippy::pedantic` en CI.
- Merge de `develop` pour la freshness, avec résolution du conflit CHANGELOG : les entrées de cette PR et celle du timeout Ollama (#1591) sont **toutes deux conservées**.