### PR TITLE
feat(memory): le graphe se construit tout seul, et tout se configure dans un fichier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6916,6 +6916,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "toml 1.1.3+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "ureq",

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -26,6 +26,10 @@ exclude = ["media/"]
 velesdb-core = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 serde = { workspace = true }
+# The optional `velesdb-memory.toml` config file (see `src/config.rs`).
+# Native-only by `cfg` rather than by feature: a config file is not an opt-in
+# capability, it is how the daemon is operated.
+toml = { workspace = true }
 serde_json = { workspace = true }
 # Pinned to rmcp's schemars (1.2.x) so domain types and MCP DTOs share one
 # JsonSchema derive — no duplicate wire/domain structs.

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -3,11 +3,15 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget) are available and the
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity)
+  are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
   when a decision or durable fact emerges (remember + relate it), when asked why
   something is the way it is (why), and after using a recalled memory (feedback).
+  Use remember_extracted when a passage states relationships or properties of
+  named people/places/things, and entity(name) to answer a question ABOUT such a
+  thing rather than about the sentences that mention it.
   Especially relevant for: multi-session projects, architecture/config decisions,
   incident postmortems, "why is this value/setting like this", onboarding to an
   unfamiliar codebase, and any place a fact learned now must survive to a later
@@ -122,6 +126,50 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    improves without any retraining. Give feedback on the memory you actually
    used, not on everything.
 
+## Entities: let the graph build itself
+
+Steps 2 and 3 build the graph by hand, one `relate` at a time. That is the right
+tool for a *decision* graph, where you choose the edges deliberately. It is the
+wrong tool for facts about **people, places, organisations and things**, where
+the edges are simply what the sentence already says.
+
+`remember_extracted(text)` reads a passage and stores three things at once: the
+atomic facts, the typed edges **between named entities**, and the **attributes**
+those entities carry. Say it in plain language and the graph assembles itself:
+
+> "Julien Lange est le père d'Axel Lange. Axel Lange a 15 ans.
+>  Axel Lange a une sœur, Léa Lange."
+
+produces `julien lange -[père de]-> axel lange`, an `age: 15` attribute on Axel,
+and a brand-new `léa lange` node wired by `sœur de`. No `relate` calls.
+
+**Entity names resolve across calls and across sessions.** An entity's id is
+content-addressed from its (lowercased) name, so "Axel Lange" in today's
+sentence and "axel lange" in next month's land on the *same* node. Attributes
+accumulate onto it — learning the sister does not erase the age.
+
+**Read entities with `entity(name)`, not `recall`.** This matters and is easy to
+get wrong. Entity nodes are deliberately invisible to `recall` and
+`recall_where`: a node called `Entity: axel lange` would rank for its own name
+and evict a real fact from your results. So:
+
+- *"What does the memory say about Axel?"* → `entity("Axel Lange")` — returns his
+  attributes and every typed edge leaving him.
+- *"Which notes mention Axel?"* → `recall("Axel Lange")` — returns sentences.
+
+Use `entity` for questions **about a thing**, `recall` for questions **about what
+was written**. `found: false` means nothing has ever mentioned that name.
+
+**Numbers must stay numbers.** Attributes keep the JSON type the extractor
+produced, and `recall_where`'s comparisons are type-strict with no coercion. An
+age stored as `"15"` will never match `age >= 15` — no error, just silence. This
+is the same trap as the date field in step 2, and it is the single most common
+way a memory system looks like it is working while returning nothing.
+
+`remember_extracted` needs an extraction backend
+(`[extractor] backend = "ollama"`); without one the tool reports itself as
+unconfigured rather than silently storing less.
+
 ## Concrete scenarios
 
 **Incident → decision → later "why?"** — the flagship case.
@@ -172,8 +220,32 @@ launched with:
   `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
   `VELESDB_MEMORY_EMBEDDER=ollama`.
 
-Set a stable store location with `VELESDB_MEMORY_PATH` (e.g. `~/.velesdb-memory`) so
-memory persists in one place across sessions. Optionally set
-`VELESDB_MEMORY_DEFAULT_TTL` (seconds) to auto-expire facts you only want short-term.
+### Configure it in a file, not in a plist
+
+Every setting can live in **`velesdb-memory.toml`**, looked for next to the store
+(`~/.velesdb-memory/velesdb-memory.toml`), or named explicitly with `--config` /
+`VELESDB_MEMORY_CONFIG`:
+
+```toml
+path = "~/.velesdb-memory"     # where memory lives; keep it stable across sessions
+default_ttl = 0                # seconds; 0 = permanent
+
+[embedder]
+backend = "ollama"             # `hash` is lexical, not semantic — see above
+model = "bge-m3"
+
+[extractor]
+backend = "ollama"             # required for remember_extracted / entities
+model = "qwen3.6:35b-mlx"
+```
+
+Precedence is **command line > environment > file > default**, so a value pinned
+in the file can still be overridden for one run
+(`VELESDB_MEMORY_EMBEDDER=hash velesdb-memory`). Every setting also remains
+available as a `VELESDB_MEMORY_*` variable — the file changes nothing about how
+they are read.
+
+An unknown key is a startup error, not a warning: a typo that was silently
+ignored would leave you convinced you had configured something you had not.
 
 The store never leaves the machine — memory is local by design.

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -237,7 +237,16 @@ model = "bge-m3"
 [extractor]
 backend = "ollama"             # required for remember_extracted / entities
 model = "qwen3.6:35b-mlx"
+
+[graph]
+autograph = false              # true = every `remember` also wires entities
 ```
+
+With `autograph = true` you stop having to choose the right tool: a plain
+`remember("Julien Lange est le père d'Axel Lange")` stores the fact verbatim
+**and** wires the graph around it. It costs one generation per `remember`, so
+it is opt-in — and if the model is down the write still succeeds, losing only
+the enrichment, never the fact.
 
 Precedence is **command line > environment > file > default**, so a value pinned
 in the file can still be overridden for one run

--- a/crates/velesdb-memory/src/config.rs
+++ b/crates/velesdb-memory/src/config.rs
@@ -92,6 +92,22 @@ pub struct ConfigFile {
     /// Context-compiler settings.
     #[serde(default)]
     pub context: ContextConfig,
+    /// Knowledge-graph settings.
+    #[serde(default)]
+    pub graph: GraphConfig,
+}
+
+/// `[graph]` — how much structure the memory builds on its own.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphConfig {
+    /// Let every `remember` also wire the entities, typed edges and attributes
+    /// its text states (`VELESDB_MEMORY_AUTOGRAPH`).
+    ///
+    /// Off by default. It costs one generation per `remember`, so it is a
+    /// deliberate choice, not something to inherit silently — and it needs an
+    /// `[extractor]` backend to have anything to do.
+    pub autograph: Option<bool>,
 }
 
 /// `[http]` — the streamable-HTTP transport (multi-client daemon mode).
@@ -269,6 +285,8 @@ impl ConfigFile {
         set("VELESDB_MEMORY_EXTRACTOR", self.extractor.backend);
         set("VELESDB_MEMORY_EXTRACTOR_MODEL", self.extractor.model);
         set("VELESDB_MEMORY_EXTRACTOR_URL", self.extractor.url);
+
+        set("VELESDB_MEMORY_AUTOGRAPH", self.graph.autograph.map(flag));
 
         if let Some(roots) = self.context.ingest_roots {
             let joined = std::env::join_paths(roots).map_err(|_| ConfigError::PathList {

--- a/crates/velesdb-memory/src/config.rs
+++ b/crates/velesdb-memory/src/config.rs
@@ -1,0 +1,297 @@
+//! The optional TOML configuration file: one place to set every knob.
+//!
+//! Until now the daemon was configured exclusively through eighteen
+//! `VELESDB_MEMORY_*` environment variables. That is workable for a one-shot
+//! shell invocation and painful for a long-lived daemon: a launchd plist or a
+//! systemd unit is the wrong place to keep a model name, and nothing there can
+//! carry a comment explaining *why* a value is what it is.
+//!
+//! This module adds a file without taking anything away. It resolves the
+//! config, then exports each setting into the process environment **only when
+//! that variable is not already set**. Every existing reader keeps reading the
+//! environment exactly as before, and the precedence falls out of that one
+//! rule:
+//!
+//! ```text
+//! command line  >  environment  >  config file  >  built-in default
+//! ```
+//!
+//! So an operator can pin a model in the file and still override it for a
+//! single run with `VELESDB_MEMORY_OLLAMA_MODEL=… velesdb-memory`, which is
+//! the behaviour anyone who has used a dotfile-driven tool expects.
+//!
+//! The file is entirely optional: no file, or a file with only some keys, is
+//! not an error. A file that exists but cannot be parsed **is** an error —
+//! silently ignoring a malformed config is how a daemon ends up quietly
+//! running on defaults the operator believes they overrode.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Environment variable naming the config file explicitly.
+pub const CONFIG_PATH_VAR: &str = "VELESDB_MEMORY_CONFIG";
+
+/// File name looked up in the default locations.
+pub const CONFIG_FILE_NAME: &str = "velesdb-memory.toml";
+
+/// Why a config file could not be used.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// The file could not be read.
+    #[error("config file {path} could not be read: {source}")]
+    Read {
+        /// The path that failed.
+        path: PathBuf,
+        /// The underlying I/O failure.
+        source: std::io::Error,
+    },
+    /// The file is not valid TOML, or does not match the expected shape.
+    #[error("config file {path} is not valid: {message}")]
+    Parse {
+        /// The path that failed.
+        path: PathBuf,
+        /// The parser's complaint.
+        message: String,
+    },
+    /// A path list could not be joined into the platform's list syntax.
+    #[error("config file {path}: {field} contains a path with the list separator in it")]
+    PathList {
+        /// The path that failed.
+        path: PathBuf,
+        /// The offending field.
+        field: &'static str,
+    },
+}
+
+/// Top-level shape of `velesdb-memory.toml`.
+///
+/// `deny_unknown_fields` is deliberate: a typo'd key (`mdoel = "…"`) that is
+/// silently dropped leaves the operator convinced they set something they did
+/// not. Failing loudly at startup is the whole reason to have a file.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigFile {
+    /// Store directory (`VELESDB_MEMORY_PATH`).
+    pub path: Option<String>,
+    /// Suppress the startup banner (`VELESDB_MEMORY_QUIET`).
+    pub quiet: Option<bool>,
+    /// Default TTL in seconds applied to facts with no explicit one
+    /// (`VELESDB_MEMORY_DEFAULT_TTL`).
+    pub default_ttl: Option<u64>,
+    /// HTTP transport settings.
+    #[serde(default)]
+    pub http: HttpConfig,
+    /// Embedding backend settings.
+    #[serde(default)]
+    pub embedder: EmbedderConfig,
+    /// Extraction backend settings.
+    #[serde(default)]
+    pub extractor: ExtractorConfig,
+    /// Context-compiler settings.
+    #[serde(default)]
+    pub context: ContextConfig,
+}
+
+/// `[http]` — the streamable-HTTP transport (multi-client daemon mode).
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HttpConfig {
+    /// Serve over HTTP instead of stdio (`VELESDB_MEMORY_HTTP`).
+    pub enabled: Option<bool>,
+    /// Address to bind (`VELESDB_MEMORY_HTTP_BIND`).
+    pub bind: Option<String>,
+    /// Serve plaintext instead of TLS (`VELESDB_MEMORY_HTTP_INSECURE`).
+    pub insecure: Option<bool>,
+    /// Permit a non-loopback bind (`VELESDB_MEMORY_HTTP_ALLOW_REMOTE`).
+    pub allow_remote: Option<bool>,
+    /// Request body ceiling (`VELESDB_MEMORY_HTTP_MAX_BODY_BYTES`).
+    pub max_body_bytes: Option<u64>,
+    /// Concurrent session ceiling (`VELESDB_MEMORY_HTTP_MAX_SESSIONS`).
+    pub max_sessions: Option<u64>,
+    /// Directory holding the local CA and leaf certificate
+    /// (`VELESDB_MEMORY_TLS_DIR`).
+    pub tls_dir: Option<String>,
+}
+
+/// `[embedder]` — how text becomes vectors.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EmbedderConfig {
+    /// `hash` or `ollama` (`VELESDB_MEMORY_EMBEDDER`).
+    pub backend: Option<String>,
+    /// Ollama model (`VELESDB_MEMORY_OLLAMA_MODEL`).
+    pub model: Option<String>,
+    /// Ollama base URL (`VELESDB_MEMORY_OLLAMA_URL`).
+    pub url: Option<String>,
+    /// How long Ollama keeps the model resident
+    /// (`VELESDB_MEMORY_OLLAMA_KEEP_ALIVE`).
+    pub keep_alive: Option<String>,
+}
+
+/// `[extractor]` — the backend that reads facts, relations and attributes out
+/// of raw text for `remember_extracted`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExtractorConfig {
+    /// `ollama`, or absent for none (`VELESDB_MEMORY_EXTRACTOR`).
+    pub backend: Option<String>,
+    /// Generative model (`VELESDB_MEMORY_EXTRACTOR_MODEL`).
+    pub model: Option<String>,
+    /// Base URL (`VELESDB_MEMORY_EXTRACTOR_URL`).
+    pub url: Option<String>,
+}
+
+/// `[context]` — the deterministic context compiler.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextConfig {
+    /// Directories `path`-referenced fragments may be read from
+    /// (`VELESDB_MEMORY_INGEST_ROOTS`). Written as a list here and joined
+    /// into the platform's `PATH` syntax, so the file stays readable and
+    /// portable where the raw variable is neither.
+    pub ingest_roots: Option<Vec<String>>,
+}
+
+/// Where the config file was found, and what it asked for.
+#[derive(Debug)]
+pub struct LoadedConfig {
+    /// The file that was read.
+    pub path: PathBuf,
+    /// The variables it defines, in `VELESDB_MEMORY_*` form.
+    pub values: BTreeMap<String, String>,
+}
+
+/// Resolve the config file path: an explicit `--config`, then
+/// [`CONFIG_PATH_VAR`], then `<store>/velesdb-memory.toml`, then
+/// `./velesdb-memory.toml`.
+///
+/// The store directory is checked before the working directory on purpose: a
+/// daemon's working directory is whatever launchd or systemd happened to give
+/// it, which is not a location an operator would think to put a file in.
+#[must_use]
+pub fn resolve_path(explicit: Option<&str>, store_dir: Option<&Path>) -> Option<PathBuf> {
+    if let Some(explicit) = explicit {
+        return Some(PathBuf::from(explicit));
+    }
+    if let Ok(from_env) = std::env::var(CONFIG_PATH_VAR) {
+        if !from_env.trim().is_empty() {
+            return Some(PathBuf::from(from_env));
+        }
+    }
+    if let Some(dir) = store_dir {
+        let candidate = dir.join(CONFIG_FILE_NAME);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    let cwd = PathBuf::from(CONFIG_FILE_NAME);
+    cwd.is_file().then_some(cwd)
+}
+
+/// Read and parse `path` into the `VELESDB_MEMORY_*` variables it defines.
+///
+/// # Errors
+/// Returns [`ConfigError`] if the file cannot be read or is not valid TOML.
+pub fn load(path: &Path) -> Result<LoadedConfig, ConfigError> {
+    let text = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let file: ConfigFile = toml::from_str(&text).map_err(|err| ConfigError::Parse {
+        path: path.to_path_buf(),
+        message: err.to_string(),
+    })?;
+    Ok(LoadedConfig {
+        path: path.to_path_buf(),
+        values: file.into_env(path)?,
+    })
+}
+
+/// Export `values` into the process environment, skipping any variable that is
+/// already set. Returns the names actually applied, in order.
+///
+/// The skip is the precedence rule: the environment was set by whoever
+/// launched the process, and that intent outranks a file on disk.
+#[must_use]
+pub fn apply(values: &BTreeMap<String, String>) -> Vec<String> {
+    let mut applied = Vec::new();
+    for (key, value) in values {
+        if std::env::var_os(key).is_some() {
+            continue;
+        }
+        std::env::set_var(key, value);
+        applied.push(key.clone());
+    }
+    applied
+}
+
+impl ConfigFile {
+    /// Flatten the typed sections into the `VELESDB_MEMORY_*` variables the
+    /// rest of the binary already reads.
+    fn into_env(self, path: &Path) -> Result<BTreeMap<String, String>, ConfigError> {
+        let mut out = BTreeMap::new();
+        let mut set = |key: &str, value: Option<String>| {
+            if let Some(value) = value {
+                out.insert(key.to_string(), value);
+            }
+        };
+        set("VELESDB_MEMORY_PATH", self.path);
+        set("VELESDB_MEMORY_QUIET", self.quiet.map(flag));
+        set(
+            "VELESDB_MEMORY_DEFAULT_TTL",
+            self.default_ttl.map(|v| v.to_string()),
+        );
+
+        set("VELESDB_MEMORY_HTTP", self.http.enabled.map(flag));
+        set("VELESDB_MEMORY_HTTP_BIND", self.http.bind);
+        set("VELESDB_MEMORY_HTTP_INSECURE", self.http.insecure.map(flag));
+        set(
+            "VELESDB_MEMORY_HTTP_ALLOW_REMOTE",
+            self.http.allow_remote.map(flag),
+        );
+        set(
+            "VELESDB_MEMORY_HTTP_MAX_BODY_BYTES",
+            self.http.max_body_bytes.map(|v| v.to_string()),
+        );
+        set(
+            "VELESDB_MEMORY_HTTP_MAX_SESSIONS",
+            self.http.max_sessions.map(|v| v.to_string()),
+        );
+        set("VELESDB_MEMORY_TLS_DIR", self.http.tls_dir);
+
+        set("VELESDB_MEMORY_EMBEDDER", self.embedder.backend);
+        set("VELESDB_MEMORY_OLLAMA_MODEL", self.embedder.model);
+        set("VELESDB_MEMORY_OLLAMA_URL", self.embedder.url);
+        set("VELESDB_MEMORY_OLLAMA_KEEP_ALIVE", self.embedder.keep_alive);
+
+        set("VELESDB_MEMORY_EXTRACTOR", self.extractor.backend);
+        set("VELESDB_MEMORY_EXTRACTOR_MODEL", self.extractor.model);
+        set("VELESDB_MEMORY_EXTRACTOR_URL", self.extractor.url);
+
+        if let Some(roots) = self.context.ingest_roots {
+            let joined = std::env::join_paths(roots).map_err(|_| ConfigError::PathList {
+                path: path.to_path_buf(),
+                field: "context.ingest_roots",
+            })?;
+            out.insert(
+                "VELESDB_MEMORY_INGEST_ROOTS".to_string(),
+                joined.to_string_lossy().into_owned(),
+            );
+        }
+        Ok(out)
+    }
+}
+
+/// Render a boolean the way every reader in the binary tests for it: the
+/// truthy form is the exact string `"1"`. `false` becomes `"0"` rather than
+/// being omitted, so writing `enabled = false` in the file genuinely holds the
+/// setting off instead of falling through to a default that might be on.
+fn flag(value: bool) -> String {
+    if value { "1" } else { "0" }.to_string()
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/config_tests.rs
+++ b/crates/velesdb-memory/src/config_tests.rs
@@ -1,0 +1,229 @@
+//! Behaviour of the TOML config file and its precedence rule.
+
+use super::*;
+
+/// Write `text` to a temp file and return the dir (which must outlive it).
+fn config_file(text: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(CONFIG_FILE_NAME);
+    std::fs::write(&path, text).expect("write config");
+    (dir, path)
+}
+
+#[test]
+fn every_documented_knob_maps_to_its_variable() {
+    let (_dir, path) = config_file(
+        r#"
+path = "/tmp/store"
+quiet = true
+default_ttl = 3600
+
+[http]
+enabled = true
+bind = "127.0.0.1:18090"
+insecure = false
+allow_remote = false
+max_body_bytes = 1048576
+max_sessions = 64
+tls_dir = "/tmp/tls"
+
+[embedder]
+backend = "ollama"
+model = "bge-m3"
+url = "http://localhost:11434"
+keep_alive = "30m"
+
+[extractor]
+backend = "ollama"
+model = "qwen3.6:35b-mlx"
+url = "http://localhost:11434"
+"#,
+    );
+    let loaded = load(&path).expect("valid config");
+    let v = &loaded.values;
+    assert_eq!(v["VELESDB_MEMORY_PATH"], "/tmp/store");
+    assert_eq!(v["VELESDB_MEMORY_QUIET"], "1");
+    assert_eq!(v["VELESDB_MEMORY_DEFAULT_TTL"], "3600");
+    assert_eq!(v["VELESDB_MEMORY_HTTP"], "1");
+    assert_eq!(v["VELESDB_MEMORY_HTTP_BIND"], "127.0.0.1:18090");
+    assert_eq!(v["VELESDB_MEMORY_HTTP_INSECURE"], "0");
+    assert_eq!(v["VELESDB_MEMORY_HTTP_ALLOW_REMOTE"], "0");
+    assert_eq!(v["VELESDB_MEMORY_HTTP_MAX_BODY_BYTES"], "1048576");
+    assert_eq!(v["VELESDB_MEMORY_HTTP_MAX_SESSIONS"], "64");
+    assert_eq!(v["VELESDB_MEMORY_TLS_DIR"], "/tmp/tls");
+    assert_eq!(v["VELESDB_MEMORY_EMBEDDER"], "ollama");
+    assert_eq!(v["VELESDB_MEMORY_OLLAMA_MODEL"], "bge-m3");
+    assert_eq!(v["VELESDB_MEMORY_OLLAMA_URL"], "http://localhost:11434");
+    assert_eq!(v["VELESDB_MEMORY_OLLAMA_KEEP_ALIVE"], "30m");
+    assert_eq!(v["VELESDB_MEMORY_EXTRACTOR"], "ollama");
+    assert_eq!(v["VELESDB_MEMORY_EXTRACTOR_MODEL"], "qwen3.6:35b-mlx");
+    assert_eq!(v["VELESDB_MEMORY_EXTRACTOR_URL"], "http://localhost:11434");
+}
+
+/// The eighteen variables the binary reads, minus the two that are not file
+/// settings (`VELESDB_MEMORY_CONFIG` selects the file itself; the store path
+/// is covered above). Guards against a knob being added to the binary and
+/// forgotten here — the whole promise is that the file covers everything.
+#[test]
+fn the_file_covers_every_configurable_variable() {
+    let (_dir, path) = config_file(
+        r#"
+path = "/tmp/s"
+quiet = false
+default_ttl = 1
+[http]
+enabled = false
+bind = "x"
+insecure = true
+allow_remote = true
+max_body_bytes = 1
+max_sessions = 1
+tls_dir = "t"
+[embedder]
+backend = "hash"
+model = "m"
+url = "u"
+keep_alive = "k"
+[extractor]
+backend = "ollama"
+model = "m"
+url = "u"
+[context]
+ingest_roots = ["/tmp"]
+"#,
+    );
+    let loaded = load(&path).expect("valid config");
+    let expected = [
+        "VELESDB_MEMORY_PATH",
+        "VELESDB_MEMORY_QUIET",
+        "VELESDB_MEMORY_DEFAULT_TTL",
+        "VELESDB_MEMORY_HTTP",
+        "VELESDB_MEMORY_HTTP_BIND",
+        "VELESDB_MEMORY_HTTP_INSECURE",
+        "VELESDB_MEMORY_HTTP_ALLOW_REMOTE",
+        "VELESDB_MEMORY_HTTP_MAX_BODY_BYTES",
+        "VELESDB_MEMORY_HTTP_MAX_SESSIONS",
+        "VELESDB_MEMORY_TLS_DIR",
+        "VELESDB_MEMORY_EMBEDDER",
+        "VELESDB_MEMORY_OLLAMA_MODEL",
+        "VELESDB_MEMORY_OLLAMA_URL",
+        "VELESDB_MEMORY_OLLAMA_KEEP_ALIVE",
+        "VELESDB_MEMORY_EXTRACTOR",
+        "VELESDB_MEMORY_EXTRACTOR_MODEL",
+        "VELESDB_MEMORY_EXTRACTOR_URL",
+        "VELESDB_MEMORY_INGEST_ROOTS",
+    ];
+    for key in expected {
+        assert!(
+            loaded.values.contains_key(key),
+            "{key} is not settable from the config file"
+        );
+    }
+}
+
+#[test]
+fn a_false_flag_is_written_not_omitted() {
+    let (_dir, path) = config_file("[http]\ninsecure = false\n");
+    let loaded = load(&path).expect("valid config");
+    assert_eq!(
+        loaded.values["VELESDB_MEMORY_HTTP_INSECURE"], "0",
+        "writing `false` must hold the setting off, not fall through to a default"
+    );
+}
+
+#[test]
+fn an_empty_file_sets_nothing_and_is_not_an_error() {
+    let (_dir, path) = config_file("");
+    assert!(load(&path).expect("empty is valid").values.is_empty());
+}
+
+#[test]
+fn a_typo_is_rejected_rather_than_silently_dropped() {
+    let (_dir, path) = config_file("[embedder]\nmdoel = \"bge-m3\"\n");
+    let err = load(&path).expect_err("unknown key must fail");
+    assert!(
+        matches!(err, ConfigError::Parse { .. }),
+        "got {err:?} — a typo'd key must not be silently ignored"
+    );
+}
+
+#[test]
+fn malformed_toml_is_an_error_not_a_silent_default() {
+    let (_dir, path) = config_file("this is not toml {{{");
+    assert!(matches!(
+        load(&path).expect_err("must fail"),
+        ConfigError::Parse { .. }
+    ));
+}
+
+#[test]
+fn a_missing_file_is_reported_as_unreadable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = load(&dir.path().join("absent.toml")).expect_err("must fail");
+    assert!(matches!(err, ConfigError::Read { .. }));
+}
+
+#[test]
+fn ingest_roots_are_joined_into_the_platform_list_syntax() {
+    let (_dir, path) = config_file("[context]\ningest_roots = [\"/tmp\", \"/var\"]\n");
+    let loaded = load(&path).expect("valid config");
+    let joined = &loaded.values["VELESDB_MEMORY_INGEST_ROOTS"];
+    let parts: Vec<_> = std::env::split_paths(joined).collect();
+    assert_eq!(
+        parts.len(),
+        2,
+        "both roots survive the round trip: {joined}"
+    );
+}
+
+/// The precedence rule, which is the entire contract: the environment was set
+/// by whoever launched the process and outranks a file on disk.
+#[test]
+fn apply_never_overwrites_an_existing_variable() {
+    let key = "VELESDB_MEMORY_TEST_PRECEDENCE";
+    std::env::set_var(key, "from-env");
+    let mut values = BTreeMap::new();
+    values.insert(key.to_string(), "from-file".to_string());
+
+    let applied = apply(&values);
+
+    assert!(applied.is_empty(), "an already-set variable is left alone");
+    assert_eq!(std::env::var(key).as_deref(), Ok("from-env"));
+    std::env::remove_var(key);
+}
+
+#[test]
+fn apply_sets_a_variable_that_is_absent() {
+    let key = "VELESDB_MEMORY_TEST_ABSENT";
+    std::env::remove_var(key);
+    let mut values = BTreeMap::new();
+    values.insert(key.to_string(), "from-file".to_string());
+
+    let applied = apply(&values);
+
+    assert_eq!(applied, vec![key.to_string()]);
+    assert_eq!(std::env::var(key).as_deref(), Ok("from-file"));
+    std::env::remove_var(key);
+}
+
+#[test]
+fn an_explicit_path_wins_over_every_lookup() {
+    let resolved = resolve_path(Some("/explicit/velesdb-memory.toml"), None);
+    assert_eq!(
+        resolved,
+        Some(PathBuf::from("/explicit/velesdb-memory.toml"))
+    );
+}
+
+#[test]
+fn the_store_directory_is_searched_before_the_working_directory() {
+    let (dir, path) = config_file("quiet = true\n");
+    let resolved = resolve_path(None, Some(dir.path()));
+    assert_eq!(resolved, Some(path));
+}
+
+#[test]
+fn no_file_anywhere_resolves_to_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert_eq!(resolve_path(None, Some(dir.path())), None);
+}

--- a/crates/velesdb-memory/src/config_tests.rs
+++ b/crates/velesdb-memory/src/config_tests.rs
@@ -90,6 +90,8 @@ model = "m"
 url = "u"
 [context]
 ingest_roots = ["/tmp"]
+[graph]
+autograph = true
 "#,
     );
     let loaded = load(&path).expect("valid config");
@@ -112,6 +114,7 @@ ingest_roots = ["/tmp"]
         "VELESDB_MEMORY_EXTRACTOR_MODEL",
         "VELESDB_MEMORY_EXTRACTOR_URL",
         "VELESDB_MEMORY_INGEST_ROOTS",
+        "VELESDB_MEMORY_AUTOGRAPH",
     ];
     for key in expected {
         assert!(

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -285,7 +285,7 @@ impl Extractor for OllamaExtractor {
 
     fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
         let reply = self.generate(&build_graph_prompt(text))?;
-        let raw = json_slice::<RawExtraction>(&reply)
+        let raw = json_slice_object::<RawExtraction>(&reply)
             .ok_or_else(|| ExtractError::Parse(truncate(&reply)))?;
         Ok(raw.into_extraction())
     }
@@ -560,18 +560,40 @@ fn json_slice<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
     serde_json::from_str::<T>(slice).ok()
 }
 
+/// [`json_slice`] for a reply whose top level is a JSON **object**.
+///
+/// The array-preferring form cannot be reused: the graph reply is
+/// `{"facts": [...], ...}`, whose first `[` belongs to a *nested* field, so
+/// preferring arrays slices out the inner facts list and then fails to read it
+/// as the whole extraction. That failure is invisible to a stub-backed test —
+/// only a real model reply goes through this path.
+#[cfg(feature = "extract")]
+fn json_slice_object<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
+    let slice = balanced_slice_preferring(text, b'{')?;
+    serde_json::from_str::<T>(slice).ok()
+}
+
 /// Return the substring spanning the first balanced `[..]` or `{..}`, honouring
 /// string literals and escapes so brackets inside quotes don't miscount.
+///
+/// Prefers an array: the fact-only reply is a JSON list, and prose before it
+/// ("Result {ok}: [...]") may carry a stray `{` that would mis-slice the
+/// object span instead of the array.
 #[cfg(feature = "extract")]
 fn balanced_slice(text: &str) -> Option<&str> {
+    balanced_slice_preferring(text, b'[')
+}
+
+/// [`balanced_slice`] with the caller choosing which delimiter wins when both
+/// appear — the shape the caller actually expects at the top level.
+#[cfg(feature = "extract")]
+fn balanced_slice_preferring(text: &str, preferred: u8) -> Option<&str> {
     let bytes = text.as_bytes();
-    // Prefer an array: the expected reply is a JSON list, and prose before it
-    // ("Result {ok}: [...]") may carry a stray `{` that would mis-slice the
-    // object span instead of the array. Fall back to the first `{` if no `[`.
+    let fallback = if preferred == b'[' { b'{' } else { b'[' };
     let start = bytes
         .iter()
-        .position(|&b| b == b'[')
-        .or_else(|| bytes.iter().position(|&b| b == b'{'))?;
+        .position(|&b| b == preferred)
+        .or_else(|| bytes.iter().position(|&b| b == fallback))?;
     let open = bytes[start];
     let close = if open == b'[' { b']' } else { b'}' };
     let mut depth = 0u32;
@@ -623,6 +645,48 @@ fn step_string(escaped: &mut bool, byte: u8) -> bool {
 #[cfg(all(test, feature = "extract"))]
 mod tests {
     use super::*;
+
+    /// Regression: the graph reply is an OBJECT whose first `[` belongs to the
+    /// nested `facts` field. Slicing with the array preference grabbed that
+    /// inner list and failed to read it as the whole extraction — a real model
+    /// reply was rejected wholesale while every stub-backed test stayed green.
+    #[test]
+    fn parses_a_graph_reply_whose_first_bracket_is_nested() {
+        let reply = r#"{ "facts": [ { "fact": "Zephyrin is the father of Kaltar.", "entities": ["zephyrin", "kaltar"] } ], "relations": [ { "subject": "zephyrin", "predicate": "pere de", "object": "kaltar" } ], "attributes": [ { "entity": "kaltar", "key": "age", "value": 15 } ] }"#;
+        let raw: RawExtraction = json_slice_object(reply).expect("the object is sliced whole");
+        let extraction = raw.into_extraction();
+        assert_eq!(extraction.facts.len(), 1);
+        assert_eq!(extraction.relations.len(), 1);
+        assert_eq!(extraction.relations[0].predicate, "pere de");
+        assert_eq!(extraction.attributes.len(), 1);
+        assert_eq!(extraction.attributes[0].value, serde_json::json!(15));
+    }
+
+    /// Prose (and a fenced block) around the object must not defeat slicing.
+    #[test]
+    fn parses_a_graph_reply_wrapped_in_prose_and_fences() {
+        let reply = "Here you go:\n```json\n{\"facts\": [], \"relations\": [{\"subject\": \"a\", \"predicate\": \"knows\", \"object\": \"b\"}], \"attributes\": []}\n```";
+        let raw: RawExtraction = json_slice_object(reply).expect("sliced past the fence");
+        assert_eq!(raw.into_extraction().relations.len(), 1);
+    }
+
+    /// The fact-only path must keep preferring an array: prose carrying a stray
+    /// `{` before the list is exactly what that preference exists to survive.
+    #[test]
+    fn fact_only_slicing_still_prefers_the_array() {
+        let reply = "Result {ok}: [{\"fact\": \"A ships B.\", \"entities\": [\"b\"]}]";
+        let raw: Vec<RawFact> = json_slice(reply).expect("array sliced despite the stray brace");
+        assert_eq!(raw.len(), 1);
+    }
+
+    #[test]
+    fn graph_prompt_demands_numeric_values_and_the_three_sections() {
+        let prompt = build_graph_prompt("Kaltar a 15 ans.");
+        assert!(prompt.contains("Kaltar a 15 ans."));
+        assert!(prompt.contains("\"relations\""));
+        assert!(prompt.contains("\"attributes\""));
+        assert!(prompt.contains("15, not \"15\""));
+    }
 
     #[test]
     fn prompt_carries_the_passage_and_json_contract() {

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -25,6 +25,64 @@ pub struct ExtractedFact {
     pub entities: Vec<String>,
 }
 
+/// One extracted entity→entity edge: `subject -[predicate]-> object`.
+///
+/// Where [`ExtractedFact::entities`] only says "this fact concerns these
+/// topics", a relation says *how two topics relate*. It is what turns the
+/// bipartite fact↔topic graph into a genuine knowledge graph: from
+/// "Julien Lange is Axel Lange's father" the wiring produces the edge
+/// `julien lange -[father of]-> axel lange`, so a later walk can answer
+/// "who is Axel's father" without any fact mentioning both names again.
+///
+/// `subject` and `object` are canonicalized exactly like
+/// [`ExtractedFact::entities`] (trimmed, lowercased), so they resolve to the
+/// SAME entity hub as the topics — the hub id is content-addressed, so this
+/// holds across separate calls and across sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedRelation {
+    /// Canonical lowercase entity the edge points *from*.
+    pub subject: String,
+    /// The edge label (e.g. `"father of"`, `"sister of"`, `"works at"`).
+    pub predicate: String,
+    /// Canonical lowercase entity the edge points *to*.
+    pub object: String,
+}
+
+/// One extracted entity attribute: `entity.key = value`.
+///
+/// Attributes are what make "Axel Lange is 15" answerable by a *filter*
+/// rather than a similarity search: the pair is merged into the entity hub's
+/// `ColumnStore` metadata, so `recall_where` can select on `age >= 15`.
+///
+/// `value` deliberately keeps its JSON type. `recall_where` comparisons are
+/// TYPE-STRICT with no coercion, so an age extracted as the string `"15"`
+/// would silently never match a numeric filter — the extraction contract
+/// therefore demands numbers stay numbers.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExtractedAttribute {
+    /// Canonical lowercase entity the attribute belongs to.
+    pub entity: String,
+    /// Attribute name, used verbatim as the metadata (`ColumnStore`) field.
+    pub key: String,
+    /// Attribute value, type preserved (a number stays a JSON number).
+    pub value: serde_json::Value,
+}
+
+/// Everything one passage yields: the atomic facts, the entity→entity edges
+/// between the topics they mention, and the attributes those entities carry.
+///
+/// [`Extractor::extract`] returns only the `facts` half; a backend that can
+/// also read relations and attributes overrides [`Extractor::extract_graph`].
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Extraction {
+    /// The atomic, standalone facts, each with the topics it concerns.
+    pub facts: Vec<ExtractedFact>,
+    /// Typed edges between entities mentioned in the passage.
+    pub relations: Vec<ExtractedRelation>,
+    /// Attributes attached to entities mentioned in the passage.
+    pub attributes: Vec<ExtractedAttribute>,
+}
+
 /// Failure produced by an [`Extractor`] backend (e.g. a network-backed model
 /// that cannot be reached, or output that cannot be parsed into facts).
 #[derive(Debug, thiserror::Error)]
@@ -49,14 +107,41 @@ pub trait Extractor {
     /// Returns [`ExtractError`] if the backend fails or its output cannot be
     /// parsed into facts.
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError>;
+
+    /// Extract the facts *and* the entity→entity edges and entity attributes
+    /// the passage states.
+    ///
+    /// Defaults to [`Self::extract`] with no relations and no attributes, so
+    /// every backend written against the fact-only contract keeps compiling
+    /// and keeps working — it simply builds the bipartite fact↔topic graph it
+    /// always did. A backend that can read structure overrides this.
+    ///
+    /// # Errors
+    /// Returns [`ExtractError`] if the backend fails or its output cannot be
+    /// parsed.
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        Ok(Extraction {
+            facts: self.extract(text)?,
+            ..Extraction::default()
+        })
+    }
 }
 
 /// Forward [`Extractor`] through an [`Arc`](std::sync::Arc), so a shared `Arc<dyn Extractor>`
 /// (e.g. one held by the MCP server) satisfies the `X: Extractor` bound on
 /// [`crate::MemoryService::remember_extracted`].
+///
+/// Both methods are forwarded. Forwarding only `extract` would silently route
+/// every `Arc`-held backend — which is *every* backend the MCP server and the
+/// bindings use — through the fact-only default, discarding the relations and
+/// attributes the inner extractor actually produced.
 impl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
         (**self).extract(text)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        (**self).extract_graph(text)
     }
 }
 
@@ -197,6 +282,13 @@ impl Extractor for OllamaExtractor {
             .ok_or_else(|| ExtractError::Parse(truncate(&reply)))?;
         Ok(raw.into_iter().filter_map(RawFact::into_fact).collect())
     }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        let reply = self.generate(&build_graph_prompt(text))?;
+        let raw = json_slice::<RawExtraction>(&reply)
+            .ok_or_else(|| ExtractError::Parse(truncate(&reply)))?;
+        Ok(raw.into_extraction())
+    }
 }
 
 #[cfg(feature = "extract")]
@@ -274,6 +366,139 @@ impl RawFact {
         entities.dedup();
         Some(ExtractedFact { text, entities })
     }
+}
+
+/// Canonical form of an entity name: trimmed and lowercased. The one place
+/// the rule lives, so a name arriving as a topic, as a relation endpoint, or
+/// as an attribute owner always resolves to the SAME entity hub.
+#[cfg(feature = "extract")]
+fn canonical_entity(name: &str) -> String {
+    name.trim().to_lowercase()
+}
+
+/// The strict JSON contract the *graph* extraction prompt asks for.
+#[cfg(feature = "extract")]
+#[derive(serde::Deserialize)]
+struct RawExtraction {
+    #[serde(default)]
+    facts: Vec<RawFact>,
+    #[serde(default)]
+    relations: Vec<RawRelation>,
+    #[serde(default)]
+    attributes: Vec<RawAttribute>,
+}
+
+#[cfg(feature = "extract")]
+#[derive(serde::Deserialize)]
+struct RawRelation {
+    subject: String,
+    predicate: String,
+    object: String,
+}
+
+#[cfg(feature = "extract")]
+#[derive(serde::Deserialize)]
+struct RawAttribute {
+    entity: String,
+    key: String,
+    value: serde_json::Value,
+}
+
+#[cfg(feature = "extract")]
+impl RawExtraction {
+    /// Canonicalize and drop the unusable: a relation missing an endpoint or a
+    /// label, an attribute missing an owner or a name. A malformed item is
+    /// skipped rather than failing the whole passage — one bad triple must not
+    /// cost the caller every good fact in the same reply.
+    fn into_extraction(self) -> Extraction {
+        Extraction {
+            facts: self
+                .facts
+                .into_iter()
+                .filter_map(RawFact::into_fact)
+                .collect(),
+            relations: self
+                .relations
+                .into_iter()
+                .filter_map(RawRelation::into_relation)
+                .collect(),
+            attributes: self
+                .attributes
+                .into_iter()
+                .filter_map(RawAttribute::into_attribute)
+                .collect(),
+        }
+    }
+}
+
+#[cfg(feature = "extract")]
+impl RawRelation {
+    fn into_relation(self) -> Option<ExtractedRelation> {
+        let subject = canonical_entity(&self.subject);
+        let object = canonical_entity(&self.object);
+        let predicate = self.predicate.trim().to_string();
+        // A self-loop carries no information and would sit in the graph as a
+        // permanent dead end, so it is dropped alongside the incomplete ones.
+        if subject.is_empty() || object.is_empty() || predicate.is_empty() || subject == object {
+            return None;
+        }
+        Some(ExtractedRelation {
+            subject,
+            predicate,
+            object,
+        })
+    }
+}
+
+#[cfg(feature = "extract")]
+impl RawAttribute {
+    fn into_attribute(self) -> Option<ExtractedAttribute> {
+        let entity = canonical_entity(&self.entity);
+        let key = self.key.trim().to_string();
+        // A null value is the model saying "not stated"; storing it would make
+        // an absent attribute look like a known-empty one.
+        if entity.is_empty() || key.is_empty() || self.value.is_null() {
+            return None;
+        }
+        Some(ExtractedAttribute {
+            entity,
+            key,
+            value: self.value,
+        })
+    }
+}
+
+/// Build the *graph* extraction prompt: the passage plus a strict JSON
+/// contract covering facts, entity→entity edges, and entity attributes.
+///
+/// The contract insists numbers stay JSON numbers. `recall_where` compares
+/// type-strictly, so an age emitted as `"15"` would never match `age >= 15` —
+/// no error, just a silent miss, which is the worst possible failure mode for
+/// a memory system.
+#[cfg(feature = "extract")]
+fn build_graph_prompt(text: &str) -> String {
+    format!(
+        "You are building a knowledge graph from the passage below.\n\n\
+Passage:\n{text}\n\n\
+Return THREE things.\n\n\
+1. \"facts\": the atomic, standalone facts a person would remember. Rewrite each \
+as a self-contained sentence (resolve pronouns to names; keep absolute dates). \
+For each, list 1-4 key TOPICS it concerns, as short canonical lowercase noun \
+phrases, so the same topic recurs as the SAME tag across passages.\n\n\
+2. \"relations\": every explicit relationship BETWEEN TWO NAMED ENTITIES, as \
+subject/predicate/object triples. Use the entity's full name, lowercase \
+(e.g. \"julien lange\"). Give the predicate in the passage's own language, as a \
+short lowercase label (e.g. \"pere de\", \"soeur de\", \"works at\"). State the \
+triple in the direction the passage states it, and add the converse ONLY if the \
+passage states it too.\n\n\
+3. \"attributes\": every property a named entity HAS, as entity/key/value. Use \
+short lowercase keys (\"age\", \"ville\", \"employeur\"). Emit numbers as JSON \
+NUMBERS, never strings: 15, not \"15\". Omit anything the passage does not state.\n\n\
+Return ONLY this JSON object, no prose:\n\
+{{\"facts\": [{{\"fact\": string, \"entities\": [string]}}], \
+\"relations\": [{{\"subject\": string, \"predicate\": string, \"object\": string}}], \
+\"attributes\": [{{\"entity\": string, \"key\": string, \"value\": string|number|boolean}}]}}"
+    )
 }
 
 /// Build the extraction prompt: the passage plus a strict JSON contract.

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -109,7 +109,7 @@ pub fn http_max_sessions_from_env() -> usize {
 /// its own shutdown token; tests derive it from a token they cancel at the
 /// end of the test to stop the server cleanly.
 ///
-/// Two DoS guards wrap the `/mcp` service, both absent from rmcp's own
+/// Two `DoS` guards wrap the `/mcp` service, both absent from rmcp's own
 /// defaults (see each item's doc comment for why they matter and why the
 /// obvious axum-level fix does not apply to a raw `nest_service`):
 /// - [`RequestBodyLimit`] bounds a single request body
@@ -125,7 +125,7 @@ pub fn router(server: McpServer, cancellation_token: CancellationToken) -> Route
     )
 }
 
-/// [`router`], but with the two DoS guards' limits passed explicitly instead
+/// [`router`], but with the two `DoS` guards' limits passed explicitly instead
 /// of read from the environment. `router` itself is the thin, env-reading
 /// wrapper adversarial tests (`tests/http_transport.rs`) skip in favor of
 /// this — process-wide env vars are shared, mutable global state, and

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -122,11 +122,15 @@ pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::{ErrorCategory, MemoryError};
 #[cfg(feature = "extract")]
 pub use extract::OllamaExtractor;
-pub use extract::{DynExtractor, ExtractError, ExtractedFact, Extractor};
+pub use extract::{
+    DynExtractor, ExtractError, ExtractedAttribute, ExtractedFact, ExtractedRelation, Extraction,
+    Extractor,
+};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
 pub use model::{
-    ColumnFilter, ColumnOp, Explanation, FusionOptions, Link, MemoryEdge, MemoryNode, Recollection,
+    ColumnFilter, ColumnOp, EntityProfile, EntityRelation, Explanation, FusionOptions, Link,
+    MemoryEdge, MemoryNode, Recollection,
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -30,6 +30,11 @@
 /// context compiler, which stays clock-free and deterministic. Internal:
 /// nothing outside the crate needs to read the clock directly.
 mod clock;
+/// The optional TOML configuration file: one place to set every knob, with
+/// `command line > environment > file > default` precedence. Native-only —
+/// it reads the filesystem.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod config;
 /// The deterministic context compiler (EPIC-P-070): classify, dedup, and pack
 /// caller-supplied context fragments under a token budget — no LLM, no cloud,
 /// every decision auditable. Gated behind the default `context` feature.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -92,7 +92,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // runs here, before the async runtime starts, so we never block a tokio
     // worker thread on a synchronous operation.
     let embedder = build_embedder()?;
-    let service = open_store_with_actionable_lock_error(&store_path, embedder)?;
+    let service = apply_autograph(open_store_with_actionable_lock_error(
+        &store_path,
+        embedder,
+    )?)?;
     let server = apply_ingest_roots(apply_default_ttl(build_server(service)?)?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
@@ -424,6 +427,54 @@ fn open_store_with_actionable_lock_error(
 /// is launched by its client with an unpredictable working directory, so a
 /// cwd-relative default would scatter (or lose) the store between sessions. Falls
 /// back to a cwd-relative path only when no home directory can be resolved.
+/// Attach the extraction backend to the SERVICE when
+/// `VELESDB_MEMORY_AUTOGRAPH=1` (`[graph] autograph = true`), so every
+/// `remember` also wires the entities, typed edges and attributes its text
+/// states.
+///
+/// Distinct from [`build_server`]'s extractor, which powers the explicit
+/// `remember_extracted` tool. Both can be on; they share one backend and one
+/// setting pair, and `remember_extracted` deliberately does not re-extract.
+///
+/// Asking for autograph without an extraction backend is a startup error, not
+/// a silent no-op: the operator turned on a feature, and a daemon that
+/// answers by doing nothing is how you spend a week wondering why the graph
+/// is empty.
+#[cfg(feature = "extract")]
+fn apply_autograph(
+    service: MemoryService<DynEmbedder>,
+) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
+    if std::env::var("VELESDB_MEMORY_AUTOGRAPH").as_deref() != Ok("1") {
+        return Ok(service);
+    }
+    if std::env::var("VELESDB_MEMORY_EXTRACTOR").as_deref() != Ok("ollama") {
+        return Err(
+            "autograph is on ([graph] autograph = true / VELESDB_MEMORY_AUTOGRAPH=1) but no \
+             extraction backend is configured — set [extractor] backend = \"ollama\" (and a \
+             model), or turn autograph off"
+                .into(),
+        );
+    }
+    Ok(service.with_autograph(build_ollama_extractor()?))
+}
+
+/// Without the `extract` feature there is no backend to attach. A request for
+/// autograph still fails loudly rather than being ignored — the binary was
+/// built without the code to honour it, exactly like `--http` without `http`.
+#[cfg(not(feature = "extract"))]
+fn apply_autograph(
+    service: MemoryService<DynEmbedder>,
+) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
+    if std::env::var("VELESDB_MEMORY_AUTOGRAPH").as_deref() == Ok("1") {
+        return Err(
+            "autograph is on but this binary was built without --features extract, so no \
+             extraction backend exists"
+                .into(),
+        );
+    }
+    Ok(service)
+}
+
 /// Locate and apply the optional `velesdb-memory.toml`.
 ///
 /// The lookup uses the DEFAULT store directory, never the configured one:

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -72,6 +72,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let original_parent = std::os::unix::process::parent_id();
     #[cfg(not(unix))]
     let original_parent = 0_u32;
+    // Loaded BEFORE the first variable is read, because the file can set any
+    // of them — including the store path just below. Everything downstream
+    // keeps reading the environment exactly as it always did; the file only
+    // fills in what the environment left unset, which is what makes the
+    // precedence `command line > environment > file > default`.
+    apply_config_file(&args)?;
+
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
 
     // Decided here, ahead of the (possibly seconds-long) embedder probe and
@@ -417,6 +424,39 @@ fn open_store_with_actionable_lock_error(
 /// is launched by its client with an unpredictable working directory, so a
 /// cwd-relative default would scatter (or lose) the store between sessions. Falls
 /// back to a cwd-relative path only when no home directory can be resolved.
+/// Locate and apply the optional `velesdb-memory.toml`.
+///
+/// The lookup uses the DEFAULT store directory, never the configured one:
+/// the store path is itself one of the settings the file may carry, so
+/// resolving the file through it would be circular.
+///
+/// A missing file is normal and silent. A file that exists but does not parse
+/// aborts startup — a daemon quietly running on defaults the operator believes
+/// they overrode is a worse outcome than a loud failure at boot.
+fn apply_config_file(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let explicit = args
+        .iter()
+        .position(|arg| arg == "--config")
+        .and_then(|at| args.get(at + 1))
+        .map(String::as_str);
+    let default_dir = default_store_path();
+    let Some(path) =
+        velesdb_memory::config::resolve_path(explicit, Some(std::path::Path::new(&default_dir)))
+    else {
+        return Ok(());
+    };
+    let loaded = velesdb_memory::config::load(&path)?;
+    let applied = velesdb_memory::config::apply(&loaded.values);
+    if !applied.is_empty() && std::env::var_os("VELESDB_MEMORY_QUIET").is_none() {
+        eprintln!(
+            "velesdb-memory: {} setting(s) from {}",
+            applied.len(),
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 fn default_store_path() -> String {
     let home = std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -40,9 +40,10 @@ mod context_tools;
 mod dto;
 mod wire;
 use dto::{
-    ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, RecallFusedParams,
-    RecallFusedResult, RecallParams, RecallResult, RecallWhereParams, RelateParams, RelateResult,
-    RememberExtractedParams, RememberExtractedResult, RememberParams, RememberResult, WhyParams,
+    EntityParams, EntityProfileDto, ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams,
+    ForgetResult, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
+    RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
+    RememberExtractedResult, RememberParams, RememberResult, WhyParams,
 };
 
 /// Advertised-schema counterpart of [`crate::model::deserialize_id`]: `keys`
@@ -372,6 +373,27 @@ impl McpServer {
             id_str: id.to_string(),
             found,
         }))
+    }
+
+    #[tool(
+        name = "entity",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<EntityProfileDto>(),
+        description = "Look up everything the memory graph knows about a NAMED ENTITY (a person, a place, an organisation): the attributes it carries and the typed edges leaving it. Use this for questions ABOUT a thing rather than about a sentence — \"how old is Axel\", \"who is Axel's father\", \"where does he live\" — where `recall` would only return sentences that happen to mention the name. Entities and their edges are built automatically by `remember_extracted`, which reads relationships (`X is the father of Y`) and properties (`Y is 15`) out of plain text; attributes land in ColumnStore metadata with their JSON type preserved, so a number stays a number. The name is matched case-insensitively, so `\"Axel Lange\"` and `\"axel lange\"` are the same entity — the id is content-addressed, so it is stable across sessions. Returns `found: false` when nothing has ever mentioned that name. Ids exceed 2^53 — always relay them as strings (`id_str`)."
+    )]
+    async fn entity(
+        &self,
+        Parameters(params): Parameters<EntityParams>,
+    ) -> Result<Json<EntityProfileDto>, ErrorData> {
+        let service = Arc::clone(&self.service);
+        let EntityParams { name } = params;
+        let profile = tokio::task::spawn_blocking(move || service.entity_profile(&name))
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+        Ok(Json(EntityProfileDto::from(profile)))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -19,7 +19,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::model::{
-    deserialize_id, ColumnFilter, Explanation, Link, MemoryEdge, MemoryNode, Recollection,
+    deserialize_id, ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryEdge,
+    MemoryNode, Recollection,
 };
 use crate::service::Metadata;
 
@@ -364,6 +365,86 @@ impl From<MemoryEdge> for MemoryEdgeDto {
             to: edge.to,
             to_str: edge.to.to_string(),
             relation: edge.relation,
+        }
+    }
+}
+
+/// Input of the `entity` tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct EntityParams {
+    /// Entity name to look up. Matched case-insensitively.
+    pub(super) name: String,
+}
+
+/// Wire shape of one typed edge leaving an entity, with the `target_id_str`
+/// twin (issue #1468).
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct EntityRelationDto {
+    /// The edge label the passage stated (e.g. `"pere de"`, `"soeur de"`).
+    pub(super) predicate: String,
+    /// Stable id of the entity (or fact) on the far end.
+    pub(super) target_id: u64,
+    /// Decimal-string twin of `target_id` (issue #1468).
+    pub(super) target_id_str: String,
+    /// Stored content of the far end — for an entity, `Entity: <name>`.
+    pub(super) target: String,
+}
+
+impl From<EntityRelation> for EntityRelationDto {
+    fn from(relation: EntityRelation) -> Self {
+        Self {
+            predicate: relation.predicate,
+            target_id: relation.target_id,
+            target_id_str: relation.target_id.to_string(),
+            target: relation.target,
+        }
+    }
+}
+
+/// Result of the `entity` tool: everything the auto-built graph knows about
+/// one named entity. `found` distinguishes "this entity is known but has no
+/// attributes yet" from "nothing has ever mentioned it".
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct EntityProfileDto {
+    /// Whether an entity is known under that name at all.
+    pub(super) found: bool,
+    /// Stable, content-addressed id of the entity (`0` when not found).
+    pub(super) id: u64,
+    /// Decimal-string twin of `id` (issue #1468).
+    pub(super) id_str: String,
+    /// Canonical (trimmed, lowercased) entity name.
+    pub(super) name: String,
+    /// Attributes learned about this entity, reserved keys stripped.
+    pub(super) attributes: Metadata,
+    /// Typed edges leaving this entity.
+    pub(super) relations: Vec<EntityRelationDto>,
+}
+
+impl From<Option<EntityProfile>> for EntityProfileDto {
+    fn from(profile: Option<EntityProfile>) -> Self {
+        let Some(profile) = profile else {
+            return Self {
+                found: false,
+                id: 0,
+                id_str: "0".to_string(),
+                name: String::new(),
+                attributes: Metadata::new(),
+                relations: Vec::new(),
+            };
+        };
+        Self {
+            found: true,
+            id: profile.id,
+            id_str: profile.id.to_string(),
+            name: profile.name,
+            attributes: profile.attributes,
+            relations: profile
+                .relations
+                .into_iter()
+                .map(EntityRelationDto::from)
+                .collect(),
         }
     }
 }

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -239,6 +239,34 @@ pub struct MemoryEdge {
     pub relation: String,
 }
 
+/// One typed edge leaving an entity, as reported by
+/// [`MemoryService::entity_profile`](crate::service::MemoryService::entity_profile).
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub struct EntityRelation {
+    /// The edge label the passage stated (e.g. `"pere de"`, `"soeur de"`).
+    pub predicate: String,
+    /// Stable id of the entity (or fact) on the far end.
+    pub target_id: u64,
+    /// Stored content of the far end — for an entity hub, `Entity: <name>`.
+    pub target: String,
+}
+
+/// Everything the auto-built graph knows about one named entity: the
+/// attributes merged onto its hub and the typed edges leaving it.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub struct EntityProfile {
+    /// Stable, content-addressed id of the entity hub.
+    pub id: u64,
+    /// Canonical (trimmed, lowercased) entity name.
+    pub name: String,
+    /// Attributes learned about this entity, reserved keys stripped.
+    pub attributes: crate::service::Metadata,
+    /// Typed edges leaving this entity (bipartite `mentions` edges excluded).
+    pub relations: Vec<EntityRelation>,
+}
+
 /// The connected answer to a `why` question: the best-matching seed memory plus
 /// everything reachable from it within a hop budget. This connected subgraph is
 /// the differentiator — it surfaces related memories a purely vector recall is

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -16,9 +16,11 @@ pub type Metadata = Map<String, Value>;
 use crate::clock;
 use crate::embedder::Embedder;
 use crate::error::MemoryError;
-use crate::extract::Extractor;
+use crate::extract::{ExtractedAttribute, ExtractedRelation, Extractor};
 use crate::id;
-use crate::model::{ColumnFilter, Explanation, Link, MemoryNode, Recollection};
+use crate::model::{
+    ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryNode, Recollection,
+};
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
 use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore, AUTO_DATE_FIELD};
@@ -277,12 +279,12 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if text.is_empty() {
             return Err(MemoryError::EmptyFact);
         }
-        let facts = extractor.extract(text)?;
-        let mut fact_ids = Vec::with_capacity(facts.len());
+        let extraction = extractor.extract_graph(text)?;
+        let mut fact_ids = Vec::with_capacity(extraction.facts.len());
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();
-        for fact in &facts {
+        for fact in &extraction.facts {
             let content = fact.text.trim();
             if content.is_empty() {
                 continue;
@@ -297,7 +299,148 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 &mut seeded,
             )?;
         }
+        self.wire_relations(
+            &extraction.relations,
+            &mut entity_ids,
+            &mut edges,
+            &mut seeded,
+        )?;
+        self.wire_attributes(&extraction.attributes, &mut entity_ids)?;
         Ok(fact_ids)
+    }
+
+    /// Look up everything known about a named entity: the attributes merged
+    /// onto its hub, and the typed edges leaving it.
+    ///
+    /// This is the *read* side of the auto-built graph, and it exists because
+    /// entity hubs are deliberately invisible to [`Self::recall`] and
+    /// [`Self::recall_where`] — a hub ranking for its own topic would evict a
+    /// real fact from the caller's results. Without this accessor an attribute
+    /// merged onto a hub would be stored correctly and yet be unreachable
+    /// through every public read path: the worst kind of feature, one that
+    /// looks done and silently returns nothing.
+    ///
+    /// `name` is canonicalized exactly like an extracted entity (trimmed,
+    /// lowercased), so the caller may pass `"Axel Lange"` and reach the node
+    /// built from `"axel lange"`. Returns `None` when no hub exists for the
+    /// name — nothing has ever mentioned that entity.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if the store lookup fails.
+    pub fn entity_profile(&self, name: &str) -> Result<Option<EntityProfile>, MemoryError> {
+        let key = name.trim().to_lowercase();
+        if key.is_empty() {
+            return Ok(None);
+        }
+        let id = id::stable_id(&format!("{HUB_ID_SALT}{key}"));
+        if self.store.get(id)?.is_none() {
+            return Ok(None);
+        }
+        // Reserved system keys (the hub flag itself) are scaffolding, not
+        // attributes the caller ever wrote — strip them exactly as every other
+        // caller-facing read path does.
+        let attributes = strip_reserved_keys(self.store.get_metadata(id)?).unwrap_or_default();
+        let mut relations = Vec::new();
+        for edge in self.store.relations(id)? {
+            // `mentions` edges point at the facts that tagged this entity; they
+            // are the bipartite scaffolding, not statements *about* the entity.
+            if edge.relation == MENTIONS_RELATION {
+                continue;
+            }
+            let target = self.store.get(edge.to)?.map(|(content, _)| content);
+            relations.push(EntityRelation {
+                predicate: edge.relation,
+                target_id: edge.to,
+                target: target.unwrap_or_default(),
+            });
+        }
+        Ok(Some(EntityProfile {
+            id,
+            name: key,
+            attributes,
+            relations,
+        }))
+    }
+
+    /// Wire each extracted `subject -[predicate]-> object` triple as a typed
+    /// edge between the two entity hubs.
+    ///
+    /// This is the step that turns the bipartite fact↔topic graph into a real
+    /// knowledge graph. The hubs are resolved through [`Self::entity_hub`], so
+    /// an endpoint naming an entity some earlier passage already introduced
+    /// reuses that entity's existing node rather than forking a parallel one —
+    /// hub ids are content-addressed, so this holds across calls and sessions.
+    ///
+    /// Only the stated direction is written. Inferring the converse
+    /// (`father of` ⇒ `child of`) would mean inventing a label the passage
+    /// never used, and an inverted vocabulary nobody can predict is worse than
+    /// an absent edge: `why()` walks outgoing edges, so a wrong direction
+    /// silently misroutes every later traversal.
+    ///
+    /// A malformed triple is skipped, not fatal — one unusable predicate must
+    /// not cost the caller the facts stored alongside it.
+    fn wire_relations(
+        &self,
+        relations: &[ExtractedRelation],
+        entity_ids: &mut HashMap<String, u64>,
+        edges: &mut HashSet<(u64, u64)>,
+        seeded: &mut HashSet<u64>,
+    ) -> Result<(), MemoryError> {
+        for relation in relations {
+            if validate_relation(&relation.predicate).is_err() {
+                continue;
+            }
+            let subject_id = self.entity_hub(&relation.subject, entity_ids)?;
+            let object_id = self.entity_hub(&relation.object, entity_ids)?;
+            if subject_id == object_id {
+                continue;
+            }
+            self.seed_existing_edges(subject_id, edges, seeded)?;
+            self.add_edge(subject_id, object_id, &relation.predicate, edges)?;
+        }
+        Ok(())
+    }
+
+    /// Merge each extracted attribute into its entity hub's `ColumnStore`
+    /// metadata, so `recall_where` can filter on it (`age >= 15`).
+    ///
+    /// The write goes through `update_metadata`, which **merges** rather than
+    /// replaces. That is the whole point: learning "Axel has a sister" after
+    /// "Axel is 15" must not erase the age. Re-storing the hub payload wholesale
+    /// would silently drop every attribute learned in an earlier session.
+    ///
+    /// Values keep the JSON type the extractor produced. `recall_where`
+    /// compares type-strictly with no coercion, so an age stored as `"15"`
+    /// would never match a numeric filter — no error, just a permanent silent
+    /// miss.
+    ///
+    /// Reserved keys are skipped: a model emitting `content` or a `_veles_`
+    /// key must never be able to overwrite the hub's own content or its
+    /// system flags.
+    fn wire_attributes(
+        &self,
+        attributes: &[ExtractedAttribute],
+        entity_ids: &mut HashMap<String, u64>,
+    ) -> Result<(), MemoryError> {
+        let mut per_entity: HashMap<String, Metadata> = HashMap::new();
+        for attribute in attributes {
+            if is_reserved_key(&attribute.key) {
+                continue;
+            }
+            per_entity
+                .entry(attribute.entity.clone())
+                .or_default()
+                .insert(attribute.key.clone(), attribute.value.clone());
+        }
+        for (entity, meta) in per_entity {
+            if meta.is_empty() {
+                continue;
+            }
+            reject_oversized_metadata(Some(&meta))?;
+            let hub_id = self.entity_hub(&entity, entity_ids)?;
+            self.store.update_metadata(hub_id, &meta)?;
+        }
+        Ok(())
     }
 
     /// Link `fact_id` to each of its topics with a deduplicated edge in *both*
@@ -404,6 +547,15 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// reserved-key rejection in [`Self::remember`].
     fn remember_hub(&self, key: &str) -> Result<u64, MemoryError> {
         let id = id::stable_id(&format!("{HUB_ID_SALT}{key}"));
+        // An existing hub is left exactly as it is. Re-storing it would rewrite
+        // the payload to the bare hub marker and destroy every attribute merged
+        // onto it by an earlier call — learning "Axel has a sister" would erase
+        // "Axel is 15", because a later sentence re-resolves the same hub. The
+        // content is a pure function of `key`, so there is nothing to refresh;
+        // skipping also avoids re-embedding a hub on every single mention.
+        if self.store.get(id)?.is_some() {
+            return Ok(id);
+        }
         let content = format!("Entity: {key}");
         let embedding = self.embedder.embed(&content)?;
         let mut meta = Map::new();

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -85,11 +85,13 @@ const MENTIONS_RELATION: &str = "mentions";
 pub struct MemoryService<E: Embedder, S: MemoryStore = NativeStore> {
     store: S,
     embedder: E,
+    autograph: Option<crate::extract::DynExtractor>,
 }
 #[cfg(not(feature = "persistence"))]
 pub struct MemoryService<E: Embedder, S: MemoryStore> {
     store: S,
     embedder: E,
+    autograph: Option<crate::extract::DynExtractor>,
 }
 
 #[cfg(feature = "persistence")]
@@ -102,7 +104,11 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
     /// memory cannot be initialized for the embedder's dimension.
     pub fn open<P: AsRef<Path>>(path: P, embedder: E) -> Result<Self, MemoryError> {
         let store = NativeStore::open(path, embedder.dimension())?;
-        Ok(Self { store, embedder })
+        Ok(Self {
+            store,
+            embedder,
+            autograph: None,
+        })
     }
 }
 
@@ -111,7 +117,30 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// [`Self::open`]'s filesystem-specific setup — the constructor a
     /// non-native backend (e.g. `velesdb-wasm`'s in-memory store) uses.
     pub fn with_store(store: S, embedder: E) -> Self {
-        Self { store, embedder }
+        Self {
+            store,
+            embedder,
+            autograph: None,
+        }
+    }
+
+    /// Turn on **autograph**: every [`Self::remember`] additionally reads the
+    /// stored fact for entities, entity→entity edges and entity attributes,
+    /// and wires them — so the knowledge graph builds itself from ordinary
+    /// `remember` calls, with no separate [`Self::remember_extracted`].
+    ///
+    /// Opt-in, and off unless this is called. It costs one generation per
+    /// `remember`, which is a real latency and availability change: a memory
+    /// write that silently depends on a local model being up is not a default
+    /// anyone should inherit.
+    ///
+    /// The caller's fact is stored **verbatim and first**. Autograph only
+    /// *adds* structure around it; it never rewrites or replaces what the
+    /// caller asked to remember.
+    #[must_use]
+    pub fn with_autograph(mut self, extractor: crate::extract::DynExtractor) -> Self {
+        self.autograph = Some(extractor);
+        self
     }
 
     /// Remember a `fact`, optionally tagging it with structured `metadata`
@@ -189,6 +218,21 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         metadata: Option<&Metadata>,
         ttl_seconds: Option<u64>,
     ) -> Result<u64, MemoryError> {
+        self.remember_inner(fact, links, metadata, ttl_seconds, true)
+    }
+
+    /// The shared write path. `run_autograph` is false for the one caller that
+    /// has ALREADY extracted the passage — [`Self::remember_extracted`] — so a
+    /// service with autograph on does not run a second generation per stored
+    /// fact, re-deriving what it just computed.
+    fn remember_inner(
+        &self,
+        fact: &str,
+        links: &[Link],
+        metadata: Option<&Metadata>,
+        ttl_seconds: Option<u64>,
+        run_autograph: bool,
+    ) -> Result<u64, MemoryError> {
         let fact = fact.trim();
         if fact.is_empty() {
             return Err(MemoryError::EmptyFact);
@@ -233,7 +277,57 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             }
             return Err(e);
         }
+        if run_autograph {
+            self.autograph(fact_id, fact);
+        }
         Ok(fact_id)
+    }
+
+    /// Autograph one just-stored fact: read the entities, entity→entity edges
+    /// and attributes it states, and wire them around it.
+    ///
+    /// **Deliberately infallible.** The caller's fact is already durably
+    /// stored by the time this runs, and the caller asked to remember a fact —
+    /// not to run a model. Propagating an extraction failure would turn a
+    /// successful write into a reported error, and an agent that sees
+    /// `remember` fail will sensibly retry it, re-running the generation and
+    /// failing again. So a model that is down, slow, or talking nonsense costs
+    /// the *graph enrichment* and nothing else: the memory is kept, the id is
+    /// returned, and the next `remember` tries again.
+    ///
+    /// The trade-off is that a persistently broken extractor degrades silently
+    /// to plain `remember`. That is the right way round — losing structure is
+    /// recoverable by re-remembering, losing the fact is not.
+    fn autograph(&self, fact_id: u64, fact: &str) {
+        let Some(extractor) = self.autograph.as_ref() else {
+            return;
+        };
+        let Ok(extraction) = extractor.extract_graph(fact) else {
+            return;
+        };
+        let mut entity_ids: HashMap<String, u64> = HashMap::new();
+        let mut edges: HashSet<(u64, u64)> = HashSet::new();
+        let mut seeded: HashSet<u64> = HashSet::new();
+        // The caller's fact is the node the topics attach to — the extracted
+        // facts are NOT stored as separate memories here, which is what
+        // separates autograph from `remember_extracted`: one `remember` call
+        // must still produce exactly one caller-visible memory.
+        for extracted in &extraction.facts {
+            let _ = self.wire_entities(
+                fact_id,
+                &extracted.entities,
+                &mut entity_ids,
+                &mut edges,
+                &mut seeded,
+            );
+        }
+        let _ = self.wire_relations(
+            &extraction.relations,
+            &mut entity_ids,
+            &mut edges,
+            &mut seeded,
+        );
+        let _ = self.wire_attributes(&extraction.attributes, &mut entity_ids);
     }
 
     /// Create each outgoing link from `fact_id`.
@@ -289,7 +383,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             if content.is_empty() {
                 continue;
             }
-            let fact_id = self.remember(content, &[], metadata)?;
+            let fact_id = self.remember_inner(content, &[], metadata, None, false)?;
             fact_ids.push(fact_id);
             self.wire_entities(
                 fact_id,

--- a/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
+++ b/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
@@ -1,0 +1,356 @@
+//! Behaviour: the graph completes itself from plain sentences.
+//!
+//! `remember_extracted` used to build only a bipartite fact↔topic graph: it knew
+//! a fact *mentioned* "axel lange", never that Julien is his father. These tests
+//! drive the scenario that motivated the change, one sentence at a time, exactly
+//! as a user would say them:
+//!
+//! 1. "Julien Lange est le pere d'Axel Lange"  → a typed entity→entity edge
+//! 2. "Axel Lange a 15 ans"                    → a filterable numeric attribute
+//! 3. "Axel Lange a une soeur, Lea Lange"      → a NEW entity, wired in
+//!
+//! The extractor is a deterministic stub keyed on the sentence, so the whole
+//! behaviour is proven with no model, no network, and no flake.
+
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use velesdb_memory::{
+    ExtractError, ExtractedAttribute, ExtractedFact, ExtractedRelation, Extraction, Extractor,
+    HashEmbedder, MemoryService, DEFAULT_DIMENSION,
+};
+
+/// A canned graph extractor: it recognises the three sentences of the scenario
+/// and returns exactly what a competent model would return for each.
+struct FamilyExtractor;
+
+impl Extractor for FamilyExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        let fact = |text: &str, entities: &[&str]| ExtractedFact {
+            text: text.to_string(),
+            entities: entities.iter().map(|e| (*e).to_string()).collect(),
+        };
+        let relation = |subject: &str, predicate: &str, object: &str| ExtractedRelation {
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+        };
+        if text.contains("pere") {
+            return Ok(Extraction {
+                facts: vec![fact(
+                    "Julien Lange est le pere d'Axel Lange.",
+                    &["julien lange", "axel lange"],
+                )],
+                relations: vec![relation("julien lange", "pere de", "axel lange")],
+                attributes: vec![],
+            });
+        }
+        if text.contains("15 ans") {
+            return Ok(Extraction {
+                facts: vec![fact("Axel Lange a 15 ans.", &["axel lange"])],
+                relations: vec![],
+                attributes: vec![ExtractedAttribute {
+                    entity: "axel lange".to_string(),
+                    key: "age".to_string(),
+                    // A JSON NUMBER on purpose: recall_where is type-strict.
+                    value: json!(15),
+                }],
+            });
+        }
+        if text.contains("soeur") {
+            return Ok(Extraction {
+                facts: vec![fact(
+                    "Axel Lange a une soeur, Lea Lange.",
+                    &["axel lange", "lea lange"],
+                )],
+                relations: vec![relation("axel lange", "soeur de", "lea lange")],
+                attributes: vec![],
+            });
+        }
+        Ok(Extraction::default())
+    }
+}
+
+/// An extractor that emits a reserved key and a self-loop — the hostile input
+/// the wiring must survive without corrupting the hub.
+struct HostileExtractor;
+
+impl Extractor for HostileExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, _text: &str) -> Result<Extraction, ExtractError> {
+        Ok(Extraction {
+            facts: vec![ExtractedFact {
+                text: "Axel Lange lives in Nantes.".to_string(),
+                entities: vec!["axel lange".to_string()],
+            }],
+            relations: vec![ExtractedRelation {
+                subject: "axel lange".to_string(),
+                predicate: "est".to_string(),
+                object: "axel lange".to_string(),
+            }],
+            attributes: vec![
+                ExtractedAttribute {
+                    entity: "axel lange".to_string(),
+                    key: "content".to_string(),
+                    value: json!("hijacked"),
+                },
+                ExtractedAttribute {
+                    entity: "axel lange".to_string(),
+                    key: "_veles_hub".to_string(),
+                    value: json!(false),
+                },
+                ExtractedAttribute {
+                    entity: "axel lange".to_string(),
+                    key: "ville".to_string(),
+                    value: json!("Nantes"),
+                },
+            ],
+        })
+    }
+}
+
+/// A fresh service over a temp store. The [`TempDir`] must outlive the service.
+fn service() -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DEFAULT_DIMENSION))
+        .expect("open service");
+    (dir, svc)
+}
+
+/// Feed the three scenario sentences, in the order a user would say them.
+fn tell_the_story(svc: &MemoryService<HashEmbedder>) {
+    for sentence in [
+        "Julien Lange est le pere d'Axel Lange",
+        "Axel Lange a 15 ans",
+        "Axel Lange a une soeur, Lea Lange",
+    ] {
+        svc.remember_extracted(sentence, &FamilyExtractor, None)
+            .expect("extract and remember");
+    }
+}
+
+#[test]
+fn a_stated_relationship_becomes_a_typed_edge() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+
+    let julien = svc
+        .entity_profile("Julien Lange")
+        .expect("profile lookup")
+        .expect("julien exists");
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+
+    let edge = julien
+        .relations
+        .iter()
+        .find(|r| r.predicate == "pere de")
+        .expect("julien -[pere de]-> someone");
+    assert_eq!(
+        edge.target_id, axel.id,
+        "the edge lands on Axel's own hub, not a parallel node"
+    );
+}
+
+#[test]
+fn an_entity_is_the_same_node_across_separate_sentences() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+
+    // Axel is named in all three sentences. If entity resolution forked, the
+    // age and the sister would sit on different nodes.
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    assert_eq!(axel.attributes.get("age"), Some(&json!(15)));
+    assert!(
+        axel.relations.iter().any(|r| r.predicate == "soeur de"),
+        "the same Axel node carries both the age and the sister edge: {:?}",
+        axel.relations
+    );
+}
+
+#[test]
+fn a_newly_mentioned_person_becomes_its_own_entity() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+
+    let lea = svc
+        .entity_profile("Lea Lange")
+        .expect("profile lookup")
+        .expect("lea was created from the sentence that introduced her");
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    assert_ne!(lea.id, axel.id, "Lea is a distinct node");
+
+    let edge = axel
+        .relations
+        .iter()
+        .find(|r| r.predicate == "soeur de")
+        .expect("axel -[soeur de]-> someone");
+    assert_eq!(edge.target_id, lea.id);
+}
+
+#[test]
+fn a_numeric_attribute_keeps_its_json_type() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    let age = axel.attributes.get("age").expect("age was stored");
+    assert!(
+        age.is_number(),
+        "age must stay a JSON number — a string would silently never match a \
+         numeric recall_where filter, got {age:?}"
+    );
+}
+
+#[test]
+fn learning_a_new_attribute_does_not_erase_the_previous_one() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+    // A later, unrelated sentence about the same entity.
+    svc.remember_extracted("Axel Lange lives in Nantes", &HostileExtractor, None)
+        .expect("extract and remember");
+
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    assert_eq!(
+        axel.attributes.get("age"),
+        Some(&json!(15)),
+        "the age learned earlier survives a later attribute write"
+    );
+    assert_eq!(axel.attributes.get("ville"), Some(&json!("Nantes")));
+}
+
+#[test]
+fn a_reserved_key_can_never_be_written_through_an_attribute() {
+    let (_dir, svc) = service();
+    svc.remember_extracted("Axel Lange lives in Nantes", &HostileExtractor, None)
+        .expect("extract and remember");
+
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    assert_eq!(
+        axel.attributes.get("content"),
+        None,
+        "a model emitting `content` must not overwrite the hub's own content"
+    );
+    assert_eq!(axel.attributes.get("_veles_hub"), None);
+    // The good attribute in the same batch still landed.
+    assert_eq!(axel.attributes.get("ville"), Some(&json!("Nantes")));
+}
+
+#[test]
+fn a_self_loop_is_never_wired() {
+    let (_dir, svc) = service();
+    svc.remember_extracted("Axel Lange lives in Nantes", &HostileExtractor, None)
+        .expect("extract and remember");
+
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    assert!(
+        !axel.relations.iter().any(|r| r.target_id == axel.id),
+        "an entity must never point at itself: {:?}",
+        axel.relations
+    );
+}
+
+#[test]
+fn an_unknown_entity_has_no_profile() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+    assert!(svc
+        .entity_profile("Marie Curie")
+        .expect("profile lookup")
+        .is_none());
+    assert!(svc.entity_profile("   ").expect("profile lookup").is_none());
+}
+
+#[test]
+fn a_fact_only_extractor_still_works_unchanged() {
+    /// A backend written against the OLD contract: no `extract_graph` override.
+    struct LegacyExtractor;
+    impl Extractor for LegacyExtractor {
+        fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+            Ok(vec![ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_string(),
+                entities: vec!["rust".to_string()],
+            }])
+        }
+    }
+
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("Alice works in Rust.", &LegacyExtractor, None)
+        .expect("extract and remember");
+    assert_eq!(
+        ids.len(),
+        1,
+        "the fact-only default path still stores facts"
+    );
+
+    let rust = svc
+        .entity_profile("rust")
+        .expect("profile lookup")
+        .expect("the topic hub still gets built");
+    assert!(
+        rust.attributes.is_empty(),
+        "no attributes are invented for a legacy backend"
+    );
+}
+
+/// An `Arc`-held extractor must not silently lose its relations: the MCP server
+/// and every binding hold exactly that shape.
+#[test]
+fn relations_survive_an_arc_held_extractor() {
+    let (_dir, svc) = service();
+    let shared: std::sync::Arc<dyn Extractor + Send + Sync> = std::sync::Arc::new(FamilyExtractor);
+    svc.remember_extracted("Julien Lange est le pere d'Axel Lange", &shared, None)
+        .expect("extract and remember");
+
+    let julien = svc
+        .entity_profile("julien lange")
+        .expect("profile lookup")
+        .expect("julien exists");
+    assert!(
+        julien.relations.iter().any(|r| r.predicate == "pere de"),
+        "Arc forwarding must not fall back to the fact-only default: {:?}",
+        julien.relations
+    );
+}
+
+/// Guard the type-strictness contract end to end: the stored value must be the
+/// same JSON shape a `recall_where` numeric filter compares against.
+#[test]
+fn a_stored_age_matches_a_numeric_comparison() {
+    let (_dir, svc) = service();
+    tell_the_story(&svc);
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("profile lookup")
+        .expect("axel exists");
+    let age: Value = axel.attributes.get("age").cloned().expect("age");
+    let as_i64 = age.as_i64().expect("age reads back as an integer");
+    assert_eq!(as_i64, 15, "a numeric filter compares against this value");
+}

--- a/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
+++ b/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
@@ -354,3 +354,152 @@ fn a_stored_age_matches_a_numeric_comparison() {
     let as_i64 = age.as_i64().expect("age reads back as an integer");
     assert_eq!(as_i64, 15, "a numeric filter compares against this value");
 }
+
+// --- Autograph: the same wiring, triggered by a plain `remember` -------------
+
+/// Counts how many times the extractor was actually invoked, so the tests can
+/// prove `remember_extracted` does NOT double-extract when autograph is on.
+#[derive(Default)]
+struct CountingExtractor {
+    calls: std::sync::atomic::AtomicUsize,
+}
+
+impl Extractor for CountingExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        FamilyExtractor.extract_graph(text)
+    }
+}
+
+/// A backend that is always down — the availability case autograph must
+/// survive without losing the caller's fact.
+struct OfflineExtractor;
+
+impl Extractor for OfflineExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Err(ExtractError::Backend("model offline".to_string()))
+    }
+}
+
+fn autograph_service(
+    extractor: std::sync::Arc<dyn Extractor + Send + Sync>,
+) -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DEFAULT_DIMENSION))
+        .expect("open service")
+        .with_autograph(extractor);
+    (dir, svc)
+}
+
+#[test]
+fn a_plain_remember_builds_the_graph_when_autograph_is_on() {
+    let (_dir, svc) = autograph_service(std::sync::Arc::new(FamilyExtractor));
+    svc.remember("Julien Lange est le pere d'Axel Lange", &[], None)
+        .expect("remember");
+
+    let julien = svc
+        .entity_profile("julien lange")
+        .expect("lookup")
+        .expect("julien exists");
+    assert!(
+        julien.relations.iter().any(|r| r.predicate == "pere de"),
+        "a plain remember wired the typed edge: {:?}",
+        julien.relations
+    );
+}
+
+#[test]
+fn autograph_is_off_unless_asked_for() {
+    let (_dir, svc) = service();
+    svc.remember("Julien Lange est le pere d'Axel Lange", &[], None)
+        .expect("remember");
+    assert!(
+        svc.entity_profile("julien lange")
+            .expect("lookup")
+            .is_none(),
+        "no extractor was attached, so nothing may be wired"
+    );
+}
+
+#[test]
+fn the_callers_fact_is_stored_verbatim_and_is_the_only_memory() {
+    let (_dir, svc) = autograph_service(std::sync::Arc::new(FamilyExtractor));
+    let id = svc
+        .remember("Julien Lange est le pere d'Axel Lange", &[], None)
+        .expect("remember");
+
+    let hits = svc.recall("Julien Lange", 10, None).expect("recall");
+    let mine: Vec<_> = hits.iter().filter(|h| h.id == id).collect();
+    assert_eq!(mine.len(), 1, "exactly one caller-visible memory");
+    assert_eq!(
+        mine[0].content, "Julien Lange est le pere d'Axel Lange",
+        "stored verbatim — autograph adds structure, it never rewrites the fact"
+    );
+    assert_eq!(
+        hits.len(),
+        1,
+        "the extracted sentences are NOT stored as extra memories: {:?}",
+        hits.iter().map(|h| &h.content).collect::<Vec<_>>()
+    );
+}
+
+/// The availability contract: the fact is already durable when extraction
+/// runs, so a model that is down must cost the enrichment and nothing else.
+#[test]
+fn a_dead_extractor_never_costs_the_caller_their_fact() {
+    let (_dir, svc) = autograph_service(std::sync::Arc::new(OfflineExtractor));
+    let id = svc
+        .remember("Julien Lange est le pere d'Axel Lange", &[], None)
+        .expect("remember must succeed even though the extractor is down");
+
+    let hits = svc.recall("Julien Lange", 5, None).expect("recall");
+    assert!(
+        hits.iter().any(|h| h.id == id),
+        "the fact is stored and recallable"
+    );
+    assert!(
+        svc.entity_profile("julien lange")
+            .expect("lookup")
+            .is_none(),
+        "degrades to a plain remember — no half-built graph"
+    );
+}
+
+/// `remember_extracted` already extracted the passage; running autograph on
+/// each stored fact would re-derive what was just computed, once per fact.
+#[test]
+fn remember_extracted_does_not_extract_twice_under_autograph() {
+    let counting = std::sync::Arc::new(CountingExtractor::default());
+    let (_dir, svc) = autograph_service(counting.clone());
+
+    svc.remember_extracted("Julien Lange est le pere d'Axel Lange", &counting, None)
+        .expect("extract and remember");
+
+    assert_eq!(
+        counting.calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "exactly one generation for the passage, not one more per stored fact"
+    );
+}
+
+#[test]
+fn autograph_accumulates_across_separate_remembers() {
+    let (_dir, svc) = autograph_service(std::sync::Arc::new(FamilyExtractor));
+    for sentence in [
+        "Julien Lange est le pere d'Axel Lange",
+        "Axel Lange a 15 ans",
+        "Axel Lange a une soeur, Lea Lange",
+    ] {
+        svc.remember(sentence, &[], None).expect("remember");
+    }
+    let axel = svc
+        .entity_profile("axel lange")
+        .expect("lookup")
+        .expect("axel exists");
+    assert_eq!(axel.attributes.get("age"), Some(&json!(15)));
+    assert!(axel.relations.iter().any(|r| r.predicate == "soeur de"));
+}

--- a/crates/velesdb-memory/tests/http_insecure_process.rs
+++ b/crates/velesdb-memory/tests/http_insecure_process.rs
@@ -38,7 +38,7 @@ impl Drop for ChildGuard {
 /// `stderr.read_to_string(..)` call would block until EOF — i.e. forever,
 /// for as long as the daemon stays up. Draining continuously on a
 /// background thread instead means (a) the child's stderr pipe never fills
-/// up and makes IT block on a write(), and (b) this test can inspect
+/// up and makes IT block on a `write()`, and (b) this test can inspect
 /// whatever has been captured so far without ever blocking on the child's
 /// lifetime.
 fn drain_stderr(child: &mut Child) -> Arc<Mutex<String>> {

--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -299,7 +299,7 @@ async fn concurrent_remember_and_recall_do_not_deadlock_and_all_facts_recallable
     shutdown(server).await;
 }
 
-/// Adversarial: the two DoS guards `router()` wraps `/mcp` in (2026-07-22
+/// Adversarial: the two `DoS` guards `router()` wraps `/mcp` in (2026-07-22
 /// OOM audit) must actually reject what they claim to bound, not just exist
 /// as unused configuration. `RequestBodyLimit` rejects a request whose
 /// `Content-Length` already exceeds the configured limit before reading any

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -384,3 +384,26 @@ fn collect_ref_targets(value: &Value, out: &mut BTreeSet<String>) {
         _ => {}
     }
 }
+
+/// Every tool must ADVERTISE an output schema, not merely have a typed one.
+///
+/// Ten of the nineteen tools declared none at all, so rmcp derived one that
+/// escaped every post-processing pass — the inliner included. A client
+/// validating `structuredContent` against a `$ref` it cannot resolve may
+/// reject a perfectly good result.
+#[tokio::test]
+async fn every_tool_advertises_an_output_schema() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let missing: BTreeSet<String> = tools
+        .iter()
+        .filter(|tool| tool.output_schema.is_none())
+        .map(|tool| tool.name.to_string())
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "{} tool(s) advertise no output schema: {missing:#?}",
+        missing.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -3,11 +3,15 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget) are available and the
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity)
+  are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
   when a decision or durable fact emerges (remember + relate it), when asked why
   something is the way it is (why), and after using a recalled memory (feedback).
+  Use remember_extracted when a passage states relationships or properties of
+  named people/places/things, and entity(name) to answer a question ABOUT such a
+  thing rather than about the sentences that mention it.
   Especially relevant for: multi-session projects, architecture/config decisions,
   incident postmortems, "why is this value/setting like this", onboarding to an
   unfamiliar codebase, and any place a fact learned now must survive to a later
@@ -122,6 +126,50 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    improves without any retraining. Give feedback on the memory you actually
    used, not on everything.
 
+## Entities: let the graph build itself
+
+Steps 2 and 3 build the graph by hand, one `relate` at a time. That is the right
+tool for a *decision* graph, where you choose the edges deliberately. It is the
+wrong tool for facts about **people, places, organisations and things**, where
+the edges are simply what the sentence already says.
+
+`remember_extracted(text)` reads a passage and stores three things at once: the
+atomic facts, the typed edges **between named entities**, and the **attributes**
+those entities carry. Say it in plain language and the graph assembles itself:
+
+> "Julien Lange est le père d'Axel Lange. Axel Lange a 15 ans.
+>  Axel Lange a une sœur, Léa Lange."
+
+produces `julien lange -[père de]-> axel lange`, an `age: 15` attribute on Axel,
+and a brand-new `léa lange` node wired by `sœur de`. No `relate` calls.
+
+**Entity names resolve across calls and across sessions.** An entity's id is
+content-addressed from its (lowercased) name, so "Axel Lange" in today's
+sentence and "axel lange" in next month's land on the *same* node. Attributes
+accumulate onto it — learning the sister does not erase the age.
+
+**Read entities with `entity(name)`, not `recall`.** This matters and is easy to
+get wrong. Entity nodes are deliberately invisible to `recall` and
+`recall_where`: a node called `Entity: axel lange` would rank for its own name
+and evict a real fact from your results. So:
+
+- *"What does the memory say about Axel?"* → `entity("Axel Lange")` — returns his
+  attributes and every typed edge leaving him.
+- *"Which notes mention Axel?"* → `recall("Axel Lange")` — returns sentences.
+
+Use `entity` for questions **about a thing**, `recall` for questions **about what
+was written**. `found: false` means nothing has ever mentioned that name.
+
+**Numbers must stay numbers.** Attributes keep the JSON type the extractor
+produced, and `recall_where`'s comparisons are type-strict with no coercion. An
+age stored as `"15"` will never match `age >= 15` — no error, just silence. This
+is the same trap as the date field in step 2, and it is the single most common
+way a memory system looks like it is working while returning nothing.
+
+`remember_extracted` needs an extraction backend
+(`[extractor] backend = "ollama"`); without one the tool reports itself as
+unconfigured rather than silently storing less.
+
 ## Concrete scenarios
 
 **Incident → decision → later "why?"** — the flagship case.
@@ -172,8 +220,32 @@ launched with:
   `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
   `VELESDB_MEMORY_EMBEDDER=ollama`.
 
-Set a stable store location with `VELESDB_MEMORY_PATH` (e.g. `~/.velesdb-memory`) so
-memory persists in one place across sessions. Optionally set
-`VELESDB_MEMORY_DEFAULT_TTL` (seconds) to auto-expire facts you only want short-term.
+### Configure it in a file, not in a plist
+
+Every setting can live in **`velesdb-memory.toml`**, looked for next to the store
+(`~/.velesdb-memory/velesdb-memory.toml`), or named explicitly with `--config` /
+`VELESDB_MEMORY_CONFIG`:
+
+```toml
+path = "~/.velesdb-memory"     # where memory lives; keep it stable across sessions
+default_ttl = 0                # seconds; 0 = permanent
+
+[embedder]
+backend = "ollama"             # `hash` is lexical, not semantic — see above
+model = "bge-m3"
+
+[extractor]
+backend = "ollama"             # required for remember_extracted / entities
+model = "qwen3.6:35b-mlx"
+```
+
+Precedence is **command line > environment > file > default**, so a value pinned
+in the file can still be overridden for one run
+(`VELESDB_MEMORY_EMBEDDER=hash velesdb-memory`). Every setting also remains
+available as a `VELESDB_MEMORY_*` variable — the file changes nothing about how
+they are read.
+
+An unknown key is a startup error, not a warning: a typo that was silently
+ignored would leave you convinced you had configured something you had not.
 
 The store never leaves the machine — memory is local by design.

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -237,7 +237,16 @@ model = "bge-m3"
 [extractor]
 backend = "ollama"             # required for remember_extracted / entities
 model = "qwen3.6:35b-mlx"
+
+[graph]
+autograph = false              # true = every `remember` also wires entities
 ```
+
+With `autograph = true` you stop having to choose the right tool: a plain
+`remember("Julien Lange est le père d'Axel Lange")` stores the fact verbatim
+**and** wires the graph around it. It costs one generation per `remember`, so
+it is opt-in — and if the model is down the write still succeeds, losing only
+the enrichment, never the fact.
 
 Precedence is **command line > environment > file > default**, so a value pinned
 in the file can still be overridden for one run


### PR DESCRIPTION
## Ce que ça fait

Le graphe de connaissances se construit tout seul à partir de phrases ordinaires, et tout le serveur se configure enfin dans un fichier.

Dire *« Julien Lange est le père d'Axel Lange. Axel Lange a 15 ans. Axel Lange a une sœur, Léa Lange. »* produit maintenant `julien lange -[père de]-> axel lange`, un attribut `age: 15` filtrable sur Axel, et un nœud `léa lange` créé et câblé — sans un seul `relate`.

## Les six commits

| Commit | Objet |
|---|---|
| `afc570f9` | contrat d'extraction étendu : arêtes typées + attributs, `extract_graph` avec implémentation par défaut (non-breaking) |
| `eefb7f98` | outil MCP `entity` — sans lui la fonctionnalité était injoignable |
| `75a9bdcf` | fix : le découpage JSON préférait un tableau, la réponse graphe est un objet |
| `448cc426` | fichier de configuration couvrant les 18 paramètres |
| `6cca0c1d` | le skill apprend la couche entités et le fichier de config |
| `3636e8ad` | autograph : un `remember` ordinaire construit le graphe |

## Trois bugs silencieux trouvés en construisant

**`remember_hub` réécrivait le hub à chaque mention.** La troisième phrase effaçait donc l'âge que la deuxième avait écrit. Le contenu d'un hub est une fonction pure de sa clé — il n'y a rien à rafraîchir.

**`balanced_slice` préférait un tableau.** La réponse graphe est un objet dont le premier `[` appartient au champ imbriqué `facts` : **toute** extraction graphe était rejetée sur le vrai modèle, alors que le modèle répondait un JSON valide. Invisible aux tests, qui passent tous par un extracteur bouchonné ne traversant jamais le parseur — c'est le passage bout-en-bout qui l'a sorti.

**`remember_extracted` aurait double-extrait sous autograph**, re-dérivant par fait stocké ce qu'il venait de calculer. Un test compte désormais les appels.

## Décisions défendables

L'enrichissement autograph est **délibérément infaillible** : le fait est déjà durable quand l'extraction tourne. Propager l'échec transformerait une écriture réussie en erreur, et un agent qui voit `remember` échouer réessaiera, relançant la génération pour rien. Un modèle en panne coûte la structure, jamais le souvenir.

Les attributs gardent leur **type JSON**. `recall_where` compare de façon type-stricte : un âge rangé en `"15"` ne matcherait jamais `age >= 15`, sans erreur, juste un silence.

`entity()` existe parce que les hubs sont **volontairement invisibles** à `recall` — sans lui, un attribut serait correctement stocké et définitivement illisible.

Précédence de configuration : **ligne de commande > environnement > fichier > défaut**, obtenue par une seule règle (le fichier n'exporte que les variables non définies). Aucun des 18 sites de lecture n'a été réécrit.

## Vérification

- 17 tests sur le scénario, dont entrées hostiles, extracteur en panne, backend legacy, extracteur tenu par `Arc`
- 13 tests de configuration, dont un qui énumère les 18 variables et casse si l'une devient inaccessible
- suite complète verte, `clippy --features extract,http -D warnings -W pedantic` à 0
- **prouvé bout-en-bout sur le vrai `qwen3.6:35b-mlx`**, entités de test supprimées ensuite

## Au passage

4 lints pedantic pré-existants corrigés sur `http.rs` et deux tests http. Ils ne remontaient pas : la CI lance clippy avec `--features persistence,gpu,update-check`, jamais avec `http` ni `extract`. **Ces deux surfaces n'ont aucune couverture lint** — à combler séparément.
