### PR TITLE
chore(memory): passer velesdb-memory en 0.11.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "axum",
  "criterion",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.6] — 2026-07-29
+
 ### Added
 
 - **`recall_fused` exposes `pool` over MCP.** The three bindings (Node

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.11.5"
+version = "0.11.6"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.11.5"
+version = "0.11.6"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -817,4 +817,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.6

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -507,7 +507,7 @@ matching checksum next to it.
 
 **This path only becomes active from the first release published after the
 change.** `release-memory.yml`'s `build-daemon-archive` job produces these
-archives, but the `velesdb-memory-v0.11.5` release (and everything before it)
+archives, but the `velesdb-memory-v0.11.6` release (and everything before it)
 predates it and carries no such asset, so `--from-release` against `v0.11.0`
 fails with a clear 404-explaining message rather than a bare `curl` /
 `Invoke-WebRequest` error. This is a **different artifact** than the `.mcpb`
@@ -568,4 +568,4 @@ pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.6

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -545,4 +545,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.5
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.11.6

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bascule de version, préalable à la release.

## Ce que la 0.11.6 porte

Le travail de la journée sur la mémoire :

- **`unrelate`** — l'annulation symétrique de `relate` (#1661), plus sa parité sur les trois bindings
- **Cap d'embedding** sur les sources de contexte : `compile_context` contournait le contrôle et échouait en erreur backend brute
- **Cinq validations d'entrée** trouvées par la campagne de scénarios (#1654)
- **Autographe étendu** au génitif, au pluriel et aux alliances (#1663)
- **Knob `pool`** exposé sur MCP, qui était en retard sur ses propres bindings
- **`relations_in`** et le correctif du hub orphelin (#1662)

## Ce que la 0.11.5 m'a appris, appliqué ici

**La section de changelog est écrite d'emblée.** La 0.11.5 est partie sans la sienne — restée sous `[Unreleased]`, où le travail suivant s'est empilé par-dessus, si bien que personne ne trouvait ce qu'apportait la version installée.

**Les quatre tampons de documentation étaient au rendez-vous**, dans exactement les mêmes fichiers qu'à la 0.11.5. Le bump ne les couvre pas ; seuls les gardes les voient.

## Vérifications

| Gate | Résultat |
|---|---|
| suite `velesdb-memory` | **26 binaires**, 0 échec |
| clippy pedantic | 0 |
| `check-version-sync.py` | All versions match |
| doc-freshness (versions + stamp strict) | passed |
| `cargo publish --dry-run` | **EXIT 0** |