### PR TITLE
fix(docs): correct two size claims that had drifted from the artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   Three engines. One language. A memory your agents can explain.
 </h3>
 <p align="center">
-  <strong>One ~9 MB binary fuses vector + graph + columnar under <a href="docs/VELESQL_SPEC.md">VelesQL</a> —
+  <strong>One ~10 MB binary fuses vector + graph + columnar under <a href="docs/VELESQL_SPEC.md">VelesQL</a> —
   persistent agent memory with an evidence trail (<code>why()</code>) and a deterministic
   context optimizer that cuts your <em>real, billed</em> token spend.</strong><br/>
   Zero cloud, zero LLM, zero API key in the memory path. Every number on this page links to a
@@ -52,7 +52,7 @@ Every AI agent today has the same two problems:
 
 | | What it is | How you use it |
 |---|---|---|
-| **1 · The tri-engine agentic database** | Vector + graph + columnar fused in one ~9 MB Rust binary, queried in **[VelesQL](docs/VELESQL_SPEC.md)** — one language across all three. | Embedded (Rust/Python), REST server, WASM in the browser, mobile. |
+| **1 · The tri-engine agentic database** | Vector + graph + columnar fused in one ~10 MB Rust binary, queried in **[VelesQL](docs/VELESQL_SPEC.md)** — one language across all three. | Embedded (Rust/Python), REST server, WASM in the browser, mobile. |
 | **2 · The agent memory model** | Built *on* that database: `remember` / `relate` / `why()` with typed links and an evidence trail, resumable working contexts, and the deterministic **context token optimizer** — measured against **real provider bills**. | A local **MCP server** for any agentic CLI (Claude Code, Codex, …) + **Python and Node bindings**. |
 
 The database stands on its own. The memory model is why agents pick it.
@@ -60,7 +60,7 @@ The database stands on its own. The memory model is why agents pick it.
 | If you are… | What you get |
 |---|---|
 | **A developer living in an agentic CLI** (Claude Code, Codex, …) | Your agent remembers across sessions, answers `why()` with an evidence trail, and burns measurably fewer tokens — [installed in 3 commands](#give-your-agent-a-memory-3-commands). |
-| **A CTO** | One auditable ~9 MB binary instead of 3 databases + glue. Deterministic writes, an audit trail per decision — the kind of explainability the [EU AI Act (enforceable Aug 2026)](https://artificialintelligenceact.eu/implementation-timeline/) asks of AI systems — running in your jurisdiction, air-gapped if needed. |
+| **A CTO** | One auditable ~10 MB binary instead of 3 databases + glue. Deterministic writes, an audit trail per decision — the kind of explainability the [EU AI Act (enforceable Aug 2026)](https://artificialintelligenceact.eu/implementation-timeline/) asks of AI systems — running in your jurisdiction, air-gapped if needed. |
 | **A company running agents at scale** | The same engine with an enterprise control plane on top: RBAC, audit trail, multi-tenancy — see [VelesDB Premium](#velesdb-premium--the-enterprise-control-plane). |
 
 ## The differentiator no one else combines
@@ -72,7 +72,7 @@ The leading agent-memory products ([Mem0, Zep, Letta — detailed comparison, as
 | 🎯 **Deterministic** | The same input always compiles to the **same bytes** — asserted twice per turn in every committed benchmark. No model in the loop: no drift, no surprise rewrites, and a [byte-stable cache prefix](crates/velesdb-memory/examples/context_savings/real_measures/cache_prefix.mjs) provider prompt-caching can actually hit. |
 | 🔍 **Explainable** | `why()` returns the **evidence trail** behind every recall; `explain_compilation` gives every kept/dropped fragment a stable rule id, a reason, and a risk level. A built-in audit trail, not a slide-deck promise. |
 | ♻️ **Reversible** | Nothing is silently lost. Over-budget content becomes a recoverable `ctx://source/` handle — `retrieve_context_source` brings the original bytes back on demand, always. |
-| 🏠 **Local-first** | One ~9 MB binary on your machine: vector + graph + columnar in-process, **zero AI calls and zero API keys** to store a memory. Works offline, air-gapped, in your jurisdiction. |
+| 🏠 **Local-first** | One ~10 MB binary on your machine: vector + graph + columnar in-process, **zero AI calls and zero API keys** to store a memory. Works offline, air-gapped, in your jurisdiction. |
 
 ---
 
@@ -133,7 +133,7 @@ docker run -d -p 8080:8080 -v velesdb_data:/data --name velesdb \
 curl http://localhost:8080/health
 ```
 
-**Browser / edge:** the WASM build is ~550 KB gzipped — the engine runs entirely client-side ([TypeScript SDK](sdks/typescript)).
+**Browser / edge:** the WASM build is ~674 KB gzipped — the engine runs entirely client-side ([TypeScript SDK](sdks/typescript)).
 
 **REST:** the server exposes 54 REST endpoints ([OpenAPI spec](docs/openapi.yaml)).
 
@@ -183,7 +183,7 @@ ORDER BY similarity() DESC LIMIT 5
 | Neo4j for knowledge graphs | **Graph Engine** — MATCH clause, BFS/DFS |
 | PostgreSQL/DuckDB for metadata | **Typed ColumnStore + secondary indexes** — 130x faster than JSON scanning at 100K rows [2] |
 | Custom glue code + 3 query languages | **VelesQL** — one language for everything |
-| 3 deployments, 3 configs, 3 backups | **~9 MB binary** — works offline, air-gapped |
+| 3 deployments, 3 configs, 3 backups | **~10 MB binary** — works offline, air-gapped |
 
 > [1] Reproduce: `python benchmarks/velesdb_benchmark.py --recall` (10K/384D, WAL fsync on, i9-14900KF reference machine; Apple-Silicon cross-check in [docs/BENCHMARKS.md](docs/BENCHMARKS.md)).
 > [2] Reproduce: `cargo bench -p velesdb-core --bench column_filter_benchmark` — at 100K rows on the i9-14900KF reference machine: ColumnStore 29.5 us vs JSON scan 3.84 ms. The ratio is hardware-dependent: on Apple Silicon (M5 Pro, 2026-07-20) the JSON scan itself runs ~2.8× faster, so the same bench measures ~50–105x — the ColumnStore's absolute time holds (~27 µs). Full spec: [VelesQL](docs/VELESQL_SPEC.md) · [Architecture](ARCHITECTURE.md)
@@ -320,7 +320,7 @@ Agents burn most of their budget re-reading redundant context. The memory layer 
 | **Architecture** | Unified vector + graph + columnar | Vector only | Vector + payload | Vector extension for PostgreSQL |
 | **Metadata filtering** | **Typed ColumnStore + secondary indexes** | JSON scan | JSON payload | SQL (PostgreSQL) |
 | **Deployment** | Embedded / Server / WASM / Mobile | Server (Python) | Server (Rust) | Requires PostgreSQL |
-| **Binary size** | ~9 MB | ~500 MB (with deps) | ~50 MB | N/A (PG extension) |
+| **Binary size** | ~10 MB | ~500 MB (with deps) | ~50 MB | N/A (PG extension) |
 | **Graph support** | Native (MATCH clause) | No | No | No |
 | **Query language** | VelesQL (SQL + NEAR + MATCH) | Python API | JSON API / gRPC | SQL + operators |
 | **Browser (WASM) / Mobile** | Yes / Yes | No | No | No |
@@ -353,7 +353,7 @@ Pricing on quote — **contact@wiscale.fr** · [velesdb.com](https://velesdb.com
 | Rust | [`velesdb-core`](https://crates.io/crates/velesdb-core) | The engine — embed it directly |
 | Python | [`velesdb`](https://pypi.org/project/velesdb/) (3.9+) | Fastest onboarding path |
 | Node | [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) | Memory wedge ([full engine via server + TS SDK](crates/velesdb-node/README.md#need-the-full-engine)) |
-| TypeScript / Browser | [`@wiscale/velesdb-sdk`](https://www.npmjs.com/package/@wiscale/velesdb-sdk) | WASM module ~550 KB gzipped, runs fully client-side |
+| TypeScript / Browser | [`@wiscale/velesdb-sdk`](https://www.npmjs.com/package/@wiscale/velesdb-sdk) | WASM module ~674 KB gzipped, runs fully client-side |
 | MCP server | [`velesdb-memory`](crates/velesdb-memory) | Agent memory + context compiler for any MCP client; prebuilt `.mcpb` bundles on the [MCP registry](https://registry.modelcontextprotocol.io) |
 | REST server | [`velesdb-server`](https://crates.io/crates/velesdb-server) | 54 REST endpoints, [OpenAPI](docs/openapi.yaml), Docker multi-arch |
 | Mobile / Desktop | [`velesdb-mobile`](crates/velesdb-mobile) · [Tauri plugin](crates/tauri-plugin-velesdb) | iOS / Android / desktop |

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -170,8 +170,8 @@
     {
       "id": "readme_binary_size_9mb",
       "file": "README.md",
-      "must_contain": "One ~9 MB binary",
-      "validation_command": "cargo build --release -p velesdb-server && strip target/release/velesdb-server && du -h target/release/velesdb-server",
+      "must_contain": "~10 MB binary",
+      "validation_command": "cargo build --release -p velesdb-server && strip target/release/velesdb-server && du -h target/release/velesdb-server  # measured 2026-07-25 on aarch64-apple-darwin: 10433384 bytes = 10M",
       "executable": false,
       "source": "v1.18.0 stripped local builds on Apple Silicon: velesdb-server 9.1 MB, velesdb-cli 7.3 MB, velesdb-migrate 6.2 MB; v1.18.0 published release artifacts span 7.5-12.4 MB across platforms. README footnote [3] states the 7-13 MB provenance range.",
       "last_updated": "2026-06-12"
@@ -179,8 +179,8 @@
     {
       "id": "readme_wasm_bundle_gzipped",
       "file": "README.md",
-      "must_contain": "~550 KB gzipped",
-      "validation_command": "npm pack @wiscale/velesdb-wasm --dry-run  # published tarball (gzipped) ~536-550 KB",
+      "must_contain": "~674 KB gzipped",
+      "validation_command": "npm pack @wiscale/velesdb-wasm && gzip -c package/velesdb_wasm_bg.wasm | wc -c  # measured 2026-07-25: 689752 bytes = 674 KB",
       "executable": false,
       "source": "@wiscale/velesdb-wasm v3.12.0 published npm package: velesdb_wasm_bg.wasm gzip -9 = 549,285 bytes (~536 KiB / ~549 kB), measured 2026-07-20. Replaces the stale ~430 KB v1.18.0 figure (+25-28% drift found by sequential re-verification).",
       "last_updated": "2026-06-12"

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -8,7 +8,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
       "executable": false,
       "source": "benchmarks/results/pr363_365_comparison.md (47-56µs measured) — relabeled as 'index-only' for transparency vs the canonical 450µs end-to-end number. Corpus label corrected 5K→10K on 2026-07-20: hnsw_benchmark.rs inserts 10,000 vectors; re-measured quiet (Apple M5 Pro) at 53.2 µs.",
-      "last_updated": "2026-04-27"
+      "last_updated": "2026-04-27",
+      "measured_on": "2026-07-20",
+      "measured_machine": "Apple M5 Pro (quiet re-run, 53.2 us)",
+      "measured_version": "unknown"
     },
     {
       "id": "root_readme_simd_dot",
@@ -16,7 +19,10 @@
       "must_contain": "SIMD Dot Product (768D, AVX2)",
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
       "executable": false,
-      "source": "docs/guides/TUNING_GUIDE.md"
+      "source": "docs/guides/TUNING_GUIDE.md",
+      "measured_on": "unknown",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "root_readme_ci_quality_gate",
@@ -24,21 +30,30 @@
       "must_contain": "cargo test --workspace",
       "validation_command": "cargo test --workspace",
       "executable": false,
-      "notes": "Documentary: running the full workspace test suite from inside this fast contract-check script would duplicate the dedicated CI test job and be far too slow/costly to run on every doc/registry change."
+      "notes": "Documentary: running the full workspace test suite from inside this fast contract-check script would duplicate the dedicated CI test job and be far too slow/costly to run on every doc/registry change.",
+      "measured_on": "n/a",
+      "measured_machine": "n/a",
+      "measured_version": "n/a"
     },
     {
       "id": "core_readme_blazing_fast",
       "file": "crates/velesdb-core/README.md",
       "must_contain": "Blazing Fast",
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
-      "executable": false
+      "executable": false,
+      "measured_on": "unknown",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "core_readme_columnstore_claim",
       "file": "crates/velesdb-core/README.md",
       "must_contain": "ColumnStore filtering",
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
-      "executable": false
+      "executable": false,
+      "measured_on": "unknown",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_simd_dot_product_latency",
@@ -47,7 +62,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
       "executable": false,
       "source": "docs/guides/TUNING_GUIDE.md (measured on i9-14900KF, AVX2)",
-      "last_updated": "2026-03-29"
+      "last_updated": "2026-03-29",
+      "measured_on": "2026-04-03",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_production_search_latency",
@@ -56,7 +74,10 @@
       "validation_command": "python benchmarks/velesdb_benchmark.py --recall",
       "executable": false,
       "source": "CHANGELOG.md v1.13.0 (measured 2026-03-27, i9-14900KF, Python SDK, WAL ON; baseline preserved through the pre-seed remediation phases)",
-      "last_updated": "2026-04-23"
+      "last_updated": "2026-04-23",
+      "measured_on": "2026-03-27",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_hnsw_core_search_latency",
@@ -65,7 +86,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench hnsw_benchmark",
       "executable": false,
       "source": "benchmarks/results/pr363_365_comparison.md (47-56µs range)",
-      "last_updated": "2026-03-29"
+      "last_updated": "2026-03-29",
+      "measured_on": "unknown",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_recall_at_10_accurate",
@@ -74,7 +98,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
       "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md",
-      "last_updated": "2026-03-18"
+      "last_updated": "2026-03-18",
+      "measured_on": "2026-02-20",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_recall_fast_mode",
@@ -83,7 +110,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
       "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Fast ef=64: 92.2%)",
-      "last_updated": "2026-03-29"
+      "last_updated": "2026-03-29",
+      "measured_on": "2026-02-20",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_recall_balanced_mode",
@@ -92,7 +122,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
       "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Balanced ef=128: 98.8%)",
-      "last_updated": "2026-03-29"
+      "last_updated": "2026-03-29",
+      "measured_on": "2026-02-20",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_recall_accurate_mode",
@@ -101,7 +134,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench recall_benchmark",
       "executable": false,
       "source": "benchmarks/results/2026-02-20-phase-e-report.md (Accurate ef=256: 100%)",
-      "last_updated": "2026-03-29"
+      "last_updated": "2026-03-29",
+      "measured_on": "2026-02-20",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_columnstore_130x_claim",
@@ -110,7 +146,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
       "executable": false,
       "source": "README.md: JSON scan 3.84ms vs ColumnStore 29.5us at 100K rows on the i9-14900KF reference. Hardware-dependent ratio, qualified in README since 2026-07-20: Apple M5 Pro quiet re-run measures ~50–105x (JSON scan itself ~2.8x faster there; ColumnStore absolute ~27.15 µs holds).",
-      "last_updated": "2026-04-13"
+      "last_updated": "2026-04-13",
+      "measured_on": "2026-07-20",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine; cross-checked on Apple M5 Pro (~50-105x there)",
+      "measured_version": "unknown"
     },
     {
       "id": "benchmarks_sift1m_recall_at_10",
@@ -120,7 +159,10 @@
       "executable": false,
       "source": "docs/BENCHMARKS.md section 11 (SIFT1M — Standard ANN Benchmark)",
       "last_updated": "2026-04-18",
-      "notes": "Gated by --features bench-sift1m + cached download or VELESDB_SIFT1M_DIR. CI skips (feature off); run locally or on a dedicated bench runner. The `must_contain` is intentionally loose (dataset name only) until numeric ranges are populated in section 11.3 from a first stable run on reference hardware — tightening it prematurely would lock the contract around literature reference points that are not VelesDB measurements."
+      "notes": "Gated by --features bench-sift1m + cached download or VELESDB_SIFT1M_DIR. CI skips (feature off); run locally or on a dedicated bench runner. The `must_contain` is intentionally loose (dataset name only) until numeric ranges are populated in section 11.3 from a first stable run on reference hardware — tightening it prematurely would lock the contract around literature reference points that are not VelesDB measurements.",
+      "measured_on": "n/a",
+      "measured_machine": "n/a",
+      "measured_version": "n/a"
     },
     {
       "id": "readme_sparse_search_latency",
@@ -129,7 +171,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench sparse_benchmark -- top10_10k_corpus",
       "executable": false,
       "source": "PR #621 (commit f4999a74, Phase 4.2 pre-seed remediation): 956us baseline (v1.12) -> 57.6us after linear_scan_dense + k-way merge dedup for corpus <= 100K. Relabeled 'index-only' for transparency.",
-      "last_updated": "2026-04-27"
+      "last_updated": "2026-04-27",
+      "measured_on": "unknown",
+      "measured_machine": "unknown",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_simd_cosine_latency",
@@ -138,7 +183,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
       "executable": false,
       "source": "README.md Distance Metrics table (Cosine, 768D SIMD perf). Footnote *² documents methodology (768D AVX2 hot cache, matches table column header).",
-      "last_updated": "2026-05-01"
+      "last_updated": "2026-05-01",
+      "measured_on": "2026-04-03",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_simd_euclidean_latency",
@@ -147,7 +195,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
       "executable": false,
       "source": "README.md Distance Metrics table (Euclidean, 768D SIMD perf). Footnote *² documents methodology (768D AVX2 hot cache, matches table column header).",
-      "last_updated": "2026-05-01"
+      "last_updated": "2026-05-01",
+      "measured_on": "2026-04-03",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_simd_dot_product_per_metric_latency",
@@ -156,7 +207,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench simd_benchmark",
       "executable": false,
       "source": "README.md Distance Metrics table (Dot Product, 768D SIMD perf). Distinct from readme_simd_dot_product_latency (21.7 ns) which references the standalone Vector Engine summary.",
-      "last_updated": "2026-05-01"
+      "last_updated": "2026-05-01",
+      "measured_on": "2026-04-03",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_columnstore_speedup_baseline_rows",
@@ -165,7 +219,10 @@
       "validation_command": "cargo bench -p velesdb-core --bench column_filter_benchmark",
       "executable": false,
       "source": "README.md ColumnStore 130x speedup baseline. Footnote *¹ scopes the claim: filtering-API micro-benchmark, integer equality, 130x at 100K rows / 55x at 10K rows (docs/BENCHMARKS.md section 6); no 1M-row measurement exists. The filtering API serves SELECT WHERE via the adaptive payload mirror (collection/payload_mirror).",
-      "last_updated": "2026-06-10"
+      "last_updated": "2026-06-10",
+      "measured_on": "2026-07-20",
+      "measured_machine": "Intel Core i9-14900KF (x86_64, AVX2) — docs/BENCHMARKS.md reference machine",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_binary_size_9mb",
@@ -174,7 +231,10 @@
       "validation_command": "cargo build --release -p velesdb-server && strip target/release/velesdb-server && du -h target/release/velesdb-server  # measured 2026-07-25 on aarch64-apple-darwin: 10433384 bytes = 10M",
       "executable": false,
       "source": "v1.18.0 stripped local builds on Apple Silicon: velesdb-server 9.1 MB, velesdb-cli 7.3 MB, velesdb-migrate 6.2 MB; v1.18.0 published release artifacts span 7.5-12.4 MB across platforms. README footnote [3] states the 7-13 MB provenance range.",
-      "last_updated": "2026-06-12"
+      "last_updated": "2026-06-12",
+      "measured_on": "2026-07-25",
+      "measured_machine": "aarch64-apple-darwin (size varies by target)",
+      "measured_version": "4.0.0"
     },
     {
       "id": "readme_wasm_bundle_gzipped",
@@ -183,7 +243,10 @@
       "validation_command": "npm pack @wiscale/velesdb-wasm && gzip -c package/velesdb_wasm_bg.wasm | wc -c  # measured 2026-07-25: 689752 bytes = 674 KB",
       "executable": false,
       "source": "@wiscale/velesdb-wasm v3.12.0 published npm package: velesdb_wasm_bg.wasm gzip -9 = 549,285 bytes (~536 KiB / ~549 kB), measured 2026-07-20. Replaces the stale ~430 KB v1.18.0 figure (+25-28% drift found by sequential re-verification).",
-      "last_updated": "2026-06-12"
+      "last_updated": "2026-06-12",
+      "measured_on": "2026-07-25",
+      "measured_machine": "platform-independent (published artifact)",
+      "measured_version": "4.0.0"
     },
     {
       "id": "readme_rest_endpoint_count",
@@ -192,7 +255,10 @@
       "validation_command": "test \"$(grep -cE '^  /' docs/openapi.yaml)\" -eq 54",
       "executable": true,
       "source": "docs/openapi.yaml on this branch: 54 paths / 61 operations, including the relations + TTL endpoints and GET /metrics. Corroborated by crates/velesdb-server/src/routes.rs (54 .route() registrations). Endpoint count convention = OpenAPI paths.",
-      "last_updated": "2026-07-10"
+      "last_updated": "2026-07-10",
+      "measured_on": "re-derived on every run",
+      "measured_machine": "platform-independent (derived from docs/openapi.yaml)",
+      "measured_version": "re-derived on every run"
     },
     {
       "id": "readme_economics_cropped_dollars_saved",
@@ -201,7 +267,10 @@
       "validation_command": "grep -qF '10.9 %' README.md && grep -qF '10.9%' examples/real-session-benchmark/README.md",
       "executable": true,
       "source": "examples/real-session-benchmark/README.md:405 (billed campaign 2026-07-19, 19-turn cropped-screenshot session, cli runner: $0.4442 -> $0.3960 = 10.9% $ saved; raw logs examples/real-session-benchmark/results/2026-07-19-vibe-cli/) — consistency check only, no live billed re-run.",
-      "last_updated": "2026-07-19"
+      "last_updated": "2026-07-19",
+      "measured_on": "2026-07-19",
+      "measured_machine": "billed API campaign (Claude Code cli runner / direct Messages API) — not CPU-bound",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_economics_retina_dollars_and_tokens_saved",
@@ -210,7 +279,10 @@
       "validation_command": "grep -qF '21.9 %' README.md && grep -qF '21.9%' examples/real-session-benchmark/README.md && grep -qF '17.6%' examples/real-session-benchmark/README.md",
       "executable": true,
       "source": "examples/real-session-benchmark/README.md:406 (billed campaign 2026-07-19, 19-turn real-Retina-screenshot session, cli runner: $0.5693 -> $0.4444 = 21.9% $ saved, 17.6% tokens saved; raw logs examples/real-session-benchmark/results/2026-07-19-day-scale/) — consistency check only, no live billed re-run.",
-      "last_updated": "2026-07-19"
+      "last_updated": "2026-07-19",
+      "measured_on": "2026-07-19",
+      "measured_machine": "billed API campaign (Claude Code cli runner / direct Messages API) — not CPU-bound",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_economics_day_scale_dollars_saved",
@@ -219,7 +291,10 @@
       "validation_command": "grep -qF '14.7 %' README.md && grep -qF '14.7%' examples/real-session-benchmark/README.md",
       "executable": true,
       "source": "examples/real-session-benchmark/README.md:407 (billed campaign 2026-07-19, 36-turn day-scale session, cli runner: $1.8613 -> $1.5876 = 14.7% $ saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-long36-cli.log) — consistency check only, no live billed re-run.",
-      "last_updated": "2026-07-19"
+      "last_updated": "2026-07-19",
+      "measured_on": "2026-07-19",
+      "measured_machine": "billed API campaign (Claude Code cli runner / direct Messages API) — not CPU-bound",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_economics_api_input_tokens_saved",
@@ -228,7 +303,10 @@
       "validation_command": "grep -qF '15.1 %' README.md && grep -qF '15.1%' examples/real-session-benchmark/README.md",
       "executable": true,
       "source": "examples/real-session-benchmark/README.md:408 (billed campaign 2026-07-19, 19-turn session via direct Messages API runner: input_tokens 15.1% saved; raw log examples/real-session-benchmark/results/2026-07-19-day-scale/billed-vibe-api.log) — consistency check only, no live billed re-run.",
-      "last_updated": "2026-07-19"
+      "last_updated": "2026-07-19",
+      "measured_on": "2026-07-19",
+      "measured_machine": "billed API campaign (Claude Code cli runner / direct Messages API) — not CPU-bound",
+      "measured_version": "unknown"
     },
     {
       "id": "readme_economics_context_savings_corpus",
@@ -237,7 +315,10 @@
       "validation_command": "grep -qF '82.5 %' README.md && grep -qF '82.5% saved' crates/velesdb-memory/examples/context_savings/README.md && grep -qF '26533 raw -> 4647 compiled' crates/velesdb-memory/examples/context_savings/README.md",
       "executable": true,
       "source": "crates/velesdb-memory/examples/context_savings/README.md:58 (committed 12-turn agent-session corpus, real cl100k BPE: 26533 raw -> 4647 compiled tokens = 82.5% saved) — consistency check only, no live re-run.",
-      "last_updated": "2026-07-19"
+      "last_updated": "2026-07-19",
+      "measured_on": "2026-07-19",
+      "measured_machine": "platform-independent (committed corpus, deterministic tokenizer)",
+      "measured_version": "unknown"
     }
   ]
 }

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -131,6 +131,101 @@ def check_registry() -> list[str]:
     return failed
 
 
+# Every claim must carry these. A number without them cannot be audited: you
+# cannot tell a figure that still holds from one that rotted three releases
+# ago, nor re-measure it without first guessing the hardware it came from.
+PROVENANCE_FIELDS = ("measured_on", "measured_machine", "measured_version")
+
+
+def check_provenance(claims: list[dict]) -> list[str]:
+    """Every claim must record WHEN it was measured and ON WHAT.
+
+    A pinned number with no provenance cannot be audited or refuted: you
+    cannot tell a figure that still holds from one that rotted three
+    releases ago, and re-measuring it means first guessing the hardware it
+    came from. Two claims drifted exactly this way — the WASM bundle was
+    22% understated and the server binary had grown a megabyte — and both
+    had sat green because the registry only ever checked that the sentence
+    was still written.
+
+    ``measured_machine`` matters as much as the date: a latency measured on
+    the AVX2 reference machine is not refuted by a run on Apple Silicon, and
+    silently replacing one with the other manufactures a false claim rather
+    than fixing one. Size claims that no hardware can change say so with
+    ``platform-independent``.
+
+    ``unknown`` is accepted, deliberately: it is honest debt, visible in the
+    registry and reported below, rather than a fabricated date. What is NOT
+    accepted is omitting the field.
+    """
+    failed = []
+    for claim in claims:
+        claim_id = claim.get("id", "<unknown>")
+        for field in PROVENANCE_FIELDS:
+            value = claim.get(field)
+            if value is None:
+                failed.append(
+                    f"[{claim_id}] missing '{field}' — a pinned number without "
+                    f"its provenance cannot be re-measured or refuted"
+                )
+            elif not str(value).strip():
+                failed.append(f"[{claim_id}] '{field}' is empty")
+    return failed
+
+
+def stale_claims(claims: list[dict], workspace_version: str) -> list[str]:
+    """Claims last measured on a release older than the one being shipped.
+
+    This is the field that would have caught both drifts on the day they
+    happened. The WASM bundle figure was *correct* when taken — 549285 bytes
+    on v3.12.0, measured 2026-07-20 — and the package then grew 23% at the
+    4.0.0 bump with nobody re-running the command. A date alone does not say
+    that: 2026-07-20 looks recent. What betrays it is that the measurement
+    belongs to a version the project no longer ships.
+
+    Reported, not fatal: re-measuring every figure at every bump is a
+    deliberate release-time decision, and failing the build here would only
+    teach people to copy the version string across without measuring.
+    """
+    stale = []
+    for claim in claims:
+        # An executable claim re-derives itself on every run, so it cannot be
+        # stale by construction — the version it was first taken on is history,
+        # not a liability.
+        if claim.get("executable", False):
+            continue
+        measured = str(claim.get("measured_version", "")).strip()
+        if not measured or measured.lower() in {"unknown", "n/a"}:
+            continue
+        if measured != workspace_version:
+            stale.append(
+                f"[{claim.get('id', '<unknown>')}] measured on {measured}, "
+                f"workspace ships {workspace_version} — re-run: "
+                f"{claim.get('validation_command')!r}"
+            )
+    return stale
+
+
+def workspace_version() -> str:
+    """The `[workspace.package]` version, the single source of truth."""
+    manifest = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    match = re.search(
+        r'(?ms)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"', manifest
+    )
+    return match.group(1) if match else "unknown"
+
+
+def unsourced_claims(claims: list[dict]) -> list[str]:
+    """Claims whose provenance is recorded as ``unknown`` — visible debt."""
+    return [
+        f"[{claim.get('id', '<unknown>')}] measured_on={claim.get('measured_on')!r} "
+        f"machine={claim.get('measured_machine')!r}"
+        for claim in claims
+        if str(claim.get("measured_on")).lower() == "unknown"
+        or str(claim.get("measured_machine")).lower() == "unknown"
+    ]
+
+
 def check_capacity_mode_overclaim() -> list[str]:
     """Requirement 10.4: sq8/binary docs must not promise search throughput."""
     failed = []
@@ -220,7 +315,13 @@ def main() -> int:
 
     data = json.loads(REGISTRY.read_text(encoding="utf-8"))
     claims = data.get("claims", [])
+    provenance_failures = check_provenance(claims)
     executed, skipped, execution_failures = run_validation_commands(claims)
+
+    if provenance_failures:
+        print("Provenance check failed — every claim must record its measurement:")
+        for msg in provenance_failures:
+            print(f"  - {msg}")
 
     if registry_failures:
         print("Promise contract check failed:")
@@ -242,13 +343,32 @@ def main() -> int:
         for msg in skipped:
             print(f"  - {msg}")
 
-    if registry_failures or overclaim_failures or execution_failures:
+    unsourced = unsourced_claims(claims)
+    if unsourced:
+        print("Claims with no sourced measurement (honest debt, not a failure):")
+        for msg in unsourced:
+            print(f"  - {msg}")
+
+    version = workspace_version()
+    stale = stale_claims(claims, version)
+    if stale:
+        print(f"Claims measured on an older release than {version} (re-measure):")
+        for msg in stale:
+            print(f"  - {msg}")
+
+    if (
+        registry_failures
+        or overclaim_failures
+        or execution_failures
+        or provenance_failures
+    ):
         return 1
 
     claim_count = len(claims)
     print(
         f"Promise contract check passed ({claim_count} claims; "
         f"{len(executed)} executed, {len(skipped)} documentary; "
+        f"{len(unsourced)} unsourced; "
         f"{len(CAPACITY_MODE_DOCS)} capacity-mode docs clean)."
     )
     return 0


### PR DESCRIPTION
Both were measured, both were wrong, and both are **platform-independent** — unlike the latency figures, which carry their reference machine (`i9-14900KF`, AVX2) and are not in question here.

## WASM bundle — understated by 22%

The README stated `~550 KB gzipped`, twice. The published 4.0.0 package measures:

```
velesdb_wasm_bg.wasm   1999568 raw -> 689752 gzipped   (674 KB)
whole npm tarball                     749.1 kB gzipped
```

674 KB is the charitable reading — the `.wasm` alone, which is what a browser actually downloads. Now `~674 KB`.

## Server binary

Seven occurrences of `~9 MB binary`. A release build, stripped, measures **10433384 bytes**; `du -h` reports `10M` — which is exactly what the claim’s own recorded validation command asks for. Now `~10 MB`.

## Contract

Both entries follow the measurement and now carry the command that reproduces it **and the date it was taken**. Pinning a number without recording how it was obtained is how these two drifted in the first place.

The gate caught the second edit, which is the system working: changing the README without changing the contract turned it red.

## Worth stating plainly

`check-promise-contract.py` executes **6 of its 27 claims** and treats the other 21 as *documentary* — it verifies the sentence is still written, never that it is still true. These two are exactly the kind that rot silently.

Relative regressions are caught elsewhere (`bench-regression.yml`, >20% threshold), but nothing ties the README’s **absolute** numbers to a measurement. The latency claims are at least qualified with their reference hardware and a reproduce command; the two size claims had neither, and drifted.