### PR TITLE
test(memory): borner les appels concurrents sur une session HTTP partagée

### DIFF
--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -379,3 +379,32 @@ async fn session_beyond_the_configured_cap_is_refused() {
     drop(first_client);
     shutdown(server).await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn audit_shared_session_concurrent_calls_are_bounded() {
+    let server = spawn_http_server().await;
+    let client = std::sync::Arc::new(connect(server.addr).await);
+    let mut tasks = tokio::task::JoinSet::new();
+    for i in 0..20 {
+        let client = std::sync::Arc::clone(&client);
+        tasks.spawn(
+            async move { remember(&client, &format!("shared-session audit fact {i}")).await },
+        );
+    }
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut ids = std::collections::HashSet::new();
+        while let Some(result) = tasks.join_next().await {
+            let id = result.expect("shared-session task must not panic");
+            assert!(ids.insert(id), "shared-session ids must be unique");
+        }
+        assert_eq!(ids.len(), 20);
+    })
+    .await
+    .expect("shared-session concurrent calls exceeded five seconds");
+
+    drop(client);
+    tokio::time::timeout(std::time::Duration::from_secs(5), shutdown(server))
+        .await
+        .expect("shared-session server shutdown exceeded five seconds");
+}


### PR DESCRIPTION
**P4** du plan — récupération d'un stash orphelin.

## D'où ça vient

Ce test dormait dans un stash laissé sur `feat/memory-http-transport`, une branche qui **n'existe plus ni en local ni en distant**. Le travail était donc invisible : rien ne l'aurait retrouvé autrement qu'en listant les stashs à la main.

## Ce qu'il couvre

Vingt `remember` concurrents sur **une même session MCP partagée** rendent vingt identifiants distincts, en moins de cinq secondes, et l'arrêt du serveur reste borné lui aussi.

Le test voisin déjà présent couvre la concurrence `remember`/`recall`, mais **pas la session partagée** — or c'est exactement le mode d'usage du démon HTTP, où plusieurs clients se partagent un processus.

## Note de récupération

Le stash ne s'appliquait plus : le fichier a dérivé depuis. Contenu réinjecté à la main plutôt que par `git apply`, puis reformaté.

**7 tests verts** dans `http_transport` (6 avant).