### PR TITLE
fix(hooks): scan added lines only in the pre-commit secret check

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -116,8 +116,11 @@ if [ -n "$STAGED_PY_FILES" ]; then
 fi
 
 # 7. Check for secrets (basic check)
+# Added lines only: the scan stops a secret from entering the repository, so a
+# commit that deletes one -- or merely touches a file that already contains one
+# -- must go through. '+++' is the file header, not content.
 echo -e "\n${YELLOW}🔐 Checking for potential secrets...${NC}"
-if git diff --cached --diff-filter=ACM | grep -iE '(api_key|secret|password|token)\s*=\s*["\x27][^"\x27]+["\x27]' | grep -v '#' | grep -v '//'; then
+if git diff --cached --diff-filter=ACM | grep '^+' | grep -v '^+++' | grep -iE '(api_key|secret|password|token)\s*=\s*["\x27][^"\x27]+["\x27]' | grep -v '#' | grep -v '//'; then
     echo -e "${RED}❌ Potential secret detected in staged changes!${NC}"
     echo -e "${RED}   Please remove secrets before committing.${NC}"
     exit 1

--- a/.github/workflows/gate-contracts.yml
+++ b/.github/workflows/gate-contracts.yml
@@ -1,0 +1,31 @@
+name: Gate Contracts
+
+# The suites under scripts/tests/ assert that the repository's own guards
+# behave: the pre-commit secret scan, the promise-contract checker, the
+# production-unwrap checker, the feature-claim checker. Until this workflow
+# existed none of them was run by anything, so a guard could rot -- or be
+# plain wrong -- without a single job turning red.
+#
+# Deliberately not path-filtered. A filter is how a gate quietly stops
+# running: these suites cost seconds, so they run on every change.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  script-gates:
+    name: Repository guard contracts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Run the guard contract suites
+        run: python -m unittest discover -s scripts/tests -p "test_*.py" -t . -v

--- a/scripts/tests/test_pre_commit_secret_scan.py
+++ b/scripts/tests/test_pre_commit_secret_scan.py
@@ -1,0 +1,128 @@
+"""Contract tests for the secret scan in .githooks/pre-commit.
+
+The scan exists to stop a secret from *entering* the repository. It must
+therefore look at added lines only: a commit that deletes a credential is
+the fix, not the offence, and blocking it teaches contributors to reach for
+``--no-verify`` -- which disables every other check in the hook too.
+
+The hook is driven through its real entrypoint. Staging a single Markdown
+file keeps the Rust and Python sections skipped, so each case costs
+milliseconds and still exercises the shipped code rather than a copy of its
+regex.
+"""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_COMMIT_HOOK = REPO_ROOT / ".githooks" / "pre-commit"
+
+# Assembled from fragments on purpose. Spelled out on one line, these
+# fixtures would themselves match the scan under test, and this file could
+# not be committed -- correctly so, since the scan cannot tell a fixture
+# from the real thing.
+_ENV_VAR = "MY_API" + "_KEY"
+_PLACEHOLDER = "your-secret" + "-key"
+SECRET_LINE = f'export {_ENV_VAR}="{_PLACEHOLDER}"'
+
+_OTHER_VAR = "OTHER_TO" + "KEN"
+OTHER_SECRET_LINE = f'export {_OTHER_VAR}="live-value"'
+
+
+class PreCommitSecretScanTests(unittest.TestCase):
+    """Drive the shipped hook against synthetic commits."""
+
+    def _run_hook(self, before: str, after: str):
+        """Commit ``before``, stage ``after``, then run the hook on it.
+
+        Returns the CompletedProcess of the hook invocation.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            run = lambda *args: subprocess.run(  # noqa: E731
+                args, cwd=repo, capture_output=True, text=True, check=True
+            )
+            run("git", "init", "-q")
+            run("git", "config", "user.email", "test@example.com")
+            run("git", "config", "user.name", "test")
+
+            doc = repo / "NOTES.md"
+            doc.write_text(before, encoding="utf-8")
+            run("git", "add", "NOTES.md")
+            run("git", "commit", "-q", "--no-verify", "-m", "baseline")
+
+            doc.write_text(after, encoding="utf-8")
+            run("git", "add", "NOTES.md")
+
+            return subprocess.run(
+                ["bash", str(PRE_COMMIT_HOOK)],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+            )
+
+    def test_01_removing_a_secret_is_allowed(self):
+        """Deleting a credential must not be blocked.
+
+        This is the defect: scanning the whole diff makes the ``-`` line
+        match, so the commit that removes a secret is the one refused.
+        """
+        result = self._run_hook(
+            before=f"# Notes\n\n```bash\n{SECRET_LINE}\n```\n",
+            after="# Notes\n\nSecrets now live in the environment.\n",
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "removing a secret must be allowed, got:\n"
+            f"{result.stdout}\n{result.stderr}",
+        )
+
+    def test_02_adding_a_secret_is_still_blocked(self):
+        """The scan must keep catching a credential being introduced."""
+        result = self._run_hook(
+            before="# Notes\n",
+            after=f"# Notes\n\n```bash\n{SECRET_LINE}\n```\n",
+        )
+        self.assertEqual(
+            result.returncode,
+            1,
+            "adding a secret must be blocked, got:\n"
+            f"{result.stdout}\n{result.stderr}",
+        )
+
+    def test_03_a_secret_added_beside_a_removal_is_still_blocked(self):
+        """A removal in the same diff must not mask an addition."""
+        result = self._run_hook(
+            before=f"# Notes\n\n```bash\n{SECRET_LINE}\n```\n",
+            after=f"# Notes\n\n```bash\n{OTHER_SECRET_LINE}\n```\n",
+        )
+        self.assertEqual(
+            result.returncode,
+            1,
+            "an added secret must be caught even when the diff also removes"
+            f" one, got:\n{result.stdout}\n{result.stderr}",
+        )
+
+    def test_04_unchanged_context_lines_do_not_trigger(self):
+        """A pre-existing credential must not block unrelated edits.
+
+        Context lines carry no ``+``; only a diff-wide scan would see them.
+        """
+        body = f"# Notes\n\n```bash\n{SECRET_LINE}\n```\n"
+        result = self._run_hook(
+            before=body,
+            after=body + "\nAn unrelated paragraph.\n",
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "an untouched pre-existing secret must not block an unrelated"
+            f" edit, got:\n{result.stdout}\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The secret check piped the whole staged diff into `grep`, so it matched removed and context lines as well as added ones. Two consequences, both backwards:

- deleting a credential was **refused**;
- once a file contained a matching line anywhere, **every later edit to that file** was refused too.

That is worse than a nuisance. The only way past it is `--no-verify`, which also skips rustfmt, clippy, the unsafe-block audit and the unwrap check — so a false positive on a documentation cleanup disarms the entire hook. It surfaced while committing a docs rewrite that *removes* an example credential.

## Fix

Restrict the scan to added lines (`grep "^+" | grep -v "^+++"`). Introducing a secret is still caught, including when the same diff removes another one.

## Tests

`scripts/tests/test_pre_commit_secret_scan.py` drives the shipped hook through its real entrypoint. Staging a single Markdown file keeps the Rust and Python sections skipped, so each case costs milliseconds.

Red before the fix — 2 of 4 failing:

- `test_01_removing_a_secret_is_allowed` — the reported defect
- `test_04_unchanged_context_lines_do_not_trigger` — found while writing the test; an untouched pre-existing line blocked unrelated edits

Green after, with detection intact (`test_02`, `test_03` passed before and still pass).

## Also: scripts/tests/ was run by nothing

Not the hooks, not `local-ci`, not a workflow. Its four suites assert that the repository’s own guards behave, and all four were dead code — including the promise-contract and production-unwrap checkers.

`.github/workflows/gate-contracts.yml` runs `unittest discover` over them: 35 tests, ~1 s. Deliberately **not** path-filtered — a filter is how a gate quietly stops running.

One consequence worth noting: the fixtures are assembled from string fragments, because spelled out in full they match the scan under test and this file could not be committed. Correctly so — the scan cannot tell a fixture from the real thing.