### PR TITLE
fix(release): ship the extraction backend in the prebuilt daemon archives too

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -17,7 +17,7 @@
 # published separately by release-mcpb.yml are built with DEFAULT features
 # (stdio only — no `http`/`ollama`), so they can't run as the shared
 # multi-client daemon scripts/install-memory-daemon.{sh,ps1} set up. The
-# daemon archives are the SAME crate built with `--features ollama,http`
+# daemon archives are the SAME crate built with `--features ollama,http,extract`
 # instead, letting `--from-release` / `-FromRelease` in those install
 # scripts install a working daemon binary with no Rust toolchain on the
 # target machine.
@@ -43,7 +43,7 @@ on:
         type: boolean
         default: true
       publish_daemon_archive:
-        description: 'Build and attach the --features ollama,http daemon archives to the GitHub Release'
+        description: 'Build and attach the --features ollama,http,extract daemon archives to the GitHub Release'
         type: boolean
         default: true
 
@@ -371,7 +371,7 @@ jobs:
           fi
 
   # ===========================================================================
-  # 5. Build the daemon binary for each platform (--features ollama,http)
+  # 5. Build the daemon binary for each platform (--features ollama,http,extract)
   # ===========================================================================
   #
   # Same crate/bin as the default-feature .mcpb bundles in release-mcpb.yml,
@@ -421,8 +421,8 @@ jobs:
         with:
           shared-key: "release-memory-daemon-${{ matrix.target }}"
 
-      - name: Build velesdb-memory (--features ollama,http)
-        run: cargo build --release --locked -p velesdb-memory --bin velesdb-memory --target ${{ matrix.target }} --features ollama,http
+      - name: Build velesdb-memory (--features ollama,http,extract)
+        run: cargo build --release --locked -p velesdb-memory --bin velesdb-memory --target ${{ matrix.target }} --features ollama,http,extract
 
       - name: Package archive + checksum
         shell: bash
@@ -519,7 +519,7 @@ jobs:
           # velesdb-memory release must never become the repo's "Latest
           # release" (that belongs to the workspace vX.Y.Z release).
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "$TAG" --latest=false --notes "velesdb-memory $TAG — daemon archives (--features ollama,http) for install-memory-daemon.sh/.ps1 --from-release." || true
+            gh release create "$TAG" --title "$TAG" --latest=false --notes "velesdb-memory $TAG — daemon archives (--features ollama,http,extract) for install-memory-daemon.sh/.ps1 --from-release." || true
           fi
           ls -la daemon-archives/
           gh release upload "$TAG" daemon-archives/* --clobber

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -739,7 +739,7 @@ Windows in three places:
 
 ### Installing the daemon without a Rust toolchain
 
-Both installers default to `cargo install --features ollama,http`, which
+Both installers default to `cargo install --features ollama,http,extract`, which
 needs a Rust toolchain on the machine. Pass `--from-release[=TAG]` (`.sh`) or
 `-FromRelease` / `-FromReleaseTag <TAG>` (`.ps1`, which has no PowerShell
 equivalent of the shell flag's optional inline value) to instead download a

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -47,7 +47,7 @@
 #   --wire-only              Skip build/daemon setup: only (re-)verify CA trust and re-wire the
 #                            clients against an already-installed daemon (no prompts, fast)
 #   --force-restart          Reload the daemon even if already running
-#   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http) from a
+#   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http,extract) from a
 #                            GitHub Release archive instead of `cargo install` (default TAG: the
 #                            latest published velesdb-memory-vX.Y.Z release). Needs no Rust
 #                            toolchain. Only active from the first release that publishes the
@@ -395,7 +395,7 @@ build_daemon() {
 }
 
 # ---- 4b. --from-release: install a prebuilt daemon binary, no cargo needed --
-# Mirrors build_daemon()'s guarantee (--features ollama,http) without a Rust
+# Mirrors build_daemon()'s guarantee (--features ollama,http,extract) without a Rust
 # toolchain, by downloading the same binary release-memory.yml's
 # build-daemon-archive job produces. Only active from the first release that
 # ships the archive onward (added after 0.11.0) — an older/pinned tag simply


### PR DESCRIPTION
The installers now build with `ollama,http,extract` (#1600), but the archives that `--from-release` downloads were still built with `ollama,http`.

So the path that exists **precisely for machines without a Rust toolchain** handed them a strictly lesser product: `remember_extracted` advertised by the server, and impossible in that binary. Two ways to install, two different capability sets, and nothing said so.

`extract` costs one dependency already pulled in by `ollama`, and the backend stays **inert** until `VELESDB_MEMORY_EXTRACTOR` names a model — so compiling it in changes nothing for anyone who does not want it, and makes enabling it a config edit rather than a rebuild.

Aligned in all six places the feature set was written down (`release-memory.yml` header, the `workflow_dispatch` description, the job comment, the build step name, the `cargo build` line, the release notes text), plus the README sentence describing what the installers default to and the two installer comments that promised parity with it — so the claim and the build stay one thing.

Verified: `grep` finds no remaining `--features ollama,http` without `extract` anywhere in the repo; YAML parses; installer passes `bash -n`.