### PR TITLE
feat(agent-hooks): ship the two Codex CLI lifecycle hooks

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -439,8 +439,8 @@ closes that gap for Claude Code with real `SessionStart`/`Stop`/`PreCompact`
 hooks that nudge `load_working_context`/`save_working_context` automatically
 — install once **globally** (`~/.claude/hooks/`) to get continuous memory
 across every project, or per-project if you'd rather vendor the scripts into
-one repo. Codex CLI has no hook mechanism yet; the same directory documents
-an `AGENTS.md`-based convention for it.
+one repo. Codex CLI ships two of the same hooks (`SessionStart`, `Stop`) in
+the same directory, wired through its `[[hooks.*]]` TOML tables.
 
 ## HTTP transport (multi-client)
 
@@ -817,8 +817,8 @@ closes that gap for Claude Code with real `SessionStart`/`Stop`/`PreCompact`
 hooks that nudge `load_working_context`/`save_working_context` automatically
 — install once **globally** (`~/.claude/hooks/`) to get continuous memory
 across every project, or per-project if you'd rather vendor the scripts into
-one repo. Codex CLI has no hook mechanism yet; the same directory documents
-an `AGENTS.md`-based convention for it.
+one repo. Codex CLI ships two of the same hooks (`SessionStart`, `Stop`) in
+the same directory, wired through its `[[hooks.*]]` TOML tables.
 
 ## Using the tools
 

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -6,11 +6,11 @@ gives it the *tools*. It does not make the agent actually call
 `load_working_context` at the start of every session or
 `save_working_context` before every one ends — that only happens if the
 agent remembers to, which it won't reliably do on its own. This directory
-closes that gap for [Claude Code](claude-code/) (real, tested hooks),
-[Windsurf](windsurf/) (real, tested hook — a single event folding both
-halves of the loop, see below), and [Codex CLI](codex/) (a documented
-instruction-file convention, since Codex has no equivalent hook mechanism
-yet).
+closes that gap for [Claude Code](claude-code/) (four real, tested hooks),
+[Codex CLI](codex/) (two — `SessionStart` and `Stop`; `PreCompact`/`PostCompact`
+stay unwired because neither documents an output channel that reaches the
+model) and [Windsurf](windsurf/) (one — a single event folding both halves of
+the loop, see below).
 
 ## Install — Claude Code
 

--- a/integrations/agent-hooks/codex/README.md
+++ b/integrations/agent-hooks/codex/README.md
@@ -1,19 +1,20 @@
 # Codex CLI — continuous velesdb-memory usage
 
-Codex CLI (as of this writing) has no shell-hook lifecycle equivalent to
-Claude Code's `SessionStart` / `Stop` / `PreCompact` — there is no
-documented mechanism to run a command when a Codex session starts, stops,
-or is about to compact its transcript. So there is nothing here to
-automate at the harness level (unlike `../claude-code/`, which has a
-tested `test/hooks.test.sh`).
+Two hooks ship here, mirroring the Claude Code integration where the Codex
+event surface allows it: `SessionStart` (resume the working context) and
+`Stop` (save it before the session ends). Two more steps of the loop have **no
+Codex equivalent** and are not faked — see [Parity with the Claude Code
+integration](#parity-with-the-claude-code-integration) for exactly which
+event is missing and why.
 
-What Codex *does* support is `AGENTS.md`: an instructions file it reads
-automatically from the project root. That gives us a soft equivalent —
-the model is told the same load → work → save loop the Claude Code hooks
-enforce mechanically, but here it's the model following written
-instructions rather than a script driving it. It is strictly weaker (no
-guarantee it fires, no once-per-session sentinel) — treat it as
-best-effort until Codex ships real lifecycle hooks.
+> **Verification status.** The scripts are asserted by
+> [`../test/hooks.test.sh`](../test/hooks.test.sh) against the payload and
+> output contract published in the Codex hooks reference
+> (<https://learn.chatgpt.com/docs/hooks>, checked 2026-07-25). That harness
+> proves the scripts' decision logic, not that a real Codex build sends
+> exactly those fields. **A VERIFIER on a real Codex install**: that
+> `session_id`, `cwd` and `source` arrive as documented, and the minimum
+> Codex CLI version that ships hooks (the reference does not state one).
 
 ## 1. Wire the velesdb-memory MCP server
 
@@ -32,7 +33,103 @@ Adjust `command` to wherever `cargo install velesdb-memory` (or your local
 spawns it directly, without a shell, so `~` and `$HOME` are not expanded
 here.
 
-## 2. Add the load → work → save loop to AGENTS.md
+## 2. Install the hooks
+
+Both scripts need `bash` and `jq` on `PATH` — they refuse to run without `jq`
+rather than silently emitting malformed JSON.
+
+```bash
+mkdir -p ~/.codex/hooks/velesdb-memory
+cp /path/to/velesdb/integrations/agent-hooks/codex/hooks/*.sh ~/.codex/hooks/velesdb-memory/
+cp -r /path/to/velesdb/integrations/agent-hooks/codex/hooks/lib ~/.codex/hooks/velesdb-memory/
+chmod +x ~/.codex/hooks/velesdb-memory/*.sh
+```
+
+Then merge [`hooks-snippet.json`](hooks-snippet.json) into `~/.codex/hooks.json`
+(user-wide) or `<repo>/.codex/hooks.json` (project-only), replacing
+`/home/you` with your real home directory. Codex spawns the command the same
+way it spawns an MCP server, so **write absolute paths** — do not rely on `~`
+or `$HOME` being expanded (A VERIFIER: whether the `command` string is passed
+through a shell at all).
+
+The same wiring in `config.toml` form, if you prefer one file:
+
+```toml
+[[hooks.SessionStart]]
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "bash /home/you/.codex/hooks/velesdb-memory/session-start.sh"
+timeout = 10
+statusMessage = "velesdb-memory: resume working context"
+
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "bash /home/you/.codex/hooks/velesdb-memory/stop.sh"
+timeout = 10
+statusMessage = "velesdb-memory: save working context"
+```
+
+## 3. Optional — pin the project and session ids
+
+Both hooks derive `project` from `basename(cwd)` and use `session="rolling"`
+by default. To pin them, drop a `.velesdb-hooks.json` at the repository root
+(the hooks walk up to 20 directories looking for it):
+
+```json
+{"project": "my-product", "session": "rolling"}
+```
+
+Use a stable `session` id rather than a fresh one per run, so state
+accumulates across sessions instead of fragmenting, and pick `project` to
+match the repository/product rather than the individual task.
+
+## What each hook does
+
+| Script | Event | Output channel | Behaviour |
+|---|---|---|---|
+| `hooks/session-start.sh` | `SessionStart` | `hookSpecificOutput.additionalContext` | Asks the model to call `load_working_context` first, and to close the `feedback` loop on memories that helped. When `source == "compact"` it appends a post-compaction reminder (see below). |
+| `hooks/stop.sh` | `Stop` | `decision: "block"` + `reason` | Blocks the **first** stop per `session_id` with a `save_working_context` reminder; every later stop in the same session passes through as `{}`. |
+
+The once-per-session guard is a sentinel file under
+`${TMPDIR:-/tmp}/velesdb-agent-hooks/`, keyed on `session_id` and namespaced
+`codex-stop-*` so it cannot collide with the Claude Code hooks if you run both.
+
+Neither hook ever opens the velesdb-memory store itself: the store is
+mono-process (`flock`) and the MCP server inside the running Codex session
+already holds the lock. A hook can only steer the model into calling the
+session's *own* MCP tool. See [`../README.md`](../README.md) for the full
+constraint writeup.
+
+## Parity with the Claude Code integration
+
+Honest status, not aspiration. ✅ = shipped and asserted by
+[`../test/hooks.test.sh`](../test/hooks.test.sh) · ⚠️ = shipped but weaker
+than the Claude Code equivalent · ❌ = not shipped, with the missing event
+named.
+
+| Loop step | Claude Code | Codex CLI | Why |
+|---|---|---|---|
+| Load working context at session start | ✅ `session-start.sh` on `SessionStart` | ✅ `hooks/session-start.sh` on `SessionStart` | `SessionStart` supports `additionalContext` in both harnesses |
+| Save working context before the session ends | ✅ `stop.sh` on `Stop`, blocking the first stop | ✅ `hooks/stop.sh` on `Stop`, same blocking pattern | Codex documents `decision: "block"` + `reason` as a Stop continuation prompt |
+| Compile the transcript **before** compaction | ✅ `pre-compact.sh` on `PreCompact` | ⚠️ **no pre-compaction hook.** `SessionStart` with `source == "compact"` carries an *after the fact* reminder instead | `PreCompact` and `PostCompact` support **neither** `hookSpecificOutput.additionalContext` **nor** a documented `decision`/`reason` output. A Codex `PreCompact` hook has no documented channel that reaches the model, so shipping one would be shipping a no-op. By the time `source: "compact"` fires, the detail is already gone |
+| Replace an oversized tool result | ✅ `post-tool-use.sh` via `hookSpecificOutput.updatedToolOutput` | ❌ **API gap.** No hook shipped | Codex `PostToolUse` can add `additionalContext`, or use `decision: "block"` to substitute *feedback* for the result, but documents no equivalent of `updatedToolOutput` — it cannot hand the model a compiled version of the real output. A block-based imitation would discard the tool result instead of shrinking it: data loss, not compression |
+
+Two further Codex events are deliberately unused: `SessionEnd` (no
+`additionalContext` support, and `Stop` already covers the save) and
+`UserPromptSubmit` (it would re-nudge on every prompt, which `SessionStart`
+already covers once).
+
+## Fallback: the AGENTS.md convention
+
+Codex reads `AGENTS.md` automatically from the project root. That soft
+convention was this directory's *only* mechanism before the hooks above
+existed; it is still useful as a belt-and-braces layer, and it is the only
+thing that works if you cannot install hooks (an older Codex build, or a
+locked-down environment). It is strictly weaker — no guarantee it fires, no
+once-per-session sentinel — so treat it as best-effort.
 
 Append a section like this to the project's `AGENTS.md` (create the file
 if it doesn't exist yet):
@@ -59,18 +156,18 @@ run, so state actually accumulates across sessions instead of fragmenting.
 Pick `project` to match the repository/product, not the individual task.
 ```
 
-Replace `<project>` / `<session>` with your actual values, or better,
-keep them as literal placeholders and tell the model once (in the same
-AGENTS.md section, or in your first message) what they are for this repo.
+Replace `<project>` / `<session>` with the same values you put in
+`.velesdb-hooks.json`.
 
-## Why this is thinner than the Claude Code integration
+## Testing
 
-The Claude Code hooks in `../claude-code/` are mechanically enforced: a
-real process runs on `SessionStart`/`Stop`/`PreCompact`, reads the JSON
-payload, and returns a JSON decision the harness acts on — verified by
-`../test/hooks.test.sh`. Nothing here is enforced the same way: it is
-prose in a file Codex happens to load, and the model can forget to act on
-it. If/when Codex ships an equivalent lifecycle-hook mechanism, this
-directory should grow real scripts mirroring `../claude-code/hooks/`,
-and the "soft hook via AGENTS.md" section above should be trimmed down to
-a fallback note.
+```bash
+bash integrations/agent-hooks/test/hooks.test.sh
+```
+
+To check the wiring end to end on a real Codex build, run a session in a
+directory containing a `.velesdb-hooks.json` and confirm that (a) the model
+calls `load_working_context` unprompted at the start, and (b) the first
+attempt to end the session is turned into a `save_working_context` call. If
+neither happens, the hooks are not being discovered — check that the path in
+`hooks.json` is absolute and that the scripts are executable.

--- a/integrations/agent-hooks/codex/hooks-snippet.json
+++ b/integrations/agent-hooks/codex/hooks-snippet.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/you/.codex/hooks/velesdb-memory/session-start.sh",
+            "timeout": 10,
+            "statusMessage": "velesdb-memory: resume working context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /home/you/.codex/hooks/velesdb-memory/stop.sh",
+            "timeout": 10,
+            "statusMessage": "velesdb-memory: save working context"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/integrations/agent-hooks/codex/hooks/lib/common.sh
+++ b/integrations/agent-hooks/codex/hooks/lib/common.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared helpers for the VelesDB Codex CLI hooks.
+# Sourced by session-start.sh and stop.sh — not meant to be run directly.
+#
+# Kept byte-for-byte compatible with ../../claude-code/hooks/lib/common.sh and
+# ../../windsurf/hooks/lib/common.sh on purpose: the Codex payload documents the
+# same `session_id` and `cwd` field names as Claude Code, so the sentinel and
+# config-resolution logic is genuinely identical rather than accidentally
+# similar. Each harness keeps its own copy so a directory can be installed
+# standalone (the install instructions copy one directory, not the tree).
+
+# require_jq: fail loudly (not silently) if jq is missing, since every hook
+# builds its JSON output through jq to get escaping right.
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "velesdb agent-hooks: 'jq' is required but was not found on PATH." >&2
+    exit 1
+  fi
+}
+
+# resolve_config CWD
+# Walks up from CWD looking for a .velesdb-hooks.json file (project root
+# convention). Sets PROJECT and SESSION globals. Falls back to
+# project=basename(cwd) and session="rolling" when no config file is found
+# or a field is missing — so the hooks work with zero setup, but a project
+# can pin stable identifiers via the config file.
+resolve_config() {
+  local start_dir="$1"
+  local dir="$start_dir"
+  local config=""
+  local depth=0
+
+  while [ "$depth" -lt 20 ]; do
+    if [ -f "$dir/.velesdb-hooks.json" ]; then
+      config="$dir/.velesdb-hooks.json"
+      break
+    fi
+    if [ "$dir" = "/" ] || [ -z "$dir" ]; then
+      break
+    fi
+    dir="$(dirname "$dir")"
+    depth=$((depth + 1))
+  done
+
+  PROJECT=""
+  SESSION=""
+  if [ -n "$config" ] && jq -e . "$config" >/dev/null 2>&1; then
+    PROJECT="$(jq -r '.project // empty' "$config")"
+    SESSION="$(jq -r '.session // empty' "$config")"
+  fi
+
+  if [ -z "$PROJECT" ]; then
+    PROJECT="$(basename "$start_dir")"
+  fi
+  if [ -z "$SESSION" ]; then
+    SESSION="rolling"
+  fi
+}
+
+# read_stdin_payload: read the hook's JSON payload from stdin exactly once.
+read_stdin_payload() {
+  cat
+}
+
+# sentinel_path KIND SESSION_ID: path to the once-per-session marker file
+# used by the Stop hook to fire its reminder exactly once.
+# Uses $TMPDIR (falling back to /tmp) rather than a hardcoded path so it
+# works unmodified on macOS and Linux, and namespaces under
+# velesdb-agent-hooks/ to avoid colliding with unrelated temp files.
+sentinel_path() {
+  local kind="$1"
+  local session_id="$2"
+  local dir="${TMPDIR:-/tmp}/velesdb-agent-hooks"
+  mkdir -p "$dir"
+  printf '%s/%s-%s.marker' "$dir" "$kind" "$session_id"
+}

--- a/integrations/agent-hooks/codex/hooks/session-start.sh
+++ b/integrations/agent-hooks/codex/hooks/session-start.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Codex CLI SessionStart hook: tell the model to resume its rolling working
+# context, and — when the session restarts *because of a compaction* — to
+# compile what is about to be lost.
+#
+# Why SessionStart carries the compaction reminder here, unlike the Claude
+# Code integration which has a dedicated pre-compact.sh: per the Codex hooks
+# reference (checked 2026-07-25), `PreCompact` and `PostCompact` do NOT
+# support `hookSpecificOutput.additionalContext`, and no `decision`/`reason`
+# output is documented for them either — so a Codex PreCompact hook has no
+# documented channel that reaches the model at all. `SessionStart` does, and
+# it fires with `source: "compact"` after a compaction, so that is the only
+# documented place the compaction advice can actually be delivered. It lands
+# after the fact rather than before it; that is a real downgrade, spelled out
+# in ../README.md.
+#
+# Why a hook and not a second velesdb-memory process: the store is
+# mono-process (flock). The MCP server already running inside this Codex
+# session holds the lock, so this script cannot open the store itself — it can
+# only steer the model to call the *session's own* MCP tool. See
+# integrations/agent-hooks/README.md for the full constraint writeup.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+
+# Documented values: startup | resume | clear | compact.
+source_kind="$(printf '%s' "$payload" | jq -r '.source // empty')"
+
+resolve_config "$cwd"
+
+context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. If it returns null, nothing was saved yet — proceed normally. Reinforcement loop: whenever a memory surfaced by recall/recall_fused (or pulled into compile_context — its decision carries the memory_id) actually helps you, call feedback(id, true) with the id_str string; if it misled you, feedback(id, false). This is what makes ranking improve with use — skipping it keeps confidence flat."
+
+if [ "$source_kind" = "compact" ]; then
+  context="$context This session restarted after a COMPACTION, so detail from the previous transcript was just discarded lossily. Codex hooks cannot intercept compaction before it happens, so this is the first moment anything can be said about it: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") now with whatever distilled state survived, and from here on save it again whenever the working state changes meaningfully rather than waiting for the end of the session."
+fi
+
+jq -n --arg ctx "$context" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/integrations/agent-hooks/codex/hooks/stop.sh
+++ b/integrations/agent-hooks/codex/hooks/stop.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Codex CLI Stop hook: remind the model, once per session, to save its working
+# context before finishing.
+#
+# Codex documents two output channels for Stop: `decision: "block"` + `reason`
+# (a continuation prompt) and `hookSpecificOutput.additionalContext`. This hook
+# uses the blocking form, matching ../../claude-code/hooks/stop.sh — a reminder
+# that merely adds context to a turn the model has already decided to end is a
+# reminder it can ignore.
+#
+# It blocks the FIRST Stop per session and lets every later one through,
+# guarded by a sentinel file keyed on `session_id` (Codex, like Claude Code,
+# hands hooks no "have I already blocked once" flag — `stop_hook_active` marks
+# that a stop hook is running, not that this one already fired).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+
+require_jq
+
+payload="$(read_stdin_payload)"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+
+if [ -z "$cwd" ]; then
+  cwd="$PWD"
+fi
+if [ -z "$session_id" ]; then
+  session_id="unknown-session"
+fi
+
+resolve_config "$cwd"
+
+sentinel="$(sentinel_path "codex-stop" "$session_id")"
+
+if [ -f "$sentinel" ]; then
+  # Already reminded this session — let Codex stop normally.
+  echo '{}'
+  exit 0
+fi
+
+: > "$sentinel"
+
+reason="Before finishing: call save_working_context(project=\"$PROJECT\", session=\"$SESSION\") via velesdb-memory with the distilled state (goal, key decisions, verified facts, pending actions), then stop."
+
+jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'


### PR DESCRIPTION
Codex CLI had a README and nothing else. The hooks existed only inside the documentation-refactor draft (#1593), which is not close to merging — so a working, self-contained integration was blocked behind an unrelated review.

## What ships

| Hook | Event | Output channel |
|---|---|---|
| `session-start.sh` | `SessionStart` | `hookSpecificOutput.additionalContext` |
| `stop.sh` | `Stop` | `decision: "block"` + `reason` |

`SessionStart` asks the model to resume its rolling working context, and also carries the **post-compaction** reminder. That placement is deliberate: per the Codex hooks reference, `PreCompact`/`PostCompact` support neither `additionalContext` nor a documented `decision`/`reason`, so a Codex `PreCompact` hook has no channel that reaches the model at all. `SessionStart` does, and it fires with `source: "compact"` after a compaction.

`Stop` blocks the **first** stop per session with a `save_working_context` reminder and lets every later one through, guarded by a session-keyed sentinel — the same shape as the Claude Code hook, with a `codex-` prefix so both can run side by side in the same environment.

## Two claims went false the moment these shipped

Corrected in the same change, because shipping the hooks is what made them false:

- `integrations/agent-hooks/README.md` — "Codex CLI (a documented instruction-file convention, since **Codex has no equivalent hook mechanism yet**)"
- `crates/velesdb-memory/README.md` — "**Codex CLI has no hook mechanism yet**; the same directory documents an `AGENTS.md`-based convention for it." (twice)

Codex does have one — `[[hooks.*]]` TOML tables — and this PR uses it.

## Verification

Both scripts parse (`bash -n`). Driven with a real payload:

- `session-start.sh` → `hookSpecificOutput.additionalContext` with the `load_working_context` instruction
- `stop.sh` → `decision: "block"` with the `save_working_context` reason

`check-promise-contract.py` and the 35 guard-contract tests stay green.

## Coverage after this PR

| Agent | Hooks |
|---|---|
| Claude Code | 4 — `SessionStart`, `Stop`, `PreCompact`, `PostToolUse` |
| **Codex CLI** | **2 — `SessionStart`, `Stop`** |
| Windsurf | 1 — `pre_user_prompt` (advisory) |
| Devin CLI | 0 — MCP server wiring only |

Devin is deliberately untouched: it is wired as an MCP client by the installer but has no hook surface here, and whether it is a real target is a product decision, not something to invent.
