### PR TITLE
docs(mcp): corriger le plafond annoncé pour le knob pool

### DIFF
--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -174,8 +174,8 @@ pub(super) struct RecallFusedParams {
     /// the `limit` cutoff (default: `limit` scaled up, floored at 64). That
     /// default is already deep enough for a graph-reached fact to surface;
     /// widen it to give a reranker more to work with, narrow it to confine
-    /// fusion to the strongest vector hits. Capped at the same ceiling
-    /// `limit` and `hops` carry.
+    /// fusion to the strongest vector hits. Capped at 1000, the same ceiling
+    /// `limit` carries — NOT the one `hops` carries, which is 10.
     #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) pool: Option<usize>,
     /// Name of the metadata field holding each fact's date as a `YYYYMMDD`


### PR DESCRIPTION
Défaut trouvé par la vérification adversariale de #1672 — **après son merge**.

Le doc-comment de `pool` devient la `description` du slot dans le schéma que **tout agent MCP lit**. Il annonçait :

> Capped at the same ceiling `limit` and `hops` carry.

Les deux plafonds diffèrent : `MAX_RECALL_LIMIT = 1000` et `MAX_WHY_HOPS = 10` (`limits.rs:58` et `:61`). La phrase supposait un plafond commun inexistant — et contredisait `MCP_TOOLS.md`, exact lui, **dans la même PR**.

Une description d'outil n'est pas un commentaire : c'est du contrat. Un appelant la lit et calibre ses appels dessus.

`mcp_schema_bdd` : 8/8.