### PR TITLE
fix(memory): unrelate — l'annulation symetrique de relate + garde de publiabilite en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,25 @@ jobs:
       - name: Test the velesdb-memory extract feature
         run: cargo test -p velesdb-memory --features extract,ollama,persistence
 
+      # velesdb-memory publishes independently, and `cargo publish` verifies
+      # the tarball against velesdb-core AS PUBLISHED ON CRATES.IO — not the
+      # core sitting next to it in this workspace. Any call into a core API
+      # that is not released yet therefore compiles perfectly here and breaks
+      # the release, at tag time, with nothing left to do but revert.
+      #
+      # That is not hypothetical: 0.11.3 shipped exactly that way (its MCPB
+      # bundles reached the registry before packaging failed; no crate was
+      # ever published), and the same trap was caught by hand on a PR again
+      # on 2026-07-28. The identical dry-run existed only in
+      # `release-memory.yml` ("Validate packaging"), i.e. AFTER the tag — too
+      # late by construction. Running it per PR is what makes the invariant
+      # "develop is always publishable" enforceable instead of aspirational.
+      #
+      # `--locked` mirrors the release job and fails on any Cargo.lock drift
+      # rather than silently updating it.
+      - name: Validate velesdb-memory packaging (dry-run, publishability gate)
+        run: cargo publish -p velesdb-memory --dry-run --locked
+
       - name: Run Clippy (strict)
         run: |
           cargo clippy --workspace --all-targets --features persistence,gpu,update-check \

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`unrelate` — `relate`'s exact undo (#1661).** The graph was the only
+  facet whose writes were one-way: a mistaken edge could only be removed by
+  destroying the facts at its endpoints. `unrelate(from, to, relation)`
+  removes exactly the named edge(s), touches neither the facts nor any
+  entity, refuses exactly what `relate` refuses (empty label, self-loop),
+  and is idempotent — an absent edge answers `{ found: false }`, not an
+  error, so a cleanup is replayable. Exposed as an MCP tool, on
+  `MemoryService`, and on the `MemoryStore` trait (native + WASM backends).
+  Scope: the store does not distinguish an explicit edge from an
+  autograph-derived one, so both are removable — correcting an autograph
+  edge is better done by `forget` + `remember` of the source fact.
+
 ### Fixed
 
 Five input defects found by a systematic scenario campaign against the 0.11.4

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -221,7 +221,7 @@ end-to-end *extraction* comparison on the real
 
 | Family | Tools |
 |---|---|
-| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `forget`, `why`, `feedback`, `remember_extracted` |
+| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `unrelate`, `forget`, `entity`, `why`, `feedback`, `remember_extracted` |
 | Context compiler | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `suggest_budget` |
 | Session resumption | `save_working_context`, `load_working_context`, `list_working_contexts` |
 

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -653,6 +653,10 @@ macro_rules! delegate_untouched_store_methods {
             self.inner.relations(id)
         }
 
+        fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
+            self.inner.unrelate(edge_id)
+        }
+
         fn count(&self) -> usize {
             self.inner.count()
         }

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -135,7 +135,7 @@ pub use extract::{
 pub use mcp::McpServer;
 pub use model::{
     ColumnFilter, ColumnOp, EntityProfile, EntityRelation, Explanation, FusionOptions, Link,
-    MemoryEdge, MemoryNode, Recollection,
+    MemoryEdge, MemoryNode, Recollection, UnrelateOutcome,
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -43,7 +43,8 @@ use dto::{
     EntityParams, EntityProfileDto, ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams,
     ForgetResult, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
     RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
-    RememberExtractedResult, RememberParams, RememberResult, WhyParams,
+    RememberExtractedResult, RememberParams, RememberResult, UnrelateParams, UnrelateResult,
+    WhyParams,
 };
 
 /// Advertised-schema counterpart of [`crate::model::deserialize_id`]: `keys`
@@ -347,6 +348,31 @@ impl McpServer {
     }
 
     #[tool(
+        name = "unrelate",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<UnrelateResult>(),
+        description = "Remove the typed link `from` -relation-> `to` — `relate`'s exact undo, so a mistaken edge no longer costs the facts at its endpoints. Only the edge is removed: the two memories, and any entity, are untouched. Idempotent: removing an absent edge answers `found: false` instead of erroring, so a cleanup can be replayed safely; `removed` counts the edges actually deleted. It refuses exactly what `relate` refuses (empty relation, `from` == `to`). Scope: the store does not distinguish a link you created with `relate` from one auto-derived from a passage, so `unrelate` removes both alike — to correct an auto-derived link, prefer `forget` + `remember` of the source fact, otherwise remembering the same passage again can rebuild the edge removed here. Same id wire contract as `relate`: pass ids as decimal strings (`id_str`) — a JSON-number id above 2^53 loses precision on float-lossy clients.",
+        input_schema = id_wire_input_schema::<UnrelateParams>(&["from", "to"])
+    )]
+    async fn unrelate(
+        &self,
+        Parameters(params): Parameters<UnrelateParams>,
+    ) -> Result<Json<UnrelateResult>, ErrorData> {
+        let service = Arc::clone(&self.service);
+        let UnrelateParams { from, to, relation } = params;
+        let outcome = tokio::task::spawn_blocking(move || service.unrelate(from, to, &relation))
+            .await
+            .map_err(join_error)?
+            .map_err(to_error)?;
+        Ok(Json(UnrelateResult {
+            found: outcome.found,
+            removed: outcome.removed,
+        }))
+    }
+
+    #[tool(
         name = "forget",
         // Sans declaration explicite, rmcp derive un schema de sortie qui
         // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
@@ -473,7 +499,7 @@ impl McpServer {
 /// "context")]` variant since the context-compiler tools only exist in that
 /// build.
 #[cfg(feature = "context")]
-const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, recall, recall_fused, recall_where, relate, forget, feedback, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
+const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, recall, recall_fused, recall_where, relate, unrelate, forget, feedback, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
 
 #[cfg(not(feature = "context"))]
 const SERVER_INSTRUCTIONS: &str = "Local-first memory for AI agents: remember facts, recall them \

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -241,6 +241,37 @@ pub(super) struct RelateResult {
     pub(super) edge_id_str: String,
 }
 
+/// Parameters for the `unrelate` tool — `relate`'s exact undo, so the two
+/// share the id wire contract (number or decimal string, issue #1468).
+#[derive(Deserialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct UnrelateParams {
+    /// Source memory id of the link to remove — the side it points FROM.
+    /// Accepts a JSON number or a decimal string: always relay a previous
+    /// response's `id_str` here (issue #1468).
+    #[serde(deserialize_with = "deserialize_id")]
+    pub(super) from: u64,
+    /// Target memory id of the link to remove — the side it points TO. Same
+    /// string-or-number contract as `from`.
+    #[serde(deserialize_with = "deserialize_id")]
+    pub(super) to: u64,
+    /// Directional relationship label of the link to remove, exactly as it
+    /// was given to `relate`.
+    pub(super) relation: String,
+}
+
+/// Result of the `unrelate` tool — the service's
+/// [`UnrelateOutcome`](crate::model::UnrelateOutcome), flattened to the wire.
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct UnrelateResult {
+    /// Whether at least one matching edge existed and was removed. `false`
+    /// means no such edge — a replayed cleanup or a typo, not an error.
+    pub(super) found: bool,
+    /// How many matching edges were removed.
+    pub(super) removed: usize,
+}
+
 /// Parameters for the `forget` tool.
 #[derive(Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1202,3 +1202,100 @@ fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
         Some("velesdb")
     );
 }
+
+// ---------------------------------------------------------------------------
+// unrelate (issue #1661) and entity relations_in
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unrelate_tool_removes_the_edge_and_is_idempotent() {
+    let (_dir, srv) = server();
+    let Json(a) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember a");
+    let Json(b) = srv
+        .remember(Parameters(RememberParams {
+            fact: "the cause behind the decision".to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember b");
+    srv.relate(Parameters(RelateParams {
+        from: a.id,
+        to: b.id,
+        relation: "caused_by".to_owned(),
+    }))
+    .await
+    .expect("relate");
+
+    let Json(res) = srv
+        .unrelate(Parameters(UnrelateParams {
+            from: a.id,
+            to: b.id,
+            relation: "caused_by".to_owned(),
+        }))
+        .await
+        .expect("unrelate");
+    assert!(res.found, "the edge existed");
+    assert_eq!(res.removed, 1);
+
+    let Json(res) = srv
+        .unrelate(Parameters(UnrelateParams {
+            from: a.id,
+            to: b.id,
+            relation: "caused_by".to_owned(),
+        }))
+        .await
+        .expect("a second unrelate must not error — cleanups are replayable");
+    assert!(!res.found, "already removed");
+    assert_eq!(res.removed, 0);
+
+    let (_ids, edge_count) = why_one_hop(&srv).await;
+    assert_eq!(edge_count, 0, "the edge must be gone from traversal");
+}
+
+#[tokio::test]
+async fn unrelate_refuses_a_self_loop_as_invalid_params() {
+    let (_dir, srv) = server();
+    let Json(a) = srv
+        .remember(Parameters(RememberParams {
+            fact: DECISION.to_owned(),
+            links: Vec::new(),
+            metadata: None,
+            ttl_seconds: None,
+        }))
+        .await
+        .expect("remember");
+    let err = srv
+        .unrelate(Parameters(UnrelateParams {
+            from: a.id,
+            to: a.id,
+            relation: "supports".to_owned(),
+        }))
+        .await
+        .map(|_| ())
+        .expect_err("a self-loop is refused exactly like relate's");
+    assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+}
+
+/// The wire contract shared with `relate` (#1468): ids arrive as JSON numbers
+/// or decimal strings alike.
+#[test]
+fn unrelate_params_accept_string_or_number_ids_on_the_wire() {
+    let params: UnrelateParams = serde_json::from_value(serde_json::json!({
+        "from": "18446744073709551615",
+        "to": 42,
+        "relation": "caused_by"
+    }))
+    .expect("string and number ids must both deserialize");
+    assert_eq!(params.from, u64::MAX);
+    assert_eq!(params.to, 42);
+}

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -255,12 +255,28 @@ pub struct MemoryNode {
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub struct MemoryEdge {
+    /// Stable id of the edge itself — what
+    /// [`MemoryStore::unrelate`](crate::storage::MemoryStore::unrelate)
+    /// removes by.
+    pub id: u64,
     /// Source memory id.
     pub from: u64,
     /// Target memory id.
     pub to: u64,
     /// Relationship label.
     pub relation: String,
+}
+
+/// Outcome of [`MemoryService::unrelate`](crate::service::MemoryService::unrelate):
+/// idempotent by design, so an absent edge is a `found: false` answer, not an
+/// error — a cleanup must be replayable.
+#[derive(Debug, Clone, Copy, Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub struct UnrelateOutcome {
+    /// Whether at least one matching edge existed and was removed.
+    pub found: bool,
+    /// How many matching edges were removed (parallel duplicates included).
+    pub removed: usize,
 }
 
 /// One typed edge leaving an entity, as reported by

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -20,6 +20,7 @@ use crate::extract::{ExtractedAttribute, ExtractedRelation, Extractor};
 use crate::id;
 use crate::model::{
     ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryNode, Recollection,
+    UnrelateOutcome,
 };
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
@@ -915,6 +916,61 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         self.ensure_exists(from)?;
         self.ensure_exists(to)?;
         self.store.relate(from, to, relation)
+    }
+
+    /// Remove the edge(s) `from -relation-> to`: [`Self::relate`]'s exact
+    /// undo (issue #1661), so a mistaken edge no longer costs the facts at
+    /// its endpoints. Neither the facts nor any entity hub are touched —
+    /// collecting an orphaned hub stays [`Self::forget`]'s job.
+    ///
+    /// Idempotent: an absent edge is `found: false`, not an error, so a
+    /// cleanup is replayable. It refuses exactly what `relate` refuses
+    /// (empty label, self-loop), and deliberately does NOT require the
+    /// endpoints to exist — the edge of a forgotten fact is already gone,
+    /// and reporting that as an error would break replay.
+    ///
+    /// Scope: the store does not distinguish an explicit edge from one the
+    /// autograph derived from a passage, so `unrelate` removes both alike.
+    /// To correct an autograph edge, prefer `forget` + `remember` of the
+    /// source fact — otherwise a later `remember` of the same passage can
+    /// rebuild the edge removed here.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError::InvalidRelation`] for a bad label,
+    /// [`MemoryError::SelfRelation`] if both endpoints are the same memory,
+    /// or a storage error if lookup or removal fails.
+    pub fn unrelate(
+        &self,
+        from: u64,
+        to: u64,
+        relation: &str,
+    ) -> Result<UnrelateOutcome, MemoryError> {
+        validate_relation(relation)?;
+        if from == to {
+            return Err(MemoryError::SelfRelation(from));
+        }
+        let removed = self.remove_matching_edges(from, to, relation)?;
+        Ok(UnrelateOutcome {
+            found: removed > 0,
+            removed,
+        })
+    }
+
+    /// [`Self::unrelate`]'s removal pass: resolve `from`'s outgoing edges and
+    /// delete every one matching `(to, relation)` by its id, counting them.
+    fn remove_matching_edges(
+        &self,
+        from: u64,
+        to: u64,
+        relation: &str,
+    ) -> Result<usize, MemoryError> {
+        let mut removed = 0usize;
+        for edge in self.store.relations(from)? {
+            if edge.to == to && edge.relation == relation && self.store.unrelate(edge.id)? {
+                removed += 1;
+            }
+        }
+        Ok(removed)
     }
 
     /// Forget (delete) the memory with `fact_id`. Returns whether a memory

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -175,6 +175,13 @@ pub trait MemoryStore {
     /// Returns [`MemoryError`] if storage access fails.
     fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
 
+    /// Remove the edge with `edge_id`. Returns `true` when it existed —
+    /// idempotent: removing an absent edge is `Ok(false)`, never an error.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError>;
+
     /// The total number of live (non-expired) tracked facts, including
     /// internal entity hubs — used as a corpus-size proxy for idf weighting.
     fn count(&self) -> usize;
@@ -351,11 +358,19 @@ impl MemoryStore for NativeStore {
             .relations(id)?
             .into_iter()
             .map(|edge| MemoryEdge {
+                id: edge.id(),
                 from: edge.source(),
                 to: edge.target(),
                 relation: edge.label().to_owned(),
             })
             .collect())
+    }
+
+    fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
+        self.memory
+            .semantic()
+            .unrelate(edge_id)
+            .map_err(MemoryError::from)
     }
 
     fn count(&self) -> usize {

--- a/crates/velesdb-memory/tests/unrelate_bdd.rs
+++ b/crates/velesdb-memory/tests/unrelate_bdd.rs
@@ -1,0 +1,155 @@
+//! BDD integration tests for `MemoryService::unrelate` (issue #1661).
+//!
+//! `relate` was the only write with no undo: a mistaken edge could only be
+//! removed by destroying the facts at its endpoints. `unrelate` is its exact
+//! symmetric — same refusals, idempotent on an absent edge (a cleanup must be
+//! replayable), and it never touches the facts or entity hubs themselves.
+//!
+//! Categories: Nominal, Edge, Negative.
+
+mod common;
+
+use common::service;
+use velesdb_memory::extract::{ExtractError, ExtractedFact, Extractor};
+use velesdb_memory::MemoryError;
+
+/// One fact tagged with one topic, so an autograph `about` edge exists.
+struct OneTopicExtractor;
+
+impl Extractor for OneTopicExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![ExtractedFact {
+            text: "The parser handles VelesQL.".to_string(),
+            entities: vec!["parser".to_string()],
+        }])
+    }
+}
+
+#[test]
+fn unrelate_removes_the_exact_edge_and_reports_it() {
+    let (_dir, svc) = service();
+    let from = svc
+        .remember("decision: split the module", &[], None)
+        .expect("remember");
+    let to = svc
+        .remember("cause: the file went past the gate", &[], None)
+        .expect("remember");
+    svc.relate(from, to, "caused_by").expect("relate");
+
+    let outcome = svc.unrelate(from, to, "caused_by").expect("unrelate");
+
+    assert!(
+        outcome.found,
+        "the edge existed and must be reported as found"
+    );
+    assert_eq!(
+        outcome.removed, 1,
+        "exactly the one matching edge is removed"
+    );
+    let explanation = svc
+        .why("decision: split the module", 2, None)
+        .expect("why after unrelate");
+    assert!(
+        explanation.edges.is_empty(),
+        "the removed edge must no longer be traversable, got {:?}",
+        explanation.edges
+    );
+}
+
+#[test]
+fn unrelate_leaves_both_endpoints_alive() {
+    let (_dir, svc) = service();
+    let from = svc.remember("fact alpha", &[], None).expect("remember");
+    let to = svc.remember("fact beta", &[], None).expect("remember");
+    svc.relate(from, to, "supports").expect("relate");
+
+    svc.unrelate(from, to, "supports").expect("unrelate");
+
+    // `relate` validates that BOTH endpoints still exist — recreating the
+    // edge proves unrelate removed only the edge, not the facts.
+    svc.relate(from, to, "supports")
+        .expect("both endpoints must have survived the unrelate");
+}
+
+#[test]
+fn unrelate_on_an_absent_edge_is_an_idempotent_no_op() {
+    let (_dir, svc) = service();
+    let from = svc.remember("fact alpha", &[], None).expect("remember");
+    let to = svc.remember("fact beta", &[], None).expect("remember");
+    svc.relate(from, to, "supports").expect("relate");
+
+    svc.unrelate(from, to, "supports").expect("first unrelate");
+    let outcome = svc
+        .unrelate(from, to, "supports")
+        .expect("second unrelate must not error");
+
+    assert!(
+        !outcome.found,
+        "an already-removed edge is reported not-found"
+    );
+    assert_eq!(outcome.removed, 0);
+}
+
+#[test]
+fn unrelate_only_removes_the_named_relation() {
+    let (_dir, svc) = service();
+    let from = svc.remember("fact alpha", &[], None).expect("remember");
+    let to = svc.remember("fact beta", &[], None).expect("remember");
+    svc.relate(from, to, "supports").expect("relate supports");
+    svc.relate(from, to, "contradicts")
+        .expect("relate contradicts");
+
+    let outcome = svc.unrelate(from, to, "supports").expect("unrelate");
+
+    assert!(outcome.found);
+    assert_eq!(outcome.removed, 1, "the other label must be untouched");
+    let explanation = svc.why("fact alpha", 1, None).expect("why");
+    assert_eq!(
+        explanation.edges.len(),
+        1,
+        "the `contradicts` edge must survive, got {:?}",
+        explanation.edges
+    );
+    assert_eq!(explanation.edges[0].relation, "contradicts");
+}
+
+#[test]
+fn unrelate_refuses_the_same_inputs_relate_refuses() {
+    let (_dir, svc) = service();
+    let id = svc.remember("fact alpha", &[], None).expect("remember");
+
+    let err = svc.unrelate(id, id, "supports").expect_err("self-loop");
+    assert!(
+        matches!(err, MemoryError::SelfRelation(_)),
+        "a self-loop is refused exactly like relate's, got {err:?}"
+    );
+
+    let other = svc.remember("fact beta", &[], None).expect("remember");
+    let err = svc.unrelate(id, other, "").expect_err("empty label");
+    assert!(
+        matches!(err, MemoryError::InvalidRelation(_)),
+        "an empty label is refused exactly like relate's, got {err:?}"
+    );
+}
+
+/// The store does not distinguish an explicit edge from an autograph one, so
+/// `unrelate` removes both alike. Correcting an autograph edge should instead
+/// go through forget + remember of the source fact — a later `remember` of
+/// the same passage can rebuild the edge removed here.
+#[test]
+fn unrelate_also_removes_an_autograph_edge() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &OneTopicExtractor, None)
+        .expect("remember_extracted");
+    let hub = svc
+        .entity_profile("parser")
+        .expect("entity_profile")
+        .expect("hub exists")
+        .id;
+
+    let outcome = svc.unrelate(ids[0], hub, "about").expect("unrelate");
+
+    assert!(outcome.found, "the autograph `about` edge is removable too");
+    assert_eq!(outcome.removed, 1);
+}

--- a/crates/velesdb-memory/tests/unrelate_bdd.rs
+++ b/crates/velesdb-memory/tests/unrelate_bdd.rs
@@ -141,7 +141,8 @@ fn unrelate_also_removes_an_autograph_edge() {
     let (_dir, svc) = service();
     let ids = svc
         .remember_extracted("seed", &OneTopicExtractor, None)
-        .expect("remember_extracted");
+        .expect("remember_extracted")
+        .ids;
     let hub = svc
         .entity_profile("parser")
         .expect("entity_profile")

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -303,11 +303,16 @@ impl MemoryStore for WasmStore {
             // graph-reached fact relative to the native ranking.
             .filter(|e| e.source == id && inner.live_fact(e.target).is_some())
             .map(|e| MemoryEdge {
+                id: e.id,
                 from: e.source,
                 to: e.target,
                 relation: e.label.clone(),
             })
             .collect())
+    }
+
+    fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
+        Ok(self.inner.borrow_mut().graph.delete_edge_by_id(edge_id))
     }
 
     fn count(&self) -> usize {

--- a/crates/velesdb-wasm/src/memory_store_tests.rs
+++ b/crates/velesdb-wasm/src/memory_store_tests.rs
@@ -114,6 +114,25 @@ fn test_relations_only_returns_outgoing_edges() {
 }
 
 #[test]
+fn test_unrelate_removes_the_edge_and_is_idempotent() {
+    let store = WasmStore::new(4);
+    store.store(1, "a", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.store(2, "b", &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    let edge_id = store.relate(1, 2, "decided_in").unwrap();
+
+    assert!(store.unrelate(edge_id).unwrap(), "the edge existed");
+    assert!(store.relations(1).unwrap().is_empty(), "edge is gone");
+    assert!(
+        !store.unrelate(edge_id).unwrap(),
+        "removing an absent edge is Ok(false), never an error"
+    );
+    assert!(
+        store.get(1).unwrap().is_some() && store.get(2).unwrap().is_some(),
+        "unrelate must not touch the endpoints"
+    );
+}
+
+#[test]
 fn test_query_filtered_matches_exact_metadata() {
     let store = WasmStore::new(4);
     let m = meta(&[("project", Value::String("veles".to_string()))]);

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -21,12 +21,12 @@ The tool surface is feature-gated at build time:
 
 | Feature | Default? | Tools it adds |
 |---|---|---|
-| `mcp` | yes | `remember`, `recall`, `recall_where`, `recall_fused`, `feedback`, `relate`, `forget`, `why`, `remember_extracted` |
+| `mcp` | yes | `remember`, `recall`, `recall_where`, `recall_fused`, `feedback`, `relate`, `unrelate`, `forget`, `entity`, `why`, `remember_extracted` |
 | `context` | yes | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context`, `list_working_contexts`, `suggest_budget` |
 | `extract` | no | none — it enables the *backend* `remember_extracted` needs (see that tool) |
 
 `default = ["mcp", "persistence", "context"]`, so a plain
-`cargo install velesdb-memory` advertises all **18** tools. They are served by
+`cargo install velesdb-memory` advertises all **20** tools. They are served by
 one MCP server: the context router is combined into the memory router in
 `McpServer::new`, never a second server.
 
@@ -43,8 +43,9 @@ number silently loses precision in any JavaScript-based client.
 - Every memory tool that returns an id also returns a decimal-string twin:
   `id_str`, `edge_id_str`, `ids_str`, `from_str`/`to_str`. **Relay the string
   form**, not the number.
-- Every memory tool that accepts an id (`relate`'s `from`/`to`, `forget`'s and
-  `feedback`'s `id`, `remember`'s `links[].target`) accepts a JSON number *or*
+- Every memory tool that accepts an id (`relate`/`unrelate`'s `from`/`to`,
+  `forget`'s and `feedback`'s `id`, `remember`'s `links[].target`) accepts a
+  JSON number *or*
   a decimal string, and advertises both in its input schema.
 - The compiler tools instead take a per-request switch:
   `policy.ids_as_strings: true` rewrites every id field of that response
@@ -193,6 +194,34 @@ relate { "from": "9876543210", "to": "1234", "relation": "depends_on" }
 → { "edge_id": 42, "edge_id_str": "42" }
 ```
 
+## `unrelate`
+
+Remove a typed edge — `relate`'s exact undo, so a mistaken edge no longer
+costs the facts at its endpoints.
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `from` | integer or decimal string | yes | The side the link points **from**, exactly as given to `relate`. |
+| `to` | integer or decimal string | yes | The side the link points **to**. |
+| `relation` | string | yes | The label of the link to remove. |
+
+Returns `{ found, removed }`. Idempotent: removing an absent edge answers
+`found: false` instead of erroring, so a cleanup can be replayed safely.
+Only the edge is removed — the two memories, and any entity, are untouched
+(collecting an orphaned entity stays `forget`'s job). It refuses exactly what
+`relate` refuses: an empty `relation`, and `from` equal to `to`.
+
+**Scope.** The store does not distinguish a link created with `relate` from
+one auto-derived from a passage (`remember_extracted`, autograph), so
+`unrelate` removes both alike. To correct an auto-derived link, prefer
+`forget` + `remember` of the source fact — otherwise remembering the same
+passage again can rebuild the edge removed here.
+
+```jsonc
+unrelate { "from": "9876543210", "to": "1234", "relation": "depends_on" }
+→ { "found": true, "removed": 1 }
+```
+
 ## `forget`
 
 Permanently delete a memory by id, removing the fact and its graph links.
@@ -205,6 +234,27 @@ Returns `{ id, id_str, found }`. `found: false` means nothing was stored under
 that id — a stale id or a typo. That is a no-op, not an error, but it is
 reported distinctly from a real deletion. The deletion itself cannot be
 undone; for time-based expiry use `remember`'s `ttl_seconds` instead.
+
+## `entity`
+
+Look up everything the auto-built graph knows about one named entity: the
+attributes merged onto its node and the typed edges leaving it.
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | yes | Matched case-insensitively (trimmed, lowercased). |
+
+Returns `{ found, id, id_str, name, attributes, relations }`. `found: false`
+means nothing has ever mentioned that entity; `name` always echoes the
+canonicalized queried name so parallel lookups stay pairable. `relations` are
+the typed edges **leaving** the entity, with the bipartite `mentions`
+scaffolding excluded.
+
+```jsonc
+entity { "name": "Theo Durand" }
+→ { "found": true, "name": "theo durand", "attributes": { "age": 15 },
+    "relations": [ { "predicate": "frere de", … } ] }
+```
 
 ## `why`
 


### PR DESCRIPTION
## Quoi

Closes #1661

Trois commits atomiques :

1. **`feat(memory)`** — `MemoryService::unrelate(from, to, relation)` : mêmes refus que `relate` (label vide → `InvalidRelation`, boucle → `SelfRelation`), résolution par `relations(from)` filtrée sur `(to, relation)`, suppression de **chaque** arête correspondante par id, réponse `{found, removed}`. Idempotent : arête absente = `found: false`, jamais une erreur, pour qu'un nettoyage soit rejouable. Ni les faits ni les hubs ne sont touchés — ramasser un hub orphelin reste le travail de `forget`. `MemoryEdge` porte l'id d'arête (sans lui le service ne peut nommer ce qu'il supprime) ; `MemoryStore` gagne `unrelate`, implémenté par le natif (délégation à `SemanticMemory::unrelate`, **déjà publié**) et le wasm (`delete_edge_by_id`).
2. **`feat(mcp)`** — outil `unrelate` (`{from, to, relation}` en nombre-ou-chaîne décimale via le même désérialiseur que `relate`, #1468 ; schéma de sortie sans `$ref`). Au passage : la référence MCP ne documentait **pas du tout** l'outil `entity`, servi depuis plusieurs versions — section ajoutée, compte d'outils corrigé (18 → 20).
3. **`ci`** — voir ci-dessous, c'est le cœur de cette PR.

## Le correctif structurel : `cargo publish --dry-run` à chaque PR

`velesdb-memory` se publie indépendamment, et `cargo publish` vérifie son tarball contre le **`velesdb-core` de crates.io**, pas celui de l'arbre. Un appel vers une API core pas encore publiée compile donc parfaitement en local ET en CI, puis casse la release au moment du tag.

Ce dry-run existait déjà — mais uniquement dans `release-memory.yml` ("Validate packaging"), donc **après le tag**, trop tard par construction. Il aurait attrapé la 0.11.3 (partie ainsi : bundles MCPB au registre MCP, aucun crate publié) et il aurait attrapé la première version de cette PR avant relecture humaine. L'étape est ajoutée au job `lint` (toolchain déjà présent, cache cargo chaud), avec `--locked` comme le job de release.

`--locked` ne pose aucun problème avec le lockfile du dépôt : le dry-run passe sans dérive (vérifié, sortie ci-dessous).

## Périmètre volontairement réduit

Cette PR portait initialement aussi `incoming_relations` (core), `relations_in` sur `entity`, et le correctif #1662. **Retirés** : ils appellent une API core non publiée, donc ils rendaient `develop` non-publiable — exactement l'invariant que le nouveau garde CI protège. Ils sont parqués dans #1667 (draft), qui ferme #1662 quand le core portant `incoming_relations` sera publié.

## Preuves

Critère d'acceptation, arbre propre :

```
$ cargo publish -p velesdb-memory --dry-run --locked
   Packaged 162 files, 1.9MiB (553.8KiB compressed)
   Verifying velesdb-memory v0.11.5
    Finished `dev` profile [unoptimized + debuginfo] target(s)
   Uploading velesdb-memory v0.11.5
warning: aborting upload due to dry run
EXIT=0
```

Avant réduction, la même commande sortait `EXIT 101` sur `error[E0599]: no method named 'incoming_relations' found for reference '&SemanticMemory'` — l'erreur ne nommait QUE `incoming_relations`, ce qui confirme que `SemanticMemory::unrelate` résout bien contre le core publié.

TDD, rouge exécuté avant chaque correctif :
- service : `error[E0599]: no method named 'unrelate' found for struct 'MemoryService'` → 6 tests BDD verts (arête exacte + `why` vide, endpoints vivants, idempotence, label seul retiré, mêmes refus que `relate`, arête d'autographe retirable).
- MCP : `cannot find type 'UnrelateParams'` → 3 tests verts (idempotence bout-en-bout, self-loop → `INVALID_PARAMS`, ids chaîne-ou-nombre).
- wasm : `test_unrelate_removes_the_edge_and_is_idempotent` (endpoints intacts après suppression).

Gates (tous relancés après la dernière édition) :
- `cargo fmt --all --check` OK
- clippy `-D warnings -D clippy::pedantic` : `-p velesdb-memory --all-targets --features mcp,context,persistence` ✔ ; `--workspace --features persistence,gpu,update-check` (hors python/node) ✔ ; `-p velesdb-node --lib` ✔ ; `PYO3_PYTHON=python3 -p velesdb-python --lib` ✔
- `cargo test -p velesdb-memory --features mcp,context,persistence` : 23 suites, 0 échec (dont `mcp_schema_bdd`)
- `cargo test -p velesdb-memory --features extract,ollama,persistence` : 23 suites, 0 échec
- `cargo test -p velesdb-wasm --lib` : 647 ok ; `cargo test -p velesdb-core --features persistence --lib agent:: --test-threads=1` : 203 ok (core inchangé par cette PR)
- `lizard -C 8 -a 8` : 0 avertissement sur les fonctions touchées (le seul restant, `query_ranked` à 9 paramètres, préexiste à l'identique sur develop)

Auto-merge non armé.
