### PR TITLE
chore(backmerge): main → develop après la release 4.1.0

### DIFF
--- a/.agents/skills/core-parity-audit/SKILL.md
+++ b/.agents/skills/core-parity-audit/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: core-parity-audit
+description: "Re-run the VelesDB core-vs-ecosystem gap analysis (code + documentation). Use when asked to audit API parity, check that every crate/SDK/integration/doc has caught up to velesdb-core, verify the core↔children architecture is clean, or produce a parity matrix. velesdb-core is the single source of truth; the VelesDB Core License boundary is enforced in every recommendation."
+trigger: /core-parity-audit
+---
+
+# /core-parity-audit
+
+Audit whether every component that depends on `velesdb-core` has kept up with it — in **code and documentation** — and whether the **core↔children architecture is clean**. Produces two artifacts: a capability-level **parity matrix** and an **architecture-cleanliness verdict**.
+
+## Two non-negotiable rules
+
+1. **`velesdb-core` is the single source of truth — always.** Children (server, cli, python, wasm, mobile, migrate, tauri, ts-sdk, langchain, llamaindex, haystack, integrations/common, docs) may legitimately expose **more** surface than core (idiomatic helpers, ops endpoints, framework adapters) — that is healthy enrichment, **not** a parity defect. Judge two things *separately*: (a) does the child enrich core? (good) vs (b) is the boundary clean? (the real question).
+
+2. **Respect the VelesDB Core License boundary.** See [references/license-boundary.md](references/license-boundary.md). In short:
+   - `velesdb-core`, all Rust crates, and the TS SDK are under **VelesDB Core License 1.0** (source-available, Elastic-2.0-based). Its *protected capabilities* are query, administration, indexing, ingestion, storage, graph traversal, knowledge-graph, and columnar filtering.
+   - `integrations/{langchain,llamaindex,haystack,common}` are **MIT**.
+   - **A reimplementation or copy of core's protected logic inside an MIT integration is BOTH an architecture smell AND a license-leakage risk.** Flag it at higher severity. The only valid remediation is **"expose it via the binding and have the MIT layer *call* it"** — never "copy core logic into the integration," never relicense Core code as MIT or vice-versa.
+   - Never recommend stripping `VelesDB®` notices or paid-feature gating. Follow the project **no-AI-attribution** rule in any report/PR/commit you generate.
+
+## Usage
+
+```
+/core-parity-audit                 # full audit: parity matrix + architecture verdict
+/core-parity-audit --matrix-only   # capability parity matrix only (skip architecture probes)
+/core-parity-audit --arch-only     # architecture-cleanliness verdict only (skip the matrix)
+/core-parity-audit --component <k> # focus on one component (e.g. wasm, langchain)
+```
+
+This audit is read-only. It does not modify source; it writes report artifacts to a scratch dir (default `/tmp`) and summarizes in chat. Use the [Workflow tool](#orchestration) — this is a fan-out, multi-agent job (ultracode-class).
+
+## Components that depend on velesdb-core (the work-list)
+
+Re-derive this from the workspace each run (`Cargo.toml` members + `sdks/` + `integrations/` + `docs/`), but the stable set is:
+
+| key | path | wraps core via | license |
+|-----|------|----------------|---------|
+| server | `crates/velesdb-server` | direct (Axum REST) | Core 1.0 |
+| cli | `crates/velesdb-cli` | direct (embedded REPL) | Core 1.0 |
+| python | `crates/velesdb-python` | direct (PyO3 + `.pyi` stub) | Core 1.0 |
+| wasm | `crates/velesdb-wasm` | direct, **no `persistence` feature** | Core 1.0 |
+| mobile | `crates/velesdb-mobile` | direct (UniFFI) | Core 1.0 |
+| migrate | `crates/velesdb-migrate` | direct (ETL tool) | Core 1.0 |
+| tauri | `crates/tauri-plugin-velesdb` | direct (commands) | Core 1.0 |
+| ts-sdk | `sdks/typescript` | REST + WASM backends | Core 1.0 |
+| langchain | `integrations/langchain` | velesdb python binding + common | **MIT** |
+| llamaindex | `integrations/llamaindex` | velesdb python binding + common | **MIT** |
+| haystack | `integrations/haystack` | velesdb python binding | **MIT** |
+| common | `integrations/common` | shared base for the 3 integrations | **MIT** |
+| docs | `docs/` + `README.md` | documents the public surface | Core 1.0 |
+
+Per-component inspection hints live in [references/component-inventory.md](references/component-inventory.md).
+
+## Methodology (6 phases)
+
+Author the Workflow scripts fresh each run (the codebase evolves; do **not** hard-code last run's capability list — re-extract it). The pattern that worked:
+
+### Phase 0 — Discover (inline)
+Map the work-list: `Cargo.toml` members, `sdks/`, `integrations/`, `docs/`. Capture `velesdb-core`'s public re-exports from `crates/velesdb-core/src/lib.rs` and the public methods of `Database`, `VectorCollection`, `GraphCollection`, `MetadataCollection`, `AnyCollection`, and the `agent::` module. These seed Phase 1.
+
+### Phase 1 — Build the canonical core catalog (barrier)
+Fan out ~3 agents by domain (management/config/enums · data plane · query/graph/memory) to extract `velesdb-core`'s **public capabilities** — grouped, not every micro-method (e.g. all `search_with_*` = one "filtered search"). Each capability = `{id (domain-prefixed), group, name, core_symbols[], signature, notes}`. Merge + dedupe by id → **one canonical catalog**. This is the source-of-truth column. (Last run: ~81 capabilities across 20 domains; expect drift.)
+
+### Phase 2 — Map each component (pipeline, one agent per component)
+Inject the **same** catalog into every component agent. Each rates **every** capability `full | partial | absent | na` with `file:symbol`/endpoint/doc-section evidence, and lists `extra_surface` (capabilities the child exposes that are NOT in core — the enrichment). For `docs`: `full` = documented with usage, `absent` = undocumented public capability (a doc gap).
+
+### Phase 3 — Adversarially verify gaps (pipeline stage 2)
+Hand each component's `absent`/`partial` rows to a **skeptic** agent that tries to **refute** them — grep harder (helpers, aliases, `.pyi` stubs, base classes in `integrations/common`, parent protocols). The parity campaign closed many gaps; naïve greps re-report them. Reconcile mapper status with verifier overturns. (Last run the verifier correctly overturned Python `collection_diagnostics`/`update_guardrails`/`create_index`/`reorder_for_locality` — they *are* exposed.)
+
+### Phase 4 — Architecture-cleanliness audit (barrier)
+This answers the real question. Fan out:
+- **1 dependency-direction agent**: `velesdb-core/Cargo.toml` must list **no** child; every child depends on core; no cycles. Any inversion = `concern`.
+- **1 boundary agent per child**: does it *delegate* canonical logic to core or *reimplement* it? Is the reimplementation justified (WASM has no `persistence` feature → reimplements storage + a VelesQL executor) or a divergence smell? Are contracts (enums, wire codec, `VELES-###` error codes) sourced from core or re-derived (drift risk)? Is the extra surface composed from core primitives or does it bypass core to touch internals?
+- **4 cross-cutting divergence probes**: (1) **fusion math** single-sourced vs reimplemented (core `fusion/` vs `velesdb_common.fusion` vs `wasm/fusion.rs` vs ts-sdk); (2) **string→u64 ID hashing** consistency (`velesdb_common.ids.stable_hash_id` vs haystack `_str_id_to_int` vs mobile vs migrate `stable_point_id` — different algorithms = interop divergence); (3) **VelesQL parser/executor sync** (WASM reimplements the executor; ECOSYSTEM_PARITY notes WASM conformance is **parser-only** — executor behaviour is NOT fixture-checked); (4) **distance + quantization kernel fidelity** (WASM/mobile recompute distance/quant — same results as core? recall@10 ≥ 0.95 fidelity?).
+
+Each finding: `severity info|smell|concern`, `divergence_risk` bool, `file:line` evidence. **License lens:** a divergence/duplication in an MIT integration that copies core's *protected* logic is escalated.
+
+### Phase 5 — Verify concerns + synthesize
+Adversarially re-check every `concern` (and `smell` with `divergence_risk`) — many "concerns" are justified design (feature-gating, pure-client wire-building, idiomatic enrichment). Then synthesize:
+- **Parity matrix** — run `scripts/gen_matrix.py` over the Phase 2/3 JSON results → cell-level markdown matrix + per-component scorecard + gap buckets (user-facing vs core-internal/ops). Exclude core-internal domains (observability counters, durability/WAL tuning, registry generations, column-store kernels) from the "should expose" denominator — they were never meant to cross the binding boundary.
+- **Architecture verdict** — per-child cleanliness + the 4 probe verdicts + the dependency-direction result, each concern with its verification status and a **license-aware** remediation.
+
+### Orchestration
+Drive Phases 1–5 with the **Workflow tool** (`parallel` for the catalog barrier and the architecture fan-out; `pipeline` for component map→verify). Save each workflow's structured result, feed Phase-2/3 JSON to `scripts/gen_matrix.py`. If agents get rate-limited (it happens at ~25+ concurrent), re-run only the failed components in a small follow-up workflow reusing the existing catalog — do **not** resume-cache the failed nulls.
+
+## Outputs
+
+1. `PARITY_MATRIX.md` — capability × component matrix (`✅ full · ⚠️ partial · ❌ absent · · n/a`), scorecard, gap buckets.
+2. Architecture verdict (in chat + optional `ARCHITECTURE_VERDICT.md`): is `velesdb-core` the uncontested source of truth? Is the boundary clean? Concerns ranked, each with license-aware remediation.
+3. Reconcile against `docs/reference/ECOSYSTEM_PARITY.md` "Remaining Gaps" — flag anything genuinely new vs already-documented-by-design.
+
+## Interpreting results
+
+- `partial`/`na` are usually **by design** (WASM no-persistence, Haystack DocumentStore protocol bounds, agent-memory not over REST, CLI has no memory surface). Don't report these as "not caught up."
+- The actionable signal is **`absent` in a user-facing domain** that is **not** already documented as by-design, **plus** any architecture `concern` confirmed in Phase 5.
+- Enrichment (`extra_surface`) is the headline good news — list it, don't penalize it.

--- a/.agents/skills/core-parity-audit/references/component-inventory.md
+++ b/.agents/skills/core-parity-audit/references/component-inventory.md
@@ -1,0 +1,25 @@
+# Component inspection hints
+
+How each child exposes (or should expose) core's surface, and what counts as `full | partial | absent | na`. Re-verify paths each run — modules move.
+
+## Rust crates (delegate to `velesdb_core::` directly)
+
+- **server** (`crates/velesdb-server`): HTTP adapters in `src/routes.rs`, `src/handlers/`, `src/types.rs`. `full` = a REST endpoint exposes it. `na` = pure Rust accessor with no REST meaning. Enrichment seen: `/health`, `/ready`, `/metrics` (Prometheus), `/vacuum`, `/compact`, SSE traversal stream, bearer-auth/TLS/rate-limit.
+- **cli** (`crates/velesdb-cli`): `src/repl_*_cmds.rs`, `src/commands.rs`, `src/handlers/`, `src/import.rs`, `src/repl_execute.rs`. Embedded core → VelesQL paths broadly reachable. **Agent memory has no CLI surface by design → `na`, not `absent`** (don't let the mapper over-report).
+- **python** (`crates/velesdb-python`): `#[pymethods]`/`#[pyfunction]` in `src/*.rs` **and** `python/velesdb/__init__.pyi`. `full` only if in **both** binding and stub. Enrichment: NumPy/DataFrame fast paths, `train_pq`, embedders.
+- **wasm** (`crates/velesdb-wasm`): `#[wasm_bindgen]` exports. Built **without `persistence`** → persistence/WAL/HNSW/streaming are `na` by design; it reimplements an in-memory store + VelesQL executor (`velesql_exec*.rs`) + brute-force search. Enrichment: IndexedDB persistence, Web-Worker traversal offload.
+- **mobile** (`crates/velesdb-mobile`): `#[uniffi::export]`. `full` = exported to Swift/Kotlin. Semantic-only agent memory by design. Enrichment: `MobileGraphStore`, `compact_storage`, `train_pq`.
+- **migrate** (`crates/velesdb-migrate`): ETL tool — most data/query rows are legitimately `na`. Focus on whether it writes through core APIs (`upsert_bulk`) and provisions indexes/analyze post-load. Enrichment: 10 source connectors, resumable checkpoints, retry/backoff.
+- **tauri** (`crates/tauri-plugin-velesdb`): `#[tauri::command]` handlers. Enrichment: event stream, `get_app_data_dir`, persisted memory snapshots.
+
+## Clients / integrations
+
+- **ts-sdk** (`sdks/typescript`): `src/client.ts`, `src/client/`, `src/backends/`, `src/agent-memory.ts`, `src/query-builder.ts`, `src/types.ts`, `src/capabilities.ts`. **Pure client** — `full` = it builds the right wire payload / parses the response. The query-builder/filter DSL compiling to wire is clean. `concern` if it computes *results* (ranking/fusion/distance) itself, or hardcodes enum/`VELES-###` contracts that can drift.
+- **langchain** (`integrations/langchain`): `src/langchain_velesdb/*.py`. **MIT** — must reuse `integrations/common`, call the `velesdb` binding, never embed protected logic. Enrichment: MMR, graph-toolkit (LLM extraction), retrievers.
+- **llamaindex** (`integrations/llamaindex`): `src/llamaindex_velesdb/*.py`. Same MIT rule. Enrichment: score-threshold query, graph retrievers.
+- **haystack** (`integrations/haystack`): `src/haystack_velesdb/document_store.py`. Bounded by Haystack 2.x `DocumentStore` protocol (`write_documents`/`filter_documents`/`embedding_retrieval`/`count`/`delete`). Graph/agent-memory/sparse-named are `na` by protocol. **Watch:** its own `_str_id_to_int` may diverge from `velesdb_common.ids.stable_hash_id`.
+- **common** (`integrations/common`): `src/velesdb_common/*.py` — the shared MIT base (`ids`, `fusion`, `graph`, `security`, `collection_admin`). Verify the 3 integrations actually reuse it instead of re-deriving id-hashing/fusion/security per-package.
+
+## Docs
+
+`docs/reference/api-reference.md`, `VELESQL_CONTRACT.md`, `VELESQL_CHEATSHEET.md`, `ECOSYSTEM_PARITY.md`, `docs/guides/`, `README.md`. `full` = capability documented with usage; `partial` = mentioned but thin; `absent` = undocumented public capability (a doc gap); `na` = purely internal symbol. Reconcile findings against the `ECOSYSTEM_PARITY.md` "Remaining Gaps" list.

--- a/.agents/skills/core-parity-audit/references/license-boundary.md
+++ b/.agents/skills/core-parity-audit/references/license-boundary.md
@@ -1,0 +1,41 @@
+# License boundary — what the parity audit must enforce
+
+`velesdb-core` is the **single source of truth** *and* a **licensed asset**. The gap analysis must reason about both at once.
+
+## The two licenses in this repo
+
+| Surface | License | Notes |
+|---------|---------|-------|
+| `velesdb-core` (source of truth) | **VelesDB Core License 1.0** | Source-available, based on Elastic License 2.0 (ELv2). `Copyright (c) 2024-2026 Wiscale France`. `VelesDB®` is a registered trademark. |
+| `crates/velesdb-{server,cli,python,wasm,mobile,migrate}`, `tauri-plugin-velesdb` | **VelesDB Core License 1.0** | `license-file = LICENSE` (root or `../../LICENSE`). |
+| `sdks/typescript` | **VelesDB Core License 1.0** | `"license": "SEE LICENSE IN LICENSE"`. |
+| `integrations/{langchain,llamaindex,haystack,common}` | **MIT** | `pyproject.toml license = MIT`. |
+| `docs/`, `README.md` | repo (Core License 1.0) | |
+
+## What the Core License protects (verbatim concepts)
+
+The license names these as the Software's capabilities that may not be re-offered or competitively reimplemented: **query, administration, indexing, ingestion, storage, graph traversal, knowledge-graph, columnar filtering, management** — i.e. exactly the canonical logic in `velesdb-core`.
+
+Key limitations the audit should be aware of:
+1. **No Hosted/Managed Service** — exposing core's capabilities to third parties as a service needs a commercial license.
+2. **No Competitive Offering** — may not build a competing database/vector-db/graph-db/search/query engine from it.
+3. **No Circumvention of Paid Features** — do not disable/remove licensing-gated functionality.
+4. **No Removal of Notices/Trademarks** — keep `VelesDB®` and copyright notices intact.
+
+Internal use, and integrating VelesDB as a **backend component** of your own product (end users get only results, not core DB access), are explicitly allowed.
+
+## Why this matters for gap-closing recommendations
+
+The MIT integrations (`langchain`, `llamaindex`, `haystack`, `common`) wrap the **Core-Licensed** Python binding. That is the *intended* shape: an MIT thin layer that **calls** the licensed engine. It stays clean — and license-compliant — only as long as the MIT layer does **not embed or copy** core's protected logic.
+
+Therefore the audit's remediation rules are:
+
+- ✅ **Valid:** "Capability X is missing in the MIT integration → expose X on the `velesdb` binding (Core License) and have the integration **call** it." The protected logic stays in core; the MIT layer only orchestrates.
+- ❌ **Invalid (never recommend):** "Copy core's fusion math / distance kernel / VelesQL execution / id-hashing into the MIT integration." That both forks the source of truth (architecture violation) **and** risks relicensing protected logic as MIT (license violation).
+- ❌ **Invalid:** relicensing Core-License code as MIT, or pulling MIT code into core in a way that muddies the Core License.
+- ⚠️ **Escalate:** any Phase-4 `duplication`/`reimplementation`/`fidelity` finding located in an **MIT** package that touches a protected capability — it is simultaneously an architecture smell and a potential license leak. Rank it above the same finding in a Core-Licensed crate.
+
+## Reporting hygiene
+
+- Reports, PRs, commits, and issues you generate must follow the project **no-AI-attribution** rule (no `Co-Authored-By`, no AI/tool credit) and must not strip or alter `VelesDB®`/copyright notices.
+- The audit artifacts themselves are internal use — fine to produce and share within the org.

--- a/.agents/skills/core-parity-audit/scripts/gen_matrix.py
+++ b/.agents/skills/core-parity-audit/scripts/gen_matrix.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Render the core-parity matrix from one or more workflow result JSON files.
+
+Each input JSON is the structured result of the map→verify workflow(s):
+    { "catalog": [ {id, group, name, core_symbols, ...}, ... ],   # at least one input carries it
+      "components": [ {key, label, rows:[{capability_id,status,evidence,notes}], extra_surface, ...}, ... ] }
+
+Usage:
+    gen_matrix.py OUT.md RESULT1.json [RESULT2.json ...]
+
+Status glyphs: full=✅  partial=⚠️  absent=❌  na=·
+The skill (core-parity-audit) explains how the result JSONs are produced.
+"""
+import json
+import sys
+from collections import Counter
+
+GLYPH = {"full": "✅", "partial": "⚠️", "absent": "❌", "na": "·"}
+
+# canonical column order + display labels (extend if new components appear)
+ORDER = ["server", "cli", "python", "wasm", "mobile", "migrate", "tauri",
+         "ts-sdk", "langchain", "llamaindex", "haystack", "common", "docs"]
+LABELS = {"server": "Server", "cli": "CLI", "python": "Python", "wasm": "WASM",
+          "mobile": "Mobile", "migrate": "Migrate", "tauri": "Tauri", "ts-sdk": "TS SDK",
+          "langchain": "LangChain", "llamaindex": "LlamaIndex", "haystack": "Haystack",
+          "common": "int/common", "docs": "Docs"}
+
+# Core-internal / ops domains: never expected to cross the binding boundary, so
+# they are excluded from the "user-facing coverage" denominator.
+INTERNAL_GROUPS = {"Observability", "Config surface", "Persistence",
+                   "Validation & guardrails", "Database lifecycle",
+                   "Query planning / introspection", "Indexes"}
+
+
+def load_inputs(paths):
+    catalog, by_key = [], {}
+    seen_caps = set()
+    for p in paths:
+        doc = json.load(open(p))
+        doc = doc.get("result", doc)
+        if isinstance(doc, str):
+            doc = json.loads(doc)
+        for cap in doc.get("catalog", []) or []:
+            if cap.get("id") and cap["id"] not in seen_caps:
+                seen_caps.add(cap["id"])
+                catalog.append(cap)
+        for comp in doc.get("components", []) or []:
+            by_key[comp["key"]] = comp  # later file wins on dup key
+    return catalog, by_key
+
+
+def status_of(comp, cid):
+    for row in comp.get("rows", []):
+        if row["capability_id"] == cid:
+            return row["status"]
+    return "na"
+
+
+def main():
+    if len(sys.argv) < 3:
+        sys.exit("usage: gen_matrix.py OUT.md RESULT1.json [RESULT2.json ...]")
+    out_path, inputs = sys.argv[1], sys.argv[2:]
+    catalog, by_key = load_inputs(inputs)
+    cat = {c["id"]: c for c in catalog}
+    present = [k for k in ORDER if k in by_key] + [k for k in by_key if k not in ORDER]
+
+    groups = []
+    for c in catalog:
+        if c["group"] not in groups:
+            groups.append(c["group"])
+
+    out = []
+    out.append("# VelesDB Core → Ecosystem Public-API Parity Matrix\n")
+    out.append(f"**Source of truth:** `velesdb-core` — **{len(catalog)} capabilities** across {len(groups)} domains, "
+               f"× {len(present)} components. Every gap adversarially re-verified.\n")
+    out.append("Legend: ✅ full · ⚠️ partial / reduced · ❌ absent (plausible gap) · · N/A by design\n")
+
+    hdr = "| Capability | " + " | ".join(LABELS.get(k, k) for k in present) + " |"
+    sep = "|" + "---|" * (len(present) + 1)
+    for g in groups:
+        out.append(f"\n### {g}\n")
+        out.append(hdr)
+        out.append(sep)
+        for c in catalog:
+            if c["group"] != g:
+                continue
+            cells = [GLYPH.get(status_of(by_key[k], c["id"]), "?") for k in present]
+            out.append(f"| {c['name']} | " + " | ".join(cells) + " |")
+
+    out.append("\n## Coverage scorecard (per component)\n")
+    out.append("| Component | full | partial | absent | n/a | user-facing coverage* |")
+    out.append("|---|---|---|---|---|---|")
+    for k in present:
+        comp = by_key[k]
+        st = Counter(r["status"] for r in comp.get("rows", []))
+        uf_full = uf_part = uf_abs = 0
+        for r in comp.get("rows", []):
+            grp = cat.get(r["capability_id"], {}).get("group", "")
+            if grp and grp not in INTERNAL_GROUPS:
+                uf_full += r["status"] == "full"
+                uf_part += r["status"] == "partial"
+                uf_abs += r["status"] == "absent"
+        denom = uf_full + uf_part + uf_abs
+        cov = f"{round(100 * (uf_full + 0.5 * uf_part) / denom)}%" if denom else "n/a"
+        out.append(f"| {LABELS.get(k, k)} | {st.get('full', 0)} | {st.get('partial', 0)} | "
+                   f"{st.get('absent', 0)} | {st.get('na', 0)} | {cov} |")
+    out.append("\n*User-facing coverage = (full + ½·partial) / (full+partial+absent) over user-facing domains "
+               "(excludes core-internal observability/config/durability/registry plumbing).\n")
+
+    open(out_path, "w").write("\n".join(out))
+
+    # gap buckets to stderr (so chat synthesis can read them)
+    uf, internal = [], []
+    for k in present:
+        for r in by_key[k].get("rows", []):
+            if r["status"] != "absent":
+                continue
+            grp = cat.get(r["capability_id"], {}).get("group", "")
+            (internal if grp in INTERNAL_GROUPS else uf).append((k, r["capability_id"]))
+    print(f"wrote {out_path}: {len(catalog)} caps × {len(present)} components", file=sys.stderr)
+    print(f"absent — user-facing: {len(uf)}  core-internal/ops: {len(internal)}", file=sys.stderr)
+    print("\nuser-facing absent by capability (missing in →):", file=sys.stderr)
+    for cid, _ in Counter(c for _, c in uf).most_common():
+        comps = [k for k, cc in uf if cc == cid]
+        print(f"  {cid:38} {', '.join(comps)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.velesdb-hooks.json
+++ b/.velesdb-hooks.json
@@ -1,0 +1,4 @@
+{
+  "project": "velesdb",
+  "session": "rolling"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] — 2026-07-26
+
+Mineure : 38 commits depuis la 4.0.0. Le verrou de gouvernance CORE-2 couvre
+desormais les lectures graphe REST, l'audit des capacites honore les
+denegations, et velesdb-memory corrige quatre defauts constates en usage reel.
+
 ### Fixed
 
 - **`velesdb-core`**: the allocation backstop (#899) is no longer disturbed by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,7 +5818,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6818,7 +6818,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6924,7 +6924,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.22"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "4.0.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "4.1.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v4.0.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v4.1.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.0.0"
+LABEL version="4.1.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/velesdb)](https://pypi.org/project/velesdb/)
 [![Python](https://img.shields.io/pypi/pyversions/velesdb)](https://pypi.org/project/velesdb/)
 [![License](https://img.shields.io/badge/license-VelesDB_Core_1.0-blue)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-4.0.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
+[![Version](https://img.shields.io/badge/version-4.1.0-blue)](https://github.com/cyberlife-coder/VelesDB/releases)
 
 Python bindings for [VelesDB](https://github.com/cyberlife-coder/VelesDB) — a high-performance vector database for AI applications. `numpy>=1.20` ships as a hard runtime dependency since v1.13.8, so a single `pip install velesdb` is sufficient.
 

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "4.0.0"
+version = "4.1.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -661,7 +661,7 @@ curl http://localhost:8080/health
 Response:
 
 ```json
-{"status": "ok", "version": "4.0.0"}
+{"status": "ok", "version": "4.1.0"}
 ```
 
 ### `GET /ready` -- Readiness Probe
@@ -675,13 +675,13 @@ curl http://localhost:8080/ready
 Response (ready):
 
 ```json
-{"status": "ready", "version": "4.0.0"}
+{"status": "ready", "version": "4.1.0"}
 ```
 
 Response (not ready):
 
 ```json
-{"status": "not_ready", "version": "4.0.0"}
+{"status": "not_ready", "version": "4.1.0"}
 ```
 
 ### Kubernetes Example

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "4.0.0"
+version = "4.1.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="4.0.0",
+    version="4.1.0",
     lifespan=lifespan
 )
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: July 24, 2026 (VelesDB v4.0.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: July 26, 2026 (VelesDB v4.1.0). Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | **Last Updated**: 2026-07-24 (VelesDB v4.0.0)
+**Version**: 3.10.0 | **Last Updated**: 2026-07-26 (VelesDB v4.1.0)
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }
 ```
 

--- a/docs/guides/CLI_REPL.md
+++ b/docs/guides/CLI_REPL.md
@@ -1,6 +1,6 @@
 # 💻 CLI & REPL Reference
 
-*Version 4.0.0 — 2026-06-12*
+*Version 4.1.0 — 2026-06-12*
 
 Complete guide to the VelesDB command-line interface and the interactive REPL.
 
@@ -36,7 +36,7 @@ cargo build --release -p velesdb-cli
 
 ```bash
 velesdb --version
-# velesdb 4.0.0
+# velesdb 4.1.0
 ```
 
 ---
@@ -269,7 +269,7 @@ velesdb> \info
 ┌─────────────────────┬────────────────────┐
 │ Property            │ Value              │
 ├─────────────────────┼────────────────────┤
-│ Version             │ 4.0.0              │
+│ Version             │ 4.1.0              │
 │ Data directory      │ ./data             │
 │ Collections         │ 3                  │
 │ Total vectors       │ 125,000            │
@@ -342,7 +342,7 @@ Session settings are **not persisted** across REPL sessions. To persist them, us
 ```
 $ velesdb repl ./my_db
 
-VelesDB v4.0.0 - Interactive REPL
+VelesDB v4.1.0 - Interactive REPL
 Type \help for help, \quit to exit.
 
 velesdb> \show

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 4.0.0 — May 2026*
+*Version 4.1.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 4.0.0
+# Version: 4.1.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 4.0.0 -- May 2026*
+*Version 4.1.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.0.0/velesdb-4.0.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.1.0/velesdb-4.1.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-4.0.0-amd64.deb
+sudo dpkg -i velesdb-4.1.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:4.0.0
+docker pull ghcr.io/cyberlife-coder/velesdb:4.1.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:4.0.0
+  ghcr.io/cyberlife-coder/velesdb:4.1.0
 ```
 
 ### Build locally

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 4.0.0 -- 2026-06-12*
+*Version 4.1.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -299,7 +299,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }
 ```
 
@@ -318,7 +318,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }
 ```
 
@@ -327,7 +327,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }
 ```
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 4.0.0
+  version: 4.1.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v4.0.0
+# VelesDB Architecture Diagrams — v4.1.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-24 (v4.0.0; velesdb-memory 0.11.0)
+Last updated: 2026-07-26 (v4.1.0; velesdb-memory 0.11.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 4.0.0
+> **VelesDB version:** 4.1.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-24 (VelesDB v4.0.0)
+> Last updated: 2026-07-26 (VelesDB v4.1.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "4.0.0"
+  "version": "4.1.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.0.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "4.0.0"
+version = "4.1.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "4.0.0"
+version = "4.1.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "4.0.0"
+version = "4.1.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "4.0.0"
+version = "4.1.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "4.0.0"
+version = "4.1.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.0.0"
+__version__ = "4.1.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@4.0.0
+cargo add --quiet velesdb-core@4.1.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@4.0.0
+cargo install --quiet --locked velesdb-server@4.1.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v4.0.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v4.1.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^3.8.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Report du bump 4.1.0 et de son commit de merge sur `develop`.

Sans ce backmerge, `develop` reste en `4.0.0` alors que le tag `v4.1.0` est posé : la prochaine PR repartirait d'une base dont la version ment. C'est exactement l'écart qui avait laissé `develop` 38 commits au-delà de `v4.0.0` sans que personne ne le voie.

Aucun conflit. `check-version-sync` et les contrats verts en local.

> Côté privé, le backmerge équivalent s'est révélé **inutile** : les arbres de `main` et `develop` y sont identiques, seul le commit de merge diffère — GitHub refuse d'ailleurs une PR à diff zéro.