### PR TITLE
perf(memory): keep the Ollama model resident instead of reloading it

### DIFF
--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -152,9 +152,54 @@ impl Embedder for OllamaEmbedder {
 }
 
 /// Build the JSON request body for the embeddings endpoint.
+/// How long Ollama keeps a model resident after a request. `-1` means "for as
+/// long as the server runs", which is what a daemon wants: the model loads once
+/// and every later call is warm.
+///
+/// Ollama's own default unloads after a few idle minutes, and the reload is not
+/// a rounding error — measured on this repo's extraction model, 14.19 s cold
+/// against 0.22 s warm. An agent that pauses between calls pays that cliff
+/// almost every time, which is precisely the usage pattern here.
+///
+/// Override with `VELESDB_MEMORY_OLLAMA_KEEP_ALIVE` (any value Ollama accepts,
+/// e.g. `30m`, or `0` to unload immediately) when pinning the weights costs
+/// more RAM than the latency is worth.
+#[cfg(feature = "ollama")]
+pub(crate) const DEFAULT_KEEP_ALIVE: i64 = -1;
+
+/// The configured keep-alive as Ollama expects it on the wire.
+///
+/// The TYPE matters, and getting it wrong fails silently. Ollama reads `-1`
+/// (a JSON **number**) as "never unload", but a JSON **string** `"-1"` is not
+/// a duration it can parse, so it is dropped and the default 5-minute unload
+/// applies — the call looks accepted and the model still disappears. Measured:
+/// numeric `-1` yields `expires_at` in year 2318, the string `"-1"` yields
+/// five minutes. Duration forms like `30m` are strings and must stay strings.
+///
+/// So: parse as a number when it is one, pass through as a string otherwise.
+#[cfg(feature = "ollama")]
+pub(crate) fn keep_alive() -> serde_json::Value {
+    let raw = std::env::var("VELESDB_MEMORY_OLLAMA_KEEP_ALIVE")
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty());
+    match raw {
+        None => serde_json::Value::from(DEFAULT_KEEP_ALIVE),
+        Some(value) => value.parse::<i64>().map_or_else(
+            |_| serde_json::Value::String(value.clone()),
+            serde_json::Value::from,
+        ),
+    }
+}
+
 #[cfg(feature = "ollama")]
 fn build_request_body(model: &str, text: &str) -> String {
-    serde_json::json!({ "model": model, "prompt": text }).to_string()
+    serde_json::json!({
+        "model": model,
+        "prompt": text,
+        "keep_alive": keep_alive(),
+    })
+    .to_string()
 }
 
 /// Ollama `/api/embeddings` response shape.
@@ -229,6 +274,25 @@ mod ollama_tests {
         let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
         assert_eq!(json["model"], "all-minilm");
         assert_eq!(json["prompt"], "hello world");
+    }
+
+    #[test]
+    fn request_body_pins_the_model_in_memory() {
+        // Without `keep_alive` Ollama applies its own default and unloads the
+        // model after a few idle minutes, so a call that follows a quiet spell
+        // pays a full reload. Measured on this repo's own extraction model:
+        // 14.19 s cold against 0.22 s warm — a 64x cliff an agent hits every
+        // time it pauses to think.
+        let body = build_request_body("all-minilm", "hello world");
+        let json: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+        assert_eq!(
+            json["keep_alive"], DEFAULT_KEEP_ALIVE,
+            "request must pin the model for the daemon's lifetime"
+        );
+        assert!(
+            json["keep_alive"].is_number(),
+            "Ollama ignores a STRING \"-1\" and unloads after 5 minutes anyway"
+        );
     }
 
     #[test]

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -132,6 +132,11 @@ impl OllamaExtractor {
             "prompt": prompt,
             "stream": false,
             "think": false,
+            // Extraction models are large — the one this crate documents as an
+            // example is 21.9 GB — so an unload between calls is the dominant
+            // cost, not the generation. Shares the embedder's knob so one
+            // setting governs every Ollama call the daemon makes.
+            "keep_alive": crate::embedder::keep_alive(),
             "options": { "temperature": 0 },
         })
         .to_string();


### PR DESCRIPTION
Neither the embedder nor the extractor sent `keep_alive`, so Ollama applied its own default and unloaded the model after a few idle minutes. Every call that followed a quiet spell paid a full reload.

## Measured

Against this repo's documented example extraction model (`qwen3.6:35b-mlx`, 21.9 GB), on an idle daemon:

| | latency |
|---|---|
| cold | **14.19 s** |
| warm | **0.22 s** |

A 64× cliff, hit almost every time: an agent pauses between tool calls far longer than five minutes, which is exactly when the model is gone.

## The wire type is the whole trick — and getting it wrong fails silently

Ollama reads `-1` as a JSON **number** to mean "never unload". The JSON **string** `"-1"` is not a duration it can parse, so it is dropped and the five-minute default applies — the request still returns `200` and the model still disappears.

Verified against a live Ollama by reading back `/api/ps`:

```
keep_alive: -1     -> expires_at 2318-11-04   (pinned)
keep_alive: "24h"  -> expires_at +24h         (honoured)
keep_alive: "-1"   -> expires_at +5 min       (silently ignored)
```

So the value is emitted as a number when it parses as one, and as a string otherwise — which keeps duration forms like `30m` working.

**The first version of this patch sent the string.** It passed a naive equality assertion and would have shipped a no-op. The test therefore asserts the field `is_number()`, not merely that it equals `-1`.

## Configuration

`VELESDB_MEMORY_OLLAMA_KEEP_ALIVE` overrides the default:

- `0` — unload immediately (previous behaviour, minus the guesswork)
- `30m` — bounded residency
- unset — pinned for the daemon's lifetime

One knob governs every Ollama call the daemon makes, embedding and extraction alike. Machines where pinning 21.9 GB of weights costs more than the latency is worth can dial it back without a rebuild.

## Why this matters more than it looks

The extraction path is the one that makes `why` useful: `remember_extracted` splits raw text into atomic facts and wires the fact↔topic edges that `why` traverses. On a store built only with `remember`, `why` returns isolated nodes — sampled on a real store, 4 of 5 queries came back with **1 node and 0 edges**. Making extraction cheap enough to actually use is what populates that graph.

373 tests, clippy (`-D warnings`) and rustfmt stay green.
