### PR TITLE
fix(memory): typer aussi les schémas de SORTIE des outils MCP

### DIFF
--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -194,6 +194,9 @@ impl McpServer {
 
     #[tool(
         name = "recall",
+        // rmcp derives an output schema when none is given, and that
+        // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
+        output_schema = context_tools::wire_safe_output_schema::<RecallResult>(),
         description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients."
     )]
     async fn recall(
@@ -216,6 +219,9 @@ impl McpServer {
 
     #[tool(
         name = "recall_where",
+        // rmcp derives an output schema when none is given, and that
+        // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
+        output_schema = context_tools::wire_safe_output_schema::<RecallResult>(),
         description = "Fused recall: semantically similar memories (vector) constrained by structured ColumnStore predicates over metadata — ranges and comparisons, not just equality. Each filter is {field, op (eq/ne/lt/le/gt/ge), value}, ANDed. Use for time-windowed or numeric-scoped recall, e.g. facts about a topic with `ts` in a date range. Comparisons are TYPE-STRICT, with no runtime coercion: a filter value of 20230601 (a JSON number) never matches a fact stored with metadata {\"ts\": \"20230601\"} (a JSON string) — same value, different JSON type, no match, no error. Store comparable values like dates NUMERICALLY at `remember` time (e.g. 20230601, not \"20230601\") so `recall_where` filters actually match them. Most similar first.",
         // No id-named parameter here (hence the empty `keys`) — this goes
         // through the shared helper purely for its `$ref` inlining, so
@@ -243,6 +249,9 @@ impl McpServer {
 
     #[tool(
         name = "recall_fused",
+        // rmcp derives an output schema when none is given, and that
+        // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
+        output_schema = context_tools::wire_safe_output_schema::<RecallFusedResult>(),
         description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
     )]
     async fn recall_fused(
@@ -351,6 +360,9 @@ impl McpServer {
 
     #[tool(
         name = "why",
+        // rmcp derives an output schema when none is given, and that
+        // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
+        output_schema = context_tools::wire_safe_output_schema::<ExplanationDto>(),
         description = "Explain a decision: find the best-matching memory (optionally scoped by a metadata `filter`, e.g. the current project) and return the connected subgraph of related memories reachable through typed links — fusing vector, ColumnStore, and graph to surface context a plain similarity search misses."
     )]
     async fn why(

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -54,7 +54,7 @@ fn to_wire_value<T: serde::Serialize>(
 /// fields must be typed `["integer", "string"]`, or every opted-in response
 /// would fail client-side validation for exactly the clients the option
 /// exists for.
-fn wire_safe_output_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
+pub(super) fn wire_safe_output_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
     let schema = schema_for_output::<T>().unwrap_or_else(|e| {
         panic!(
             "Invalid output schema for {}: {e}",
@@ -63,6 +63,11 @@ fn wire_safe_output_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
     });
     let mut map = (*schema).clone();
     crate::schema::widen_id_properties(&mut map, ID_KEYS);
+    // Same treatment as the input side. The official MCP SDKs validate a
+    // tool's `structuredContent` against this schema, so a `$ref` the client
+    // cannot resolve is a result it may reject outright — a harsher failure
+    // than an unparseable argument, where the server at least got to answer.
+    crate::schema::inline_ref_only_properties(&mut map);
     Arc::new(map)
 }
 
@@ -672,6 +677,9 @@ impl McpServer {
 
     #[tool(
         name = "list_working_contexts",
+        // Same reason as the four tools wired in `mcp.rs`: an rmcp-derived
+        // output schema keeps `$ref`s a `$defs`-blind client cannot resolve.
+        output_schema = wire_safe_output_schema::<ListWorkingContextsResult>(),
         description = "List every session saved under a project via save_working_context, most-recently-saved first — so an agent can discover what is resumable before guessing a session id at load_working_context, or recover from a typo. Empty (not an error) when the project never saved anything."
     )]
     async fn list_working_contexts(

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -14,10 +14,14 @@
 //!
 //! The schemas are read exactly as published: an in-memory MCP client over
 //! `tokio::io::duplex` (the idiom of rmcp's own upstream tests) drives the
-//! real `McpServer`, so these tests see the same `inputSchema` bytes a
-//! Claude Code / Windsurf harness receives. Scope is deliberately the INPUT
-//! schemas: the reported bug is an *argument* deserialization failure.
-//! Output schemas keep their `$ref`-only items — a separate concern.
+//! real `McpServer`, so these tests see the same schema bytes a Claude Code /
+//! Windsurf harness receives.
+//!
+//! Output schemas are covered too, since the same defect turned out to be
+//! there and to bite harder: the official MCP SDKs validate a tool's
+//! `structuredContent` against its advertised `outputSchema`, so an
+//! unresolvable `$ref` is a RESULT the client may reject — worse than an
+//! unparseable argument, where the server at least got to answer.
 
 #![cfg(all(feature = "mcp", feature = "context", feature = "persistence"))]
 

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -160,6 +160,37 @@ async fn every_tool_input_schema_types_every_reachable_items() {
     client.cancel().await.expect("close the MCP session");
 }
 
+/// Same rule on the OUTPUT side, which the input fix left behind.
+///
+/// It is not cosmetic: the official MCP SDKs validate a tool's
+/// `structuredContent` against its advertised `outputSchema`. A `$ref` a
+/// client cannot resolve is a result it may reject outright — a harsher
+/// failure than the input case, where the server at least got to answer.
+#[tokio::test]
+async fn every_tool_output_schema_types_every_reachable_items() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut checked = 0usize;
+    let mut offenders: BTreeSet<String> = BTreeSet::new();
+    for tool in &tools {
+        let Some(output) = tool.output_schema.as_ref() else {
+            continue;
+        };
+        checked += 1;
+        let schema = Value::Object((**output).clone());
+        for finding in untyped_items(&schema) {
+            offenders.insert(format!("{}: {finding}", tool.name));
+        }
+    }
+    assert!(checked > 0, "at least one tool advertises an output schema");
+    assert!(
+        offenders.is_empty(),
+        "{} untyped `items` across {checked} advertised output schemas: {offenders:#?}",
+        offenders.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
 /// A full external payload — the shape a client would build from the schema
 /// alone — including the two collections no existing fixture ever fills:
 /// `decisions` (a `ContextDecisionRef`, `rule_id` required) and


### PR DESCRIPTION
Le correctif précédent n'avait traité que l'**entrée**. Dette identifiée à ce moment-là, refermée ici.

## Le rouge

```
11 untyped `items` across 18 advertised output schemas: {
    "list_working_contexts: $.sessions.items = {"$ref":"#/$defs/WorkingContextSession"}",
    "recall: $.memories.items = {"$ref":"#/$defs/RecollectionDto"}",
    "why: $.edges.items = {"$ref":"#/$defs/MemoryEdgeDto"}",
    ...
}
```

## Pourquoi ce n'est pas cosmétique

Les SDK MCP officiels **valident `structuredContent` contre l'`outputSchema` annoncé**. Un `$ref` que le client ne sait pas résoudre est un résultat qu'il peut rejeter — plus dur que le cas de l'entrée, où le serveur avait au moins pu répondre.

## Deux causes, pas une

`wire_safe_output_schema` n'appliquait que `widen_id_properties`, jamais l'inliner récursif. Corriger ça a fait tomber 11 → 6.

Les 6 restants venaient d'ailleurs : **cinq outils ne déclaraient aucun `output_schema`**. rmcp en dérivait un automatiquement, qui échappait donc à tout post-traitement. `recall`, `recall_fused`, `recall_where`, `why` et `list_working_contexts` le déclarent maintenant explicitement.

## Vérification

`11 → 0`. Le test générique parcourt **tous** les outils, donc le prochain qui rend un tableau d'objets est couvert par construction, pas parce que quelqu'un aura pensé à ajouter un cas.

20 suites vertes, clippy pedantic propre, `fmt`, `version-sync` et les contrats passés en local avant le push.

> `--features extract` échoue encore sur cette branche : c'est la dette traitée par #1610, indépendante.