### PR TITLE
fix(memory): ecrire metadata et TTL en un seul appel

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -294,6 +294,37 @@ impl SemanticMemory {
         Ok(())
     }
 
+    /// Store a fact with BOTH structured metadata and a durable TTL, in one
+    /// write.
+    ///
+    /// Composing `store_with_ttl` then `update_metadata` looks equivalent but
+    /// is not: the fact is already live and expiring between the two calls, so
+    /// a short TTL can lapse in the gap and the metadata write then fails with
+    /// `NotFound(... is expired ...)` — the caller sees a valid write error
+    /// out. `store_internal` has always accepted both; this exposes that.
+    ///
+    /// `ttl_seconds == 0` deletes, exactly like [`Self::store_with_ttl`].
+    ///
+    /// # Errors
+    /// Returns the same errors as [`Self::store`].
+    pub fn store_with_metadata_and_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Map<String, Value>,
+        ttl_seconds: u64,
+    ) -> Result<(), AgentMemoryError> {
+        if ttl_seconds == 0 {
+            memory_helpers::validate_dimension(self.dimension, embedding.len())?;
+            return self.delete(id);
+        }
+        let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
+        self.store_internal(id, content, embedding, Some(metadata), Some(expires_at))?;
+        self.ttl.set_expiry(MemoryKind::Semantic, id, expires_at);
+        Ok(())
+    }
+
     /// Durably sets (or refreshes) the TTL of an existing fact.
     ///
     /// Unlike `AgentMemory::set_semantic_ttl` (in-memory map only, lost on

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -753,10 +753,16 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     ) -> Result<(), MemoryError> {
         match (metadata, ttl_seconds) {
             (Some(meta), Some(ttl)) => {
-                // store_with_ttl writes the fact + the durable expiry; update_metadata
-                // then merges the metadata while preserving `_veles_expires_at`.
-                self.store.store_with_ttl(id, fact, embedding, ttl)?;
-                self.store.update_metadata(id, meta)?;
+                // ONE write, not two. The previous `store_with_ttl` then
+                // `update_metadata` pair left the fact live and expiring
+                // between the calls: a short TTL could lapse in the gap and
+                // the metadata write then failed with `NotFound(... is
+                // expired ...)` — the caller got an error on a fact that was
+                // valid when they asked for it. Observed with a 1 s TTL on a
+                // loaded machine. Every TTL'd write takes this arm, since the
+                // auto date stamp means `metadata` is always `Some`.
+                self.store
+                    .store_with_metadata_and_ttl(id, fact, embedding, meta, ttl)?;
             }
             (Some(meta), None) => self.store.store_with_metadata(id, fact, embedding, meta)?,
             (None, Some(ttl)) => self.store.store_with_ttl(id, fact, embedding, ttl)?,

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -62,6 +62,29 @@ pub trait MemoryStore {
         ttl_seconds: u64,
     ) -> Result<(), MemoryError>;
 
+    /// Store a fact with BOTH metadata and a durable TTL, in ONE write.
+    ///
+    /// Default: the historical two-call sequence, so a backend written before
+    /// this method keeps compiling and behaving as it did. Backends that can
+    /// write both at once should override it — the two-call form leaves the
+    /// fact live and expiring between the calls, so a short TTL can lapse in
+    /// the gap and the metadata write then fails on a fact that was perfectly
+    /// valid when the caller asked for it.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if persistence fails.
+    fn store_with_metadata_and_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.store_with_ttl(id, content, embedding, ttl_seconds)?;
+        self.update_metadata(id, metadata)
+    }
+
     /// Merge `metadata` into an already-stored fact's payload, preserving any
     /// durable TTL. Used to combine metadata with an expiry (store both in
     /// two calls rather than needing every metadata×TTL combination as a
@@ -218,6 +241,20 @@ impl MemoryStore for NativeStore {
         self.memory
             .semantic()
             .update_metadata(id, metadata)
+            .map_err(MemoryError::from)
+    }
+
+    fn store_with_metadata_and_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.memory
+            .semantic()
+            .store_with_metadata_and_ttl(id, content, embedding, metadata, ttl_seconds)
             .map_err(MemoryError::from)
     }
 

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -138,3 +138,55 @@ fn test_count_reflects_live_facts() {
     store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
     assert_eq!(store.count(), 2);
 }
+
+/// One write must carry BOTH the metadata and the durable expiry.
+///
+/// The composed form — `store_with_ttl` then `update_metadata` — looks
+/// equivalent but leaves the fact live and expiring between the two calls: a
+/// short TTL can lapse in the gap, and the metadata write then fails with
+/// `NotFound(... is expired ...)` on a fact that was valid when the caller
+/// asked for it. Observed in the wild with a 1 s TTL under load.
+#[test]
+fn test_store_with_metadata_and_ttl_writes_both_in_one_call() {
+    let (_dir, store) = store();
+    let mut meta = Metadata::new();
+    meta.insert("project".to_string(), Value::from("veles"));
+
+    store
+        .store_with_metadata_and_ttl(1, "short-lived", &[1.0, 0.0, 0.0, 0.0], &meta, 60)
+        .expect("a metadata+ttl write must succeed");
+
+    let stored = store
+        .get_metadata(1)
+        .expect("get_metadata")
+        .expect("the fact must exist");
+
+    assert_eq!(
+        stored.get("project"),
+        Some(&Value::from("veles")),
+        "the caller metadata must survive the write that also set the expiry"
+    );
+    assert!(
+        stored.keys().any(|k| k.contains("expires")),
+        "the durable expiry must be persisted by the same write; keys: {:?}",
+        stored.keys().collect::<Vec<_>>()
+    );
+}
+
+/// A zero TTL deletes, exactly like the TTL-only path — the combined write
+/// must not quietly turn "expire now" into "store forever with metadata".
+#[test]
+fn test_store_with_metadata_and_ttl_zero_deletes() {
+    let (_dir, store) = store();
+    let meta = Metadata::new();
+    store.store(1, "doomed", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+
+    store
+        .store_with_metadata_and_ttl(1, "doomed", &[1.0, 0.0, 0.0, 0.0], &meta, 0)
+        .expect("a zero ttl must not error");
+
+    assert!(
+        store.get(1).expect("get").is_none(),
+        "ttl_seconds == 0 must delete, matching store_with_ttl"
+    );
+}


### PR DESCRIPTION
Défaut **produit**, révélé par un test que j'avais d'abord pris pour un flake de timing.

## Le symptôme

```
remember with 1s ttl: Memory(NotFound("memory id … is expired"))
```

C'est **l'écriture** qui échoue, pas une lecture. `remember_with_ttl` retourne une erreur sur un fait parfaitement valide.

## La cause

`store_fact` écrivait un fait à TTL en **deux appels** — `store_with_ttl` puis `update_metadata`. Entre les deux, le fait est déjà vivant et déjà en train d'expirer : un TTL court peut s'écouler dans l'intervalle, et la seconde écriture échoue alors sur un fait que l'appelant venait de demander.

**Ce n'est pas un cas de bord étroit.** Le tampon de date automatique rend la métadonnée *toujours* présente, donc **absolument tout** `remember_with_ttl` empruntait ce chemin. Un utilisateur posant un TTL court sur une machine chargée obtenait une erreur à l'écriture.

## Le correctif

La primitive manquait, pas la capacité : `store_internal` du cœur accepte **depuis toujours** `metadata` et `expires_at` ensemble — seules les deux méthodes publiques les séparaient.

`store_with_metadata_and_ttl` expose la combinaison, avec la même sémantique que `store_with_ttl` sur `ttl_seconds = 0` (suppression).

Côté `velesdb-memory`, la méthode de trait a une **implémentation par défaut** qui reproduit l'ancienne séquence : un backend écrit avant ce changement compile et se comporte comme avant. Seul le backend natif, qui sait faire mieux, la surcharge.

## Vérification

Deux tests épinglent le contrat de la primitive :

| Test | Ce qu'il empêche |
|---|---|
| `..._writes_both_in_one_call` | que la métadonnée de l'appelant soit perdue par l'écriture qui pose l'expiration |
| `..._zero_deletes` | qu'un TTL nul se transforme en « stocker pour toujours avec métadonnée » |

Les 5 tests `ttl_bdd` restent verts, dont `remember_with_ttl_combines_with_metadata` qui pinne la sémantique à ne pas casser. Clippy pedantic à 0 sur les deux crates.

⚠️ `http_insecure_flag_serves_plain_http` échoue localement sur cette branche pour une cause **sans rapport** — la résolution du fichier de config, corrigée par #1633 encore non mergée.