### PR TITLE
fix(server): gate plain REST graph reads through the CORE-2 governance check

### DIFF
--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -14,6 +14,7 @@ use axum::{
     Json,
 };
 use velesdb_core::collection::graph::{GraphEdge, TraversalConfig};
+use velesdb_core::observer::QueryOperationKind;
 
 use crate::handlers::helpers::auto_core_error_response;
 use crate::types::ErrorResponse;
@@ -95,6 +96,35 @@ pub(super) fn get_graph_collection_or_404(
     ))
 }
 
+/// Shared graph preamble for **read** operations: resolves the collection via
+/// [`graph_preamble`], then routes the read through the control-plane gate
+/// (CORE-2). Graph reads have no metadata-filter channel to narrow, so a
+/// denied or scope-narrowed decision refuses the request (fail closed)
+/// rather than running it unfiltered.
+///
+/// Mirrors the gate `MATCH` (`handlers::match_query`) and embedding
+/// [`super::handlers_extended::graph_search`] already apply — centralized
+/// here so every plain REST graph read is governed the same way instead of
+/// each handler wiring the check individually.
+#[allow(clippy::result_large_err)]
+pub(super) fn graph_read_preamble(
+    state: &AppState,
+    name: &str,
+    operation: QueryOperationKind,
+) -> Result<velesdb_core::GraphCollection, (StatusCode, Json<ErrorResponse>)> {
+    let coll = graph_preamble(state, name)?;
+    match state.db.authorize_read(name, operation, None, None) {
+        Ok(None) => Ok(coll),
+        Ok(Some(_)) | Err(_) => Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Read denied by governance policy".to_string(),
+                code: None,
+            }),
+        )),
+    }
+}
+
 /// Get edges from a collection's graph filtered by label.
 #[utoipa::path(
     get,
@@ -123,7 +153,7 @@ pub async fn get_edges(
         )
     })?;
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let edges: Vec<EdgeResponse> = coll
         .get_edges(Some(&label))
@@ -270,7 +300,7 @@ pub async fn traverse_graph(
     State(state): State<Arc<AppState>>,
     Json(request): Json<TraverseRequest>,
 ) -> Result<Json<TraverseResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let config = TraversalConfig::with_range(1, request.max_depth)
         .with_limit(request.limit)
@@ -335,7 +365,7 @@ pub async fn get_node_degree(
     Path((name, node_id)): Path<(String, u64)>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DegreeResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let (in_degree, out_degree) = coll.node_degree(node_id);
     Ok(Json(DegreeResponse {
         in_degree,

--- a/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
@@ -11,11 +11,12 @@ use axum::{
     Json,
 };
 use velesdb_core::collection::graph::TraversalConfig;
+use velesdb_core::observer::QueryOperationKind;
 
 use crate::types::ErrorResponse;
 use crate::AppState;
 
-use super::handlers::graph_preamble;
+use super::handlers::{graph_preamble, graph_read_preamble};
 use super::types::{
     EdgeCountResponse, EdgeResponse, EdgesResponse, GraphSearchRequest, GraphSearchResponse,
     GraphSearchResultItem, NodeEdgeQueryParams, NodeListResponse, NodePayloadResponse,
@@ -78,7 +79,7 @@ pub async fn get_edge_count(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<EdgeCountResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     Ok(Json(EdgeCountResponse {
         count: coll.edge_count(),
     }))
@@ -101,7 +102,7 @@ pub async fn list_nodes(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodeListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let node_ids = coll.all_node_ids();
     let count = node_ids.len();
     Ok(Json(NodeListResponse { node_ids, count }))
@@ -127,7 +128,7 @@ pub async fn get_node_edges(
     Query(params): Query<NodeEdgeQueryParams>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<EdgesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let raw_edges = match params.direction.to_lowercase().as_str() {
         "in" => coll.get_incoming(node_id),
@@ -214,7 +215,7 @@ pub async fn get_node_payload(
     Path((name, node_id)): Path<(String, u64)>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodePayloadResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let payload = coll.get_node_payload(node_id).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -254,7 +255,7 @@ pub async fn traverse_parallel(
         ));
     }
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let config = TraversalConfig::with_range(1, request.max_depth)
         .with_limit(request.limit)

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -68,6 +68,20 @@ async fn post(app: &axum::Router, uri: &str, body: Value) -> StatusCode {
         .status()
 }
 
+async fn get(app: &axum::Router, uri: &str) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .expect("test: build GET request"),
+        )
+        .await
+        .expect("test: GET request")
+        .status()
+}
+
 async fn delete(app: &axum::Router, uri: &str) -> StatusCode {
     app.clone()
         .oneshot(
@@ -258,5 +272,122 @@ async fn read_gate_denies_rest_search_end_to_end() {
     assert!(
         !status.is_success(),
         "denied hybrid read must not return success, got {status}"
+    );
+}
+
+/// End-to-end proof that the CORE-2 read gate also covers the plain REST
+/// graph endpoints, not just `/search*`, `MATCH`, and the embedding
+/// `/graph/search` — see `graph_read_preamble` in `handlers/graph/handlers.rs`.
+/// Before the fix this test guards, `graph_preamble` never consulted the
+/// observer at all, so a denied principal could still list nodes, dump edges,
+/// read node payloads, and traverse the graph through these endpoints while
+/// `/search` correctly refused them.
+#[tokio::test]
+async fn read_gate_denies_rest_graph_reads_end_to_end() {
+    const GRAPH: &str = "observed_graph";
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app_with_observer(&dir, Arc::new(DenyingReadObserver));
+
+    // Writes are not read-gated: collection creation and seeding an edge must
+    // still succeed under a deny-all observer.
+    let status = post(
+        &app,
+        "/collections",
+        json!({"name": GRAPH, "collection_type": "graph"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create graph collection");
+
+    // add_edge requires both endpoints to already have a stored payload
+    // (VELES-022 NodeNotFound otherwise) — seed nodes 1 and 2 first.
+    for node_id in [1, 2] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!(
+                        "/collections/{GRAPH}/graph/nodes/{node_id}/payload"
+                    ))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(json!({"payload": {}}).to_string()))
+                    .expect("test: build PUT request"),
+            )
+            .await
+            .expect("test: PUT request");
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "seed node {node_id} payload must not be read-gated"
+        );
+    }
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/edges"),
+        json!({"id": 1, "source": 1, "target": 2, "label": "KNOWS"}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "add_edge must not be read-gated"
+    );
+
+    // Every plain REST graph read must be refused end-to-end.
+    let status = get(
+        &app,
+        &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
+    )
+    .await;
+    assert!(!status.is_success(), "get_edges denied read, got {status}");
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/traverse"),
+        json!({"source": 1, "strategy": "bfs"}),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "traverse_graph denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_degree denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await;
+    assert!(
+        !status.is_success(),
+        "get_edge_count denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await;
+    assert!(!status.is_success(), "list_nodes denied read, got {status}");
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_edges denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_payload denied read, got {status}"
+    );
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/traverse/parallel"),
+        json!({"sources": [1]}),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "traverse_parallel denied read, got {status}"
     );
 }

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -275,6 +275,25 @@ async fn read_gate_denies_rest_search_end_to_end() {
     );
 }
 
+async fn put(app: &axum::Router, uri: &str, body: Value) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build PUT request"),
+        )
+        .await
+        .expect("test: PUT request")
+        .status()
+}
+
+fn assert_denied(status: StatusCode, what: &str) {
+    assert!(!status.is_success(), "{what} denied read, got {status}");
+}
+
 /// End-to-end proof that the CORE-2 read gate also covers the plain REST
 /// graph endpoints, not just `/search*`, `MATCH`, and the embedding
 /// `/graph/search` — see `graph_read_preamble` in `handlers/graph/handlers.rs`.
@@ -301,22 +320,10 @@ async fn read_gate_denies_rest_graph_reads_end_to_end() {
     // add_edge requires both endpoints to already have a stored payload
     // (VELES-022 NodeNotFound otherwise) — seed nodes 1 and 2 first.
     for node_id in [1, 2] {
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("PUT")
-                    .uri(format!(
-                        "/collections/{GRAPH}/graph/nodes/{node_id}/payload"
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(json!({"payload": {}}).to_string()))
-                    .expect("test: build PUT request"),
-            )
-            .await
-            .expect("test: PUT request");
+        let uri = format!("/collections/{GRAPH}/graph/nodes/{node_id}/payload");
+        let status = put(&app, &uri, json!({"payload": {}})).await;
         assert_eq!(
-            response.status(),
+            status,
             StatusCode::NO_CONTENT,
             "seed node {node_id} payload must not be read-gated"
         );
@@ -335,59 +342,50 @@ async fn read_gate_denies_rest_graph_reads_end_to_end() {
     );
 
     // Every plain REST graph read must be refused end-to-end.
-    let status = get(
-        &app,
-        &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
-    )
-    .await;
-    assert!(!status.is_success(), "get_edges denied read, got {status}");
-
-    let status = post(
-        &app,
-        &format!("/collections/{GRAPH}/graph/traverse"),
-        json!({"source": 1, "strategy": "bfs"}),
-    )
-    .await;
-    assert!(
-        !status.is_success(),
-        "traverse_graph denied read, got {status}"
+    assert_denied(
+        get(
+            &app,
+            &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
+        )
+        .await,
+        "get_edges",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_degree denied read, got {status}"
+    assert_denied(
+        post(
+            &app,
+            &format!("/collections/{GRAPH}/graph/traverse"),
+            json!({"source": 1, "strategy": "bfs"}),
+        )
+        .await,
+        "traverse_graph",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await;
-    assert!(
-        !status.is_success(),
-        "get_edge_count denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await,
+        "get_node_degree",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await;
-    assert!(!status.is_success(), "list_nodes denied read, got {status}");
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_edges denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await,
+        "get_edge_count",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_payload denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await,
+        "list_nodes",
     );
-
-    let status = post(
-        &app,
-        &format!("/collections/{GRAPH}/graph/traverse/parallel"),
-        json!({"sources": [1]}),
-    )
-    .await;
-    assert!(
-        !status.is_success(),
-        "traverse_parallel denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await,
+        "get_node_edges",
+    );
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await,
+        "get_node_payload",
+    );
+    assert_denied(
+        post(
+            &app,
+            &format!("/collections/{GRAPH}/graph/traverse/parallel"),
+            json!({"sources": [1]}),
+        )
+        .await,
+        "traverse_parallel",
     );
 }


### PR DESCRIPTION
## Description

Continuous code-review pass. `get_edges`, `traverse_graph`, `get_node_degree`, `list_nodes`, `get_node_edges`, `get_node_payload`, `get_edge_count`, and `traverse_parallel` all resolved their `GraphCollection` via `graph_preamble()`, which only records a metric and looks up the collection — it never consults `Database::authorize_read()`.

Sibling read paths already route through this gate: `VelesQL MATCH` (`match_query.rs`), `/graph/search` embedding search (`handlers_extended.rs::graph_search`), and `/search*` (`search/*.rs`). So a deployment with a registered observer (tenant scoping / RBAC) could deny a principal on every other read path while these eight plain REST graph endpoints still returned data unfiltered — a governance bypass for anyone routing graph reads through the plain CRUD endpoints instead of `MATCH`.

No open GitHub issues or P0s exist for this repo right now, so this cycle's highest-value finding (surfaced via a parallel review of `velesdb-core`, `velesdb-server`, and the SDK bindings) was this consistency gap in the CORE-2 read-gate rollout.

Fixes # (none — proactive review finding, no tracking issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## What changed

- Added `graph_read_preamble()` in `handlers/graph/handlers.rs`: wraps `graph_preamble()` and additionally calls `authorize_read(..., QueryOperationKind::GraphTraversal, None, None)`, failing closed (403) on `Deny` or scope-narrowing — graph reads have no metadata-filter channel to apply a narrowed scope to.
- Routed the eight affected read handlers (three in `handlers.rs`, five in `handlers_extended.rs`) through `graph_read_preamble()` instead of the ungated `graph_preamble()`.
- Left write endpoints (`add_edge`, `add_edges_batch`, `remove_edge`, `upsert_node_payload`) untouched — `authorize_read` is a read-only gate, matching the existing convention (writes are documented as not read-gated elsewhere in the test suite).
- Left the already-correctly-gated `graph_search` (embedding search) and `match_query` (`MATCH`) handlers untouched to avoid any change to their existing check ordering.

With no observer registered (the default, single-tenant deployment) this is unobservable: `authorize_read` is a single `Option` check that returns `Ok(None)` and the handler proceeds exactly as before (zero-overhead contract, per `gated_search.rs`'s own doc comment).

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

Added `read_gate_denies_rest_graph_reads_end_to_end` to `tests/observer_lifecycle_tests.rs`, extending the existing `DenyingReadObserver` pattern already used for `/search*`. It seeds a graph collection + edge (writes, unaffected) under a deny-all observer, then asserts all eight endpoints refuse the read.

Verified the test actually catches the regression: stashed the two handler-file changes, reran the new test (failed, `add_edge` seed showed the gap indirectly through downstream 404s and then explicit non-2xx assertions), restored the fix, reran (passed).

```
cargo test -p velesdb-server --test observer_lifecycle_tests -- --test-threads=1   # 4 passed
cargo test -p velesdb-server --test api_integration graph -- --test-threads=4      # 19 passed (no-observer default path unaffected)
cargo clippy -p velesdb-server --all-targets -- -D warnings                        # clean
cargo fmt -p velesdb-server -- --check                                             # clean
python3 scripts/check_prod_unwraps.py                                              # PASSED
```

**Test Configuration:**
- OS: Linux (container)
- Rust version: per `rust-toolchain.toml`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Two other findings from this review cycle were lower priority and left for a follow-up pass:
- `WalBatcher` (group-commit) is fully implemented and configurable but never wired into `LogPayloadStorage`'s write path — silent no-op config.
- `/guardrails` PUT and other maintenance routes have no privilege separation from ordinary query API keys.
