### PR TITLE
fix(memory): schémas de sortie complets, et --features http compile enfin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Check each velesdb-memory feature in isolation
         run: |
           set -eu
-          for feat in ollama extract context persistence; do
+          for feat in mcp http context persistence ollama extract; do
             echo "::group::--features $feat"
             cargo check -p velesdb-memory --no-default-features --features "$feat"
             echo "::endgroup::"

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -573,6 +573,9 @@ fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 ///
 /// Sized for the job the hook does: a tool result big enough to be worth
 /// compiling, compressed to something an agent can still read in full.
+// Tous ses consommateurs sont gates sur `context` : sans cette feature la
+// constante est reellement morte, et -D warnings en fait une erreur.
+#[cfg(feature = "context")]
 const DEFAULT_COMPILE_STDIN_BUDGET: u64 = 2_000;
 
 /// Parsed `compile-stdin` invocation.

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -158,6 +158,10 @@ impl McpServer {
 
     #[tool(
         name = "remember",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<RememberResult>(),
         description = "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering — metadata is capped at 64 KiB serialized. Set `ttl_seconds` to make the fact expire after a delay (a durable TTL that survives restarts); omit it for a permanent memory. Returns the fact's stable id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
         input_schema = id_wire_input_schema::<RememberParams>(&["target"])
     )]
@@ -196,7 +200,7 @@ impl McpServer {
         name = "recall",
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
-        output_schema = context_tools::wire_safe_output_schema::<RecallResult>(),
+        output_schema = crate::schema::wire_safe_output_schema::<RecallResult>(),
         description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients."
     )]
     async fn recall(
@@ -221,7 +225,7 @@ impl McpServer {
         name = "recall_where",
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
-        output_schema = context_tools::wire_safe_output_schema::<RecallResult>(),
+        output_schema = crate::schema::wire_safe_output_schema::<RecallResult>(),
         description = "Fused recall: semantically similar memories (vector) constrained by structured ColumnStore predicates over metadata — ranges and comparisons, not just equality. Each filter is {field, op (eq/ne/lt/le/gt/ge), value}, ANDed. Use for time-windowed or numeric-scoped recall, e.g. facts about a topic with `ts` in a date range. Comparisons are TYPE-STRICT, with no runtime coercion: a filter value of 20230601 (a JSON number) never matches a fact stored with metadata {\"ts\": \"20230601\"} (a JSON string) — same value, different JSON type, no match, no error. Store comparable values like dates NUMERICALLY at `remember` time (e.g. 20230601, not \"20230601\") so `recall_where` filters actually match them. Most similar first.",
         // No id-named parameter here (hence the empty `keys`) — this goes
         // through the shared helper purely for its `$ref` inlining, so
@@ -251,7 +255,7 @@ impl McpServer {
         name = "recall_fused",
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
-        output_schema = context_tools::wire_safe_output_schema::<RecallFusedResult>(),
+        output_schema = crate::schema::wire_safe_output_schema::<RecallFusedResult>(),
         description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
     )]
     async fn recall_fused(
@@ -295,6 +299,10 @@ impl McpServer {
 
     #[tool(
         name = "feedback",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<FeedbackResult>(),
         description = "Reinforce a recalled memory with an outcome: `success=true` if the fact was useful, `false` if it was noise. This durably updates the fact's learned confidence, which `recall` uses to re-rank future results — over repeated feedback, useful facts drift up and noise drifts down, so the memory improves with use without retraining the model. Returns the fact's new confidence in [0,1].",
         input_schema = id_wire_input_schema::<FeedbackParams>(&["id"])
     )]
@@ -317,6 +325,10 @@ impl McpServer {
 
     #[tool(
         name = "relate",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<RelateResult>(),
         description = "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Direction matters: traversal follows OUTGOING edges only, so point `from` at the memory you will later ask `why` about and `to` at its evidence (decision → cause, fact → source) — an edge pointing INTO a memory is invisible to `why(that memory)`. Idempotent per (from, relation, to). Returns the new edge id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
         input_schema = id_wire_input_schema::<RelateParams>(&["from", "to"])
     )]
@@ -338,6 +350,10 @@ impl McpServer {
 
     #[tool(
         name = "forget",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<ForgetResult>(),
         description = "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the requested id plus `found`: `true` if a memory actually existed and was deleted, `false` if nothing was stored under that id (a stale id or a typo) — a no-op, not an error, but distinguishable from a real deletion.",
         input_schema = id_wire_input_schema::<ForgetParams>(&["id"])
     )]
@@ -362,7 +378,7 @@ impl McpServer {
         name = "why",
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
-        output_schema = context_tools::wire_safe_output_schema::<ExplanationDto>(),
+        output_schema = crate::schema::wire_safe_output_schema::<ExplanationDto>(),
         description = "Explain a decision: find the best-matching memory (optionally scoped by a metadata `filter`, e.g. the current project) and return the connected subgraph of related memories reachable through typed links — fusing vector, ColumnStore, and graph to surface context a plain similarity search misses."
     )]
     async fn why(
@@ -387,6 +403,10 @@ impl McpServer {
 
     #[tool(
         name = "remember_extracted",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<RememberExtractedResult>(),
         description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns the stored facts' ids."
     )]
     async fn remember_extracted(

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use rmcp::handler::server::tool::{schema_for_input, schema_for_output};
+use rmcp::handler::server::tool::schema_for_input;
 use rmcp::handler::server::wrapper::{Json, Parameters};
 use rmcp::model::{ErrorCode, JsonObject};
 use rmcp::{tool, tool_router, ErrorData};
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::{join_error, to_error, McpServer};
-use crate::context::wire::{stringify_id_fields, ID_KEYS};
+use crate::context::wire::stringify_id_fields;
 use crate::context::{
     fragment_id, segment_transcript, suggest_token_budget, CompilePolicy, CompileRequest,
     CompiledContext, ContextCompiler, ContextDecision, ContextFragment, ContextSavings, MediaRef,
@@ -54,22 +54,7 @@ fn to_wire_value<T: serde::Serialize>(
 /// fields must be typed `["integer", "string"]`, or every opted-in response
 /// would fail client-side validation for exactly the clients the option
 /// exists for.
-pub(super) fn wire_safe_output_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
-    let schema = schema_for_output::<T>().unwrap_or_else(|e| {
-        panic!(
-            "Invalid output schema for {}: {e}",
-            std::any::type_name::<T>()
-        )
-    });
-    let mut map = (*schema).clone();
-    crate::schema::widen_id_properties(&mut map, ID_KEYS);
-    // Same treatment as the input side. The official MCP SDKs validate a
-    // tool's `structuredContent` against this schema, so a `$ref` the client
-    // cannot resolve is a result it may reject outright — a harsher failure
-    // than an unparseable argument, where the server at least got to answer.
-    crate::schema::inline_ref_only_properties(&mut map);
-    Arc::new(map)
-}
+pub(super) use crate::schema::wire_safe_output_schema;
 
 /// Input-side counterpart: `fragments[].id` accepts an integer or a decimal
 /// string ([`crate::context::wire::deserialize_optional_id`]), so the
@@ -539,6 +524,10 @@ impl McpServer {
 
     #[tool(
         name = "context_savings",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = wire_safe_output_schema::<ContextSavings>(),
         description = "Aggregate the token (and cost) savings of past compile_context calls, optionally per project. Figures are local estimates recorded per compilation (metadata only, never content); `truncated` reports when the sweep hit the recall cap."
     )]
     async fn context_savings(
@@ -587,6 +576,10 @@ impl McpServer {
 
     #[tool(
         name = "retrieve_context_source",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = wire_safe_output_schema::<RetrieveContextSourceResult>(),
         description = "Fetch back the exact original content behind a ctx://source/<hash> handle from a compiled context — what compile_context externalized or partially packed is recoverable, not lost."
     )]
     async fn retrieve_context_source(
@@ -609,6 +602,10 @@ impl McpServer {
 
     #[tool(
         name = "save_working_context",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = wire_safe_output_schema::<SaveWorkingContextResult>(),
         description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert). Serialized size is capped at 1 MiB. Returns the stored fact's id.",
         input_schema = wire_safe_input_schema::<SaveWorkingContextParams>()
     )]
@@ -633,6 +630,10 @@ impl McpServer {
 
     #[tool(
         name = "load_working_context",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = wire_safe_output_schema::<LoadWorkingContextResult>(),
         description = "Resume a session: load back the working context previously saved by save_working_context under the same project + session id — the goal, constraints, verified facts, open hypotheses, decisions, exact evidence, and pending actions a PRIOR session left off with. Call this at the START of a new session before doing anything else, so work continues instead of restarting. `found: false` (with `working: null`) means nothing was ever saved under that exact project + session — not an error, but check `other_sessions`: if it lists a similarly-named session, `session` was likely a typo, not a genuinely fresh start. `other_sessions` is always filled in, on a hit too: if it lists a session that looks more like the one you meant, you may have just resumed the WRONG session. Use `list_working_contexts` to browse a project's sessions up front."
     )]
     async fn load_working_context(
@@ -697,6 +698,10 @@ impl McpServer {
 
     #[tool(
         name = "suggest_budget",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = wire_safe_output_schema::<SuggestedBudget>(),
         description = "Suggest a starting token_budget for compile_context, for a named target model — looked up in a static, committed model-name to context-window table (dated \"as of\", NEVER a network call). Pass `reserve_tokens` (default 0) to reserve room for the response, mirroring compile_context's own `policy.response_reserve_tokens`. `window`/`suggested_budget` come back null when the model is not in the table — an honest \"unknown\", never a guess; extend the table in a new release instead of relying on this for an unlisted model."
     )]
     async fn suggest_budget(

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -369,3 +369,33 @@ fn is_rust_int_format(format: &str) -> bool {
 #[cfg(test)]
 #[path = "schema_tests.rs"]
 mod tests;
+
+/// Les champs d'id qui traversent le fil sous forme entiere OU chaine
+/// decimale. Definis ici et non dans `context::wire` : `schema.rs` est gate
+/// sur `mcp`, alors que `context::wire` l'est sur `context` — et les outils
+/// de `mcp.rs` en ont besoin meme quand `context` est absente, ce qui est le
+/// cas de `--features http`.
+#[cfg(feature = "mcp")]
+pub(crate) const WIRE_ID_KEYS: &[&str] =
+    &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+
+/// Le schema de sortie ANNONCE d'un outil : ids elargis, puis `$ref` inlines
+/// et `$defs` inatteignables elagues.
+///
+/// Vit ici plutot que dans `mcp/context_tools.rs` parce que les outils de
+/// `mcp.rs` l'appellent aussi : le laisser dans un module gate sur `context`
+/// cassait `--features http`, qui active `mcp` sans `context`.
+#[cfg(feature = "mcp")]
+pub(crate) fn wire_safe_output_schema<T: schemars::JsonSchema + std::any::Any>(
+) -> std::sync::Arc<rmcp::model::JsonObject> {
+    let schema = rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|e| {
+        panic!(
+            "Invalid output schema for {}: {e}",
+            std::any::type_name::<T>()
+        )
+    });
+    let mut map = (*schema).clone();
+    widen_id_properties(&mut map, WIRE_ID_KEYS);
+    inline_ref_only_properties(&mut map);
+    std::sync::Arc::new(map)
+}


### PR DESCRIPTION
Deux boucles d'un même audit, la seconde ayant révélé une régression que j'avais introduite.

## Les dix derniers schémas de sortie

Dix outils sur dix-neuf n'en déclaraient **aucun** : `context_savings`, `feedback`, `forget`, `load_working_context`, `relate`, `remember`, `remember_extracted`, `retrieve_context_source`, `save_working_context`, `suggest_budget`.

rmcp en dérivait un automatiquement, qui **échappait à tout post-traitement** — inliner compris — et gardait des `$ref` qu'un client aveugle aux `$defs` ne résout pas. Les SDK MCP validant `structuredContent` contre le schéma annoncé, un `$ref` irrésolvable est un **résultat correct que le client peut rejeter**.

Coût mesuré : **107 803 → 107 837 octets**, soit **+34 octets** pour dix schémas. L'élagage des `$defs` absorbe l'ajout, et le total reste sous les 108 162 d'avant tous ces correctifs.

Le contrat précédent vérifiait la *forme* des schémas présents, pas leur *présence* — d'où dix outils passés au travers. Le nouveau exige que tout outil en **annonce** un.

## `--features http` ne compilait plus

Étendre la matrice CI à `mcp` et `http` a immédiatement trouvé deux défauts.

**Une régression que j'ai introduite** (PR #1611, sur `develop`, jamais sur `main` — donc rien de publié) : `mcp.rs` référençait `context_tools::wire_safe_output_schema` en neuf endroits, or `mod context_tools` est gaté sur `context`. Avec `--features http`, qui active `mcp` **sans** `context`, la résolution échouait.

Correctif structurel plutôt que rustine : le helper remonte dans `schema.rs`, gaté sur `mcp`, avec ses clés d'id — puisque les outils de `mcp.rs` en ont besoin sans `context`.

**Un défaut préexistant** : `DEFAULT_COMPILE_STDIN_BUDGET` est morte dès que `context` est absente. Gatée sur son consommateur réel, pas masquée par un `allow(dead_code)`.

`http` n'était pas un choix arbitraire : il agrège treize dépendances et **c'est le transport du démon en production**. Ne pas le tester isolément laissait la combinaison la plus utilisée hors couverture.

## Vérification

Six features vertes isolément sous `RUSTFLAGS=-Dwarnings`, comme la CI : `mcp`, `http`, `context`, `persistence`, `ollama`, `extract`. 20 suites de tests, clippy pedantic propre.