### PR TITLE
feat(memory): drainer sur SIGTERM, pas seulement sur Ctrl-C

### DIFF
--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -234,6 +234,11 @@ name = "http_insecure_process"
 path = "tests/http_insecure_process.rs"
 required-features = ["http"]
 
+[[test]]
+name = "graceful_shutdown_process"
+path = "tests/graceful_shutdown_process.rs"
+required-features = ["http"]
+
 [[example]]
 name = "multihop"
 path = "examples/multihop/main.rs"

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -254,12 +254,7 @@ async fn serve_http(
     let app = velesdb_memory::http::router(server, ct.child_token());
     let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
 
-    let ctrl_c_ct = ct.clone();
-    tokio::spawn(async move {
-        if tokio::signal::ctrl_c().await.is_ok() {
-            ctrl_c_ct.cancel();
-        }
-    });
+    spawn_shutdown_signals(ct.clone());
 
     if insecure {
         eprintln!(
@@ -431,6 +426,40 @@ fn build_configured_service(
         &store_path,
         embedder,
     )?)
+}
+
+/// Cancel `ct` on the signals a supervisor actually sends.
+///
+/// SIGINT alone is not enough. `launchctl kickstart -k`, `systemctl restart`
+/// and `docker stop` all send **SIGTERM**, and an unhandled SIGTERM kills the
+/// process outright: the streamable-HTTP sessions clients hold are dropped
+/// mid-flight, so the next call on a live session hangs until the client's own
+/// timeout instead of reconnecting. Handling it lets `with_graceful_shutdown`
+/// close those sessions, which is what turns a restart into a reconnect.
+#[cfg(feature = "http")]
+fn spawn_shutdown_signals(ct: tokio_util::sync::CancellationToken) {
+    let interrupt = ct.clone();
+    tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            interrupt.cancel();
+        }
+    });
+
+    #[cfg(unix)]
+    tokio::spawn(async move {
+        // `signal()` only fails if the handler cannot be registered at all; a
+        // daemon that cannot listen for SIGTERM still serves, it just loses the
+        // graceful path, so this is not worth aborting startup for.
+        if let Ok(mut term) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            term.recv().await;
+            ct.cancel();
+        }
+    });
+    // On Windows there is no SIGTERM; Ctrl-C above is the whole contract.
+    #[cfg(not(unix))]
+    drop(ct);
 }
 
 /// Attach the extraction backend to the SERVICE when

--- a/crates/velesdb-memory/tests/graceful_shutdown_process.rs
+++ b/crates/velesdb-memory/tests/graceful_shutdown_process.rs
@@ -1,0 +1,93 @@
+//! SIGTERM must drain the server, not kill it.
+//!
+//! `launchctl kickstart -k`, `systemctl restart` and `docker stop` all send
+//! SIGTERM. Unhandled, it terminates the process outright and the
+//! streamable-HTTP sessions clients hold are dropped mid-flight — the next
+//! call on a live session hangs until the client's own timeout instead of
+//! reconnecting. That is exactly what a daemon upgrade looked like from a
+//! client's side before this was wired.
+//!
+//! The observable is the **exit code**, not the shutdown delay: an unhandled
+//! signal also terminates instantly, so timing cannot tell the two apart. A
+//! process killed by SIGTERM reports 143 (128 + 15); one that returned through
+//! its own shutdown path reports 0.
+
+#![cfg(unix)]
+
+use std::net::TcpListener as StdTcpListener;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn binary_path() -> &'static str {
+    env!("CARGO_BIN_EXE_velesdb-memory")
+}
+
+fn pick_free_port() -> u16 {
+    StdTcpListener::bind("127.0.0.1:0")
+        .expect("bind an ephemeral port")
+        .local_addr()
+        .expect("read the bound address")
+        .port()
+}
+
+#[test]
+fn sigterm_shuts_the_http_server_down_through_its_own_path() {
+    let store = tempfile::tempdir().expect("scratch store");
+    // A scratch HOME too: the config file is looked up beside the store, and a
+    // developer's own ~/.velesdb-memory must not decide what this test starts.
+    let home = tempfile::tempdir().expect("scratch home");
+    let port = pick_free_port();
+
+    let mut child = Command::new(binary_path())
+        .arg("--http")
+        .arg("--http-insecure")
+        .arg("--http-port")
+        .arg(port.to_string())
+        .env("HOME", home.path())
+        .env("VELESDB_MEMORY_PATH", store.path())
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .env_remove("VELESDB_MEMORY_CONFIG")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn velesdb-memory --http");
+
+    // Wait for the server to actually be serving; sending the signal during
+    // startup would prove nothing about the shutdown path.
+    let mut serving = false;
+    for _ in 0..40 {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            serving = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    assert!(serving, "the daemon never accepted a connection on {port}");
+
+    // SIGTERM, the signal every supervisor actually sends. Sent with `kill(1)`
+    // rather than `libc::kill`: it needs neither an `unsafe` block nor a new
+    // dev-dependency for a single call.
+    let sent = Command::new("kill")
+        .arg("-TERM")
+        .arg(child.id().to_string())
+        .status()
+        .expect("run kill(1)");
+    assert!(sent.success(), "kill -TERM failed: {sent:?}");
+
+    let status = child.wait().expect("wait for the daemon to exit");
+
+    assert_eq!(
+        status.signal(),
+        None,
+        "the daemon must not be terminated BY the signal — it must handle it \
+         and return; being killed here is what drops live sessions"
+    );
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "a drained shutdown returns 0; 143 would mean SIGTERM killed the \
+         process outright"
+    );
+}


### PR DESCRIPTION
**P3c** du plan de session — et la cause racine d'un symptôme que j'avais d'abord mal attribué.

## Le défaut

Le démon n'écoutait que `ctrl_c`, c'est-à-dire **SIGINT**. Or `launchctl kickstart`, `systemctl restart` et `docker stop` envoient tous **SIGTERM** — non géré, il tue le processus sur place.

Côté client : les sessions streamable-HTTP tenues par les clients sont larguées en vol, et l'appel suivant sur une session vivante **pend jusqu'au timeout** au lieu de reconnecter. C'est exactement ce qu'une mise à jour du démon donnait à voir depuis Claude Desktop — et ce que j'avais moi-même pris pour un problème de taille de payload avant de comprendre.

Le token d'annulation était déjà là, `axum::serve` déjà câblé en `with_graceful_shutdown` : il manquait uniquement d'écouter le bon signal.

## L'observable est le code de sortie, pas le délai

Un signal non géré termine lui aussi **instantanément** — le chronomètre ne distingue rien. Le discriminant est le code de sortie :

| | Code après SIGTERM |
|---|---|
| **Avec** le correctif | **0** — retour par le chemin d'arrêt du serveur |
| Sans | **143** (128+15) — tué **par** le signal |

Test de régression **prouvé rouge** avant le correctif, avec le bon message : `left: Some(15)` — le processus était bien terminé par le signal 15.

## Détails de mise en œuvre

Le test isole **`HOME` en plus du store** : le fichier de configuration se cherche à côté du store, et le `~/.velesdb-memory` d'un développeur ne doit pas décider de ce que ce test démarre.

`kill(1)` plutôt que `libc::kill` : ni bloc `unsafe`, ni dépendance de dev supplémentaire pour un seul appel.

Le helper est gaté derrière la feature `http` — `tokio_util` n'est une dépendance que là. Le déclarer sans garde cassait la compilation sans features, **attrapé par le hook pre-commit**, dont le clippy est plus large que celui que je lançais.

Windows n'a pas de SIGTERM ; Ctrl-C y reste tout le contrat, et la compilation conditionnelle le dit.