### PR TITLE
fix(server): gate plain REST graph reads through the CORE-2 governance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ureq::Agent` bounded at 60 s, the same pattern `extract.rs` has used for its
   own Ollama calls since it was written. Proven by a test that stands up a
   socket which accepts and never replies: 30.0 s before, bounded after.
+- **`velesdb-server`**: eight plain REST graph read endpoints — `get_edges`,
+  `traverse_graph`, `get_node_degree`, `get_edge_count`, `list_nodes`,
+  `get_node_edges`, `get_node_payload` and `traverse_parallel` — resolved their
+  collection through `graph_preamble()`, which recorded a metric and looked the
+  collection up but **never consulted `Database::authorize_read()`**. Every
+  sibling read path (VelesQL `MATCH`, `/graph/search`, `/search*`) already routed
+  through that gate, so a registered observer could deny a principal on all of
+  them while these eight still returned nodes, edges and payloads unfiltered.
+  They now go through `graph_read_preamble()`, which fails closed with `403` on a
+  `Deny` **and** on a scope-narrowing decision, since a graph read has no
+  metadata-filter channel to apply a narrowed scope to — the same choice already
+  made by `MATCH` and `/graph/search`. Write endpoints are untouched:
+  `authorize_read` is a read-only gate. With no observer registered (the default
+  single-tenant deployment) this is unobservable, `authorize_read` being a single
+  `Option` check returning `Ok(None)`. Note for operators running a
+  scope-narrowing observer: such a read previously returned data **unfiltered**
+  and now returns `403`.
 
 ### Added
 

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -14,6 +14,7 @@ use axum::{
     Json,
 };
 use velesdb_core::collection::graph::{GraphEdge, TraversalConfig};
+use velesdb_core::observer::QueryOperationKind;
 
 use crate::handlers::helpers::auto_core_error_response;
 use crate::types::ErrorResponse;
@@ -95,6 +96,35 @@ pub(super) fn get_graph_collection_or_404(
     ))
 }
 
+/// Shared graph preamble for **read** operations: resolves the collection via
+/// [`graph_preamble`], then routes the read through the control-plane gate
+/// (CORE-2). Graph reads have no metadata-filter channel to narrow, so a
+/// denied or scope-narrowed decision refuses the request (fail closed)
+/// rather than running it unfiltered.
+///
+/// Mirrors the gate `MATCH` (`handlers::match_query`) and embedding
+/// [`super::handlers_extended::graph_search`] already apply — centralized
+/// here so every plain REST graph read is governed the same way instead of
+/// each handler wiring the check individually.
+#[allow(clippy::result_large_err)]
+pub(super) fn graph_read_preamble(
+    state: &AppState,
+    name: &str,
+    operation: QueryOperationKind,
+) -> Result<velesdb_core::GraphCollection, (StatusCode, Json<ErrorResponse>)> {
+    let coll = graph_preamble(state, name)?;
+    match state.db.authorize_read(name, operation, None, None) {
+        Ok(None) => Ok(coll),
+        Ok(Some(_)) | Err(_) => Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                error: "Read denied by governance policy".to_string(),
+                code: None,
+            }),
+        )),
+    }
+}
+
 /// Get edges from a collection's graph filtered by label.
 #[utoipa::path(
     get,
@@ -123,7 +153,7 @@ pub async fn get_edges(
         )
     })?;
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let edges: Vec<EdgeResponse> = coll
         .get_edges(Some(&label))
@@ -270,7 +300,7 @@ pub async fn traverse_graph(
     State(state): State<Arc<AppState>>,
     Json(request): Json<TraverseRequest>,
 ) -> Result<Json<TraverseResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let config = TraversalConfig::with_range(1, request.max_depth)
         .with_limit(request.limit)
@@ -335,7 +365,7 @@ pub async fn get_node_degree(
     Path((name, node_id)): Path<(String, u64)>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DegreeResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let (in_degree, out_degree) = coll.node_degree(node_id);
     Ok(Json(DegreeResponse {
         in_degree,

--- a/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
@@ -11,11 +11,12 @@ use axum::{
     Json,
 };
 use velesdb_core::collection::graph::TraversalConfig;
+use velesdb_core::observer::QueryOperationKind;
 
 use crate::types::ErrorResponse;
 use crate::AppState;
 
-use super::handlers::graph_preamble;
+use super::handlers::{graph_preamble, graph_read_preamble};
 use super::types::{
     EdgeCountResponse, EdgeResponse, EdgesResponse, GraphSearchRequest, GraphSearchResponse,
     GraphSearchResultItem, NodeEdgeQueryParams, NodeListResponse, NodePayloadResponse,
@@ -78,7 +79,7 @@ pub async fn get_edge_count(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<EdgeCountResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     Ok(Json(EdgeCountResponse {
         count: coll.edge_count(),
     }))
@@ -101,7 +102,7 @@ pub async fn list_nodes(
     Path(name): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodeListResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let node_ids = coll.all_node_ids();
     let count = node_ids.len();
     Ok(Json(NodeListResponse { node_ids, count }))
@@ -127,7 +128,7 @@ pub async fn get_node_edges(
     Query(params): Query<NodeEdgeQueryParams>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<EdgesResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let raw_edges = match params.direction.to_lowercase().as_str() {
         "in" => coll.get_incoming(node_id),
@@ -214,7 +215,7 @@ pub async fn get_node_payload(
     Path((name, node_id)): Path<(String, u64)>,
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodePayloadResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
     let payload = coll.get_node_payload(node_id).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -254,7 +255,7 @@ pub async fn traverse_parallel(
         ));
     }
 
-    let coll = graph_preamble(&state, &name)?;
+    let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
     let config = TraversalConfig::with_range(1, request.max_depth)
         .with_limit(request.limit)

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -68,6 +68,20 @@ async fn post(app: &axum::Router, uri: &str, body: Value) -> StatusCode {
         .status()
 }
 
+async fn get(app: &axum::Router, uri: &str) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .expect("test: build GET request"),
+        )
+        .await
+        .expect("test: GET request")
+        .status()
+}
+
 async fn delete(app: &axum::Router, uri: &str) -> StatusCode {
     app.clone()
         .oneshot(
@@ -258,5 +272,122 @@ async fn read_gate_denies_rest_search_end_to_end() {
     assert!(
         !status.is_success(),
         "denied hybrid read must not return success, got {status}"
+    );
+}
+
+/// End-to-end proof that the CORE-2 read gate also covers the plain REST
+/// graph endpoints, not just `/search*`, `MATCH`, and the embedding
+/// `/graph/search` — see `graph_read_preamble` in `handlers/graph/handlers.rs`.
+/// Before the fix this test guards, `graph_preamble` never consulted the
+/// observer at all, so a denied principal could still list nodes, dump edges,
+/// read node payloads, and traverse the graph through these endpoints while
+/// `/search` correctly refused them.
+#[tokio::test]
+async fn read_gate_denies_rest_graph_reads_end_to_end() {
+    const GRAPH: &str = "observed_graph";
+    let dir = TempDir::new().expect("test: dir");
+    let app = create_test_app_with_observer(&dir, Arc::new(DenyingReadObserver));
+
+    // Writes are not read-gated: collection creation and seeding an edge must
+    // still succeed under a deny-all observer.
+    let status = post(
+        &app,
+        "/collections",
+        json!({"name": GRAPH, "collection_type": "graph"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "create graph collection");
+
+    // add_edge requires both endpoints to already have a stored payload
+    // (VELES-022 NodeNotFound otherwise) — seed nodes 1 and 2 first.
+    for node_id in [1, 2] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!(
+                        "/collections/{GRAPH}/graph/nodes/{node_id}/payload"
+                    ))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(json!({"payload": {}}).to_string()))
+                    .expect("test: build PUT request"),
+            )
+            .await
+            .expect("test: PUT request");
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "seed node {node_id} payload must not be read-gated"
+        );
+    }
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/edges"),
+        json!({"id": 1, "source": 1, "target": 2, "label": "KNOWS"}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "add_edge must not be read-gated"
+    );
+
+    // Every plain REST graph read must be refused end-to-end.
+    let status = get(
+        &app,
+        &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
+    )
+    .await;
+    assert!(!status.is_success(), "get_edges denied read, got {status}");
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/traverse"),
+        json!({"source": 1, "strategy": "bfs"}),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "traverse_graph denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_degree denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await;
+    assert!(
+        !status.is_success(),
+        "get_edge_count denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await;
+    assert!(!status.is_success(), "list_nodes denied read, got {status}");
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_edges denied read, got {status}"
+    );
+
+    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await;
+    assert!(
+        !status.is_success(),
+        "get_node_payload denied read, got {status}"
+    );
+
+    let status = post(
+        &app,
+        &format!("/collections/{GRAPH}/graph/traverse/parallel"),
+        json!({"sources": [1]}),
+    )
+    .await;
+    assert!(
+        !status.is_success(),
+        "traverse_parallel denied read, got {status}"
     );
 }

--- a/crates/velesdb-server/tests/observer_lifecycle_tests.rs
+++ b/crates/velesdb-server/tests/observer_lifecycle_tests.rs
@@ -275,6 +275,25 @@ async fn read_gate_denies_rest_search_end_to_end() {
     );
 }
 
+async fn put(app: &axum::Router, uri: &str, body: Value) -> StatusCode {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("test: build PUT request"),
+        )
+        .await
+        .expect("test: PUT request")
+        .status()
+}
+
+fn assert_denied(status: StatusCode, what: &str) {
+    assert!(!status.is_success(), "{what} denied read, got {status}");
+}
+
 /// End-to-end proof that the CORE-2 read gate also covers the plain REST
 /// graph endpoints, not just `/search*`, `MATCH`, and the embedding
 /// `/graph/search` — see `graph_read_preamble` in `handlers/graph/handlers.rs`.
@@ -301,22 +320,10 @@ async fn read_gate_denies_rest_graph_reads_end_to_end() {
     // add_edge requires both endpoints to already have a stored payload
     // (VELES-022 NodeNotFound otherwise) — seed nodes 1 and 2 first.
     for node_id in [1, 2] {
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("PUT")
-                    .uri(format!(
-                        "/collections/{GRAPH}/graph/nodes/{node_id}/payload"
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(json!({"payload": {}}).to_string()))
-                    .expect("test: build PUT request"),
-            )
-            .await
-            .expect("test: PUT request");
+        let uri = format!("/collections/{GRAPH}/graph/nodes/{node_id}/payload");
+        let status = put(&app, &uri, json!({"payload": {}})).await;
         assert_eq!(
-            response.status(),
+            status,
             StatusCode::NO_CONTENT,
             "seed node {node_id} payload must not be read-gated"
         );
@@ -335,59 +342,50 @@ async fn read_gate_denies_rest_graph_reads_end_to_end() {
     );
 
     // Every plain REST graph read must be refused end-to-end.
-    let status = get(
-        &app,
-        &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
-    )
-    .await;
-    assert!(!status.is_success(), "get_edges denied read, got {status}");
-
-    let status = post(
-        &app,
-        &format!("/collections/{GRAPH}/graph/traverse"),
-        json!({"source": 1, "strategy": "bfs"}),
-    )
-    .await;
-    assert!(
-        !status.is_success(),
-        "traverse_graph denied read, got {status}"
+    assert_denied(
+        get(
+            &app,
+            &format!("/collections/{GRAPH}/graph/edges?label=KNOWS"),
+        )
+        .await,
+        "get_edges",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_degree denied read, got {status}"
+    assert_denied(
+        post(
+            &app,
+            &format!("/collections/{GRAPH}/graph/traverse"),
+            json!({"source": 1, "strategy": "bfs"}),
+        )
+        .await,
+        "traverse_graph",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await;
-    assert!(
-        !status.is_success(),
-        "get_edge_count denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/degree")).await,
+        "get_node_degree",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await;
-    assert!(!status.is_success(), "list_nodes denied read, got {status}");
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_edges denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/edges/count")).await,
+        "get_edge_count",
     );
-
-    let status = get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await;
-    assert!(
-        !status.is_success(),
-        "get_node_payload denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes")).await,
+        "list_nodes",
     );
-
-    let status = post(
-        &app,
-        &format!("/collections/{GRAPH}/graph/traverse/parallel"),
-        json!({"sources": [1]}),
-    )
-    .await;
-    assert!(
-        !status.is_success(),
-        "traverse_parallel denied read, got {status}"
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/edges")).await,
+        "get_node_edges",
+    );
+    assert_denied(
+        get(&app, &format!("/collections/{GRAPH}/graph/nodes/1/payload")).await,
+        "get_node_payload",
+    );
+    assert_denied(
+        post(
+            &app,
+            &format!("/collections/{GRAPH}/graph/traverse/parallel"),
+            json!({"sources": [1]}),
+        )
+        .await,
+        "traverse_parallel",
     );
 }


### PR DESCRIPTION
Reprend [#1605](https://github.com/cyberlife-coder/VelesDB/pull/1605), fermée accidentellement en renommant sa branche pour satisfaire le contrôle Git Flow. Contenu de code **identique à l'octet** ; s'y ajoutent la ré-attribution des commits et une entrée de CHANGELOG.

## Le trou

`get_edges`, `traverse_graph`, `get_node_degree`, `get_edge_count`, `list_nodes`, `get_node_edges`, `get_node_payload` et `traverse_parallel` résolvaient leur collection via `graph_preamble()`, qui enregistrait une métrique et faisait la résolution — mais **ne consultait jamais `Database::authorize_read()`**.

Tous les chemins de lecture voisins (VelesQL `MATCH`, `/graph/search`, `/search*`) passent déjà par ce verrou depuis CORE-1/CORE-2. Un observateur enregistré pouvait donc refuser un principal sur *tous* les autres chemins pendant que ces huit endpoints REST continuaient de servir nœuds, arêtes et payloads **non filtrés**.

## Le correctif

`graph_read_preamble()` enveloppe `graph_preamble()` et applique `authorize_read()`. Il **échoue fermé** (`403`) sur un `Deny` **et** sur une décision de restriction de portée, une lecture graphe n'ayant aucun canal de filtre de métadonnées où appliquer une portée réduite — c'est le choix déjà fait par `MATCH` et `/graph/search`, donc cohérent et non inédit.

Les endpoints d'écriture sont inchangés : `authorize_read` est un verrou de lecture.

## Portée réelle du changement

Sans observateur enregistré — le déploiement mono-tenant par défaut — c'est **inobservable** : `authorize_read` est un simple `Option` qui rend `Ok(None)`.

⚠️ **Pour les opérateurs faisant tourner un observateur à restriction de portée** : une telle lecture servait auparavant des données **non filtrées** et rend désormais un `403`. C'est la correction voulue, mais c'est une rupture sémantique, désormais documentée au CHANGELOG.

## Test

`read_gate_denies_rest_graph_reads_end_to_end` — réellement rouge avant, vert après : `graph_preamble` ne consultait jamais l'observateur. Il asserte que les écritures réussissent toujours, puis que les huit endpoints de lecture sont refusés. Réutilise le harnais existant `DenyingReadObserver` + `create_test_app_with_observer`.

## Reste à faire, assumé

Les annotations utoipa des huit handlers ne déclarent pas le nouveau `403`. L'ajouter modifierait la spec générée et imposerait une régénération d'OpenAPI — j'ai préféré ne pas élargir le rayon d'impact d'un correctif de sécurité prêt par ailleurs. À traiter séparément.