### PR TITLE
fix(memory): forget ramasse les entités que plus aucun fait ne mentionne

### DIFF
--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -915,8 +915,60 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Returns [`MemoryError`] if the existence check or the deletion fails.
     pub fn forget(&self, fact_id: u64) -> Result<bool, MemoryError> {
         let found = self.store.get(fact_id)?.is_some();
+        // Read the fact's hubs BEFORE the delete: afterwards its edges are gone
+        // and there is no way back to the entities it created.
+        let hubs = self.hubs_linked_from(fact_id)?;
         self.store.delete(fact_id)?;
+        self.collect_orphan_hubs(&hubs)?;
         Ok(found)
+    }
+
+    /// The entity hubs `fact_id` points at.
+    ///
+    /// Hubs are recognised by the reserved [`HUB_FIELD`] marker rather than by
+    /// the edge label, so a caller's own `relate` to a hub is seen too.
+    fn hubs_linked_from(&self, fact_id: u64) -> Result<Vec<u64>, MemoryError> {
+        let mut hubs = Vec::new();
+        for edge in self.store.relations(fact_id)? {
+            if self.is_hub(edge.to)? {
+                hubs.push(edge.to);
+            }
+        }
+        Ok(hubs)
+    }
+
+    /// Delete every hub in `hubs` that no surviving fact mentions any more.
+    ///
+    /// An entity outlives the fact that introduced it as long as another fact
+    /// still refers to it — forgetting "Axel is 15" must not erase Axel while
+    /// "Axel has a sister" is still stored. Only a hub whose every `mentions`
+    /// target is gone is itself removed, so entities do not accumulate as
+    /// unreachable scaffolding once the facts behind them are retracted.
+    fn collect_orphan_hubs(&self, hubs: &[u64]) -> Result<(), MemoryError> {
+        for &hub in hubs {
+            if !self.hub_still_mentioned(hub)? {
+                self.store.delete(hub)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether `hub` still points at a fact that exists.
+    fn hub_still_mentioned(&self, hub: u64) -> Result<bool, MemoryError> {
+        for edge in self.store.relations(hub)? {
+            if edge.relation == MENTIONS_RELATION && self.store.get(edge.to)?.is_some() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Whether `id` is an entity hub (carries the reserved [`HUB_FIELD`]).
+    fn is_hub(&self, id: u64) -> Result<bool, MemoryError> {
+        Ok(self
+            .store
+            .get_metadata(id)?
+            .is_some_and(|meta| meta.contains_key(HUB_FIELD)))
     }
 
     /// Explain a `decision`: find the best-matching memory (optionally scoped to

--- a/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
+++ b/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
@@ -1,0 +1,113 @@
+//! BDD integration tests for the entity-hub garbage collection `forget` runs.
+//!
+//! An entity hub is scaffolding the memory builds on its own. Before this, it
+//! outlived every fact that created it: retracting a fact left its entities
+//! behind for good, so the graph accumulated nodes nothing could reach. These
+//! tests pin both halves of the contract — the orphan goes, the entity another
+//! fact still needs stays.
+//!
+//! Categories: Nominal, Edge, Negative.
+
+mod common;
+
+use common::service;
+use velesdb_memory::extract::{ExtractError, ExtractedFact, Extractor};
+
+/// Two facts sharing the topic `rust`; only the first mentions `parser`.
+/// Forgetting the first must therefore collect `parser` and keep `rust`.
+struct SharedTopicExtractor;
+
+impl Extractor for SharedTopicExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![
+            ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_string(),
+                entities: vec!["rust".to_string(), "parser".to_string()],
+            },
+            ExtractedFact {
+                text: "Bob maintains the Rust toolchain.".to_string(),
+                entities: vec!["rust".to_string()],
+            },
+        ])
+    }
+}
+
+#[test]
+fn forget_collects_a_hub_no_surviving_fact_mentions() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &SharedTopicExtractor, None)
+        .expect("remember_extracted");
+
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile")
+            .is_some(),
+        "precondition: the hub must exist before the fact is forgotten"
+    );
+
+    svc.forget(ids[0])
+        .expect("forget the only fact citing parser");
+
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile after forget")
+            .is_none(),
+        "a hub no surviving fact mentions must not outlive it"
+    );
+}
+
+#[test]
+fn forget_keeps_a_hub_another_fact_still_mentions() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &SharedTopicExtractor, None)
+        .expect("remember_extracted");
+
+    svc.forget(ids[0]).expect("forget the first fact");
+
+    assert!(
+        svc.entity_profile("rust")
+            .expect("entity_profile after forget")
+            .is_some(),
+        "an entity a surviving fact still refers to must be kept — forgetting \
+         one fact about it is not forgetting the entity"
+    );
+}
+
+#[test]
+fn forgetting_every_fact_leaves_no_hub_behind() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &SharedTopicExtractor, None)
+        .expect("remember_extracted");
+
+    for id in ids {
+        svc.forget(id).expect("forget");
+    }
+
+    for entity in ["rust", "parser"] {
+        assert!(
+            svc.entity_profile(entity)
+                .expect("entity_profile after forgetting everything")
+                .is_none(),
+            "no hub may survive once every fact behind it is retracted ({entity})"
+        );
+    }
+}
+
+#[test]
+fn forget_on_a_plain_fact_without_hubs_still_reports_found() {
+    let (_dir, svc) = service();
+    let id = svc
+        .remember("a fact that created no entity", &[], None)
+        .expect("remember");
+
+    let found = svc.forget(id).expect("forget");
+
+    assert!(
+        found,
+        "hub collection must not change the found contract for a fact that \
+         never created a hub"
+    );
+}


### PR DESCRIPTION
**P3a** du plan de session.

## Le problème

Supprimer un fait laissait derrière lui les entités qu'il avait créées. Le graphe accumulait des nœuds que rien ne pouvait atteindre, et une rétractation était **incomplète en silence**.

Vérifié en direct : après avoir oublié deux faits de test, les entités correspondantes existaient toujours, avec leurs attributs et leurs arêtes.

## Le correctif

`forget` lit les hubs du fait **avant** de le supprimer — après, ses arêtes ont disparu et il n'y a plus de chemin vers eux — puis retire ceux qu'aucun fait survivant ne mentionne.

La règle est délibérément conservatrice : **une entité survit tant qu'un autre fait s'y réfère**. Oublier « Axel a 15 ans » ne doit pas effacer Axel tant que « Axel a une sœur » est stocké.

Les hubs sont reconnus par le marqueur réservé, pas par le libellé d'arête, pour qu'un `relate` posé par un appelant vers un hub compte aussi.

## Vérification — quatre tests, dont deux prouvés rouges

| Test | Sans le correctif |
|---|---|
| `forget_collects_a_hub_no_surviving_fact_mentions` | **ÉCHOUE** — « a hub no surviving fact mentions must not outlive it » |
| `forgetting_every_fact_leaves_no_hub_behind` | **ÉCHOUE** |
| `forget_keeps_a_hub_another_fact_still_mentions` | passe déjà — garde-fou contre une suppression trop zélée |
| `forget_on_a_plain_fact_without_hubs_still_reports_found` | passe déjà — garde-fou sur le contrat `found` |

Les deux derniers doivent passer **dans les deux états** : ils protègent contre la sur-correction.