### PR TITLE
fix(memory): orienter le triplet de parenté énoncé au possessif

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,17 @@ jobs:
             echo "::endgroup::"
           done
 
+      # `extract` was CHECKED above but never TESTED: no `cargo test` in this
+      # workflow passes the feature, so its nineteen unit tests — the graph
+      # prompt contract and the reply parser among them — have never run on
+      # CI. A test that cannot fail the build is documentation, not a gate.
+      #
+      # Paired with `ollama` because `extract` alone does not compile (see the
+      # comment above). The tests reached this way are pure parsing and
+      # prompt-building: none opens a socket, so no service is needed.
+      - name: Test the velesdb-memory extract feature
+        run: cargo test -p velesdb-memory --features extract,ollama,persistence
+
       - name: Run Clippy (strict)
         run: |
           cargo clippy --workspace --all-targets --features persistence,gpu,update-check \

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -83,6 +83,227 @@ pub struct Extraction {
     pub attributes: Vec<ExtractedAttribute>,
 }
 
+// --- Orienting a kinship triple stated possessively ---------------------------
+//
+// A copule ("X est le pere de Y") hangs the relation on its own grammatical
+// subject, so subject-of-sentence and subject-of-triple coincide. A possessive
+// ("X a une soeur, Y") hangs it on the OTHER one: it is Y who is X's sister.
+// Models reliably read the first and reliably mirror the second, and a mirrored
+// kinship triple is worse than a missing edge — `entity("Lea Lange")` then
+// answers, with the same confidence as any true edge, that Lea is Axel's
+// *brother*. The prompt asks for the right direction; this pass guarantees it
+// for the construction that gets it wrong, whatever backend produced the triple.
+
+/// Kinship nouns a possessive can introduce, folded (no accents, no ligature)
+/// and singular, since the markers below are singular too. Doubling as the
+/// predicate whitelist: a triple is only ever re-pointed when its label is one
+/// of these, so a non-kinship edge between the same two people is left alone.
+const KINSHIP_NOUNS: &[&str] = &[
+    "pere",
+    "mere",
+    "frere",
+    "soeur",
+    "fils",
+    "fille",
+    "oncle",
+    "tante",
+    "cousin",
+    "cousine",
+    "neveu",
+    "niece",
+    "grand-pere",
+    "grand-mere",
+    "beau-pere",
+    "belle-mere",
+    "demi-frere",
+    "demi-soeur",
+    "epoux",
+    "epouse",
+    "mari",
+    "femme",
+    "father",
+    "mother",
+    "brother",
+    "sister",
+    "son",
+    "daughter",
+    "uncle",
+    "aunt",
+    "husband",
+    "wife",
+];
+
+/// What precedes the kinship noun when the sentence hangs the relation on the
+/// person it introduces rather than on its own subject. The trailing space is
+/// load-bearing: without it `" a un "` would also fire on `"a une"`.
+const POSSESSIVE_MARKERS: &[&str] = &[" a un ", " a une ", " a pour ", " has a ", " has an "];
+
+/// Diacritics and ligatures folded to ASCII, so `"sœur"`, `"soeur"` and
+/// `"Sœur"` are one token — the passage and the model's label rarely agree on
+/// accents, and the whole pass hinges on matching one against the other.
+const FOLDINGS: &[(char, &str)] = &[
+    ('à', "a"),
+    ('â', "a"),
+    ('ä', "a"),
+    ('é', "e"),
+    ('è', "e"),
+    ('ê', "e"),
+    ('ë', "e"),
+    ('î', "i"),
+    ('ï', "i"),
+    ('ô', "o"),
+    ('ö', "o"),
+    ('ù', "u"),
+    ('û', "u"),
+    ('ü', "u"),
+    ('ç', "c"),
+    ('œ', "oe"),
+    ('æ', "ae"),
+];
+
+/// Lowercase `text` and fold its diacritics away. Every offset produced from
+/// the result indexes the *folded* string, never the original.
+fn fold(text: &str) -> String {
+    let mut folded = String::with_capacity(text.len());
+    for ch in text.chars().flat_map(char::to_lowercase) {
+        match FOLDINGS.iter().find(|(from, _)| *from == ch) {
+            Some((_, to)) => folded.push_str(to),
+            None => folded.push(ch),
+        }
+    }
+    folded
+}
+
+/// A possessive construction located in a folded passage. `start`/`end` bracket
+/// the kinship noun itself: the person who *has* the relative is named before
+/// it, the one it introduces after it.
+struct Possessive {
+    noun: &'static str,
+    start: usize,
+    end: usize,
+}
+
+/// The earliest possessive construction in `folded`, if any.
+fn find_possessive(folded: &str) -> Option<Possessive> {
+    POSSESSIVE_MARKERS
+        .iter()
+        .filter_map(|marker| folded.find(marker).map(|at| at + marker.len()))
+        .filter_map(|start| noun_at(folded, start))
+        .min_by_key(|possessive| possessive.start)
+}
+
+/// The kinship noun sitting at `start`, if the marker introduces one.
+fn noun_at(folded: &str, start: usize) -> Option<Possessive> {
+    let rest = folded.get(start..)?;
+    let noun = KINSHIP_NOUNS
+        .iter()
+        .find(|noun| starts_with_word(rest, noun))?;
+    Some(Possessive {
+        noun,
+        start,
+        end: start + noun.len(),
+    })
+}
+
+/// `rest` begins with `word` as a whole word, so `"soeurette"` never reads as
+/// `"soeur"`.
+fn starts_with_word(rest: &str, word: &str) -> bool {
+    match rest.strip_prefix(word) {
+        Some(tail) => !tail.starts_with(char::is_alphanumeric),
+        None => false,
+    }
+}
+
+/// Every distinct entity the triples name, deduplicated.
+fn endpoint_names(relations: &[ExtractedRelation]) -> Vec<String> {
+    let mut names: Vec<String> = relations
+        .iter()
+        .flat_map(|relation| [relation.subject.clone(), relation.object.clone()])
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// The endpoint named closest to the left of the noun: the person who HAS the
+/// relative.
+fn holder_of(before: &str, names: &[String]) -> Option<String> {
+    names
+        .iter()
+        .filter_map(|name| before.rfind(&fold(name)).map(|at| (at, name)))
+        .max_by_key(|(at, _)| *at)
+        .map(|(_, name)| name.clone())
+}
+
+/// The endpoint the noun introduces: the first one named after it.
+fn bearer_of(after: &str, names: &[String]) -> Option<String> {
+    names
+        .iter()
+        .filter_map(|name| after.find(&fold(name)).map(|at| (at, name)))
+        .min_by_key(|(at, _)| *at)
+        .map(|(_, name)| name.clone())
+}
+
+/// The head word of a predicate label, folded: `"sœur de"` → `"soeur"`.
+fn predicate_stem(predicate: &str) -> String {
+    fold(predicate)
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Whether the triple runs between exactly these two entities, either way round.
+fn joins(relation: &ExtractedRelation, one: &str, other: &str) -> bool {
+    (relation.subject == one && relation.object == other)
+        || (relation.subject == other && relation.object == one)
+}
+
+/// Point one triple the way the passage states it.
+///
+/// The triple built on the noun the passage used belongs to the person that
+/// noun introduced; any *other* kinship label over the same pair is its
+/// converse and therefore runs the other way. Anything else is untouched.
+fn reorient(relation: &mut ExtractedRelation, noun: &str, holder: &str, bearer: &str) {
+    let stem = predicate_stem(&relation.predicate);
+    if !KINSHIP_NOUNS.contains(&stem.as_str()) || !joins(relation, holder, bearer) {
+        return;
+    }
+    let (subject, object) = if stem == noun {
+        (bearer, holder)
+    } else {
+        (holder, bearer)
+    };
+    relation.subject = subject.to_string();
+    relation.object = object.to_string();
+}
+
+/// Re-point the kinship triples a possessive construction states, so the label
+/// sits on the person who actually carries it.
+///
+/// A no-op unless the passage contains a possessive naming a kinship noun AND
+/// both sides of it resolve to entities the triples already mention — the pass
+/// never invents an edge, never drops one, and never touches a copule.
+pub(crate) fn orient_possessive_kinship(passage: &str, relations: &mut [ExtractedRelation]) {
+    let folded = fold(passage);
+    let Some(possessive) = find_possessive(&folded) else {
+        return;
+    };
+    let names = endpoint_names(relations);
+    let Some(holder) = holder_of(&folded[..possessive.start], &names) else {
+        return;
+    };
+    let Some(bearer) = bearer_of(&folded[possessive.end..], &names) else {
+        return;
+    };
+    if holder == bearer {
+        return;
+    }
+    for relation in relations.iter_mut() {
+        reorient(relation, possessive.noun, &holder, &bearer);
+    }
+}
+
 /// Failure produced by an [`Extractor`] backend (e.g. a network-backed model
 /// that cannot be reached, or output that cannot be parsed into facts).
 #[derive(Debug, thiserror::Error)]
@@ -495,6 +716,10 @@ fuites\", not \"est utilise pour la surveillance de fuites de donnees\". If you 
 cannot say it in 3 words, pick the closest short label.\n\
 State the triple in the direction the passage states it, and add the converse \
 ONLY if the passage states it too.\n\
+DIRECTION: the subject is whoever CARRIES the relation, not the subject of the \
+sentence. \"A a une soeur, B\" means B is A's sister, so the triple is \
+B/\"soeur de\"/A — never A/\"soeur de\"/B. Same for every possessive \
+(\"a un frere\", \"a une fille\", \"has a brother\").\n\
 Every named entity the passage RELATES to another must appear in at least one \
 triple — an entity that only receives attributes and no edge is a dead end in \
 the graph.\n\n\
@@ -722,6 +947,23 @@ mod tests {
             prompt.contains("at least one triple"),
             "an entity with attributes but no edge is a dead end — the prompt \
              must ask for the edge"
+        );
+    }
+
+    /// The prompt must state the possessive rule explicitly: asked only to
+    /// "state the triple in the direction the passage states it", the model
+    /// read the grammatical subject as the subject of the triple and mirrored
+    /// every possessive.
+    #[test]
+    fn graph_prompt_states_which_side_carries_the_relation() {
+        let prompt = build_graph_prompt("Axel Lange a une soeur, Lea Lange.");
+        assert!(
+            prompt.contains("whoever CARRIES the relation"),
+            "the rule must name the carrier, not just \"the direction\""
+        );
+        assert!(
+            prompt.contains("never A/\"soeur de\"/B"),
+            "the counter-example is what makes the rule unambiguous"
         );
     }
 

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -347,9 +347,10 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let Some(extractor) = self.autograph.as_ref() else {
             return;
         };
-        let Ok(extraction) = extractor.extract_graph(fact) else {
+        let Ok(mut extraction) = extractor.extract_graph(fact) else {
             return;
         };
+        crate::extract::orient_possessive_kinship(fact, &mut extraction.relations);
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();
@@ -418,7 +419,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if text.is_empty() {
             return Err(MemoryError::EmptyFact);
         }
-        let extraction = extractor.extract_graph(text)?;
+        let mut extraction = extractor.extract_graph(text)?;
+        crate::extract::orient_possessive_kinship(text, &mut extraction.relations);
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();

--- a/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
+++ b/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
@@ -66,7 +66,12 @@ impl Extractor for FamilyExtractor {
                     "Axel Lange a une soeur, Lea Lange.",
                     &["axel lange", "lea lange"],
                 )],
-                relations: vec![relation("axel lange", "soeur de", "lea lange")],
+                // Both triples, mirrored, exactly as a real model returns them
+                // for a possessive — see the orientation tests further down.
+                relations: vec![
+                    relation("axel lange", "soeur de", "lea lange"),
+                    relation("lea lange", "frere de", "axel lange"),
+                ],
                 attributes: vec![],
             });
         }
@@ -173,8 +178,8 @@ fn an_entity_is_the_same_node_across_separate_sentences() {
         .expect("axel exists");
     assert_eq!(axel.attributes.get("age"), Some(&json!(15)));
     assert!(
-        axel.relations.iter().any(|r| r.predicate == "soeur de"),
-        "the same Axel node carries both the age and the sister edge: {:?}",
+        axel.relations.iter().any(|r| r.predicate == "frere de"),
+        "the same Axel node carries both the age and the sibling edge: {:?}",
         axel.relations
     );
 }
@@ -194,12 +199,12 @@ fn a_newly_mentioned_person_becomes_its_own_entity() {
         .expect("axel exists");
     assert_ne!(lea.id, axel.id, "Lea is a distinct node");
 
-    let edge = axel
+    let edge = lea
         .relations
         .iter()
         .find(|r| r.predicate == "soeur de")
-        .expect("axel -[soeur de]-> someone");
-    assert_eq!(edge.target_id, lea.id);
+        .expect("lea -[soeur de]-> someone");
+    assert_eq!(edge.target_id, axel.id);
 }
 
 #[test]
@@ -355,6 +360,149 @@ fn a_stored_age_matches_a_numeric_comparison() {
     assert_eq!(as_i64, 15, "a numeric filter compares against this value");
 }
 
+// --- Direction of a kinship triple (issue #1653) -----------------------------
+//
+// A copule ("X est le pere de Y") states the relation on its own grammatical
+// subject, so subject-of-sentence and subject-of-triple coincide. A possessive
+// ("X a une soeur, Y") states it on the OTHER one: it is Y who is X's sister.
+// The daemon took the grammatical subject either way, which does not merely
+// lose an edge — it makes `entity("Lea Lange")` answer, confidently, that Lea
+// is Axel's *brother*.
+
+/// The triples the 0.11.4 daemon actually returned for the three constructions,
+/// verbatim — accents, ligature and all. The copule is right; both possessive
+/// sentences come back mirrored.
+struct MeasuredExtractor;
+
+impl MeasuredExtractor {
+    const COPULE: &'static str = "Julien Lange est le père d'Axel Lange.";
+    const SISTER: &'static str = "Axel Lange a une sœur, Léa Lange.";
+    const BROTHER: &'static str = "Marie Dupont a un frère, Paul Dupont.";
+}
+
+impl Extractor for MeasuredExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        let relation = |subject: &str, predicate: &str, object: &str| ExtractedRelation {
+            subject: subject.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+        };
+        let relations = match text {
+            Self::COPULE => vec![relation("julien lange", "pere de", "axel lange")],
+            Self::SISTER => vec![
+                relation("axel lange", "soeur de", "léa lange"),
+                relation("léa lange", "frere de", "axel lange"),
+            ],
+            Self::BROTHER => vec![relation("marie dupont", "frere de", "paul dupont")],
+            _ => vec![],
+        };
+        Ok(Extraction {
+            facts: vec![ExtractedFact {
+                text: text.to_string(),
+                entities: vec![],
+            }],
+            relations,
+            attributes: vec![],
+        })
+    }
+}
+
+/// The predicates leaving `name`'s hub, so a direction can be asserted as the
+/// pair (who states it, about whom) rather than "an edge exists somewhere".
+fn outgoing(svc: &MemoryService<HashEmbedder>, name: &str) -> Vec<(String, u64)> {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .map(|profile| {
+            profile
+                .relations
+                .into_iter()
+                .map(|r| (r.predicate, r.target_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The hub id of `name`, which must already exist.
+fn hub_id(svc: &MemoryService<HashEmbedder>, name: &str) -> u64 {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .unwrap_or_else(|| panic!("{name} has a hub"))
+        .id
+}
+
+/// The nominal case, and the only guard against a "fix" that flips everything:
+/// a copule already binds the relation to the grammatical subject.
+#[test]
+fn a_copule_keeps_the_relation_on_the_grammatical_subject() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(MeasuredExtractor::COPULE, &MeasuredExtractor, None)
+        .expect("extract and remember");
+
+    let axel = hub_id(&svc, "axel lange");
+    assert!(
+        outgoing(&svc, "julien lange").contains(&("pere de".to_string(), axel)),
+        "julien -[pere de]-> axel must survive untouched, got {:?}",
+        outgoing(&svc, "julien lange")
+    );
+    assert!(
+        outgoing(&svc, "axel lange").is_empty(),
+        "the child states nothing about the father here: {:?}",
+        outgoing(&svc, "axel lange")
+    );
+}
+
+#[test]
+fn a_possessive_binds_the_relation_to_the_person_it_introduces() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(MeasuredExtractor::SISTER, &MeasuredExtractor, None)
+        .expect("extract and remember");
+
+    let axel = hub_id(&svc, "axel lange");
+    let lea = hub_id(&svc, "léa lange");
+    assert!(
+        outgoing(&svc, "léa lange").contains(&("soeur de".to_string(), axel)),
+        "Lea is the one introduced as the sister: lea -[soeur de]-> axel, got {:?}",
+        outgoing(&svc, "léa lange")
+    );
+    assert!(
+        outgoing(&svc, "axel lange").contains(&("frere de".to_string(), lea)),
+        "and Axel is her brother: axel -[frere de]-> lea, got {:?}",
+        outgoing(&svc, "axel lange")
+    );
+    assert!(
+        !outgoing(&svc, "léa lange")
+            .iter()
+            .any(|(predicate, _)| predicate == "frere de"),
+        "Lea must never be reported as anyone's brother: {:?}",
+        outgoing(&svc, "léa lange")
+    );
+}
+
+/// The same construction with a single triple and the masculine noun: the
+/// converse edge is not what carries the fix.
+#[test]
+fn a_possessive_with_one_triple_is_oriented_too() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(MeasuredExtractor::BROTHER, &MeasuredExtractor, None)
+        .expect("extract and remember");
+
+    let marie = hub_id(&svc, "marie dupont");
+    assert!(
+        outgoing(&svc, "paul dupont").contains(&("frere de".to_string(), marie)),
+        "Paul is the brother: paul -[frere de]-> marie, got {:?}",
+        outgoing(&svc, "paul dupont")
+    );
+    assert!(
+        outgoing(&svc, "marie dupont").is_empty(),
+        "Marie is not her own brother's brother: {:?}",
+        outgoing(&svc, "marie dupont")
+    );
+}
+
 // --- Autograph: the same wiring, triggered by a plain `remember` -------------
 
 /// Counts how many times the extractor was actually invoked, so the tests can
@@ -501,5 +649,22 @@ fn autograph_accumulates_across_separate_remembers() {
         .expect("lookup")
         .expect("axel exists");
     assert_eq!(axel.attributes.get("age"), Some(&json!(15)));
-    assert!(axel.relations.iter().any(|r| r.predicate == "soeur de"));
+    assert!(axel.relations.iter().any(|r| r.predicate == "frere de"));
+}
+
+/// The plain-`remember` path is where the defect was measured, so it gets the
+/// same orientation guarantee as `remember_extracted` — the correction cannot
+/// live in one write path only.
+#[test]
+fn autograph_orients_a_possessive_the_same_way() {
+    let (_dir, svc) = autograph_service(std::sync::Arc::new(MeasuredExtractor));
+    svc.remember(MeasuredExtractor::SISTER, &[], None)
+        .expect("remember");
+
+    let axel = hub_id(&svc, "axel lange");
+    assert!(
+        outgoing(&svc, "léa lange").contains(&("soeur de".to_string(), axel)),
+        "autograph orients it too: lea -[soeur de]-> axel, got {:?}",
+        outgoing(&svc, "léa lange")
+    );
 }


### PR DESCRIPTION
## Le défaut

L'autographe prenait le **sujet grammatical de la phrase** comme sujet du triplet.

- Avec une copule (`X est le père de Y`) les deux coïncident → correct.
- Avec un possessif (`X a un/une <relation>, Y`) ils s'opposent : c'est Y qui porte la relation envers X → **direction inversée**, et genre du prédicat incohérent avec son sujet.

Mesuré sur le démon 0.11.4 le 2026-07-28 :

| Phrase | Produit | Attendu |
|---|---|---|
| `Bruno Durand est le père d'Theo Durand.` | `bruno --pere de--> theo` | ✅ |
| `Theo Durand a une sœur, Camille Durand.` | `theo --soeur de--> camille` + `camille --frere de--> theo` | `camille --soeur de--> theo` + `theo --frere de--> camille` |
| `Marie Dupont a un frère, Paul Dupont.` | `marie --frere de--> paul` | `paul --frere de--> marie` |

C'est plus grave qu'une arête absente : `entity("Camille Durand")` répondait, avec la même assurance que pour une arête vraie, que Camille est le *frère* d'Theo.

## La correction

Deux couches, aucune ne suffit seule.

**1. Le prompt** (`build_graph_prompt`) énonce la règle et son contre-exemple : le sujet est celui qui *porte* la relation, pas le sujet de la phrase. Corrige la cause à la source — mais ne se vérifie pas, un modèle peut toujours l'ignorer.

**2. Une passe déterministe post-extraction** (`orient_possessive_kinship`, `src/extract.rs`), appliquée dans les **deux** chemins d'écriture (`remember_extracted` *et* `autograph`) juste après `extract_graph`, donc quel que soit le backend qui a produit les triplets — LLM, stub, ou implémentation tierce du trait `Extractor`.

Elle repère le possessif dans la phrase (marqueurs `a un` / `a une` / `a pour` / `has a`, suivis d'un nom de parenté), identifie le *détenteur* (nommé avant le nom) et le *porteur* (nommé après), puis oriente : le triplet bâti sur le nom que la phrase emploie appartient au porteur ; tout autre prédicat de parenté sur la même paire est son converse et va dans l'autre sens.

Garde-fous : elle ne touche qu'un prédicat de parenté connu reliant **exactement** les deux personnes nommées. Elle n'invente aucune arête, n'en supprime aucune, ne touche jamais une copule. Comparaison sur une forme repliée (accents et ligature `œ` neutralisés), sans quoi `sœur` dans la phrase et `soeur` dans le prédicat ne se rencontrent jamais.

## Preuve

Test écrit **avant** le correctif, sortie rouge réelle :

```
---- a_possessive_binds_the_relation_to_the_person_it_introduces stdout ----
Camille is the one introduced as the sister: camille -[soeur de]-> theo, got [("frere de", 14262053274889288606)]
---- a_possessive_with_one_triple_is_oriented_too stdout ----
Paul is the brother: paul -[frere de]-> marie, got []
test result: FAILED. 15 passed; 6 failed
```

Le test de la copule était **vert avant comme après** : c'est la seule protection contre une correction qui inverserait tout.

Les tests pilotent un extracteur injecté reproduisant verbatim la sortie du démon (accents et ligature compris) — zéro dépendance à un LLM.

Trois assertions existantes figeaient le mauvais sens (`theo -[soeur de]-> camille`) : elles encodaient le défaut et sont corrigées avec lui. Le stub `FamilyExtractor` émet désormais les deux triplets miroir, comme un vrai modèle.

## Gates

| Gate | Résultat |
|---|---|
| `cargo fmt --all` | propre |
| `cargo clippy -p velesdb-memory --all-targets --features mcp,context,persistence -- -D warnings -D clippy::pedantic` | 0 |
| `cargo test -p velesdb-memory --features mcp,context,persistence` | 646 tests, 0 échec |
| `python3 -m lizard -C 8 -a 8` (3 fichiers touchés) | 0 avertissement — CCN max 8, moyenne 2,1 sur `extract.rs` |
| `cargo check -p velesdb-memory --no-default-features --features <feat>` × 6 | vert |

Closes #1653

