### PR TITLE
test(core): épingler ce que la garde de carry-forward protège vraiment

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -211,11 +211,22 @@ impl SemanticMemory {
     /// entity tags) of the live prior version of `id` into `payload`, so a
     /// content re-store (`remember`) does not silently wipe learned state.
     ///
-    /// Only keys `payload` does not already carry are copied: caller metadata
-    /// is already in `payload` and the explicit `expires_at` is attached after
-    /// this pass, so a carried-forward value is only used when nothing else
-    /// overwrites it. An unknown, unreadable or expired prior version
-    /// contributes nothing — this is best-effort enrichment, never a failure.
+    /// Only keys `payload` does not already carry are copied — that guard,
+    /// and it alone, is what keeps a carried-forward value from shadowing
+    /// something the caller meant.
+    ///
+    /// The ordering with `attach_expiry` is deliberately NOT part of the
+    /// argument: `attach_expiry` is a no-op on `None` and an unconditional
+    /// insert on `Some`, so running it before or after this pass gives the
+    /// same payload either way. An earlier revision of this comment claimed
+    /// the explicit expiry wins *because* it is attached afterwards; mutation
+    /// testing showed the two orderings are strictly equivalent, so the
+    /// reasoning was false even though the code was right. Justifying a
+    /// correct behaviour by the wrong mechanism is how the next reader ends
+    /// up preserving the mechanism instead of the behaviour.
+    ///
+    /// An unknown, unreadable or expired prior version contributes nothing —
+    /// this is best-effort enrichment, never a failure.
     fn carry_forward_reserved_keys(&self, collection: &Collection, id: u64, payload: &mut Value) {
         if !self.stored_ids.read().contains(&id) {
             return;

--- a/crates/velesdb-core/src/agent/semantic_memory_tests.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory_tests.rs
@@ -1433,4 +1433,47 @@ mod tests {
             "an expired prior version must not leak its reserved keys forward"
         );
     }
+    /// What the `!contains_key` guard of `carry_forward_reserved_keys` actually
+    /// protects — and the reason this test exists separately from the expiry
+    /// one next to it.
+    ///
+    /// The durable expiry is guaranteed TWICE: carry-forward may copy an old
+    /// one, then `attach_expiry` overwrites it unconditionally. So no
+    /// single-fault mutation of the guard can change the expiry, and a test
+    /// phrased around it is inert by construction — mutation testing showed
+    /// exactly that.
+    ///
+    /// The learned state has no second mechanism. `_veles_confidence` is
+    /// written by reinforcement, never re-supplied by a content re-store, and
+    /// the guard is the only thing standing between it and the payload the
+    /// caller hands in. Remove the guard and a re-store that carries its own
+    /// value has it silently replaced by the stale one.
+    #[test]
+    fn test_restore_keeps_a_freshly_supplied_reserved_key_over_the_carried_one() {
+        let dir = tempdir().unwrap();
+        let db = Arc::new(Database::open(dir.path()).unwrap());
+        let ttl = Arc::new(MemoryTtl::new());
+        let sm = SemanticMemory::new(Arc::clone(&db), 4, Arc::clone(&ttl)).unwrap();
+        let emb = vec![1.0_f32, 0.0, 0.0, 0.0];
+        let mut learned = serde_json::Map::new();
+        learned.insert("_veles_confidence".to_string(), serde_json::json!(0.10));
+        sm.store_with_metadata(1, "a fact the agent has doubted", &emb, &learned)
+            .unwrap();
+        // A re-store that supplies its OWN value for the same reserved key.
+        let mut refreshed = serde_json::Map::new();
+        refreshed.insert("_veles_confidence".to_string(), serde_json::json!(0.90));
+        sm.store_with_metadata(1, "the same fact, now trusted", &emb, &refreshed)
+            .unwrap();
+        let payload = sm
+            .get_metadata(1)
+            .expect("the re-stored fact is readable")
+            .expect("and it exists");
+        assert_eq!(
+            payload.get("_veles_confidence"),
+            Some(&serde_json::json!(0.90)),
+            "a value the caller supplied must not be shadowed by the carried-forward \
+             one — got {:?}",
+            payload.get("_veles_confidence")
+        );
+    }
 }


### PR DESCRIPTION
Défaut trouvé par la vérification adversariale de #1673 — **par test de mutation**, pas par lecture.

## Le test ne protégeait rien de ce qu'il nomme

`test_restore_explicit_ttl_wins_over_carried_forward_expiry` asserte sur la **carte TTL**, que `store_with_ttl` écrit directement — jamais sur le payload que `carry_forward` touche. Il a survécu à la suppression de l'appel `carry_forward`, au retrait de sa garde `!contains_key`, et à l'inversion avec `attach_expiry`.

## En cherchant à le rendre discriminant, deux découvertes

**L'inversion d'ordre est un mutant équivalent.** `attach_expiry` est un no-op sur `None` et un insert inconditionnel sur `Some` : l'ordre est indifférent. Aucun test ne peut l'attraper — et la rustdoc qui justifiait le comportement *par cet ordre* disait donc faux, même si le code est juste. Corrigée.

> Justifier un comportement correct par le mauvais mécanisme, c'est ainsi que le lecteur suivant préserve le mécanisme au lieu du comportement.

**L'expiry est garantie deux fois.** `carry_forward` peut copier l'ancienne, `attach_expiry` écrase ensuite inconditionnellement. Un test formulé autour d'elle est **inerte par construction**, quoi qu'on écrive. L'assertion que j'avais d'abord ajoutée n'aurait fait qu'ajouter du bruit rassurant — elle est retirée.

## Ce que la garde protège réellement

L'**état appris**. `_veles_confidence` est écrit par le renforcement et jamais re-fourni par un re-stockage de contenu : là, pas de second mécanisme. C'est ce test qui manquait.

Prouvé rouge en retirant la garde :

```
assertion  failed: a value the caller supplied must not be
shadowed by the carried-forward one — got Some(Number(0.1))
```

La valeur périmée écrasait bien celle de l'appelant.

## Vérifications

`semantic_memory_tests` : **66 passed**. clippy pedantic core : 0.