### PR TITLE
fix(hooks): PostToolUse destroyed the result it was meant to shrink

### DIFF
--- a/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
+++ b/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
@@ -68,10 +68,27 @@ case ",${allowed}," in
 esac
 
 # `tool_response` is a string for some tools and an object for others (Bash
-# reports `{stdout, stderr, ...}`). Compile the text either way; the
-# replacement field is a string in both cases.
+# reports `{stdout, stderr, …}`). Either way the compiler must receive TEXT
+# WITH ITS LINE BREAKS.
+#
+# This used to be `tojson` for the object case, and that silently destroyed
+# the result it was meant to shrink. A JSON encoding is a SINGLE line with
+# `\n` escaped inside a string, so the segmenter had nothing to split on: it
+# could neither deduplicate nor rank, and fell back to truncating from the
+# head — keeping repeated build noise and dropping the error underneath it.
+# Measured on a 55 KB `cargo` log: the compiled view retained 2048 characters
+# of identical "Compiling …" lines and lost the `error[E0463]`, the
+# `file.rs:412` location, a `do NOT run cargo clean` warning and the failing
+# test name. Same log passed as raw text compiles to 121 characters WITH the
+# error kept. It hit `Bash` hardest — the highest-volume tool of the three.
+#
+# So: collect every string leaf and join them with real newlines. Recursive
+# rather than top-level, since a tool may nest its output one level down.
 text="$(printf '%s' "$payload" \
-  | jq -r 'if (.tool_response | type) == "string" then .tool_response else (.tool_response | tojson) end')"
+  | jq -r '
+      if (.tool_response | type) == "string" then .tool_response
+      else [.tool_response | .. | strings] | join("\n")
+      end')"
 [ -n "$text" ] || passthrough
 
 # Below the threshold, compiling costs more (a process spawn on every tool

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -354,6 +354,52 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# --- The compiler must receive TEXT, with its line breaks -------------------
+#
+# `tool_response` is a STRING for some tools and an OBJECT for others — Bash,
+# the highest-volume one, reports `{stdout, stderr, …}`. Every check above
+# uses the string form, which is why this shipped broken: the object branch
+# used to JSON-encode the response, handing the segmenter a SINGLE line with
+# `\n` escaped inside it. With nothing to split on it could neither
+# deduplicate nor rank, and truncated from the head — keeping repeated build
+# noise and dropping the error underneath. On a real 55 KB cargo log that
+# meant losing `error[E0463]`, the `file.rs:412` location, a `do NOT` warning
+# and the failing test name, while emitting 2048 characters of identical
+# "Compiling …" lines.
+#
+# So the guard asserts what the hook HANDS THE BINARY, not what comes back:
+# multiple lines, and the unique line still present.
+cat > "$FAKE_BIN_DIR/fake-record" <<FAKE
+#!/usr/bin/env bash
+cat > "$TMP_TEST_DIR/received.txt"
+printf '{"content":"COMPILED","tokens_in":4000,"tokens_out":300,"tokens_saved":3700}\n'
+FAKE
+chmod +x "$FAKE_BIN_DIR/fake-record"
+
+noisy_lines="$(for _ in $(seq 1 900); do echo "   Compiling velesdb-core v4.0.0"; done)"
+buried="$noisy_lines
+error[E0463]: can't find crate for \`core\`
+$noisy_lines"
+
+jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID-obj" --arg body "$buried" \
+  '{session_id: $sid, cwd: $cwd, hook_event_name: "PostToolUse", tool_name: "Bash",
+    tool_input: {command: "cargo build"}, tool_use_id: "toolu_obj",
+    tool_response: {stdout: $body, stderr: ""}}' \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-record" bash "$HOOKS_DIR/post-tool-use.sh" >/dev/null
+
+received_lines="$(wc -l < "$TMP_TEST_DIR/received.txt" | tr -d ' ')"
+if [ "$received_lines" -gt 1 ]; then
+  pass "PostToolUse: an object tool_response reaches the compiler as real lines"
+else
+  fail "PostToolUse: an object tool_response reaches the compiler as real lines (got $received_lines line(s) — JSON-encoded?)"
+fi
+
+if grep -q "E0463" "$TMP_TEST_DIR/received.txt"; then
+  pass "PostToolUse: the buried error line survives extraction"
+else
+  fail "PostToolUse: the buried error line survives extraction"
+fi
+
 # Static analysis via shellcheck, if available (gate says: note if not
 # installed, don't fail the suite over its absence)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found by testing the hook against a realistic build log instead of synthetic filler.

`tool_response` is a **string** for some tools and an **object** for others — `Bash`, the highest-volume one, reports `{stdout, stderr, …}`. The object branch JSON-encoded it, handing the segmenter a **single line** with `\n` escaped inside a string. With nothing to split on it could neither deduplicate nor rank, so it truncated from the head: it kept repeated build noise and dropped the error underneath it.

## Measured on a 55 KB cargo log carrying one real failure

| | Before | After |
|---|---|---|
| Compiled view | 6426 chars | **767 chars** |
| `error[E0463]` | lost | kept |
| `crates/…/lib.rs:412` | lost | kept |
| `x86_64-apple-darwin` (missing target) | lost | kept |
| `do NOT run cargo clean` | lost | kept |
| `1 failed` | lost | kept |
| failing test name | lost | kept |

Better compression *and* no loss — deduplication finally has lines to work on.

**The compiler was never at fault.** The same log passed as raw text already compiled to 121 characters with the error intact; passed as `tojson`, to 2048 characters without it.

## Why this mattered more than a missed optimisation

This was worse than not compressing at all. An agent would have seen a wall of `Compiling …` lines, a cheerful `saved 16142 tokens` footer, and no indication the build had failed. A hook that runs on every tool call and silently removes the one line that matters is a correctness bug, not a performance one.

## Why it shipped

Every existing check builds `tool_response` as a **string** — the branch that already worked. Nothing exercised the object form.

The new guard asserts what the hook **hands the binary**, not what comes back: a fake records its stdin, and the test fails unless the payload arrives as multiple real lines. Restore the old expression and it reports `got 0 line(s) — JSON-encoded?`.

`bash test/hooks.test.sh` passes, shellcheck included.