### PR TITLE
chore(memory): passer velesdb-memory en 0.11.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "axum",
  "criterion",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.4"
+version = "0.11.5"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.4"
+version = "0.11.5"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -817,4 +817,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -507,7 +507,7 @@ matching checksum next to it.
 
 **This path only becomes active from the first release published after the
 change.** `release-memory.yml`'s `build-daemon-archive` job produces these
-archives, but the `velesdb-memory-v0.11.4` release (and everything before it)
+archives, but the `velesdb-memory-v0.11.5` release (and everything before it)
 predates it and carries no such asset, so `--from-release` against `v0.11.0`
 fails with a clear 404-explaining message rather than a bare `curl` /
 `Invoke-WebRequest` error. This is a **different artifact** than the `.mcpb`
@@ -568,4 +568,4 @@ pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -494,4 +494,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.4
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bascule de version seule. Le contenu est déjà sur `develop`.

## Pourquoi une version de plus, le même jour

La **0.11.4 est publiée** sur crates.io, npm et le registre MCP avec des exemples de documentation portant des noms de personnes réelles — dont des mineurs. Le plus exposé est la description de l'outil `entity`, **transmise à chaque client MCP qui liste les outils**.

#1658 a retiré ces noms du dépôt, mais aucun de ces trois registres ne permet de corriger une version en place. Seule une version suivante fait parvenir le texte propre aux utilisateurs.

## Vérifications

```
python3 scripts/check-version-sync.py    ->  All versions match
cargo publish -p velesdb-memory --dry-run ->  EXIT 0
```

Le dry-run est le contrôle précis qui avait fait échouer la 0.11.3 : `Validate` y était rouge, ce qui avait sauté les cinq jobs avals — crates.io, npm, binaires node, archives daemon et attachement des binaires.

Manifestes alignés : `velesdb-memory/Cargo.toml`, `velesdb-node/Cargo.toml`, `velesdb-node/package.json`, `package-lock.json`, `server.json`, `Cargo.lock`.

## Après merge

Branche `release/memory-0.11.5` vers `main`, CI verte sur le commit exact, puis tag `velesdb-memory-v0.11.5` (contrainte REL-06). La 0.11.4 sera ensuite yankée sur crates.io et dépréciée sur npm — deux gestes réversibles qui limitent sa diffusion future sans prétendre effacer le passé.