### PR TITLE
feat(autograph): orienter aussi le génitif, le pluriel et les alliances (#1663)

### DIFF
--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -83,22 +83,45 @@ pub struct Extraction {
     pub attributes: Vec<ExtractedAttribute>,
 }
 
-// --- Orienting a kinship triple stated possessively ---------------------------
+// --- Orienting a kinship triple, whichever form states it ---------------------
 //
 // A copule ("X est le pere de Y") hangs the relation on its own grammatical
-// subject, so subject-of-sentence and subject-of-triple coincide. A possessive
-// ("X a une soeur, Y") hangs it on the OTHER one: it is Y who is X's sister.
-// Models reliably read the first and reliably mirror the second, and a mirrored
-// kinship triple is worse than a missing edge — `entity("Camille Durand")` then
-// answers, with the same confidence as any true edge, that Camille is Theo's
-// *brother*. The prompt asks for the right direction; this pass guarantees it
-// for the construction that gets it wrong, whatever backend produced the triple.
+// subject, so subject-of-sentence and subject-of-triple coincide. Three other
+// forms hang it on the OTHER one, and a model mirrors all three:
+//
+//   possessive  "X a une soeur, Y"        → Y carries "soeur de", toward X
+//   genitive    "la soeur de X est Y"     → the same reading, reversed order
+//               "X's sister is Y"
+//   plural      "X a deux soeurs, Y et Z" → the same, with SEVERAL carriers
+//
+// A mirrored kinship triple is worse than a missing edge — `entity("Camille
+// Durand")` then answers, with the same confidence as any true edge, that
+// Camille is Theo's *brother*. The prompt asks for the right direction; this
+// pass guarantees it for the constructions that get it wrong, whatever backend
+// produced the triple.
+//
+// Two invariants make the pass safe to run over a backend that may be
+// hallucinating, and every rule below is bounded so as to keep them: it never
+// invents an edge and never drops one. It only ever re-points triples the
+// extractor already returned, between endpoints it already named.
 
-/// Kinship nouns a possessive can introduce, folded (no accents, no ligature)
-/// and singular, since the markers below are singular too. Doubling as the
+/// Kinship nouns a passage can hang a relation on, folded (no accents, no
+/// ligature) and singular — every matcher below tolerates a plural `s`. Doubling
+/// as the
 /// predicate whitelist: a triple is only ever re-pointed when its label is one
 /// of these, so a non-kinship edge between the same two people is left alone.
+///
+/// Alliances (`"beau-frere"`, `"godmother"`, `"petit-fils"`) sit here beside
+/// the blood ties because they behave identically: grammatically they are the
+/// same possessive, and the converse of one is simply whichever OTHER label of
+/// this table the extractor put on the same pair — see [`reorient`]. Listing
+/// the noun is therefore the whole of the work; nothing below special-cases it.
+///
+/// Deliberately NOT here: `"partner"` / `"compagnon"`. "X has a partner, Y" is
+/// a business relation as often as a family one, and a wrong re-point is worse
+/// than none at all.
 const KINSHIP_NOUNS: &[&str] = &[
+    // Blood ties, fr.
     "pere",
     "mere",
     "frere",
@@ -113,14 +136,32 @@ const KINSHIP_NOUNS: &[&str] = &[
     "niece",
     "grand-pere",
     "grand-mere",
+    "grand-oncle",
+    "grand-tante",
+    "arriere-grand-pere",
+    "arriere-grand-mere",
+    "petit-fils",
+    "petite-fille",
+    // Alliances and step-family, fr.
     "beau-pere",
     "belle-mere",
+    "beau-frere",
+    "belle-soeur",
+    "beau-fils",
+    "belle-fille",
+    "gendre",
+    "bru",
     "demi-frere",
     "demi-soeur",
+    "parrain",
+    "marraine",
+    "filleul",
+    "filleule",
     "epoux",
     "epouse",
     "mari",
     "femme",
+    // Blood ties, en.
     "father",
     "mother",
     "brother",
@@ -129,14 +170,74 @@ const KINSHIP_NOUNS: &[&str] = &[
     "daughter",
     "uncle",
     "aunt",
+    "nephew",
+    "grandfather",
+    "grandmother",
+    "grandson",
+    "granddaughter",
+    // Alliances and step-family, en.
     "husband",
     "wife",
+    "father-in-law",
+    "mother-in-law",
+    "brother-in-law",
+    "sister-in-law",
+    "son-in-law",
+    "daughter-in-law",
+    "stepfather",
+    "stepmother",
+    "stepbrother",
+    "stepsister",
+    "half-brother",
+    "half-sister",
+    "godfather",
+    "godmother",
+    "godson",
+    "goddaughter",
 ];
 
 /// What precedes the kinship noun when the sentence hangs the relation on the
 /// person it introduces rather than on its own subject. The trailing space is
 /// load-bearing: without it `" a un "` would also fire on `"a une"`.
-const POSSESSIVE_MARKERS: &[&str] = &[" a un ", " a une ", " a pour ", " has a ", " has an "];
+///
+/// The counting determiners are what make a plural construction readable at
+/// all: `"a deux soeurs, Camille et Lea"` matches no singular marker.
+const POSSESSIVE_MARKERS: &[&str] = &[
+    " a un ",
+    " a une ",
+    " a pour ",
+    " a des ",
+    " a deux ",
+    " a trois ",
+    " a quatre ",
+    " has a ",
+    " has an ",
+    " has two ",
+    " has three ",
+    " has four ",
+];
+
+/// What sits between a kinship noun and the name of whoever HOLDS it in a
+/// genitive: `"la soeur DE Theo"`, `"the sister OF Theo"`.
+const GENITIVE_LINKS: &[&str] = &[" de ", " d'", " of "];
+
+/// The clitic the English genitive marks its holder with, holder first:
+/// `"Theo's sister is Camille"`.
+const SAXON_MARKER: &str = "'s ";
+
+/// The copula that closes a genitive and introduces its carrier:
+/// `"la soeur de Theo EST Camille"`.
+const GENITIVE_COPULAS: &[&str] = &[" est ", " sont ", " is ", " are "];
+
+/// Articles a copula may put in front of the name it introduces. Stepping over
+/// one is what lets the carrier still be *required* to sit right after the
+/// copula, which is the whole of the genitive's safety.
+const LEADING_ARTICLES: &[&str] = &["le ", "la ", "les ", "l'", "the "];
+
+/// What may join two carriers of one construction: `"Camille Durand ET Lea
+/// Durand"`. Longest first, so `", et "` is never read as `", "` followed by
+/// something that is not a name — which would end the walk one carrier early.
+const ENUMERATION_SEPARATORS: &[&str] = &[", et ", ", and ", " et ", " and ", " & ", ", "];
 
 /// Diacritics and ligatures folded to ASCII, so `"sœur"`, `"soeur"` and
 /// `"Sœur"` are one token — the passage and the model's label rarely agree on
@@ -159,6 +260,9 @@ const FOLDINGS: &[(char, &str)] = &[
     ('ç', "c"),
     ('œ', "oe"),
     ('æ', "ae"),
+    // A typographic apostrophe, so `"Theo’s"` and `"d’Theo"` reach the same
+    // matchers as their ASCII spellings — most editors substitute it silently.
+    ('\u{2019}', "'"),
 ];
 
 /// Lowercase `text` and fold its diacritics away. Every offset produced from
@@ -174,44 +278,70 @@ fn fold(text: &str) -> String {
     folded
 }
 
-/// A possessive construction located in a folded passage. `start`/`end` bracket
-/// the kinship noun itself: the person who *has* the relative is named before
-/// it, the one it introduces after it.
-struct Possessive {
+/// A kinship relation the passage states: every one of `bearers` carries
+/// `noun`, and `holder` is the one they carry it toward.
+struct Kinship {
     noun: &'static str,
-    start: usize,
-    end: usize,
+    holder: String,
+    bearers: Vec<String>,
 }
 
-/// The earliest possessive construction in `folded`, if any.
-fn find_possessive(folded: &str) -> Option<Possessive> {
-    POSSESSIVE_MARKERS
+/// How many bytes `word` occupies at the start of `rest` when it is written
+/// there as a whole word, a plural `s` included. `None` when it is not.
+///
+/// `"soeurette"` therefore never reads as `"soeur"`, and — the case that
+/// matters — `"brother-in-law"` never reads as `"brother"`: a hyphen CONTINUES
+/// a compound noun, so it bars the match exactly like a letter. Without that,
+/// the pass would recognise the bare noun, then treat the sentence's own label
+/// as the *converse* of it and point the edge precisely the wrong way. A
+/// missing edge would have been the better outcome.
+fn word_prefix_len(rest: &str, word: &str) -> Option<usize> {
+    let tail = rest.strip_prefix(word)?;
+    let (tail, plural) = match tail.strip_prefix('s') {
+        Some(shorter) => (shorter, 1),
+        None => (tail, 0),
+    };
+    let glued = |ch: char| ch.is_alphanumeric() || ch == '-';
+    (!tail.starts_with(glued)).then_some(word.len() + plural)
+}
+
+/// Whether `head` ENDS on `word` as a whole word, a plural `s` included — the
+/// mirror of [`word_prefix_len`], for the genitive, where the noun precedes its
+/// link instead of following a marker.
+fn ends_with_word(head: &str, word: &str) -> bool {
+    ends_exactly(head, word)
+        || head
+            .strip_suffix('s')
+            .is_some_and(|singular| ends_exactly(singular, word))
+}
+
+/// `head` ends on `word` with no letter and no hyphen glued in front of it, so
+/// `"la belle-soeur"` is never read as ending on `"soeur"`.
+fn ends_exactly(head: &str, word: &str) -> bool {
+    head.strip_suffix(word)
+        .is_some_and(|lead| !lead.ends_with(|ch: char| ch.is_alphanumeric() || ch == '-'))
+}
+
+/// The kinship noun written at the start of `text`, and how many bytes it
+/// occupies there.
+fn noun_at(text: &str) -> Option<(&'static str, usize)> {
+    KINSHIP_NOUNS
         .iter()
-        .filter_map(|marker| folded.find(marker).map(|at| at + marker.len()))
-        .filter_map(|start| noun_at(folded, start))
-        .min_by_key(|possessive| possessive.start)
+        .find_map(|noun| word_prefix_len(text, noun).map(|len| (*noun, len)))
 }
 
-/// The kinship noun sitting at `start`, if the marker introduces one.
-fn noun_at(folded: &str, start: usize) -> Option<Possessive> {
-    let rest = folded.get(start..)?;
-    let noun = KINSHIP_NOUNS
+/// The kinship noun `head` ends on.
+fn noun_before(head: &str) -> Option<&'static str> {
+    KINSHIP_NOUNS
         .iter()
-        .find(|noun| starts_with_word(rest, noun))?;
-    Some(Possessive {
-        noun,
-        start,
-        end: start + noun.len(),
-    })
+        .copied()
+        .find(|noun| ends_with_word(head, noun))
 }
 
-/// `rest` begins with `word` as a whole word, so `"soeurette"` never reads as
-/// `"soeur"`.
-fn starts_with_word(rest: &str, word: &str) -> bool {
-    match rest.strip_prefix(word) {
-        Some(tail) => !tail.starts_with(char::is_alphanumeric),
-        None => false,
-    }
+/// The text left once the first of `prefixes` that `text` starts with is
+/// stepped over.
+fn strip_any<'a>(text: &'a str, prefixes: &[&str]) -> Option<&'a str> {
+    prefixes.iter().find_map(|prefix| text.strip_prefix(prefix))
 }
 
 /// Every distinct entity the triples name, deduplicated.
@@ -235,13 +365,201 @@ fn holder_of(before: &str, names: &[String]) -> Option<String> {
         .map(|(_, name)| name.clone())
 }
 
-/// The endpoint the noun introduces: the first one named after it.
-fn bearer_of(after: &str, names: &[String]) -> Option<String> {
+/// The longest endpoint name written exactly at the start of `text`. Longest,
+/// so `"theo durand"` wins over a bare `"theo"` that also happens to be an
+/// endpoint — the shorter one would leave `" durand"` in front of the walk and
+/// silently truncate the enumeration.
+fn name_at(text: &str, names: &[String]) -> Option<String> {
     names
         .iter()
-        .filter_map(|name| after.find(&fold(name)).map(|at| (at, name)))
-        .min_by_key(|(at, _)| *at)
-        .map(|(_, name)| name.clone())
+        .filter(|name| text.starts_with(&fold(name)))
+        .max_by_key(|name| name.len())
+        .cloned()
+}
+
+/// The longest endpoint name `head` ENDS on — who a clitic belongs to.
+fn name_before(head: &str, names: &[String]) -> Option<String> {
+    names
+        .iter()
+        .filter(|name| head.ends_with(&fold(name)))
+        .max_by_key(|name| name.len())
+        .cloned()
+}
+
+/// The first endpoint named anywhere in `text`, and where its mention begins.
+fn first_name(text: &str, names: &[String]) -> Option<(usize, String)> {
+    names
+        .iter()
+        .filter_map(|name| text.find(&fold(name)).map(|at| (at, name)))
+        .min_by_key(|(at, name)| (*at, std::cmp::Reverse(name.len())))
+        .map(|(at, name)| (at, name.clone()))
+}
+
+/// `first`, plus every further endpoint the SAME enumeration lists after it.
+///
+/// The walk stops at the first thing that is not a separator followed by an
+/// endpoint. That bound is what keeps a following sentence from contributing a
+/// carrier — re-pointing "Bruno est le pere de Theo" as though Bruno were a
+/// sister of Theo is far worse than the edge it would have added.
+fn enumeration_from(text: &str, first: String, names: &[String]) -> Vec<String> {
+    let mut rest = &text[fold(&first).len()..];
+    let mut bearers = vec![first];
+    while let Some((name, tail)) = next_enumerated(rest, names) {
+        bearers.push(name);
+        rest = tail;
+    }
+    bearers
+}
+
+/// Verbs that mark the name before them as the SUBJECT of a new clause
+/// rather than another item in a list.
+///
+/// `", et "` and `" et "` are enumeration separators AND the way French joins
+/// two clauses, so the separator alone cannot tell "a sister, Camille, and
+/// Lea" from "a sister, Camille, and Bruno IS the father of Marie". What
+/// separates them is what follows the name: an item is followed by another
+/// separator or by the end of its clause, a subject is followed by a verb.
+const CLAUSE_VERBS: &[&str] = &[
+    " est ",
+    " sont ",
+    " etait ",
+    " etaient ",
+    " a ",
+    " ont ",
+    " avait ",
+    " avaient ",
+    " is ",
+    " are ",
+    " was ",
+    " were ",
+    " has ",
+    " have ",
+    " had ",
+];
+
+/// The next endpoint of an enumeration, and what follows its mention.
+///
+/// Returns `None` when the name opens a new clause — bounding the walk at the
+/// sentence is not enough, because a sentence holds several clauses. Letting
+/// one through re-points an edge the passage states CORRECTLY: "Bruno est le
+/// pere de Marie" became "Marie est le pere de Bruno", a confident falsehood
+/// where there had been none. Strictly worse than the edge the walk exists to
+/// add.
+fn next_enumerated<'a>(rest: &'a str, names: &[String]) -> Option<(String, &'a str)> {
+    let tail = strip_any(rest, ENUMERATION_SEPARATORS)?;
+    let name = name_at(tail, names)?;
+    let cut = fold(&name).len();
+    let after = &tail[cut..];
+    if CLAUSE_VERBS.iter().any(|verb| after.starts_with(verb)) {
+        return None;
+    }
+    Some((name, after))
+}
+
+/// The carriers a possessive introduces: the first endpoint named after the
+/// noun, plus the rest of its enumeration.
+fn bearers_after(after: &str, names: &[String]) -> Vec<String> {
+    match first_name(after, names) {
+        Some((at, first)) => enumeration_from(&after[at..], first, names),
+        None => Vec::new(),
+    }
+}
+
+/// The carriers written RIGHT at the start of `text`, one article tolerated.
+/// Requiring them there is what keeps a genitive from reaching across a clause
+/// it does not own.
+fn bearers_at(text: &str, names: &[String]) -> Vec<String> {
+    [Some(text), strip_any(text, LEADING_ARTICLES)]
+        .into_iter()
+        .flatten()
+        .find_map(|text| name_at(text, names).map(|first| enumeration_from(text, first, names)))
+        .unwrap_or_default()
+}
+
+/// The earliest possessive construction in `folded`: `"X a une soeur, Y"`.
+fn find_possessive(folded: &str, names: &[String]) -> Option<Kinship> {
+    let (start, noun, end) = POSSESSIVE_MARKERS
+        .iter()
+        .filter_map(|marker| folded.find(marker).map(|at| at + marker.len()))
+        .filter_map(|start| {
+            let (noun, len) = noun_at(folded.get(start..)?)?;
+            Some((start, noun, start + len))
+        })
+        .min_by_key(|(start, _, _)| *start)?;
+    Some(Kinship {
+        noun,
+        holder: holder_of(folded.get(..start)?, names)?,
+        bearers: bearers_after(folded.get(end..)?, names),
+    })
+}
+
+/// The earliest genitive construction in `folded`, either word order.
+fn find_genitive(folded: &str, names: &[String]) -> Option<Kinship> {
+    find_of_genitive(folded, names).or_else(|| find_saxon_genitive(folded, names))
+}
+
+/// `"<noun> de <holder> est <bearer>"` — the French genitive and its English
+/// `"of"` twin, scanned left to right so the earliest reading wins.
+fn find_of_genitive(folded: &str, names: &[String]) -> Option<Kinship> {
+    let mut links: Vec<(usize, usize)> = GENITIVE_LINKS
+        .iter()
+        .flat_map(|link| folded.match_indices(link).map(|(at, m)| (at, m.len())))
+        .collect();
+    links.sort_unstable();
+    links
+        .into_iter()
+        .find_map(|(at, len)| of_genitive_at(folded, at, len, names))
+}
+
+/// One `"<noun> de <holder> est <bearer>"` reading, anchored on the link at
+/// `at`.
+///
+/// Every step has to hold exactly — the noun ENDS where the link starts, the
+/// holder STARTS where it ends, and the copula follows the holder's name
+/// immediately. That is what keeps a copule out: "Camille est la soeur de Theo"
+/// carries the very same `"<noun> de <holder>"` fragment and is already right,
+/// but its "est" sits on the wrong side of the noun, so nothing follows the
+/// holder and the reading is rejected rather than mirrored.
+fn of_genitive_at(folded: &str, at: usize, len: usize, names: &[String]) -> Option<Kinship> {
+    let noun = noun_before(folded.get(..at)?)?;
+    let after_link = folded.get(at + len..)?;
+    let holder = name_at(after_link, names)?;
+    let after_holder = after_link.get(fold(&holder).len()..)?;
+    let bearers = bearers_at(strip_any(after_holder, GENITIVE_COPULAS)?, names);
+    Some(Kinship {
+        noun,
+        holder,
+        bearers,
+    })
+}
+
+/// `"<holder>'s <noun> is <bearer>"` — the English genitive, holder first.
+fn find_saxon_genitive(folded: &str, names: &[String]) -> Option<Kinship> {
+    folded
+        .match_indices(SAXON_MARKER)
+        .find_map(|(at, marker)| saxon_genitive_at(folded, at, marker.len(), names))
+}
+
+/// One `"<holder>'s <noun> is <bearer>"` reading, anchored on the clitic at
+/// `at`. As tight as [`of_genitive_at`]: the holder's name must end on the
+/// clitic, the noun must start right after it, and the copula must follow it.
+fn saxon_genitive_at(folded: &str, at: usize, len: usize, names: &[String]) -> Option<Kinship> {
+    let holder = name_before(folded.get(..at)?, names)?;
+    let (noun, noun_len) = noun_at(folded.get(at + len..)?)?;
+    let after_noun = folded.get(at + len + noun_len..)?;
+    let bearers = bearers_at(strip_any(after_noun, GENITIVE_COPULAS)?, names);
+    Some(Kinship {
+        noun,
+        holder,
+        bearers,
+    })
+}
+
+/// The kinship relation the passage states, in whichever form states it. The
+/// possessive is tried first: its marker is the most specific, so a sentence
+/// that could be read both ways reads as the possessive it is.
+fn find_kinship(folded: &str, names: &[String]) -> Option<Kinship> {
+    find_possessive(folded, names).or_else(|| find_genitive(folded, names))
 }
 
 /// The head word of a predicate label, folded: `"sœur de"` → `"soeur"`.
@@ -251,6 +569,17 @@ fn predicate_stem(predicate: &str) -> String {
         .next()
         .unwrap_or_default()
         .to_string()
+}
+
+/// The kinship noun a predicate label names, plural tolerated (`"sœurs de"` →
+/// `"soeur"`). `None` for any non-kinship label, which is what leaves an
+/// unrelated edge between the same two people untouched.
+fn predicate_noun(predicate: &str) -> Option<&'static str> {
+    let stem = predicate_stem(predicate);
+    KINSHIP_NOUNS
+        .iter()
+        .copied()
+        .find(|noun| word_prefix_len(&stem, noun) == Some(stem.len()))
 }
 
 /// Whether the triple runs between exactly these two entities, either way round.
@@ -263,10 +592,15 @@ fn joins(relation: &ExtractedRelation, one: &str, other: &str) -> bool {
 ///
 /// The triple built on the noun the passage used belongs to the person that
 /// noun introduced; any *other* kinship label over the same pair is its
-/// converse and therefore runs the other way. Anything else is untouched.
+/// converse and therefore runs the other way. That single rule is also all an
+/// alliance ever needs: list `"beau-frere"` in the table and its converse is
+/// whatever else the extractor labelled the pair with. Anything else is
+/// untouched.
 fn reorient(relation: &mut ExtractedRelation, noun: &str, holder: &str, bearer: &str) {
-    let stem = predicate_stem(&relation.predicate);
-    if !KINSHIP_NOUNS.contains(&stem.as_str()) || !joins(relation, holder, bearer) {
+    let Some(stem) = predicate_noun(&relation.predicate) else {
+        return;
+    };
+    if !joins(relation, holder, bearer) {
         return;
     }
     let (subject, object) = if stem == noun {
@@ -278,29 +612,29 @@ fn reorient(relation: &mut ExtractedRelation, noun: &str, holder: &str, bearer: 
     relation.object = object.to_string();
 }
 
-/// Re-point the kinship triples a possessive construction states, so the label
-/// sits on the person who actually carries it.
+/// Re-point the kinship triples the passage states, so each label sits on the
+/// person who actually carries it.
 ///
-/// A no-op unless the passage contains a possessive naming a kinship noun AND
-/// both sides of it resolve to entities the triples already mention — the pass
-/// never invents an edge, never drops one, and never touches a copule.
-pub(crate) fn orient_possessive_kinship(passage: &str, relations: &mut [ExtractedRelation]) {
+/// A no-op unless the passage contains a possessive or a genitive naming a
+/// kinship noun AND both sides of it resolve to entities the triples already
+/// mention — the pass never invents an edge, never drops one, and never touches
+/// a copule. A construction naming several carriers re-points the triple of
+/// each; one that names a carrier no triple mentions simply has no triple to
+/// re-point, since synthesising the edge would break the never-invent rule that
+/// makes this pass safe over a hallucinating backend.
+pub(crate) fn orient_kinship(passage: &str, relations: &mut [ExtractedRelation]) {
     let folded = fold(passage);
-    let Some(possessive) = find_possessive(&folded) else {
-        return;
-    };
     let names = endpoint_names(relations);
-    let Some(holder) = holder_of(&folded[..possessive.start], &names) else {
+    let Some(kinship) = find_kinship(&folded, &names) else {
         return;
     };
-    let Some(bearer) = bearer_of(&folded[possessive.end..], &names) else {
-        return;
-    };
-    if holder == bearer {
-        return;
-    }
-    for relation in relations.iter_mut() {
-        reorient(relation, possessive.noun, &holder, &bearer);
+    for bearer in &kinship.bearers {
+        if *bearer == kinship.holder {
+            continue;
+        }
+        for relation in relations.iter_mut() {
+            reorient(relation, kinship.noun, &kinship.holder, bearer);
+        }
     }
 }
 

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -355,7 +355,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let Ok(mut extraction) = extractor.extract_graph(fact) else {
             return;
         };
-        crate::extract::orient_possessive_kinship(fact, &mut extraction.relations);
+        crate::extract::orient_kinship(fact, &mut extraction.relations);
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();
@@ -431,7 +431,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             return Err(MemoryError::EmptyFact);
         }
         let mut extraction = extractor.extract_graph(text)?;
-        crate::extract::orient_possessive_kinship(text, &mut extraction.relations);
+        crate::extract::orient_kinship(text, &mut extraction.relations);
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64)> = HashSet::new();
         let mut seeded: HashSet<u64> = HashSet::new();

--- a/crates/velesdb-memory/tests/kinship_forms_bdd.rs
+++ b/crates/velesdb-memory/tests/kinship_forms_bdd.rs
@@ -1,0 +1,470 @@
+//! Behaviour: a kinship triple points the way the passage states it, whatever
+//! FORM the passage uses to state it.
+//!
+//! The orientation pass shipped covering one form only — the possessive
+//! ("X a une soeur, Y"). Three others reach it just as often and were left to
+//! the prompt alone, which is to say unproven:
+//!
+//! * **alliances** — "X a un beau-frere, Y", "X has a godson, Y": the same
+//!   possessive, with a noun the table did not list, so the pass walked past it.
+//! * **the genitive** — "la soeur de X est Y", "X's sister is Y": the same
+//!   carrier/holder reading, in the opposite word order.
+//! * **the plural** — "X a deux soeurs, Y et Z": one construction naming SEVERAL
+//!   carriers, of which only the first was ever oriented.
+//!
+//! Every form is checked in BOTH directions: the construction that must be
+//! corrected, and the copule over the same nouns that must survive untouched.
+//! The copule is the guard — without it a "fix" that simply mirrors everything
+//! would pass every other assertion here.
+//!
+//! The extractor is a deterministic stub keyed on the sentence, so the whole
+//! behaviour is proven with no model, no network and no flake.
+
+use tempfile::TempDir;
+use velesdb_memory::{
+    ExtractError, ExtractedFact, ExtractedRelation, Extraction, Extractor, HashEmbedder,
+    MemoryService, DEFAULT_DIMENSION,
+};
+
+/// One triple as an extractor backend spells it: subject, predicate, object.
+type Triple = (&'static str, &'static str, &'static str);
+
+/// A canned extractor's whole input: each sentence, with the triples a model
+/// returns for it. Named, because the bare tuple type is unreadable inline.
+type Script = &'static [(&'static str, &'static [Triple])];
+
+/// The empty script entry, so a sentence the script does not know yields no
+/// triples rather than panicking.
+const NO_TRIPLES: &[Triple] = &[];
+
+/// One triple, spelled the way an extractor backend returns it.
+fn relation(subject: &str, predicate: &str, object: &str) -> ExtractedRelation {
+    ExtractedRelation {
+        subject: subject.to_string(),
+        predicate: predicate.to_string(),
+        object: object.to_string(),
+    }
+}
+
+/// A stub returning, for each sentence, the triples a competent model returns
+/// for it — mirrored where a model mirrors them, correct where it gets them
+/// right. The map is the test's whole input: no branch of the pass under test
+/// can influence what it produces.
+struct ScriptedExtractor {
+    script: Script,
+}
+
+impl Extractor for ScriptedExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        let triples = self
+            .script
+            .iter()
+            .find(|(sentence, _)| *sentence == text)
+            .map_or(NO_TRIPLES, |(_, triples)| *triples);
+        Ok(Extraction {
+            facts: vec![ExtractedFact {
+                text: text.to_string(),
+                entities: vec![],
+            }],
+            relations: triples.iter().map(|(s, p, o)| relation(s, p, o)).collect(),
+            attributes: vec![],
+        })
+    }
+}
+
+/// A fresh service over a temp store. The [`TempDir`] must outlive the service.
+fn service() -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DEFAULT_DIMENSION))
+        .expect("open service");
+    (dir, svc)
+}
+
+/// The predicates leaving `name`'s hub, so a direction is asserted as the pair
+/// (who states it, about whom) rather than "an edge exists somewhere".
+fn outgoing(svc: &MemoryService<HashEmbedder>, name: &str) -> Vec<(String, u64)> {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .map(|profile| {
+            profile
+                .relations
+                .into_iter()
+                .map(|r| (r.predicate, r.target_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The hub id of `name`, which must already exist.
+fn hub_id(svc: &MemoryService<HashEmbedder>, name: &str) -> u64 {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .unwrap_or_else(|| panic!("{name} has a hub"))
+        .id
+}
+
+/// Remember `sentence` through `script`, then assert `carrier` is the one the
+/// `predicate` hangs on and `held` the one it points at.
+fn assert_carries(
+    script: Script,
+    sentence: &'static str,
+    carrier: &str,
+    predicate: &str,
+    held: &str,
+) {
+    let (_dir, svc) = service();
+    svc.remember_extracted(sentence, &ScriptedExtractor { script }, None)
+        .expect("extract and remember");
+    let target = hub_id(&svc, held);
+    assert!(
+        outgoing(&svc, carrier).contains(&(predicate.to_string(), target)),
+        "{sentence:?}: expected {carrier} -[{predicate}]-> {held}, got {:?}",
+        outgoing(&svc, carrier)
+    );
+    assert!(
+        !outgoing(&svc, held)
+            .iter()
+            .any(|(label, _)| label == predicate),
+        "{sentence:?}: {held} must not also carry {predicate}, got {:?}",
+        outgoing(&svc, held)
+    );
+}
+
+// --- Alliances: the possessive, with a noun the table did not list -----------
+
+const ALLIANCES: Script = &[
+    // A possessive: mirrored by the model, so the pass must re-point it.
+    (
+        "Marie Dupont a un beau-frère, Paul Martin.",
+        &[("marie dupont", "beau-frere de", "paul martin")],
+    ),
+    (
+        "Marie Dupont a un petit-fils, Hugo Martin.",
+        &[("marie dupont", "petit-fils de", "hugo martin")],
+    ),
+    (
+        "Marie Dupont has a brother-in-law, Paul Martin.",
+        &[("marie dupont", "brother-in-law of", "paul martin")],
+    ),
+    (
+        "Marie Dupont has a godson, Hugo Martin.",
+        &[("marie dupont", "godson of", "hugo martin")],
+    ),
+    // A copule: already right, and must survive the pass untouched.
+    (
+        "Paul Martin est le beau-frère de Marie Dupont.",
+        &[("paul martin", "beau-frere de", "marie dupont")],
+    ),
+    (
+        "Hugo Martin is the godson of Marie Dupont.",
+        &[("hugo martin", "godson of", "marie dupont")],
+    ),
+];
+
+#[test]
+fn a_possessive_naming_an_in_law_binds_it_to_the_person_it_introduces() {
+    assert_carries(
+        ALLIANCES,
+        "Marie Dupont a un beau-frère, Paul Martin.",
+        "paul martin",
+        "beau-frere de",
+        "marie dupont",
+    );
+}
+
+#[test]
+fn a_possessive_naming_a_grandchild_binds_it_to_the_person_it_introduces() {
+    assert_carries(
+        ALLIANCES,
+        "Marie Dupont a un petit-fils, Hugo Martin.",
+        "hugo martin",
+        "petit-fils de",
+        "marie dupont",
+    );
+}
+
+/// The hyphenated English compound is the trap: read as the bare noun it
+/// contains, `"brother-in-law"` would be oriented as `"brother"` — the pass
+/// would then treat the sentence's own label as the CONVERSE of itself and
+/// point the edge exactly the wrong way.
+#[test]
+fn a_hyphenated_english_compound_is_not_read_as_the_noun_it_contains() {
+    assert_carries(
+        ALLIANCES,
+        "Marie Dupont has a brother-in-law, Paul Martin.",
+        "paul martin",
+        "brother-in-law of",
+        "marie dupont",
+    );
+}
+
+#[test]
+fn a_possessive_naming_a_godchild_binds_it_to_the_person_it_introduces() {
+    assert_carries(
+        ALLIANCES,
+        "Marie Dupont has a godson, Hugo Martin.",
+        "hugo martin",
+        "godson of",
+        "marie dupont",
+    );
+}
+
+/// The other direction, and the only guard against a "fix" that flips
+/// everything: a copule already hangs the relation on its grammatical subject.
+#[test]
+fn a_copule_over_an_alliance_keeps_the_relation_on_its_subject() {
+    assert_carries(
+        ALLIANCES,
+        "Paul Martin est le beau-frère de Marie Dupont.",
+        "paul martin",
+        "beau-frere de",
+        "marie dupont",
+    );
+    assert_carries(
+        ALLIANCES,
+        "Hugo Martin is the godson of Marie Dupont.",
+        "hugo martin",
+        "godson of",
+        "marie dupont",
+    );
+}
+
+// --- The genitive: the same reading, the opposite word order -----------------
+//
+// A possessive names the holder first and the carrier last ("Theo a une soeur,
+// Camille"). A genitive does the reverse — "la soeur DE Theo est Camille",
+// "Theo's sister is Camille" — and a model mirrors it just as reliably. The
+// carrier/holder reading is identical; only the surface order differs.
+//
+// The copule below is what stops the rule from over-reaching. "Camille est la
+// soeur de Theo" contains the very same "<noun> de <holder>" fragment, and it
+// is ALREADY right: what separates the two is that the genitive's copula
+// follows the holder's name, while the copule's precedes the noun.
+
+const GENITIVES: Script = &[
+    // A genitive: mirrored by the model, so the pass must re-point it.
+    (
+        "La sœur de Theo Durand est Camille Durand.",
+        &[("theo durand", "soeur de", "camille durand")],
+    ),
+    // The label is English because the sentence is. The extraction contract
+    // asks for a predicate "in the passage's own language", and this pass reads
+    // the sentence's noun and the triple's label as ONE language: a French
+    // label on an English sentence is taken for the converse relation, and the
+    // edge comes out backwards. Same-language is the contract, not a shortcut.
+    (
+        "Theo Durand's sister is Camille Durand.",
+        &[("theo durand", "sister of", "camille durand")],
+    ),
+    (
+        "The brother of Marie Dupont is Paul Dupont.",
+        &[("marie dupont", "brother of", "paul dupont")],
+    ),
+    // A copule carrying the same fragment: already right, must not move.
+    (
+        "Camille Durand est la sœur de Theo Durand.",
+        &[("camille durand", "soeur de", "theo durand")],
+    ),
+    (
+        "Bruno Durand est le père de Theo Durand.",
+        &[("bruno durand", "pere de", "theo durand")],
+    ),
+];
+
+#[test]
+fn a_french_genitive_binds_the_relation_to_the_person_the_copula_names() {
+    assert_carries(
+        GENITIVES,
+        "La sœur de Theo Durand est Camille Durand.",
+        "camille durand",
+        "soeur de",
+        "theo durand",
+    );
+}
+
+#[test]
+fn an_english_saxon_genitive_binds_the_relation_to_the_person_the_copula_names() {
+    assert_carries(
+        GENITIVES,
+        "Theo Durand's sister is Camille Durand.",
+        "camille durand",
+        "sister of",
+        "theo durand",
+    );
+}
+
+#[test]
+fn an_english_of_genitive_binds_the_relation_to_the_person_the_copula_names() {
+    assert_carries(
+        GENITIVES,
+        "The brother of Marie Dupont is Paul Dupont.",
+        "paul dupont",
+        "brother of",
+        "marie dupont",
+    );
+}
+
+/// The guard that keeps the genitive rule from swallowing the copule: the same
+/// "<noun> de <holder>" fragment appears in both, and here the triple is
+/// already right. A rule that fired on the fragment alone would mirror it.
+#[test]
+fn a_copule_ending_on_the_same_fragment_is_left_alone() {
+    assert_carries(
+        GENITIVES,
+        "Camille Durand est la sœur de Theo Durand.",
+        "camille durand",
+        "soeur de",
+        "theo durand",
+    );
+    assert_carries(
+        GENITIVES,
+        "Bruno Durand est le père de Theo Durand.",
+        "bruno durand",
+        "pere de",
+        "theo durand",
+    );
+}
+
+// --- The plural: one construction, SEVERAL carriers --------------------------
+//
+// "Theo a deux soeurs, Camille et Lea" states two relations, not one. The pass
+// read the first name after the noun and stopped, so Lea's triple — mirrored
+// exactly like Camille's — was left mirrored. This is a change of FORM: the
+// same construction now yields as many oriented pairs as it names.
+//
+// The enumeration therefore has to be BOUNDED. Walking every name after the
+// noun would let the NEXT sentence contribute a carrier, and re-pointing
+// "Bruno est le père de Theo" as if Bruno were a sister of Theo is a far worse
+// outcome than the missing edge it replaces. Hence the second scenario.
+
+const PLURALS: Script = &[
+    (
+        "Marie Dupont a une sœur, Camille Dupont, et Bruno Dupont est le père de Marie Dupont.",
+        &[
+            ("marie dupont", "soeur de", "camille dupont"),
+            ("bruno dupont", "pere de", "marie dupont"),
+        ],
+    ),
+    (
+        "Le père de Theo Durand est Bruno Durand et Marie Dupont est la mère de Theo Durand.",
+        &[
+            ("theo durand", "pere de", "bruno durand"),
+            ("marie dupont", "mere de", "theo durand"),
+        ],
+    ),
+    (
+        "Theo Durand a deux sœurs, Camille Durand et Lea Durand.",
+        &[
+            ("theo durand", "soeur de", "camille durand"),
+            ("theo durand", "soeur de", "lea durand"),
+        ],
+    ),
+    (
+        "Theo Durand a une sœur, Camille Durand. Bruno Durand est le père de Theo Durand.",
+        &[
+            ("theo durand", "soeur de", "camille durand"),
+            ("bruno durand", "pere de", "theo durand"),
+        ],
+    ),
+];
+
+#[test]
+fn a_plural_possessive_orients_every_carrier_it_names() {
+    for carrier in ["camille durand", "lea durand"] {
+        assert_carries(
+            PLURALS,
+            "Theo Durand a deux sœurs, Camille Durand et Lea Durand.",
+            carrier,
+            "soeur de",
+            "theo durand",
+        );
+    }
+}
+
+/// The enumeration must stop at the sentence it belongs to. Here the following
+/// sentence names Bruno, who is Theo's father and no one's sister: an unbounded
+/// walk would take him for a carrier and turn a correct edge inside out.
+#[test]
+fn an_enumeration_never_reaches_into_the_next_sentence() {
+    const PASSAGE: &str =
+        "Theo Durand a une sœur, Camille Durand. Bruno Durand est le père de Theo Durand.";
+    let (_dir, svc) = service();
+    svc.remember_extracted(PASSAGE, &ScriptedExtractor { script: PLURALS }, None)
+        .expect("extract and remember");
+
+    let theo = hub_id(&svc, "theo durand");
+    assert!(
+        outgoing(&svc, "camille durand").contains(&("soeur de".to_string(), theo)),
+        "the possessive is still oriented: camille -[soeur de]-> theo, got {:?}",
+        outgoing(&svc, "camille durand")
+    );
+    assert!(
+        outgoing(&svc, "bruno durand").contains(&("pere de".to_string(), theo)),
+        "the next sentence's copule must survive untouched: bruno -[pere de]-> theo, got {:?}",
+        outgoing(&svc, "bruno durand")
+    );
+    assert!(
+        outgoing(&svc, "theo durand").is_empty(),
+        "Theo states nothing here — he is the holder in both, got {:?}",
+        outgoing(&svc, "theo durand")
+    );
+}
+
+/// A sentence can hold TWO clauses, and `", et "` is how French joins them —
+/// the very string the enumeration walk strips to find another item. Bounding
+/// the walk at the sentence is therefore not enough: the coordinated clause
+/// hands it a name, and an edge that was ALREADY CORRECT comes out inverted.
+///
+/// That is strictly worse than the missing edge the pass was written to add:
+/// "Bruno est le père de Marie" turning into "Marie est le père de Bruno" is
+/// a confident falsehood the graph did not hold before.
+#[test]
+fn a_coordinated_clause_is_not_an_enumeration_item() {
+    const PASSAGE: &str =
+        "Marie Dupont a une sœur, Camille Dupont, et Bruno Dupont est le père de Marie Dupont.";
+    let (_dir, svc) = service();
+    svc.remember_extracted(PASSAGE, &ScriptedExtractor { script: PLURALS }, None)
+        .expect("extract and remember");
+
+    let marie = hub_id(&svc, "marie dupont");
+    assert!(
+        outgoing(&svc, "camille dupont").contains(&("soeur de".to_string(), marie)),
+        "the possessive is still oriented: camille -[soeur de]-> marie, got {:?}",
+        outgoing(&svc, "camille dupont")
+    );
+    assert!(
+        outgoing(&svc, "bruno dupont").contains(&("pere de".to_string(), marie)),
+        "the coordinated clause is a CLAUSE, not an item: bruno -[pere de]-> marie \
+         must survive untouched, got {:?}",
+        outgoing(&svc, "bruno dupont")
+    );
+    assert!(
+        !outgoing(&svc, "marie dupont")
+            .iter()
+            .any(|(predicate, _)| predicate == "pere de"),
+        "Marie is nobody's father — an inverted edge here is worse than no edge, got {:?}",
+        outgoing(&svc, "marie dupont")
+    );
+}
+
+/// Same boundary, genitive side: the walk runs after the carriers a genitive
+/// names, and `" et "` joins the next clause just as readily.
+#[test]
+fn a_coordinated_clause_after_a_genitive_is_not_an_item() {
+    const PASSAGE: &str =
+        "Le père de Theo Durand est Bruno Durand et Marie Dupont est la mère de Theo Durand.";
+    let (_dir, svc) = service();
+    svc.remember_extracted(PASSAGE, &ScriptedExtractor { script: PLURALS }, None)
+        .expect("extract and remember");
+
+    let theo = hub_id(&svc, "theo durand");
+    assert!(
+        outgoing(&svc, "marie dupont").contains(&("mere de".to_string(), theo)),
+        "the second clause states its own edge: marie -[mere de]-> theo, got {:?}",
+        outgoing(&svc, "marie dupont")
+    );
+}


### PR DESCRIPTION
Ferme #1663. La passe déterministe n'orientait que le **possessif** ; le génitif, le pluriel et les alliances n'étaient gardés que par le prompt — donc par la bonne volonté du modèle.

| Construction | Avant | Après |
|---|---|---|
| `X est le père de Y` (copule) | correcte | inchangée, et **testée** pour le rester |
| `X a une sœur, Y` (possessif) | déterministe | inchangée |
| `la sœur de X est Y` / `X's sister is Y` | prompt seul | **déterministe** |
| `X a deux sœurs, Y et Z` (pluriel) | prompt seul | **déterministe** |
| beau-frère, marraine, petit-fils… | hors table | **dans la table** |

Les alliances ne sont que des entrées : grammaticalement c'est le même possessif, et le converse d'une étiquette est simplement l'autre étiquette que l'extracteur a posée sur la même paire.

## La régression que ce travail a failli livrer

La première version bornait la marche d'énumération à la **phrase**. Insuffisant : `", et "` est à la fois un séparateur d'énumération **et** la façon dont le français joint deux propositions.

```
"Marie Dupont a une sœur, Camille Dupont, et Bruno Dupont est le père de Marie Dupont."

  avant ce correctif : marie -[pere de]-> bruno      ← INVERSÉ
  attendu et obtenu  : bruno -[pere de]-> marie
```

Une arête **déjà correcte** ressortait inversée. C'est *strictement pire* que l'arête manquante que la passe existe pour ajouter : une fausseté confiante là où il n'y en avait aucune. Le commentaire du code prétendait pourtant s'en protéger — la garantie était surdéclarée.

La marche s'arrête désormais à la **proposition**. Le signal qui distingue les deux cas : un item d'énumération est suivi d'un séparateur ou d'une fin ; un sujet est suivi d'un **verbe**.

Rouge d'abord, sortie réelle :

```
the coordinated clause is a CLAUSE, not an item:
bruno -[pere de]-> marie must survive untouched, got []
```

## Vérifications

| Gate | Résultat |
|---|---|
| `kinship_forms_bdd` | **13/13**, dont le pluriel — la garde ne casse pas les vraies énumérations |
| suite `velesdb-memory` | 24 binaires, 0 échec |
| `--features extract,ollama,persistence` | 0 échec |
| clippy pedantic | 0 |
| lizard `-C 8 -a 8` | 0 avertissement |

Chaque forme est couverte dans les **deux sens** : la construction corrigée, et la copule qui doit rester intacte — c'est elle qui protège contre une correction qui inverserait tout.