### PR TITLE
fix(memory): borner le prédicat de l'autographe, et exiger l'arête

### DIFF
--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -487,10 +487,17 @@ For each, list 1-4 key TOPICS it concerns, as short canonical lowercase noun \
 phrases, so the same topic recurs as the SAME tag across passages.\n\n\
 2. \"relations\": every explicit relationship BETWEEN TWO NAMED ENTITIES, as \
 subject/predicate/object triples. Use the entity's full name, lowercase \
-(e.g. \"julien lange\"). Give the predicate in the passage's own language, as a \
-short lowercase label (e.g. \"pere de\", \"soeur de\", \"works at\"). State the \
-triple in the direction the passage states it, and add the converse ONLY if the \
-passage states it too.\n\n\
+(e.g. \"julien lange\").\n\
+The predicate is a LABEL, not a sentence: **at most 3 words**, lowercase, in \
+the passage's own language (e.g. \"pere de\", \"soeur de\", \"works at\", \
+\"moteur de recherche\"). NEVER restate the sentence — write \"surveille les \
+fuites\", not \"est utilise pour la surveillance de fuites de donnees\". If you \
+cannot say it in 3 words, pick the closest short label.\n\
+State the triple in the direction the passage states it, and add the converse \
+ONLY if the passage states it too.\n\
+Every named entity the passage RELATES to another must appear in at least one \
+triple — an entity that only receives attributes and no edge is a dead end in \
+the graph.\n\n\
 3. \"attributes\": every property a named entity HAS, as entity/key/value. Use \
 short lowercase keys (\"age\", \"ville\", \"employeur\"). Emit numbers as JSON \
 NUMBERS, never strings: 15, not \"15\". Omit anything the passage does not state.\n\n\
@@ -693,6 +700,29 @@ mod tests {
         let prompt = build_prompt("Alice adopted a dog in 2021.");
         assert!(prompt.contains("Alice adopted a dog in 2021."));
         assert!(prompt.contains("\"fact\": string"));
+    }
+
+    /// The graph prompt has to bound the predicate explicitly. Asking for "a
+    /// short label" was not enough: on real content the model answered
+    /// "est utilise pour la surveillance de fuites de donnees" — a restated
+    /// sentence, which makes the edge unreadable in `entity()`.
+    #[test]
+    fn graph_prompt_bounds_the_predicate_and_demands_edges() {
+        let prompt = build_graph_prompt("Ahmia is an onion search engine.");
+        assert!(prompt.contains("Ahmia is an onion search engine."));
+        assert!(
+            prompt.contains("at most 3 words"),
+            "the predicate length must be a hard bound, not a suggestion"
+        );
+        assert!(
+            prompt.contains("NEVER restate the sentence"),
+            "the counter-example is what stops a restated sentence"
+        );
+        assert!(
+            prompt.contains("at least one triple"),
+            "an entity with attributes but no edge is a dead end — the prompt \
+             must ask for the edge"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**P3b** du plan de session. Deux défauts constatés **sur du contenu réel**, pas en test bouchonné.

## Les défauts

Le prompt demandait « une étiquette courte » sans contrainte dure, et le modèle répondait par des phrases : `est utilisé pour la surveillance de fuites de données` comme prédicat d'arête — illisible dans `entity()`.

Et une entité pouvait recevoir ses attributs **sans aucune arête** : `torcrawl.py` se retrouvait en cul-de-sac dans le graphe, joignable par personne.

## Le correctif

Le prompt pose maintenant une limite explicite (**au plus 3 mots**), un **contre-exemple tiré du défaut observé**, et la règle qu'une entité que le passage met en relation doit apparaître dans au moins un triplet.

## Mesure — même contenu, même modèle (`qwen3.6:35b-mlx`)

| Entité | Avant | Après |
|---|---|---|
| `dehashed` | « est utilisé pour la surveillance de fuites de données » — **9 mots** | « surveille fuites sur » — **3 mots** |
| `ahmia` | « est un moteur de recherche onion » — **6 mots** | « est type de » — **3 mots** |
| `torcrawl.py` | **aucune arête** | **1 arête** — « sert au crawl de » |

## Deux nuances que je ne cache pas

**La limite est une consigne, pas une contrainte de code.** Un prédicat est sorti à 4 mots. La faire respecter par rejet coûterait l'arête entière — pire qu'un libellé un peu long. Rien n'est donc rejeté.

**La concision se paie en précision.** « est type de » dit moins que « est un moteur de recherche onion ». Le compromis est assumé : un graphe se lit par ses arêtes courtes, et l'information détaillée reste dans le fait lui-même.

Test unitaire sur le contrat du prompt (bornes et exigence d'arête), pour qu'un futur allègement du texte se voie.