### PR TITLE
fix(memory): --features extract compile désormais seule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,21 @@ jobs:
       - name: Check --no-default-features (workspace matrix gap, #1472)
         run: cargo check --workspace --no-default-features
 
+      # The workspace check above unifies features across crates, so a feature
+      # that only compiles because a SIBLING feature happens to be on still
+      # passes it. `--features extract` alone did not compile: it pulls
+      # `dep:ureq` but not `ollama`, while extract.rs calls a helper gated on
+      # `ollama`. Each optional feature of velesdb-memory is therefore checked
+      # in isolation.
+      - name: Check each velesdb-memory feature in isolation
+        run: |
+          set -eu
+          for feat in ollama extract context persistence; do
+            echo "::group::--features $feat"
+            cargo check -p velesdb-memory --no-default-features --features "$feat"
+            echo "::endgroup::"
+          done
+
       - name: Run Clippy (strict)
         run: |
           cargo clippy --workspace --all-targets --features persistence,gpu,update-check \

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -164,7 +164,7 @@ impl Embedder for OllamaEmbedder {
 /// Override with `VELESDB_MEMORY_OLLAMA_KEEP_ALIVE` (any value Ollama accepts,
 /// e.g. `30m`, or `0` to unload immediately) when pinning the weights costs
 /// more RAM than the latency is worth.
-#[cfg(feature = "ollama")]
+#[cfg(any(feature = "ollama", feature = "extract"))]
 pub(crate) const DEFAULT_KEEP_ALIVE: i64 = -1;
 
 /// The configured keep-alive as Ollama expects it on the wire.
@@ -177,7 +177,10 @@ pub(crate) const DEFAULT_KEEP_ALIVE: i64 = -1;
 /// five minutes. Duration forms like `30m` are strings and must stay strings.
 ///
 /// So: parse as a number when it is one, pass through as a string otherwise.
-#[cfg(feature = "ollama")]
+// Also reachable from `extract.rs`, whose Ollama client sends the same
+// field. Gating this on `ollama` alone broke `--features extract` on its
+// own: `extract` pulls `dep:ureq`, not `ollama`.
+#[cfg(any(feature = "ollama", feature = "extract"))]
 pub(crate) fn keep_alive() -> serde_json::Value {
     let raw = std::env::var("VELESDB_MEMORY_OLLAMA_KEEP_ALIVE")
         .ok()

--- a/crates/velesdb-memory/src/id.rs
+++ b/crates/velesdb-memory/src/id.rs
@@ -32,6 +32,11 @@ pub fn stable_id(text: &str) -> u64 {
 ///
 /// Delegates to [`velesdb_core::hash_id_bytes`], the exported bytes-level
 /// counterpart of [`velesdb_core::hash_id`].
+// Only `context/media.rs` content-addresses raw bytes, so outside that
+// feature this is genuinely unreachable — and `id` is a `pub(crate)`
+// module, so `pub` does not make it live. Gating it on its actual
+// consumer keeps `-D warnings` honest instead of silencing dead_code.
+#[cfg(feature = "context")]
 #[must_use]
 pub fn stable_id_bytes(bytes: &[u8]) -> u64 {
     velesdb_core::hash_id_bytes(bytes)
@@ -59,11 +64,13 @@ mod tests {
         assert_eq!(stable_id(""), 0xcbf2_9ce4_8422_2325);
     }
 
+    #[cfg(feature = "context")]
     #[test]
     fn stable_id_bytes_agrees_with_stable_id_on_valid_utf8() {
         assert_eq!(stable_id_bytes("hello".as_bytes()), stable_id("hello"));
     }
 
+    #[cfg(feature = "context")]
     #[test]
     fn stable_id_bytes_hashes_non_utf8_bytes() {
         let bytes = [0xFFu8, 0x00, 0x89, 0x50, 0x4E, 0x47];


### PR DESCRIPTION
Dette pré-existante, reproduite puis corrigée.

## Le rouge

```
$ cargo check -p velesdb-memory --no-default-features --features extract
error[E0425]: cannot find function `keep_alive` in module `crate::embedder`
```

puis, une fois celle-là levée :

```
error[E0425]: cannot find value `DEFAULT_KEEP_ALIVE` in this scope
```

Les deux sont gatés sur `ollama`, alors qu'`extract.rs` les appelle et que `extract = ["dep:ureq"]` ne tire pas `ollama`.

## Le correctif

`cfg(any(feature = "ollama", feature = "extract"))` plutôt que d'ajouter `ollama` aux dépendances d'`extract` : un utilisateur qui ne veut que l'extraction n'a pas à embarquer l'embedder.

## Pourquoi la CI ne pouvait pas l'attraper

Son garde-fou est `cargo check --workspace --no-default-features`. Sur un **workspace**, les features s'unifient entre crates : une feature qui ne compile que grâce à une voisine activée ailleurs passe quand même. C'est exactement ce qui s'est produit — `ollama` était toujours présent via un autre membre.

Chaque feature optionnelle de `velesdb-memory` est désormais vérifiée **isolément**, dans une boucle bornée avec des groupes de log lisibles.

## Matrice vérifiée en local

`<aucune>`, `extract`, `ollama`, `ollama,extract`, `context`, `persistence`, `context,persistence` — les sept passent.