### PR TITLE
fix(memory): stop offering working-context sessions that cannot be loaded

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -738,15 +738,13 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             self.prune_working_index(project, session)?;
             return Ok(None);
         }
-        match self.store.get(slot)? {
-            Some((content, _)) => serde_json::from_str(&content)
-                .map(Some)
-                .map_err(|err| MemoryError::WorkingContextCodec(err.to_string())),
-            None => {
-                self.prune_working_index(project, session)?;
-                Ok(None)
-            }
-        }
+        let Some((content, _)) = self.store.get(slot)? else {
+            self.prune_working_index(project, session)?;
+            return Ok(None);
+        };
+        serde_json::from_str(&content)
+            .map(Some)
+            .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))
     }
 
     /// Drop `session` from `project`'s index once its context is gone — a

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -735,14 +735,42 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             .flatten()
             .is_some_and(|meta| meta.get(CTX_WORKING_FIELD) == Some(&Value::Bool(true)));
         if !marked {
+            self.prune_working_index(project, session)?;
             return Ok(None);
         }
         match self.store.get(slot)? {
             Some((content, _)) => serde_json::from_str(&content)
                 .map(Some)
                 .map_err(|err| MemoryError::WorkingContextCodec(err.to_string())),
-            None => Ok(None),
+            None => {
+                self.prune_working_index(project, session)?;
+                Ok(None)
+            }
         }
+    }
+
+    /// Drop `session` from `project`'s index once its context is gone — a
+    /// `forget` on the underlying fact leaves the index entry behind, and
+    /// nothing else ever removes one.
+    ///
+    /// Self-healing on the READ path deliberately: it keeps
+    /// [`Self::list_working_contexts`] O(1) (no scan, no per-entry lookup)
+    /// while still letting the index converge back to the truth, because
+    /// this is the one place that already paid for the store lookup and
+    /// learned the entry is dead. A no-op when the session was not listed,
+    /// so the common "never saved anything" miss costs one index read.
+    fn prune_working_index(&self, project: &str, session: &str) -> Result<(), MemoryError> {
+        let Some(mut index) = self.working_index(project)? else {
+            return Ok(());
+        };
+        let before = index.sessions.len();
+        index.sessions.retain(|entry| entry.session != session);
+        if index.sessions.len() == before {
+            return Ok(());
+        }
+        let content = serde_json::to_string(&index)
+            .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))?;
+        self.write_working_index(project, &content)
     }
 
     /// Every session ever saved under `project`'s working-context index
@@ -812,6 +840,16 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         }
         let content = serde_json::to_string(&index)
             .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))?;
+        self.write_working_index(project, &content)
+    }
+
+    /// Persist a serialized index into `project`'s reserved index slot.
+    /// Shared by the append path ([`Self::update_working_index`]) and the
+    /// prune path ([`Self::prune_working_index`]) so both write the same
+    /// marker metadata — an index written without
+    /// [`CTX_WORKING_INDEX_FIELD`] would be treated as a squatter and read
+    /// back as empty.
+    fn write_working_index(&self, project: &str, content: &str) -> Result<(), MemoryError> {
         let slot = working_index_id(project);
         let embedding = self
             .embedder
@@ -820,7 +858,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             (CTX_WORKING_INDEX_FIELD, Value::Bool(true)),
             (CTX_PROJECT_FIELD, Value::String(project.to_owned())),
         ]);
-        self.store_fact(slot, &content, &embedding, Some(&meta), None)?;
+        self.store_fact(slot, content, &embedding, Some(&meta), None)?;
         Ok(())
     }
 }

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -636,8 +636,9 @@ impl McpServer {
         let LoadWorkingContextParams { project, session } = params;
         let service = Arc::clone(&self.service);
         let lookup_project = project.clone();
+        let lookup_session = session.clone();
         let working = tokio::task::spawn_blocking(move || {
-            service.load_working_context(&lookup_project, &session)
+            service.load_working_context(&lookup_project, &lookup_session)
         })
         .await
         .map_err(join_error)?
@@ -653,6 +654,11 @@ impl McpServer {
                 .map_err(to_error)?
                 .into_iter()
                 .map(|s| s.session)
+                // Never propose the session just reported missing: the field
+                // is named `other_sessions` and exists to catch a typo, so
+                // echoing the requested id back is a contradiction the caller
+                // cannot act on.
+                .filter(|candidate| candidate != &session)
                 .collect()
         };
         Ok(Json(LoadWorkingContextResult {

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -1228,3 +1228,85 @@ fn test_save_working_context_params_accept_stringified_working() {
     .expect("a JSON-encoded `working` string must deserialize");
     assert_eq!(params.working.goal.as_deref(), Some("resume the campaign"));
 }
+
+#[tokio::test]
+async fn test_load_working_context_never_suggests_the_session_it_just_denied() {
+    // Given a saved session whose backing fact is then deleted, so the
+    // project index still carries the entry while the context is gone.
+    let (_dir, srv) = server();
+    let Json(saved) = srv
+        .save_working_context(Parameters(SaveWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "session-gone".to_owned(),
+            working: working(),
+        }))
+        .await
+        .expect("save_working_context");
+    srv.forget(Parameters(super::super::dto::ForgetParams { id: saved.id }))
+        .await
+        .expect("forget");
+
+    // When loading that same session back
+    let Json(loaded) = srv
+        .load_working_context(Parameters(LoadWorkingContextParams {
+            project: "veles".to_owned(),
+            session: "session-gone".to_owned(),
+        }))
+        .await
+        .expect("load_working_context");
+
+    // Then the answer must not contradict itself: the field is named
+    // `other_sessions` and documented as OTHER sessions, so proposing the
+    // very session just reported missing is nonsense to act on.
+    assert!(!loaded.found);
+    assert!(
+        !loaded.other_sessions.contains(&"session-gone".to_owned()),
+        "other_sessions suggests the session it just denied: {:?}",
+        loaded.other_sessions
+    );
+}
+
+#[tokio::test]
+async fn test_list_working_contexts_drops_a_session_whose_context_is_gone() {
+    // Given two saved sessions, one of which is then deleted
+    let (_dir, srv) = server();
+    for session in ["kept", "dropped"] {
+        let Json(saved) = srv
+            .save_working_context(Parameters(SaveWorkingContextParams {
+                project: "veles".to_owned(),
+                session: session.to_owned(),
+                working: working(),
+            }))
+            .await
+            .expect("save_working_context");
+        if session == "dropped" {
+            srv.forget(Parameters(super::super::dto::ForgetParams { id: saved.id }))
+                .await
+                .expect("forget");
+            // The read path is what prunes: loading the dead entry lets the
+            // index converge back to the truth without a scan.
+            srv.load_working_context(Parameters(LoadWorkingContextParams {
+                project: "veles".to_owned(),
+                session: session.to_owned(),
+            }))
+            .await
+            .expect("load_working_context");
+        }
+    }
+
+    // When listing what is resumable
+    let Json(listed) = srv
+        .list_working_contexts(Parameters(ListWorkingContextsParams {
+            project: "veles".to_owned(),
+        }))
+        .await
+        .expect("list_working_contexts");
+    let names: Vec<&str> = listed.sessions.iter().map(|s| s.session.as_str()).collect();
+
+    // Then only the session that can actually be resumed is offered.
+    assert!(names.contains(&"kept"), "kept session missing: {names:?}");
+    assert!(
+        !names.contains(&"dropped"),
+        "list offers a session load cannot return: {names:?}"
+    );
+}


### PR DESCRIPTION
Found while auditing the full MCP surface against the running daemon.

`save_working_context` appends a session to its project index, and **nothing ever removed one**. A `forget` on the underlying fact leaves the entry behind, so the index outlives the context it points at.

## Two symptoms, both reproduced before the fix

`list_working_contexts` advertised sessions that `load_working_context` then reported as `found: false`. That tool exists so an agent can discover what is resumable — and it was naming things that are not.

Worse, the miss answer contradicted itself:

```json
{"found": false, "other_sessions": ["latence"], "working": null}
```

…for a request whose `session` **was** `latence`. The field is named `other_sessions` and documented as *other* sessions; echoing back the id just reported missing is not something a caller can act on.

## Fix

- the miss path filters the requested session out of `other_sessions`;
- `load_working_context` prunes a dead entry from the index when it finds one.

Pruning on the **read** path is deliberate. It keeps `list_working_contexts` O(1) — the documented contract, no scan and no per-entry lookup — while still letting the index converge back to the truth, because the load is the one place that already paid for the store lookup and *learned* the entry is dead. The index write happens only when there is something to remove.

`write_working_index` is factored out so the append and prune paths write the same marker metadata. An index written without the reserved marker would be read back as a squatter, i.e. as empty — that symmetry is load-bearing, not cosmetic.

## Tests

Both new tests express the contract through public MCP tools only (`save` returns the id, `forget` deletes it, the index keeps the entry):

- `test_load_working_context_never_suggests_the_session_it_just_denied`
- `test_list_working_contexts_drops_a_session_whose_context_is_gone`

Red before, green after. The crate's **363 tests**, clippy (`-D warnings`) and rustfmt stay green.

## Audit context

This came out of a full sweep of the 18 advertised MCP tools against the live daemon. Worth recording what the sweep did **not** find, since it is reassuring:

- **schema fidelity: 18/18, no gap.** For every tool, the fields declared `required` in the advertised schema match exactly those the server rejects a call for.
- **functional: 18 of 19 calls pass**, with the response contents checked, not merely the absence of an error.

The one non-passing call is `remember_extracted`, which is **not** a defect: its advertised description already states the precondition (`VELESDB_MEMORY_EXTRACTOR`, `--features extract`), and the test daemon is built without it.

Not covered by this sweep: error paths and edge cases (over-budget payloads, invalid ids, concurrency).
