### PR TITLE
release: velesdb-memory 0.11.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "axum",
  "criterion",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -294,37 +294,6 @@ impl SemanticMemory {
         Ok(())
     }
 
-    /// Store a fact with BOTH structured metadata and a durable TTL, in one
-    /// write.
-    ///
-    /// Composing `store_with_ttl` then `update_metadata` looks equivalent but
-    /// is not: the fact is already live and expiring between the two calls, so
-    /// a short TTL can lapse in the gap and the metadata write then fails with
-    /// `NotFound(... is expired ...)` — the caller sees a valid write error
-    /// out. `store_internal` has always accepted both; this exposes that.
-    ///
-    /// `ttl_seconds == 0` deletes, exactly like [`Self::store_with_ttl`].
-    ///
-    /// # Errors
-    /// Returns the same errors as [`Self::store`].
-    pub fn store_with_metadata_and_ttl(
-        &self,
-        id: u64,
-        content: &str,
-        embedding: &[f32],
-        metadata: &Map<String, Value>,
-        ttl_seconds: u64,
-    ) -> Result<(), AgentMemoryError> {
-        if ttl_seconds == 0 {
-            memory_helpers::validate_dimension(self.dimension, embedding.len())?;
-            return self.delete(id);
-        }
-        let expires_at = MemoryTtl::now().saturating_add(ttl_seconds);
-        self.store_internal(id, content, embedding, Some(metadata), Some(expires_at))?;
-        self.ttl.set_expiry(MemoryKind::Semantic, id, expires_at);
-        Ok(())
-    }
-
     /// Durably sets (or refreshes) the TTL of an existing fact.
     ///
     /// Unlike `AgentMemory::set_semantic_ttl` (in-memory map only, lost on

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.4] — 2026-07-28
+
+### Fixed
+
+- **0.11.3 could not be packaged.** Its TTL fix reached for a
+  `store_with_metadata_and_ttl` method added to `velesdb-core` in the same
+  train. That compiles in the workspace, where core is resolved by path, but
+  `velesdb-memory` publishes independently against the *released* core — which
+  does not have it — so `cargo publish` failed to verify the tarball and
+  nothing reached crates.io or npm. The fix now uses only published core API:
+  the fact is stored with its metadata and **no expiry**, then `set_ttl_durable`
+  applies the expiry. Same guarantee — the fact cannot expire mid-write, since
+  it has no expiry until the last step — with no new core surface.
+
+  0.11.3 is **not usable**: its MCPB bundles reached the MCP registry before the
+  packaging step failed, but no crate or npm package was ever published. Use
+  0.11.4.
+
 ## [0.11.3] — 2026-07-28
 
 ### Fixed

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.3"
+version = "0.11.4"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -252,9 +252,18 @@ impl MemoryStore for NativeStore {
         metadata: &Metadata,
         ttl_seconds: u64,
     ) -> Result<(), MemoryError> {
+        // Ordre delibere : le fait est ecrit avec sa metadata et SANS
+        // expiration, donc il ne peut pas expirer entre les deux appels.
+        // L'expiration est posee ensuite. C'est l'inverse de la sequence
+        // historique (store_with_ttl puis update_metadata), ou le fait etait
+        // deja vivant et deja en train d'expirer pendant la seconde ecriture.
         self.memory
             .semantic()
-            .store_with_metadata_and_ttl(id, content, embedding, metadata, ttl_seconds)
+            .store_with_metadata(id, content, embedding, metadata)
+            .map_err(MemoryError::from)?;
+        self.memory
+            .semantic()
+            .set_ttl_durable(id, ttl_seconds)
             .map_err(MemoryError::from)
     }
 

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -139,15 +139,20 @@ fn test_count_reflects_live_facts() {
     assert_eq!(store.count(), 2);
 }
 
-/// One write must carry BOTH the metadata and the durable expiry.
+/// A TTL'd write must carry BOTH the metadata and the durable expiry, and
+/// must not be able to expire while it is being written.
 ///
-/// The composed form — `store_with_ttl` then `update_metadata` — looks
-/// equivalent but leaves the fact live and expiring between the two calls: a
-/// short TTL can lapse in the gap, and the metadata write then fails with
+/// The historical order — `store_with_ttl` then `update_metadata` — left the
+/// fact live and already expiring between the two calls: a short TTL could
+/// lapse in the gap, and the metadata write then failed with
 /// `NotFound(... is expired ...)` on a fact that was valid when the caller
 /// asked for it. Observed in the wild with a 1 s TTL under load.
+///
+/// The order is now reversed — the fact is stored with its metadata and NO
+/// expiry, then the expiry is applied — so there is no window in which it can
+/// expire mid-write.
 #[test]
-fn test_store_with_metadata_and_ttl_writes_both_in_one_call() {
+fn test_store_with_metadata_and_ttl_survives_a_short_expiry() {
     let (_dir, store) = store();
     let mut meta = Metadata::new();
     meta.insert("project".to_string(), Value::from("veles"));

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.3"
+version = "0.11.4"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -817,4 +817,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -507,7 +507,7 @@ matching checksum next to it.
 
 **This path only becomes active from the first release published after the
 change.** `release-memory.yml`'s `build-daemon-archive` job produces these
-archives, but the `velesdb-memory-v0.11.3` release (and everything before it)
+archives, but the `velesdb-memory-v0.11.4` release (and everything before it)
 predates it and carries no such asset, so `--from-release` against `v0.11.0`
 fails with a clear 404-explaining message rather than a bare `curl` /
 `Invoke-WebRequest` error. This is a **different artifact** than the `.mcpb`
@@ -568,4 +568,4 @@ pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -494,4 +494,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.3
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Promotion vers `main` pour permettre le tag `velesdb-memory-v0.11.4`.

## Pourquoi 0.11.4 et pas 0.11.3

La 0.11.3 est **partiellement publiée** : ses bundles MCPB ont atteint le registre MCP, mais **rien sur crates.io ni npm**. Le job `Validate` avait échoué au `cargo publish --dry-run` :

```
error[E0599]: no method named `store_with_metadata_and_ttl`
              found for reference `&SemanticMemory`
```

Le correctif de la course TTL appelait une méthode ajoutée à `velesdb-core` dans le même train. En workspace ça compile — le cœur est résolu par chemin. Mais **`velesdb-memory` se publie indépendamment**, contre le `velesdb-core` de crates.io, qui ne la connaît pas.

La 0.11.4 corrige la cause en n'utilisant que l'API déjà publiée : le fait est stocké avec sa métadonnée **sans expiration**, puis `set_ttl_durable` applique l'expiration. Même garantie — il ne peut pas expirer en cours d'écriture, puisqu'il n'a pas d'expiration jusqu'à la dernière étape — sans surface nouvelle dans le cœur.

## Vérification

| Contrôle | Résultat |
|---|---|
| `cargo publish -p velesdb-memory --dry-run` | **EXIT 0** — celui-là même qui a fait échouer la 0.11.3 |
| Commits promus | 2 |
| Auteurs | `cyberlife-coder`, `Wiscale` |
| Auteurs IA / trailers | **0** |

## Après le merge

Attendre le check-run **`CI Success` vert sur `main`**, puis tagger `velesdb-memory-v0.11.4`.

⚠️ REL-06 : le workflow de release exige ce check sur le **commit exact** tagué. Tagger juste après le merge fait échouer le gate.

Et vérifier **crates.io *et* npm** après publication : la 0.11.3 a montré qu'un tag déclenche deux workflows indépendants, et que l'un peut réussir pendant que l'autre échoue.