### PR TITLE
fix(install): build the daemon with the extraction backend compiled in

### DIFF
--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -48,6 +48,10 @@
 #   -Store <path>             Store directory (default: $env:USERPROFILE\.velesdb-memory)
 #   -TlsDir <path>            TLS material (CA + leaf cert) directory (default: $env:USERPROFILE\.velesdb-memory-tls)
 #   -OllamaUrl <url>          Ollama endpoint (default: http://localhost:11434)
+#   -ExtractorModel <model>   Ollama chat model powering `remember_extracted` (fact extraction
+#                             + auto-built fact<->topic graph). Unset by default: the tool then
+#                             reports extraction as unconfigured. The daemon is always BUILT with
+#                             the backend, so enabling it later is a config edit, not a rebuild.
 #   -OllamaModel <model>      Ollama embedding model (default: all-minilm)
 #   -Ttl <seconds>            Default TTL for new facts (default: prompted, empty = permanent)
 #   -Yes                      Assume yes to interactive prompts (e.g. `ollama pull`)
@@ -90,6 +94,11 @@ param(
     [string]$OllamaUrl = 'http://localhost:11434',
 
     [string]$OllamaModel = 'all-minilm',
+    # Empty means "no extraction backend". Deliberately NOT defaulted to a
+    # model: setting VELESDB_MEMORY_EXTRACTOR without
+    # VELESDB_MEMORY_EXTRACTOR_MODEL makes the daemon refuse to start, so a
+    # default would break every install whose machine lacks that model.
+    [string]$ExtractorModel = '',
 
     [string]$Ttl = '',
 
@@ -298,12 +307,12 @@ function Initialize-Ollama {
 
 # ---- 4. Build (cargo) or install a prebuilt release archive -----------------
 function Build-Daemon {
-    Write-Warn 'Building velesdb-memory (--features ollama,http)...'
+    Write-Warn 'Building velesdb-memory (--features ollama,http,extract)...'
     # Always both features regardless of the runtime embedder choice above:
     # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
     # choice, so flipping it later is a restart, never a rebuild.
     cargo install --path "$script:RepoRoot/crates/velesdb-memory" --bin velesdb-memory `
-        --features ollama,http --force
+        --features ollama,http,extract --force
     if ($LASTEXITCODE -ne 0) {
         Write-ErrorMsg 'cargo install failed.'
         exit 1
@@ -413,6 +422,11 @@ function New-DaemonWrapper {
     # store/TLS path or Ollama URL isn't guaranteed to avoid all of those —
     # doesn't get parsed as a batch operator instead of literal text.
     $ttlLine = if ($script:Ttl -ne '') { "set `"VELESDB_MEMORY_DEFAULT_TTL=$script:Ttl`"" } else { '' }
+    # Both variables or neither: VELESDB_MEMORY_EXTRACTOR alone is a startup
+    # failure (see $ExtractorModel's declaration).
+    $extractorLines = if ($ExtractorModel -ne '') {
+        "set `"VELESDB_MEMORY_EXTRACTOR=ollama`"`r`nset `"VELESDB_MEMORY_EXTRACTOR_MODEL=$ExtractorModel`""
+    } else { '' }
 
     # A Scheduled Task action carries no environment block of its own, so this
     # wrapper is how the daemon's env vars actually reach the process — the
@@ -427,6 +441,7 @@ set "VELESDB_MEMORY_TLS_DIR=$script:TlsDir"
 set "VELESDB_MEMORY_EMBEDDER=$script:Embedder"
 set "VELESDB_MEMORY_OLLAMA_URL=$OllamaUrl"
 set "VELESDB_MEMORY_OLLAMA_MODEL=$OllamaModel"
+$extractorLines
 $ttlLine
 "$BinPath" --http --http-port $Port >> "$LogsDir\daemon.out.log" 2>> "$LogsDir\daemon.err.log"
 "@

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -33,6 +33,10 @@
 #   --store=PATH             Store directory (default: $HOME/.velesdb-memory)
 #   --tls-dir=PATH           TLS material (CA + leaf cert) directory (default: $HOME/.velesdb-memory-tls)
 #   --ollama-url=URL         Ollama endpoint (default: http://localhost:11434)
+#   --extractor-model=MODEL  Ollama chat model powering `remember_extracted` (fact extraction
+#                            + auto-built fact<->topic graph). Unset by default: the tool then
+#                            reports extraction as unconfigured. The daemon is always BUILT with
+#                            the backend, so enabling it later is a plist edit, not a rebuild.
 #   --ollama-model=MODEL     Ollama embedding model (default: all-minilm; when unset it is
 #                            auto-matched to an existing store's dimension, and any model whose
 #                            dimension differs from that store is rejected — see VELES-004)
@@ -87,6 +91,12 @@ STORE="$HOME/.velesdb-memory"
 TLS_DIR="$HOME/.velesdb-memory-tls"
 OLLAMA_URL="http://localhost:11434"
 OLLAMA_MODEL="all-minilm"
+# Empty means "no extraction backend": `remember_extracted` stays advertised and
+# reports itself unconfigured. Deliberately NOT defaulted to a model — setting
+# VELESDB_MEMORY_EXTRACTOR without VELESDB_MEMORY_EXTRACTOR_MODEL makes the
+# daemon refuse to start, so a default here would break every install whose
+# machine has not pulled that model.
+EXTRACTOR_MODEL=""
 OLLAMA_MODEL_SET=0
 TTL=""
 TTL_SET=0
@@ -121,6 +131,7 @@ for arg in "$@"; do
     --tls-dir=*) TLS_DIR="${arg#*=}" ;;
     --ollama-url=*) OLLAMA_URL="${arg#*=}" ;;
     --ollama-model=*) OLLAMA_MODEL="${arg#*=}"; OLLAMA_MODEL_SET=1 ;;
+    --extractor-model=*) EXTRACTOR_MODEL="${arg#*=}" ;;
     --ttl=*) TTL="${arg#*=}"; TTL_SET=1 ;;
     --yes) ASSUME_YES=1 ;;
     --skip-client=*) SKIP_CLIENTS="$SKIP_CLIENTS ${arg#*=}" ;;
@@ -375,12 +386,12 @@ setup_ollama() {
 
 # ---- 4. Build --------------------------------------------------------------
 build_daemon() {
-  echo -e "${YELLOW}🔨 Building velesdb-memory (--features ollama,http)...${NC}"
+  echo -e "${YELLOW}🔨 Building velesdb-memory (--features ollama,http,extract)...${NC}"
   # Always both features regardless of the runtime embedder choice above:
   # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
   # choice, so flipping it later is a restart, never a rebuild.
   cargo install --path "$REPO_ROOT/crates/velesdb-memory" --bin velesdb-memory \
-    --features ollama,http --force
+    --features ollama,http,extract --force
 }
 
 # ---- 4b. --from-release: install a prebuilt daemon binary, no cargo needed --
@@ -556,6 +567,13 @@ setup_daemon() {
   # Empty TTL means "permanent" (VELESDB_MEMORY_DEFAULT_TTL unset) — matches
   # the server's own default, so omit the key entirely rather than setting it
   # to an empty string.
+  # Wired only when a model was given: see EXTRACTOR_MODEL's declaration for
+  # why an unconditional VELESDB_MEMORY_EXTRACTOR would be a startup failure.
+  EXTRACTOR_PLIST_ENTRY=""
+  if [ -n "$EXTRACTOR_MODEL" ]; then
+    EXTRACTOR_PLIST_ENTRY="    <key>VELESDB_MEMORY_EXTRACTOR</key><string>ollama</string>
+    <key>VELESDB_MEMORY_EXTRACTOR_MODEL</key><string>$EXTRACTOR_MODEL</string>"
+  fi
   TTL_PLIST_ENTRY=""
   if [ -n "$TTL" ]; then
     TTL_PLIST_ENTRY="    <key>VELESDB_MEMORY_DEFAULT_TTL</key><string>$TTL</string>"
@@ -581,6 +599,7 @@ setup_daemon() {
     <key>VELESDB_MEMORY_EMBEDDER</key><string>$EMBEDDER</string>
     <key>VELESDB_MEMORY_OLLAMA_URL</key><string>$OLLAMA_URL</string>
     <key>VELESDB_MEMORY_OLLAMA_MODEL</key><string>$OLLAMA_MODEL</string>
+$EXTRACTOR_PLIST_ENTRY
 $TTL_PLIST_ENTRY
   </dict>
   <key>RunAtLoad</key><true/>


### PR DESCRIPTION
Both installers hardcoded `--features ollama,http`. `remember_extracted` is advertised by every daemon they produce and **could never work in one**: the tool is registered unconditionally and reports extraction as unconfigured at call time, so the installer was making impossible a capability the server keeps announcing.

## The gap is visible from inside the product

`crates/velesdb-node/Cargo.toml:31` compiles the very same crate with `extract` on. So the Node binding has fact extraction while a daemon installed by these scripts does not — same engine, opposite capabilities, and nothing said so.

## Change

`extract` costs one small dependency (`ureq`, already pulled in by `ollama`), so it is now always compiled in. Enabling it becomes a config edit rather than a rebuild.

Wiring stays **opt-in**, via `--extractor-model=MODEL` (`.sh`) / `-ExtractorModel <model>` (`.ps1`), deliberately with no default: `VELESDB_MEMORY_EXTRACTOR` set *without* `VELESDB_MEMORY_EXTRACTOR_MODEL` makes the daemon **refuse to start**, so a default here would break every install whose machine has not pulled that model. Both variables are written together or not at all.

## Why it matters

Extraction is what populates the fact↔topic graph that `why` traverses: `remember_extracted` splits raw text into atomic facts and wires the edges in both directions, which is what lets a walk hop from one fact to its siblings.

Sampled on a real store built only with `remember`:

| query | result |
|---|---|
| `release 0.9.0` | 1 node, 0 edges |
| `VelesDB Premium` | 1 node, 0 edges |
| `gate` | 1 node, 0 edges |
| `documentation` | 1 node, 0 edges |
| `worktree` | 3 nodes, 2 edges |

Four out of five queries return an isolated node. The graph `why` is meant to walk barely exists, because nothing builds it automatically.

## Not covered here

The prebuilt release archives (`release-memory.yml`) still build `--features ollama,http`, so `--from-release` installs remain without the backend. Aligning those touches published artifacts and belongs in its own change.
