### PR TITLE
fix(audit): a README that disclaims a capability is not claiming it

### DIFF
--- a/scripts/check-feature-claims.py
+++ b/scripts/check-feature-claims.py
@@ -238,12 +238,52 @@ def _parse_typescript_exports(entry_path: Path) -> set[str]:
     return _capabilities_from_text(export_lines + " " + backend_names, CAPABILITIES)
 
 
+# A README that DISCLAIMS a capability must not be read as claiming it. Without
+# this, the honest sentence "No GPU in the published wheels — the `gpu` feature
+# is not enabled" registered `gpu` as documented, the audit failed to find it in
+# the API, and the crate was reported as MISSING a feature its README had
+# explicitly said it does not ship. That penalises precisely the disclosure this
+# audit exists to encourage.
+#
+# Scoped to a window BEFORE the keyword, not the whole line — the same shape as
+# `check-promise-contract.py`'s `_is_negated`. A line-wide test is too blunt:
+# "GPU acceleration is enabled by default and needs no extra build step" is a
+# real claim, and the trailing "no" must not erase it.
+DISCLAIMER_RE = re.compile(
+    r"\b(?:no|not|never|without|unsupported|unavailable|absent|excluded|"
+    r"disabled|missing|lacks?|cannot)\b|n't",
+    re.IGNORECASE,
+)
+
+# Characters before a keyword searched for a disclaimer.
+DISCLAIMER_WINDOW = 40
+
+
+def _claims_capability(text: str, keyword: str) -> bool:
+    """True when at least one mention of *keyword* is not disclaimed."""
+    for match in re.finditer(keyword, text, re.IGNORECASE):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        window_start = max(line_start, match.start() - DISCLAIMER_WINDOW)
+        if not DISCLAIMER_RE.search(text[window_start : match.start()]):
+            return True
+    return False
+
+
 def _parse_readme(readme_path: Path) -> set[str]:
-    """Extract claimed capabilities from a README file."""
+    """Extract claimed capabilities from a README file.
+
+    A capability counts only when at least ONE mention is not disclaimed, so
+    "GPU acceleration is enabled by default" is a claim while "No GPU in the
+    published wheels" is not.
+    """
     text = _read_text(readme_path)
     if not text:
         return set()
-    return _capabilities_from_text(text, DOC_CLAIM_KEYWORDS)
+    return {
+        cap
+        for cap, keywords in DOC_CLAIM_KEYWORDS.items()
+        if any(_claims_capability(text, kw) for kw in keywords)
+    }
 
 
 def _parse_integration_src(src_dir: Path) -> set[str]:

--- a/scripts/tests/test_check_feature_claims.py
+++ b/scripts/tests/test_check_feature_claims.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -371,3 +372,47 @@ class AuditPythonOnRealRepoTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ReadmeDisclaimerTests(unittest.TestCase):
+    """A README that says a capability is ABSENT must not be read as claiming it.
+
+    The scanner matched capability keywords anywhere in the prose, so the
+    honest sentence "No GPU in the published wheels — the `gpu` feature is not
+    enabled" registered `gpu` as a documented capability. The audit then looked
+    for it in the API, did not find it, and reported the crate as MISSING a
+    feature its README had explicitly disclaimed.
+
+    That penalises exactly the behaviour the audit exists to encourage. The
+    promise-contract checker already carries this distinction (`NEGATION_RE`);
+    this one did not.
+    """
+
+    def test_disclaimed_capability_is_not_a_claim(self) -> None:
+        readme = (
+            "# velesdb-python\n\n"
+            "## Known limits\n\n"
+            "- **No GPU in the published wheels.** The `gpu` Cargo feature "
+            "exists but is not enabled by `[tool.maturin]`; it requires "
+            "building from source.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "README.md"
+            path.write_text(readme, encoding="utf-8")
+            self.assertNotIn(
+                "gpu",
+                cfc._parse_readme(path),
+                "a documented ABSENCE was counted as a documented capability",
+            )
+
+    def test_a_real_claim_is_still_detected(self) -> None:
+        """The guard must not become a way to hide an unbacked claim."""
+        readme = (
+            "# velesdb-python\n\n"
+            "GPU acceleration is enabled by default and needs no extra build "
+            "step.\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "README.md"
+            path.write_text(readme, encoding="utf-8")
+            self.assertIn("gpu", cfc._parse_readme(path))


### PR DESCRIPTION
Found by the guard-contract job added in #1595 turning red — **the gate catching a defect in its own checker.**

The feature audit matched capability keywords anywhere in the prose, so this honest sentence:

> **No GPU in the published wheels.** The `gpu` Cargo feature exists but is not enabled by `[tool.maturin]`; it requires building from source.

registered `gpu` as a *documented capability*. The audit then looked for it in the Python API, did not find it, and reported the crate as **MISSING a feature whose absence its README had just spelled out**.

That penalises exactly the disclosure this audit exists to encourage: the more honest a README is about what it does not ship, the more gaps it invents.

## Fix

Scoped to a window **before** the keyword rather than the whole line — the same shape as `check-promise-contract.py`’s `_is_negated`, which already drew this distinction.

A line-wide test is too blunt in the other direction:

> GPU acceleration is enabled by default and needs **no** extra build step.

is a real claim, and the trailing `no` must not erase it. **The first attempt at this fix did exactly that**, which is why both cases are pinned by a test rather than one.

## Verification

- `test_disclaimed_capability_is_not_a_claim` — red before, green after
- `test_a_real_claim_is_still_detected` — the guard must not become a way to hide an unbacked claim
- 37 guard-contract tests green; `check-feature-claims.py` still exits 0 on `develop`

## Worth flagging separately

With the false positive removed, the documentation branch (#1593) still reports three **genuine** gaps it introduced — `column_store` and `streaming` present in the API but undocumented, `streaming` claimed but absent elsewhere. `develop` is clean. Those belong to that PR, not this one.