### PR TITLE
refactor: passer six fonctions sous le seuil de complexite

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -3,6 +3,7 @@
 //! Stores facts and knowledge as vectors with similarity search.
 //! Each fact has an ID, content text, embedding vector, and optional metadata.
 
+use crate::collection::Collection;
 use crate::{Database, Point};
 use parking_lot::RwLock;
 use serde_json::{Map, Value};
@@ -198,36 +199,47 @@ impl SemanticMemory {
         memory_helpers::validate_dimension(self.dimension, embedding.len())?;
         let collection = memory_helpers::get_collection(&self.db, &self.collection_name)?;
         let mut payload = build_payload(content, metadata);
-        // Preserve reserved system keys (`_veles_*`: durable TTL, RL confidence,
-        // entity tags) from a prior version of this fact, so a content re-store
-        // (`remember`) does not silently wipe learned state. Caller metadata is
-        // already in `payload` and the explicit `expires_at` below still wins,
-        // so a carried-forward value is only used when nothing overwrites it.
-        if self.stored_ids.read().contains(&id) {
-            if let Ok(existing) = memory_helpers::ensure_live(
-                &collection,
-                &self.collection_name,
-                &self.ttl,
-                MemoryKind::Semantic,
-                id,
-            ) {
-                if let (Some(prior), Some(obj)) = (
-                    existing.payload.as_ref().and_then(Value::as_object),
-                    payload.as_object_mut(),
-                ) {
-                    for (k, v) in prior {
-                        if k.starts_with("_veles_") && !obj.contains_key(k) {
-                            obj.insert(k.clone(), v.clone());
-                        }
-                    }
-                }
-            }
-        }
+        self.carry_forward_reserved_keys(&collection, id, &mut payload);
         memory_helpers::attach_expiry(&mut payload, expires_at);
         let point = Point::new(id, embedding.to_vec(), Some(payload));
         memory_helpers::upsert_points(&collection, vec![point])?;
         self.stored_ids.write().insert(id);
         Ok(())
+    }
+
+    /// Copies the reserved system keys (`_veles_*`: durable TTL, RL confidence,
+    /// entity tags) of the live prior version of `id` into `payload`, so a
+    /// content re-store (`remember`) does not silently wipe learned state.
+    ///
+    /// Only keys `payload` does not already carry are copied: caller metadata
+    /// is already in `payload` and the explicit `expires_at` is attached after
+    /// this pass, so a carried-forward value is only used when nothing else
+    /// overwrites it. An unknown, unreadable or expired prior version
+    /// contributes nothing — this is best-effort enrichment, never a failure.
+    fn carry_forward_reserved_keys(&self, collection: &Collection, id: u64, payload: &mut Value) {
+        if !self.stored_ids.read().contains(&id) {
+            return;
+        }
+        let Ok(existing) = memory_helpers::ensure_live(
+            collection,
+            &self.collection_name,
+            &self.ttl,
+            MemoryKind::Semantic,
+            id,
+        ) else {
+            return;
+        };
+        let (Some(prior), Some(obj)) = (
+            existing.payload.as_ref().and_then(Value::as_object),
+            payload.as_object_mut(),
+        ) else {
+            return;
+        };
+        for (k, v) in prior {
+            if k.starts_with("_veles_") && !obj.contains_key(k) {
+                obj.insert(k.clone(), v.clone());
+            }
+        }
     }
 
     /// Stores a fact under `preferred_id`, or under a freshly allocated id when

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -1254,4 +1254,139 @@ mod tests {
             "reserved key in updates must not clobber the durable expiry"
         );
     }
+
+    // ── Reserved-key carry-forward on re-store ────────────────────────────────
+
+    /// Re-storing the same id (a `remember` on an already-known fact) rewrites
+    /// the payload from scratch. Reserved `_veles_*` system keys written by
+    /// other subsystems (RL confidence, entity tags) must be carried forward
+    /// from the previous version, or a plain content refresh silently wipes
+    /// learned state.
+    #[test]
+    fn test_restore_carries_forward_reserved_system_keys() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        let mut meta = meta_one("_veles_confidence", serde_json::json!(0.75));
+        meta.insert(
+            "_veles_entities".to_string(),
+            serde_json::json!(["parking_lot"]),
+        );
+        meta.insert("project".to_string(), serde_json::json!("veles"));
+        sm.store_with_metadata(1, "first version", &emb, &meta)
+            .unwrap();
+
+        sm.store(1, "second version", &emb).unwrap();
+
+        let after = sm.get_metadata(1).unwrap().expect("fact still stored");
+        assert_eq!(
+            after.get("_veles_confidence"),
+            Some(&serde_json::json!(0.75)),
+            "reserved RL confidence must survive a content re-store"
+        );
+        assert_eq!(
+            after.get("_veles_entities"),
+            Some(&serde_json::json!(["parking_lot"])),
+            "reserved entity tags must survive a content re-store"
+        );
+        assert_eq!(
+            after.get("content"),
+            Some(&serde_json::json!("second version")),
+            "the new content must win"
+        );
+        assert!(
+            !after.contains_key("project"),
+            "non-reserved user metadata is NOT carried forward (only `_veles_*` is)"
+        );
+    }
+
+    /// Carry-forward never overrides: a reserved key supplied by the caller in
+    /// the new metadata wins over the value stored under the previous version.
+    #[test]
+    fn test_restore_caller_reserved_key_wins_over_carried_forward() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        sm.store_with_metadata(
+            1,
+            "first",
+            &emb,
+            &meta_one("_veles_confidence", serde_json::json!(0.10)),
+        )
+        .unwrap();
+        sm.store_with_metadata(
+            1,
+            "second",
+            &emb,
+            &meta_one("_veles_confidence", serde_json::json!(0.90)),
+        )
+        .unwrap();
+
+        let after = sm.get_metadata(1).unwrap().expect("fact still stored");
+        assert_eq!(
+            after.get("_veles_confidence"),
+            Some(&serde_json::json!(0.90)),
+            "the caller's reserved value must not be shadowed by the prior one"
+        );
+    }
+
+    /// An explicit TTL still wins over a carried-forward `_veles_expires_at`:
+    /// the durable expiry parameter is applied after the carry-forward pass.
+    #[test]
+    fn test_restore_explicit_ttl_wins_over_carried_forward_expiry() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        sm.store_with_ttl(1, "mortal fact", &emb, 10).unwrap();
+        let first = ttl
+            .get(MemoryKind::Semantic, 1)
+            .expect("TTL tracked at store time")
+            .expires_at;
+
+        sm.store_with_ttl(1, "mortal fact, refreshed", &emb, 9_999)
+            .unwrap();
+        let second = ttl
+            .get(MemoryKind::Semantic, 1)
+            .expect("TTL still tracked after re-store")
+            .expires_at;
+
+        assert!(
+            second > first,
+            "the explicit expiry must overwrite the carried-forward one \
+             (first={first}, second={second})"
+        );
+    }
+
+    /// Carry-forward reads the *live* prior version: an id whose fact has
+    /// expired contributes nothing, so a re-store starts from a clean payload.
+    #[test]
+    fn test_restore_after_expiry_carries_nothing_forward() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+
+        let meta = meta_one("_veles_confidence", serde_json::json!(0.75));
+        sm.store_with_metadata(1, "doomed", &emb, &meta).unwrap();
+        ttl.set_ttl(MemoryKind::Semantic, 1, 0);
+        assert!(sm.get(1).unwrap().is_none(), "fact must be expired");
+
+        // `store_with_ttl` re-arms the TTL map, so the refreshed fact is live
+        // again and its payload observable.
+        sm.store_with_ttl(1, "fresh start", &emb, 9_999).unwrap();
+
+        let after = sm.get_metadata(1).unwrap().expect("fact re-stored");
+        assert!(
+            !after.contains_key("_veles_confidence"),
+            "an expired prior version must not leak its reserved keys forward"
+        );
+    }
 }

--- a/crates/velesdb-node/src/convert.rs
+++ b/crates/velesdb-node/src/convert.rs
@@ -257,33 +257,58 @@ pub fn build_transcript_compile_request(
 pub fn to_compiled_js(
     compiled: &velesdb_memory::context::CompiledContext,
 ) -> napi::Result<crate::dto::CompiledContextJs> {
-    let internal =
-        |what: &str| napi::Error::from_reason(format!("[INTERNAL] compiled context: {what}"));
-    let mut value =
-        serde_json::to_value(compiled).map_err(|err| internal(&format!("serialize: {err}")))?;
+    let mut value = serde_json::to_value(compiled)
+        .map_err(|err| compiled_internal(&format!("serialize: {err}")))?;
     stringify_id_fields(&mut value);
     let Value::Object(mut map) = value else {
-        return Err(internal("not an object"));
+        return Err(compiled_internal("not an object"));
     };
-    let field = |map: &mut serde_json::Map<String, Value>, key: &str| {
-        map.remove(key)
-            .ok_or_else(|| internal(&format!("missing field {key}")))
-    };
-    let content = match field(&mut map, "content")? {
-        Value::String(text) => text,
-        _ => return Err(internal("content is not a string")),
-    };
-    let risk = match field(&mut map, "risk")? {
-        Value::String(level) => level,
-        _ => return Err(internal("risk is not a string")),
-    };
+    compiled_envelope(&mut map)
+}
+
+/// The `[INTERNAL]` error of the compiled-context marshalling: every variant
+/// signals a bug in this conversion (the wire JSON of a `CompiledContext` is
+/// always a complete object), never bad caller input.
+fn compiled_internal(what: &str) -> napi::Error {
+    napi::Error::from_reason(format!("[INTERNAL] compiled context: {what}"))
+}
+
+/// Take a top-level field out of the serialized compiled context.
+fn compiled_field(map: &mut serde_json::Map<String, Value>, key: &str) -> napi::Result<Value> {
+    map.remove(key)
+        .ok_or_else(|| compiled_internal(&format!("missing field {key}")))
+}
+
+/// [`compiled_field`] for the two fields the typed envelope declares as
+/// `String` rather than raw wire JSON.
+fn compiled_string_field(
+    map: &mut serde_json::Map<String, Value>,
+    key: &str,
+) -> napi::Result<String> {
+    match compiled_field(map, key)? {
+        Value::String(text) => Ok(text),
+        _ => Err(compiled_internal(&format!("{key} is not a string"))),
+    }
+}
+
+/// Lift the top-level fields of an id-stringified compiled context into the
+/// typed envelope. Any field not declared by [`crate::dto::CompiledContextJs`]
+/// stays behind in `map` and is dropped — the envelope is the binding's
+/// contract, not a mirror of the domain type.
+fn compiled_envelope(
+    map: &mut serde_json::Map<String, Value>,
+) -> napi::Result<crate::dto::CompiledContextJs> {
+    // The two string fields are taken first, keeping the order in which a
+    // malformed envelope surfaces its error unchanged.
+    let content = compiled_string_field(map, "content")?;
+    let risk = compiled_string_field(map, "risk")?;
     Ok(crate::dto::CompiledContextJs {
         content,
-        sections: field(&mut map, "sections")?,
-        decisions: field(&mut map, "decisions")?,
-        sources: field(&mut map, "sources")?,
-        retrieval_handles: field(&mut map, "retrieval_handles")?,
-        insights: field(&mut map, "insights")?,
+        sections: compiled_field(map, "sections")?,
+        decisions: compiled_field(map, "decisions")?,
+        sources: compiled_field(map, "sources")?,
+        retrieval_handles: compiled_field(map, "retrieval_handles")?,
+        insights: compiled_field(map, "insights")?,
         risk,
     })
 }

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -17,9 +17,10 @@ use velesdb_memory::context::{
     ContextSavings, ContextSource, WorkingContext,
 };
 use velesdb_memory::{
-    format_dated_context, limits, ColumnFilter, ColumnOp, DynEmbedder, ErrorCategory, Explanation,
-    FusionOptions, HashEmbedder, Link, MemoryError, MemoryService, Metadata, OllamaEmbedder,
-    OllamaExtractor, Recollection, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    format_dated_context, limits, ColumnFilter, ColumnOp, DatedContext, DynEmbedder, ErrorCategory,
+    Explanation, FusionOptions, HashEmbedder, Link, MemoryEdge, MemoryError, MemoryNode,
+    MemoryService, Metadata, OllamaEmbedder, OllamaExtractor, Recollection, DEFAULT_DIMENSION,
+    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
@@ -79,6 +80,26 @@ fn parse_op(op: &str) -> PyResult<ColumnOp> {
     }
 }
 
+/// The Python `[(field, op, value)]` tuple list of `recall_where` as engine
+/// [`ColumnFilter`]s. The first unknown operator (or unconvertible value)
+/// aborts the whole conversion, so a typo never silently degrades into a
+/// narrower filter set.
+fn to_column_filters(
+    py: Python<'_>,
+    filters: Vec<(String, String, Py<PyAny>)>,
+) -> PyResult<Vec<ColumnFilter>> {
+    filters
+        .into_iter()
+        .map(|(field, op, value)| {
+            Ok(ColumnFilter {
+                field,
+                op: parse_op(&op)?,
+                value: python_to_json(py, &value)?,
+            })
+        })
+        .collect()
+}
+
 /// Build the requested embedder. `"hash"` is deterministic and offline;
 /// `"ollama"` calls a local embedding model (real semantic recall).
 fn build_embedder(kind: &str, url: Option<String>, model: Option<String>) -> PyResult<DynEmbedder> {
@@ -132,27 +153,71 @@ fn recollection_to_dict(py: Python<'_>, r: Recollection) -> PyResult<Py<PyAny>> 
     Ok(dict.into())
 }
 
+/// Maps `items` to a Python list, one dict per item.
+fn py_list_of<'py, T>(
+    py: Python<'py>,
+    items: &[T],
+    to_dict: impl Fn(Python<'py>, &T) -> PyResult<Bound<'py, PyDict>>,
+) -> PyResult<Bound<'py, PyList>> {
+    let list = PyList::empty(py);
+    for item in items {
+        list.append(to_dict(py, item)?)?;
+    }
+    Ok(list)
+}
+
+/// One [`MemoryNode`] of an explanation subgraph as `{id, content, hop}`.
+fn explanation_node_to_dict<'py>(py: Python<'py>, n: &MemoryNode) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item(PyString::intern(py, "id"), n.id)?;
+    d.set_item(PyString::intern(py, "content"), &n.content)?;
+    d.set_item(PyString::intern(py, "hop"), n.hop)?;
+    Ok(d)
+}
+
+/// One [`MemoryEdge`] of an explanation subgraph as `{from, to, relation}`.
+fn explanation_edge_to_dict<'py>(
+    py: Python<'py>,
+    edge: &MemoryEdge,
+) -> PyResult<Bound<'py, PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item(PyString::intern(py, "from"), edge.from)?;
+    d.set_item(PyString::intern(py, "to"), edge.to)?;
+    d.set_item(PyString::intern(py, "relation"), &edge.relation)?;
+    Ok(d)
+}
+
 /// An [`Explanation`] as `{nodes: [{id, content, hop}], edges: [{from, to, relation}]}`.
 fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
-    let nodes = PyList::empty(py);
-    for n in &e.nodes {
-        let d = PyDict::new(py);
-        d.set_item(PyString::intern(py, "id"), n.id)?;
-        d.set_item(PyString::intern(py, "content"), &n.content)?;
-        d.set_item(PyString::intern(py, "hop"), n.hop)?;
-        nodes.append(d)?;
-    }
-    let edges = PyList::empty(py);
-    for edge in &e.edges {
-        let d = PyDict::new(py);
-        d.set_item(PyString::intern(py, "from"), edge.from)?;
-        d.set_item(PyString::intern(py, "to"), edge.to)?;
-        d.set_item(PyString::intern(py, "relation"), &edge.relation)?;
-        edges.append(d)?;
-    }
+    let nodes = py_list_of(py, &e.nodes, explanation_node_to_dict)?;
+    let edges = py_list_of(py, &e.edges, explanation_edge_to_dict)?;
     let out = PyDict::new(py);
     out.set_item(PyString::intern(py, "nodes"), nodes)?;
     out.set_item(PyString::intern(py, "edges"), edges)?;
+    Ok(out.into())
+}
+
+/// The shared `Vec<Recollection>` → Python list-of-dicts marshalling of every
+/// recall path (`recall`, `recall_where`, `recall_fused`).
+fn recollections_to_list(py: Python<'_>, hits: Vec<Recollection>) -> PyResult<Bound<'_, PyList>> {
+    let list = PyList::empty(py);
+    for hit in hits {
+        list.append(recollection_to_dict(py, hit)?)?;
+    }
+    Ok(list)
+}
+
+/// The `date_field` shape of `recall_fused`: the memories plus the
+/// chronological timeline and its "now" anchor.
+fn dated_recall_to_dict(
+    py: Python<'_>,
+    memories: &Bound<'_, PyList>,
+    ctx: DatedContext,
+) -> PyResult<Py<PyAny>> {
+    let out = PyDict::new(py);
+    out.set_item(PyString::intern(py, "memories"), memories)?;
+    out.set_item(PyString::intern(py, "dated_context"), ctx.timeline)?;
+    out.set_item(PyString::intern(py, "now"), ctx.now)?;
     Ok(out.into())
 }
 
@@ -257,11 +322,7 @@ impl PyMemoryService {
                 .recall(query, k, filter.as_ref())
                 .map_err(to_py_err)
         })?;
-        let list = PyList::empty(py);
-        for hit in hits {
-            list.append(recollection_to_dict(py, hit)?)?;
-        }
-        Ok(list.into())
+        Ok(recollections_to_list(py, hits)?.into())
     }
 
     /// Fused vector + `ColumnStore` recall: like [`recall`](Self::recall) but the
@@ -278,22 +339,9 @@ impl PyMemoryService {
         k: usize,
     ) -> PyResult<Py<PyAny>> {
         let k = limits::clamp_recall_limit(k);
-        let filters: Vec<ColumnFilter> = filters
-            .into_iter()
-            .map(|(field, op, value)| {
-                Ok(ColumnFilter {
-                    field,
-                    op: parse_op(&op)?,
-                    value: python_to_json(py, &value)?,
-                })
-            })
-            .collect::<PyResult<Vec<_>>>()?;
+        let filters = to_column_filters(py, filters)?;
         let hits = py.detach(|| self.svc.recall_where(query, k, &filters).map_err(to_py_err))?;
-        let list = PyList::empty(py);
-        for hit in hits {
-            list.append(recollection_to_dict(py, hit)?)?;
-        }
-        Ok(list.into())
+        Ok(recollections_to_list(py, hits)?.into())
     }
 
     /// Fused vector + graph recall: like [`recall`](Self::recall), but also
@@ -333,20 +381,10 @@ impl PyMemoryService {
         let dated = date_field
             .as_ref()
             .map(|field| format_dated_context(&hits, field));
-
-        let memories = PyList::empty(py);
-        for hit in hits {
-            memories.append(recollection_to_dict(py, hit)?)?;
-        }
+        let memories = recollections_to_list(py, hits)?;
         match dated {
             None => Ok(memories.into()),
-            Some(ctx) => {
-                let out = PyDict::new(py);
-                out.set_item(PyString::intern(py, "memories"), memories)?;
-                out.set_item(PyString::intern(py, "dated_context"), ctx.timeline)?;
-                out.set_item(PyString::intern(py, "now"), ctx.now)?;
-                Ok(out.into())
-            }
+            Some(ctx) => dated_recall_to_dict(py, &memories, ctx),
         }
     }
 

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -339,14 +339,24 @@ impl WasmStore {
     /// at scoring time — never re-fetched through the time-sensitive
     /// `live_fact` after ranking, so a TTL lapsing mid-query can't corrupt
     /// an admitted hit's content or metadata.
-    fn query_ranked<T>(
+    ///
+    /// `predicate` and `row` are named type parameters rather than
+    /// `impl Trait` arguments: the closure signatures carry commas of their
+    /// own (`Map<String, Value>`, `(u64, f32, &Fact)`), which a source-level
+    /// parameter counter reads as extra parameters and reports as an
+    /// eight-parameter overrun on a six-parameter function.
+    fn query_ranked<T, P, R>(
         &self,
         embedding: &[f32],
         k: usize,
         offset: usize,
-        predicate: impl Fn(&Map<String, Value>) -> bool,
-        row: impl Fn(u64, f32, &Fact) -> T,
-    ) -> Result<Vec<T>, MemoryError> {
+        predicate: P,
+        row: R,
+    ) -> Result<Vec<T>, MemoryError>
+    where
+        P: Fn(&Map<String, Value>) -> bool,
+        R: Fn(u64, f32, &Fact) -> T,
+    {
         let inner = self.inner.borrow();
         let mut ids = Vec::new();
         let mut data = Vec::new();


### PR DESCRIPTION
## Pourquoi

Six fonctions dépassaient le seuil de complexité du dépôt (CCN ≤ 8,
paramètres ≤ 8), toutes préexistantes. Elles sont ramenées sous le seuil sans
aucun changement de comportement.

| Fonction | Avant | Après |
|---|---|---|
| `store_internal` — `velesdb-core/src/agent/semantic_memory.rs` | CCN 10 | CCN 4 (+ aide à 5) |
| `query_ranked` — `velesdb-wasm/src/memory_store.rs` | 9 paramètres comptés | 6 |
| `to_compiled_js` — `velesdb-node/src/convert.rs` | CCN 12 | CCN 2 (+ montage à 8) |
| `explanation_to_dict` — `velesdb-python/src/agent_memory_service.rs` | CCN 13 | CCN 5 |
| `recall_fused` — idem | CCN 12 | CCN 7 |
| `recall_where` — idem | CCN 9 | CCN 5 |

`python3 -m lizard -C 8 -a 8` sur les cinq fichiers touchés : **0 avertissement**.

## Ce que ça change vraiment

Ce ne sont pas des découpages cosmétiques : chaque extraction nomme une
préoccupation qui était noyée.

- **core** — le report des clés système `_veles_*` d'une version antérieure
  d'un fait vers la nouvelle avait sa propre logique (trois niveaux
  d'imbrication) au milieu du chemin d'écriture partagé. Elle devient
  `carry_forward_reserved_keys`, avec ses conditions de sortie à plat.
- **python** — la boucle `PyList::empty` + `recollection_to_dict` était
  recopiée à l'identique dans `recall`, `recall_where` et `recall_fused`. Elle
  est nommée une fois (`recollections_to_list`) et les trois chemins la
  partagent enfin.
- **node** — `to_compiled_js` mêlait sérialisation, transformation des ids et
  extraction manuelle de sept champs via deux fermetures locales. Le montage
  de l'enveloppe part dans `compiled_envelope`.
- **wasm** — cas particulier, détaillé plus bas : la fonction ne dépassait
  rien, c'est le compteur qui la lisait mal.

## `query_ranked` : un faux positif corrigé à la source

`query_ranked` prend six paramètres. Les signatures de ses deux fermetures
contiennent leurs propres virgules (`Map<String, Value>`, `(u64, f32, &Fact)`),
qu'un compteur travaillant sur le texte source lit comme des paramètres
supplémentaires — d'où les neuf annoncés. Les fermetures passent en paramètres
de type nommés avec clause `where` : l'ambiguïté disparaît, et c'est la forme
idiomatique dès qu'une signature porte plusieurs fermetures.

## Une fonction laissée pile au seuil, en connaissance de cause

`compiled_envelope` (node) est à CCN 8 — au seuil, donc conforme, mais sans
marge. La descendre plus bas exigerait d'éclater sept affectations de champs
en helpers positionnels indexés sur un tableau de clés, moins lisibles que le
littéral de structure explicite. J'ai préféré la lisibilité au coussin.

## Preuves

**Aucun changement de comportement.** Chaque refactor est couvert par des
tests qui passent avant et après, et le pouvoir de détection de chaque suite
a été vérifié par mutation — un test qu'on n'a pas vu tomber ne prouve rien.

| Périmètre | Tests | Mutation injectée | Résultat |
|---|---|---|---|
| core | 63 (`semantic_memory_tests`) | bloc de report retiré | 1 rouge : `left: None / right: Some(Number(0.75))` |
| wasm | 647 unitaires | — (changement de signature pur) | 647 verts |
| node | 42 (`__test__/index.spec.mjs`) | `sections`/`decisions` intervertis | 6 rouges, dont `one decision per fragment, 1 !== 3` |
| python | 545 passés / 0 échec (`-m "not slow"`) | relation d'arête figée + premier hit ignoré + clé `dated_context` renommée | 10 rouges |

Le report des clés `_veles_*` n'avait **aucune** couverture : les quatre tests
qui la fixent sont dans un commit séparé, **avant** le remaniement.

## Barrières

Toutes relancées après la dernière édition, sur une cible dédiée.

- `cargo fmt --all -- --check` : propre
- clippy pedantic `-D warnings`, les quatre jeux (velesdb-memory
  `mcp,context,persistence` ; workspace `persistence,gpu,update-check` ;
  velesdb-node ; velesdb-python) : verts
- `cargo test -p velesdb-memory` sur `mcp,context,persistence` **et**
  `extract,ollama,persistence` : verts
- boucle d'isolation sur cible neuve, `mcp http context persistence ollama
  extract` : **zéro avertissement**
- `cargo publish -p velesdb-memory --dry-run` sur arbre propre : **exit 0**
  (aucune API core nouvelle n'est requise)
- `python3 -m lizard -C 8 -a 8` sur les fichiers touchés : 0 avertissement
