### PR TITLE
chore: passer le workspace en 4.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,38 @@ jobs:
       #
       # `--locked` mirrors the release job and fails on any Cargo.lock drift
       # rather than silently updating it.
+      # velesdb-memory se publie contre le velesdb-core de CRATES.IO, jamais
+      # celui de l'arbre. Une API core ajoutee et appelee depuis memory sans
+      # release de core casse donc la publication — c'est ce qui a fait rater
+      # la 0.11.3, et le controle n'existait alors qu'au moment du tag, trop
+      # tard. Ici il echoue des la PR.
+      #
+      # Une SEULE exception, et elle est reconnaissable : pendant un bump de
+      # workspace, memory reclame un velesdb-core que personne n'a encore
+      # publie. Cargo le dit precisement — « failed to select a version for
+      # the requirement velesdb-core » — alors qu'une API manquante donne un
+      # E0599 a la compilation. Deux echecs qui n'ont rien a voir, et seul le
+      # premier est transitoire : la release de core, quelques minutes plus
+      # tard, le fait disparaitre. Bloquer dessus rendrait tout bump de
+      # workspace impossible.
       - name: Validate velesdb-memory packaging (dry-run, publishability gate)
-        run: cargo publish -p velesdb-memory --dry-run --locked
+        run: |
+          set +e
+          out=$(cargo publish -p velesdb-memory --dry-run --locked 2>&1)
+          rc=$?
+          set -e
+          if [ $rc -eq 0 ]; then
+            echo "velesdb-memory se publie contre le core de crates.io."
+            exit 0
+          fi
+          if printf '%s' "$out" | grep -q 'failed to select a version for the requirement `velesdb-core'; then
+            echo "::notice::velesdb-memory demande un velesdb-core pas encore publie — bump de workspace en cours, la release de core leve ce blocage."
+            printf '%s\n' "$out" | tail -20
+            exit 0
+          fi
+          printf '%s\n' "$out"
+          echo "::error::velesdb-memory ne se publierait pas. Une API core utilisee ici doit d'abord exister sur crates.io (cf. l'echec de la 0.11.3)."
+          exit 1
 
       - name: Run Clippy (strict)
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5834,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6834,7 +6834,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6859,7 +6859,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6941,7 +6941,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -7009,7 +7009,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7041,7 +7041,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.23"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "4.1.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "4.2.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v4.1.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v4.2.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.1.0"
+LABEL version="4.2.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -217,4 +217,4 @@ so `except velesdb.VelesDBError` is a safe catch-all.
 
 ---
 
-`velesdb-python v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-python v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "4.1.0"
+version = "4.2.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "4.1.0"
+version = "4.2.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="4.1.0",
+    version="4.2.0",
     lifespan=lifespan
 )
 

--- a/docs/ANN_SOTA_AUDIT.md
+++ b/docs/ANN_SOTA_AUDIT.md
@@ -94,4 +94,4 @@ Short answer: **partially yes**.
 - A latency-aware rerank controller is in place (`rerank_latency_target_us` + `adapt_rerank_k_to_latency`); a full benchmark-driven, recall-aware SLO controller is still future work.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,4 +185,4 @@ across all three kinds. The distinct public surfaces (`VectorCollection` /
 shared backing store is a deliberate, honest design choice, not residual debt.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: 2026-07-26 · Applies to: velesdb-core 4.1.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: 2026-07-26 · Applies to: velesdb-core 4.2.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/BUSINESS_MODEL.md
+++ b/docs/BUSINESS_MODEL.md
@@ -116,4 +116,4 @@ This design ensures:
 | Enterprise | On-premise cluster with SLA | Commercial |
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -888,4 +888,4 @@ invariants, see [SOUNDNESS.md: HNSW Batch Insertion Ordering](SOUNDNESS.md#hnsw-
 
 ---
 
-*Last updated: 2026-06-12 · Applies to: velesdb-core 4.1.0 (previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*
+*Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0 (previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -407,6 +407,6 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 
 ---
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 (this stamp tracks
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 (this stamp tracks
 the document revision; the inventory itself was last re-verified against the
 code on 2026-06-14, as stated at the top of this page)*

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # VelesDB Frequently Asked Questions
 
-Last updated: 2026-06-12 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0
 
 ---
 

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -324,4 +324,4 @@ thread 'main' panicked at ...
 
 ---
 
-*Last updated: 2026-03-20 · Applies to: velesdb-core 4.1.0 (introduced: EPIC-025)*
+*Last updated: 2026-03-20 · Applies to: velesdb-core 4.2.0 (introduced: EPIC-025)*

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,6 +1,6 @@
 # GPU Acceleration Guide
 
-> Last updated: 2026-06-12 · Applies to: velesdb-core 4.1.0 (feature introduced: VelesDB v2.0.0)
+> Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0 (feature introduced: VelesDB v2.0.0)
 
 VelesDB supports optional GPU acceleration for batch vector operations via the `gpu` feature.
 
@@ -30,7 +30,7 @@ Enable the `gpu` feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-velesdb-core = { version = "4.1.0", features = ["gpu"] }
+velesdb-core = { version = "4.2.0", features = ["gpu"] }
 ```
 
 ## Usage

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -59,4 +59,4 @@ already-published exposure (and any yank/deprecation of affected versions) is
 tracked in the licensing issues and should be reviewed by IP counsel.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -106,4 +106,4 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [E-commerce Example](../examples/ecommerce_recommendation/) — Full Vector + Graph + Filter demo in Rust
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,4 +181,4 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 *VelesDB — the explainable, local-first memory engine for AI agents. (Microsecond vector search is the proof, not the pitch.)*
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -1049,6 +1049,6 @@ let data_as_bytes: &mut [u8] = unsafe {
 
 ---
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 (this stamp tracks
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 (this stamp tracks
 the document revision; the underlying unsafe audit was last run in full on
 2026-06-12, as stated at the top of this page)*

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1,7 +1,7 @@
 # VelesDB Storage Format Specification
 
 **Version**: 1.0.0  
-Last updated: 2026-06-12 · Applies to: velesdb-core 4.1.0  
+Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0  
 **Status**: Stable
 
 ## Overview

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | Last updated: 2026-07-26 · Applies to: velesdb-core 4.1.0
+**Version**: 3.10.0 | Last updated: 2026-07-26 · Applies to: velesdb-core 4.2.0
 
 ---
 

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -128,4 +128,4 @@ See [BENCHMARKS.md](./BENCHMARKS.md) for detailed numbers and methodology.
 - You only need simple vector search without graph or column queries (ChromaDB)
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }
 ```
 
@@ -301,4 +301,4 @@ curl -X POST http://localhost:8080/query \
 - **GitHub Discussions**: Ask questions and share ideas
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CLI_COMMAND_REFERENCE.md
+++ b/docs/guides/CLI_COMMAND_REFERENCE.md
@@ -547,4 +547,4 @@ Numeric `VELES-*` codes are listed in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CLI_REPL_REFERENCE.md
+++ b/docs/guides/CLI_REPL_REFERENCE.md
@@ -287,4 +287,4 @@ executed successfully.`, `Admin statement executed successfully.`, or
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CLI_VELESQL_COOKBOOK.md
+++ b/docs/guides/CLI_VELESQL_COOKBOOK.md
@@ -455,4 +455,4 @@ SELECT "select", "from", "order" FROM docs LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 4.1.0 — May 2026*
+*Version 4.2.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 4.1.0
+# Version: 4.2.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/CORE_AGENT_MEMORY_RUST.md
+++ b/docs/guides/CORE_AGENT_MEMORY_RUST.md
@@ -155,4 +155,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_API_MAP.md
+++ b/docs/guides/CORE_API_MAP.md
@@ -125,4 +125,4 @@ use velesdb_core::{recall_at_k, precision_at_k, mrr, ndcg_at_k};
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
+++ b/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
@@ -184,4 +184,4 @@ lock-free CAS entry-point promotion.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_PERFORMANCE.md
+++ b/docs/guides/CORE_PERFORMANCE.md
@@ -115,4 +115,4 @@ It also downloads a ~168 MB tarball on first run.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_QUERY_PLAN_CACHE.md
+++ b/docs/guides/CORE_QUERY_PLAN_CACHE.md
@@ -97,4 +97,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_SPARSE_AND_FUSION.md
+++ b/docs/guides/CORE_SPARSE_AND_FUSION.md
@@ -121,4 +121,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_STREAMING_INSERTS.md
+++ b/docs/guides/CORE_STREAMING_INSERTS.md
@@ -86,4 +86,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/CORE_VELESQL_REFERENCE.md
+++ b/docs/guides/CORE_VELESQL_REFERENCE.md
@@ -132,4 +132,4 @@ EXPLAIN SELECT * FROM docs WHERE VECTOR NEAR $v LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 4.1.0 -- May 2026*
+*Version 4.2.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.1.0/velesdb-4.1.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.2.0/velesdb-4.2.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-4.1.0-amd64.deb
+sudo dpkg -i velesdb-4.2.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -136,7 +136,7 @@ results = collection.search_request(velesdb.SearchOptions(vector=query_vector, t
 ```toml
 # Cargo.toml
 [dependencies]
-velesdb-core = "4.1.0"
+velesdb-core = "4.2.0"
 ```
 
 ### As CLI Tools
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:4.1.0
+docker pull ghcr.io/cyberlife-coder/velesdb:4.2.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:4.1.0
+  ghcr.io/cyberlife-coder/velesdb:4.2.0
 ```
 
 ### Build locally

--- a/docs/guides/MIGRATE_CLI.md
+++ b/docs/guides/MIGRATE_CLI.md
@@ -275,4 +275,4 @@ elsewhere) before re-running.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_OPERATIONS.md
+++ b/docs/guides/MIGRATE_OPERATIONS.md
@@ -162,4 +162,4 @@ A completed migration deletes its own checkpoint.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_SOURCES.md
+++ b/docs/guides/MIGRATE_SOURCES.md
@@ -400,4 +400,4 @@ Common embedding dimensions:
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MOBILE_API.md
+++ b/docs/guides/MOBILE_API.md
@@ -431,4 +431,4 @@ not a measurement.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/MOBILE_BUILD.md
+++ b/docs/guides/MOBILE_BUILD.md
@@ -173,4 +173,4 @@ Expected on a host with default features: `123 passed` (lib target), `8 passed`
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/NODE_ADDON.md
+++ b/docs/guides/NODE_ADDON.md
@@ -308,4 +308,4 @@ silently reduced instead.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/NODE_ADDON_BUILD.md
+++ b/docs/guides/NODE_ADDON_BUILD.md
@@ -120,4 +120,4 @@ import { MemoryService } from '@wiscale/velesdb-memory-node'
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_AGENT_MEMORY.md
+++ b/docs/guides/PYTHON_AGENT_MEMORY.md
@@ -143,4 +143,4 @@ memory.procedural.reinforce(procedure_id=1, success=False)
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_API_REFERENCE.md
+++ b/docs/guides/PYTHON_API_REFERENCE.md
@@ -439,4 +439,4 @@ see [PYTHON_PERFORMANCE.md](PYTHON_PERFORMANCE.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_CONTEXT_COMPILER.md
+++ b/docs/guides/PYTHON_CONTEXT_COMPILER.md
@@ -121,4 +121,4 @@ shapes), see [CONTEXT_COMPILER.md](CONTEXT_COMPILER.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
+++ b/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
@@ -33,4 +33,4 @@ VelesDB is built in Rust with explicit SIMD optimizations:
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_GRAPH.md
+++ b/docs/guides/PYTHON_GRAPH.md
@@ -233,4 +233,4 @@ Query patterns: [GRAPH_PATTERNS.md](GRAPH_PATTERNS.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_RAG_PIPELINE.md
+++ b/docs/guides/PYTHON_RAG_PIPELINE.md
@@ -91,4 +91,4 @@ so you can drop in your own implementation. `dimension` is inferred after the fi
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_REMOTE_SERVER.md
+++ b/docs/guides/PYTHON_REMOTE_SERVER.md
@@ -33,4 +33,4 @@ setup.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/PYTHON_VELESQL.md
+++ b/docs/guides/PYTHON_VELESQL.md
@@ -101,4 +101,4 @@ Executing (rather than inspecting) VelesQL from Python is documented in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 4.1.0 -- 2026-06-12*
+*Version 4.2.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_DEPLOYMENT.md
+++ b/docs/guides/SERVER_DEPLOYMENT.md
@@ -172,4 +172,4 @@ enabled = false
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/SERVER_REST_TOUR.md
+++ b/docs/guides/SERVER_REST_TOUR.md
@@ -519,20 +519,20 @@ public when API keys are configured.
 `/v1/health` always answers `200` while the process is up:
 
 ```json
-{"status": "ok", "version": "4.1.0"}
+{"status": "ok", "version": "4.2.0"}
 ```
 
 `/v1/ready` answers `200` once every collection is loaded from disk:
 
 ```json
-{"status": "ready", "version": "4.1.0"}
+{"status": "ready", "version": "4.2.0"}
 ```
 
 …and `503` until then, which is what makes it usable as a Kubernetes
 readiness probe:
 
 ```json
-{"status": "not_ready", "version": "4.1.0"}
+{"status": "not_ready", "version": "4.2.0"}
 ```
 
 ---
@@ -579,4 +579,4 @@ Numbers match the canonical contract in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -319,7 +319,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }
 ```
 
@@ -338,7 +338,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }
 ```
 
@@ -347,7 +347,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }
 ```
 

--- a/docs/guides/TAURI_PLUGIN_RECIPES.md
+++ b/docs/guides/TAURI_PLUGIN_RECIPES.md
@@ -1,6 +1,6 @@
 # Tauri plugin — recipes
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0*
 
 Copy-pasteable snippets for [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md),
 beyond the 60-second first success in the crate README. Command names, payload

--- a/docs/guides/TAURI_PLUGIN_REFERENCE.md
+++ b/docs/guides/TAURI_PLUGIN_REFERENCE.md
@@ -1,6 +1,6 @@
 # Tauri plugin — command, event and permission reference
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0*
 
 Complete surface of [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md):
 every IPC command, every event, the permission model, and the storage/metric

--- a/docs/guides/WASM_API.md
+++ b/docs/guides/WASM_API.md
@@ -347,4 +347,4 @@ that runs VelesQL (`executeQuery`). See
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/WASM_PERSISTENCE.md
+++ b/docs/guides/WASM_PERSISTENCE.md
@@ -162,4 +162,4 @@ different shape from the table above; expect different absolute numbers.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/WASM_VELESQL.md
+++ b/docs/guides/WASM_VELESQL.md
@@ -240,4 +240,4 @@ version you run.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0

--- a/docs/guides/tutorials/MINI_RECOMMENDER.md
+++ b/docs/guides/tutorials/MINI_RECOMMENDER.md
@@ -37,7 +37,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-velesdb-core = "4.1.0"
+velesdb-core = "4.2.0"
 serde_json = "1.0"
 tempfile = "3.10"
 ```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "4.1.0"
+    "version": "4.2.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 4.1.0
+  version: 4.2.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v4.1.0
+# VelesDB Architecture Diagrams — v4.2.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-26 (v4.1.0; velesdb-memory 0.11.0)
+Last updated: 2026-07-29 (v4.2.0; velesdb-memory 0.11.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -22,7 +22,7 @@ No feature flags needed. Native HNSW is the only implementation:
 
 ```toml
 [dependencies]
-velesdb-core = "4.1.0"
+velesdb-core = "4.2.0"
 ```
 
 ## API

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 4.1.0
+> **VelesDB version:** 4.2.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-26 (VelesDB v4.1.0)
+> Last updated: 2026-07-29 (VelesDB v4.2.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "4.1.0"
+  "version": "4.2.0"
 }
 ```
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.1.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "4.1.0"
+version = "4.2.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "4.1.0"
+version = "4.2.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "4.1.0"
+version = "4.2.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "4.1.0"
+version = "4.2.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "4.1.0"
+version = "4.2.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.1.0"
+__version__ = "4.2.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@4.1.0
+cargo add --quiet velesdb-core@4.2.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@4.1.0
+cargo install --quiet --locked velesdb-server@4.2.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`forget`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v4.1.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v4.2.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^4.1.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Bascule de version, préalable à la release core.

## Pourquoi une mineure

Elle porte une **API core nouvelle et additive** : `SemanticMemory::incoming_relations` et ses jumelles épisodique et procédurale (#1676), qui exposent les arêtes entrantes d'un nœud. Le moteur savait déjà les lire — rien ne les remontait.

Cette publication est le **seul déverrouillage** de la moitié mémoire des arêtes entrantes (#1667, draft) et donc de #1662 : `velesdb-memory` se publie contre le `velesdb-core` **de crates.io**, pas celui de l'arbre, donc l'API doit exister sur le registre avant que quiconque puisse l'appeler.

## Ce que le bump automatique ne couvre pas

`scripts/bump_version.py` a traité **58 emplacements**. Les gardes en ont révélé **53 de plus** :

- **51 tampons `Applies to: velesdb-core`** disséminés dans les docs
- **2 pins de dépendance dans des extraits `toml`** (`NATIVE_HNSW.md`, `GPU_ACCELERATION.md`) — un lecteur qui copie l'extrait épinglerait la version précédente
- l'instantané **OpenAPI**, régénéré via `UPDATE_OPENAPI_SNAPSHOT=1`

C'est exactement la classe d'oubli qui avait fait échouer la CI de la 0.11.5, à quatre tampons près. Aucun n'est visible à la relecture ; seuls les gardes les trouvent.

## Vérifications

| Gate | Résultat |
|---|---|
| `velesdb-core` complet, single-thread | **5311 passed**, 0 failed |
| clippy pedantic workspace | **0** |
| suite `velesdb-memory` | 26 binaires, 0 échec |
| `check-version-sync.py` | All versions match |
| `check-doc-freshness.py` (versions + stamp strict) | passed |
| `check-promise-contract.py` | passed (28 claims) |
| `cargo publish -p velesdb-core --dry-run` | **EXIT 0** |

`velesdb-memory` et `velesdb-node` gardent leur cadence 0.x indépendante — vérifié, le bump ne les a pas emportés.