### PR TITLE
feat(memory): exposer les arêtes entrantes, et ne plus ramasser un hub référencé

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -653,6 +653,10 @@ macro_rules! delegate_untouched_store_methods {
             self.inner.relations(id)
         }
 
+        fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+            self.inner.incoming_relations(id)
+        }
+
         fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
             self.inner.unrelate(edge_id)
         }

--- a/crates/velesdb-memory/src/id.rs
+++ b/crates/velesdb-memory/src/id.rs
@@ -110,6 +110,10 @@ mod tests {
                 *expected,
                 "stable_id({input:?}) drifted from its pre-refactor golden vector"
             );
+            // `stable_id_bytes` only exists under `context` (see its own
+            // gate above), so the assertion must carry the same gate — the
+            // golden vectors for `stable_id` are checked either way.
+            #[cfg(feature = "context")]
             assert_eq!(
                 stable_id_bytes(input.as_bytes()),
                 *expected,

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -462,6 +462,15 @@ pub(super) struct EntityProfileDto {
     pub(super) attributes: Metadata,
     /// Typed edges leaving this entity.
     pub(super) relations: Vec<EntityRelationDto>,
+    /// Typed edges pointing AT this entity, each naming its SOURCE.
+    ///
+    /// Without these, a question is only answerable from one side: the graph
+    /// holds `camille --soeur de--> theo`, so asking what Theo's outgoing
+    /// edges say never finds Camille. The edge exists, it simply leaves the
+    /// other node. Nothing is inferred here — the converse of a kinship
+    /// label needs the gender, which the graph does not hold; this reports
+    /// only what is stored.
+    pub(super) relations_in: Vec<EntityRelationDto>,
 }
 
 impl EntityProfileDto {
@@ -482,6 +491,7 @@ impl EntityProfileDto {
                 name: canonical_entity_name(queried),
                 attributes: Metadata::new(),
                 relations: Vec::new(),
+                relations_in: Vec::new(),
             };
         };
         Self {
@@ -492,6 +502,11 @@ impl EntityProfileDto {
             attributes: profile.attributes,
             relations: profile
                 .relations
+                .into_iter()
+                .map(EntityRelationDto::from)
+                .collect(),
+            relations_in: profile
+                .relations_in
                 .into_iter()
                 .map(EntityRelationDto::from)
                 .collect(),

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -310,7 +310,7 @@ pub struct RememberedExtraction {
 }
 
 /// Everything the auto-built graph knows about one named entity: the
-/// attributes merged onto its hub and the typed edges leaving it.
+/// attributes merged onto its hub and the typed edges touching it.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub struct EntityProfile {
@@ -320,8 +320,12 @@ pub struct EntityProfile {
     pub name: String,
     /// Attributes learned about this entity, reserved keys stripped.
     pub attributes: crate::service::Metadata,
-    /// Typed edges leaving this entity (bipartite `mentions` edges excluded).
+    /// Typed edges leaving this entity (bipartite scaffolding excluded).
     pub relations: Vec<EntityRelation>,
+    /// Typed edges pointing AT this entity (bipartite scaffolding excluded).
+    /// Here [`EntityRelation::target_id`]/[`EntityRelation::target`] name the
+    /// far end the edge comes FROM — its source.
+    pub relations_in: Vec<EntityRelation>,
 }
 
 /// The connected answer to a `why` question: the best-matching seed memory plus

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -19,8 +19,8 @@ use crate::error::MemoryError;
 use crate::extract::{ExtractedAttribute, ExtractedRelation, Extractor};
 use crate::id;
 use crate::model::{
-    ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryNode, Recollection,
-    RememberedExtraction, UnrelateOutcome,
+    ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryEdge, MemoryNode,
+    Recollection, RememberedExtraction, UnrelateOutcome,
 };
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
@@ -69,6 +69,10 @@ const HUB_ID_SALT: &str = "\u{0}_veles_entity_hub\u{0}";
 /// `why()` walk crossed a hub, so it can weight the reached fact by that
 /// hub's specificity instead of a flat constant.
 const MENTIONS_RELATION: &str = "mentions";
+/// Edge label a fact uses to point at a hub it is tagged with (the fact → hub
+/// direction) — [`MENTIONS_RELATION`]'s bipartite twin, written by
+/// [`MemoryService::remember_extracted`]'s `wire_entity`.
+const ABOUT_RELATION: &str = "about";
 
 /// Local-first agent memory backed by a single `VelesDB` instance.
 ///
@@ -487,24 +491,53 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             name: key,
             attributes: strip_reserved_keys(self.store.get_metadata(id)?).unwrap_or_default(),
             relations: self.outgoing_entity_relations(id)?,
+            relations_in: self.incoming_entity_relations(id)?,
         }))
     }
 
     /// The typed edges leaving `id`, resolved to their target's content.
     ///
-    /// `mentions` edges are dropped: they point at the facts that tagged this
-    /// entity, which is the bipartite scaffolding, not a statement *about* it.
+    /// Scaffolding edges (`mentions`, and `about` for symmetry — a hub never
+    /// has an outgoing `about`) are dropped: they point at the facts that
+    /// tagged this entity, not at a statement *about* it.
     fn outgoing_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
+        self.resolve_entity_relations(self.store.relations(id)?, |edge| edge.to)
+    }
+
+    /// The typed edges pointing at `id`, resolved to their SOURCE's content —
+    /// for an incoming edge the far end is where it comes *from*.
+    ///
+    /// Without these, a question is only answerable from one side: the graph
+    /// holds `camille --soeur de--> theo`, so reading Theo's outgoing edges
+    /// never finds Camille. The edge exists, it simply leaves the other node.
+    ///
+    /// The scaffolding filter is the incoming mirror of
+    /// [`Self::outgoing_entity_relations`]'s: `about` edges are dropped (they
+    /// are the fact → hub half of the `about`/`mentions` pair), and `mentions`
+    /// with them for symmetry.
+    fn incoming_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
+        self.resolve_entity_relations(self.store.incoming_relations(id)?, |edge| edge.from)
+    }
+
+    /// Shared resolver for both edge directions: skip the bipartite
+    /// scaffolding labels, resolve each edge's far end (`far_end` picks which
+    /// endpoint that is) to its stored content.
+    fn resolve_entity_relations(
+        &self,
+        edges: Vec<MemoryEdge>,
+        far_end: impl Fn(&MemoryEdge) -> u64,
+    ) -> Result<Vec<EntityRelation>, MemoryError> {
         let mut relations = Vec::new();
-        for edge in self.store.relations(id)? {
-            if edge.relation == MENTIONS_RELATION {
+        for edge in edges {
+            if edge.relation == MENTIONS_RELATION || edge.relation == ABOUT_RELATION {
                 continue;
             }
-            let target = self.store.get(edge.to)?.map(|(content, _)| content);
+            let far = far_end(&edge);
+            let content = self.store.get(far)?.map(|(content, _)| content);
             relations.push(EntityRelation {
                 predicate: edge.relation,
-                target_id: edge.to,
-                target: target.unwrap_or_default(),
+                target_id: far,
+                target: content.unwrap_or_default(),
             });
         }
         Ok(relations)
@@ -675,7 +708,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // not dedup by endpoint+label, only by edge id).
         self.seed_existing_edges(fact_id, edges, seeded)?;
         self.seed_existing_edges(entity_id, edges, seeded)?;
-        self.add_edge(fact_id, entity_id, "about", edges)?;
+        self.add_edge(fact_id, entity_id, ABOUT_RELATION, edges)?;
         self.add_edge(entity_id, fact_id, MENTIONS_RELATION, edges)?;
         Ok(())
     }
@@ -1053,10 +1086,37 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(())
     }
 
-    /// Whether `hub` still points at a fact that exists.
+    /// Whether anything alive still needs `hub`.
+    ///
+    /// Two references count, and the second is why this reads BOTH
+    /// directions (issue #1662):
+    ///
+    /// - an outgoing `mentions` edge to a live fact — the pair
+    ///   [`Self::wire_entities`] writes, the ordinary case;
+    /// - an incoming edge from a live NON-HUB fact — what a caller's own
+    ///   `relate` writes, and it writes one direction only. Relating a fact
+    ///   to a hub is reachable (`entity()` hands out the hub id), so reading
+    ///   outgoing edges alone swept hubs from under live callers' edges,
+    ///   losing them in silence.
+    ///
+    /// Incoming edges from another HUB are deliberately ignored: hub↔hub
+    /// edges exist (`wire_relations` writes them), and counting them would
+    /// let two hubs keep each other alive forever — a leak whose outcome
+    /// depends on collection order, which is worse than the bug being fixed.
     fn hub_still_mentioned(&self, hub: u64) -> Result<bool, MemoryError> {
         for edge in self.store.relations(hub)? {
             if edge.relation == MENTIONS_RELATION && self.store.get(edge.to)?.is_some() {
+                return Ok(true);
+            }
+        }
+        self.hub_has_live_referent(hub)
+    }
+
+    /// Whether a live non-hub fact points AT `hub` — see
+    /// [`Self::hub_still_mentioned`] for why hub→hub edges do not count.
+    fn hub_has_live_referent(&self, hub: u64) -> Result<bool, MemoryError> {
+        for edge in self.store.incoming_relations(hub)? {
+            if self.store.get(edge.from)?.is_some() && !self.is_hub(edge.from)? {
                 return Ok(true);
             }
         }

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -175,6 +175,13 @@ pub trait MemoryStore {
     /// Returns [`MemoryError`] if storage access fails.
     fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
 
+    /// The incoming edges of `id` — the mirror of [`Self::relations`], with
+    /// the same liveness rule applied to the far end (here the *source*).
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
+
     /// Remove the edge with `edge_id`. Returns `true` when it existed —
     /// idempotent: removing an absent edge is `Ok(false)`, never an error.
     ///
@@ -352,18 +359,13 @@ impl MemoryStore for NativeStore {
     }
 
     fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
-        Ok(self
-            .memory
-            .semantic()
-            .relations(id)?
-            .into_iter()
-            .map(|edge| MemoryEdge {
-                id: edge.id(),
-                from: edge.source(),
-                to: edge.target(),
-                relation: edge.label().to_owned(),
-            })
-            .collect())
+        Ok(to_memory_edges(self.memory.semantic().relations(id)?))
+    }
+
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        Ok(to_memory_edges(
+            self.memory.semantic().incoming_relations(id)?,
+        ))
     }
 
     fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
@@ -376,6 +378,22 @@ impl MemoryStore for NativeStore {
     fn count(&self) -> usize {
         self.memory.semantic().count()
     }
+}
+
+/// Map core [`GraphEdge`](velesdb_core::collection::graph::GraphEdge)s to the
+/// wire-facing [`MemoryEdge`] shape — shared by both edge directions, so the
+/// two can never disagree on which endpoint or id they report.
+#[cfg(feature = "persistence")]
+fn to_memory_edges(edges: Vec<velesdb_core::collection::graph::GraphEdge>) -> Vec<MemoryEdge> {
+    edges
+        .into_iter()
+        .map(|edge| MemoryEdge {
+            id: edge.id(),
+            from: edge.source(),
+            to: edge.target(),
+            relation: edge.label().to_owned(),
+        })
+        .collect()
 }
 
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
+++ b/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
@@ -96,3 +96,56 @@ fn forget_on_a_plain_fact_without_hubs_still_reports_found() {
          never created a hub"
     );
 }
+
+/// Issue #1662. The collector decided a hub was orphaned by reading only its
+/// OUTGOING `mentions` edges — the pairs `remember_extracted` writes in both
+/// directions. A `relate` posed by hand writes one direction only, and
+/// relating a fact TO a hub is reachable: `entity()` hands out the hub id and
+/// `relate` accepts any live target.
+///
+/// So a live fact could point at a hub the collector could not see, and the
+/// hub was swept from under it — the caller's own edge silently lost, with
+/// no error anywhere.
+#[test]
+fn forget_keeps_a_hub_a_live_fact_still_points_at() {
+    let (_dir, svc) = service();
+    let ids = svc
+        .remember_extracted("seed", &SharedTopicExtractor, None)
+        .expect("remember_extracted")
+        .ids;
+    let hub = svc
+        .entity_profile("parser")
+        .expect("entity_profile")
+        .expect("precondition: the hub exists")
+        .id;
+
+    // A caller's own edge, one direction only — exactly what `relate` writes.
+    let anchor = svc
+        .remember(
+            "An unrelated note that cites the parser hub by hand.",
+            &[],
+            None,
+        )
+        .expect("remember the anchor fact");
+    svc.relate(anchor, hub, "cites").expect("relate by hand");
+
+    // The only fact whose extraction created `parser` goes away.
+    svc.forget(ids[0]).expect("forget the extracted fact");
+
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile after forget")
+            .is_some(),
+        "a hub a live fact still points at must survive the loss of its last \
+         `mentions` edge — the caller's edge is the reference the collector missed"
+    );
+
+    // And once that anchor goes too, nothing references the hub any more.
+    svc.forget(anchor).expect("forget the anchor");
+    assert!(
+        svc.entity_profile("parser")
+            .expect("entity_profile after the anchor is gone")
+            .is_none(),
+        "with its last referent gone the hub is collected as before"
+    );
+}

--- a/crates/velesdb-memory/tests/kinship_forms_bdd.rs
+++ b/crates/velesdb-memory/tests/kinship_forms_bdd.rs
@@ -99,6 +99,21 @@ fn outgoing(svc: &MemoryService<HashEmbedder>, name: &str) -> Vec<(String, u64)>
         .unwrap_or_default()
 }
 
+/// The predicates pointing AT `name`'s hub, each paired with the hub the edge
+/// comes FROM — the mirror of [`outgoing`], read from the other side.
+fn incoming(svc: &MemoryService<HashEmbedder>, name: &str) -> Vec<(String, u64)> {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .map(|profile| {
+            profile
+                .relations_in
+                .into_iter()
+                .map(|r| (r.predicate, r.target_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// The hub id of `name`, which must already exist.
 fn hub_id(svc: &MemoryService<HashEmbedder>, name: &str) -> u64 {
     svc.entity_profile(name)
@@ -466,5 +481,59 @@ fn a_coordinated_clause_after_a_genitive_is_not_an_item() {
         outgoing(&svc, "marie dupont").contains(&("mere de".to_string(), theo)),
         "the second clause states its own edge: marie -[mere de]-> theo, got {:?}",
         outgoing(&svc, "marie dupont")
+    );
+}
+
+// --- The other side of the edge ---------------------------------------------
+
+/// A kinship edge is stated once, in one direction. Reading only the edges
+/// LEAVING a hub therefore answers the question from one side only: the graph
+/// holds `camille --soeur de--> theo`, so asking what Theo's outgoing edges
+/// say never finds Camille — the edge exists, it simply leaves the other node.
+///
+/// `relations_in` closes that half. Nothing is inferred: the converse of a
+/// kinship label needs the gender, which the graph does not hold, so the
+/// incoming side reports the label AS STATED and names the source it comes
+/// from — not a guessed reciprocal.
+#[test]
+fn an_entity_sees_the_edges_that_point_at_it_not_only_the_ones_it_states() {
+    const PASSAGE: &str =
+        "Theo Durand a une sœur, Camille Durand. Bruno Durand est le père de Theo Durand.";
+    let (_dir, svc) = service();
+    svc.remember_extracted(PASSAGE, &ScriptedExtractor { script: PLURALS }, None)
+        .expect("extract and remember");
+
+    let camille = hub_id(&svc, "camille durand");
+    let bruno = hub_id(&svc, "bruno durand");
+    let theo = hub_id(&svc, "theo durand");
+
+    assert!(
+        outgoing(&svc, "camille durand").contains(&("soeur de".to_string(), theo)),
+        "precondition: the edge is stated camille -[soeur de]-> theo, got {:?}",
+        outgoing(&svc, "camille durand")
+    );
+    assert!(
+        incoming(&svc, "theo durand").contains(&("soeur de".to_string(), camille)),
+        "Theo must see the edge that points at him, naming Camille as its SOURCE, got {:?}",
+        incoming(&svc, "theo durand")
+    );
+    assert!(
+        incoming(&svc, "theo durand").contains(&("pere de".to_string(), bruno)),
+        "the copule points at Theo too and must be reported the same way, got {:?}",
+        incoming(&svc, "theo durand")
+    );
+    assert!(
+        !incoming(&svc, "camille durand")
+            .iter()
+            .any(|(predicate, _)| predicate == "soeur de"),
+        "the edge leaves Camille, so it is not one of HER incoming edges, got {:?}",
+        incoming(&svc, "camille durand")
+    );
+    assert!(
+        !incoming(&svc, "theo durand")
+            .iter()
+            .any(|(predicate, _)| predicate == "about" || predicate == "mentions"),
+        "the fact↔hub scaffolding is not a statement about the entity, got {:?}",
+        incoming(&svc, "theo durand")
     );
 }

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -98,6 +98,18 @@ fn matches_all(payload: &Map<String, Value>, filter: &Metadata) -> bool {
     filter.iter().all(|(k, v)| payload.get(k) == Some(v))
 }
 
+/// Map one stored [`WasmEdge`](crate::graph_store::WasmEdge) to the
+/// wire-facing [`MemoryEdge`] shape — shared by both edge directions, so the
+/// two can never disagree on which endpoint or id they report.
+fn to_memory_edge(e: &crate::graph_store::WasmEdge) -> MemoryEdge {
+    MemoryEdge {
+        id: e.id,
+        from: e.source,
+        to: e.target,
+        relation: e.label.clone(),
+    }
+}
+
 struct Inner {
     dimension: usize,
     facts: HashMap<u64, Fact>,
@@ -302,12 +314,20 @@ impl MemoryStore for WasmStore {
             // degree — counting dead edges would under-weight every
             // graph-reached fact relative to the native ranking.
             .filter(|e| e.source == id && inner.live_fact(e.target).is_some())
-            .map(|e| MemoryEdge {
-                id: e.id,
-                from: e.source,
-                to: e.target,
-                relation: e.label.clone(),
-            })
+            .map(to_memory_edge)
+            .collect())
+    }
+
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        let inner = self.inner.borrow();
+        Ok(inner
+            .graph
+            .edges()
+            .iter()
+            // Mirror of `relations`: the far end is the SOURCE here, and an
+            // edge from a TTL-expired fact is just as dead as one into it.
+            .filter(|e| e.target == id && inner.live_fact(e.source).is_some())
+            .map(to_memory_edge)
             .collect())
     }
 


### PR DESCRIPTION
Ferme #1662. Réapplication sur `develop` à jour du travail parqué en #1667, débloqué par la publication de `velesdb-core` 4.2.0.

## Le déverrouillage, mesuré

```
ce matin  : cargo publish -p velesdb-memory --dry-run  →  EXIT 101
            error[E0599]: no method named  for &SemanticMemory
maintenant: EXIT 0
```

`velesdb-memory` se publie contre le core **de crates.io**. Tant que 4.2.0 n'y était pas, ce travail ne pouvait pas atterrir sans rendre `develop` impubliable.

## Ce que ça apporte

**`entity` répond enfin des deux côtés.** Le graphe contient `camille —soeur de→ theo` ; interroger les arêtes de Theo ne trouvait **jamais** Camille — l'arête existe, elle part de l'autre nœud. `relations_in` nomme la **source** de chaque entrante.

Rien n'est inféré : le converse d'un lien de parenté demande le genre, que le graphe ne porte pas. On expose ce qui est stocké.

**#1662 — un hub référencé n'est plus balayé.** La collecte d'orphelins ne lisait que les `mentions` **sortantes**, celles que `remember_extracted` écrit par paires. Un `relate` posé à la main n'en écrit qu'une, et relier un fait à un hub est atteignable — `entity()` rend l'id du hub. Un fait vivant pouvait donc pointer un hub invisible au collecteur, et **l'arête de l'appelant disparaissait en silence**.

**Décision conservée telle quelle :** les entrantes venant d'un autre **hub** ne comptent pas. `wire_relations` écrit des arêtes hub↔hub ; les compter laisserait deux hubs se maintenir mutuellement à vie — une fuite dont l'issue dépend de l'ordre de collecte, donc pire que le défaut corrigé. `forgetting_every_fact_leaves_no_hub_behind` reste vert : c'est lui qui le prouve.

## Pourquoi réappliqué et non fusionné

#1667 était trop ancienne : `develop` avait réécrit les mêmes zones — `unrelate`, `MemoryEdge.id`, les refactors de complexité — et la fusion produisait **quatre conflits enchevêtrés** dans le trait, le service et le store wasm. Forcer une résolution là fait disparaître du code sans bruit. Le travail est petit et délimité ; le réappliquer délibérément était plus sûr que de se battre contre un historique périmé.

## Trouvé au passage

Un **gate de feature manquant dans `id.rs`** : `stable_id_bytes` n'existe que sous `context`, l'assertion qui l'utilise ne portait pas le même gate. Même famille que les deux fonctions mortes rattrapées plus tôt — et seule la boucle d'isolation par feature l'attrape.

## Vérifications

| Gate | Résultat |
|---|---|
| suite `velesdb-memory` | **26 binaires**, 0 échec |
| clippy pedantic | 0 |
| boucle d'isolation, 6 features, **cible neuve** | 0 avertissement |
| `cargo publish --dry-run` | **EXIT 0** |