### PR TITLE
refactor(core): dedupe secondary-index type, traversal metrics, score-context construction

### DIFF
--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -679,6 +679,21 @@ impl Collection {
     // Graph traversal with TraversalConfig
     // -------------------------------------------------------------------------
 
+    /// Times a traversal and records its duration/result count on the edge
+    /// store's traversal metrics.
+    fn with_traversal_metrics(
+        &self,
+        traverse: impl FnOnce() -> Vec<TraversalResult>,
+    ) -> Vec<TraversalResult> {
+        let start = std::time::Instant::now();
+        let results = traverse();
+        self.graph
+            .edge_store
+            .metrics()
+            .record_traversal(start.elapsed(), results.len() as u64);
+        results
+    }
+
     /// BFS traversal using the core `concurrent_bfs_stream` iterator.
     ///
     /// Wraps [`Self::traverse_bfs_config_inner`] with traversal metrics timing.
@@ -688,13 +703,7 @@ impl Collection {
         source_id: u64,
         config: &TraversalConfig,
     ) -> Vec<TraversalResult> {
-        let start = std::time::Instant::now();
-        let results = self.traverse_bfs_config_inner(source_id, config);
-        self.graph
-            .edge_store
-            .metrics()
-            .record_traversal(start.elapsed(), results.len() as u64);
-        results
+        self.with_traversal_metrics(|| self.traverse_bfs_config_inner(source_id, config))
     }
 
     /// Inner BFS traversal without metrics (see [`Self::traverse_bfs_config`]).
@@ -747,13 +756,7 @@ impl Collection {
         source_id: u64,
         config: &TraversalConfig,
     ) -> Vec<TraversalResult> {
-        let start = std::time::Instant::now();
-        let results = self.traverse_dfs_config_inner(source_id, config);
-        self.graph
-            .edge_store
-            .metrics()
-            .record_traversal(start.elapsed(), results.len() as u64);
-        results
+        self.with_traversal_metrics(|| self.traverse_dfs_config_inner(source_id, config))
     }
 
     /// Inner DFS traversal without metrics (see [`Self::traverse_dfs_config`]).

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -5,6 +5,11 @@ use crate::error::Result;
 use crate::index::{JsonValue, SecondaryIndex};
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Shared secondary-index map, matching [`QueryState::secondary_indexes`](crate::collection::types::QueryState::secondary_indexes).
+type SecondaryIndexMap = Arc<RwLock<HashMap<String, SecondaryIndex>>>;
 
 /// Index information response for API.
 #[derive(Debug, Clone)]
@@ -350,9 +355,7 @@ impl Collection {
     ///
     /// Returns `None` for `Not` wrapping non-`In` conditions and unsupported conditions.
     fn bitmap_from_condition(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         cond: &crate::filter::Condition,
     ) -> Option<roaring::RoaringBitmap> {
         match cond {
@@ -395,9 +398,7 @@ impl Collection {
 
     /// Looks up a single equality field in the secondary indexes.
     fn bitmap_for_eq_field(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         field: &str,
         value: &serde_json::Value,
     ) -> Option<roaring::RoaringBitmap> {
@@ -419,9 +420,7 @@ impl Collection {
     /// Time complexity: O(N × log K) where N = `values.len()`, K = index keys.
     /// Space: O(|result|) — single accumulator bitmap, no intermediate allocations.
     fn bitmap_for_in_field(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         field: &str,
         values: &[serde_json::Value],
     ) -> Option<roaring::RoaringBitmap> {
@@ -449,9 +448,7 @@ impl Collection {
     /// Always return `None` to force a correct full-scan + post-filter.
     #[allow(clippy::unnecessary_wraps)] // Reason: uniform Option return for bitmap_from_condition dispatch
     fn bitmap_for_not_in(
-        _indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        _indexes: &SecondaryIndexMap,
         _inner: &crate::filter::Condition,
     ) -> Option<roaring::RoaringBitmap> {
         None
@@ -459,9 +456,7 @@ impl Collection {
 
     /// Builds a range bitmap for Gt/Gte/Lt/Lte using `SecondaryIndex::range_bitmap`.
     fn bitmap_for_range_field(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         field: &str,
         value: &serde_json::Value,
         cond: &crate::filter::Condition,
@@ -483,9 +478,7 @@ impl Collection {
 
     /// Intersects bitmaps from AND-ed conditions.
     fn bitmap_from_and(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         conditions: &[crate::filter::Condition],
     ) -> Option<roaring::RoaringBitmap> {
         let mut result: Option<roaring::RoaringBitmap> = None;
@@ -506,9 +499,7 @@ impl Collection {
     /// must return `None` because the union would be incomplete -- the
     /// post-filter must evaluate the full OR instead.
     fn bitmap_from_or(
-        indexes: &std::sync::Arc<
-            parking_lot::RwLock<std::collections::HashMap<String, SecondaryIndex>>,
-        >,
+        indexes: &SecondaryIndexMap,
         conditions: &[crate::filter::Condition],
     ) -> Option<roaring::RoaringBitmap> {
         let mut result = roaring::RoaringBitmap::new();

--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -343,18 +343,7 @@ impl Collection {
         results: &[SearchResult],
         per_result_let: &[Vec<(String, f32)>],
     ) -> Ordering {
-        let ctx_i = ScoreContext::with_let_bindings(
-            results[i].score,
-            results[i].point.payload.as_ref(),
-            results[i].component_scores.as_deref(),
-            per_result_let.get(i).map(Vec::as_slice),
-        );
-        let ctx_j = ScoreContext::with_let_bindings(
-            results[j].score,
-            results[j].point.payload.as_ref(),
-            results[j].component_scores.as_deref(),
-            per_result_let.get(j).map(Vec::as_slice),
-        );
+        let (ctx_i, ctx_j) = Self::score_context_pair(i, j, results, per_result_let);
         ctx_i
             .resolve_variable(name)
             .total_cmp(&ctx_j.resolve_variable(name))
@@ -368,6 +357,20 @@ impl Collection {
         results: &[SearchResult],
         per_result_let: &[Vec<(String, f32)>],
     ) -> Ordering {
+        let (ctx_i, ctx_j) = Self::score_context_pair(i, j, results, per_result_let);
+        let val_i = evaluate_arithmetic(expr, &ctx_i);
+        let val_j = evaluate_arithmetic(expr, &ctx_j);
+        val_i.total_cmp(&val_j)
+    }
+
+    /// Builds the `ScoreContext` pair for comparing results `i` and `j`, each
+    /// with its own LET bindings, score, payload, and component breakdown.
+    fn score_context_pair<'a>(
+        i: usize,
+        j: usize,
+        results: &'a [SearchResult],
+        per_result_let: &'a [Vec<(String, f32)>],
+    ) -> (ScoreContext<'a>, ScoreContext<'a>) {
         let ctx_i = ScoreContext::with_let_bindings(
             results[i].score,
             results[i].point.payload.as_ref(),
@@ -380,9 +383,7 @@ impl Collection {
             results[j].component_scores.as_deref(),
             per_result_let.get(j).map(Vec::as_slice),
         );
-        let val_i = evaluate_arithmetic(expr, &ctx_i);
-        let val_j = evaluate_arithmetic(expr, &ctx_j);
-        val_i.total_cmp(&val_j)
+        (ctx_i, ctx_j)
     }
 
     /// Applies ASC/DESC direction, accounting for distance metric inversion.

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -150,12 +150,29 @@ impl LogPayloadStorage {
         wal_len: u64,
     ) -> io::Result<(FxHashMap<u64, u64>, u64)> {
         let snapshot_path = dir.join("payloads.snapshot");
-        if let Ok((snapshot_index, snapshot_wal_pos)) = snapshot::load_snapshot(&snapshot_path) {
-            let index = Self::replay_wal_from(log_path, snapshot_index, snapshot_wal_pos, wal_len)?;
-            Ok((index, snapshot_wal_pos))
-        } else {
-            let index = Self::replay_wal_from(log_path, FxHashMap::default(), 0, wal_len)?;
-            Ok((index, 0))
+        match snapshot::load_snapshot(&snapshot_path) {
+            Ok((snapshot_index, snapshot_wal_pos)) => {
+                let index =
+                    Self::replay_wal_from(log_path, snapshot_index, snapshot_wal_pos, wal_len)?;
+                Ok((index, snapshot_wal_pos))
+            }
+            Err(e) => {
+                // `NotFound` is the expected cold-start case (no snapshot yet).
+                // Any other error kind means a snapshot existed but failed to
+                // load (corrupt header, truncated file, bad CRC) — surface it
+                // so operators can see recovery fell back to a full WAL
+                // replay instead of the fast path, even though the fallback
+                // itself is correct.
+                if e.kind() != io::ErrorKind::NotFound {
+                    tracing::warn!(
+                        error = %e,
+                        path = %snapshot_path.display(),
+                        "payload snapshot failed to load, falling back to full WAL replay"
+                    );
+                }
+                let index = Self::replay_wal_from(log_path, FxHashMap::default(), 0, wal_len)?;
+                Ok((index, 0))
+            }
         }
     }
 


### PR DESCRIPTION
Remplace #1646, dont le **contenu est repris à l'identique** mais qui ne pouvait pas être mergée.

## Pourquoi une nouvelle PR

#1646 échouait sur deux checks, et la cause était la même pour les deux :

**Les quatre commits étaient authored par `Claude <noreply@anthropic.com>`**, avec quatre trailers d'attribution IA. C'est ce qui faisait échouer `cla-assistant` — le bot ne reconnaît pas cet auteur comme contributeur signataire — et c'est surtout une violation directe de la règle du dépôt : aucun commit ne doit être attribué à une identité non humaine, **y compris sur une PR qu'on n'a pas ouverte**.

La branche `claude/funny-fermat-ywbats` était par ailleurs rejetée par `Git Flow` : seuls `feature/*`, `feat/*`, `fix/*`, `refactor/*`, `chore/*`, `docs/*`… peuvent viser `develop`.

Une réécriture d'auteur suffisait ; le préfixe imposait de toute façon une nouvelle branche.

## Ce qui a été fait

Les quatre commits sont cherry-pickés sur `develop` à jour, ré-authorés, et leurs trailers retirés.

**Vérifié que rien d'autre n'a bougé** — comparaison du contenu ajouté/retiré de chaque commit avec son original :

| Original | Nouveau | Contenu |
|---|---|---|
| `3c7a211d` | `6bc945fb` | identique |
| `433b3fa4` | `397db1fe` | identique |
| `a95e5eac` | `1585fa3a` | identique |
| `2d876bf5` | `ed1e32eb` | identique |

Les hachages de diff bruts différaient sur un commit : uniquement les **numéros de ligne**, le fichier ayant bougé de 6 lignes entre l'ancien `develop` et l'actuel. Le contenu, lui, est intact.

## Contenu

- `index_management` — déduplication du type de map d'index secondaires
- `graph_api` — extraction d'un helper `with_traversal_metrics`
- `ordering` — extraction d'un helper `score_context_pair`
- `log_payload` — les échecs de chargement de snapshot autres que `NotFound` sont désormais journalisés au lieu d'être avalés

`cargo check` et `clippy --pedantic` sur `velesdb-core` : **EXIT 0**.

Une fois cette PR mergée, #1646 peut être fermée.