### PR TITLE
docs: say what the system gains you, and how it works, before asking for a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,35 @@ The leading agent-memory products ([Mem0, Zep, Letta — detailed comparison, as
 
 ---
 
+## How it works, in plain terms
+
+Four things happen, and none of them calls an AI provider.
+
+**1 · It stores facts, not conversations.** You give it one statement — *"the
+API port is 6333 because 3000 collided with the web UI"* — and it lands in a
+local file store. No model call, nothing sent anywhere.
+
+**2 · It finds them by meaning.** Asking *"which port did we settle on"* reaches
+that fact even though none of the words match. A local embedding model turns
+text into coordinates; close meaning means close coordinates.
+
+**3 · It connects them, and that is the part a search engine cannot do.** Each
+fact is linked to the topics it mentions. `why()` starts from the best match and
+then **walks those links**, so it returns the answer *plus the facts that
+explain it* — including ones sharing no vocabulary with your question.
+
+> The links have to exist. Store facts one by one and the graph stays flat, so
+> `why()` behaves like a search. Hand a paragraph to `remember_extracted` and it
+> splits it into facts and wires the links for you.
+
+**4 · It compresses what is too big, before you pay for it.** Give the compiler
+your accumulated context and a token budget; it returns a smaller version with
+**one recorded decision per fragment** — kept, abstracted, or dropped — and a
+handle to fetch any original back verbatim. Same input, same bytes out, every
+time. That is what the [82.5 % below](#the-numbers--every-one-from-a-committed-harness) measures.
+
+---
+
 ## Get started in 60 seconds
 
 **Fastest path — Python, under 5 seconds median, [measured](docs/quickstart/timing-results.md):**

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -17,6 +17,61 @@ traceability the [EU AI Act](https://artificialintelligenceact.eu/implementation
 meet** those data-residency and explainability expectations rather than claiming
 certified compliance.
 
+## What you actually gain
+
+Two problems cost you real money and real quality every day, and this fixes both.
+
+**Your agent forgets.** Close the session, and everything it learned about your
+codebase is gone. Tomorrow you explain it again. velesdb-memory keeps those
+facts on your disk and hands them back at the start of the next session.
+
+**Every turn re-sends the whole conversation.** That is what you are billed for,
+and a context stuffed with repeated logs is also a context where the model pays
+less attention to what matters. The compiler shrinks that payload before it is
+sent — deterministically, with no AI call of its own.
+
+| What improves | Measured | How it was measured |
+|---|---|---|
+| Context sent to the model | **82.5 % smaller** on a 12-turn coding session (80–87 % per turn as it grows) | [committed corpus, real cl100k tokenizer](examples/context_savings) — recompiled twice per run, byte-identical |
+| Your actual bill | **10.9 % to 21.9 %** saved on the same session, A/B, real billing | [billed campaign](../../examples/real-session-benchmark#billed-campaign-results-2026-07-19-cli-runner-claude-sonnet-5) |
+| Cost of storing a memory | **zero AI calls** — nothing is sent anywhere | the write path never calls a model |
+| A 55 KB build log entering context | **767 characters**, error and file:line kept | the `PostToolUse` hook, below |
+
+The honest part: those percentages come from *our* corpus on *our* sessions.
+The spread is published as prominently as the best figure, and every number
+above is pinned to its source by a [contract the CI
+enforces](../../docs/reference/promise-contract.json) — if a figure drifts from
+what the code produces, the build goes red.
+
+## How it works, in four steps
+
+Nothing here needs an AI provider. Everything runs on your machine.
+
+**1. It stores facts, not transcripts.** You (or your agent) call `remember`
+with one fact: *"the API port is 6333 because 3000 collided with the web UI"*.
+It is written to a local file store. No model call, no network.
+
+**2. It finds them by meaning, not keywords.** `recall` matches on sense, so
+asking about *"which port did we settle on"* finds that fact even though the
+words differ. This uses a local embedding model of your choosing.
+
+**3. It connects them, which is the part that matters.** Facts are linked to
+the topics they mention. `why` starts from the best match and then *walks those
+links*, so it returns the answer **plus the facts that explain it** — including
+ones sharing no words with your question. A plain search cannot do that.
+
+> Those links have to exist. If you only ever call `remember`, the graph stays
+> flat and `why` behaves like a search. Point `remember_extracted` at a
+> paragraph and it splits it into facts and wires the links for you.
+
+**4. It compresses what is too big, at the right moment.** Four hooks fire
+automatically in your agent: two remind it to save and reload its state around
+a session, one does the same before a compaction, and `PostToolUse` is the one
+that *replaces* an oversized tool result with a compiled view — so the payload
+never enters the conversation at all. Nothing is deleted: the untouched
+original is written to a file and its path is quoted in the replacement, so the
+agent can read the full thing whenever the summary is not enough.
+
 > **Release 0.11.1** (patch) — **MCP tool parameters are now harness-proof on
 > both wire directions.** Real MCP client harnesses were observed serializing
 > non-string arguments as JSON-encoded strings once their view of the

--- a/crates/velesdb-memory/examples/context_savings/README.md
+++ b/crates/velesdb-memory/examples/context_savings/README.md
@@ -56,8 +56,8 @@ turn | fragments | raw_tokens | compiled_tokens | saved% | latency_ms
   12 |        18 |       2776 |             534 |  80.8% |       23.8
 
 session totals: 26533 raw -> 4647 compiled real tokens = 82.5% saved
-compile latency (with source/event persistence, default): mean 27.3 ms, max 36.4 ms
-compile latency (stateless: store_sources/record_events off): mean 0.5 ms, max 0.7 ms
+compile latency (with source/event persistence, default): mean 24.5 ms, max 37.2 ms
+compile latency (stateless: store_sources/record_events off): mean 0.7 ms, max 0.9 ms
 cache-marked prefix: byte-stable across all 12 turns (45 real tokens reusable by provider prompt caching)
 reproducibility: OK (every turn compiled twice, byte-identical)
 ```

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -21,6 +21,57 @@ with an auditable decision per fragment.
 > reopens it and `why()` still walks the graph to context that shares no words
 > with the question.
 
+## What you actually gain
+
+Two problems cost you real money and real quality every day, and this addon
+fixes both — in your own Node process, with no service to run.
+
+**Your agent forgets.** Close the process and everything it learned is gone.
+The store is a directory on disk, so a new process reopens it and the facts are
+still there.
+
+**Every turn re-sends the whole conversation.** That is what you are billed for,
+and a context padded with repeated logs is also one where the model attends less
+to what matters. `compileContext` shrinks that payload before you send it —
+deterministically, and without calling any model itself.
+
+| What improves | Measured | How it was measured |
+|---|---|---|
+| Context sent to the model | **82.5 % smaller** over a 12-turn coding session (80.8–87.4 % per turn as it grows) | [committed corpus, real cl100k tokenizer](../velesdb-memory/examples/context_savings) — every turn compiled twice, byte-identical |
+| Compile cost | **0.7 ms** stateless, 24.5 ms with source/event persistence on | same run |
+| Storing a memory | **zero AI calls** — nothing leaves the process | the write path never calls a model |
+| Prompt-cache prefix | **byte-stable across all 12 turns** (45 tokens reusable) | same run |
+
+Those percentages come from *our* corpus. Every figure is pinned to its
+committed source by a [contract the CI enforces](../../docs/reference/promise-contract.json):
+if one drifts from what the code produces, the build goes red.
+
+## How it works, in four steps
+
+Everything below runs in-process. No server, no network, no API key.
+
+**1. It stores facts, not transcripts.** `remember` takes one fact — *"the API
+port is 6333 because 3000 collided with the web UI"* — and writes it to a local
+directory. No model call.
+
+**2. It finds them by meaning.** `recall` matches on sense, so *"which port did
+we settle on"* reaches that fact although the words differ.
+
+**3. It connects them — the part a search engine cannot do.** Facts are linked
+to the topics they mention, and `why` walks those links: it returns the best
+match **plus the facts that explain it**, including ones sharing no words with
+your question. That is what the GIF above shows across a restart.
+
+> Those links have to exist. If you only ever call `remember`, the graph stays
+> flat and `why` degrades to a search. `rememberExtracted` takes a paragraph,
+> splits it into facts and wires the links for you.
+
+**4. It compresses what is too big.** `compileContext` takes your accumulated
+context and a token budget, and returns a compiled view with **one auditable
+decision per fragment** — kept, abstracted, or dropped — plus a handle to fetch
+any original back. Nothing is destroyed; `retrieveContextSource` returns the
+exact bytes.
+
 ## Install
 
 ```bash

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -316,9 +316,9 @@
       "executable": true,
       "source": "crates/velesdb-memory/examples/context_savings/README.md:58 (committed 12-turn agent-session corpus, real cl100k BPE: 26533 raw -> 4647 compiled tokens = 82.5% saved) — consistency check only, no live re-run.",
       "last_updated": "2026-07-19",
-      "measured_on": "2026-07-19",
+      "measured_on": "2026-07-26",
       "measured_machine": "platform-independent (committed corpus, deterministic tokenizer)",
-      "measured_version": "unknown"
+      "measured_version": "4.0.0"
     }
   ]
 }


### PR DESCRIPTION
Both crate READMEs opened by describing what the thing **is**, then went straight to install instructions. A reader who does not already know why they would want this had nothing to go on — the measured savings lived in the root README and the benchmark example, never where someone lands from crates.io or npm.

Each now opens with two short sections, placed **before** the install steps because that is the order a newcomer needs them in.

### What you actually gain

The two problems stated plainly — the agent forgets between sessions, and every turn re-sends the whole conversation and you are billed for it — then a table of what improves, with the number, the corpus, and a link to the run that produced it.

### How it works, in four steps

Store facts → find them by meaning → connect them so `why` can walk the links → compress what is too big. No jargon, and each step says what does **not** happen: no model call, no network, nothing deleted.

The step-3 caveat is stated rather than buried:

> Those links have to exist. If you only ever call `remember`, the graph stays flat and `why` degrades to a search.

That single fact decides whether the feature is worth anything, and it was nowhere in either README.

## Figures re-measured today, not copied forward

Re-ran the committed corpus on this code with a real cl100k tokenizer:

```
session totals: 26533 raw -> 4647 compiled real tokens = 82.5% saved
per turn: 80.8% – 87.4%
reproducibility: OK (every turn compiled twice, byte-identical)
```

**Identical to the committed headline** — so the claim is confirmed current, not restated. Compile latency moved slightly and is updated to what the run actually printed (24.5 ms mean with source/event persistence, 0.7 ms stateless). The contract entry is re-dated to `2026-07-26` / `4.0.0`.

`check-promise-contract.py`, `check-feature-claims.py` and the 35 guard-contract tests stay green; every link added resolves.