### PR TITLE
[BLOQUÉE] feat(memory): arêtes entrantes — entity relations_in + collecte d'orphelins (#1662)

### DIFF
--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -260,6 +260,27 @@ impl EpisodicMemory {
         )
     }
 
+    /// Returns the incoming relations of an event (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Episodic,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -674,6 +674,33 @@ pub(super) fn relations_of(
         .collect())
 }
 
+/// Returns the incoming relation edges of a memory point, filtering out edges
+/// whose source is TTL-expired in the given subsystem.
+///
+/// The mirror of [`relations_of`]: the queried endpoint is the live one, so
+/// the TTL filter guards the *far* end — here `source()`, not `target()`.
+/// Shared by `SemanticMemory::incoming_relations`,
+/// `EpisodicMemory::incoming_relations`, and
+/// `ProceduralMemory::incoming_relations`.
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn incoming_relations_of(
+    db: &Database,
+    collection_name: &str,
+    id: u64,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    Ok(collection
+        .get_incoming_edges(id)
+        .into_iter()
+        .filter(|edge| !ttl.is_expired(kind, edge.source()))
+        .collect())
+}
+
 /// Removes a relation edge from a memory collection.
 ///
 /// Returns `true` when the edge existed and was removed. Shared by

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -347,6 +347,27 @@ impl ProceduralMemory {
         )
     }
 
+    /// Returns the incoming relations of a procedure (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Procedural,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -366,6 +366,27 @@ impl SemanticMemory {
         )
     }
 
+    /// Returns the incoming relations of a fact (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Semantic,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// Returns `true` when the edge existed and was removed.

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -910,6 +910,50 @@ mod tests {
         assert!(sm.relations(1).unwrap().is_empty());
     }
 
+    /// incoming_relations() is the mirror of relations(): the edge `1 -> 2`
+    /// is visible from `2`'s side with its source intact, and only there.
+    #[test]
+    fn test_incoming_relations_exposes_the_edge_from_the_target_side() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "context", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        let edge_id = sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        let incoming = sm.incoming_relations(2).unwrap();
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].id(), edge_id);
+        assert_eq!(incoming[0].source(), 1);
+        assert_eq!(incoming[0].label(), "RELATES_TO");
+        assert!(
+            sm.incoming_relations(1).unwrap().is_empty(),
+            "the source side has no incoming edge"
+        );
+    }
+
+    /// incoming_relations() drops an edge whose SOURCE is TTL-expired — the
+    /// mirror of relations() filtering expired targets: the live endpoint is
+    /// always the queried one, the filter guards the far end.
+    #[test]
+    fn test_incoming_relations_filters_expired_source() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "ephemeral", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        sm.set_ttl_durable(1, 0).unwrap(); // source expires immediately
+
+        assert!(
+            sm.incoming_relations(2).unwrap().is_empty(),
+            "an edge from an expired source is dead and must not be reported"
+        );
+    }
+
     /// relate() refuses missing and expired endpoints (write surfaces must
     /// not resurrect or dangle).
     #[test]

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -653,6 +653,10 @@ macro_rules! delegate_untouched_store_methods {
             self.inner.relations(id)
         }
 
+        fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+            self.inner.incoming_relations(id)
+        }
+
         fn count(&self) -> usize {
             self.inner.count()
         }

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -423,6 +423,15 @@ pub(super) struct EntityProfileDto {
     pub(super) attributes: Metadata,
     /// Typed edges leaving this entity.
     pub(super) relations: Vec<EntityRelationDto>,
+    /// Typed edges pointing AT this entity, each naming its SOURCE.
+    ///
+    /// Without these, a question is only answerable from one side: the graph
+    /// holds `camille --soeur de--> theo`, so asking what Theo's outgoing
+    /// edges say never finds Camille. The edge exists, it simply leaves the
+    /// other node. Nothing is inferred here — the converse of a kinship
+    /// label needs the gender, which the graph does not hold; this reports
+    /// only what is stored.
+    pub(super) relations_in: Vec<EntityRelationDto>,
 }
 
 impl EntityProfileDto {
@@ -443,6 +452,7 @@ impl EntityProfileDto {
                 name: canonical_entity_name(queried),
                 attributes: Metadata::new(),
                 relations: Vec::new(),
+                relations_in: Vec::new(),
             };
         };
         Self {
@@ -453,6 +463,11 @@ impl EntityProfileDto {
             attributes: profile.attributes,
             relations: profile
                 .relations
+                .into_iter()
+                .map(EntityRelationDto::from)
+                .collect(),
+            relations_in: profile
+                .relations_in
                 .into_iter()
                 .map(EntityRelationDto::from)
                 .collect(),

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -277,7 +277,7 @@ pub struct EntityRelation {
 }
 
 /// Everything the auto-built graph knows about one named entity: the
-/// attributes merged onto its hub and the typed edges leaving it.
+/// attributes merged onto its hub and the typed edges touching it.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub struct EntityProfile {
@@ -287,8 +287,12 @@ pub struct EntityProfile {
     pub name: String,
     /// Attributes learned about this entity, reserved keys stripped.
     pub attributes: crate::service::Metadata,
-    /// Typed edges leaving this entity (bipartite `mentions` edges excluded).
+    /// Typed edges leaving this entity (bipartite scaffolding excluded).
     pub relations: Vec<EntityRelation>,
+    /// Typed edges pointing AT this entity (bipartite scaffolding excluded).
+    /// Here [`EntityRelation::target_id`]/[`EntityRelation::target`] name the
+    /// far end the edge comes FROM — its source.
+    pub relations_in: Vec<EntityRelation>,
 }
 
 /// The connected answer to a `why` question: the best-matching seed memory plus

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -19,7 +19,8 @@ use crate::error::MemoryError;
 use crate::extract::{ExtractedAttribute, ExtractedRelation, Extractor};
 use crate::id;
 use crate::model::{
-    ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryNode, Recollection,
+    ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryEdge, MemoryNode,
+    Recollection,
 };
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
@@ -68,6 +69,10 @@ const HUB_ID_SALT: &str = "\u{0}_veles_entity_hub\u{0}";
 /// `why()` walk crossed a hub, so it can weight the reached fact by that
 /// hub's specificity instead of a flat constant.
 const MENTIONS_RELATION: &str = "mentions";
+/// Edge label a fact uses to point at a hub it is tagged with (the fact → hub
+/// direction) — [`MENTIONS_RELATION`]'s bipartite twin, written by
+/// [`MemoryService::remember_extracted`]'s `wire_entity`.
+const ABOUT_RELATION: &str = "about";
 
 /// Local-first agent memory backed by a single `VelesDB` instance.
 ///
@@ -480,24 +485,49 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             name: key,
             attributes: strip_reserved_keys(self.store.get_metadata(id)?).unwrap_or_default(),
             relations: self.outgoing_entity_relations(id)?,
+            relations_in: self.incoming_entity_relations(id)?,
         }))
     }
 
     /// The typed edges leaving `id`, resolved to their target's content.
     ///
-    /// `mentions` edges are dropped: they point at the facts that tagged this
-    /// entity, which is the bipartite scaffolding, not a statement *about* it.
+    /// Scaffolding edges (`mentions`, and `about` for symmetry — a hub never
+    /// has outgoing `about`) are dropped: they point at the facts that tagged
+    /// this entity, not at a statement *about* it.
     fn outgoing_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
+        self.resolve_entity_relations(self.store.relations(id)?, |edge| edge.to)
+    }
+
+    /// The typed edges pointing at `id`, resolved to their SOURCE's content —
+    /// for an incoming edge the far end is where it comes *from*.
+    ///
+    /// The scaffolding filter is the incoming mirror of
+    /// [`Self::outgoing_entity_relations`]'s: `about` edges are dropped (they
+    /// are the fact → hub half of the `about`/`mentions` pair), and `mentions`
+    /// with them for symmetry.
+    fn incoming_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
+        self.resolve_entity_relations(self.store.incoming_relations(id)?, |edge| edge.from)
+    }
+
+    /// Shared resolver for both edge directions: skip the bipartite
+    /// scaffolding labels, resolve each edge's far end (`far_end` picks which
+    /// endpoint that is) to its stored content.
+    fn resolve_entity_relations(
+        &self,
+        edges: Vec<MemoryEdge>,
+        far_end: impl Fn(&MemoryEdge) -> u64,
+    ) -> Result<Vec<EntityRelation>, MemoryError> {
         let mut relations = Vec::new();
-        for edge in self.store.relations(id)? {
-            if edge.relation == MENTIONS_RELATION {
+        for edge in edges {
+            if edge.relation == MENTIONS_RELATION || edge.relation == ABOUT_RELATION {
                 continue;
             }
-            let target = self.store.get(edge.to)?.map(|(content, _)| content);
+            let far = far_end(&edge);
+            let content = self.store.get(far)?.map(|(content, _)| content);
             relations.push(EntityRelation {
                 predicate: edge.relation,
-                target_id: edge.to,
-                target: target.unwrap_or_default(),
+                target_id: far,
+                target: content.unwrap_or_default(),
             });
         }
         Ok(relations)
@@ -651,7 +681,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // not dedup by endpoint+label, only by edge id).
         self.seed_existing_edges(fact_id, edges, seeded)?;
         self.seed_existing_edges(entity_id, edges, seeded)?;
-        self.add_edge(fact_id, entity_id, "about", edges)?;
+        self.add_edge(fact_id, entity_id, ABOUT_RELATION, edges)?;
         self.add_edge(entity_id, fact_id, MENTIONS_RELATION, edges)?;
         Ok(())
     }
@@ -974,10 +1004,37 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(())
     }
 
-    /// Whether `hub` still points at a fact that exists.
+    /// Whether anything alive still needs `hub`.
+    ///
+    /// Two references count, and the second is why this reads BOTH
+    /// directions (issue #1662):
+    ///
+    /// - an outgoing `mentions` edge to a live fact — the pair
+    ///   [`Self::wire_entities`] writes, the ordinary case;
+    /// - an incoming edge from a live NON-HUB fact — what a caller's own
+    ///   `relate` writes, and it writes one direction only. Relating a fact
+    ///   to a hub is reachable (`entity()` hands out the hub id), so reading
+    ///   outgoing edges alone swept hubs from under live callers' edges,
+    ///   losing them in silence.
+    ///
+    /// Incoming edges from another HUB are deliberately ignored: hub↔hub
+    /// edges exist (`wire_relations` writes them), and counting them would
+    /// let two hubs keep each other alive forever — a leak whose outcome
+    /// depends on collection order, which is worse than the bug being fixed.
     fn hub_still_mentioned(&self, hub: u64) -> Result<bool, MemoryError> {
         for edge in self.store.relations(hub)? {
             if edge.relation == MENTIONS_RELATION && self.store.get(edge.to)?.is_some() {
+                return Ok(true);
+            }
+        }
+        self.hub_has_live_referent(hub)
+    }
+
+    /// Whether a live non-hub fact points AT `hub` — see
+    /// [`Self::hub_still_mentioned`] for why hub→hub edges do not count.
+    fn hub_has_live_referent(&self, hub: u64) -> Result<bool, MemoryError> {
+        for edge in self.store.incoming_relations(hub)? {
+            if self.store.get(edge.from)?.is_some() && !self.is_hub(edge.from)? {
                 return Ok(true);
             }
         }

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -175,6 +175,13 @@ pub trait MemoryStore {
     /// Returns [`MemoryError`] if storage access fails.
     fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
 
+    /// The incoming edges of `id` — the mirror of [`Self::relations`], with
+    /// the same liveness rule applied to the far end (here the *source*).
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
+
     /// The total number of live (non-expired) tracked facts, including
     /// internal entity hubs — used as a corpus-size proxy for idf weighting.
     fn count(&self) -> usize;
@@ -345,22 +352,32 @@ impl MemoryStore for NativeStore {
     }
 
     fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
-        Ok(self
-            .memory
-            .semantic()
-            .relations(id)?
-            .into_iter()
-            .map(|edge| MemoryEdge {
-                from: edge.source(),
-                to: edge.target(),
-                relation: edge.label().to_owned(),
-            })
-            .collect())
+        Ok(to_memory_edges(self.memory.semantic().relations(id)?))
+    }
+
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        Ok(to_memory_edges(
+            self.memory.semantic().incoming_relations(id)?,
+        ))
     }
 
     fn count(&self) -> usize {
         self.memory.semantic().count()
     }
+}
+
+/// Map core [`GraphEdge`](velesdb_core::collection::graph::GraphEdge)s to the
+/// wire-facing [`MemoryEdge`] shape — shared by both edge directions.
+#[cfg(feature = "persistence")]
+fn to_memory_edges(edges: Vec<velesdb_core::collection::graph::GraphEdge>) -> Vec<MemoryEdge> {
+    edges
+        .into_iter()
+        .map(|edge| MemoryEdge {
+            from: edge.source(),
+            to: edge.target(),
+            relation: edge.label().to_owned(),
+        })
+        .collect()
 }
 
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
+++ b/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
@@ -111,3 +111,55 @@ fn forget_on_a_plain_fact_without_hubs_still_reports_found() {
          never created a hub"
     );
 }
+
+/// Issue #1662. The collector decided a hub was orphaned by reading only its
+/// OUTGOING `mentions` edges — the pairs `remember_extracted` writes in both
+/// directions. A `relate` posed by hand writes one direction only, and
+/// relating a fact TO a hub is reachable: `entity()` hands out the hub id and
+/// `relate` accepts any live target.
+///
+/// So a live fact could point at a hub the collector could not see, and the
+/// hub was swept from under it — the caller's own edge silently lost, with
+/// no error anywhere.
+#[test]
+fn forget_keeps_a_hub_a_live_fact_still_points_at() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &SharedTopicExtractor, None)
+        .expect("remember_extracted");
+    let hub = svc
+        .entity_profile("parser")
+        .expect("entity_profile")
+        .expect("precondition: the hub exists")
+        .id;
+
+    // A caller's own edge, one direction only — exactly what `relate` writes.
+    let anchor = svc
+        .remember(
+            "An unrelated note that cites the parser hub by hand.",
+            &[],
+            None,
+        )
+        .expect("remember the anchor fact");
+    svc.relate(anchor, hub, "cites").expect("relate by hand");
+
+    // The only fact whose extraction created `parser` goes away.
+    svc.forget(ids[0]).expect("forget the extracted fact");
+
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile after forget")
+            .is_some(),
+        "a hub a live fact still points at must survive the loss of its last \
+         `mentions` edge — the caller's edge is the reference the collector missed"
+    );
+
+    // And once that anchor goes too, nothing references the hub any more.
+    svc.forget(anchor).expect("forget the anchor");
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile after the anchor is gone")
+            .is_none(),
+        "with its last referent gone the hub is collected as before"
+    );
+}

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -98,6 +98,16 @@ fn matches_all(payload: &Map<String, Value>, filter: &Metadata) -> bool {
     filter.iter().all(|(k, v)| payload.get(k) == Some(v))
 }
 
+/// Map one stored [`WasmEdge`](crate::graph_store::WasmEdge) to the
+/// wire-facing [`MemoryEdge`] shape — shared by both edge directions.
+fn to_memory_edge(e: &crate::graph_store::WasmEdge) -> MemoryEdge {
+    MemoryEdge {
+        from: e.source,
+        to: e.target,
+        relation: e.label.clone(),
+    }
+}
+
 struct Inner {
     dimension: usize,
     facts: HashMap<u64, Fact>,
@@ -302,11 +312,20 @@ impl MemoryStore for WasmStore {
             // degree — counting dead edges would under-weight every
             // graph-reached fact relative to the native ranking.
             .filter(|e| e.source == id && inner.live_fact(e.target).is_some())
-            .map(|e| MemoryEdge {
-                from: e.source,
-                to: e.target,
-                relation: e.label.clone(),
-            })
+            .map(to_memory_edge)
+            .collect())
+    }
+
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(inner
+            .graph
+            .edges()
+            .iter()
+            // Mirror of `relations`: the far end is the SOURCE here, and an
+            // edge from a TTL-expired fact is just as dead as one into it.
+            .filter(|e| e.target == id && inner.live_fact(e.source).is_some())
+            .map(to_memory_edge)
             .collect())
     }
 


### PR DESCRIPTION
**Cette PR est volontairement en draft : elle ne peut pas merger aujourd'hui.**

## Pourquoi elle est bloquée

`velesdb-memory` se publie sur crates.io contre le **velesdb-core publié (4.1.0)**, pas contre celui de l'arbre. Cette PR ajoute une API core (`SemanticMemory::incoming_relations`), donc :

```
$ cargo publish -p velesdb-memory --dry-run
error[E0599]: no method named `incoming_relations` found for reference `&SemanticMemory`
error: could not compile `velesdb-memory` (lib) due to 1 previous error
EXIT 101
```

C'est le mode d'échec **exact** qui a fait rater la release 0.11.3. Merger ceci laisserait `develop` dans un état où `velesdb-memory` ne peut plus se publier — un piège pour la prochaine release.

**Condition de déblocage : la publication d'un velesdb-core portant `incoming_relations` (4.2.0 attendue).** Ce jour-là, le dry-run passe à EXIT 0 et cette PR sort du draft.

Le garde qui rend cette classe d'erreur détectable dès la PR arrive dans #1666 (`cargo publish --dry-run` à chaque PR, alors qu'il n'existait qu'au moment du tag).

## Ce que ça apporte

###  répond enfin des deux côtés

Le graphe contient `camille --soeur de--> theo`. Demander ce que disent les arêtes de Theo ne trouve **jamais** Camille : l'arête existe, elle part de l'autre nœud. `entity` gagne `relations_in`, qui nomme la **source** de chaque arête entrante.

**Rien n'est inféré** : le converse d'un lien de parenté demande le genre, que le graphe ne porte pas. On expose ce qui est stocké, on n'invente pas.

### #1662 — un hub référencé n'est plus balayé

La collecte d'orphelins ne lisait que les `mentions` **sortantes** du hub — les paires que `remember_extracted` écrit dans les deux sens. Un `relate` posé à la main n'écrit qu'un sens, et relier un fait à un hub est atteignable : `entity()` rend l'id du hub.

Un fait vivant pouvait donc pointer un hub que le collecteur ne voyait pas, et le hub était supprimé sous lui — **l'arête de l'appelant perdue en silence**, sans aucune erreur.

Test rouge d'abord, sortie réelle :

```
panicked at forget_orphan_hubs_bdd.rs:145:
a hub a live fact still points at must survive the loss of its last `mentions`
edge — the caller's edge is the reference the collector missed
```

**Décision explicite** : les arêtes entrantes venant d'un autre **hub** ne comptent pas. `wire_relations` écrit des arêtes hub↔hub, et les compter laisserait deux hubs se maintenir mutuellement à vie — une fuite dont l'issue dépend de l'ordre de collecte, donc pire que le défaut corrigé. C'est `forgetting_every_fact_leaves_no_hub_behind`, resté vert, qui le prouve.

## Vérifications

| Gate | Résultat |
|---|---|
| suite `forget_orphan_hubs_bdd` | **5/5** |
| suite `velesdb-memory` | 22 binaires, 0 échec |
| `velesdb-core` (agent, single-thread) | 205 passed |
| clippy pedantic × 4 jeux (memory, CI workspace, node, python) | **0** |
| boucle d'isolation par feature, **cible neuve** | 0 avertissement sur les 6 |
| lizard `-C 8 -a 8` | 1 avertissement, `store_internal` CCN 10 — **préexistant sur develop**, non traversé ici |

Closes #1662.