### PR TITLE
docs: dire la vraie MSRV, et cesser de reproposer ce qui la casse

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,15 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # MSRV-bound: serial_test 4.x requires rustc 1.93.1, the workspace is on
+      # 1.90 (roaring 0.11.4 floors it there). Every 4.x PR therefore fails
+      # eight CI jobs on the same message and has to be closed by hand — #1624
+      # was. Merging one would mean raising a promise made to users: a product
+      # decision tracked in #1638, not a side effect of a test-only bump.
+      # REMOVE this entry when the MSRV rises to 1.93.1 or above.
+      - dependency-name: "serial_test"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/sdks/typescript"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,12 @@ Git hooks are provided in `.githooks/` — activate with: `git config core.hooks
 
 ### Prerequisites
 
-- Rust 1.89+ (stable) — enforced as MSRV (required for `avx512vpopcntdq` `target_feature` stabilized in 1.89; see `crates/velesdb-core/src/simd_native/x86_avx512.rs`)
+- Rust 1.90+ (stable) — the workspace MSRV, declared in `Cargo.toml`
+  (`rust-version`) and pinned in `rust-toolchain.toml` so local matches CI.
+  Two things force it: `avx512vpopcntdq` `target_feature`, stabilized in 1.89
+  (see `crates/velesdb-core/src/simd_native/x86_avx512.rs`), and `roaring
+  0.11.4`, which declares `rust-version = 1.90.0` — on 1.89 the workspace only
+  builds when that dependency is already cached.
 - Docker (optional, for integration tests)
 
 ### Building from Source


### PR DESCRIPTION
**P4** du plan — la décision MSRV, **implémentée** plutôt que recommandée.

## La doc mentait

`CONTRIBUTING.md` annonçait **« Rust 1.89+ »** aux contributeurs. La MSRV réelle est **1.90** : déclarée dans `Cargo.toml`, épinglée dans `rust-toolchain.toml`, et la CI en donne la raison —

> `roaring 0.11.4` declares `rust-version = 1.90.0`, so a 1.89 toolchain only builds when the dep is already in cache.

Un contributeur qui suivait la doc à la lettre se retrouvait avec un build qui échoue — ou, pire, qui **passe par accident** parce que la dépendance était en cache.

Toutes les autres surfaces disaient déjà 1.90 (`velesdb-core`, `velesdb-server`, `tauri-plugin` et ses exemples). `CONTRIBUTING` était la seule fausse.

**Volontairement pas corrigé** : `sdks/typescript/README.md` mentionne « MSRV Rust 1.89 » sous **« Previous (v1.14.0) »**. C'était vrai à cette version — c'est un historique, pas une affirmation au présent. Le corriger falsifierait le journal.

## La décision est maintenant tenue, pas répétée

`serial_test` 4.x exige rustc **1.93.1** et échoue donc sur **huit jobs**, toujours sur le même message. [#1624](https://github.com/cyberlife-coder/VelesDB/pull/1624) a dû être fermée à la main ; sans garde, la suivante revient chaque semaine.

La montée majeure de `serial_test` est désormais ignorée par dependabot, avec :

- la raison (MSRV-bound, pas un défaut de la dépendance),
- le ticket d'arbitrage produit ([#1638](https://github.com/cyberlife-coder/VelesDB/issues/1638)),
- et la **condition explicite de retrait** : quand la MSRV atteindra 1.93.1.

L'`ignore` est posé dans la section `cargo`, pas au niveau global — la section `github-actions` a déjà le sien, pour une raison sans rapport.

## Vérification

YAML relu par le parseur (`yaml.safe_load`), gates documentaires verts.

Le guard `index` échoue sur `develop` pour `docs/CORE_PREMIUM_SPLIT.md` — corrigé dans [#1630](https://github.com/cyberlife-coder/VelesDB/pull/1630), sans rapport avec ce diff qui ne touche pas `docs/`. **Tant que #1630 n'est pas mergée, chaque nouvelle PR hérite de ce check rouge.**