### PR TITLE
docs: guide de migration 4.0.0 — la majeure était passée sans notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,17 @@ codacy-cli analyze
 
 Or use the local CI script: `.\scripts\local-ci.ps1` (Full) or `.\scripts\local-ci.ps1 -Quick` (fmt + clippy only).
 
-Git hooks are provided in `.githooks/` — activate with: `git config core.hooksPath .githooks`
+Git hooks are provided in `.githooks/` — activate them with the setup script for
+your platform, `./scripts/setup-hooks.sh` (Linux/macOS) or
+`.\scripts\setup-hooks.ps1` (Windows). Both set `core.hooksPath`; the shell one
+also restores the executable bit, which a fresh clone can lose and which git
+ignores silently — an un-executable hook does not fail, it simply never runs.
+
+The bare equivalent is `git config core.hooksPath .githooks`.
+
+Three hooks then apply: `commit-msg` rejects AI-attributed authors and AI
+attribution trailers, `pre-commit` validates the change, and `pre-push` runs the
+full local gate.
 
 > **Note (SSH pushes):** the pre-push hook runs the full validation (~15 min) while
 > git already holds the connection to GitHub open; if that SSH connection dies in

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -94,241 +94,36 @@ The `code` field is optional and omitted when no structured code applies. Use it
 programmatic error handling (e.g., retry on `VELES-006`, display user hint on `VELES-004`).
 See [ERROR_CODES.md](../../docs/reference/ERROR_CODES.md) for the full list.
 
-## Authentication
-
-VelesDB supports optional API key authentication. When no keys are configured, the server runs in **local dev mode** (all requests are accepted). When one or more keys are configured, every request must include a valid `Authorization: Bearer <key>` header.
-
-### Enabling Authentication
-
-**Via environment variable** (comma-separated list):
-
-```bash
-VELESDB_API_KEYS="sk-prod-abc123,sk-prod-def456" velesdb-server
-```
-
-**Via `velesdb.toml`**:
-
-```toml
-[auth]
-api_keys = ["sk-prod-abc123", "sk-prod-def456"]
-```
-
-You can configure as many keys as you need. This is useful for rotating keys without downtime: add the new key, deploy, then remove the old key.
-
-### Making Authenticated Requests
-
-```bash
-curl -X GET http://localhost:8080/collections \
-  -H "Authorization: Bearer sk-prod-abc123"
-```
-
-If authentication is enabled and the header is missing or invalid, the server returns `401 Unauthorized`:
-
-```json
-{"error": "Unauthorized", "message": "missing Authorization header"}
-```
-
-### Public Endpoints (No Auth Required)
-
-The following endpoints bypass authentication even when API keys are configured:
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /health`, `GET /v1/health` | Liveness probe |
-| `GET /ready`, `GET /v1/ready` | Readiness probe |
-
-This allows load balancers and orchestrators to probe the server without
-credentials. `GET /metrics` (Prometheus) is **gated by the API key** when
-auth is enabled — see `src/auth.rs::is_public_path` and finding F-02 in
-the auth audit; the metrics endpoint can leak collection names and
-write rates, so it is intentionally not in the public list.
-
-## TLS / HTTPS
-
-VelesDB supports native TLS via rustls (no OpenSSL dependency). When both a certificate and private key are provided, the server binds with HTTPS instead of HTTP.
-
-### Generating Self-Signed Certificates (Development)
-
-```bash
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
-  -days 365 -nodes -subj "/CN=localhost"
-```
-
-### Configuring TLS
-
-**Via environment variables**:
-
-```bash
-VELESDB_TLS_CERT=./cert.pem VELESDB_TLS_KEY=./key.pem velesdb-server
-```
-
-**Via CLI flags**:
-
-```bash
-velesdb-server --tls-cert ./cert.pem --tls-key ./key.pem
-```
-
-**Via `velesdb.toml`**:
-
-```toml
-[tls]
-cert = "/etc/velesdb/cert.pem"
-key  = "/etc/velesdb/key.pem"
-```
-
-Both `cert` and `key` must be provided together. The server will refuse to start if only one is set or if the files do not exist.
-
-### Making Requests Over HTTPS
-
-With a self-signed certificate:
-
-```bash
-curl --cacert cert.pem https://localhost:8080/health
-```
-
-Or skip verification during development (not for production):
-
-```bash
-curl -k https://localhost:8080/health
-```
-
-## Graceful Shutdown
-
-VelesDB performs a clean shutdown when it receives **SIGINT** (Ctrl+C) or **SIGTERM** (on Unix). The shutdown sequence:
-
-1. **Stop accepting new connections** -- the listening socket is closed immediately.
-2. **Drain in-flight requests** -- the server waits up to `shutdown_timeout_secs` (default: 30 seconds) for active connections to complete.
-3. **Flush all WALs** -- every collection's Write-Ahead Log is flushed to disk, ensuring no acknowledged writes are lost.
-4. **Exit** -- the process terminates cleanly.
-
-If the drain timeout expires with connections still active, the server logs a warning and proceeds to the WAL flush.
-
-### Configuring the Drain Timeout
-
-**Via `velesdb.toml`**:
-
-```toml
-[server]
-shutdown_timeout_secs = 60
-```
-
-The default is 30 seconds, which is sufficient for most workloads.
-
-## Health & Readiness Probes
-
-### `GET /health` -- Liveness Probe
-
-Always returns `200 OK` as long as the process is running. Use this for container liveness checks.
-
-```bash
-curl http://localhost:8080/health
-```
-
-Response:
-
-```json
-{"status": "ok", "version": "4.1.0"}
-```
-
-### `GET /ready` -- Readiness Probe
-
-Returns `200 OK` once the database has finished loading all collections from disk. Returns `503 Service Unavailable` while loading.
-
-```bash
-curl http://localhost:8080/ready
-```
-
-Response (ready):
-
-```json
-{"status": "ready", "version": "4.1.0"}
-```
-
-Response (not ready):
-
-```json
-{"status": "not_ready", "version": "4.1.0"}
-```
-
-### Kubernetes Example
-
-```yaml
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 10
-
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 8080
-  initialDelaySeconds: 2
-  periodSeconds: 5
-```
-
-## Distance Metrics
-
-| Metric | API Value | Aliases | Use Case |
-|--------|-----------|---------|----------|
-| Cosine | `cosine` | | Text embeddings |
-| Euclidean | `euclidean` | | Spatial data |
-| Dot Product | `dot` | `dotproduct`, `inner`, `ip` | Pre-normalized vectors |
-| Hamming | `hamming` | | Binary vectors |
-| Jaccard | `jaccard` | | Set similarity |
-
-## Performance
-
-Numbers match the canonical contract in
-[`docs/reference/promise-contract.json`](../../docs/reference/promise-contract.json)
-(i9-14900KF, AVX2, `--release`, `target-cpu=native`):
-
-- **Cosine similarity**: ~33 ns per operation (768D)
-- **Dot product**: ~21.7 ns per operation (768D), ~35 Gelem/s
-- **HNSW search (index-only)**: ~55 µs (10K vectors, 768D, Balanced mode, k=10)
-- **End-to-end search p50**: ~450 µs (10K/384D, WAL ON, recall ≥ 96%)
-
-## Configuration Reference
-
-VelesDB loads configuration with the following priority (highest wins):
-
-**CLI flags > Environment variables > `velesdb.toml` file > Built-in defaults**
-
-A custom config file path can be specified with `--config /path/to/velesdb.toml` or `VELESDB_CONFIG`.
-
-### Environment Variables and CLI Flags
-
-| Environment Variable | CLI Flag | Default | Description |
-|---------------------|----------|---------|-------------|
-| `VELESDB_HOST` | `--host` | `127.0.0.1` | Bind address. Use `0.0.0.0` for network access. |
-| `VELESDB_PORT` | `--port` / `-p` | `8080` | Server port. |
-| `VELESDB_DATA_DIR` | `--data-dir` / `-d` | `./velesdb_data` | Data directory for persistent storage. |
-| `VELESDB_CONFIG` | `--config` / `-c` | `./velesdb.toml` | Path to TOML configuration file (optional). |
-| `VELESDB_API_KEYS` | -- | *(empty)* | Comma-separated API keys. When set, enables Bearer token auth. |
-| `VELESDB_TLS_CERT` | `--tls-cert` | *(none)* | Path to TLS certificate file (PEM). Requires `VELESDB_TLS_KEY`. |
-| `VELESDB_TLS_KEY` | `--tls-key` | *(none)* | Path to TLS private key file (PEM). Requires `VELESDB_TLS_CERT`. |
-| `RUST_LOG` | -- | `info` | Log level filter (e.g. `warn`, `info`, `debug`, `trace`). |
-| `VELESDB_NO_UPDATE_CHECK` | -- | *(unset)* | Set to `1` to disable startup update check. |
-
-### TOML Configuration File
-
-```toml
-[server]
-host = "0.0.0.0"
-port = 8080
-data_dir = "/var/lib/velesdb"
-shutdown_timeout_secs = 30
-
-[auth]
-api_keys = ["sk-prod-abc123", "sk-prod-def456"]
-
-[tls]
-cert = "/etc/velesdb/cert.pem"
-key  = "/etc/velesdb/key.pem"
-```
-
-All sections are optional; declare only what you override.
+## Operations
+
+Everything an operator configures — API keys and their rotation, TLS, the
+graceful-shutdown sequence and its WAL flush guarantee, the `/health` and
+`/ready` probes — lives in **[Server security](../../docs/guides/SERVER_SECURITY.md)**,
+which is the canonical reference and covers each of them in more depth than a
+README should.
+
+Docker, Kubernetes manifests, rate limiting, CORS and the startup update check
+are in **[Deployment](../../docs/guides/SERVER_DEPLOYMENT.md)**.
+
+The short version:
+
+| Concern | Set | Default |
+|---|---|---|
+| API keys | `VELESDB_API_KEYS`, or `api_keys` in `velesdb.toml` | none — the server runs in local dev mode and accepts every request |
+| TLS | `VELESDB_TLS_CERT` / `VELESDB_TLS_KEY`, or `--tls-cert` / `--tls-key` | off (plain HTTP) |
+| Data directory | `VELESDB_DATA_DIR` | `./data` |
+| Bind address | `VELESDB_HOST` / `VELESDB_PORT` | `127.0.0.1:8080` |
+| Config file | `VELESDB_CONFIG` or `--config` | `./velesdb.toml` if present |
+
+Configuration priority, highest first: **CLI flags > environment variables >
+`velesdb.toml` > built-in defaults**. Every section of the file is optional;
+declare only what you override.
+
+Distance metrics accepted by the API (`cosine`, `euclidean`, `dot` — aliases
+`dotproduct`, `inner`, `ip` —, `hamming`, `jaccard`) are listed with their use
+cases in the [REST tour](../../docs/guides/SERVER_REST_TOUR.md); measured
+latency figures live in the [benchmarks](../../docs/BENCHMARKS.md), pinned to
+[`promise-contract.json`](../../docs/reference/promise-contract.json).
 
 ## Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ Detailed guides for using VelesDB features. **[Full guides index →](./guides/R
 | [Write Concurrency](./guides/WRITE_CONCURRENCY.md) | Single-writer-per-collection model, batching patterns, Enterprise tier |
 | [Use Cases](./guides/USE_CASES.md) | Common use cases and recommended configurations |
 | [Migration v1.6](./guides/MIGRATION_v1.6.md) / [v1.7](./guides/MIGRATION_v1.7.md) | Version migration guides |
+| [Migration v3.3.0](./guides/MIGRATION_v3.3.0.md) | Error codes, REST statuses and query results that changed in 3.3.0. |
+| [Migration v4.0.0](./guides/MIGRATION_v4.0.0.md) | The 4.0.0 breaking changes — start with the WASM `weighted` reordering, which is silent. |
 | [Troubleshooting](./NEW_USER_TROUBLESHOOTING.md) | Solutions for common issues new users encounter |
 
 ### API reference, per binding
@@ -154,6 +156,7 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 | [GPU acceleration](./GPU_ACCELERATION.md) | What the `gpu` feature accelerates, and what it does not. |
 | [ANN state-of-the-art audit](./ANN_SOTA_AUDIT.md) | How the index compares to published ANN work. |
 | [Core wiring debt](./CORE_WIRING_DEBT.md) | Known gaps between what core exposes and what the surfaces use. |
+| [Core / Premium split](./CORE_PREMIUM_SPLIT.md) | Where the open-core boundary sits, and the contract both repos read identically. |
 
 ---
 

--- a/docs/guides/MIGRATION_v4.0.0.md
+++ b/docs/guides/MIGRATION_v4.0.0.md
@@ -1,0 +1,130 @@
+# Migrating to VelesDB 4.0.0
+
+VelesDB 4.0.0 is a **hardening + API-cleanup** release. Most of it is additive,
+but it is versioned **4.0.0 (MAJOR)** because of one removed Rust core API and
+several client-observable changes.
+
+Read this in order: **section 1 changes your results with no error at all**,
+which is the only failure mode you cannot discover by watching your logs.
+
+---
+
+## 1. WASM `weighted` fusion returns a different order (silent)
+
+`multi_query_search(..., strategy: "weighted")` in `velesdb-wasm` used to
+hardcode a non-overridable `avg=0.5, max=0.3, hit=0.2` split. It now uses the
+canonical `0.6 / 0.3 / 0.1` weights shared with core, the Python bindings and
+the `velesdb_common` fusion builder.
+
+**This reorders results** for every WASM caller that did not pass explicit
+weights. Nothing errors; the ranking simply changes.
+
+*Migration* — pick one:
+
+```js
+// (a) Keep the old ranking exactly: pass the previous split explicitly.
+store.multi_query_search(queries, {
+  strategy: "weighted",
+  weights: { avg: 0.5, max: 0.3, hit: 0.2 },
+});
+
+// (b) Adopt the canonical weights (recommended — consistent across surfaces).
+store.multi_query_search(queries, { strategy: "weighted" });
+```
+
+If you have recall or ordering assertions in tests, re-baseline them.
+Full note: `crates/velesdb-wasm/CHANGELOG.md`.
+
+---
+
+## 2. `AnyCollection::into_vector_facade` is removed (Rust core API)
+
+The facade coerced *any* variant into a `VectorCollection`, so the kind a
+caller captured could diverge from the collection's real kind.
+
+```rust
+// Before (3.11–3.12)
+let vectors = any.into_vector_facade();
+
+// After — variant-checked, returns Err(self) when it is not a vector collection
+let vectors = any.into_vector()?;
+```
+
+`into_vector()` returns `Err(self)` instead of silently coercing, so handle
+the error branch rather than unwrapping it.
+
+---
+
+## 3. Metadata is now size-capped at 64 KiB
+
+Caller-supplied `metadata` on `remember` / `remember_with_ttl`, and
+per-fragment metadata in the context compiler, were unbounded — an arbitrarily
+large JSON blob could be persisted as a DoS vector.
+
+`MAX_METADATA_BYTES` (64 KiB) is now enforced on **every** adapter (MCP,
+Python, Node, WASM) and returns a typed `MemoryError::MetadataTooLarge`.
+
+*Migration*: keep metadata to identifiers and facets — project, author, type,
+status, dates. If you were embedding documents or payloads in metadata, store
+them as the fact itself, or as a context-compiler source, and keep metadata for
+what you filter on.
+
+---
+
+## 4. `save_working_context` capped at 1 MiB, `load_working_context` stricter
+
+`save_working_context` is now bounded by the existing `MAX_FACT_BYTES` ceiling
+(1 MiB). A larger working context is rejected rather than persisted.
+
+`load_working_context` now **verifies the reserved system marker** before
+returning a stored context. A slot squatted by an unrelated fact yields `None`
+instead of that foreign fact being served back as your session state.
+
+*Migration*: if a load that used to return something now returns `None`, the
+slot was never a genuine working context. Re-save it once and it behaves
+normally. Note that `found: false` is not an error — check `other_sessions` in
+the response for a near-miss on the session id.
+
+---
+
+## 5. Missing graph-edge endpoint: one error code in both schema modes
+
+`add_edge` / `add_edges_batch` reject an edge whose `source` or `target` has no
+stored node payload. Until now the *error* depended on the schema mode:
+
+| Schema mode | Before | After |
+|---|---|---|
+| Schemaless | `Error::NodeNotFound` — `VELES-022`, REST `404` | unchanged |
+| **Strict** | `Error::SchemaValidation` — `VELES-017`, REST `400` | **`Error::NodeNotFound` — `VELES-022`, REST `404`** |
+
+*Migration*: if you match on `VELES-017` or on REST `400` to detect a missing
+edge endpoint under a strict schema, match `VELES-022` / `404` instead. The
+same condition now reports the same way regardless of schema mode.
+
+---
+
+## 6. `MemoryError::SegmentationError` replaces a misleading variant
+
+A forced `segmentation.format: "jsonl"` that failed to parse used to surface as
+`MemoryError::ContextOverLimit` — an "over limit" prefix on what is really a
+format/parsing failure, not a budget breach. It is now a dedicated
+`MemoryError::SegmentationError`.
+
+Both remain in the same `INVALID_PARAMS` MCP category (same JSON-RPC code), so
+only code matching on the **variant or the message** is affected.
+
+---
+
+## Upgrading
+
+No data-format or storage migration is required — 4.0.0 reads 3.x databases
+unchanged. Update your dependency pin (crate `velesdb-core`,
+`@wiscale/velesdb-sdk` / `@wiscale/velesdb-wasm`, PyPI `velesdb`) to `4.x`,
+then review sections 1–6 against your client code.
+
+Start with section 1: it is the only change that alters behavior without
+raising anything.
+
+---
+
+Last updated: 2026-07-27 · Applies to: velesdb-core 4.1.0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# VelesDB - Git Hooks Setup (Linux / macOS)
+# =============================================================================
+# Point git at the project's hooks so pre-commit and pre-push validation runs
+# locally, before CI has to say no.
+#
+# Usage: ./scripts/setup-hooks.sh
+#
+# The Windows equivalent is scripts/setup-hooks.ps1. Both do the same thing;
+# this one additionally restores the executable bit, which a fresh clone can
+# lose (zip download, `core.fileMode=false`, some CI checkouts) and which git
+# silently ignores — an un-executable hook does not fail, it just never runs.
+# =============================================================================
+
+set -euo pipefail
+
+BLUE=$'\033[0;34m'; CYAN=$'\033[0;36m'; GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'; RED=$'\033[0;31m'; RESET=$'\033[0m'
+
+# Run from the repository root whatever directory the user invoked this from.
+cd "$(git rev-parse --show-toplevel)"
+
+printf '\n%s\n' "${BLUE}═══════════════════════════════════════════════════════════════════${RESET}"
+printf '%s\n'   "${BLUE}  VelesDB - Git Hooks Setup${RESET}"
+printf '%s\n\n' "${BLUE}═══════════════════════════════════════════════════════════════════${RESET}"
+
+if [ ! -d .githooks ]; then
+  printf '%s\n' "${RED}❌ .githooks/ not found — are you in the VelesDB repository?${RESET}"
+  exit 1
+fi
+
+printf '%s\n' "${CYAN}📋 Configuring git hooks path...${RESET}"
+git config core.hooksPath .githooks
+
+configured=$(git config --get core.hooksPath || true)
+if [ "$configured" != ".githooks" ]; then
+  printf '%s\n' "${RED}❌ Failed to configure git hooks (core.hooksPath is '${configured}')${RESET}"
+  exit 1
+fi
+
+printf '%s\n\n' "${GREEN}✅ Git hooks configured — hooks directory: .githooks/${RESET}"
+
+# Restore the executable bit where it is missing. git records it, but a
+# checkout with core.fileMode=false (or an archive extraction) can drop it.
+restored=0
+for hook in .githooks/*; do
+  [ -f "$hook" ] || continue
+  if [ ! -x "$hook" ]; then
+    chmod +x "$hook"
+    restored=$((restored + 1))
+  fi
+done
+if [ "$restored" -gt 0 ]; then
+  printf '%s\n\n' "${YELLOW}🔧 Restored the executable bit on ${restored} hook(s).${RESET}"
+fi
+
+printf '%s\n' "${CYAN}📌 Active hooks:${RESET}"
+declare -a described=()
+[ -f .githooks/commit-msg ] && described+=("   - commit-msg  : rejects AI-attributed authors and AI attribution trailers")
+[ -f .githooks/pre-commit ] && described+=("   - pre-commit  : validates the change before each commit")
+[ -f .githooks/pre-push ]   && described+=("   - pre-push    : full local validation before pushing to origin")
+if [ ${#described[@]} -eq 0 ]; then
+  printf '%s\n' "${RED}   (none found in .githooks/ — nothing will run)${RESET}"
+  exit 1
+fi
+printf '%s\n' "${described[@]}"
+
+printf '\n%s\n' "${YELLOW}💡 Workflow:${RESET}"
+printf '%s\n' "   1. Make your changes"
+printf '%s\n' "   2. git commit -m '...'      # commit-msg + pre-commit run"
+printf '%s\n' "   3. git push origin <branch> # pre-push runs the full local gate"
+
+printf '\n%s\n\n' "${BLUE}═══════════════════════════════════════════════════════════════════${RESET}"


### PR DESCRIPTION
Closes #1628 — **P1** du plan de session.

## Le problème

`docs/guides/` portait `MIGRATION_v1.6`, `v1.7` et `v3.3.0`. **Rien pour 4.0.0**, alors que le workspace est déjà en 4.1.0. Une majeure est passée sans notice, en rompant le précédent que 3.3.0 avait établi.

## Six ruptures, ordonnées par risque réel

Chacune vérifiée contre la section 4.0.0 du CHANGELOG, pas reprise de l'énoncé de l'issue — l'issue en citait trois, il y en avait six.

L'ordre du guide n'est pas celui du CHANGELOG : **la rupture silencieuse passe en premier**, parce que c'est la seule qu'un utilisateur ne peut pas découvrir en lisant ses logs.

| # | Rupture | Surface |
|---|---|---|
| **1** | `multi_query_search(strategy: "weighted")` — poids `0.5/0.3/0.2` → `0.6/0.3/0.1`. **Résultats réordonnés, aucune erreur levée.** | WASM |
| 2 | `AnyCollection::into_vector_facade` retiré → `into_vector()` (renvoie `Err(self)` au lieu de coercer) | Rust core |
| 3 | Cap métadonnées 64 KiB (`MAX_METADATA_BYTES`, `MetadataTooLarge`) | MCP, Python, Node, WASM |
| 4 | `save_working_context` plafonné à 1 MiB ; `load_working_context` vérifie le marqueur système | velesdb-memory |
| 5 | Arête manquante : `VELES-017`/`400` → `VELES-022`/`404` en schéma strict | core, REST |
| 6 | `MemoryError::SegmentationError` remplace un `ContextOverLimit` trompeur | contexte |

Pour la n°1, le guide donne les deux issues : figer les anciens poids explicitement, ou adopter les canoniques.

## Une ligne principale rouge réparée au passage

En lançant les gates j'ai trouvé **develop rouge** sur les guards `index` et `stamp` : `docs/CORE_PREMIUM_SPLIT.md` n'était ni indexé ni daté. Sans rapport avec l'issue, mais une ligne principale rouge bloque tout le monde.

J'ai vérifié sur un **develop nu** avant de conclure que ce n'était pas mon changement — la mesure contre la base, pas la présomption.

## Vérification

Chaque gate lancé séparément et sans pipe, **après** le dernier changement :

`check-doc-freshness` (`index`, `stamp`, `versions`), `check-feature-claims`, `check-promise-contract`, `check-doc-contract`, `check-version-sync` — **tous EXIT 0**.