### PR TITLE
fix(memory): typer les slots optionnels du schéma MCP annoncé

### DIFF
--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -713,14 +713,28 @@ fn test_compile_context_input_schema_advertises_fragment_media_field() {
         .get("anyOf")
         .or_else(|| media_property.get("oneOf"))
     {
-        // Optional fields sometimes wrap the ref in anyOf: [{$ref}, {type: null}]
+        // An optional field is `anyOf: [<MediaRef>, {type: "null"}]`. The
+        // first branch used to be a bare `$ref`; since the union branches are
+        // inlined too (a `$defs`-blind caller could not resolve it, so the
+        // whole slot read as "anything"), it now carries the definition
+        // directly. Accept both: follow a `$ref` when there is still one,
+        // otherwise take the branch as-is. Picking "the non-null branch"
+        // rather than "the branch with a `$ref`" is what makes this
+        // independent of whether inlining happened.
         one_of
             .as_array()
-            .and_then(|variants| variants.iter().find(|v| v.get("$ref").is_some()))
-            .and_then(|v| v.get("$ref"))
-            .and_then(serde_json::Value::as_str)
-            .map(|r| r.trim_start_matches("#/$defs/"))
-            .map_or(media_property, |name| &schema["$defs"][name])
+            .and_then(|variants| {
+                variants
+                    .iter()
+                    .find(|variant| variant.get("type").is_none_or(|ty| ty != "null"))
+            })
+            .map_or(media_property, |branch| {
+                branch
+                    .get("$ref")
+                    .and_then(serde_json::Value::as_str)
+                    .map(|name| name.trim_start_matches("#/$defs/"))
+                    .map_or(branch, |name| &schema["$defs"][name])
+            })
     } else {
         media_property
     };

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -132,8 +132,32 @@ pub struct ColumnFilter {
     pub field: String,
     /// Comparison operator.
     pub op: ColumnOp,
-    /// Value to compare against (numbers, strings, booleans).
+    /// Value to compare against.
+    ///
+    /// The comparison is TYPE-STRICT with no coercion, so the JSON type sent
+    /// here is part of the query: `20260601` (number) never matches a fact
+    /// stored as `"20260601"` (string) — same value, no match, and **no
+    /// error**. A wrong type here is therefore the one mistake this API
+    /// cannot report; it just returns nothing.
+    ///
+    /// Which is why the advertised type is spelled out rather than left as
+    /// the empty schema `serde_json::Value` would produce. `{}` says "send
+    /// anything", on the single field where sending the wrong thing fails
+    /// silently.
+    #[schemars(schema_with = "comparable_json_value")]
     pub value: Value,
+}
+
+/// The JSON types a `ColumnFilter` can actually compare: number, string,
+/// boolean. Objects and arrays are not orderable and never match; `null` is
+/// not a value to compare against.
+fn comparable_json_value(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": ["number", "string", "boolean"],
+        "description": "Value to compare against. TYPE-STRICT: the JSON type must match \
+                        how the fact was stored (a number never matches a string), and a \
+                        mismatch returns no results rather than an error.",
+    })
 }
 
 /// Tuning knobs for

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -260,27 +260,97 @@ fn inline_in_map(
     if depth >= MAX_INLINE_DEPTH {
         return;
     }
+    inline_property_slots(map, defs, chain, depth);
+    inline_item_slots(map, defs, chain, depth);
+    inline_union_branches(map, defs, chain, depth);
+    inline_remaining_keywords(map, defs, chain, depth);
+}
+
+/// The keywords `inline_in_map` walks as argument paths, each with its own
+/// pass — listed once here so the generic descent cannot walk them twice.
+#[cfg(feature = "mcp")]
+const SLOT_KEYWORDS: [&str; 6] = [
+    "$defs",
+    "properties",
+    "items",
+    "anyOf",
+    "oneOf",
+    "prefixItems",
+];
+
+#[cfg(feature = "mcp")]
+fn inline_property_slots(
+    map: &mut Map<String, Value>,
+    defs: &Map<String, Value>,
+    chain: &mut InlineChain,
+    depth: usize,
+) {
     if let Some(Value::Object(properties)) = map.get_mut("properties") {
         for slot in properties.values_mut() {
             inline_slot(slot, defs, chain, depth);
         }
     }
-    if let Some(items) = map.get_mut("items") {
-        match items {
-            // Tuple form: `items` is an array of per-position schemas.
-            Value::Array(entries) => {
-                for entry in entries {
-                    inline_slot(entry, defs, chain, depth);
-                }
+}
+
+#[cfg(feature = "mcp")]
+fn inline_item_slots(
+    map: &mut Map<String, Value>,
+    defs: &Map<String, Value>,
+    chain: &mut InlineChain,
+    depth: usize,
+) {
+    match map.get_mut("items") {
+        // Tuple form: `items` is an array of per-position schemas.
+        Some(Value::Array(entries)) => {
+            for entry in entries {
+                inline_slot(entry, defs, chain, depth);
             }
-            single => inline_slot(single, defs, chain, depth),
+        }
+        Some(single) => inline_slot(single, defs, chain, depth),
+        None => {}
+    }
+}
+
+/// Union branches are argument paths too.
+///
+/// `Option<T>` is the common case: schemars renders it
+/// `anyOf: [{"$ref": …}, {"type": "null"}]`, and a `$defs`-blind harness that
+/// cannot resolve the first branch degrades the WHOLE slot to "anything" —
+/// which is how `source`, `goal` and `memory_id` reached callers as a bare
+/// `{}` (2026-07-28). Treating each branch as a slot is what makes an
+/// optional field as self-describing as a required one.
+///
+/// `allOf` stays out on purpose: [`ref_only_target`] already reads its
+/// single-element form as a wrapper around the slot itself, and inlining it
+/// here as a branch would fight that.
+#[cfg(feature = "mcp")]
+fn inline_union_branches(
+    map: &mut Map<String, Value>,
+    defs: &Map<String, Value>,
+    chain: &mut InlineChain,
+    depth: usize,
+) {
+    for keyword in ["anyOf", "oneOf", "prefixItems"] {
+        if let Some(Value::Array(branches)) = map.get_mut(keyword) {
+            for branch in branches {
+                inline_slot(branch, defs, chain, depth);
+            }
         }
     }
+}
+
+/// Generic descent for everything the dedicated passes did not claim.
+#[cfg(feature = "mcp")]
+fn inline_remaining_keywords(
+    map: &mut Map<String, Value>,
+    defs: &Map<String, Value>,
+    chain: &mut InlineChain,
+    depth: usize,
+) {
     for (key, value) in map.iter_mut() {
-        if key == "$defs" || key == "properties" || key == "items" {
-            continue;
+        if !SLOT_KEYWORDS.contains(&key.as_str()) {
+            inline_in_value(value, defs, chain, depth);
         }
-        inline_in_value(value, defs, chain, depth);
     }
 }
 

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -120,6 +120,106 @@ fn check_items(items: &Value, path: &str, found: &mut Vec<String>) {
     walk_schema(items, path, found);
 }
 
+/// Every reachable **property** slot, not just every `items` slot.
+///
+/// The `items` rule above was written after the 2026-07-26 field report and
+/// it holds — but it is narrower than the defect it was meant to close.
+/// On 2026-07-28 a real call was rejected again, this time on properties:
+/// `save_working_context`'s `source`, `goal` and `memory_id` were advertised
+/// as `{}` — the empty schema, which says "anything". The caller sent a
+/// string, the server wanted a `SourceReference`, and the schema had said
+/// nothing to prevent it. Third occurrence of one family, third shape.
+///
+/// So the invariant here is deliberately shape-agnostic: it does not look
+/// for `$ref`, `allOf`, `anyOf` or any other construct the next regression
+/// might use. It asks the only question that matters to a caller — *can I
+/// tell what may go in this slot?* — and a slot answers yes when it carries
+/// a direct `type`, or an `anyOf`/`oneOf` whose branches each do, or an
+/// `enum`/`const` that enumerates its own values.
+fn untyped_properties(schema: &Value) -> Vec<String> {
+    let mut found = Vec::new();
+    walk_properties(schema, "$", &mut found);
+    found
+}
+
+fn walk_properties(node: &Value, path: &str, found: &mut Vec<String>) {
+    let Value::Object(map) = node else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = map.get("properties") {
+        for (name, slot) in properties {
+            let slot_path = format!("{path}.{name}");
+            if !describes_its_own_type(slot) {
+                found.push(format!("{slot_path} = {slot}"));
+            }
+            walk_properties(slot, &slot_path, found);
+        }
+    }
+    if let Some(items) = map.get("items") {
+        match items {
+            Value::Array(entries) => {
+                for (index, entry) in entries.iter().enumerate() {
+                    walk_properties(entry, &format!("{path}.items[{index}]"), found);
+                }
+            }
+            single => walk_properties(single, &format!("{path}.items"), found),
+        }
+    }
+    for keyword in ["anyOf", "oneOf", "allOf", "prefixItems"] {
+        if let Some(Value::Array(entries)) = map.get(keyword) {
+            for (index, entry) in entries.iter().enumerate() {
+                walk_properties(entry, &format!("{path}.{keyword}[{index}]"), found);
+            }
+        }
+    }
+    if let Some(extra @ Value::Object(_)) = map.get("additionalProperties") {
+        walk_properties(extra, &format!("{path}.additionalProperties"), found);
+    }
+}
+
+/// A slot is self-describing when a `$defs`-blind caller can name what goes
+/// in it: a direct `type`, a union whose every branch has one, or a closed
+/// set of literal values.
+fn describes_its_own_type(slot: &Value) -> bool {
+    let Value::Object(map) = slot else {
+        return false;
+    };
+    if map.contains_key("type") || map.contains_key("enum") || map.contains_key("const") {
+        return true;
+    }
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(Value::Array(branches)) = map.get(keyword) {
+            if !branches.is_empty() && branches.iter().all(describes_its_own_type) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// The 2026-07-28 regression: an advertised `{}` is a promise that anything
+/// fits, and the server keeps none of it.
+#[tokio::test]
+async fn every_tool_input_schema_types_every_reachable_property() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    assert!(!tools.is_empty(), "the server advertises at least one tool");
+    let mut offenders: BTreeSet<String> = BTreeSet::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for finding in untyped_properties(&schema) {
+            offenders.insert(format!("{}: {finding}", tool.name));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "{} property slot(s) advertise no type at all — a caller reading the schema cannot \
+         know what to send, and the server rejects what it guesses: {offenders:#?}",
+        offenders.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
 /// The regression that cost four round trips: `save_working_context`'s
 /// nested arrays must be self-describing.
 #[tokio::test]
@@ -404,6 +504,124 @@ async fn every_tool_advertises_an_output_schema() {
         missing.is_empty(),
         "{} tool(s) advertise no output schema: {missing:#?}",
         missing.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// `required` must be the WHOLE truth about what a call needs.
+///
+/// The two rules above make each slot self-describing; this one makes the
+/// *set* of slots honest — a distinct property, and one nothing checked.
+///
+/// It is a guard, not a repair. It was written on 2026-07-28 after a
+/// scenario campaign appeared to show four tools rejecting a call that
+/// carried exactly their declared-required fields. They do not: the server's
+/// `required` was right all along — `compile_context` does advertise
+/// `query`. The truncated `required` came from the client rendering the
+/// schema, and the campaign trusted that rendering instead of the wire. The
+/// finding was retracted; this test is what proved it wrong.
+///
+/// It earns its place anyway, because the property it pins had no coverage
+/// and the two sibling rules cannot express it: they describe individual
+/// slots, never which ones a call must carry. It does what a first-time
+/// caller does — build the minimal call the schema describes, send it, and
+/// require that the answer is not a complaint about a field the schema never
+/// asked for. Business-rule rejections ("fact text must not be empty",
+/// "memory 1 does not exist") are expected and fine; the dummy values are
+/// deliberately trivial. Only `missing field` means the schema lied.
+fn minimal_arguments(schema: &Value) -> Value {
+    let Value::Object(map) = schema else {
+        return Value::Null;
+    };
+    let mut out = Map::new();
+    let (Some(Value::Array(required)), Some(Value::Object(properties))) =
+        (map.get("required"), map.get("properties"))
+    else {
+        return Value::Object(out);
+    };
+    for name in required.iter().filter_map(Value::as_str) {
+        let slot = properties.get(name).unwrap_or(&Value::Null);
+        out.insert(name.to_string(), dummy_for(slot));
+    }
+    Value::Object(out)
+}
+
+/// The cheapest value the slot's advertised type admits. Nested objects are
+/// built from their own `required`, so a lie one level down is caught too —
+/// `explain_compilation`'s `request` is exactly that case.
+fn dummy_for(slot: &Value) -> Value {
+    let Value::Object(map) = slot else {
+        return Value::Null;
+    };
+    let primary = match map.get("type") {
+        Some(Value::String(name)) => name.clone(),
+        Some(Value::Array(names)) => names
+            .iter()
+            .filter_map(Value::as_str)
+            .find(|name| *name != "null")
+            .unwrap_or("null")
+            .to_string(),
+        _ => {
+            // A union slot: take the first branch that names a type.
+            for keyword in ["anyOf", "oneOf"] {
+                if let Some(Value::Array(branches)) = map.get(keyword) {
+                    if let Some(branch) = branches
+                        .iter()
+                        .find(|b| matches!(b, Value::Object(m) if m.get("type").is_some_and(|t| t != "null")))
+                    {
+                        return dummy_for(branch);
+                    }
+                }
+            }
+            return Value::Null;
+        }
+    };
+    match primary.as_str() {
+        "string" => Value::String(String::new()),
+        "number" | "integer" => json!(1),
+        "boolean" => Value::Bool(true),
+        "array" => json!([]),
+        "object" => minimal_arguments(slot),
+        _ => Value::Null,
+    }
+}
+
+#[tokio::test]
+async fn every_tool_accepts_a_call_carrying_exactly_its_required_fields() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    assert!(!tools.is_empty(), "the server advertises at least one tool");
+    let mut liars: BTreeSet<String> = BTreeSet::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        let arguments = as_args(minimal_arguments(&schema));
+        let outcome = client
+            .call_tool(
+                CallToolRequestParams::new(tool.name.clone()).with_arguments(arguments.clone()),
+            )
+            .await;
+        let complaint = match &outcome {
+            Err(error) => error.to_string(),
+            Ok(result) => result
+                .content
+                .iter()
+                .filter_map(|item| item.as_text().map(|text| text.text.clone()))
+                .collect::<String>(),
+        };
+        if complaint.contains("missing field") {
+            liars.insert(format!(
+                "{}: sent {} -> {}",
+                tool.name,
+                Value::Object(arguments),
+                complaint.trim()
+            ));
+        }
+    }
+    assert!(
+        liars.is_empty(),
+        "{} tool(s) reject a call carrying exactly the fields their schema declares required \
+         — `required` understates the real contract: {liars:#?}",
+        liars.len()
     );
     client.cancel().await.expect("close the MCP session");
 }


### PR DESCRIPTION
Ferme #1652. Troisième occurrence d'une même famille, et cette fois avec l'invariant plutôt qu'une rustine de plus.

## Le défaut

`Option<T>` est rendu par schemars en `anyOf: [{$ref}, {"type":"null"}]`. L'inliner descendait dans `properties` et `items`, mais **pas dans les branches d'une union** — la branche `$ref` restait donc non résolue, et un harnais aveugle aux `$defs` dégradait le slot **entier** en « n'importe quoi ».

Concrètement, `save_working_context` annonçait `source`, `goal` et `memory_id` comme `{}`. Un appelant qui suivait le schéma envoyait une chaîne :

```
invalid type: string "…", expected struct SourceReference
```

**Douze slots** sur cinq outils. Trouvé en usage réel, pas par lecture.

## Le correctif

Les branches d'`anyOf`/`oneOf` sont traitées comme des slots à part entière. `allOf` reste délibérément exclu : sa forme à un élément est déjà lue par `ref_only_target` comme un enveloppement du slot lui-même, et l'inliner ici la ferait entrer en conflit.

`recall_where.filters.value` déclare en plus son type explicitement (`[number, string, boolean]`). Ce champ le méritait plus que tout autre : la comparaison y est **stricte en type et sans coercition**, donc une erreur de type n'y produit aucune erreur — elle renvoie zéro résultat. Annoncer `{}` sur le seul champ où se tromper est silencieux était le pire endroit possible.

## Ce qui empêche la quatrième occurrence

Le code documentait déjà deux corrections de cette famille (2026-07-24, puis 2026-07-26 au prix de « quatre allers-retours »), avec ce constat : *« chasser un SEUL niveau a laissé le trou identique un cran plus bas »*. C'est exactement ce qui vient de se reproduire.

Le nouveau test ne cherche donc **aucune construction particulière**. Il pose à chaque slot feuille la seule question qui intéresse un appelant — *puis-je savoir ce que je mets ici ?* — et accepte trois réponses : un `type` direct, une union dont chaque branche en a un, ou un `enum`/`const`. Une quatrième forme de régression échouera sans qu'on ait à l'anticiper.

Lancé avant correctif, il nomme les 12 slots. Après : vert.

## Un test de plus, et une trouvaille retirée

`every_tool_accepts_a_call_carrying_exactly_its_required_fields` construit, pour chaque outil, l'appel minimal que son schéma décrit, l'envoie, et exige que la réponse ne soit pas une plainte sur un champ jamais demandé.

Il a été écrit pour prouver une trouvaille de campagne — que quatre outils sous-déclaraient leur `required`. **Il a prouvé le contraire** : le serveur avait raison, c'est le rendu de schéma côté client qui tronquait, et la campagne l'avait cru sur parole. La trouvaille est retirée (#1654), le test reste : la propriété qu'il épingle n'avait aucune couverture, et les deux règles voisines ne peuvent pas l'exprimer — elles décrivent des slots isolés, jamais l'ensemble qu'un appel doit porter.

## Vérifications

| | |
|---|---|
| Suite `velesdb-memory` | 22 binaires, **0 échec** |
| clippy pedantic | 0 |
| lizard `-C 8 -a 8` | **0** avertissement (1 avant) |

`inline_in_map` passe de **CCN 11 à 3** : elle était déjà au-dessus du seuil Codacy sur `develop`, et je la traversais — la laisser « un peu moins mauvaise » n'aurait pas passé la barre.

Un test existant a été adapté : `test_compile_context_input_schema_advertises_fragment_media_field` résolvait `media` en cherchant un `$ref` dans le `anyOf`, que le correctif remplace par la définition inlinée. Il sélectionne désormais **la branche non-`null`**, ce qui le rend indépendant de la présence ou non d'un inlining.