### PR TITLE
fix(memory): chercher la config à côté du store effectif, pas du défaut

### DIFF
--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -234,6 +234,11 @@ name = "http_insecure_process"
 path = "tests/http_insecure_process.rs"
 required-features = ["http"]
 
+[[test]]
+name = "config_store_path_process"
+path = "tests/config_store_path_process.rs"
+required-features = ["http"]
+
 [[example]]
 name = "multihop"
 path = "examples/multihop/main.rs"

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -496,9 +496,15 @@ fn apply_config_file(args: &[String]) -> Result<(), Box<dyn std::error::Error>> 
         .position(|arg| arg == "--config")
         .and_then(|at| args.get(at + 1))
         .map(String::as_str);
-    let default_dir = default_store_path();
+    // The EFFECTIVE store, not the default one. `VELESDB_MEMORY_PATH` moves the
+    // store, and the config file lives beside it — looking it up in the default
+    // directory instead means a caller who moved the store silently reads a
+    // config from a store they are not using. That is how a test spawning this
+    // binary with its own scratch store picked up the developer's personal
+    // `~/.velesdb-memory/velesdb-memory.toml`.
+    let store_dir = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
     let Some(path) =
-        velesdb_memory::config::resolve_path(explicit, Some(std::path::Path::new(&default_dir)))
+        velesdb_memory::config::resolve_path(explicit, Some(std::path::Path::new(&store_dir)))
     else {
         return Ok(());
     };

--- a/crates/velesdb-memory/tests/config_store_path_process.rs
+++ b/crates/velesdb-memory/tests/config_store_path_process.rs
@@ -1,0 +1,101 @@
+//! The config file is looked up beside the **effective** store, not the
+//! default one.
+//!
+//! `VELESDB_MEMORY_PATH` moves the store, and `velesdb-memory.toml` lives
+//! beside it. Resolving it against the default directory instead means a
+//! caller who moved the store silently reads the config of a store they are
+//! not using — and, on a developer machine, picks up a personal
+//! `~/.velesdb-memory/velesdb-memory.toml` in the middle of a test run.
+//!
+//! Spawns the real binary: the lookup happens in `main`, before any library
+//! entry point, so nothing below the process boundary can observe it.
+
+use std::io::Read;
+use std::net::TcpListener as StdTcpListener;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_velesdb-memory")
+}
+
+/// A port the OS just confirmed free. Bound and released, so the daemon can
+/// take it — the usual small race is acceptable in a test.
+fn pick_free_port() -> u16 {
+    StdTcpListener::bind("127.0.0.1:0")
+        .expect("bind an ephemeral port")
+        .local_addr()
+        .expect("read the bound address")
+        .port()
+}
+
+/// Kills the child on the way out, whatever the test does — no daemon is left
+/// running behind a failed assertion.
+struct ChildGuard(Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Start the daemon against `store`, let it get past its config load, and
+/// return whatever it printed on stderr.
+fn startup_stderr(store: &std::path::Path) -> String {
+    let mut child = Command::new(binary_path())
+        .arg("--http")
+        .arg("--http-insecure")
+        .arg("--http-port")
+        .arg(pick_free_port().to_string())
+        .env("VELESDB_MEMORY_PATH", store)
+        .env_remove("VELESDB_MEMORY_CONFIG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn velesdb-memory");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+    let mut guard = ChildGuard(child);
+
+    std::thread::sleep(Duration::from_secs(2));
+    let _ = guard.0.kill();
+    let _ = guard.0.wait();
+
+    let mut out = String::new();
+    let _ = stderr.read_to_string(&mut out);
+    out
+}
+
+#[test]
+fn a_config_beside_the_moved_store_is_the_one_that_is_read() {
+    let store = tempfile::tempdir().expect("scratch store");
+    // A setting that is inert on its own, so the test observes the *lookup*
+    // rather than a behaviour change: the banner names the file it loaded.
+    std::fs::write(
+        store.path().join("velesdb-memory.toml"),
+        "[http]\nmax_sessions = 7\n",
+    )
+    .expect("write the scratch config");
+
+    let stderr = startup_stderr(store.path());
+
+    let expected = store.path().join("velesdb-memory.toml");
+    assert!(
+        stderr.contains(&expected.display().to_string()),
+        "the config beside the moved store must be the one loaded; \
+         stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn no_config_beside_the_moved_store_loads_nothing() {
+    let store = tempfile::tempdir().expect("scratch store");
+
+    let stderr = startup_stderr(store.path());
+
+    assert!(
+        !stderr.contains("setting(s) from"),
+        "an empty store must load no config at all — not the default store's; \
+         stderr was: {stderr}"
+    );
+}


### PR DESCRIPTION
Défaut trouvé **par un test**, pas par relecture — et il vient de la fonctionnalité de config livrée dans #1627.

## Le bug

`apply_config_file` résolvait le fichier de configuration contre `default_store_path()`, **sans regarder `VELESDB_MEMORY_PATH`**. Déplacer le store laissait donc le démon lire la config d'un store qu'il n'utilise pas — en silence, puisque rien ne signale qu'on a chargé le mauvais fichier.

## Comment il s'est manifesté

`http_insecure_flag_serves_plain_http` échouait sur ma machine :

```
Error: "autograph is on ... but no extraction backend is configured"
```

…alors que ce test **isole pourtant son store** dans un dossier temporaire. Le démon lisait mon `~/.velesdb-memory/velesdb-memory.toml` personnel, où `autograph` est activé, sans hériter de l'extracteur que launchd fournit au démon de service.

**Un fichier de config sur le poste d'un développeur cassait la suite de tests du dépôt.**

C'est précisément le défaut que la doc de `resolve_path` décrit pourtant correctement — « le répertoire du store est consulté avant le répertoire courant, parce que le répertoire de travail d'un démon est celui que launchd lui a donné ». Le store en question doit être l'**effectif**.

## Vérification

Deux tests de régression, **prouvés rouges** avant le correctif. Le message d'échec montre le bug littéralement :

```
the config beside the moved store must be the one loaded; stderr was:
velesdb-memory: 1 setting(s) from /Users/julien/.velesdb-memory/velesdb-memory.toml
```

Ils lancent le vrai binaire : la résolution se fait dans `main`, avant tout point d'entrée de bibliothèque, donc rien sous la frontière de processus ne peut l'observer. Mon premier jet passait par `--version`, qui sort **avant** le chargement de la config — corrigé après l'avoir vu échouer.

23 suites vertes, clippy pedantic à 0.

## Flake signalé, pas modifié

`expired_fact_is_no_longer_recalled` (`ttl_bdd`) a échoué une fois pendant le run complet, et passe **deux fois de suite en isolation**, sur cette branche comme sur `develop`. Test sensible au temps, mis en défaut par la charge de mes propres démons de test — même famille que le test HNSW gradué de #1632. Signalé ici plutôt que corrigé à l'aveugle.