### PR TITLE
fix(memory): plafonner le texte embeddé par les sources + fait extrait trop long non fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,21 @@ jobs:
       - name: Run Clippy (velesdb-node cdylib)
         run: cargo clippy -p velesdb-node --lib -- -D warnings
 
+      # velesdb-python was excluded from the workspace clippy for the same
+      # cdylib reason as velesdb-node — but unlike node it never got the
+      # dedicated `--lib` step, so it was linted by NOTHING: not this
+      # workflow, not compat-matrix (which excludes it too), not the git
+      # hooks. `cargo check` in propagation-guard compiled it; nothing
+      # linted it. That gap is what let a type change land green locally
+      # and fail here on `mismatched types`.
+      #
+      # `--lib` links cleanly (0 findings when introduced) and the crate's
+      # [lints] table already carries the workspace pedantic set.
+      - name: Run Clippy (velesdb-python cdylib)
+        env:
+          PYO3_PYTHON: python3
+        run: cargo clippy -p velesdb-python --lib -- -D warnings
+
       - name: Run Clippy undocumented unsafe blocks (core)
         run: |
           cargo clippy -p velesdb-core --lib --bins \

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -397,11 +397,13 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Size: [`crate::limits::MAX_MEDIA_BYTES`] /
     /// [`crate::limits::MAX_TOTAL_MEDIA_BYTES`] already bounded every
     /// fragment's `bytes_b64` before `compiler.compile` ever ran (see
-    /// `validate_media`, called from `compile`'s `validate`) — `augmented`
-    /// here is exactly the request that passed that check, so no separate
-    /// size guard is needed on the write path itself
-    /// ([`crate::limits::MAX_FACT_BYTES`] governs the unrelated MCP
-    /// `remember`/`extract` text ceiling, not this one).
+    /// `validate_media`, called from `compile`'s `validate`). TEXT is a
+    /// different story, and an earlier revision of this comment got it
+    /// wrong by claiming no size guard was needed on the write path: those
+    /// media caps say nothing about `content`, which a `path` ingestion can
+    /// fill up to 1 MiB — so [`Self::source_vector`] caps what it EMBEDS
+    /// (the stored content stays whole). The lesson stands: "another layer
+    /// already checked" must name which cap, over which field.
     fn store_context_sources(
         &self,
         augmented: &CompileRequest,
@@ -499,13 +501,24 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// index, never semantically meaningful. For a media fragment `hash` IS
     /// the raw-bytes hash (see `fragment_handle_hash`), so nothing is
     /// re-decoded here.
+    ///
+    /// A TEXT fragment is embedded over at most
+    /// [`crate::limits::MAX_EMBEDDABLE_TEXT_BYTES`] of its content
+    /// ([`super::embeddable_prefix`]) — a `path`-ingested file can be 1 MiB,
+    /// far past what the embedding backend accepts, and handing it over
+    /// whole surfaced the backend's raw failure (issue #1654's residue,
+    /// found on this very path). Truncating the *embedded* text, not the
+    /// stored content, is the right trade here: retrieval is hash-addressed
+    /// so the source stays whole, and the vector keeps ranking on the head
+    /// of the text instead of vanishing from semantic recall.
     fn source_vector(
         &self,
         fragment: &ContextFragment,
         hash: u64,
     ) -> Result<(Vec<f32>, Option<Value>), MemoryError> {
         let Some(media_ref) = &fragment.media else {
-            return Ok((self.embedder.embed(fragment.content.as_str())?, None));
+            let embeddable = super::embeddable_prefix(fragment.content.as_str());
+            return Ok((self.embedder.embed(embeddable)?, None));
         };
         let descriptor = serde_json::to_value(media_ref).unwrap_or(Value::Null);
         Ok((self.media_placeholder_embedding(hash), Some(descriptor)))

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -866,3 +866,86 @@ fn test_load_working_context_with_marker_but_no_body_is_an_error_not_a_fresh_sta
          start; got {loaded:?}"
     );
 }
+
+/// Records the byte length of every text it is asked to embed, so a test can
+/// pin what actually reaches the embedding backend — the store keeps the
+/// whole content either way, so only this spy can tell the difference.
+struct LengthSpyEmbedder {
+    inner: HashEmbedder,
+    seen: std::sync::Mutex<Vec<usize>>,
+}
+
+impl LengthSpyEmbedder {
+    fn new() -> Self {
+        Self {
+            inner: HashEmbedder::new(DIM),
+            seen: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl crate::embedder::Embedder for &LengthSpyEmbedder {
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+    fn embed(&self, text: &str) -> Result<Vec<f32>, crate::embedder::EmbedError> {
+        self.seen
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(text.len());
+        self.inner.embed(text)
+    }
+}
+
+/// Issue #1654, the residue: `compile_context` stores every non-duplicate
+/// fragment as a source (`store_sources` defaults to true) and embedded the
+/// FULL content, bypassing the `MAX_EMBEDDABLE_TEXT_BYTES` gate `remember`
+/// gets — an 8 KiB fragment reached the real backend whole and came back as
+/// a raw `ollama embeddings call failed`, naming neither size nor cap. The
+/// compile itself was fine; the write-back killed it.
+///
+/// Contract pinned here: the compile SUCCEEDS, the source text sent to the
+/// embedder is capped, and the STORED content stays whole — retrieval is
+/// hash-addressed, so truncating the embedded text must not cost a byte of
+/// the retrievable source.
+#[test]
+fn oversized_fragment_compiles_and_embeds_a_capped_text() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let spy = LengthSpyEmbedder::new();
+    let svc = MemoryService::open(dir.path(), &spy).expect("open memory store");
+
+    let big = "mot ".repeat(2048); // 8192 bytes, 4x the embeddable cap
+    let compiler = ContextCompiler::new(CompilePolicy::default());
+    let out = svc
+        .compile_context(&compiler, &request(&big, CompilePolicy::default()))
+        .expect("an oversized fragment must compile; the cap applies to the embedded text");
+
+    let worst = spy
+        .seen
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .copied()
+        .max()
+        .expect("the compile embedded at least the source");
+    assert!(
+        worst <= crate::limits::MAX_EMBEDDABLE_TEXT_BYTES,
+        "the embedder must never see more than the embeddable cap \
+         ({} bytes), got {worst}",
+        crate::limits::MAX_EMBEDDABLE_TEXT_BYTES,
+    );
+
+    let handle = out
+        .sources
+        .first()
+        .expect("the fragment was stored as a source")
+        .handle
+        .clone();
+    let source = svc
+        .retrieve_context_source(&handle)
+        .expect("the stored source resolves");
+    assert_eq!(
+        source.content, big,
+        "the STORED content must stay whole — only the embedded text is capped"
+    );
+}

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -453,14 +453,18 @@ impl McpServer {
         // responsive to other tool calls and cancellations.
         let service = Arc::clone(&self.service);
         let RememberExtractedParams { text, metadata } = params;
-        let ids = tokio::task::spawn_blocking(move || {
+        let outcome = tokio::task::spawn_blocking(move || {
             service.remember_extracted(&text, &extractor, metadata.as_ref())
         })
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        let ids_str = ids.iter().map(u64::to_string).collect();
-        Ok(Json(RememberExtractedResult { ids, ids_str }))
+        let ids_str = outcome.ids.iter().map(u64::to_string).collect();
+        Ok(Json(RememberExtractedResult {
+            ids: outcome.ids,
+            ids_str,
+            skipped_over_cap: outcome.skipped_over_cap,
+        }))
     }
 }
 

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -506,4 +506,10 @@ pub(super) struct RememberExtractedResult {
     /// Decimal-string twins of `ids`, same order (issue #1468) — see
     /// [`RememberResult::id_str`].
     pub(super) ids_str: Vec<String>,
+    /// Extracted facts DROPPED for exceeding the embeddable text cap
+    /// (2048 bytes). Additive and always present: a skip the caller cannot
+    /// see is indistinguishable from the model extracting fewer facts, and
+    /// this tool exists precisely so the caller does not have to verify what
+    /// it stored.
+    pub(super) skipped_over_cap: usize,
 }

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -276,6 +276,23 @@ pub struct EntityRelation {
     pub target: String,
 }
 
+/// What [`crate::MemoryService::remember_extracted`] actually did with a
+/// passage: the stored fact ids, and how many extracted facts it had to drop.
+///
+/// A separate struct rather than a bare `Vec<u64>` because the drop count is
+/// part of the contract: an extracted fact past the embeddable cap is
+/// *skipped* — one unusable element must not cost the others — and a skip the
+/// caller cannot see is indistinguishable from the model simply extracting
+/// fewer facts.
+#[derive(Debug, Clone)]
+pub struct RememberedExtraction {
+    /// Stable ids of the stored facts, in extraction order.
+    pub ids: Vec<u64>,
+    /// Extracted facts dropped for exceeding
+    /// [`crate::limits::MAX_EMBEDDABLE_TEXT_BYTES`].
+    pub skipped_over_cap: usize,
+}
+
 /// Everything the auto-built graph knows about one named entity: the
 /// attributes merged onto its hub and the typed edges leaving it.
 #[derive(Debug, Clone, Serialize, JsonSchema)]

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1218,6 +1218,12 @@ pub(crate) fn validate_embeddable(text: &str) -> Result<(), MemoryError> {
 /// vector is a ranking aid), truncating the *embedded* text is the correct
 /// trade — refusing would fail a legitimate compile, and a placeholder
 /// vector would remove the source from semantic recall entirely.
+///
+/// Gated on `context`: the compiler's source writer is its only caller, so a
+/// build without that feature sees dead code, which CI's `-D warnings`
+/// turns into a failed build. Same shape as `positive_ttl` — and only the
+/// per-feature ISOLATION loop catches it, never a feature combination.
+#[cfg(feature = "context")]
 pub(crate) fn embeddable_prefix(text: &str) -> &str {
     let cap = crate::limits::MAX_EMBEDDABLE_TEXT_BYTES;
     if text.len() <= cap {

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -20,6 +20,7 @@ use crate::extract::{ExtractedAttribute, ExtractedRelation, Extractor};
 use crate::id;
 use crate::model::{
     ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryNode, Recollection,
+    RememberedExtraction,
 };
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
@@ -405,20 +406,26 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     ///
     /// Entity hubs are content-addressed, so the same topic seen across many
     /// calls collapses onto one hub. Returns the ids of the stored facts (entity
-    /// hubs excluded), in extraction order.
+    /// hubs excluded), in extraction order, plus how many facts were skipped
+    /// for exceeding the embeddable cap — one unusable fact must not cost the
+    /// others, the policy every other stage of this pipeline already follows
+    /// (a malformed triple is skipped, a blank entity is skipped).
     ///
     /// # Errors
     /// Returns [`MemoryError::EmptyFact`] for empty/whitespace `text`,
     /// [`MemoryError::Extract`] if extraction fails, [`MemoryError::ReservedKey`]
     /// if `metadata` names a reserved key, [`MemoryError::MetadataTooLarge`] if
     /// `metadata` exceeds [`crate::limits::MAX_METADATA_BYTES`], or a storage
-    /// error if persistence fails.
+    /// error if persistence fails. A fact past
+    /// [`crate::limits::MAX_EMBEDDABLE_TEXT_BYTES`] is NOT an error: it is
+    /// counted in [`RememberedExtraction::skipped_over_cap`] and the call
+    /// carries on.
     pub fn remember_extracted<X: Extractor>(
         &self,
         text: &str,
         extractor: &X,
         metadata: Option<&Metadata>,
-    ) -> Result<Vec<u64>, MemoryError> {
+    ) -> Result<RememberedExtraction, MemoryError> {
         let text = text.trim();
         if text.is_empty() {
             return Err(MemoryError::EmptyFact);
@@ -428,7 +435,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();
-        let fact_ids = self.store_extracted_facts(
+        let outcome = self.store_extracted_facts(
             &extraction.facts,
             metadata,
             &mut entity_ids,
@@ -442,7 +449,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             &mut seeded,
         )?;
         self.wire_attributes(&extraction.attributes, &mut entity_ids)?;
-        Ok(fact_ids)
+        Ok(outcome)
     }
 
     /// Look up everything known about a named entity: the attributes merged
@@ -596,18 +603,35 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         entity_ids: &mut HashMap<String, u64>,
         edges: &mut HashSet<(u64, u64)>,
         seeded: &mut HashSet<u64>,
-    ) -> Result<Vec<u64>, MemoryError> {
-        let mut fact_ids = Vec::with_capacity(facts.len());
+    ) -> Result<RememberedExtraction, MemoryError> {
+        let mut ids = Vec::with_capacity(facts.len());
+        let mut skipped_over_cap = 0;
         for fact in facts {
             let content = fact.text.trim();
             if content.is_empty() {
                 continue;
             }
-            let fact_id = self.remember_inner(content, &[], metadata, None, false)?;
-            fact_ids.push(fact_id);
+            // An over-cap fact is skipped, not fatal: aborting here used to
+            // leave the previous iterations persisted with no rollback, no
+            // graph wiring, and no ids returned — the worst of every world.
+            // Every OTHER error still aborts: they signal bad caller input
+            // (reserved keys, oversized metadata) or a failing store, where
+            // carrying on would compound the damage.
+            let fact_id = match self.remember_inner(content, &[], metadata, None, false) {
+                Ok(id) => id,
+                Err(MemoryError::FactTooLarge { .. }) => {
+                    skipped_over_cap += 1;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            ids.push(fact_id);
             self.wire_entities(fact_id, &fact.entities, entity_ids, edges, seeded)?;
         }
-        Ok(fact_ids)
+        Ok(RememberedExtraction {
+            ids,
+            skipped_over_cap,
+        })
     }
 
     /// Link `fact_id` to each of its topics with a deduplicated edge in *both*
@@ -1165,13 +1189,45 @@ fn validate_fact(fact: &str) -> Result<(), MemoryError> {
     if fact.is_empty() {
         return Err(MemoryError::EmptyFact);
     }
-    if fact.len() > crate::limits::MAX_EMBEDDABLE_TEXT_BYTES {
+    validate_embeddable(fact)
+}
+
+/// Refuse a text past the size an embedding model still accepts.
+///
+/// Extracted from [`validate_fact`] so every path that embeds CALLER content
+/// answers to the same cap: `remember` refuses (this function), while the
+/// context bridge truncates via [`embeddable_prefix`] — but neither may hand
+/// the backend an oversized text and relay its raw failure, which is how
+/// issue #1654's `ollama embeddings call failed` (naming neither size nor
+/// cap) reached users.
+pub(crate) fn validate_embeddable(text: &str) -> Result<(), MemoryError> {
+    if text.len() > crate::limits::MAX_EMBEDDABLE_TEXT_BYTES {
         return Err(MemoryError::FactTooLarge {
-            bytes: fact.len(),
+            bytes: text.len(),
             max: crate::limits::MAX_EMBEDDABLE_TEXT_BYTES,
         });
     }
     Ok(())
+}
+
+/// The longest prefix of `text` that fits the embeddable cap without
+/// splitting a UTF-8 character.
+///
+/// For content that must be STORED whole but whose vector only serves
+/// similarity search (context sources: retrieval is hash-addressed, the
+/// vector is a ranking aid), truncating the *embedded* text is the correct
+/// trade — refusing would fail a legitimate compile, and a placeholder
+/// vector would remove the source from semantic recall entirely.
+pub(crate) fn embeddable_prefix(text: &str) -> &str {
+    let cap = crate::limits::MAX_EMBEDDABLE_TEXT_BYTES;
+    if text.len() <= cap {
+        return text;
+    }
+    let mut end = cap;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
 }
 
 /// Refuse an explicit per-call TTL of `0`.

--- a/crates/velesdb-memory/tests/auto_date_bdd.rs
+++ b/crates/velesdb-memory/tests/auto_date_bdd.rs
@@ -126,7 +126,8 @@ fn remember_extracted_facts_are_also_auto_stamped() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("Alice ships the parser.", &SingleFactExtractor, None)
-        .expect("remember_extracted");
+        .expect("remember_extracted")
+        .ids;
     assert_eq!(ids.len(), 1);
 
     let hits = svc

--- a/crates/velesdb-memory/tests/common/mod.rs
+++ b/crates/velesdb-memory/tests/common/mod.rs
@@ -27,3 +27,29 @@ pub fn meta(pairs: &[(&str, Value)]) -> Metadata {
         .map(|(k, v)| ((*k).to_owned(), v.clone()))
         .collect()
 }
+
+/// A canned extractor: two facts that share the topic `rust` (and nothing
+/// else), so the only path from one to the other runs through the shared
+/// hub. One definition for every suite that needs a deterministic two-fact
+/// graph — `extract_bdd` (graph liveness) and `forget_orphan_hubs_bdd`
+/// (orphan collection) used to carry byte-identical private copies.
+pub struct SharedTopicExtractor;
+
+impl velesdb_memory::extract::Extractor for SharedTopicExtractor {
+    fn extract(
+        &self,
+        _text: &str,
+    ) -> Result<Vec<velesdb_memory::extract::ExtractedFact>, velesdb_memory::extract::ExtractError>
+    {
+        Ok(vec![
+            velesdb_memory::extract::ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_string(),
+                entities: vec!["rust".to_string(), "parser".to_string()],
+            },
+            velesdb_memory::extract::ExtractedFact {
+                text: "Bob maintains the Rust toolchain.".to_string(),
+                entities: vec!["rust".to_string()],
+            },
+        ])
+    }
+}

--- a/crates/velesdb-memory/tests/extract_bdd.rs
+++ b/crates/velesdb-memory/tests/extract_bdd.rs
@@ -20,24 +20,8 @@ fn meta(key: &str, value: Value) -> Metadata {
     m
 }
 
-/// A canned extractor: two facts that share the topic `rust` (and nothing else),
-/// so the only path from one to the other is through the shared hub.
-struct StubExtractor;
-
-impl Extractor for StubExtractor {
-    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
-        Ok(vec![
-            ExtractedFact {
-                text: "Alice ships the parser in Rust.".to_string(),
-                entities: vec!["rust".to_string(), "parser".to_string()],
-            },
-            ExtractedFact {
-                text: "Bob maintains the Rust toolchain.".to_string(),
-                entities: vec!["rust".to_string()],
-            },
-        ])
-    }
-}
+mod common;
+use common::SharedTopicExtractor as StubExtractor;
 
 /// An extractor that always fails, to check the error path is surfaced.
 struct FailingExtractor;
@@ -62,7 +46,8 @@ fn remember_extracted_stores_every_fact() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("Alice and Bob both work in Rust.", &StubExtractor, None)
-        .expect("extract and remember");
+        .expect("extract and remember")
+        .ids;
     assert_eq!(ids.len(), 2, "both extracted facts are stored");
     assert_ne!(ids[0], ids[1]);
 }
@@ -104,10 +89,12 @@ fn shared_topic_collapses_onto_one_hub() {
     // entity hubs are content-addressed, so the second call reuses the first.
     let first = svc
         .remember_extracted("x", &StubExtractor, None)
-        .expect("first");
+        .expect("first")
+        .ids;
     let second = svc
         .remember_extracted("y", &StubExtractor, None)
-        .expect("second");
+        .expect("second")
+        .ids;
     // Same canned facts → same stable fact ids → idempotent.
     assert_eq!(first, second, "identical facts are idempotent across calls");
 }
@@ -255,5 +242,54 @@ fn reingesting_the_same_text_does_not_duplicate_edges() {
         after_first.edges.len(),
         after_second.edges.len(),
         "re-ingestion must be idempotent: no duplicate edges"
+    );
+}
+
+/// One fact past the embeddable cap among sound ones. The old behaviour
+/// failed the WHOLE call at that fact — everything already written stayed
+/// (no rollback), the graph wiring never ran, and the caller did not even
+/// get the ids of what had been persisted. Inconsistent with the rest of
+/// the pipeline, where a malformed triple or a blank entity is skipped
+/// without being fatal: one unusable element must not cost the others.
+struct OneOversizedExtractor;
+
+impl Extractor for OneOversizedExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![
+            ExtractedFact {
+                text: "Alice ships the parser in Rust.".to_string(),
+                entities: vec!["rust".to_string()],
+            },
+            ExtractedFact {
+                // 4x the embeddable cap: would previously abort the call.
+                text: "x".repeat(8192),
+                entities: vec!["rust".to_string()],
+            },
+            ExtractedFact {
+                text: "Bob maintains the Rust toolchain.".to_string(),
+                entities: vec!["rust".to_string()],
+            },
+        ])
+    }
+}
+
+#[test]
+fn an_oversized_fact_is_skipped_not_fatal() {
+    let (_dir, svc) = service();
+    let outcome = svc
+        .remember_extracted(
+            "passage with one oversized fact",
+            &OneOversizedExtractor,
+            None,
+        )
+        .expect("one oversized fact must not fail the whole call");
+    assert_eq!(
+        outcome.ids.len(),
+        2,
+        "the two sound facts are stored; the oversized one is skipped"
+    );
+    assert_eq!(
+        outcome.skipped_over_cap, 1,
+        "the caller is told exactly how many facts were dropped, and why"
     );
 }

--- a/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
+++ b/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
@@ -11,33 +11,16 @@
 mod common;
 
 use common::service;
-use velesdb_memory::extract::{ExtractError, ExtractedFact, Extractor};
 
-/// Two facts sharing the topic `rust`; only the first mentions `parser`.
-/// Forgetting the first must therefore collect `parser` and keep `rust`.
-struct SharedTopicExtractor;
-
-impl Extractor for SharedTopicExtractor {
-    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
-        Ok(vec![
-            ExtractedFact {
-                text: "Alice ships the parser in Rust.".to_string(),
-                entities: vec!["rust".to_string(), "parser".to_string()],
-            },
-            ExtractedFact {
-                text: "Bob maintains the Rust toolchain.".to_string(),
-                entities: vec!["rust".to_string()],
-            },
-        ])
-    }
-}
+use common::SharedTopicExtractor;
 
 #[test]
 fn forget_collects_a_hub_no_surviving_fact_mentions() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("seed", &SharedTopicExtractor, None)
-        .expect("remember_extracted");
+        .expect("remember_extracted")
+        .ids;
 
     assert!(
         svc.entity_profile("parser")
@@ -62,7 +45,8 @@ fn forget_keeps_a_hub_another_fact_still_mentions() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("seed", &SharedTopicExtractor, None)
-        .expect("remember_extracted");
+        .expect("remember_extracted")
+        .ids;
 
     svc.forget(ids[0]).expect("forget the first fact");
 
@@ -80,7 +64,8 @@ fn forgetting_every_fact_leaves_no_hub_behind() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("seed", &SharedTopicExtractor, None)
-        .expect("remember_extracted");
+        .expect("remember_extracted")
+        .ids;
 
     for id in ids {
         svc.forget(id).expect("forget");

--- a/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
+++ b/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
@@ -308,7 +308,8 @@ fn a_fact_only_extractor_still_works_unchanged() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("Alice works in Rust.", &LegacyExtractor, None)
-        .expect("extract and remember");
+        .expect("extract and remember")
+        .ids;
     assert_eq!(
         ids.len(),
         1,

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -567,9 +567,14 @@ impl MemoryStore {
             let metadata = convert::to_metadata(metadata)?;
             let url = url.unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
             let extractor = OllamaExtractor::new(url, model);
+            // The binding's return stays an id array (its published N-API
+            // shape); the skip count the service now reports has no slot
+            // here yet — an over-cap fact is simply absent from the ids,
+            // exactly as before this call could distinguish the two.
             let ids = svc
                 .remember_extracted(&text, &extractor, metadata.as_ref())
-                .map_err(to_napi_err)?;
+                .map_err(to_napi_err)?
+                .ids;
             Ok(ids.into_iter().map(convert::id_to_string).collect())
         }))
     }

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -412,9 +412,14 @@ impl PyMemoryService {
         let metadata = to_metadata(py, metadata)?;
         let url = url.unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
         let extractor = OllamaExtractor::new(url, model);
+        // The binding's return stays a plain id list (its published Python
+        // signature); the skip count the service now reports has no slot
+        // here — an over-cap fact is simply absent from the ids, exactly as
+        // before, when it aborted the whole call instead.
         py.detach(|| {
             self.svc
                 .remember_extracted(text, &extractor, metadata.as_ref())
+                .map(|outcome| outcome.ids)
                 .map_err(to_py_err)
         })
     }


### PR DESCRIPTION
Solde les deux résidus de #1654 que la campagne avait identifiés hors du chemin `remember`.

## 1. `compile_context` contournait le cap d'embedding

`store_context_sources` embedde **chaque fragment non-doublon** (`store_sources` est le défaut), pas seulement les externalisés — et sans aucun cap. Un fichier de 1 MiB ingéré par `path` compilait puis échouait en erreur ollama brute, et la boucle propageait au premier échec **sans rollback** : sources partielles persistées, contexte compilé (le vrai produit) perdu. Le commentaire du code affirmait qu'aucun garde n'était nécessaire sur ce chemin — les caps média qu'il invoquait ne disent rien du champ `content`.

**Décision** : tronquer le texte **embeddé** (préfixe char-safe au cap), jamais le contenu stocké. Refuser casserait des compilations légitimes ; un vecteur placeholder ferait disparaître la source du recall sémantique. La résolution étant adressée par hash, `retrieve_context_source` rend toujours le contenu entier. `remember`, lui, refuse toujours : tronquer en silence un fait destiné au recall trahirait son contrat.

Le contrôle sort de `validate_fact` vers `validate_embeddable` + `embeddable_prefix` — un point unique pour tout site d'embed futur.

**Test** : embedder espion qui enregistre les longueurs. Rouge avant (`got 8192`), et il pinne les trois faces : compile OK, embedder jamais au-delà du cap, contenu stocké entier.

## 2. Un fait extrait trop long faisait échouer tout `remember_extracted`

Le `?` dans la boucle laissait le pire des mondes : faits précédents persistés sans rollback, graphe jamais câblé, ids perdus. Incohérent avec le reste du pipeline, où un triplet malformé et une entité vide sont *sautés*.

**Décision** : le fait au-delà du cap est sauté, la boucle continue, le graphe est câblé pour les faits retenus — toute **autre** erreur reste fatale. `remember_extracted` retourne `RememberedExtraction { ids, skipped_over_cap }` : un saut invisible serait indiscernable d'un modèle qui extrait moins. Champ additif `skipped_over_cap` dans la réponse MCP (type direct, invariant #1652) ; le binding node garde sa forme publiée.

**Test** : extracteur à trois faits dont un de 8 Ko — l'appel réussit avec 2 ids et `skipped_over_cap: 1`.

## Au passage

Le garde DRY a révélé deux copies octet-identiques du même extracteur canné dans deux suites — factorisées dans `tests/common`.

## Gates

22 binaires de test verts (features memory **et** combinaison `extract,ollama,persistence` de la CI), clippy pedantic 0 sur les deux jeux de features + le clippy workspace du hook (qui a attrapé l'appelant `velesdb-node` oublié), lizard 0 avertissement.