### PR TITLE
perf(memory): élaguer les $defs que l'inlining a rendus inatteignables

### DIFF
--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -431,6 +431,25 @@ fn test_explain_compilation_output_schema_advertises_string_ids() {
     assert_ids_widened(&found);
 }
 
+/// Navigate to `fragments[].<property>` **as published**, i.e. through the
+/// inlined `items`, not through `$defs`.
+///
+/// Unreferenced `$defs` entries are pruned once inlining has copied them to
+/// their use sites (worth 40 KB across the 18 tools). A `$defs`-blind client
+/// never reads that pool anyway, so asserting the contract where the client
+/// actually finds it is strictly stronger than asserting it in the pool.
+fn published_fragment_property<'a>(
+    schema: &'a serde_json::Value,
+    property: &str,
+) -> &'a serde_json::Value {
+    let fragments = if schema["properties"]["fragments"].is_null() {
+        &schema["properties"]["request"]["properties"]["fragments"]
+    } else {
+        &schema["properties"]["fragments"]
+    };
+    &fragments["items"]["properties"][property]
+}
+
 #[test]
 fn test_compile_context_input_schema_advertises_string_fragment_id() {
     // fragments[].id accepts a decimal string on input (see
@@ -439,7 +458,7 @@ fn test_compile_context_input_schema_advertises_string_fragment_id() {
     let tool = McpServer::compile_context_tool_attr();
     let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
 
-    let id_type = &schema["$defs"]["ContextFragment"]["properties"]["id"]["type"];
+    let id_type = &published_fragment_property(&schema, "id")["type"];
     let types = id_type
         .as_array()
         .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
@@ -466,7 +485,7 @@ fn test_explain_compilation_input_schema_keeps_top_level_fragment_id_strict() {
         "top-level fragment_id stays integer-only"
     );
     // …while the nested fragments[].id is widened, like compile_context's.
-    let id_type = &schema["$defs"]["ContextFragment"]["properties"]["id"]["type"];
+    let id_type = &published_fragment_property(&schema, "id")["type"];
     let types = id_type
         .as_array()
         .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
@@ -678,7 +697,7 @@ fn test_compile_context_input_schema_advertises_fragment_media_field() {
     let tool = McpServer::compile_context_tool_attr();
     let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
 
-    let media_property = &schema["$defs"]["ContextFragment"]["properties"]["media"];
+    let media_property = published_fragment_property(&schema, "media");
     assert!(
         !media_property.is_null(),
         "fragments[].media must be advertised on compile_context's input schema"

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -168,6 +168,83 @@ pub(crate) fn inline_ref_only_properties(map: &mut Map<String, Value>) {
     };
     let mut chain = InlineChain::new();
     inline_in_map(map, &defs, &mut chain, 0);
+    prune_unreferenced_defs(map);
+}
+
+/// Drop every `$defs` entry no `$ref` can still reach.
+///
+/// Inlining copies a definition to each site that referenced it, so its
+/// `$defs` entry usually becomes dead weight — measured at **55 % of the
+/// published schema bytes** (83 KB of 148 KB across the 18 tools) once both
+/// the input and output sides were inlined. Keeping it costs every client
+/// that reads `tools/list`, and the whole point of inlining was that a
+/// `$defs`-blind client never looks there.
+///
+/// Only *unreachable* entries go: 65 `$ref`s legitimately survive (a bound a
+/// cycle guard stopped, an `anyOf` arm), and a definition still reachable —
+/// directly or through another definition — is kept. The fixpoint below is
+/// what makes that transitive: dropping one entry can orphan another.
+#[cfg(feature = "mcp")]
+fn prune_unreferenced_defs(map: &mut Map<String, Value>) {
+    let Some(Value::Object(defs)) = map.get("$defs") else {
+        return;
+    };
+    let names: Vec<String> = defs.keys().cloned().collect();
+    let defs = defs.clone();
+
+    let mut live: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    // Seed with everything referenced outside `$defs` itself.
+    let mut outside = map.clone();
+    outside.remove("$defs");
+    collect_refs(&Value::Object(outside), &mut live);
+
+    // Fixpoint: a live definition's own `$ref`s keep their targets alive.
+    loop {
+        let mut grown = false;
+        for name in &names {
+            if !live.contains(name) {
+                continue;
+            }
+            if let Some(def) = defs.get(name) {
+                let before = live.len();
+                collect_refs(def, &mut live);
+                grown |= live.len() != before;
+            }
+        }
+        if !grown {
+            break;
+        }
+    }
+
+    if let Some(Value::Object(defs)) = map.get_mut("$defs") {
+        defs.retain(|name, _| live.contains(name));
+        if defs.is_empty() {
+            map.remove("$defs");
+        }
+    }
+}
+
+/// Every `#/$defs/<name>` target reachable from `value`.
+#[cfg(feature = "mcp")]
+fn collect_refs(value: &Value, out: &mut std::collections::BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(target)) = map.get("$ref") {
+                if let Some(name) = target.strip_prefix("#/$defs/") {
+                    out.insert(name.to_owned());
+                }
+            }
+            for sub in map.values() {
+                collect_refs(sub, out);
+            }
+        }
+        Value::Array(entries) => {
+            for sub in entries {
+                collect_refs(sub, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// One schema node: inline its `properties` and `items` slots, then descend

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -319,3 +319,68 @@ fn assert_payload_survived_the_round_trip(round_tripped: &serde_json::Value) {
     );
     assert_eq!(round_tripped["pending_actions"], json!(["re-run the gate"]));
 }
+
+/// Pruning unreferenced `$defs` must never orphan a surviving `$ref`.
+///
+/// Inlining copies definitions to their use sites, leaving most `$defs`
+/// entries dead — 55 % of the published bytes, measured. Dropping them is
+/// worth 40 KB across the 18 tools, but a definition still reachable through
+/// a cycle guard's leftover `$ref`, or through another definition, MUST
+/// survive. This walks every advertised schema and resolves every `$ref`
+/// against what actually shipped.
+#[tokio::test]
+async fn no_advertised_ref_points_at_a_pruned_definition() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut dangling: BTreeSet<String> = BTreeSet::new();
+    for tool in &tools {
+        for (kind, schema) in [
+            ("input", Some(Value::Object((*tool.input_schema).clone()))),
+            (
+                "output",
+                tool.output_schema
+                    .as_ref()
+                    .map(|s| Value::Object((**s).clone())),
+            ),
+        ] {
+            let Some(schema) = schema else { continue };
+            let available: BTreeSet<String> = schema
+                .get("$defs")
+                .and_then(Value::as_object)
+                .map(|defs| defs.keys().cloned().collect())
+                .unwrap_or_default();
+            let mut wanted = BTreeSet::new();
+            collect_ref_targets(&schema, &mut wanted);
+            for name in wanted.difference(&available) {
+                dangling.insert(format!("{} ({kind}): #/$defs/{name}", tool.name));
+            }
+        }
+    }
+    assert!(
+        dangling.is_empty(),
+        "{} `$ref`(s) point at a definition that was pruned away: {dangling:#?}",
+        dangling.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+fn collect_ref_targets(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(Value::String(target)) = map.get("$ref") {
+                if let Some(name) = target.strip_prefix("#/$defs/") {
+                    out.insert(name.to_owned());
+                }
+            }
+            for sub in map.values() {
+                collect_ref_targets(sub, out);
+            }
+        }
+        Value::Array(entries) => {
+            for sub in entries {
+                collect_ref_targets(sub, out);
+            }
+        }
+        _ => {}
+    }
+}


### PR DESCRIPTION
J'avais refusé de qualifier de « négligeable » la croissance du schéma après l'inlining récursif, faute de l'avoir mesurée. Mesure faite, sur les 18 outils réellement publiés :

| | octets | |
|---|---:|---|
| avant inlining (0.11.1) | 108 162 | référence |
| après inlining, sans élagage | **148 310** | **+37 %** |
| après élagage | **107 803** | **−359 o vs l'origine** |

## Le constat

L'inlining copie chaque définition à tous les sites qui la référencent, ce qui rend son entrée `$defs` inutile : **55 % des octets publiés, soit 83 Ko**. Un client aveugle aux `$defs` ne lit jamais ce pool — c'était précisément la raison d'inliner.

Le schéma redevient donc **plus petit qu'avant** tout en étant entièrement auto-descriptif. On a gagné la correction *et* la taille.

## Ce qui n'est pas supprimé

Seules les entrées **inatteignables**. 35 `$ref` survivent légitimement — une borne arrêtée par le garde de cycle, un bras d'`anyOf` — et leur cible est conservée. Le calcul est un **point fixe** : supprimer une entrée peut en orpheliner une autre, donc on itère jusqu'à stabilité.

## Le risque, et sa preuve

Le danger de cette optimisation est évident : créer un `$ref` orphelin. Nouveau test `no_advertised_ref_points_at_a_pruned_definition` — il résout **chaque** référence contre ce qui a réellement été livré, entrée et sortie, sur tous les outils.

## Trois tests existants déplacés, pas affaiblis

Ils naviguaient via `schema["$defs"]["ContextFragment"]`, une entrée désormais élaguée. J'ai vérifié que leur contrat tient au site inliné — `type = ["integer", "string", "null"]` — avant de toucher quoi que ce soit, et je les ai pointés sur le chemin publié.

C'est l'inverse d'un affaiblissement : ils vérifient maintenant le contrat **là où le client le lit**, pas dans un pool de références qu'il ne consulte pas.

20 suites vertes sous `-Dwarnings`, clippy pedantic propre, matrice de features validée.