### PR TITLE
fix(memory): exposer le knob pool de recall_fused sur l'outil MCP

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`recall_fused` exposes `pool` over MCP.** The three bindings (Node
+  `{pool?}`, WASM `{pool?}`, Python `options={"pool": …}`) had long exposed
+  the depth of the oversampled vector pool fusion re-ranks; the MCP tool —
+  the server they all sit on — never did, so an MCP caller could not narrow
+  or widen it. Worse than merely absent: an undeclared argument is not
+  refused, so `{"pool": 1}` looked accepted and still returned a full-depth
+  result. The knob is now advertised (carrying a direct `type`, as every slot
+  must) and routed through the same `FusionOptions::from_knobs` as the
+  bindings, so all four transports share one default (`max(limit × 8, 64)`),
+  one floor (1 — `pool: 0` never oversamples an empty set) and one ceiling.
+
 - **`unrelate` — `relate`'s exact undo (#1661).** The graph was the only
   facet whose writes were one-way: a mistaken edge could only be removed by
   destroying the facts at its endpoints. `unrelate(from, to, relation)`

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -255,7 +255,7 @@ impl McpServer {
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
         output_schema = crate::schema::wire_safe_output_schema::<RecallFusedResult>(),
-        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
+        description = "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach and `pool` the depth of the vector candidate pool fusion re-ranks; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first."
     )]
     async fn recall_fused(
         &self,
@@ -265,7 +265,7 @@ impl McpServer {
             .limit
             .unwrap_or(DEFAULT_RECALL_LIMIT)
             .min(MAX_RECALL_LIMIT);
-        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost, None);
+        let opts = FusionOptions::from_knobs(params.hops, params.graph_boost, params.pool);
         let service = Arc::clone(&self.service);
         let RecallFusedParams {
             query,

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -170,6 +170,14 @@ pub(super) struct RecallFusedParams {
     /// similarity more.
     #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) graph_boost: Option<f64>,
+    /// Depth of the oversampled vector candidate pool fusion re-ranks before
+    /// the `limit` cutoff (default: `limit` scaled up, floored at 64). That
+    /// default is already deep enough for a graph-reached fact to surface;
+    /// widen it to give a reranker more to work with, narrow it to confine
+    /// fusion to the strongest vector hits. Capped at the same ceiling
+    /// `limit` and `hops` carry.
+    #[serde(default, deserialize_with = "super::wire::lenient")]
+    pub(super) pool: Option<usize>,
     /// Name of the metadata field holding each fact's date as a `YYYYMMDD`
     /// integer (e.g. `"ts"`, `"occurred_at"`). When set, the result adds a
     /// `dated_context` timeline (facts date-prefixed and ordered oldest-first)

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -526,6 +526,7 @@ async fn recall_fused_folds_in_a_graph_reached_fact() {
             filter: None,
             hops: None,
             graph_boost: None,
+            pool: None,
             date_field: None,
         }))
         .await
@@ -565,6 +566,7 @@ async fn recall_fused_with_date_field_returns_a_dated_timeline() {
             filter: None,
             hops: None,
             graph_boost: None,
+            pool: None,
             date_field: Some("ts".to_owned()),
         }))
         .await
@@ -601,6 +603,7 @@ async fn recall_fused_without_date_field_omits_the_timeline() {
             filter: None,
             hops: None,
             graph_boost: None,
+            pool: None,
             date_field: None,
         }))
         .await
@@ -645,6 +648,7 @@ async fn recall_fused_survives_a_non_finite_graph_boost() {
             filter: None,
             hops: None,
             graph_boost: Some(f64::NAN),
+            pool: None,
             date_field: None,
         }))
         .await
@@ -659,6 +663,8 @@ async fn recall_fused_survives_a_non_finite_graph_boost() {
 async fn recall_fused_limit_is_capped_at_max() {
     let (_dir, srv) = server();
     // The call must succeed (capped, not rejected) even with an absurd limit.
+    // `pool` joins limit/hops here because it feeds the same oversampled
+    // vector search: uncapped, it is exactly the unbounded-scan risk they are.
     let Json(result) = srv
         .recall_fused(Parameters(RecallFusedParams {
             query: "anything".to_owned(),
@@ -666,10 +672,11 @@ async fn recall_fused_limit_is_capped_at_max() {
             filter: None,
             hops: Some(usize::MAX),
             graph_boost: None,
+            pool: Some(usize::MAX),
             date_field: None,
         }))
         .await
-        .expect("recall_fused with huge limit/hops must succeed (silently capped)");
+        .expect("recall_fused with huge limit/hops/pool must succeed (silently capped)");
     let _ = result;
 }
 
@@ -1190,11 +1197,13 @@ fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
         "limit": "6",
         "hops": "2",
         "graph_boost": "0.15",
+        "pool": "128",
         "filter": "{\"project\": \"velesdb\"}"
     }))
     .expect("stringified scalar/object arguments must deserialize");
     assert_eq!(params.limit, Some(6));
     assert_eq!(params.hops, Some(2));
+    assert_eq!(params.pool, Some(128));
     assert!((params.graph_boost.unwrap() - 0.15).abs() < f64::EPSILON);
     let filter = params.filter.expect("filter must parse from a JSON string");
     assert_eq!(

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -201,12 +201,12 @@ impl FusionOptions {
     /// ([`clamp_hops`](crate::limits::clamp_hops)), `graph_boost` defaulted when
     /// absent, and `pool` clamped to the recall ceiling
     /// ([`clamp_recall_limit`](crate::limits::clamp_recall_limit)) or left at the
-    /// proven default. The MCP `recall_fused` tool (which exposes no `pool`, so
-    /// passes `None`) and the Python `recall_fused` binding both build their
-    /// options here so the transports can't drift on what they accept. A
-    /// non-finite `graph_boost` is not filtered here — that guard lives in
-    /// [`Self::sanitized`], applied by fusion itself so *every* caller is
-    /// covered, not just this constructor.
+    /// proven default. The MCP `recall_fused` tool and the Python
+    /// `recall_fused` binding both build their options here — same three
+    /// knobs, same clamps — so the transports can't drift on what they
+    /// accept. A non-finite `graph_boost` is not filtered here — that guard
+    /// lives in [`Self::sanitized`], applied by fusion itself so *every*
+    /// caller is covered, not just this constructor.
     #[must_use]
     pub fn from_knobs(hops: Option<usize>, graph_boost: Option<f64>, pool: Option<usize>) -> Self {
         let defaults = Self::default();

--- a/crates/velesdb-memory/tests/mcp_recall_fused_pool_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_recall_fused_pool_bdd.rs
@@ -1,0 +1,223 @@
+//! `recall_fused`'s `pool` knob, seen from the wire.
+//!
+//! The three bindings (Node `{pool?}`, Python `{"pool": int}`, WASM
+//! `{pool?}`) have all exposed the oversampled-pool depth for a while; the
+//! MCP tool never did. That is the drift running the unusual way — the
+//! server behind the bindings is the one lagging — and it is invisible to a
+//! caller, because an unknown argument is not refused: `RecallFusedParams`
+//! ignores what it does not declare, so `{"pool": 1}` returns a full-depth
+//! result while looking accepted.
+//!
+//! So this suite asserts on the EFFECT, not on acceptance. `pool` is the
+//! depth of the vector candidate pool fusion re-ranks: at `1` only the top
+//! vector hit may enter, so a store holding several facts must come back
+//! with a single memory even though `limit` allows ten. A tool that merely
+//! swallowed the argument returns all of them, and the assertion names the
+//! count.
+//!
+//! Everything is read through a real `McpServer` over `tokio::io::duplex`
+//! (the idiom of `mcp_schema_bdd`), so both the schema and the behaviour
+//! are the ones a Claude Code / Windsurf harness actually gets.
+
+#![cfg(all(feature = "mcp", feature = "persistence"))]
+
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::RunningService;
+use rmcp::{RoleClient, ServiceExt};
+use serde_json::{json, Map, Value};
+use tempfile::TempDir;
+use velesdb_memory::mcp::McpServer;
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+/// Facts with no `relate` edge between them, so nothing is graph-reached and
+/// the returned count is exactly the vector pool's depth capped by `limit` —
+/// the property under test, with no fusion promotion blurring it.
+const FACTS: [&str; 6] = [
+    "we chose parking_lot to avoid lock poisoning",
+    "the on-call rotation moved to Tuesdays",
+    "EPIC-317 xyzzy quux frobnicate",
+    "PR #42 swaps the mutex implementation",
+    "the release train leaves on Thursday",
+    "the staging cluster runs three replicas",
+];
+
+/// Boot the real `McpServer` over an in-memory duplex pipe and complete the
+/// MCP handshake. The `TempDir` is returned so the caller keeps the store
+/// alive for the test's duration.
+async fn connected() -> (TempDir, RunningService<RoleClient, ()>) {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let (server_side, client_side) = tokio::io::duplex(1 << 20);
+    tokio::spawn(async move {
+        if let Ok(running) = McpServer::new(service).serve(server_side).await {
+            let _ = running.waiting().await;
+        }
+    });
+    let client = ().serve(client_side).await.expect("MCP initialize handshake over duplex");
+    (store_dir, client)
+}
+
+fn as_args(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        other => panic!("expected a JSON object, got {other:?}"),
+    }
+}
+
+/// Store [`FACTS`] through the `remember` tool, unlinked.
+async fn seed(client: &RunningService<RoleClient, ()>) {
+    for fact in FACTS {
+        let stored = client
+            .call_tool(
+                CallToolRequestParams::new("remember")
+                    .with_arguments(as_args(json!({ "fact": fact }))),
+            )
+            .await
+            .expect("remember call");
+        assert_ne!(
+            stored.is_error,
+            Some(true),
+            "remember reported a tool error: {:?}",
+            stored.content
+        );
+    }
+}
+
+/// Call `recall_fused` with `arguments` and return how many memories came
+/// back.
+async fn fused_count(client: &RunningService<RoleClient, ()>, arguments: Value) -> usize {
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("recall_fused").with_arguments(as_args(arguments.clone())),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("recall_fused({arguments}) call: {e}"));
+    assert_ne!(
+        result.is_error,
+        Some(true),
+        "recall_fused({arguments}) reported a tool error: {:?}",
+        result.content
+    );
+    result
+        .structured_content
+        .expect("recall_fused returns structured content")["memories"]
+        .as_array()
+        .expect("`memories` is an array")
+        .len()
+}
+
+/// The knob has to be advertised before anyone can use it — and advertised
+/// with a direct `type`, the invariant `mcp_schema_bdd` pins for every slot.
+#[tokio::test]
+async fn recall_fused_advertises_pool_as_a_typed_slot() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let tool = tools
+        .iter()
+        .find(|tool| tool.name == "recall_fused")
+        .expect("recall_fused is advertised");
+    let schema = Value::Object((*tool.input_schema).clone());
+    let slot = schema["properties"].get("pool").unwrap_or_else(|| {
+        panic!(
+            "recall_fused advertises no `pool` parameter, though all three bindings expose \
+             one; properties: {}",
+            schema["properties"]
+        )
+    });
+    assert!(
+        slot.get("type").is_some(),
+        "`pool` must advertise a direct `type` keyword (a $defs-blind harness stringifies \
+         anything else); got: {slot}"
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// The effect, not the acceptance: a narrowed pool admits fewer candidates,
+/// so fewer memories come back than the same call left at the default.
+#[tokio::test]
+async fn a_narrowed_pool_admits_fewer_candidates_than_the_default() {
+    let (_store, client) = connected().await;
+    seed(&client).await;
+
+    let default_depth = fused_count(&client, json!({ "query": FACTS[0], "limit": 10 })).await;
+    assert_eq!(
+        default_depth,
+        FACTS.len(),
+        "with the proven default pool, `limit: 10` returns every stored fact"
+    );
+
+    let narrowed = fused_count(
+        &client,
+        json!({ "query": FACTS[0], "limit": 10, "pool": 1 }),
+    )
+    .await;
+    assert_eq!(
+        narrowed, 1,
+        "`pool: 1` admits only the top vector hit, so one memory comes back — \
+         {default_depth} means the tool took the argument and threw it away"
+    );
+
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// A harness that stringifies a schema-degraded scalar (`"2"`, not `2`) is
+/// served identically — the tolerance every other `recall_fused` knob
+/// already carries, extended to this one rather than left as a gap.
+#[tokio::test]
+async fn a_stringified_pool_is_honoured_like_a_numeric_one() {
+    let (_store, client) = connected().await;
+    seed(&client).await;
+
+    let numeric = fused_count(
+        &client,
+        json!({ "query": FACTS[0], "limit": 10, "pool": 2 }),
+    )
+    .await;
+    let stringified = fused_count(
+        &client,
+        json!({ "query": FACTS[0], "limit": 10, "pool": "2" }),
+    )
+    .await;
+    assert_eq!(numeric, 2, "`pool: 2` admits two candidates");
+    assert_eq!(
+        stringified, numeric,
+        "a stringified `pool` must reach the same depth as the numeric form"
+    );
+
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// The two degenerate ends of an untrusted knob, which the engine — not the
+/// transport — is responsible for absorbing: `0` must not oversample an
+/// empty candidate set (it is floored at 1), and a colossal value must be
+/// clamped rather than turned into an unbounded scan.
+#[tokio::test]
+async fn a_degenerate_pool_is_floored_and_a_colossal_one_clamped() {
+    let (_store, client) = connected().await;
+    seed(&client).await;
+
+    let zero = fused_count(
+        &client,
+        json!({ "query": FACTS[0], "limit": 10, "pool": 0 }),
+    )
+    .await;
+    assert_eq!(
+        zero, 1,
+        "`pool: 0` is floored at one candidate, never an empty result"
+    );
+
+    let colossal = fused_count(
+        &client,
+        json!({ "query": FACTS[0], "limit": 10, "pool": u64::MAX }),
+    )
+    .await;
+    assert_eq!(
+        colossal,
+        FACTS.len(),
+        "a colossal `pool` is clamped to the recall ceiling and still answers"
+    );
+
+    client.cancel().await.expect("close the MCP session");
+}

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -165,6 +165,7 @@ filter + graph reach).
 | `filter` | object | no | Exact-match metadata filter. |
 | `hops` | integer | no | Graph hops walked from the top vector hit (default 2, capped at 10). |
 | `graph_boost` | number | no | Weight added to a graph-reached fact's normalised vector score (default 0.15). |
+| `pool` | integer | no | Depth of the oversampled vector candidate pool fusion re-ranks before the `limit` cutoff (default `max(limit × 8, 64)`, floored at 1, capped at 1000). Same knob as the Node/WASM `pool` and the Python `options={"pool": …}`. |
 | `date_field` | string | no | Metadata key holding each fact's `YYYYMMDD` date (e.g. the automatic `_veles_date`). |
 
 Returns `{ memories, dated_context?, now? }`. `dated_context` (a


### PR DESCRIPTION
## Pourquoi

Les trois bindings exposent depuis longtemps la profondeur du pool de candidats vectoriels que la fusion reclasse :

| Surface | Forme |
|---|---|
| Node | `recallFused(q, k, filter, { pool })` |
| WASM | `recallFused(q, k, filter, { pool })` |
| Python | `recall_fused(..., options={"pool": int})` |
| **MCP** | **absent** |

C'est le serveur sur lequel les trois reposent qui était en retard sur ses propres façades — la dérive dans le sens inhabituel.

Pire qu'absent : un argument non déclaré n'est pas refusé. `RecallFusedParams` ignore ce qu'il ne connaît pas, donc `{"pool": 1}` avait l'air accepté et renvoyait quand même un résultat pleine profondeur. Même famille que les cinq défauts de la campagne 0.11.4 : une entrée acceptée qui fait autre chose que ce que l'appelant a demandé, sans le dire.

## Sémantique — identique aux bindings, par construction

Le knob passe par `FusionOptions::from_knobs`, déjà emprunté par Python, plutôt que par un clamp local. Les quatre transports partagent donc :

- **défaut** : `pool = None` → `max(limit × 8, 64)` (`fusion::pool_size`)
- **plancher** : `1` — un `pool: 0` ne sur-échantillonne jamais l'ensemble vide (`fused_recall::pool_depth`)
- **plafond** : `MAX_RECALL_LIMIT`, le même que `limit` et `hops` portent

Aucune API nouvelle du cœur n'est requise : `cargo publish --dry-run` compile bien contre le `velesdb-core 4.1.0` de crates.io.

## TDD — le rouge, cité

Test écrit avant le correctif, exécuté, échec constaté :

```
---- recall_fused_advertises_pool_as_a_typed_slot ----
recall_fused advertises no `pool` parameter, though all three bindings expose one

---- a_narrowed_pool_admits_fewer_candidates_than_the_default ----
assertion `left == right` failed: `pool: 1` admits only the top vector hit,
so one memory comes back — 6 means the tool took the argument and threw it away
  left: 6
 right: 1

test result: FAILED. 0 passed; 4 failed
```

Le `left: 6` est exactement le symptôme visé : l'argument avalé, pas refusé. Après correctif : `4 passed; 0 failed`.

Le test porte sur l'**effet**, jamais sur l'acceptation. Six faits sans arête, donc rien n'est atteint par le graphe et le compte renvoyé est exactement la profondeur du pool coupée par `limit` — `pool: 1` doit ramener une mémoire là où `limit: 10` en ramenait six. Couvre aussi la tolérance `"2"` stringifié (le harnais dégrade les scalaires), le plancher (`pool: 0` → 1) et le plafond (`u64::MAX` → clampé, pas de scan non borné).

Les schémas sont lus sur un **vrai `McpServer` en duplex**, pas sur un rendu de client : le slot `pool` porte donc bien un `type` direct, l'invariant que `mcp_schema_bdd` impose à chaque slot.

## Barrières

Toutes relancées après la dernière édition.

- `cargo fmt --all` — propre
- clippy pedantic `-D warnings` sur les quatre jeux (velesdb-memory, workspace, node, python) — 0 avertissement
- `cargo test -p velesdb-memory` sur `mcp,context,persistence` et sur `extract,ollama,persistence` — 0 échec
- boucle d'isolation sur cible **neuve**, 6 jeux (`mcp`/`http`/`context`/`persistence`/`ollama`/`extract`) — exit 0, 0 avertissement partout
- `cargo publish -p velesdb-memory --dry-run` — **exit 0**
- `python3 -m lizard -C 8 -a 8` sur les fichiers touchés — 0 avertissement
- hook pre-commit complet : **5321 passed, 0 failed**

## Note sur une barrière

Le premier passage du hook a échoué sur `velesdb-core::cache::lru_optimization_tests::test_move_to_back_o1_complexity` — un test d'horloge murale, `ratio=30.9x` contre un seuil de `<10x`. Faux négatif sous charge, pas une régression : rejoué machine au repos, il donne `1.2x` et passe. Le diff ne touche aucun fichier de `velesdb-core`. Le passage suivant, machine au repos, est vert.