### PR TITLE
feat(core): exposer les arêtes entrantes des trois mémoires

### DIFF
--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -260,6 +260,27 @@ impl EpisodicMemory {
         )
     }
 
+    /// Returns the incoming relations of an event (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Episodic,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -674,6 +674,33 @@ pub(super) fn relations_of(
         .collect())
 }
 
+/// Returns the incoming relation edges of a memory point, filtering out edges
+/// whose source is TTL-expired in the given subsystem.
+///
+/// The mirror of [`relations_of`]: the queried endpoint is the live one, so
+/// the TTL filter guards the *far* end — here `source()`, not `target()`.
+/// Shared by `SemanticMemory::incoming_relations`,
+/// `EpisodicMemory::incoming_relations`, and
+/// `ProceduralMemory::incoming_relations`.
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn incoming_relations_of(
+    db: &Database,
+    collection_name: &str,
+    id: u64,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    Ok(collection
+        .get_incoming_edges(id)
+        .into_iter()
+        .filter(|edge| !ttl.is_expired(kind, edge.source()))
+        .collect())
+}
+
 /// Removes a relation edge from a memory collection.
 ///
 /// Returns `true` when the edge existed and was removed. Shared by

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -347,6 +347,27 @@ impl ProceduralMemory {
         )
     }
 
+    /// Returns the incoming relations of a procedure (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Procedural,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -378,6 +378,27 @@ impl SemanticMemory {
         )
     }
 
+    /// Returns the incoming relations of a fact (edges pointing at it).
+    ///
+    /// The mirror of [`Self::relations`]: edges whose *source* is TTL-expired
+    /// are filtered out.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations(
+        &self,
+        id: u64,
+    ) -> Result<Vec<crate::collection::graph::GraphEdge>, AgentMemoryError> {
+        memory_helpers::incoming_relations_of(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Semantic,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// Returns `true` when the edge existed and was removed.

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -910,6 +910,50 @@ mod tests {
         assert!(sm.relations(1).unwrap().is_empty());
     }
 
+    /// incoming_relations() is the mirror of relations(): the edge `1 -> 2`
+    /// is visible from `2`'s side with its source intact, and only there.
+    #[test]
+    fn test_incoming_relations_exposes_the_edge_from_the_target_side() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "context", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        let edge_id = sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        let incoming = sm.incoming_relations(2).unwrap();
+        assert_eq!(incoming.len(), 1);
+        assert_eq!(incoming[0].id(), edge_id);
+        assert_eq!(incoming[0].source(), 1);
+        assert_eq!(incoming[0].label(), "RELATES_TO");
+        assert!(
+            sm.incoming_relations(1).unwrap().is_empty(),
+            "the source side has no incoming edge"
+        );
+    }
+
+    /// incoming_relations() drops an edge whose SOURCE is TTL-expired — the
+    /// mirror of relations() filtering expired targets: the live endpoint is
+    /// always the queried one, the filter guards the far end.
+    #[test]
+    fn test_incoming_relations_filters_expired_source() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let sm = make_semantic(Arc::clone(&db));
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        sm.store(1, "ephemeral", &emb).unwrap();
+        sm.store(2, "fact", &emb).unwrap();
+        sm.relate(1, 2, "RELATES_TO", None).unwrap();
+
+        sm.set_ttl_durable(1, 0).unwrap(); // source expires immediately
+
+        assert!(
+            sm.incoming_relations(2).unwrap().is_empty(),
+            "an edge from an expired source is dead and must not be reported"
+        );
+    }
+
     /// relate() refuses missing and expired endpoints (write surfaces must
     /// not resurrect or dangle).
     #[test]


### PR DESCRIPTION
Extrait de #1667, qui restait bloquée en draft parce qu'elle mêlait cette API core à son usage côté `velesdb-memory`.

## Pourquoi la séparer change tout

`velesdb-memory` se publie contre le `velesdb-core` **de crates.io**, pas celui de l'arbre. Tant que les deux moitiés voyageaient ensemble, la PR était impubliable :

```
cargo publish -p velesdb-memory --dry-run
error[E0599]: no method named  found for &SemanticMemory   EXIT 101
```

L'API core **seule** ne casse rien — personne ne l'appelle encore. Mesuré, pas supposé :

```
cargo publish -p velesdb-memory --dry-run   →   EXIT 0
```

Elle peut donc atterrir sur `develop` immédiatement, permettre une release core, et **ensuite** la moitié mémoire devient publiable. Une release mémoire au lieu de deux.

## Ce que ça ajoute

Purement additif, +134 lignes : `memory_helpers::incoming_relations_of` et son exposition sur les trois mémoires (sémantique, épisodique, procédurale). Le moteur savait déjà lire les arêtes entrantes (`Collection::get_incoming_edges`) — rien ne les remontait.

Attention portée au filtre TTL : pour une arête **entrante**, l'extrémité à vérifier est la `source()`, pas la `target()`. Le miroir naïf du code sortant aurait filtré le mauvais bout.

## Vérifications

| Gate | Résultat |
|---|---|
| `velesdb-core` (agent, single-thread) | **209 passed** |
| clippy pedantic core | 0 |
| suite `velesdb-memory` | 0 échec |
| `cargo publish -p velesdb-memory --dry-run` | **EXIT 0** |
| lizard `-C 8 -a 8` | 0 avertissement |

Aucune référence premium — la règle du core reste intacte.