### PR TITLE
fix(python): rendre exécutables les 97 tests Rust de velesdb-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,15 @@ jobs:
       # features disabled, so cross-crate feature-unification mismatches
       # (e.g. a cfg-gated call site in one crate vs. the feature state its
       # dependency actually ends up unified to) went undetected.
+      # velesdb-python est exclu ici depuis que `extension-module` est passe
+      # derriere sa feature `default` : ce gate le desactive, et
+      # `PYO3_NO_PYTHON: "1"` (env du WORKFLOW, plus haut) empeche alors
+      # build.rs de trouver un interpreteur pour emettre les lignes de lien —
+      # `attempted to link to Python shared library but config does not
+      # contain lib_name`. Le crate a ses propres etapes dediees (clippy
+      # --lib, tests Rust) qui, elles, posent l'environnement qu'il lui faut.
       - name: Check --no-default-features (workspace matrix gap, #1472)
-        run: cargo check --workspace --no-default-features
+        run: cargo check --workspace --no-default-features --exclude velesdb-python
 
       # The workspace check above unifies features across crates, so a feature
       # that only compiles because a SIBLING feature happens to be on still
@@ -372,7 +379,16 @@ jobs:
           python3 -m venv /tmp/velesdb-python-tests
           /tmp/velesdb-python-tests/bin/pip install --quiet --upgrade pip numpy
           SITE="$(/tmp/velesdb-python-tests/bin/python -c 'import numpy, os; print(os.path.dirname(os.path.dirname(numpy.__file__)))')"
-          PYO3_PYTHON=/tmp/velesdb-python-tests/bin/python PYTHONPATH="$SITE" \
+          # `env -u PYO3_NO_PYTHON` et pas `PYO3_NO_PYTHON: ""` : le workflow
+          # pose cette variable pour tous les jobs, et pyo3-build-config teste
+          # sa PRESENCE, pas sa valeur — une chaine vide reste definie, donc
+          # have_python_interpreter() renvoie false et PYO3_PYTHON n'est jamais
+          # lu. Le build tombe alors sur un config abi3 sans lib_name et
+          # echoue : « attempted to link to Python shared library but config
+          # does not contain lib_name ». La retirer de l'environnement est le
+          # seul moyen sur.
+          env -u PYO3_NO_PYTHON \
+            PYO3_PYTHON=/tmp/velesdb-python-tests/bin/python PYTHONPATH="$SITE" \
             cargo test -p velesdb-python --lib \
               --no-default-features --features velesdb-core/default
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,31 @@ jobs:
         env:
           RUST_TEST_THREADS: 1
 
+      # The workspace run above excludes velesdb-python, and until this step
+      # existed NO workflow ran its Rust tests: they could not even link. The
+      # crate is a `cdylib` whose pyo3 carried `extension-module` unconditionally,
+      # which tells PyO3 to leave the libpython symbols unresolved — right for a
+      # wheel loaded by an interpreter, fatal for a test binary that must supply
+      # them itself. `--no-default-features` now drops that flag (the `default`
+      # feature keeps it on for every other build, wheel included) so the harness
+      # links libpython and the tests actually run.
+      #
+      # numpy must be importable by the EMBEDDED interpreter: `extract_vector`
+      # probes the numpy C-API capsule before falling back to a plain list, and
+      # the numpy crate panics rather than erroring when the capsule is missing.
+      # An embedded interpreter resolves its prefix from the linked libpython,
+      # not from the venv's `pyvenv.cfg` (that lookup keys off the executable,
+      # which here is the test binary), so pointing PYO3_PYTHON at the venv is
+      # not enough — PYTHONPATH is what makes its site-packages visible.
+      - name: Test velesdb-python (Rust unit tests)
+        run: |
+          python3 -m venv /tmp/velesdb-python-tests
+          /tmp/velesdb-python-tests/bin/pip install --quiet --upgrade pip numpy
+          SITE="$(/tmp/velesdb-python-tests/bin/python -c 'import numpy, os; print(os.path.dirname(os.path.dirname(numpy.__file__)))')"
+          PYO3_PYTHON=/tmp/velesdb-python-tests/bin/python PYTHONPATH="$SITE" \
+            cargo test -p velesdb-python --lib \
+              --no-default-features --features velesdb-core/default
+
       # Real-stdio MCP end-to-end (6 tools + text/media retrieve round-trip).
       # The debug binary is already built by the workspace test compile above;
       # cargo build is a cache no-op that guarantees it exists.

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -15,7 +15,10 @@ categories = ["database", "science"]
 
 [lib]
 name = "velesdb"
-crate-type = ["cdylib"]
+# `rlib` alongside `cdylib` so the crate's tests have a library to link against:
+# a bare `cdylib` produces nothing a test harness can consume. maturin keeps
+# picking the cdylib for the wheel.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 velesdb-core = { workspace = true }
@@ -26,7 +29,12 @@ velesdb-core = { workspace = true }
 # zero new dependencies (`context = []` in velesdb-memory), same feature set
 # velesdb-node already builds with.
 velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract", "context"] }
-pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods", "abi3-py39", "generate-import-lib"] }
+# `extension-module` is deliberately NOT hard-coded here: it tells PyO3 to leave
+# libpython unresolved, which is right for the wheel but makes any test binary
+# unlinkable. It moves to the `extension-module` feature below, which `default`
+# turns on — so every existing build (maturin, pip, `cargo check --workspace`)
+# is unchanged, and only `--no-default-features` opts into a linkable harness.
+pyo3 = { version = "0.29", features = ["multiple-pymethods", "abi3-py39", "generate-import-lib"] }
 serde_json = { workspace = true }
 numpy = "0.29"
 parking_lot = "0.12"
@@ -36,7 +44,11 @@ parking_lot = "0.12"
 tokio = { workspace = true }
 
 [features]
-default = ["velesdb-core/default"]
+default = ["velesdb-core/default", "extension-module"]
+# On by default so the wheel keeps its current link behaviour. Turn it OFF
+# (`--no-default-features --features velesdb-core/default`) to build a test
+# binary that links libpython and can actually run the crate's unit tests.
+extension-module = ["pyo3/extension-module"]
 gpu = ["velesdb-core/gpu"]
 update-check = ["velesdb-core/update-check"]
 loom = ["velesdb-core/loom"]


### PR DESCRIPTION
Ferme #1665.

## Le problème

`crates/velesdb-python/src` contient 97 `#[test]`. Aucun ne tournait nulle part —
et ce n'était pas un oubli de configuration : ils ne **liaient** pas.

Sortie réelle sur `develop`, avant tout correctif :

```
$ cargo test -p velesdb-python --lib
error: linking with `cc` failed: exit status: 1
  = note: Undefined symbols for architecture arm64:
            "_PyBaseObject_Type", referenced from:
            "_PyBool_Type", referenced from:
            "_PyByteArray_AsString", referenced from:
            ...
          ld: symbol(s) not found for architecture arm64
error: could not compile `velesdb-python` (lib test) due to 1 previous error
```

Deux verrous dans `crates/velesdb-python/Cargo.toml` :

1. `crate-type = ["cdylib"]` seul — aucune bibliothèque qu'un harnais de test
   puisse consommer.
2. `pyo3` portait `extension-module` **en dur**. Ce drapeau demande précisément
   à PyO3 de laisser libpython non résolu : correct pour une roue chargée par un
   interpréteur, fatal pour un binaire de test qui doit fournir ces symboles.

## Le correctif

`extension-module` passe derrière une feature que `default` active. Tous les
chemins de construction existants sont donc inchangés ; seul
`--no-default-features` demande un harnais liable.

## La roue PyPI n'est pas touchée — prouvé, pas supposé

Le risque était de casser la publication PyPI. Il est écarté deux fois.

**Par construction** — la ligne de commande que maturin lance réellement :

```
cargo rustc --profile release --features pyo3/extension-module \
  --manifest-path crates/velesdb-python/Cargo.toml --lib --crate-type cdylib \
  -- -C link-args=-Wl,-install_name,@rpath/velesdb.abi3.so
```

maturin **impose lui-même** `--crate-type cdylib` et
`--features pyo3/extension-module` (depuis `[tool.maturin]` de `pyproject.toml`),
et ne désactive jamais les features par défaut. Les deux modifications sont donc
neutralisées pour la roue.

**Empiriquement** — roue construite, installée dans un venv neuf, importée :

```
$ maturin build --release
    Finished `release` profile [optimized] target(s) in 43m 34s
📦 Built wheel for abi3 Python ≥ 3.9 to velesdb-4.1.0-cp39-abi3-macosx_11_0_arm64.whl
(exit 0)

$ pip install velesdb-4.1.0-cp39-abi3-macosx_11_0_arm64.whl && python -c "import velesdb"
IMPORT OK, version = 4.1.0
SEARCH(list)  -> [{'id': 1, 'score': 1.0, 'payload': {'k': 'a'}}]
SEARCH(numpy) -> [{'id': 2, 'score': 1.0, 'payload': {'k': 'b'}}]
```

Le tag `cp39-abi3` est préservé, et le chemin numpy C-API fonctionne.

## Combien échouaient

Une fois exécutables : **97 tests, 95 passants, 2 échouants** — puis 97/97 une
fois numpy présent dans l'interpréteur. Aucun test n'était faux ; ils étaient
muets.

Les deux exceptions méritent l'étape CI telle qu'elle est écrite :
`extract_vector` sonde la capsule C de numpy avant de retomber sur une liste, et
le crate `numpy` **panique** au lieu d'échouer quand elle manque. Un interpréteur
embarqué résout son préfixe depuis la libpython liée, pas depuis le `pyvenv.cfg`
(cette recherche part de l'exécutable, ici le binaire de test) : pointer
`PYO3_PYTHON` sur le venv ne suffit pas, d'où le `PYTHONPATH`.

## Barrières

| Barrière | Résultat |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| clippy pedantic — velesdb-memory `mcp,context,persistence` | exit 0 |
| clippy pedantic — workspace (hors python/node) | exit 0 |
| clippy — velesdb-node `--lib` | exit 0 |
| clippy — velesdb-python `--lib` | exit 0 |
| `cargo test -p velesdb-memory --features mcp,context,persistence` | exit 0 — 645 passants, 0 échec (22 suites) |
| `cargo test -p velesdb-python --lib --no-default-features` | 97 passants, 0 échec |
| Boucle d'isolation, cible neuve, 6 features | 6/6 exit 0, **0 avertissement** |
| `cargo publish -p velesdb-memory --dry-run` (arbre propre) | exit 0 |
| `python3 -m lizard -C 8 -a 8` (fichiers touchés) | 0 avertissement |

Une réserve, dite franchement : `cargo test -p velesdb-memory --features
extract,ollama,persistence` est sorti en **101**, sur `tests/mcp_lifecycle.rs`
(`no initialize response within 5s`). Ce n'est pas imputable à cette PR :

- le diff ne touche **aucun** fichier de `velesdb-memory` (2 fichiers en tout) ;
- ces 4 mêmes tests sont passés plus tôt dans la même session, sur ce commit ;
- lancé en `--test-threads=1`, 3 des 4 repassent ;
- le binaire, lancé à la main, répond à `initialize` instantanément.

La machine était à une charge de 220–265 (agents concurrents) : les délais de 5 s
codés en dur dans ce fichier ne tiennent pas sous cette charge. Le fichier n'a par
ailleurs pas d'entrée `[[test]]` avec `required-features = ["mcp"]`, contrairement
aux tests `http` du même `Cargo.toml` — piste à traiter séparément.