### PR TITLE
chore(release): preparer velesdb-memory 0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "axum",
  "criterion",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] — 2026-07-28
+
+### Fixed
+
+- **`remember_with_ttl` could fail on a perfectly valid fact.** A TTL'd write
+  was two store calls — `store_with_ttl` then `update_metadata` — and the fact
+  was already live and expiring between them, so a short TTL could lapse in the
+  gap and the metadata write then failed with
+  `NotFound(... is expired ...)`. Not a narrow edge case: the automatic date
+  stamp means metadata is always present, so *every* TTL'd write took that
+  path. Core now exposes `store_with_metadata_and_ttl` (its `store_internal`
+  always accepted both) and the service issues ONE write. The storage trait
+  method carries a default implementation reproducing the old sequence, so a
+  backend written before this keeps working. (#1641)
+- **The config file was looked up beside the DEFAULT store, not the effective
+  one.** `VELESDB_MEMORY_PATH` moves the store and `velesdb-memory.toml` lives
+  beside it, so moving the store silently read the config of a store you were
+  not using — including a developer's personal `~/.velesdb-memory` in the
+  middle of a test run. (#1633)
+- **SIGTERM killed the daemon instead of draining it.** Only `ctrl_c` (SIGINT)
+  was handled, while `launchctl kickstart`, `systemctl restart` and
+  `docker stop` all send SIGTERM. Unhandled, it dropped the streamable-HTTP
+  sessions clients hold mid-flight, so the next call on a live session hung
+  until the client's own timeout instead of reconnecting — a daemon upgrade
+  looked like a broken memory. (#1636)
+- **`forget` left the entities its fact had created behind.** Entity hubs
+  outlived every fact that created them, so a retraction was silently
+  incomplete and the graph accumulated unreachable nodes. `forget` now collects
+  the hubs no surviving fact mentions — an entity another fact still refers to
+  is kept. (#1634)
+
+### Changed
+
+- **Autograph predicates are bounded and entities must be linked.** On real
+  content the extractor answered with restated sentences
+  (`est utilisé pour la surveillance de fuites de données`) where a label was
+  asked for, and an entity could receive attributes without a single edge — a
+  dead end in the graph. The prompt now carries a hard three-word bound, a
+  counter-example, and the rule that a related entity appears in at least one
+  triple. Measured on the same content: 9 words → 3, and an entity that had no
+  edge now has one. (#1635)
+
 ## [0.11.2] — 2026-07-26
 
 Patch. Four defects found in real usage, each reproduced by a test that failed

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.2"
+version = "0.11.3"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.2"
+version = "0.11.3"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -817,4 +817,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.2
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -507,7 +507,7 @@ matching checksum next to it.
 
 **This path only becomes active from the first release published after the
 change.** `release-memory.yml`'s `build-daemon-archive` job produces these
-archives, but the `velesdb-memory-v0.11.2` release (and everything before it)
+archives, but the `velesdb-memory-v0.11.3` release (and everything before it)
 predates it and carries no such asset, so `--from-release` against `v0.11.0`
 fails with a clear 404-explaining message rather than a bare `curl` /
 `Invoke-WebRequest` error. This is a **different artifact** than the `.mcpb`
@@ -568,4 +568,4 @@ pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.2
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -494,4 +494,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.2
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
**Prépare** la release — elle ne la déclenche pas. Le tag et la publication restent ta décision.

## Pourquoi maintenant

Le `CHANGELOG` portait un `[Unreleased]` **vide** alors que quatre correctifs et un changement de comportement étaient déjà mergés. Sans release, ils dorment sur `develop` et **aucun de tes utilisateurs n'en profite**.

## Ce que la 0.11.3 apporte

| Correctif | Ce que ça change pour un utilisateur |
|---|---|
| Course d'écriture TTL | `remember_with_ttl` pouvait **échouer sur un fait valide**. Pas un cas de bord : le tampon de date auto faisait passer *tout* écrit à TTL par le chemin fautif. |
| Résolution de config | Le fichier était cherché à côté du store **par défaut**, pas de l'effectif — déplacer le store lisait la config d'un autre. |
| Drain sur SIGTERM | Un redémarrage tuait les sessions en vol : côté client, une mise à jour **ressemblait à une mémoire cassée**. |
| Hubs orphelins | `forget` laissait derrière lui les entités créées par son fait — rétractation silencieusement incomplète. |
| Prédicats bornés | Étiquettes de 3 mots au lieu de phrases restituées, et une entité reliée ne reste plus un cul-de-sac. |

## Bump

Cinq surfaces, dont **trois que j'avais manquées** en les listant à la main : `server.json` et les deux entrées du `package-lock.json`. C'est `check-version-sync.py` qui les a rattrapées — exactement sa raison d'être.

Quatre tampons documentaires suivaient encore 0.11.2 (dont une référence de tag git dans `MCP_SERVER_SETUP.md`), attrapés par le guard de fraîcheur.

## Vérification

`check-version-sync` **EXIT 0** (« All versions match »), les trois guards de fraîcheur **EXIT 0**, `feature-claims`, `promise-contract`, `doc-contract` **EXIT 0**, `cargo check` **EXIT 0**.

## Après le merge — ta main

Attendre la **CI verte sur `main`**, puis tagger `velesdb-memory-v0.11.3`.

⚠️ Gotcha REL-06 : le workflow de release exige un `CI Success` sur le **commit exact** tagué. Merger puis tagger immédiatement échoue.