### PR TITLE
fix(release): publier langgraph-velesdb, absent de la matrice PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -478,6 +478,7 @@ jobs:
           - langchain-velesdb
           - llamaindex-velesdb
           - haystack-velesdb
+          - langgraph-velesdb
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -496,6 +497,21 @@ jobs:
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
         with:
           packages-dir: integrations/langchain/dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+
+      - name: Build langgraph-velesdb
+        if: matrix.package == 'langgraph-velesdb'
+        run: |
+          cd integrations/langgraph
+          pip install build
+          python -m build
+
+      - name: Publish langgraph-velesdb to PyPI
+        if: matrix.package == 'langgraph-velesdb'
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        with:
+          packages-dir: integrations/langgraph/dist/
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 

--- a/scripts/tests/test_release_publishes_every_integration.py
+++ b/scripts/tests/test_release_publishes_every_integration.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Every Python integration in the repo must be in the release matrix.
+
+`langgraph-velesdb` sat at HTTP 404 on PyPI while the v4.1.0 release run
+reported 25 successful jobs and zero skipped. There is no contradiction: the
+package was simply absent from the publish matrix, and **a job that does not
+exist cannot fail**. A green run says nothing about a package it never knew
+about, which is why this asserts the two sets are equal rather than reading
+the run's status.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+INTEGRATIONS = ROOT / "integrations"
+
+# Published on its own, outside the integration matrix.
+STANDALONE = {"velesdb-common"}
+
+
+def integration_dirs() -> dict[str, str]:
+    """`{directory: distribution name}` for every packaged integration."""
+    found: dict[str, str] = {}
+    for pyproject in sorted(INTEGRATIONS.glob("*/pyproject.toml")):
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+        name = data.get("project", {}).get("name")
+        if name:
+            found[pyproject.parent.name] = name
+    return found
+
+
+def matrix_packages() -> set[str]:
+    """The `package:` matrix values of the PyPI publish job."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    block = text.split("        package:", 1)[1].split("    steps:", 1)[0]
+    return set(re.findall(r"^\s+- (\S+)", block, re.M))
+
+
+class ReleasePublishesEveryIntegration(unittest.TestCase):
+    def test_every_packaged_integration_is_in_the_publish_matrix(self) -> None:
+        dirs = integration_dirs()
+        expected = {d for d, name in dirs.items() if name not in STANDALONE}
+        # The matrix keys are labels; each must name a real integration dir.
+        covered = {
+            directory
+            for directory in expected
+            if any(key.startswith(directory) for key in matrix_packages())
+        }
+        missing = sorted(expected - covered)
+        self.assertEqual(
+            [],
+            missing,
+            f"integration(s) never published — no matrix entry, so no job, so "
+            f"nothing to fail: {missing}",
+        )
+
+    def test_each_matrix_entry_has_a_build_and_a_publish_step(self) -> None:
+        """A matrix value with no matching step publishes nothing, silently."""
+        text = WORKFLOW.read_text(encoding="utf-8")
+        for package in sorted(matrix_packages()):
+            self.assertIn(
+                f"Build {package}", text, f"{package} has no build step"
+            )
+            self.assertIn(
+                f"Publish {package} to PyPI", text, f"{package} has no publish step"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Le paradoxe apparent

Le run de release 4.1.0 affiche **25 jobs réussis, zéro skipped**. Et pourtant :

```
langgraph-velesdb                  → HTTP 404
llama-index-vector-stores-velesdb  → HTTP 200
```

Aucune contradiction : `langgraph-velesdb` n'était pas dans la matrice de publication. **Un job qui n'existe pas ne peut pas échouer** — un run vert ne dit rien d'un paquet qu'il ignore.

C'est exactement le mode de défaillance qui rend un tableau de bord trompeur : le vert mesure ce qui a tourné, pas ce qui aurait dû.

## Le correctif

`langgraph-velesdb` rejoint la matrice avec ses étapes de build et de publication, calquées sur `langchain` — même backend `setuptools`.

## Les contrats

Le premier est **prouvé rouge** : `AssertionError: Lists differ: [] != ['langgraph']`.

- tout `integrations/*/pyproject.toml` doit avoir une entrée de matrice ;
- toute entrée de matrice doit avoir une étape de build **et** de publication — sinon elle ne publie rien, silencieusement.

## Vérifié au passage

`llamaindex` n'est **pas** un défaut, contrairement à ce que la clé de matrice laisse croire : c'est un libellé de job, et le paquet part bien sous `llama-index-vector-stores-velesdb`, qui répond 200.