### PR TITLE
fix(memory): n'annoncer qu'un type scalaire sur chaque entree MCP

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`explain_compilation` refused the `fragment_id` it had just emitted.**
+  `compile_context` rewrites every id of its response into a decimal string
+  when the request carries `policy.ids_as_strings` — the option that exists
+  so a float-lossy JSON client keeps its ids intact. `explain_compilation`,
+  whose whole job is to explain the decision behind one of those ids, took
+  `fragment_id` as a strict `u64` and rejected the string with
+  `invalid type: string "…", expected u64`. The fallback was no better: a
+  `fragment_id` is an FNV-1a 64 content hash, so it is past 2^53 in ~99.95 %
+  of cases and a JavaScript client has already rounded it on arrival. Both
+  forms failed, which made the tool unreachable by its own documented
+  selector on exactly the clients the id contract was written for. It now
+  accepts a number or a decimal string, and advertises the string.
+
+- **The two halves of a working-context round trip disagreed.**
+  `save_working_context` advertises its nested `fragment_id`/`memory_id` as
+  decimal strings (an input schema may announce only one form), while
+  `load_working_context` answered with JSON numbers. An agent that resumed a
+  session, enriched what it loaded and saved it back therefore had to
+  convert — and on a float-lossy client the value was already rounded at read
+  time, so it stored a corrupted id with the apparent exactness of a string.
+  `load_working_context` now answers in decimal strings, the exact bytes its
+  writing half accepts. The advertised output schema already typed those
+  fields `["integer", "string"]`, so no SDK-side validation changes.
+
+### Added
+
+- **`save_working_context` returns `id_str`.** It was the one tool handing
+  back an id without its decimal-string twin, while `forget`/`feedback`
+  advertise only the string form — leaving no way to relay the id it had just
+  returned. A test now derives the rule from the published surface (a name
+  the input side wants as a string and the output side answers as an
+  `integer` must carry an `_str` twin) instead of relying on the convention
+  being remembered.
+
 ## [0.11.6] — 2026-07-29
 
 ### Added

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -427,8 +427,25 @@ pub struct SourceReference {
     pub fragment_id: u64,
     /// Recoverable address of the original content (`ctx://source/<id>`).
     pub handle: String,
+    // Un doc-comment de CHAMP est publie tel quel dans la description du
+    // schema annonce (`docs/reference/mcp-tools.json`) : l'archeologie va donc
+    // ici, en commentaire ordinaire, et le contrat seul va au-dessus.
+    //
+    // Aller-retour casse jusqu'au 2026-07-29, trouve en interrogeant le
+    // serveur plutot qu'en relisant le code : `memory_id` fait partie des
+    // `super::wire::ID_KEYS`, donc une reponse sous
+    // `CompilePolicy::ids_as_strings` l'emet en CHAINE — et
+    // `save_working_context` la refusait, alors que c'est precisement la forme
+    // qu'un client a en main lorsqu'il resoumet une `SourceReference` recue
+    // d'un contexte compile.
     /// The memory backing this source, when it came from recall (US-002).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Accepts a JSON number OR a decimal string on input, exactly like
+    /// `fragment_id` just above.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "super::wire::deserialize_optional_id"
+    )]
     pub memory_id: Option<u64>,
 }
 

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -7,11 +7,9 @@
 use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
-use rmcp::handler::server::tool::schema_for_input;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::{ErrorCode, Implementation, JsonObject, ServerCapabilities, ServerInfo};
+use rmcp::model::{ErrorCode, Implementation, ServerCapabilities, ServerInfo};
 use rmcp::{tool, tool_handler, tool_router, ErrorData, ServerHandler};
-use schemars::JsonSchema;
 
 use crate::limits::{DEFAULT_WHY_HOPS, MAX_FACT_BYTES, MAX_RECALL_LIMIT, MAX_WHY_HOPS};
 use crate::model::FusionOptions;
@@ -47,36 +45,20 @@ use dto::{
     WhyParams,
 };
 
-/// Advertised-schema counterpart of [`crate::model::deserialize_id`]: `keys`
-/// (e.g. `["from", "to"]`) widen from `integer` to `["integer", "string"]` so
-/// a client generating requests from the schema can discover the
-/// decimal-string form (issue #1468). Scoped per tool — each takes a
-/// different set of id-named parameters (`relate`'s `from`/`to`,
-/// `forget`/`feedback`'s `id`, `remember`'s nested `links[].target`) — unlike
-/// the context compiler's `wire_safe_input_schema` (single hardcoded `"id"`
-/// key, `context`-feature-gated). Both reuse the same underlying
-/// [`crate::schema::widen_id_properties`] tree walk.
+/// Le constructeur de schema d'ENTREE, unique pour les vingt outils :
+/// [`crate::schema::wire_safe_input_schema`].
 ///
-/// It then applies [`crate::schema::inline_ref_only_properties`], for the
-/// same reason `wire_safe_input_schema` does: `schemars` emits a nested
-/// object or array-of-objects as a bare `$ref` into `$defs`, and a harness
-/// that does not dereference `$defs` degrades that to "untyped" — so
-/// `remember`'s `links[]` (a `Vec<Link>`) and `recall_where`'s `filters[]`
-/// (a `Vec<ColumnFilter>`) advertised an array of anything, hiding both
-/// their required fields. Order matters: widen FIRST so the copies the
-/// inliner makes inherit the widened id types.
-fn id_wire_input_schema<T: JsonSchema + std::any::Any>(keys: &[&str]) -> Arc<JsonObject> {
-    let schema = schema_for_input::<Parameters<T>>().unwrap_or_else(|e| {
-        panic!(
-            "Invalid input schema for {}: {e}",
-            std::any::type_name::<T>()
-        )
-    });
-    let mut map = (*schema).clone();
-    crate::schema::widen_id_properties(&mut map, keys);
-    crate::schema::inline_ref_only_properties(&mut map);
-    Arc::new(map)
-}
+/// `keys` nomme les proprietes que CET outil accepte en chaine decimale
+/// (`relate`/`unrelate` : `from`/`to` ; `forget`/`feedback` : `id` ;
+/// `remember` : le `links[].target` imbrique) — la tolerance d'un id est une
+/// connaissance de l'outil, jamais une regle globale :
+/// `explain_compilation.fragment_id` est un `u64` STRICT et reste annonce
+/// `integer`.
+///
+/// Il y avait deux constructeurs, celui-ci et un `wire_safe_input_schema`
+/// gate sur `context` a cle `"id"` figee ; ils appliquaient la meme suite de
+/// passes a une virgule pres. Il n'y en a plus qu'un.
+use crate::schema::wire_safe_input_schema as id_wire_input_schema;
 
 // --- The server ------------------------------------------------------------
 
@@ -119,15 +101,33 @@ impl McpServer {
     /// The full tool router: the memory tools, plus the context compiler's
     /// tools when that feature is on. Combined here — rmcp routers add — so
     /// there is exactly ONE server whichever features are enabled.
+    ///
+    /// **Et le point de passage unique du durcissement d'entree.** Mesure du
+    /// 2026-07-29 : 10 outils sur 20 ne declaraient AUCUN `input_schema`
+    /// (`recall`, `recall_fused`, `entity`, `why`, `remember_extracted`,
+    /// `context_savings`, `retrieve_context_source`, `load_working_context`,
+    /// `list_working_contexts`, `suggest_budget`) — leur schema etait celui
+    /// derive par rmcp, que rien ne post-traitait. Un durcissement declare
+    /// outil par outil laisse donc chaque route future non protegee, et rien
+    /// ne le signale : c'est une omission, pas une erreur. Ici, une route
+    /// nouvelle est couverte parce qu'elle EXISTE.
+    ///
+    /// L'attribut `#[tool(input_schema = …)]` garde ce qui, lui, est
+    /// vraiment per-outil : les cles d'id que l'outil accepte en chaine.
     fn combined_router() -> ToolRouter<McpServer> {
         #[cfg(feature = "context")]
-        {
-            Self::tool_router() + Self::context_tool_router()
-        }
+        let mut router = Self::tool_router() + Self::context_tool_router();
         #[cfg(not(feature = "context"))]
-        {
-            Self::tool_router()
+        let mut router = Self::tool_router();
+
+        // `reharden_tool_input` prend l'outil, pas un schema : `Tool` type
+        // ses deux schemas identiquement, donc c'est la signature — et non
+        // une convention de nommage — qui rend la sortie inatteignable ici.
+        for route in router.map.values_mut() {
+            crate::schema::reharden_tool_input(&mut route.attr);
         }
+        assert_every_input_slot_is_typed(&router);
+        router
     }
 
     /// Attach an extraction backend, enabling the `remember_extracted` tool.
@@ -518,6 +518,36 @@ impl ServerHandler for McpServer {
         info.instructions = Some(SERVER_INSTRUCTIONS.to_owned());
         info
     }
+}
+
+/// La post-condition du point de passage, verifiee SUR PLACE.
+///
+/// Un test lointain constate ; ici on refuse. Les schemas annonces sont
+/// statiques — ils ne dependent ni du store, ni de l'horloge, ni d'une
+/// entree — donc une violation est deterministe : elle ne peut pas se
+/// produire chez un utilisateur sans se produire aussi au premier
+/// `McpServer::new` de la suite de tests. Echouer a la construction dit ou
+/// est le probleme ; laisser passer un slot intypable le fait ressortir
+/// plusieurs jours plus tard, dans un aller-retour de deserialisation chez
+/// un agent.
+///
+/// # Panics
+/// Si une route publie un slot d'entree qui n'annonce ni `type`, ni `enum`,
+/// ni `const`.
+fn assert_every_input_slot_is_typed(router: &ToolRouter<McpServer>) {
+    let mut offenders: Vec<String> = Vec::new();
+    for route in router.map.values() {
+        for slot in crate::schema::untyped_input_slots(&route.attr.input_schema) {
+            offenders.push(format!("  {}: {slot}", route.attr.name));
+        }
+    }
+    assert!(
+        offenders.is_empty(),
+        "{} slot(s) d'entree n'annoncent aucun type — un harnais client les rend `{{}}`, le \
+         client envoie ce qu'il devine, et le serveur le refuse :\n{}",
+        offenders.len(),
+        offenders.join("\n")
+    );
 }
 
 /// Map a `spawn_blocking` join failure (a panicked or cancelled tool task) to an

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -10,9 +10,8 @@
 
 use std::sync::Arc;
 
-use rmcp::handler::server::tool::schema_for_input;
 use rmcp::handler::server::wrapper::{Json, Parameters};
-use rmcp::model::{ErrorCode, JsonObject};
+use rmcp::model::ErrorCode;
 use rmcp::{tool, tool_router, ErrorData};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -58,22 +57,16 @@ pub(super) use crate::schema::wire_safe_output_schema;
 
 /// Input-side counterpart: `fragments[].id` accepts an integer or a decimal
 /// string ([`crate::context::wire::deserialize_optional_id`]), so the
-/// advertised input schema announces both — a client generating requests
-/// from the schema must be able to discover the string form. Scoped to the
-/// `id` property only: `explain_compilation`'s own `fragment_id` parameter
-/// deserializes as a strict `u64` and stays typed `integer`.
-fn wire_safe_input_schema<T: JsonSchema + std::any::Any>() -> Arc<JsonObject> {
-    let schema = schema_for_input::<Parameters<T>>().unwrap_or_else(|e| {
-        panic!(
-            "Invalid input schema for {}: {e}",
-            std::any::type_name::<T>()
-        )
-    });
-    let mut map = (*schema).clone();
-    crate::schema::widen_id_properties(&mut map, &["id"]);
-    crate::schema::inline_ref_only_properties(&mut map);
-    Arc::new(map)
-}
+/// advertised input schema announces the string form — a client generating
+/// requests from the schema must be able to discover it.
+///
+/// Le jeu de cles n'est plus fige a `"id"` : il est passe par l'outil, comme
+/// dans `mcp.rs`, parce que `save_working_context` porte des ids sous
+/// d'autres noms (`fragment_id`, `memory_id`, imbriques dans
+/// `WorkingContext`) tandis que `explain_compilation.fragment_id` est un
+/// `u64` STRICT qu'annoncer `string` serait une promesse fausse. Un seul
+/// constructeur, donc, mais toujours une decision par outil.
+pub(super) use crate::schema::wire_safe_input_schema;
 
 // --- Thin request envelopes --------------------------------------------------
 
@@ -92,10 +85,27 @@ pub(super) struct ExplainCompilationParams {
     /// re-submitting the request reproduces the exact decisions).
     #[serde(deserialize_with = "super::wire::lenient")]
     pub request: CompileRequest,
+    // Aller-retour casse jusqu'au 2026-07-29, et casse depuis toujours :
+    // `fragment_id` est le SELECTEUR d'une decision, et la decision d'ou le
+    // client le tire lui arrive en CHAINE decimale des que la requete porte
+    // `policy.ids_as_strings` (`fragment_id` est dans
+    // `context::wire::ID_KEYS`). Ce champ etait un `u64` nu : l'outil
+    // refusait litteralement les octets qu'il venait d'emettre, et comme un
+    // `fragment_id` est un FNV-1a 64 — au-dela de 2^53 dans ~99,95 % des cas
+    // — le repli « renvoyer un nombre » etait deja arrondi chez un client
+    // JSON a nombres flottants. Les deux formes echouaient : sur un tel
+    // client, l'outil etait inatteignable par son propre selecteur.
+    //
+    // Ce n'etait pas une omission : trois tests et deux jeux de cles d'id
+    // epinglaient la forme stricte comme voulue. Ce que personne n'avait
+    // fait, c'est l'aller-retour.
     /// The fragment whose decision to return. Looked up by matching
     /// `ContextDecision::fragment_id`, UNLESS `fragment_index` is also
     /// given (see there) — still required even then, since it is the only
-    /// disambiguator when `fragment_index` is absent.
+    /// disambiguator when `fragment_index` is absent. Accepts a JSON number
+    /// OR a decimal string, so a `fragment_id` received under
+    /// [`CompilePolicy::ids_as_strings`] can be relayed back unchanged.
+    #[serde(deserialize_with = "crate::model::deserialize_id")]
     pub fragment_id: u64,
     /// Optional, 0-based position of the fragment in `request.fragments`.
     /// When given, TAKES PRIORITY over `fragment_id` for locating the
@@ -157,6 +167,13 @@ pub(super) struct SaveWorkingContextParams {
 pub(super) struct SaveWorkingContextResult {
     /// Id of the stored system fact backing this working context.
     pub id: u64,
+    /// Decimal-string twin of `id`, same contract as
+    /// [`crate::mcp::dto::RememberResult::id_str`]: the id is content-addressed
+    /// (FNV-1a 64), so it is past 2^53 and a float-lossy JSON client rounds
+    /// `id` on arrival. This was the ONE tool handing back an id without its
+    /// twin while `forget`/`feedback` accept only the decimal string — the
+    /// caller had no way to build the form the schema demands.
+    pub id_str: String,
 }
 
 /// Input of the `load_working_context` tool.
@@ -171,7 +188,7 @@ pub(super) struct LoadWorkingContextParams {
 /// Output of the `load_working_context` tool. An envelope (not a bare
 /// `Option<WorkingContext>`): the MCP spec requires the output schema's
 /// root to be an object, so a nullable root is rejected by rmcp.
-#[derive(Debug, serde::Serialize, JsonSchema)]
+#[derive(Debug, serde::Serialize, Deserialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct LoadWorkingContextResult {
     /// `true` when a working context was found under this exact project +
@@ -430,7 +447,7 @@ impl McpServer {
     #[tool(
         name = "compile_context",
         description = "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Each fragment's own `metadata` is capped at 64 KiB serialized. A fragment may set `path` (an absolute filesystem path) instead of inline `content` to ingest a file by reference — exactly one of `path`, `content`, or `media` per fragment; requires the server to be started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories, and the resolved file must be plain UTF-8 text under 1 MiB. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, token-savings insights, and `warnings` — a mechanical shortlist of externalized fragments relevant enough to the query that they are worth a second look, so checking `decisions` by hand is only needed when `warnings` is non-empty and still ambiguous. `policy.slim_response` (default false) empties `sections`/`decisions` from the response — keep it off when you need the audit trail, or re-compile without it later (compilation is deterministic). `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
-        input_schema = wire_safe_input_schema::<CompileRequest>(),
+        input_schema = wire_safe_input_schema::<CompileRequest>(&["id"]),
         output_schema = wire_safe_output_schema::<CompiledContext>()
     )]
     async fn compile_context(
@@ -466,7 +483,7 @@ impl McpServer {
     #[tool(
         name = "compile_transcript",
         description = "One-call shortcut over compile_context for a raw agent-session transcript: deterministically segments it into turns (plain marker-based — System:/User:/Human:/Assistant:/AI:/Tool:/### User/### Assistant — or JSONL, one line per turn) and, within each turn, into code/log/body sub-segments (fenced code blocks stay atomic; runs of 8+ log-like lines collapse the same way abstract.log_dedup would), then compiles the result exactly like compile_context. Exactly one of `transcript` (inline) or `path` (an absolute filesystem path, same VELESDB_MEMORY_INGEST_ROOTS allowlist as compile_context's `path` fragments but capped at 8 MiB) must be set. `segmentation.format` forces plain or jsonl instead of auto-detecting; a forced jsonl format that fails to parse is a hard error, never a silent fallback. The first turn is tagged cache-eligible when it looks like a system prompt (segmentation.cache_system_turn, default true). Returns `context` (byte-compatible with compile_context's output) plus `segmentation` — the detected format and one audit entry (turn, role, kind, byte range, fragment_id) per segment, so a caller can see exactly how the transcript was cut before trusting the compiled result.",
-        input_schema = wire_safe_input_schema::<CompileTranscriptParams>(),
+        input_schema = wire_safe_input_schema::<CompileTranscriptParams>(&[]),
         output_schema = wire_safe_output_schema::<CompileTranscriptResult>()
     )]
     async fn compile_transcript(
@@ -558,7 +575,7 @@ impl McpServer {
     #[tool(
         name = "explain_compilation",
         description = "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was; a `path` fragment is likewise re-read from disk, so the decision reflects the file's CURRENT content, not necessarily what the original compile_context call saw. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
-        input_schema = wire_safe_input_schema::<ExplainCompilationParams>(),
+        input_schema = wire_safe_input_schema::<ExplainCompilationParams>(&["id", "fragment_id"]),
         output_schema = wire_safe_output_schema::<ContextDecision>()
     )]
     async fn explain_compilation(
@@ -619,7 +636,7 @@ impl McpServer {
         // or les SDK MCP valident structuredContent contre ce schema.
         output_schema = wire_safe_output_schema::<SaveWorkingContextResult>(),
         description = "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert) — so an entirely empty `working` is REFUSED rather than allowed to wipe what a previous save stored; fill at least one field. Serialized size is capped at 1 MiB. Returns the stored fact's id.",
-        input_schema = wire_safe_input_schema::<SaveWorkingContextParams>()
+        input_schema = wire_safe_input_schema::<SaveWorkingContextParams>(&["fragment_id", "memory_id"])
     )]
     async fn save_working_context(
         &self,
@@ -637,7 +654,10 @@ impl McpServer {
         .await
         .map_err(join_error)?
         .map_err(to_error)?;
-        Ok(Json(SaveWorkingContextResult { id }))
+        Ok(Json(SaveWorkingContextResult {
+            id,
+            id_str: id.to_string(),
+        }))
     }
 
     #[tool(
@@ -651,7 +671,7 @@ impl McpServer {
     async fn load_working_context(
         &self,
         Parameters(params): Parameters<LoadWorkingContextParams>,
-    ) -> Result<Json<LoadWorkingContextResult>, ErrorData> {
+    ) -> Result<Json<Value>, ErrorData> {
         let LoadWorkingContextParams { project, session } = params;
         let service = Arc::clone(&self.service);
         let lookup_project = project.clone();
@@ -681,11 +701,36 @@ impl McpServer {
                 .filter(|candidate| candidate != &session)
                 .collect()
         };
-        Ok(Json(LoadWorkingContextResult {
+        // Les ids sortent en CHAINE decimale, sans option, contrairement au
+        // compilateur ou `ids_as_strings` est un choix de l'appelant.
+        //
+        // Ici il n'y a pas de choix a offrir : cet outil est la moitie
+        // LECTURE d'un aller-retour dont la moitie ECRITURE
+        // (`save_working_context`) n'annonce plus qu'une forme, la chaine —
+        // depuis que le schema d'entree ne peut plus publier d'union. Rendre
+        // un nombre la ou le jumeau n'accepte qu'une chaine oblige le client
+        // a convertir ; et sur un client JSON a nombres flottants, la valeur
+        // est deja arrondie a la LECTURE, donc il reecrit un id faux avec
+        // l'exactitude apparente d'une chaine. Un contexte de travail existe
+        // pour survivre a une perte de contexte : sa trace de provenance ne
+        // peut pas se rompre en silence entre deux sessions.
+        //
+        // Le schema de sortie annonce deja `["integer", "string"]` sur ces
+        // champs (`widen_id_properties`), donc emettre la branche chaine est
+        // valide au sens du schema publie : aucun SDK ne rejette la reponse.
+        let mut value = serde_json::to_value(LoadWorkingContextResult {
             found,
             working,
             other_sessions,
-        }))
+        })
+        .map_err(|err| {
+            ErrorData::internal_error(
+                format!("Failed to serialize structured content: {err}"),
+                None,
+            )
+        })?;
+        stringify_id_fields(&mut value);
+        Ok(Json(value))
     }
 
     #[tool(

--- a/crates/velesdb-memory/src/mcp/context_tools_tests.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools_tests.rs
@@ -72,6 +72,17 @@ fn decision_of(value: serde_json::Value) -> ContextDecision {
     serde_json::from_value(value).expect("valid ContextDecision wire value")
 }
 
+/// Same for `load_working_context`, which returns the wire `Value` too since
+/// 2026-07-29: its ids leave as decimal strings, so that the ONLY form
+/// `save_working_context` announces is the form its reading half hands back.
+/// Deserializing here is exactly what a Rust MCP client does — and it is why
+/// the round trip is checked on the WIRE in `tests/mcp_schema_bdd.rs` as
+/// well: `serde_json` decodes a `u64` exactly, the float-lossy client this
+/// contract exists for does not.
+fn loaded_working_of(value: serde_json::Value) -> LoadWorkingContextResult {
+    serde_json::from_value(value).expect("valid LoadWorkingContextResult wire value")
+}
+
 #[tokio::test]
 async fn test_compile_context_tool_returns_compiled_context_and_insights() {
     // Given a server and a compile request with a duplicate
@@ -455,42 +466,96 @@ fn test_compile_context_input_schema_advertises_string_fragment_id() {
     // fragments[].id accepts a decimal string on input (see
     // wire::deserialize_optional_id) — a client generating requests from the
     // advertised schema must be able to discover that.
+    //
+    // Annonce `"string"` TOUT COURT depuis le 2026-07-29, la ou le schema
+    // disait `["integer", "string", "null"]` : les harnais clients observes
+    // aplatissent une liste de formes en `{}`, si bien que la version
+    // « complete » du contrat le detruisait au lieu de le publier. La chaine
+    // est la forme qui traverse un client JSON a nombres flottants sans
+    // perdre les bits d'un id au-dela de 2^53 — c'est donc elle qu'on
+    // annonce. Le serveur, lui, accepte toujours les deux.
     let tool = McpServer::compile_context_tool_attr();
     let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
 
     let id_type = &published_fragment_property(&schema, "id")["type"];
-    let types = id_type
-        .as_array()
-        .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
-    for expected in ["integer", "string", "null"] {
-        assert!(
-            types.contains(&serde_json::json!(expected)),
-            "fragments[].id must advertise {expected} on input, got {id_type}"
-        );
-    }
+    assert_eq!(
+        id_type,
+        &serde_json::json!("string"),
+        "fragments[].id must advertise exactly one scalar type on input, got {id_type}"
+    );
+}
+
+#[tokio::test]
+async fn test_explain_compilation_accepts_the_string_fragment_id_compile_context_emitted() {
+    // Given a fragment whose id exceeds 2^53, compiled with
+    // `policy.ids_as_strings` — the option that exists precisely so a
+    // float-lossy client gets its ids intact.
+    let (_dir, srv) = server();
+    let mut big = fragment("a fact whose id is past the safe integer range");
+    big.id = Some(ID_ABOVE_JS_SAFE_INTEGER);
+    let mut req = request("deploy", vec![big], 10_000);
+    req.policy = Some(CompilePolicy {
+        ids_as_strings: true,
+        ..CompilePolicy::default()
+    });
+    let Json(compiled) = srv
+        .compile_context(Parameters(req.clone()))
+        .await
+        .expect("compile_context");
+    let emitted = compiled["decisions"][0]["fragment_id"].clone();
+    assert!(
+        emitted.is_string(),
+        "precondition: ids_as_strings emits fragment_id as a string, got {emitted}"
+    );
+
+    // When the caller asks WHY that fragment was decided the way it was,
+    // relaying the id exactly as it was handed out…
+    let arguments = serde_json::json!({
+        "request": serde_json::to_value(&req).expect("the request serializes"),
+        "fragment_id": emitted,
+    });
+
+    // …then the tool that produced the string must accept it back. It did
+    // not until 2026-07-29: `fragment_id` was a bare `u64`, so the ONLY form
+    // that survives a float-lossy client was the one form it refused, and
+    // the tool was unreachable by its own documented selector.
+    let params: ExplainCompilationParams = serde_json::from_value(arguments)
+        .expect("explain_compilation accepts the decimal-string fragment_id it emits");
+    assert_eq!(params.fragment_id, ID_ABOVE_JS_SAFE_INTEGER);
+
+    let Json(decision) = srv
+        .explain_compilation(Parameters(params))
+        .await
+        .expect("explain_compilation resolves the fragment");
+    // The answer is stringified too — the request carried `ids_as_strings`,
+    // so the whole loop stays in the one form a float-lossy client can hold.
+    assert_eq!(
+        decision["fragment_id"],
+        serde_json::json!(ID_ABOVE_JS_SAFE_INTEGER.to_string()),
+        "the decision returned is the one for that exact fragment: {decision}"
+    );
 }
 
 #[test]
-fn test_explain_compilation_input_schema_keeps_top_level_fragment_id_strict() {
-    // The widening is scoped to fragments[].id: the tool's own fragment_id
-    // parameter is deserialized as a strict u64 (a string is rejected), so
-    // its advertised type must stay integer-only — announcing a string there
-    // would over-promise.
+fn test_explain_compilation_input_schema_announces_the_string_fragment_id() {
+    // `fragment_id` selects a decision by an id `compile_context` may hand
+    // out as a decimal string (`policy.ids_as_strings`), so it carries the
+    // id contract and must ANNOUNCE the form that survives a float-lossy
+    // client. It was published `integer` — the one form the caller cannot
+    // produce past 2^53 — until 2026-07-29.
     let tool = McpServer::explain_compilation_tool_attr();
     let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
 
     assert_eq!(
         schema["properties"]["fragment_id"]["type"],
-        serde_json::json!("integer"),
-        "top-level fragment_id stays integer-only"
+        serde_json::json!("string"),
+        "top-level fragment_id announces the decimal-string form"
     );
-    // …while the nested fragments[].id is widened, like compile_context's.
+    // …while the nested fragments[].id announces the string form it accepts.
     let id_type = &published_fragment_property(&schema, "id")["type"];
-    let types = id_type
-        .as_array()
-        .unwrap_or_else(|| panic!("fragments[].id must type a list of forms, got {id_type}"));
-    assert!(
-        types.contains(&serde_json::json!("string")),
+    assert_eq!(
+        id_type,
+        &serde_json::json!("string"),
         "request.fragments[].id must advertise string on input, got {id_type}"
     );
 }
@@ -842,6 +907,7 @@ async fn test_save_working_context_tool_then_load_round_trips() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
     let recovered = loaded
         .working
         .expect("a previously saved working context must load back");
@@ -863,6 +929,7 @@ async fn test_load_working_context_tool_none_when_never_saved() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
 
     // Then there is nothing to resume
     assert!(loaded.working.is_none());
@@ -899,6 +966,7 @@ async fn test_save_working_context_tool_is_idempotent_upsert() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
     assert_eq!(loaded.working.expect("saved").goal, state.goal);
 }
 
@@ -922,6 +990,7 @@ async fn test_load_working_context_tool_reports_found_true_on_hit() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
 
     // Then `found` is true, and `other_sessions` is empty because this
     // project genuinely has no OTHER session — not because a hit suppresses
@@ -954,6 +1023,7 @@ async fn test_load_working_context_tool_surfaces_other_sessions_on_a_hit_too() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
 
     // Then the OTHER session is still surfaced. An agent that mistypes a
     // session id into another REAL session gets `found: true` and resumes
@@ -996,6 +1066,7 @@ async fn test_load_working_context_tool_reports_found_false_and_other_sessions_o
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
 
     // Then `found` is false, `working` is null, and the real session is
     // surfaced so the caller can recover from the typo.
@@ -1333,6 +1404,7 @@ async fn test_load_working_context_never_suggests_the_session_it_just_denied() {
         }))
         .await
         .expect("load_working_context");
+    let loaded = loaded_working_of(loaded);
 
     // Then the answer must not contradict itself: the field is named
     // `other_sessions` and documented as OTHER sessions, so proposing the

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -114,6 +114,108 @@ fn widen_id_schema(schema: &mut Value) {
     }
 }
 
+/// Mots-cles numeriques qu'un slot annonce `string` ne contraint plus.
+/// JSON Schema applique `minimum`/`maximum`/`multipleOf` aux nombres
+/// uniquement : les laisser sur un slot devenu `string` n'interdit rien et
+/// suggere au lecteur un type que le slot n'a plus.
+#[cfg(feature = "mcp")]
+const INERT_NUMERIC_KEYWORDS: [&str; 6] = [
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "format",
+];
+
+/// Mots-cles d'union qu'un slot rendu scalaire ne doit plus porter : les
+/// garder ferait exiger a un validateur la conjonction du type et de la
+/// branche.
+#[cfg(feature = "mcp")]
+const UNION_KEYWORDS: [&str; 4] = ["anyOf", "oneOf", "allOf", "$ref"];
+
+/// Le pendant ENTREE de [`widen_id_properties`] : chaque propriete nommee
+/// dans `keys` est annoncee `type: "string"`, tout court.
+///
+/// `widen_id_properties` reste — il sert la SORTIE, ou un id traverse en
+/// entier ou en chaine selon [`crate::context::model::CompilePolicy::ids_as_strings`]
+/// et ou les deux formes doivent donc etre annoncees. En ENTREE, une union
+/// est detruite : les harnais clients observes aplatissent
+/// `type: ["integer", "string"]` en `{}`, et le slot redevient exactement
+/// l'« intypable » que tout ce module existe pour empecher. Une seule forme
+/// annoncee, donc, et c'est la chaine — la seule qui traverse un client JSON
+/// a nombres flottants sans perdre les bits d'un id au-dela de 2^53.
+///
+/// Ce que le serveur ACCEPTE est inchange : `deserialize_id` prend toujours
+/// l'entier comme la chaine. On restreint ce que le client LIT, jamais ce
+/// qu'il peut ENVOYER.
+///
+/// **La contrepartie, et elle est obligatoire :** un id annonce `string` en
+/// entree doit etre LISIBLE exactement quelque part en sortie, sinon un
+/// client a nombres flottants n'a plus aucune forme utilisable des deux
+/// cotes. C'est le role du jumeau `<nom>_str`
+/// (cf. [`crate::mcp::dto`]) et, pour le couple
+/// `save_working_context`/`load_working_context`, de la reponse emise
+/// directement en chaines. Le test
+/// `every_lossy_id_in_a_result_offers_its_exact_string_twin`
+/// (`tests/mcp_schema_bdd.rs`) refuse la moitie sans l'autre.
+#[cfg(feature = "mcp")]
+pub(crate) fn stringify_id_properties(map: &mut Map<String, Value>, keys: &[&str]) {
+    if keys.is_empty() {
+        return;
+    }
+    if let Some(Value::Object(properties)) = map.get_mut("properties") {
+        for (name, subschema) in properties.iter_mut() {
+            if keys.contains(&name.as_str()) {
+                stringify_id_schema(subschema);
+            }
+        }
+    }
+    for value in map.values_mut() {
+        stringify_in_value(value, keys);
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn stringify_in_value(value: &mut Value, keys: &[&str]) {
+    match value {
+        Value::Object(map) => stringify_id_properties(map, keys),
+        Value::Array(items) => items
+            .iter_mut()
+            .for_each(|item| stringify_in_value(item, keys)),
+        _ => {}
+    }
+}
+
+/// Un tableau d'ids descend sur ses `items` ; tout le reste devient un
+/// `string` nu, debarrasse des mots-cles devenus inertes.
+#[cfg(feature = "mcp")]
+fn stringify_id_schema(schema: &mut Value) {
+    let Value::Object(map) = schema else {
+        return;
+    };
+    if declares_array(map) {
+        if let Some(items) = map.get_mut("items") {
+            stringify_id_schema(items);
+        }
+        return;
+    }
+    map.insert("type".to_owned(), Value::String("string".to_owned()));
+    for keyword in INERT_NUMERIC_KEYWORDS.iter().chain(UNION_KEYWORDS.iter()) {
+        map.remove(*keyword);
+    }
+}
+
+/// `"type": "array"`, ou une liste de formes qui en contient `array`.
+#[cfg(feature = "mcp")]
+fn declares_array(map: &Map<String, Value>) -> bool {
+    match map.get("type") {
+        Some(Value::String(kind)) => kind == "array",
+        Some(Value::Array(kinds)) => kinds.iter().any(|kind| kind == "array"),
+        _ => false,
+    }
+}
+
 /// Cap on how deep [`inline_ref_only_properties`] chases nested `$ref`s.
 /// The deepest real input schema needs 3 (`working` → `items` of
 /// `ContextFact` → its `source`); 8 leaves headroom while keeping a
@@ -263,19 +365,21 @@ fn inline_in_map(
     inline_property_slots(map, defs, chain, depth);
     inline_item_slots(map, defs, chain, depth);
     inline_union_branches(map, defs, chain, depth);
+    inline_additional_property_slot(map, defs, chain, depth);
     inline_remaining_keywords(map, defs, chain, depth);
 }
 
 /// The keywords `inline_in_map` walks as argument paths, each with its own
 /// pass — listed once here so the generic descent cannot walk them twice.
 #[cfg(feature = "mcp")]
-const SLOT_KEYWORDS: [&str; 6] = [
+const SLOT_KEYWORDS: [&str; 7] = [
     "$defs",
     "properties",
     "items",
     "anyOf",
     "oneOf",
     "prefixItems",
+    "additionalProperties",
 ];
 
 #[cfg(feature = "mcp")]
@@ -336,6 +440,29 @@ fn inline_union_branches(
                 inline_slot(branch, defs, chain, depth);
             }
         }
+    }
+}
+
+/// The value schema of an open map (`BTreeMap<String, T>`) is an argument
+/// path like any other.
+///
+/// Found on 2026-07-29 by the post-condition of `combined_router`, not by a
+/// test: the generic descent below walked THROUGH `additionalProperties`
+/// (inlining what was inside it) but never inlined the node ITSELF, so
+/// `compile_context`'s `policy.pricing.models` shipped
+/// `additionalProperties: {"$ref": "#/$defs/ModelPricing"}` — the exact
+/// unresolvable-`$ref` slot this whole pass exists to remove, hiding in the
+/// one keyword no pass claimed. `additionalProperties` is often the boolean
+/// `true`; [`inline_slot`] ignores a non-object silently.
+#[cfg(feature = "mcp")]
+fn inline_additional_property_slot(
+    map: &mut Map<String, Value>,
+    defs: &Map<String, Value>,
+    chain: &mut InlineChain,
+    depth: usize,
+) {
+    if let Some(extra @ Value::Object(_)) = map.get_mut("additionalProperties") {
+        inline_slot(extra, defs, chain, depth);
     }
 }
 
@@ -418,6 +545,387 @@ fn ref_only_target(prop: &Map<String, Value>) -> Option<String> {
     reference.strip_prefix("#/$defs/").map(str::to_owned)
 }
 
+// --- La scalarisation des slots d'ENTREE ------------------------------------
+
+/// Effondre chaque slot d'un schema d'ENTREE en UN type scalaire.
+///
+/// La preuve etablie le 2026-07-29, en interrogeant le serveur en JSON-RPC
+/// brut : le serveur emettait deja un schema d'entree CORRECT — une union
+/// `["integer", "string"]` sur les slots d'id, un `anyOf: [T, null]` sur les
+/// champs optionnels — et c'est le HARNAIS qui aplatit toute union en `{}`.
+/// On ne corrige pas les harnais ; on cesse d'emettre une union sur une
+/// ENTREE.
+///
+/// Attention en verifiant : `docs/reference/mcp-tools.json` est regenere
+/// APRES cette passe, il enregistre donc l'etat d'ARRIVEE et ne peut pas
+/// porter la trace de l'union de depart. Ce que l'artefact montre encore,
+/// c'est la meme union LA OU ELLE SURVIT — la SORTIE, que cette passe ne
+/// touche pas : `compile_context.decisions[].fragment_id` y vaut toujours
+/// `["integer", "string"]`, et `load_working_context.working` un
+/// `anyOf: [WorkingContext, null]`. C'est cette forme-la, sur l'entree,
+/// qu'on a cesse de publier.
+///
+/// Quatre formes s'effondrent :
+/// - `anyOf`/`oneOf` `[T, {"type": "null"}]` → `T`, **seulement** si `T`
+///   porte deja un `type` direct : un `$ref` laisse en place par le garde de
+///   cycle d'[`inline_ref_only_properties`] deviendrait sinon un slot
+///   orphelin, c'est-a-dire exactement le defaut qu'on repare ;
+/// - `"type": ["X", "null"]` → `"X"` ;
+/// - un `oneOf` de `const` → `{"type": "string", "enum": [...]}`, les
+///   descriptions de branches repliees dans celle du slot (ce qui sauve
+///   `recall_where.filters[].op` et les enums de politique) ;
+/// - un `"default": null` devenu inerte disparait.
+///
+/// N'accepte QUE [`WireInputSchema`] : appliquee a une sortie, elle ferait
+/// echouer la validation de `structuredContent` chez le client (voir le
+/// commentaire de section plus bas). S'applique APRES
+/// [`inline_ref_only_properties`] — une branche doit deja etre inlinee pour
+/// porter un type promouvable.
+#[cfg(feature = "mcp")]
+pub(crate) fn scalarize_slot_types(schema: &mut WireInputSchema) {
+    scalarize_in_map(&mut schema.0);
+}
+
+/// Les mots-cles que [`scalarize_in_map`] parcourt comme chemins d'argument,
+/// chacun avec sa propre passe — listes ici une seule fois pour que la
+/// descente generique ne les reparcoure pas.
+#[cfg(feature = "mcp")]
+const SCALARIZE_SLOT_KEYWORDS: [&str; 6] = [
+    "properties",
+    "items",
+    "anyOf",
+    "oneOf",
+    "prefixItems",
+    "additionalProperties",
+];
+
+/// Mots-cles dont la valeur est une DONNEE et non un sous-schema. Descendre
+/// dedans reviendrait a reecrire une valeur d'exemple parce qu'elle porte
+/// une cle qui ressemble a un mot-cle de schema.
+#[cfg(feature = "mcp")]
+const DATA_KEYWORDS: [&str; 4] = ["enum", "const", "default", "examples"];
+
+#[cfg(feature = "mcp")]
+fn scalarize_in_map(map: &mut Map<String, Value>) {
+    scalarize_property_slots(map);
+    scalarize_item_slots(map);
+    scalarize_union_branches(map);
+    scalarize_additional_properties(map);
+    scalarize_remaining_keywords(map);
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_property_slots(map: &mut Map<String, Value>) {
+    if let Some(Value::Object(properties)) = map.get_mut("properties") {
+        for slot in properties.values_mut() {
+            scalarize_slot(slot);
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_item_slots(map: &mut Map<String, Value>) {
+    match map.get_mut("items") {
+        // Forme tuple : `items` est un tableau de schemas par position.
+        Some(Value::Array(entries)) => entries.iter_mut().for_each(scalarize_slot),
+        Some(single) => scalarize_slot(single),
+        None => {}
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_union_branches(map: &mut Map<String, Value>) {
+    for keyword in ["anyOf", "oneOf", "prefixItems"] {
+        if let Some(Value::Array(branches)) = map.get_mut(keyword) {
+            branches.iter_mut().for_each(scalarize_slot);
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_additional_properties(map: &mut Map<String, Value>) {
+    if let Some(extra @ Value::Object(_)) = map.get_mut("additionalProperties") {
+        scalarize_slot(extra);
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_remaining_keywords(map: &mut Map<String, Value>) {
+    for (key, value) in map.iter_mut() {
+        let name = key.as_str();
+        if !SCALARIZE_SLOT_KEYWORDS.contains(&name) && !DATA_KEYWORDS.contains(&name) {
+            scalarize_in_value(value);
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn scalarize_in_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => scalarize_in_map(map),
+        Value::Array(items) => items.iter_mut().for_each(scalarize_in_value),
+        _ => {}
+    }
+}
+
+/// Un slot : ses enfants D'ABORD, lui-meme ensuite.
+///
+/// L'ordre n'est pas cosmetique. Une branche doit etre effondree avant
+/// d'etre promue : `Option<SegmentFormat>` arrive en
+/// `anyOf: [{oneOf: [const…]}, null]`, dont la premiere branche ne porte
+/// aucun `type` direct. C'est la regle (c) appliquee a la branche qui lui en
+/// donne un, et donc la regle (a) qui devient applicable au slot.
+#[cfg(feature = "mcp")]
+fn scalarize_slot(slot: &mut Value) {
+    let Value::Object(map) = slot else {
+        return;
+    };
+    scalarize_in_map(map);
+    collapse_nullable_union(map);
+    collapse_const_union(map);
+    collapse_nullable_type_list(map);
+    drop_inert_null_default(map);
+}
+
+/// (a) `anyOf`/`oneOf` `[T, {"type": "null"}]` → `T`.
+#[cfg(feature = "mcp")]
+fn collapse_nullable_union(map: &mut Map<String, Value>) {
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(promoted) = nullable_union_branch(map, keyword) {
+            promote_branch(map, keyword, promoted);
+            return;
+        }
+    }
+}
+
+/// La branche non-nulle d'une union binaire nullable, si elle porte deja un
+/// `type` scalaire direct. Sinon `None` — un `$ref` survivant ne doit jamais
+/// devenir un slot orphelin.
+#[cfg(feature = "mcp")]
+fn nullable_union_branch(map: &Map<String, Value>, keyword: &str) -> Option<Map<String, Value>> {
+    let Value::Array(branches) = map.get(keyword)? else {
+        return None;
+    };
+    if branches.len() != 2 {
+        return None;
+    }
+    let kept = match (is_null_branch(&branches[0]), is_null_branch(&branches[1])) {
+        (false, true) => &branches[0],
+        (true, false) => &branches[1],
+        _ => return None,
+    };
+    let Value::Object(kept) = kept else {
+        return None;
+    };
+    matches!(kept.get("type"), Some(Value::String(_))).then(|| kept.clone())
+}
+
+#[cfg(feature = "mcp")]
+fn is_null_branch(branch: &Value) -> bool {
+    let Value::Object(map) = branch else {
+        return false;
+    };
+    matches!(map.get("type"), Some(Value::String(kind)) if kind == "null")
+}
+
+/// Les mots-cles freres du slot (`description`, `title`, …) ecrasent ceux de
+/// la branche promue — exactement ce que fait deja `inline_slot`.
+#[cfg(feature = "mcp")]
+fn promote_branch(map: &mut Map<String, Value>, keyword: &str, mut promoted: Map<String, Value>) {
+    for (key, value) in map.iter() {
+        if key != keyword {
+            promoted.insert(key.clone(), value.clone());
+        }
+    }
+    *map = promoted;
+}
+
+/// (c) Une union dont CHAQUE branche est un `const` chaine devient un
+/// `enum` unique. C'est la forme que `schemars` donne a une enumeration
+/// unitaire, et celle qu'un harnais aplatit en `{}` alors qu'elle enumere
+/// pourtant ses propres valeurs.
+#[cfg(feature = "mcp")]
+fn collapse_const_union(map: &mut Map<String, Value>) {
+    for keyword in ["oneOf", "anyOf"] {
+        let Some(branches) = const_branches(map, keyword) else {
+            continue;
+        };
+        let description = folded_description(map.get("description"), &branches);
+        let values: Vec<Value> = branches.into_iter().map(|(value, _)| value).collect();
+        map.remove(keyword);
+        map.insert("type".to_owned(), Value::String("string".to_owned()));
+        map.insert("enum".to_owned(), Value::Array(values));
+        if let Some(text) = description {
+            map.insert("description".to_owned(), Value::String(text));
+        }
+        return;
+    }
+}
+
+/// Les `(valeur, description)` d'une union de `const` chaines, ou `None` des
+/// qu'une branche n'est pas de cette forme.
+#[cfg(feature = "mcp")]
+fn const_branches(map: &Map<String, Value>, keyword: &str) -> Option<Vec<(Value, Option<String>)>> {
+    let Value::Array(branches) = map.get(keyword)? else {
+        return None;
+    };
+    if branches.is_empty() {
+        return None;
+    }
+    let mut collected = Vec::with_capacity(branches.len());
+    for branch in branches {
+        let Some(Value::String(literal)) = branch.get("const") else {
+            return None;
+        };
+        collected.push((
+            Value::String(literal.clone()),
+            text_keyword(branch, "description"),
+        ));
+    }
+    Some(collected)
+}
+
+#[cfg(feature = "mcp")]
+fn text_keyword(node: &Value, keyword: &str) -> Option<String> {
+    match node.get(keyword) {
+        Some(Value::String(text)) => Some(text.clone()),
+        _ => None,
+    }
+}
+
+/// La description du slot, suivie d'une ligne par branche qui en portait une
+/// — sans quoi l'effondrement perdrait ce que chaque valeur signifie.
+#[cfg(feature = "mcp")]
+fn folded_description(own: Option<&Value>, branches: &[(Value, Option<String>)]) -> Option<String> {
+    let mut lines: Vec<String> = branches
+        .iter()
+        .filter_map(|(value, text)| text.as_ref().map(|text| format!("- {value}: {text}")))
+        .collect();
+    let own = match own {
+        Some(Value::String(text)) => Some(text.clone()),
+        _ => None,
+    };
+    if lines.is_empty() {
+        return own;
+    }
+    if let Some(text) = own {
+        lines.insert(0, text);
+    }
+    Some(lines.join("\n"))
+}
+
+/// (b) `"type": ["X", "null"]` → `"X"`.
+#[cfg(feature = "mcp")]
+fn collapse_nullable_type_list(map: &mut Map<String, Value>) {
+    if let Some(kept) = nullable_type_pair(map) {
+        map.insert("type".to_owned(), Value::String(kept));
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn nullable_type_pair(map: &Map<String, Value>) -> Option<String> {
+    let Value::Array(kinds) = map.get("type")? else {
+        return None;
+    };
+    let named: Vec<&str> = kinds.iter().filter_map(Value::as_str).collect();
+    if named.len() != 2 || !named.contains(&"null") {
+        return None;
+    }
+    named
+        .iter()
+        .find(|kind| **kind != "null")
+        .map(|kind| (*kind).to_owned())
+}
+
+/// (d) Un `"default": null` sur un slot devenu non-nullable n'annonce plus
+/// rien : il contredit le type qui vient d'etre pose.
+#[cfg(feature = "mcp")]
+fn drop_inert_null_default(map: &mut Map<String, Value>) {
+    let scalar = matches!(map.get("type"), Some(Value::String(kind)) if kind != "null");
+    if scalar && map.get("default") == Some(&Value::Null) {
+        map.remove("default");
+    }
+}
+
+// --- La post-condition du point de passage unique ---------------------------
+
+/// Les slots d'un schema d'ENTREE qui n'annoncent AUCUN type.
+///
+/// Verifiee sur place par `McpServer::combined_router`, a la construction du
+/// serveur, plutot que confiee a un test lointain : les schemas sont
+/// statiques, donc une violation est deterministe et vaut mieux tot.
+///
+/// Volontairement plus faible que la regle du test `mcp_schema_bdd.rs`
+/// (« UN type scalaire »). Elle admet `type: ["number", "string", "boolean"]`
+/// — `recall_where.filters[].value`, dont la comparaison est type-stricte par
+/// conception et dont le doc-comment explique pourquoi le type est epele
+/// plutot que laisse vide. Une exception motivee n'a pas sa place dans un
+/// `panic!` de constructeur ; elle vit dans la liste d'exemptions du test,
+/// qui a un controle de peremption. Ce qui est refuse ici est le defaut
+/// lui-meme : le slot qu'un harnais rend `{}`.
+#[cfg(feature = "mcp")]
+pub(crate) fn untyped_input_slots(map: &Map<String, Value>) -> Vec<String> {
+    let mut found = Vec::new();
+    collect_untyped(&Value::Object(map.clone()), "$", &mut found);
+    found
+}
+
+#[cfg(feature = "mcp")]
+fn collect_untyped(node: &Value, path: &str, found: &mut Vec<String>) {
+    let Value::Object(map) = node else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = map.get("properties") {
+        for (name, slot) in properties {
+            check_untyped_slot(slot, &format!("{path}.{name}"), found);
+        }
+    }
+    collect_untyped_items(map, path, found);
+    collect_untyped_branches(map, path, found);
+    if let Some(extra @ Value::Object(_)) = map.get("additionalProperties") {
+        check_untyped_slot(extra, &format!("{path}.additionalProperties"), found);
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn collect_untyped_items(map: &Map<String, Value>, path: &str, found: &mut Vec<String>) {
+    match map.get("items") {
+        Some(Value::Array(entries)) => {
+            for (index, entry) in entries.iter().enumerate() {
+                check_untyped_slot(entry, &format!("{path}.items[{index}]"), found);
+            }
+        }
+        Some(single) => check_untyped_slot(single, &format!("{path}.items"), found),
+        None => {}
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn collect_untyped_branches(map: &Map<String, Value>, path: &str, found: &mut Vec<String>) {
+    for keyword in ["anyOf", "oneOf", "allOf", "prefixItems"] {
+        let Some(Value::Array(entries)) = map.get(keyword) else {
+            continue;
+        };
+        for (index, entry) in entries.iter().enumerate() {
+            check_untyped_slot(entry, &format!("{path}.{keyword}[{index}]"), found);
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+fn check_untyped_slot(slot: &Value, path: &str, found: &mut Vec<String>) {
+    let typed = match slot {
+        Value::Object(map) => {
+            map.contains_key("type") || map.contains_key("enum") || map.contains_key("const")
+        }
+        _ => false,
+    };
+    if !typed {
+        found.push(format!("{path} = {slot}"));
+    }
+    collect_untyped(slot, path, found);
+}
+
 fn is_rust_int_format(format: &str) -> bool {
     matches!(
         format,
@@ -449,6 +957,153 @@ mod tests;
 pub(crate) const WIRE_ID_KEYS: &[&str] =
     &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
 
+// --- Les deux surfaces du fil, separees par le TYPE -------------------------
+//
+// Entree et sortie partageaient jusqu'ici la meme representation (un
+// `Map<String, Value>` nu), donc rien n'empechait d'appliquer a une sortie
+// une passe reservee a l'entree. Ce n'est pas une nuance de style :
+// [`scalarize_slot_types`] effondre `anyOf: [T, null]` en `T`, et les SDK MCP
+// valident `structuredContent` contre l'`outputSchema` annonce (spec
+// 2025-06-18) — retirer la branche `null` d'une sortie ferait donc echouer,
+// chez le client, les reponses legitimes du serveur lui-meme.
+//
+// Les deux surfaces sont donc deux types distincts, sans conversion de l'un
+// vers l'autre.
+//
+// Portee exacte de la barriere, parce qu'une garantie surestimee est pire
+// qu'une garantie absente. Elle tient sur ce qui SORT de ce module : hors
+// d'ici, aucune fonction n'accepte une carte nue pour lui appliquer un
+// durcissement d'ENTREE — les deux constructeurs de `WireInputSchema` sont
+// prives au module, et le seul point de passage qui reprend un schema deja
+// publie ([`reharden_tool_input`]) prend l'outil entier et ne touche que son
+// `input_schema` : il n'y a pas de parametre par lequel passer une sortie.
+// (Il a existe, sous la forme d'un `pub(crate) fn(&JsonObject)`, et
+// `rmcp::model::Tool` type ses deux schemas avec le MEME
+// `Arc<JsonObject>` : rien n'aurait signale l'erreur.)
+//
+// Elle ne tient PAS a l'interieur de `schema.rs` : `scalarize_in_map` est
+// typee sur la carte brute et `WireOutputSchema::harden` vit dans le meme
+// module. Ce que le type empeche, c'est l'accident a distance ; ici, seule
+// la lecture protege — d'ou le garde executable
+// `output_hardening_keeps_a_nullable_union_intact` dans `schema_tests.rs`,
+// qui echoue si la scalarisation atteint un jour la sortie.
+
+/// Un schema d'ENTREE en construction : ce que le client LIT pour fabriquer
+/// ses arguments. Il doit survivre au harnais qui le rend, pas seulement etre
+/// valide au sens JSON Schema.
+#[cfg(feature = "mcp")]
+pub(crate) struct WireInputSchema(Map<String, Value>);
+
+/// Un schema de SORTIE en construction : ce que le SDK client valide contre
+/// la reponse. Il doit rester fidele a ce que le serveur emet reellement,
+/// unions nullables comprises.
+#[cfg(feature = "mcp")]
+pub(crate) struct WireOutputSchema(Map<String, Value>);
+
+#[cfg(feature = "mcp")]
+impl WireInputSchema {
+    /// Le schema derive par `schemars` pour les parametres de l'outil, avant
+    /// tout durcissement.
+    fn derived<T: schemars::JsonSchema + std::any::Any>() -> Self {
+        let schema = rmcp::handler::server::tool::schema_for_input::<
+            rmcp::handler::server::wrapper::Parameters<T>,
+        >()
+        .unwrap_or_else(|e| {
+            panic!(
+                "Invalid input schema for {}: {e}",
+                std::any::type_name::<T>()
+            )
+        });
+        Self((*schema).clone())
+    }
+
+    /// Reprend un schema d'entree DEJA publie par une route, pour lui
+    /// repasser le durcissement universel. Volontairement prive au module :
+    /// c'est le seul constructeur qui accepte une carte venue de l'exterieur,
+    /// et son unique appelant est [`rehardened_input_schema`], dont le nom
+    /// dit la surface.
+    fn adopt(map: Map<String, Value>) -> Self {
+        Self(map)
+    }
+
+    /// L'ordre compte. `stringify_id_properties` d'abord, pour que les copies
+    /// faites par l'inliner heritent du type deja pose ; l'inliner ensuite,
+    /// pour que chaque branche porte un `type` direct ; la scalarisation en
+    /// dernier, parce qu'elle ne promeut qu'une branche deja typee.
+    fn harden(mut self, id_keys: &[&str]) -> Self {
+        stringify_id_properties(&mut self.0, id_keys);
+        inline_ref_only_properties(&mut self.0);
+        scalarize_slot_types(&mut self);
+        self
+    }
+
+    fn publish(self) -> std::sync::Arc<rmcp::model::JsonObject> {
+        std::sync::Arc::new(self.0)
+    }
+}
+
+#[cfg(feature = "mcp")]
+impl WireOutputSchema {
+    fn derived<T: schemars::JsonSchema + std::any::Any>() -> Self {
+        let schema = rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|e| {
+            panic!(
+                "Invalid output schema for {}: {e}",
+                std::any::type_name::<T>()
+            )
+        });
+        Self((*schema).clone())
+    }
+
+    /// Elargissement des ids puis inlining. Pas de scalarisation : voir le
+    /// commentaire de section.
+    fn harden(mut self) -> Self {
+        widen_id_properties(&mut self.0, WIRE_ID_KEYS);
+        inline_ref_only_properties(&mut self.0);
+        self
+    }
+
+    fn publish(self) -> std::sync::Arc<rmcp::model::JsonObject> {
+        std::sync::Arc::new(self.0)
+    }
+}
+
+/// Le schema d'ENTREE annonce d'un outil.
+///
+/// `id_keys` nomme les proprietes que CET outil accepte en chaine decimale
+/// (cf. [`stringify_id_properties`]) — la tolerance est per-outil, pas
+/// globale : `explain_compilation.fragment_id` est un `u64` STRICT et ne doit
+/// jamais etre annonce `string`.
+///
+/// Constructeur unique des deux qui existaient : celui de `mcp.rs` (jeu de
+/// cles par outil) et celui de `mcp/context_tools.rs` (cle `"id"` figee).
+#[cfg(feature = "mcp")]
+pub(crate) fn wire_safe_input_schema<T: schemars::JsonSchema + std::any::Any>(
+    id_keys: &[&str],
+) -> std::sync::Arc<rmcp::model::JsonObject> {
+    WireInputSchema::derived::<T>().harden(id_keys).publish()
+}
+
+/// Repasse le durcissement universel (inlining + scalarisation) sur le
+/// schema d'ENTREE d'un outil deja construit.
+///
+/// C'est le point de passage unique de `McpServer::combined_router` : une
+/// route qui n'a declare aucun `input_schema` recoit celui derive par rmcp,
+/// que rien ne post-traitait. Sans cles d'id — la tolerance d'un id est une
+/// connaissance de l'outil, elle reste dans son attribut.
+///
+/// Prend l'outil ENTIER, et non son `input_schema` : `rmcp::model::Tool`
+/// type `input_schema` et `output_schema` avec le meme `Arc<JsonObject>`,
+/// donc une signature `fn(&JsonObject)` aurait accepte un schema de sortie
+/// sans le moindre diagnostic — et scalariser une sortie fait echouer, chez
+/// le client, la validation des reponses legitimes du serveur. Ici, la
+/// sortie n'est pas atteignable : elle n'est pas un parametre.
+#[cfg(feature = "mcp")]
+pub(crate) fn reharden_tool_input(tool: &mut rmcp::model::Tool) {
+    tool.input_schema = WireInputSchema::adopt((*tool.input_schema).clone())
+        .harden(&[])
+        .publish();
+}
+
 /// Le schema de sortie ANNONCE d'un outil : ids elargis, puis `$ref` inlines
 /// et `$defs` inatteignables elagues.
 ///
@@ -458,14 +1113,5 @@ pub(crate) const WIRE_ID_KEYS: &[&str] =
 #[cfg(feature = "mcp")]
 pub(crate) fn wire_safe_output_schema<T: schemars::JsonSchema + std::any::Any>(
 ) -> std::sync::Arc<rmcp::model::JsonObject> {
-    let schema = rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|e| {
-        panic!(
-            "Invalid output schema for {}: {e}",
-            std::any::type_name::<T>()
-        )
-    });
-    let mut map = (*schema).clone();
-    widen_id_properties(&mut map, WIRE_ID_KEYS);
-    inline_ref_only_properties(&mut map);
-    std::sync::Arc::new(map)
+    WireOutputSchema::derived::<T>().harden().publish()
 }

--- a/crates/velesdb-memory/src/schema_tests.rs
+++ b/crates/velesdb-memory/src/schema_tests.rs
@@ -1,4 +1,5 @@
-//! Tests for [`strip_int_formats`](super::strip_int_formats).
+//! Tests for [`strip_int_formats`](super::strip_int_formats) and for the
+//! input-only [`scalarize_slot_types`](super::scalarize_slot_types) pass.
 
 use schemars::{schema_for, JsonSchema};
 use serde_json::json;
@@ -45,4 +46,276 @@ fn derived_schema_has_no_int_format() {
         !text.contains("\"format\""),
         "derived schema still carries an int format: {text}"
     );
+}
+
+// --- scalarize_slot_types (l'entree, et l'entree seulement) ------------------
+
+/// Fait passer un schema d'ENTREE par la scalarisation seule (sans inlining
+/// ni stringification d'id), pour observer chaque regle isolement.
+#[cfg(feature = "mcp")]
+fn scalarized(schema: serde_json::Value) -> serde_json::Value {
+    let serde_json::Value::Object(map) = schema else {
+        panic!("test: le schema d'entree est un objet JSON");
+    };
+    let mut wire = super::WireInputSchema::adopt(map);
+    super::scalarize_slot_types(&mut wire);
+    serde_json::Value::Object(wire.0)
+}
+
+/// (a) `anyOf: [T, null]` → `T`, et les mots-cles freres du slot ecrasent
+/// ceux de la branche promue.
+#[test]
+#[cfg(feature = "mcp")]
+fn collapses_a_nullable_union_into_its_typed_branch() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "media": {
+                "description": "la description du slot gagne",
+                "default": null,
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "description": "celle de la branche perd",
+                        "properties": {"data": {"type": "string"}},
+                        "required": ["data"]
+                    },
+                    {"type": "null"}
+                ]
+            }
+        }
+    }));
+
+    let media = &out["properties"]["media"];
+    assert_eq!(media["type"], json!("object"));
+    assert_eq!(media["description"], json!("la description du slot gagne"));
+    assert_eq!(media["required"], json!(["data"]));
+    assert!(media.get("anyOf").is_none(), "l'union a disparu: {media}");
+    assert!(
+        media.get("default").is_none(),
+        "(d) un `default: null` sur un slot devenu non-nullable est retire: {media}"
+    );
+}
+
+/// LE CAS NON-COLLAPSABLE : une branche sans `type` direct — un `$ref` que
+/// le garde de cycle de l'inliner a laisse en place — ne doit PAS etre
+/// promue. La promouvoir ferait du slot un « intypable » orphelin, c'est-a-
+/// dire exactement le defaut que la passe repare.
+#[test]
+#[cfg(feature = "mcp")]
+fn keeps_a_nullable_union_whose_branch_carries_no_direct_type() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "source": {
+                "anyOf": [{"$ref": "#/$defs/SourceReference"}, {"type": "null"}]
+            }
+        }
+    });
+
+    let out = scalarized(schema.clone());
+
+    assert_eq!(
+        out["properties"]["source"], schema["properties"]["source"],
+        "une branche non typee reste intacte"
+    );
+}
+
+/// (b) `"type": ["X", "null"]` → `"X"`, les contraintes numeriques survivant
+/// intactes.
+#[test]
+#[cfg(feature = "mcp")]
+fn collapses_a_nullable_type_list() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "priority": {"type": ["integer", "null"], "minimum": 0, "maximum": 255, "default": null}
+        }
+    }));
+
+    let priority = &out["properties"]["priority"];
+    assert_eq!(priority["type"], json!("integer"));
+    assert_eq!(priority["minimum"], json!(0));
+    assert_eq!(priority["maximum"], json!(255));
+    assert!(priority.get("default").is_none(), "{priority}");
+}
+
+/// (c) Un `oneOf` de `const` devient un `enum` unique, les descriptions de
+/// branches repliees dans celle du slot — sans quoi l'effondrement perdrait
+/// ce que chaque valeur signifie (`recall_where.filters[].op`).
+#[test]
+#[cfg(feature = "mcp")]
+fn collapses_a_const_union_into_an_enum_and_folds_the_branch_descriptions() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "op": {
+                "description": "Comparison operator.",
+                "oneOf": [
+                    {"const": "eq", "description": "`=`", "type": "string"},
+                    {"const": "lt", "description": "`<`", "type": "string"}
+                ]
+            }
+        }
+    }));
+
+    let op = &out["properties"]["op"];
+    assert_eq!(op["type"], json!("string"));
+    assert_eq!(op["enum"], json!(["eq", "lt"]));
+    assert!(op.get("oneOf").is_none(), "l'union a disparu: {op}");
+    let description = op["description"].as_str().expect("une description");
+    assert!(
+        description.starts_with("Comparison operator."),
+        "{description}"
+    );
+    assert!(description.contains("\"eq\": `=`"), "{description}");
+    assert!(description.contains("\"lt\": `<`"), "{description}");
+}
+
+/// Les deux regles se composent : `Option<Enum>` arrive en
+/// `anyOf: [{oneOf: [const…]}, null]`, dont la premiere branche ne porte
+/// aucun `type` direct. C'est la descente enfants-d'abord qui la rend
+/// promouvable.
+#[test]
+#[cfg(feature = "mcp")]
+fn collapses_a_nullable_const_union_through_its_branch() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "format": {
+                "anyOf": [
+                    {"oneOf": [{"const": "plain", "type": "string"}, {"const": "jsonl", "type": "string"}]},
+                    {"type": "null"}
+                ]
+            }
+        }
+    }));
+
+    let format = &out["properties"]["format"];
+    assert_eq!(format["type"], json!("string"));
+    assert_eq!(format["enum"], json!(["plain", "jsonl"]));
+}
+
+/// La marche d'arbre couvre les memes chemins que l'inliner : `items`
+/// simple, `items` tuple, et `additionalProperties`.
+#[test]
+#[cfg(feature = "mcp")]
+fn walks_items_tuple_items_and_additional_properties() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "facts": {"type": "array", "items": {"type": "object", "properties": {
+                "text": {"type": ["string", "null"]}
+            }}},
+            "pair": {"type": "array", "items": [
+                {"type": ["integer", "null"]},
+                {"type": ["boolean", "null"]}
+            ]},
+            "models": {"type": "object", "additionalProperties": {
+                "anyOf": [{"type": "object", "properties": {}}, {"type": "null"}]
+            }}
+        }
+    }));
+
+    assert_eq!(
+        out["properties"]["facts"]["items"]["properties"]["text"]["type"],
+        json!("string")
+    );
+    assert_eq!(
+        out["properties"]["pair"]["items"][0]["type"],
+        json!("integer")
+    );
+    assert_eq!(
+        out["properties"]["pair"]["items"][1]["type"],
+        json!("boolean")
+    );
+    assert_eq!(
+        out["properties"]["models"]["additionalProperties"]["type"],
+        json!("object")
+    );
+}
+
+/// Une liste de formes qui n'est pas `[X, null]` reste intacte :
+/// `recall_where.filters[].value` est polymorphe par conception, et
+/// l'effondrer arbitrairement mentirait sur ce que le serveur compare.
+#[test]
+#[cfg(feature = "mcp")]
+fn leaves_a_genuinely_polymorphic_type_list_alone() {
+    let out = scalarized(json!({
+        "type": "object",
+        "properties": {
+            "value": {"type": ["number", "string", "boolean"]}
+        }
+    }));
+
+    assert_eq!(
+        out["properties"]["value"]["type"],
+        json!(["number", "string", "boolean"])
+    );
+}
+
+// --- La SORTIE, et la regle qui ne doit jamais l'atteindre -------------------
+
+#[cfg(feature = "mcp")]
+#[derive(schemars::JsonSchema)]
+#[allow(dead_code)]
+struct NestedOut {
+    label: String,
+}
+
+#[cfg(feature = "mcp")]
+#[derive(schemars::JsonSchema)]
+#[allow(dead_code)]
+struct OptionalOut {
+    /// Ce que `load_working_context.working` et
+    /// `retrieve_context_source.media` sont : une valeur legitimement absente.
+    nested: Option<NestedOut>,
+    /// Et la forme d'id que `widen_id_properties` produit en sortie.
+    memory_id: Option<u64>,
+}
+
+/// Le durcissement de SORTIE doit garder ce qu'un `null` legitime exige.
+///
+/// C'est le garde de la regle que la separation par types documente sans
+/// pouvoir la faire respecter a l'interieur de `schema.rs` : `scalarize_in_map`
+/// y est typee sur la carte brute, donc ajouter `scalarize_in_map(&mut self.0)`
+/// a [`super::WireOutputSchema::harden`] compile. Rien, jusqu'ici, ne
+/// l'aurait vu : la regle de sortie de `tests/mcp_schema_bdd.rs`
+/// (`announces_some_type`) est satisfaite aussi bien par `T` que par
+/// `anyOf: [T, null]`.
+///
+/// Ce qui casserait alors n'est pas un schema, c'est une REPONSE : les SDK
+/// MCP valident `structuredContent` contre l'`outputSchema` annonce (spec
+/// 2025-06-18), donc un `working: null` — la reponse documentee d'une session
+/// jamais sauvegardee — serait rejete chez le client.
+#[test]
+#[cfg(feature = "mcp")]
+fn output_hardening_keeps_a_nullable_union_intact() {
+    let published = super::wire_safe_output_schema::<OptionalOut>();
+    let schema = serde_json::to_value(&*published).expect("le schema se serialise");
+
+    let nested = &schema["properties"]["nested"];
+    assert!(
+        admits_null(nested),
+        "la sortie doit continuer d'admettre `null` sur un champ optionnel, got {nested}"
+    );
+    let memory_id = &schema["properties"]["memory_id"];
+    assert!(
+        admits_null(memory_id),
+        "idem pour un id optionnel, got {memory_id}"
+    );
+}
+
+/// `null` est-il une valeur admise par ce slot — directement, dans une liste
+/// de formes, ou par une branche d'union ?
+#[cfg(feature = "mcp")]
+fn admits_null(slot: &serde_json::Value) -> bool {
+    match slot.get("type") {
+        Some(serde_json::Value::String(kind)) => kind == "null",
+        Some(serde_json::Value::Array(names)) => names.iter().any(|name| name == "null"),
+        _ => ["anyOf", "oneOf"].iter().any(|keyword| {
+            matches!(slot.get(*keyword), Some(serde_json::Value::Array(branches))
+                if branches.iter().any(admits_null))
+        }),
+    }
 }

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -72,13 +72,41 @@ fn as_args(value: Value) -> Map<String, Value> {
 /// `$defs` itself is deliberately not walked: it is the reference pool kept
 /// for spec-correct clients, not an argument path. Any `$ref` still sitting
 /// on a reachable `items` shows up here as "untyped", which is the point.
-fn untyped_items(schema: &Value) -> Vec<String> {
+fn untyped_items(schema: &Value, surface: Surface) -> Vec<String> {
     let mut found = Vec::new();
-    walk_schema(schema, "$", &mut found);
+    walk_schema(schema, "$", surface, &mut found);
     found
 }
 
-fn walk_schema(node: &Value, path: &str, found: &mut Vec<String>) {
+/// Which direction of the wire a schema governs. The two are NOT held to the
+/// same rule, and conflating them is itself a defect this file has to prevent.
+///
+/// An **input** slot is read by a client harness that must decide what bytes
+/// to send, and real harnesses flatten a union into `{}` — the same class of
+/// degradation as the `$defs` blindness this file opens on, one construct
+/// further. So an input slot gets exactly one scalar `type`.
+///
+/// An **output** slot is the opposite: the official MCP SDKs VALIDATE a tool's
+/// `structuredContent` against it. A nullable result legitimately serializes
+/// to `null`, so stripping the `null` branch there would make the server's own
+/// answers fail validation. Outputs therefore keep the looser rule — announce
+/// *some* type — and the strict one must never reach them.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Surface {
+    Input,
+    Output,
+}
+
+impl Surface {
+    fn accepts(self, slot: &Value) -> bool {
+        match self {
+            Surface::Input => describes_its_own_type(slot),
+            Surface::Output => announces_some_type(slot),
+        }
+    }
+}
+
+fn walk_schema(node: &Value, path: &str, surface: Surface, found: &mut Vec<String>) {
     let Value::Object(map) = node else {
         return;
     };
@@ -87,37 +115,61 @@ fn walk_schema(node: &Value, path: &str, found: &mut Vec<String>) {
         match items {
             Value::Array(entries) => {
                 for (index, entry) in entries.iter().enumerate() {
-                    check_items(entry, &format!("{items_path}[{index}]"), found);
+                    check_items(entry, &format!("{items_path}[{index}]"), surface, found);
                 }
             }
-            other => check_items(other, &items_path, found),
+            other => check_items(other, &items_path, surface, found),
         }
     }
     if let Some(Value::Object(properties)) = map.get("properties") {
         for (name, sub) in properties {
-            walk_schema(sub, &format!("{path}.{name}"), found);
+            walk_schema(sub, &format!("{path}.{name}"), surface, found);
         }
     }
     for keyword in ["anyOf", "oneOf", "allOf", "prefixItems"] {
         if let Some(Value::Array(entries)) = map.get(keyword) {
             for (index, entry) in entries.iter().enumerate() {
-                walk_schema(entry, &format!("{path}.{keyword}[{index}]"), found);
+                walk_schema(entry, &format!("{path}.{keyword}[{index}]"), surface, found);
             }
         }
     }
     if let Some(extra @ Value::Object(_)) = map.get("additionalProperties") {
-        walk_schema(extra, &format!("{path}.additionalProperties"), found);
+        walk_schema(
+            extra,
+            &format!("{path}.additionalProperties"),
+            surface,
+            found,
+        );
     }
 }
 
-/// One `items` slot: it must announce its own `type`, then it is walked like
-/// any other schema node.
-fn check_items(items: &Value, path: &str, found: &mut Vec<String>) {
-    let has_type = matches!(items, Value::Object(map) if map.contains_key("type"));
-    if !has_type {
+/// One `items` slot: it must announce its type per its surface's rule, then it
+/// is walked like any other schema node.
+fn check_items(items: &Value, path: &str, surface: Surface, found: &mut Vec<String>) {
+    if !surface.accepts(items) {
         found.push(format!("{path} = {items}"));
     }
-    walk_schema(items, path, found);
+    walk_schema(items, path, surface, found);
+}
+
+/// The OUTPUT rule: a slot answers "what comes back here?" with a direct
+/// `type`, a union whose every branch does, or a closed set of literals.
+/// Unions are fine — and necessary — on this side; see [`Surface`].
+fn announces_some_type(slot: &Value) -> bool {
+    let Value::Object(map) = slot else {
+        return false;
+    };
+    if map.contains_key("type") || map.contains_key("enum") || map.contains_key("const") {
+        return true;
+    }
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(Value::Array(branches)) = map.get(keyword) {
+            if !branches.is_empty() && branches.iter().all(announces_some_type) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Every reachable **property** slot, not just every `items` slot.
@@ -136,13 +188,21 @@ fn check_items(items: &Value, path: &str, found: &mut Vec<String>) {
 /// tell what may go in this slot?* — and a slot answers yes when it carries
 /// a direct `type`, or an `anyOf`/`oneOf` whose branches each do, or an
 /// `enum`/`const` that enumerates its own values.
-fn untyped_properties(schema: &Value) -> Vec<String> {
+fn untyped_properties(schema: &Value) -> Vec<Finding> {
     let mut found = Vec::new();
     walk_properties(schema, "$", &mut found);
     found
 }
 
-fn walk_properties(node: &Value, path: &str, found: &mut Vec<String>) {
+/// One offending slot: its argument path, and what it actually advertises.
+/// The path is kept apart from the rendering so an exemption can be keyed on
+/// it exactly, instead of on a substring of a message.
+struct Finding {
+    path: String,
+    slot: String,
+}
+
+fn walk_properties(node: &Value, path: &str, found: &mut Vec<Finding>) {
     let Value::Object(map) = node else {
         return;
     };
@@ -150,7 +210,10 @@ fn walk_properties(node: &Value, path: &str, found: &mut Vec<String>) {
         for (name, slot) in properties {
             let slot_path = format!("{path}.{name}");
             if !describes_its_own_type(slot) {
-                found.push(format!("{slot_path} = {slot}"));
+                found.push(Finding {
+                    path: slot_path.clone(),
+                    slot: slot.to_string(),
+                });
             }
             walk_properties(slot, &slot_path, found);
         }
@@ -177,24 +240,71 @@ fn walk_properties(node: &Value, path: &str, found: &mut Vec<String>) {
     }
 }
 
-/// A slot is self-describing when a `$defs`-blind caller can name what goes
-/// in it: a direct `type`, a union whose every branch has one, or a closed
-/// set of literal values.
+/// A slot that legitimately advertises more than one scalar type, with the
+/// reason it may.
+///
+/// Same discipline as `EXEMPTIONS` in `binding_parity_bdd.rs`: silence is not
+/// a decision, so every survivor of the rule above is written down WITH its
+/// justification — and [`no_polymorphic_exemption_is_stale`] deletes the
+/// entry the day it stops describing anything, because a stale exemption is
+/// a hole in the guard that looks like a decision.
+struct PolymorphicSlot {
+    tool: &'static str,
+    path: &'static str,
+    reason: &'static str,
+}
+
+const POLYMORPHIC_SLOTS: &[PolymorphicSlot] = &[PolymorphicSlot {
+    tool: "recall_where",
+    path: "$.filters.items.value",
+    reason: "the ColumnStore comparison is TYPE-STRICT with no coercion, so the JSON type sent \
+             here is part of the query: 20260601 (number) never matches a fact stored as \
+             \"20260601\" (string) — same value, no match, and no error. Collapsing this slot to \
+             one type would make the schema state a restriction the server does not apply, on the \
+             single field where sending the wrong type fails SILENTLY. Its own doc-comment \
+             already spells the type out rather than leaving the empty schema serde_json::Value \
+             would produce; a harness that flattens it back to {} leaves the caller exactly where \
+             the untyped form would have.",
+}];
+
+fn polymorphic_exemption(tool: &str, path: &str) -> Option<&'static PolymorphicSlot> {
+    POLYMORPHIC_SLOTS
+        .iter()
+        .find(|slot| slot.tool == tool && slot.path == path)
+}
+
+/// A slot is self-describing when a caller can name what goes in it WITHOUT
+/// resolving anything and WITHOUT choosing between alternatives: exactly one
+/// scalar `type`, or a closed set of literal values.
+///
+/// The 2026-07-29 tightening. The previous version of this function also
+/// accepted `anyOf`/`oneOf` whose every branch was itself self-describing, and
+/// a `type` holding an array of names. Both are valid JSON Schema, and both
+/// are what real client harnesses destroy: the server emitted
+/// `type: ["integer","string"]` on its id parameters and
+/// `anyOf: [SourceReference, null]` on `…verified_facts[].source`, while the
+/// harness that consumed them showed `{}` for both. So the invariant can no
+/// longer be "valid JSON Schema" — it has to be "a shape that survives the
+/// consumer". One scalar type, nothing to flatten.
+///
+/// Do not go looking for those two unions in
+/// `docs/reference/mcp-tools.json`: that artifact is regenerated AFTER the
+/// scalarization pass, so it records the state of arrival, never the state of
+/// departure. What it still shows is the same union WHERE IT SURVIVES — the
+/// output side, which this rule must never reach: `compile_context`'s
+/// `decisions[].fragment_id` is still `["integer","string"]` there, and
+/// `load_working_context`'s `working` still an `anyOf` with a `null` branch.
+/// Nor can the artifact record what a HARNESS rendered: it is the server's
+/// own emission, captured over raw JSON-RPC precisely so no client library
+/// sits between the bytes and the assertion.
 fn describes_its_own_type(slot: &Value) -> bool {
     let Value::Object(map) = slot else {
         return false;
     };
-    if map.contains_key("type") || map.contains_key("enum") || map.contains_key("const") {
+    if map.contains_key("enum") || map.contains_key("const") {
         return true;
     }
-    for keyword in ["anyOf", "oneOf"] {
-        if let Some(Value::Array(branches)) = map.get(keyword) {
-            if !branches.is_empty() && branches.iter().all(describes_its_own_type) {
-                return true;
-            }
-        }
-    }
-    false
+    matches!(map.get("type"), Some(Value::String(_)))
 }
 
 /// The 2026-07-28 regression: an advertised `{}` is a promise that anything
@@ -208,14 +318,58 @@ async fn every_tool_input_schema_types_every_reachable_property() {
     for tool in &tools {
         let schema = Value::Object((*tool.input_schema).clone());
         for finding in untyped_properties(&schema) {
-            offenders.insert(format!("{}: {finding}", tool.name));
+            if polymorphic_exemption(&tool.name, &finding.path).is_some() {
+                continue;
+            }
+            offenders.insert(format!(
+                "{}: {} = {}",
+                tool.name, finding.path, finding.slot
+            ));
         }
     }
     assert!(
         offenders.is_empty(),
-        "{} property slot(s) advertise no type at all — a caller reading the schema cannot \
-         know what to send, and the server rejects what it guesses: {offenders:#?}",
+        "{} property slot(s) advertise no single scalar type — a caller reading the schema \
+         cannot know what to send, and the server rejects what it guesses. Collapse the slot \
+         in `crate::schema::scalarize_slot_types`, or declare it in `POLYMORPHIC_SLOTS` in \
+         this file WITH the reason it must stay polymorphic: {offenders:#?}",
         offenders.len()
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// An exemption that stopped describing a real slot must be deleted, not
+/// left to rot — the twin of `no_exemption_is_stale` in
+/// `binding_parity_bdd.rs`. Without this, `POLYMORPHIC_SLOTS` would quietly
+/// become a blanket that covers paths nobody has published for months.
+#[tokio::test]
+async fn no_polymorphic_exemption_is_stale() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut offending: BTreeSet<(String, String)> = BTreeSet::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for finding in untyped_properties(&schema) {
+            offending.insert((tool.name.to_string(), finding.path));
+        }
+    }
+
+    let stale: Vec<String> = POLYMORPHIC_SLOTS
+        .iter()
+        .filter(|slot| !offending.contains(&(slot.tool.to_string(), slot.path.to_string())))
+        .map(|slot| {
+            format!(
+                "  {} {} no longer needs an exemption (it claimed: {})",
+                slot.tool, slot.path, slot.reason
+            )
+        })
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "{} stale entr(y/ies) in POLYMORPHIC_SLOTS — the slot now announces one scalar type, \
+         or moved, or stopped existing:\n{}",
+        stale.len(),
+        stale.join("\n")
     );
     client.cancel().await.expect("close the MCP session");
 }
@@ -231,7 +385,7 @@ async fn save_working_context_input_schema_types_every_reachable_items() {
         .find(|tool| tool.name == "save_working_context")
         .expect("save_working_context is advertised");
     let schema = Value::Object((*tool.input_schema).clone());
-    let untyped = untyped_items(&schema);
+    let untyped = untyped_items(&schema, Surface::Input);
     assert!(
         untyped.is_empty(),
         "save_working_context advertises {} untyped `items` (a $defs-blind harness sees an \
@@ -252,7 +406,7 @@ async fn every_tool_input_schema_types_every_reachable_items() {
     let mut offenders: BTreeSet<String> = BTreeSet::new();
     for tool in &tools {
         let schema = Value::Object((*tool.input_schema).clone());
-        for finding in untyped_items(&schema) {
+        for finding in untyped_items(&schema, Surface::Input) {
             offenders.insert(format!("{}: {finding}", tool.name));
         }
     }
@@ -282,7 +436,7 @@ async fn every_tool_output_schema_types_every_reachable_items() {
         };
         checked += 1;
         let schema = Value::Object((**output).clone());
-        for finding in untyped_items(&schema) {
+        for finding in untyped_items(&schema, Surface::Output) {
             offenders.insert(format!("{}: {finding}", tool.name));
         }
     }
@@ -376,38 +530,44 @@ async fn save_working_context_round_trips_external_payload_with_decisions_and_ev
 
 /// Every field of [`external_working_payload`] must come back byte-identical.
 /// The `fragment_id` assertions are the point of the test: sent as a decimal
-/// string past 2^53, they must return as the exact integer, not rounded.
+/// string past 2^53, they must return AS THAT SAME DECIMAL STRING.
+///
+/// It asserted `as_u64()` until 2026-07-29, and that was the defect wearing a
+/// green test. `as_u64()` passes because this client is Rust, where
+/// `serde_json` decodes a `u64` exactly — the float-lossy client the whole id
+/// contract exists for cannot, and it is the one that resumes a session.
+/// Requiring the string form here is what makes `save_working_context`'s
+/// input (`string`) and `load_working_context`'s answer the SAME bytes.
 fn assert_payload_survived_the_round_trip(round_tripped: &serde_json::Value) {
-    let expected_id: u64 = BIG_FRAGMENT_ID.parse().expect("the fixture id parses");
     assert_eq!(round_tripped["goal"], json!("ship the schema fix"));
     assert_eq!(
-        round_tripped["decisions"][0]["fragment_id"].as_u64(),
-        Some(expected_id),
-        "the decision's fragment_id must survive exactly, not rounded"
+        round_tripped["decisions"][0]["fragment_id"],
+        json!(BIG_FRAGMENT_ID),
+        "the decision's fragment_id must come back as the exact decimal string that was sent"
     );
     assert_eq!(
         round_tripped["decisions"][0]["rule_id"],
         json!("preserve.code_fence")
     );
     assert_eq!(
-        round_tripped["exact_evidence"][0]["fragment_id"].as_u64(),
-        Some(expected_id)
+        round_tripped["exact_evidence"][0]["fragment_id"],
+        json!(BIG_FRAGMENT_ID)
     );
     assert_eq!(
         round_tripped["exact_evidence"][0]["handle"],
         json!("ctx://source/evidence")
     );
     assert_eq!(
-        round_tripped["verified_facts"][0]["source"]["fragment_id"].as_u64(),
-        Some(expected_id)
+        round_tripped["verified_facts"][0]["source"]["fragment_id"],
+        json!(BIG_FRAGMENT_ID)
     );
     assert_eq!(
         round_tripped["verified_facts"][0]["source"]["handle"],
         json!("ctx://source/schema-rs")
     );
     assert_eq!(
-        round_tripped["verified_facts"][0]["source"]["memory_id"].as_u64(),
-        Some(42)
+        round_tripped["verified_facts"][0]["source"]["memory_id"],
+        json!("42")
     );
     assert_eq!(
         round_tripped["active_constraints"][0]["text"],
@@ -546,13 +706,32 @@ fn minimal_arguments(schema: &Value) -> Value {
     Value::Object(out)
 }
 
+/// The first value an enumerated slot lists, if it enumerates any.
+fn first_enum_value(map: &Map<String, Value>) -> Option<Value> {
+    match map.get("enum") {
+        Some(Value::Array(values)) => values.first().cloned(),
+        _ => None,
+    }
+}
+
 /// The cheapest value the slot's advertised type admits. Nested objects are
 /// built from their own `required`, so a lie one level down is caught too —
 /// `explain_compilation`'s `request` is exactly that case.
+///
+/// A string slot is filled with `"1"` rather than `""`, and an enumerated one
+/// with its first listed value. Both are about the same thing: a filler must
+/// be accepted by the DESERIALIZER, or the call fails on the filler and says
+/// nothing about the field under test. `""` is not a decimal id
+/// (`SourceReference::fragment_id` rejects it) and `"1"` is not a variant of
+/// `ColumnFilter::op` — with either mistake, the round-trip probe below would
+/// report a type refusal caused by a sibling.
 fn dummy_for(slot: &Value) -> Value {
     let Value::Object(map) = slot else {
         return Value::Null;
     };
+    if let Some(listed) = first_enum_value(map) {
+        return listed;
+    }
     let primary = match map.get("type") {
         Some(Value::String(name)) => name.clone(),
         Some(Value::Array(names)) => names
@@ -577,7 +756,7 @@ fn dummy_for(slot: &Value) -> Value {
         }
     };
     match primary.as_str() {
-        "string" => Value::String(String::new()),
+        "string" => Value::String("1".to_owned()),
         "number" | "integer" => json!(1),
         "boolean" => Value::Bool(true),
         "array" => json!([]),
@@ -624,4 +803,637 @@ async fn every_tool_accepts_a_call_carrying_exactly_its_required_fields() {
         liars.len()
     );
     client.cancel().await.expect("close the MCP session");
+}
+
+// --- The advertised type must be what the server actually does -------------
+//
+// Until 2026-07-29 the tolerance of an id was declared in THREE places that
+// could drift apart: the `deserialize_id` attribute on the field (the only
+// one that is real), `context::wire::ID_KEYS`, and `schema::WIRE_ID_KEYS` —
+// plus a per-tool list in each schema test. Three copies of one fact, and
+// nothing compared them.
+//
+// The test below uses NO list. It reads the published schema, and for every
+// slot it announces as a scalar it sends a real call twice — the value as a
+// JSON integer, then as a decimal string — and requires the server to behave
+// the way it just told the caller it would. `explain_compilation.fragment_id`
+// is covered because it is published, not because it is named here.
+
+/// One step of an argument path a caller can actually build.
+#[derive(Clone)]
+enum Step {
+    Property(String),
+    Items,
+    /// A value of an open map (`additionalProperties`). The key is the
+    /// caller's to choose, so the probe picks an arbitrary one.
+    MapValue,
+}
+
+/// The key the probe invents for an open-map slot. Any key is admissible by
+/// definition — `additionalProperties` is what the schema says about values
+/// under names it does not enumerate.
+const PROBE_MAP_KEY: &str = "probe";
+
+/// rmcp's marker for an argument the server could not deserialize — the one
+/// signal that separates "the wire form was refused" from "the business rule
+/// said no". Everything else (an empty fact, a missing memory, an
+/// unconfigured extractor) is a legitimate answer to a well-formed call.
+const ARGUMENT_TYPE_REFUSAL: &str = "failed to deserialize parameters:";
+
+/// Every slot the schema announces as a single scalar `integer` or `string`,
+/// with the path needed to reach it.
+///
+/// `properties`, `items` and `additionalProperties` are followed: the three
+/// keywords under which a caller can construct a value. The first version of
+/// this walk followed only the first two and its comment claimed the third
+/// could not hold a scalar slot — while `crate::schema` had just grown a
+/// dedicated `additionalProperties` scalarization pass, and three tools
+/// publish a map-valued policy through one
+/// (`compile_context.policy.pricing.models`, whose values carry an `integer`
+/// slot a caller fills in). A branch the walk skips is a branch the two
+/// rules below exempt in silence — the opposite of what a list-free guard is
+/// for. `probed_slots_reaches_a_scalar_under_additional_properties` pins it.
+fn probed_slots(schema: &Value) -> Vec<(Vec<Step>, String)> {
+    let mut found = Vec::new();
+    walk_probes(schema, &mut Vec::new(), &mut found);
+    found
+}
+
+fn walk_probes(node: &Value, path: &mut Vec<Step>, found: &mut Vec<(Vec<Step>, String)>) {
+    let Value::Object(map) = node else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = map.get("properties") {
+        for (name, slot) in properties {
+            path.push(Step::Property(name.clone()));
+            if let Some(kind) = probed_scalar(slot) {
+                found.push((path.clone(), kind));
+            }
+            walk_probes(slot, path, found);
+            path.pop();
+        }
+    }
+    if let Some(items @ Value::Object(_)) = map.get("items") {
+        path.push(Step::Items);
+        walk_probes(items, path, found);
+        path.pop();
+    }
+    if let Some(extra @ Value::Object(_)) = map.get("additionalProperties") {
+        path.push(Step::MapValue);
+        walk_probes(extra, path, found);
+        path.pop();
+    }
+}
+
+/// `"integer"` or `"string"`, and only those: the probe sends the two forms
+/// an id can take on the wire, so it is meaningless on a boolean or an
+/// object. An enumerated slot is skipped too — its value set is closed, and
+/// neither `1` nor `"1"` belongs to it.
+fn probed_scalar(slot: &Value) -> Option<String> {
+    let Value::Object(map) = slot else {
+        return None;
+    };
+    if map.contains_key("enum") || map.contains_key("const") {
+        return None;
+    }
+    match map.get("type") {
+        Some(Value::String(kind)) if kind == "integer" || kind == "string" => Some(kind.clone()),
+        _ => None,
+    }
+}
+
+/// The minimal call that carries `value` at `path`: every required sibling
+/// along the way filled with the cheapest value its own schema admits, every
+/// traversed array reduced to the single element that holds the path.
+fn call_carrying(slot: &Value, path: &[Step], value: &Value) -> Value {
+    match path.first() {
+        None => value.clone(),
+        Some(Step::Property(name)) => {
+            let mut out = as_args(minimal_arguments(slot));
+            let child = slot
+                .get("properties")
+                .and_then(|properties| properties.get(name))
+                .cloned()
+                .unwrap_or(Value::Null);
+            out.insert(name.clone(), call_carrying(&child, &path[1..], value));
+            Value::Object(out)
+        }
+        Some(Step::Items) => {
+            let child = slot.get("items").cloned().unwrap_or(Value::Null);
+            json!([call_carrying(&child, &path[1..], value)])
+        }
+        Some(Step::MapValue) => {
+            let child = slot
+                .get("additionalProperties")
+                .cloned()
+                .unwrap_or(Value::Null);
+            json!({ PROBE_MAP_KEY: call_carrying(&child, &path[1..], value) })
+        }
+    }
+}
+
+fn render_path(path: &[Step]) -> String {
+    let mut out = String::from("$");
+    for step in path {
+        match step {
+            Step::Property(name) => {
+                out.push('.');
+                out.push_str(name);
+            }
+            Step::Items => out.push_str("[]"),
+            Step::MapValue => out.push_str("{*}"),
+        }
+    }
+    out
+}
+
+/// The server's complaint about a call, or an empty string when it had none.
+async fn complaint_about(
+    client: &RunningService<RoleClient, ()>,
+    tool: &str,
+    arguments: Value,
+) -> String {
+    let outcome = client
+        .call_tool(CallToolRequestParams::new(tool.to_owned()).with_arguments(as_args(arguments)))
+        .await;
+    match &outcome {
+        Err(error) => error.to_string(),
+        Ok(result) => result
+            .content
+            .iter()
+            .filter_map(|item| item.as_text().map(|text| text.text.clone()))
+            .collect::<String>(),
+    }
+}
+
+/// THE guard that replaces the three lists: what a slot ANNOUNCES and what
+/// the server DOES are checked against each other, per slot, over the real
+/// wire.
+///
+/// - a slot announced `string` must accept a decimal string. Announcing the
+///   string form is how an id above 2^53 survives a float-lossy client; a
+///   server that then refuses it publishes a contract it does not honour, and
+///   the caller has no other form to fall back on.
+/// - a slot announced `integer` must accept the integer form. It is the
+///   trivial half, and it is what makes the first half non-vacuous: the rule
+///   cannot be satisfied by announcing `string` everywhere.
+#[tokio::test]
+async fn every_scalar_input_slot_accepts_the_form_it_announces() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    assert!(!tools.is_empty(), "the server advertises at least one tool");
+
+    let mut probed = 0usize;
+    let mut broken: Vec<String> = Vec::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for (path, kind) in probed_slots(&schema) {
+            probed += 1;
+            let announced = match kind.as_str() {
+                "string" => json!("1"),
+                _ => json!(1),
+            };
+            let arguments = call_carrying(&schema, &path, &announced);
+            let complaint = complaint_about(&client, &tool.name, arguments.clone()).await;
+            if complaint.contains(ARGUMENT_TYPE_REFUSAL) {
+                broken.push(format!(
+                    "  {} {} announces `{kind}` but refused {announced} — sent {arguments}\n    -> {}",
+                    tool.name,
+                    render_path(&path),
+                    complaint.trim()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        probed > 0,
+        "the walk found no scalar slot at all — a green run would prove nothing"
+    );
+    assert!(
+        broken.is_empty(),
+        "{} of {probed} scalar slot(s) refuse the very form their schema announces:\n{}",
+        broken.len(),
+        broken.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// A decimal string that only the ID CONTRACT accepts.
+///
+/// The complement below cannot simply be "a slot announced `integer` refuses
+/// a string": measured on 2026-07-29, ten integer slots accept `"6"` —
+/// `recall.limit`, `why.max_hops`, `compile_transcript.token_budget`… — and
+/// that is not drift. It is `mcp::wire::lenient`, a deliberate, documented
+/// server-side fallback for the harness that stringifies an argument BECAUSE
+/// its view of the schema degraded. Removing it would break exactly the
+/// clients it was written for, and the mission is to change what the client
+/// READS, never what it may SEND.
+///
+/// So the probe must separate the two tolerances, and `"+1"` does it with no
+/// list at all:
+/// - the id contract (`model::deserialize_id`,
+///   `context::wire::deserialize_optional_id`) parses with Rust's
+///   `u64::from_str`, which accepts a leading `+` (pinned by
+///   `model_tests::deserialize_id_plus_prefixed_string_parses`);
+/// - `lenient` re-parses the string AS JSON, and JSON has no leading `+`, so
+///   it refuses;
+/// - a strict `u64` refuses too.
+///
+/// Accepting `"+1"` therefore means "this field carries the id contract",
+/// which is per-field knowledge — precisely the kind that drifted across the
+/// three lists.
+const ID_CONTRACT_PROBE: &str = "+1";
+
+/// The complement, and the reason the rule above cannot be satisfied by
+/// announcing `string` everywhere: a slot that carries the id contract must
+/// be ANNOUNCED as a string, never as an integer.
+///
+/// Together the two tests replace the three lists. One direction says an
+/// announced `string` is honoured; this one says an id cannot hide behind an
+/// `integer` announcement — which is how a caller ends up relaying an
+/// `id_str` the schema told it not to send.
+///
+/// **What it does NOT catch, stated plainly.** The probe detects the id
+/// DESERIALIZER, not the id-ness of the field: a slot that genuinely holds an
+/// id but is a strict `u64` refuses `"+1"` like any counter, so it passes
+/// here — and that is the worst of the two states, since the caller can then
+/// neither read the id without rounding it nor send it back as a string.
+/// `explain_compilation.fragment_id` was exactly that, and this test
+/// certified it clean. The rule that catches the class is
+/// `every_input_slot_named_for_an_id_announces_the_string_form`, which asks a
+/// different question — does the surface itself call this name an id? — and
+/// the two are complementary, not redundant.
+#[tokio::test]
+async fn no_integer_slot_hides_the_string_id_contract() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut probed = 0usize;
+    let mut hidden: Vec<String> = Vec::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for (path, kind) in probed_slots(&schema) {
+            if kind != "integer" {
+                continue;
+            }
+            probed += 1;
+            let arguments = call_carrying(&schema, &path, &json!(ID_CONTRACT_PROBE));
+            let complaint = complaint_about(&client, &tool.name, arguments.clone()).await;
+            if !complaint.contains(ARGUMENT_TYPE_REFUSAL) {
+                hidden.push(format!(
+                    "  {} {} — sent {arguments}",
+                    tool.name,
+                    render_path(&path)
+                ));
+            }
+        }
+    }
+    assert!(
+        probed > 0,
+        "the walk found no integer slot at all — a green run would prove nothing"
+    );
+    assert!(
+        hidden.is_empty(),
+        "{} of {probed} slot(s) announced `integer` carry the string-or-number id contract — announce them \
+         `string` (add the property name to the tool's `wire_safe_input_schema` keys), or drop \
+         the contract. A caller that reads `integer` will relay a number, and an id above 2^53 \
+         does not survive that on a float-lossy client:\n{}",
+        hidden.len(),
+        hidden.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+// --- Les DEUX moities d'un aller-retour d'id -------------------------------
+//
+// Les deux regles ci-dessus ne regardent que l'ENTREE. Un aller-retour a deux
+// jambes, et la revue adversariale du 2026-07-29 a montre que durcir une
+// seule des deux fabrique une incoherence plutot que de la reparer : si
+// `feedback.id` n'accepte plus qu'une chaine alors que `recall` ne rend qu'un
+// nombre, le client n'a plus AUCUNE forme utilisable des deux cotes.
+//
+// Les deux tests qui suivent verrouillent la symetrie, et — comme les
+// precedents — sans aucune liste ecrite a la main : l'ensemble des noms qui
+// portent un id est LU sur la surface publiee. Le serveur est celui qui le
+// declare, en typant un id `["integer", "string"]` en sortie
+// (`widen_id_properties`) et en l'annoncant `string` en entree.
+
+/// Un slot nomme : ou il est, ce qu'il annonce, et la fratrie ou il vit.
+struct NamedSlot {
+    path: String,
+    name: String,
+    slot: Value,
+    siblings: BTreeSet<String>,
+}
+
+fn named_slots(schema: &Value) -> Vec<NamedSlot> {
+    let mut found = Vec::new();
+    walk_named_slots(schema, "$", &mut found);
+    found
+}
+
+fn walk_named_slots(node: &Value, path: &str, found: &mut Vec<NamedSlot>) {
+    let Value::Object(map) = node else {
+        return;
+    };
+    if let Some(Value::Object(properties)) = map.get("properties") {
+        let siblings: BTreeSet<String> = properties.keys().cloned().collect();
+        for (name, slot) in properties {
+            let child = format!("{path}.{name}");
+            found.push(NamedSlot {
+                path: child.clone(),
+                name: name.clone(),
+                slot: slot.clone(),
+                siblings: siblings.clone(),
+            });
+            walk_named_slots(slot, &child, found);
+        }
+    }
+    walk_named_children(map, path, found);
+}
+
+fn walk_named_children(map: &Map<String, Value>, path: &str, found: &mut Vec<NamedSlot>) {
+    if let Some(items @ Value::Object(_)) = map.get("items") {
+        walk_named_slots(items, &format!("{path}[]"), found);
+    }
+    if let Some(extra @ Value::Object(_)) = map.get("additionalProperties") {
+        walk_named_slots(extra, &format!("{path}{{*}}"), found);
+    }
+    for keyword in ["anyOf", "oneOf"] {
+        if let Some(Value::Array(branches)) = map.get(keyword) {
+            for (index, branch) in branches.iter().enumerate() {
+                walk_named_slots(branch, &format!("{path}|{keyword}[{index}]"), found);
+            }
+        }
+    }
+}
+
+/// The shape `crate::schema::widen_id_properties` writes on the way OUT:
+/// `["integer", "string"]`, directly or on the `items` of an id array
+/// (`fragment_ids`). It is the server saying, in its own published bytes,
+/// "a value under this name may legally be a decimal string".
+fn carries_the_id_contract(slot: &Value) -> bool {
+    if names_both_integer_and_string(slot) {
+        return true;
+    }
+    matches!(slot.get("type"), Some(Value::String(kind)) if kind == "array")
+        && slot.get("items").is_some_and(names_both_integer_and_string)
+}
+
+fn names_both_integer_and_string(slot: &Value) -> bool {
+    let Some(Value::Array(forms)) = slot.get("type") else {
+        return false;
+    };
+    let announced: BTreeSet<&str> = forms.iter().filter_map(Value::as_str).collect();
+    announced.contains("integer") && announced.contains("string")
+}
+
+fn announces_exactly(slot: &Value, kind: &str) -> bool {
+    matches!(slot.get("type"), Some(Value::String(name)) if name == kind)
+}
+
+/// Every property name any OUTPUT schema types with the id contract.
+async fn id_contract_names(client: &RunningService<RoleClient, ()>) -> BTreeSet<String> {
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut names = BTreeSet::new();
+    for tool in &tools {
+        let Some(output) = tool.output_schema.as_ref() else {
+            continue;
+        };
+        for slot in named_slots(&Value::Object((**output).clone())) {
+            if carries_the_id_contract(&slot.slot) {
+                names.insert(slot.name);
+            }
+        }
+    }
+    names
+}
+
+/// An id may only be ANNOUNCED one way on the input side, and that way is
+/// the decimal string.
+///
+/// The rule that would have caught `explain_compilation.fragment_id`, which
+/// three schema tests and two id-key lists all walked past: its own tool
+/// emits `fragment_id` as a decimal string under
+/// `CompilePolicy::ids_as_strings`, yet the parameter that selects a fragment
+/// BY that id was a strict `u64` announced `integer`. The tool refused the
+/// exact bytes it had just handed out.
+///
+/// No list: the id names are read back from the output schemas, where
+/// `widen_id_properties` types them `["integer", "string"]`. A name the
+/// server itself calls an id cannot be announced anything but `string` where
+/// a caller has to supply it.
+#[tokio::test]
+async fn every_input_slot_named_for_an_id_announces_the_string_form() {
+    let (_store, client) = connected().await;
+    let id_names = id_contract_names(&client).await;
+    assert!(
+        !id_names.is_empty(),
+        "no output schema types any field with the id contract — the rule below would be vacuous"
+    );
+
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut probed = 0usize;
+    let mut narrowed: Vec<String> = Vec::new();
+    for tool in &tools {
+        for slot in named_slots(&Value::Object((*tool.input_schema).clone())) {
+            if !id_names.contains(&slot.name) {
+                continue;
+            }
+            probed += 1;
+            if !announces_exactly(&slot.slot, "string") {
+                narrowed.push(format!(
+                    "  {} {} announces {} — the tool's own results type `{}` as \
+                     `[\"integer\", \"string\"]`",
+                    tool.name,
+                    slot.path,
+                    slot.slot.get("type").unwrap_or(&Value::Null),
+                    slot.name
+                ));
+            }
+        }
+    }
+
+    assert!(
+        probed > 0,
+        "no input slot carries an id name at all — a green run would prove nothing"
+    );
+    assert!(
+        narrowed.is_empty(),
+        "{} of {probed} input slot(s) named for an id do not announce the decimal-string form. \
+         Add the property name to that tool's `wire_safe_input_schema` keys AND give the field \
+         the id contract (`model::deserialize_id` / `context::wire::deserialize_optional_id`), \
+         or the caller cannot resubmit an id the server handed it as a string:\n{}",
+        narrowed.len(),
+        narrowed.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// The OTHER leg: if a caller may only SEND an id as a string, it must be
+/// able to READ one exactly.
+///
+/// `save_working_context` returned `{"id": <u64>}` and nothing else, while
+/// `forget`/`feedback` announce `id` as a `string`: on a float-lossy client
+/// the number is already rounded when it arrives, so there was no way to
+/// build the string the input schema demands. Every other tool returning an
+/// id already carried the `_str` twin — this rule is what makes that
+/// convention enforceable instead of remembered.
+///
+/// Still no list: the id names come from the INPUT side (a name announced
+/// `string` there is one a caller must relay), and the requirement lands on
+/// the OUTPUT slots that answer under the same name as an `integer`.
+#[tokio::test]
+async fn every_lossy_id_in_a_result_offers_its_exact_string_twin() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+
+    let mut relayed_as_strings: BTreeSet<String> = BTreeSet::new();
+    for tool in &tools {
+        for slot in named_slots(&Value::Object((*tool.input_schema).clone())) {
+            if announces_exactly(&slot.slot, "string") && slot.slot.get("enum").is_none() {
+                relayed_as_strings.insert(slot.name);
+            }
+        }
+    }
+
+    let mut probed = 0usize;
+    let mut lossy: Vec<String> = Vec::new();
+    for tool in &tools {
+        let Some(output) = tool.output_schema.as_ref() else {
+            continue;
+        };
+        for slot in named_slots(&Value::Object((**output).clone())) {
+            if !relayed_as_strings.contains(&slot.name) || !announces_exactly(&slot.slot, "integer")
+            {
+                continue;
+            }
+            probed += 1;
+            let twin = format!("{}_str", slot.name);
+            if !slot.siblings.contains(&twin) {
+                lossy.push(format!(
+                    "  {} {} has no `{twin}` beside it",
+                    tool.name, slot.path
+                ));
+            }
+        }
+    }
+
+    assert!(
+        probed > 0,
+        "no result answers an integer under a name the input side wants as a string — \
+         a green run would prove nothing"
+    );
+    assert!(
+        lossy.is_empty(),
+        "{} of {probed} result slot(s) hand back an id as a bare `integer` while the input side \
+         accepts only the decimal string. A float-lossy client rounds the number on arrival and \
+         can no longer build the string the schema asks for — add the `_str` twin, as \
+         `RememberResult`, `ForgetResult` and `why`'s nodes already do:\n{}",
+        lossy.len(),
+        lossy.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// `probed_slots` must reach a slot living under `additionalProperties`.
+///
+/// It did not, and its own doc-comment asserted the case could not exist —
+/// while `crate::schema` had just grown a dedicated `additionalProperties`
+/// scalarization pass, and three tools publish a map-valued policy through
+/// one (`compile_context.policy.pricing.models`). A slot the walk never
+/// visits is a slot the two rules above silently exempt.
+#[test]
+fn probed_slots_reaches_a_scalar_under_additional_properties() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "models": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "input_micros_per_million_tokens": {"type": "integer"}
+                    }
+                }
+            }
+        }
+    });
+    let reached: Vec<String> = probed_slots(&schema)
+        .into_iter()
+        .map(|(path, _)| render_path(&path))
+        .collect();
+    assert!(
+        reached
+            .iter()
+            .any(|path| path.ends_with("input_micros_per_million_tokens")),
+        "the probe walk never reaches a scalar under `additionalProperties`: {reached:?}"
+    );
+}
+
+/// The output rule, exercised where it actually bites: a legitimate `null`.
+///
+/// `load_working_context` answers `working: null` for a project+session that
+/// was never saved — its documented, non-error miss. The official MCP SDKs
+/// validate `structuredContent` against the advertised `outputSchema`, so the
+/// day the input-side scalarization reaches an output schema, that answer
+/// stops validating on the client and the server's own miss path breaks.
+/// Nothing in this file tested it: `Surface::Output` accepts a slot that
+/// merely carries SOME type, so a collapsed `anyOf: [WorkingContext, null]`
+/// passed exactly like the union it replaced.
+#[tokio::test]
+async fn a_missing_working_context_answers_null_and_its_schema_still_admits_it() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let tool = tools
+        .iter()
+        .find(|tool| tool.name == "load_working_context")
+        .expect("load_working_context is advertised");
+    let output = Value::Object(
+        (**tool
+            .output_schema
+            .as_ref()
+            .expect("load_working_context advertises an output schema"))
+        .clone(),
+    );
+
+    let answered = client
+        .call_tool(
+            CallToolRequestParams::new("load_working_context").with_arguments(as_args(json!({
+                "project": "velesdb",
+                "session": "never-saved-anything-under-this-one",
+            }))),
+        )
+        .await
+        .expect("load_working_context call");
+    let structured = answered
+        .structured_content
+        .expect("load_working_context returns structured content");
+    assert_eq!(
+        structured["working"],
+        Value::Null,
+        "a session that was never saved answers `working: null`: {structured}"
+    );
+
+    let slot = &output["properties"]["working"];
+    assert!(
+        admits_null(slot),
+        "the server answers `working: null` but its advertised output schema no longer admits \
+         null — an SDK that validates structuredContent rejects the server's own miss path: \
+         {slot}"
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+/// Whether a slot's advertised type accepts a JSON `null`: a direct
+/// `"null"`, a list of forms containing it, or a union with a null branch.
+fn admits_null(slot: &Value) -> bool {
+    match slot.get("type") {
+        Some(Value::String(kind)) => kind == "null",
+        Some(Value::Array(names)) => names.iter().any(|name| name == "null"),
+        _ => ["anyOf", "oneOf"].iter().any(|keyword| {
+            matches!(slot.get(*keyword), Some(Value::Array(branches))
+                if branches.iter().any(admits_null))
+        }),
+    }
 }

--- a/crates/velesdb-memory/tests/mcp_tools_drift.rs
+++ b/crates/velesdb-memory/tests/mcp_tools_drift.rs
@@ -1,0 +1,283 @@
+//! The tool surface this server actually puts on the wire, materialised as a
+//! versioned artifact.
+//!
+//! ## Why this file exists
+//!
+//! Four times now, a schema defect has been diagnosed by reading the schema as
+//! a CLIENT HARNESS rendered it, rather than as the server emitted it — and
+//! twice that rendering lied. `mcp_schema_bdd.rs` carries the retraction of one
+//! such mistake in its own comments: a `required` list that looked truncated
+//! was complete on the wire, and a campaign was built on the rendering anyway.
+//!
+//! The root cause is not any single schema bug. It is that the wire had no
+//! representation anyone could point at: the truth lived only inside a test
+//! run, so every campaign had to re-derive it, and could re-derive it wrongly.
+//!
+//! This file gives the wire a body. It boots the real [`McpServer`], speaks
+//! raw newline-delimited JSON-RPC to it — no client library between the bytes
+//! and the assertion, deliberately, since a client library is exactly the kind
+//! of intermediary that produced the wrong diagnoses — and commits the answer
+//! to `docs/reference/mcp-tools.json`. From here on, "what does the server
+//! advertise?" is answered by reading a file in the repository, and any change
+//! to it shows up in a diff during review.
+//!
+//! This is the same shape as the `openapi-drift` job for the REST surface
+//! (`.github/workflows/ci.yml`): regenerate from the code, compare with what is
+//! committed, fail on drift.
+//!
+//! ## Why no `#[ignore]`
+//!
+//! `generate_openapi_spec_files` must be `#[ignore]`d because the workspace
+//! test sweep runs it under a feature set that legitimately changes the
+//! schema. The equivalent hazard here is real but currently empty, and the
+//! distinction is worth writing down rather than rounding off.
+//!
+//! The `cfg` below is a CONJUNCTION, not an equality: every SUPERSET of
+//! `mcp` + `context` + `persistence` satisfies it too — so "under any other
+//! feature set this file compiles to nothing" would be false. One such
+//! superset already runs in CI: the `lint` job's "Test the velesdb-memory
+//! extract feature" step (`.github/workflows/ci.yml`) invokes
+//! `cargo test -p velesdb-memory --features extract,ollama,persistence`
+//! WITHOUT `--no-default-features`, so this file compiles and executes there
+//! as well. Verified by running it, not assumed: it passes, because the
+//! twenty tools are registered unconditionally — `remember_extracted` is
+//! always advertised and merely answers "no extractor configured" until one
+//! is attached, so neither `extract` nor `ollama` adds or removes a tool.
+//!
+//! The trap is therefore conditional, not present: the day a tool (or a DTO
+//! field reachable from a schema) sits behind a non-default feature, this
+//! comparison becomes feature-dependent, an artifact regenerated with the
+//! `REGENERATE` command below will not match what the `lint` job sees, and
+//! the answer is to keep the surface feature-invariant — not to regenerate
+//! under one feature set and break the other.
+//!
+//! It runs inside the required `Tests` job, which builds this crate with its
+//! default features (`mcp`, `context`, `persistence`).
+
+#![cfg(all(feature = "mcp", feature = "context", feature = "persistence"))]
+
+use std::path::{Path, PathBuf};
+
+use rmcp::service::ServiceExt;
+use serde_json::{json, Map, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, Lines};
+use velesdb_memory::mcp::McpServer;
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+/// Where the captured surface lives, relative to the workspace root. It sits
+/// under `docs/reference/` rather than in a test fixture directory on purpose:
+/// it is the contract other surfaces (bindings, SDK, guides) are checked
+/// against, not a private detail of this test.
+const ARTIFACT: &str = "docs/reference/mcp-tools.json";
+
+/// Printed verbatim on failure. A drift message that does not say how to
+/// resolve itself sends the reader hunting through CI config.
+const REGENERATE: &str =
+    "UPDATE_MCP_TOOLS_SNAPSHOT=1 cargo test -p velesdb-memory --test mcp_tools_drift";
+
+/// At most this many differing paths are reported. The point of the message is
+/// to name the change, not to reprint the artifact.
+const MAX_REPORTED_DIFFERENCES: usize = 40;
+
+/// Values longer than this are elided in the failure message.
+const MAX_VALUE_WIDTH: usize = 120;
+
+fn artifact_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("test: CARGO_MANIFEST_DIR has a parent (crates/)")
+        .parent()
+        .expect("test: crates/ has a parent (workspace root)")
+        .join(ARTIFACT)
+}
+
+fn regeneration_requested() -> bool {
+    std::env::var_os("UPDATE_MCP_TOOLS_SNAPSHOT").is_some()
+}
+
+async fn send<W>(writer: &mut W, frame: &Value)
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut line = serde_json::to_string(frame).expect("serialize a JSON-RPC frame");
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .expect("write a JSON-RPC frame to the duplex");
+    writer.flush().await.expect("flush the duplex");
+}
+
+async fn receive<R>(lines: &mut Lines<BufReader<R>>) -> Value
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let line = lines
+        .next_line()
+        .await
+        .expect("read a line from the duplex")
+        .expect("the server closed the duplex before answering");
+    serde_json::from_str(&line).expect("the server wrote a line that is not JSON")
+}
+
+/// Drive a real server through the handshake and return its `tools/list`
+/// result, with the tool array sorted by name so the artifact does not depend
+/// on registration order.
+async fn capture_tool_surface() -> Value {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let (server_side, client_side) = tokio::io::duplex(1 << 20);
+    tokio::spawn(async move {
+        if let Ok(running) = McpServer::new(service).serve(server_side).await {
+            let _ = running.waiting().await;
+        }
+    });
+
+    let (reader, mut writer) = tokio::io::split(client_side);
+    let mut lines = BufReader::new(reader).lines();
+
+    send(
+        &mut writer,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "mcp-tools-drift", "version": "1"},
+            },
+        }),
+    )
+    .await;
+    let handshake = receive(&mut lines).await;
+    assert!(
+        handshake.get("result").is_some(),
+        "the server refused the handshake: {handshake}"
+    );
+
+    send(
+        &mut writer,
+        &json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    )
+    .await;
+    send(
+        &mut writer,
+        &json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    )
+    .await;
+
+    let response = receive(&mut lines).await;
+    let mut tools = response
+        .get("result")
+        .and_then(|result| result.get("tools"))
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("tools/list did not return a tool array: {response}"))
+        .clone();
+    tools.sort_by_key(tool_name);
+
+    let mut surface = Map::new();
+    surface.insert("tools".to_string(), Value::Array(tools));
+    Value::Object(surface)
+}
+
+fn tool_name(tool: &Value) -> String {
+    tool.get("name")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn elide(value: &Value) -> String {
+    let rendered = value.to_string();
+    if rendered.chars().count() <= MAX_VALUE_WIDTH {
+        return rendered;
+    }
+    let head: String = rendered.chars().take(MAX_VALUE_WIDTH).collect();
+    format!("{head}…")
+}
+
+/// Walk both trees together and record every path where they disagree, so a
+/// failure names the slot that moved instead of printing two blobs.
+fn collect_differences(committed: &Value, current: &Value, path: &str, out: &mut Vec<String>) {
+    if out.len() >= MAX_REPORTED_DIFFERENCES || committed == current {
+        return;
+    }
+    match (committed, current) {
+        (Value::Object(was), Value::Object(now)) => {
+            let mut keys: Vec<&String> = was.keys().chain(now.keys()).collect();
+            keys.sort_unstable();
+            keys.dedup();
+            for key in keys {
+                descend(was.get(key), now.get(key), &format!("{path}/{key}"), out);
+            }
+        }
+        (Value::Array(was), Value::Array(now)) => {
+            for index in 0..was.len().max(now.len()) {
+                descend(
+                    was.get(index),
+                    now.get(index),
+                    &format!("{path}/{index}"),
+                    out,
+                );
+            }
+        }
+        _ => out.push(format!(
+            "{path}: committed {} → now {}",
+            elide(committed),
+            elide(current)
+        )),
+    }
+}
+
+fn descend(committed: Option<&Value>, current: Option<&Value>, path: &str, out: &mut Vec<String>) {
+    match (committed, current) {
+        (Some(was), Some(now)) => collect_differences(was, now, path, out),
+        (Some(was), None) => out.push(format!("{path}: REMOVED (was {})", elide(was))),
+        (None, Some(now)) => out.push(format!("{path}: ADDED ({})", elide(now))),
+        (None, None) => {}
+    }
+}
+
+#[tokio::test]
+async fn the_published_tool_surface_matches_the_committed_artifact() {
+    let surface = capture_tool_surface().await;
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&surface).expect("serialize the captured tool surface")
+    );
+    let path = artifact_path();
+
+    if regeneration_requested() {
+        std::fs::create_dir_all(path.parent().expect("the artifact path has a parent"))
+            .expect("create docs/reference/");
+        std::fs::write(&path, &rendered).expect("write the tool-surface artifact");
+        return;
+    }
+
+    let committed = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!("cannot read {ARTIFACT} ({error}) — create it with:\n  {REGENERATE}")
+    });
+    if committed == rendered {
+        return;
+    }
+
+    let committed_json: Value = serde_json::from_str(&committed).unwrap_or_else(|error| {
+        panic!("{ARTIFACT} is not valid JSON ({error}) — regenerate it with:\n  {REGENERATE}")
+    });
+    let mut differences = Vec::new();
+    collect_differences(&committed_json, &surface, "", &mut differences);
+    if differences.is_empty() {
+        differences.push("(only formatting differs)".to_string());
+    }
+
+    panic!(
+        "the advertised MCP tool surface no longer matches {ARTIFACT}.\n\
+         This is the wire, not a client's rendering of it: if the change below is\n\
+         intended, regenerate the artifact so it lands in the diff for review.\n\n\
+         {}\n\n  {REGENERATE}",
+        differences.join("\n")
+    );
+}

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -40,17 +40,24 @@ License.
 Memory ids and fragment ids are `u64` and routinely exceed 2^53, where a JSON
 number silently loses precision in any JavaScript-based client.
 
-- Every memory tool that returns an id also returns a decimal-string twin:
-  `id_str`, `edge_id_str`, `ids_str`, `from_str`/`to_str`. **Relay the string
-  form**, not the number.
-- Every memory tool that accepts an id (`relate`/`unrelate`'s `from`/`to`,
-  `forget`'s and `feedback`'s `id`, `remember`'s `links[].target`) accepts a
-  JSON number *or*
-  a decimal string, and advertises both in its input schema.
-- The compiler tools instead take a per-request switch:
+- Every tool that returns an id also returns a decimal-string twin: `id_str`,
+  `edge_id_str`, `ids_str`, `from_str`/`to_str`, `target_id_str`. **Relay the
+  string form**, not the number.
+- Every tool that accepts an id (`relate`/`unrelate`'s `from`/`to`, `forget`'s
+  and `feedback`'s `id`, `remember`'s `links[].target`,
+  `explain_compilation`'s `fragment_id`, `save_working_context`'s nested
+  `fragment_id`/`memory_id`) accepts a JSON number *or* a decimal string. Its
+  input schema **advertises only the string**: a client harness flattens a
+  two-form `type` into "anything", which destroys the contract instead of
+  publishing it, so the schema names the one form that survives a
+  float-lossy client. The server still accepts both.
+- The compiler tools additionally take a per-request switch:
   `policy.ids_as_strings: true` rewrites every id field of that response
   (`fragment_id`, `content_hash`, `memory_id`, `fragment_ids`) into decimal
   strings. Default `false`, so existing clients see today's numeric response.
+  `load_working_context` is the exception that needs no switch: it always
+  answers in decimal strings, because it is the reading half of a round trip
+  whose writing half (`save_working_context`) advertises only that form.
 
 ---
 
@@ -389,7 +396,7 @@ with event and source recording off.
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `request` | `CompileRequest` | yes | The exact request to explain. |
-| `fragment_id` | integer | yes | The fragment whose decision to return. |
+| `fragment_id` | string (or integer) | yes | The fragment whose decision to return. Relay the value `compile_context` handed you — under `policy.ids_as_strings` that is a decimal string, and this tool accepts it unchanged. |
 | `fragment_index` | integer | no | 0-based position in `request.fragments`. **Takes priority** over `fragment_id` when given. |
 
 Returns one `ContextDecision`: `{ action, rule_id, reason, relevance, risk, content_hash, handle? }`.
@@ -463,10 +470,10 @@ up instead of re-deriving it.
 `WorkingContext` is
 `{ goal?, active_constraints[], verified_facts[], open_hypotheses[], decisions[], exact_evidence[], pending_actions[] }`.
 
-Returns `{ id }` — the stored system fact backing this context. Saving again
-under the same `project` + `session` replaces the previous state (idempotent
-upsert), and refreshes the entry in the project index rather than duplicating
-it.
+Returns `{ id, id_str }` — the stored system fact backing this context; relay
+`id_str` if you intend to `forget` it. Saving again under the same `project` +
+`session` replaces the previous state (idempotent upsert), and refreshes the
+entry in the project index rather than duplicating it.
 
 ## `load_working_context`
 
@@ -481,6 +488,13 @@ Returns `{ found, working, other_sessions }`. `found: false` with
 `working: null` means nothing was ever saved under that exact pair — not an
 error, but check `other_sessions`: a similarly-named entry there usually means
 `session` was a typo rather than a genuinely fresh start.
+
+Ids inside `working` (`fragment_id`, `memory_id`) come back as **decimal
+strings**, unconditionally — the exact bytes `save_working_context` accepts,
+so an agent can enrich what it loaded and save it back without converting
+anything. Relaying them as numbers would round every id past 2^53 on a
+float-lossy client, silently breaking the provenance trail of the very tool
+that exists to survive a lost session.
 
 ## `list_working_contexts`
 

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -1,0 +1,3378 @@
+{
+  "tools": [
+    {
+      "description": "Compile context fragments into a token-budgeted, provenance-audited prompt context — deterministically, with no LLM call. Duplicates are dropped, repeated log lines collapse, code/URLs/numbers/negative constraints survive verbatim, over-budget content becomes retrievable ctx://source/ handles instead of silently vanishing, and `memory_scope` pulls relevant stored memories into the result. Each fragment's own `metadata` is capped at 64 KiB serialized. A fragment may set `path` (an absolute filesystem path) instead of inline `content` to ingest a file by reference — exactly one of `path`, `content`, or `media` per fragment; requires the server to be started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories, and the resolved file must be plain UTF-8 text under 1 MiB. Returns the assembled content plus one auditable decision per fragment (rule id, reason, risk), the sources, the retrieval handles, token-savings insights, and `warnings` — a mechanical shortlist of externalized fragments relevant enough to the query that they are worth a second look, so checking `decisions` by hand is only needed when `warnings` is non-empty and still ambiguous. `policy.slim_response` (default false) empties `sections`/`decisions` from the response — keep it off when you need the audit trail, or re-compile without it later (compilation is deterministic). `policy.ids_as_strings` (default false) rewrites every id field of the response into a decimal string, for MCP clients without u64-safe JSON number parsing.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "fragments": {
+            "description": "The context fragments to compile.",
+            "items": {
+              "description": "One unit of caller-supplied context to compile.",
+              "properties": {
+                "content": {
+                  "default": "",
+                  "description": "The fragment text. `#[serde(default)]` (V2b-1): a `path` fragment\ncarries no `content` on the wire — the adapter resolves `path` into\n`content` in a pre-pass before the pure compiler core ever sees the\nrequest, so this stays the only field the core reads.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n[`super::wire::deserialize_optional_id`]) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Free-form kind hint (`\"code\"`, `\"log\"`, `\"prose\"`, …) — classification\nworks without it, but honors it when present.",
+                  "type": "string"
+                },
+                "media": {
+                  "description": "Inline media payload (US-009, PR1). `None` (the default) keeps every\npre-0.9.0 request wire-compatible. When set, the fragment packs as one\natomic piece — see [`MediaRef`].",
+                  "properties": {
+                    "bytes_b64": {
+                      "description": "The raw media bytes, base64-encoded (standard alphabet, padded).\nCapped at [`crate::limits::MAX_MEDIA_BYTES`] and validated for\nwell-formedness at compile time — a request carrying an oversized or\nmalformed payload is rejected before any other work.",
+                      "type": "string"
+                    },
+                    "mime": {
+                      "description": "Declared MIME type (e.g. `\"image/png\"`, `\"image/jpeg\"`). Only PNG and\nJPEG headers are sniffed for dimensions; any other value (or an\nunreadable header) falls back to a deterministic, safe over-count\n(see [`super::estimator::ImageTokenEstimator`]) — never rejected for\nan unrecognized mime alone.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "mime",
+                    "bytes_b64"
+                  ],
+                  "type": "object"
+                },
+                "metadata": {
+                  "additionalProperties": true,
+                  "description": "Caller metadata. Recognized keys: `\"verbatim\": true` forces\n[`ContextAction::Preserve`]; `\"cache\": true` forces\n[`ContextAction::Cache`].",
+                  "type": "object"
+                },
+                "path": {
+                  "description": "Read this file's content from disk in place of an inline `content`\n(V2b-1 path ingestion): exactly one of `path`, non-empty `content`,\nor `media` is accepted — a fragment carrying `path` together with\n`content` or `media` is rejected. Requires the server to be started\nwith `VELESDB_MEMORY_INGEST_ROOTS` set (a colon/semicolon-separated\nallowlist of directories, platform `PATH`-list syntax); otherwise\nevery `path` fragment fails with an explicit \"ingestion disabled\"\nerror. The path must be absolute and resolve (after following\nsymlinks) to a plain file under one of the configured roots, no\nlarger than [`crate::limits::MAX_INGEST_FILE_BYTES`] and valid UTF-8.\nThe **pure compiler core never reads this field** — resolution is an\nadapter-side I/O pre-pass (see the crate's `context::ingest`\nmodule); a `path` fragment that reaches [`super::ContextCompiler`]\nunresolved is rejected with\n[`crate::error::MemoryError::IngestDisabled`].",
+                  "type": "string"
+                },
+                "priority": {
+                  "description": "Caller priority, higher packs first (default `0`).",
+                  "maximum": 255,
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "memory_scope": {
+            "description": "Which memories may be pulled in (US-002; ignored by the memoryless core).",
+            "properties": {
+              "graph_boost": {
+                "description": "Fusion weight added to graph-reached memories (default 0.15). Raise\nit (e.g. `0.5`–`0.8`) when pulling from curated fact chains built\nwith `relate`: evidence that shares **no vocabulary** with the query\ncan then out-rank lexically-noisy near-misses — the tri-engine's\nanswer to the purely lexical relevance of caller fragments.",
+                "format": "double",
+                "type": "number"
+              },
+              "hops": {
+                "description": "Graph-walk depth of the fused recall (default 2). Deeper hops reach\nlonger cause/fix chains from the vector seed.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "k": {
+                "description": "How many memories to consider (adapter-clamped).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "project": {
+                "description": "Restrict recalled memories to this project facet.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "policy": {
+            "description": "Per-request policy override; `None` uses the compiler's policy.",
+            "properties": {
+              "chunk": {
+                "default": {
+                  "boundary": "paragraph",
+                  "max_chunk_bytes": 2048,
+                  "overlap_bytes": 0
+                },
+                "description": "How oversized fragments are split before packing. Only\n[`ChunkPolicy::max_chunk_bytes`] and [`ChunkPolicy::boundary`] apply\nhere — the compiler forces `overlap_bytes` to `0`, since it emits\npieces by concatenation and an overlap prefix would duplicate content\nreported as verbatim. `overlap_bytes` is honoured only by the\nstandalone [`crate::context::chunk::chunk_text`] API.",
+                "properties": {
+                  "boundary": {
+                    "default": "paragraph",
+                    "description": "Preferred cut points.\n- \"paragraph\": Cut at blank lines (`\\n\\n`), falling back to hard splits inside an\noversized paragraph.\n- \"sentence\": Cut after sentence enders (`.`, `!`, `?` followed by whitespace).\n- \"fixed\": Cut at the byte ceiling only (char-aligned).",
+                    "enum": [
+                      "paragraph",
+                      "sentence",
+                      "fixed"
+                    ],
+                    "type": "string"
+                  },
+                  "max_chunk_bytes": {
+                    "default": 2048,
+                    "description": "Soft byte ceiling per chunk (fences may exceed it, see module doc).",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "overlap_bytes": {
+                    "default": 0,
+                    "description": "Bytes of the previous chunk to repeat at the start of the next one\n(char-aligned). `0` keeps chunks disjoint.",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "disabled_rules": {
+                "default": [],
+                "description": "Rule ids to disable (e.g. `\"abstract.log_dedup\"`). Disabled rules are\nskipped during classification; their fragments fall through to the\nnext matching rule.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "event_ttl_seconds": {
+                "description": "TTL applied to compilation events (`None` keeps them).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "ids_as_strings": {
+                "default": false,
+                "description": "Wire-compat opt-in for the MCP context tools (`compile_context`,\n`explain_compilation`): when `true`, every [`super::wire::ID_KEYS`]\nfield of the RESPONSE (`fragment_id`, `content_hash`, `memory_id`,\n`fragment_ids`) is rewritten into its decimal-string form, through\nthe exact same tree walk the Node and WASM bindings already apply on\nevery response ([`super::wire::stringify_id_fields`]). A raw MCP\nclient — one that talks JSON-RPC directly, without either binding —\nparses ids as JS `number`s (IEEE-754 doubles), which silently lose\nprecision above 2^53; string ids round-trip exactly. Default\n`false`: existing MCP clients keep today's byte-identical numeric\nresponse unless they opt in.",
+                "type": "boolean"
+              },
+              "importance": {
+                "default": {
+                  "confidence": 0.2,
+                  "recency": 0.1
+                },
+                "description": "Memory bridge only: usage-driven importance blend over the pulled\nmemories (RL confidence + batch-relative recency). The struct-level\n`#[serde(default)]` keeps 0.8.0 requests wire-compatible.",
+                "properties": {
+                  "confidence": {
+                    "default": 0.2,
+                    "description": "Weight of the learned RL confidence (`_veles_rl_*`, fed by\n[`feedback`](crate::MemoryService::feedback)). A memory with no\nfeedback history counts as the neutral `0.5`, contributing exactly\n`0`. Default `0.2`.",
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "recency": {
+                    "default": 0.1,
+                    "description": "Weight of the batch-relative recency term. Inert unless\n[`Self::recency_field`] is also set. Default `0.1`.",
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "recency_field": {
+                    "description": "Caller metadata key holding each memory's **numeric** timestamp-like\nvalue. `None` (the default) disables the recency term completely —\nthere is no standard key to guess. The scale must be monotone and\nhomogeneous across the batch (e.g. `YYYYMMDD` integers as in\n[`crate::format_dated_context`], or an epoch); it is documented, not\nverified at run time. Values are min-max normalised over the pulled\nmemories that carry the key; a memory without the key contributes `0`\n(never penalised), and a degenerate batch (`max == min`) contributes\n`0` for all.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "near_dup_dedup": {
+                "default": true,
+                "description": "Collapse near-duplicates (case/whitespace variants) in addition to\nexact duplicates. Default `true`.",
+                "type": "boolean"
+              },
+              "normalize_log_timestamps": {
+                "default": false,
+                "description": "Opt-in, deterministic: before `abstract.log_dedup` groups a `kind =\n\"log\"` fragment's repeated lines, mask each line's volatile prefix\n(ISO/syslog timestamps, bracketed hex/pid counters) with **fixed**\npatterns — never a caller-supplied regex, so the collapse stays\nreproducible — so lines identical modulo timestamp collapse into one\nannotated line instead of surviving as distinct entries. The emitted\nline is still the first occurrence's exact bytes; only the grouping\nkey changes. Default `false`: masking is opt-in because it changes\nwhat \"duplicate\" means for logs, so callers who rely on the previous\nbyte-exact grouping keep it unless they ask. See the crate README's\n\"Normalizing timestamped logs\" section for the exact patterns.",
+                "type": "boolean"
+              },
+              "pricing": {
+                "description": "Caller-supplied pricing table so the insights also report the\nestimated cost avoided for [`super::model::CompileRequest::target_model`] — the\n**wire channel** for cost accounting (MCP and the bindings cannot\nreach the Rust-only [`super::ContextCompiler::with_pricing`] builder).\nTakes precedence over a builder-injected table. `None` (default)\nreports tokens only.",
+                "properties": {
+                  "currency": {
+                    "description": "ISO-4217 currency code of every rate in the table (e.g. `\"EUR\"`).",
+                    "type": "string"
+                  },
+                  "models": {
+                    "additionalProperties": {
+                      "description": "Pricing of one model, in integer micro-units per **million** input tokens\n(e.g. a `3 USD / 1M tokens` rate is `3_000_000`).",
+                      "properties": {
+                        "input_micros_per_million_tokens": {
+                          "description": "Micro-units of the table's currency per million input tokens.",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_micros_per_million_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "description": "Rates keyed by model name (a `BTreeMap` so iteration — and therefore\nevery serialized output — is deterministically ordered).",
+                    "type": "object"
+                  },
+                  "version": {
+                    "description": "Caller-side version tag of this table (recorded in insights so a cost\nfigure is always traceable to the prices that produced it).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "version",
+                  "currency",
+                  "models"
+                ],
+                "type": "object"
+              },
+              "record_events": {
+                "default": true,
+                "description": "Memory bridge only: record a compilation event (metadata and hashes,\n**never fragment content**) so savings stay aggregatable. Default\n`true`; set `false` to opt out entirely.",
+                "type": "boolean"
+              },
+              "response_reserve_tokens": {
+                "default": 0,
+                "description": "Tokens kept aside for the model's answer; the compiler packs into\n`token_budget − response_reserve_tokens`. Default `0`: the caller\nknows their generation length, the compiler does not guess it.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "slim_response": {
+                "default": false,
+                "description": "Quick win (V2a-2): when `true`, `sections` and `decisions` are\nemptied out of the response after compilation — `content`,\n`insights`, `risk`, `warnings`, `sources`, and `retrieval_handles`\nare unaffected. The full audit trail (`sections`/`decisions`) is\nstill recoverable: re-compile the same request without\n`slim_response` (compilation is deterministic, so nothing is lost,\nonly not sent this time). Default `false`.",
+                "type": "boolean"
+              },
+              "source_ttl_seconds": {
+                "description": "TTL applied to stored sources (`None` keeps them until forgotten).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "store_sources": {
+                "default": true,
+                "description": "Memory bridge only: store each distinct fragment's original (as an\ninternal system fact, invisible to normal recall) so its\n`ctx://source/<hash>` handle round-trips. Default `true`.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "project": {
+            "description": "Project facet, recorded in provenance and used by the memory bridge.",
+            "type": "string"
+          },
+          "query": {
+            "description": "What the agent is working on — drives relevance scoring.",
+            "type": "string"
+          },
+          "target_model": {
+            "description": "Target model name — selects the row of the pricing table\n([`CompilePolicy::pricing`] on the wire, or the Rust\n[`super::ContextCompiler::with_pricing`] builder) for cost insights.\nWithout a table, insights report tokens only.",
+            "type": "string"
+          },
+          "token_budget": {
+            "description": "Hard token ceiling for the assembled content.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "query",
+          "fragments",
+          "token_budget"
+        ],
+        "type": "object"
+      },
+      "name": "compile_context",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "content": {
+            "description": "The assembled context, ready to inject into a prompt.",
+            "type": "string"
+          },
+          "decisions": {
+            "description": "One decision per input fragment (duplicates included). Emptied by\n[`CompilePolicy::slim_response`].",
+            "items": {
+              "description": "The auditable record of what happened to one fragment and why.",
+              "properties": {
+                "action": {
+                  "description": "What was done.",
+                  "oneOf": [
+                    {
+                      "const": "preserve",
+                      "description": "Emitted verbatim — critical content (code, constraints, exact values).",
+                      "type": "string"
+                    },
+                    {
+                      "const": "abstract",
+                      "description": "Emitted as a deterministic structured reduction (never a generative\nsummary) — e.g. repeated log lines collapsed with a count.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "retrieve",
+                      "description": "Not emitted, but recoverable through its `ctx://source/<id>` handle.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "drop",
+                      "description": "Not emitted and not externalized — redundant content (duplicates).",
+                      "type": "string"
+                    },
+                    {
+                      "const": "cache",
+                      "description": "Emitted verbatim at the front of the output, forming a stable prefix\nthat maximizes provider prompt-cache hits across compilations.",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "content_hash": {
+                  "description": "Content hash of the *original* fragment text (FNV-1a 64, the crate's\n[`stable id`](super::fragment_id)) — lets an auditor prove which exact\nbytes the decision covered even when the caller supplied its own id.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "fragment_id": {
+                  "description": "The fragment this decision is about (caller id, or content-derived).",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "handle": {
+                  "description": "Recoverable address of the original content, when not fully emitted.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "memory_id": {
+                  "description": "The memory backing this fragment, when it came from recall (US-002).",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string",
+                    "null"
+                  ]
+                },
+                "reason": {
+                  "description": "Human-readable explanation of the decision.",
+                  "type": "string"
+                },
+                "relevance": {
+                  "description": "Lexical relevance of the fragment to the request query, in `[0, 1]`.",
+                  "format": "float",
+                  "type": "number"
+                },
+                "risk": {
+                  "description": "Fidelity risk this single decision contributes.",
+                  "oneOf": [
+                    {
+                      "const": "low",
+                      "description": "Nothing was lost: everything fit, only exact duplicates were dropped.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "medium",
+                      "description": "Recoverable reductions happened: abstractions, or non-critical\nfragments externalized behind retrieval handles.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "high",
+                      "description": "Critical content (a preserve-classified fragment) could not be packed\n— the caller should consider retrieving it or raising the budget.",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "rule_id": {
+                  "description": "The stable id of the rule that decided (e.g. `\"preserve.code_fence\"`).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "fragment_id",
+                "content_hash",
+                "action",
+                "rule_id",
+                "relevance",
+                "risk",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "insights": {
+            "description": "Token (and optional cost) savings of this compilation.",
+            "properties": {
+              "currency": {
+                "description": "Currency of the cost figure, from the pricing table.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "estimated_cost_saved_micros": {
+                "description": "Estimated cost avoided, in micro-units of [`Self::currency`] — only\nwhen a pricing table was injected *and* it prices the target model.",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "pricing_version": {
+                "description": "Version tag of the pricing table that produced the cost figure.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tokens_in": {
+                "description": "Estimated tokens of all input fragments combined.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "tokens_out": {
+                "description": "Estimated tokens of the assembled output.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "tokens_saved": {
+                "description": "`tokens_in − tokens_out` (saturating) — the local *estimate* of what\nthis compilation avoided sending; not billed tokens.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "tokens_saved_by_rule": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "description": "Tokens saved attributed to the rule that saved them, keyed by rule id\n(`BTreeMap` for deterministic serialization order).",
+                "type": "object"
+              }
+            },
+            "required": [
+              "tokens_in",
+              "tokens_out",
+              "tokens_saved",
+              "tokens_saved_by_rule"
+            ],
+            "type": "object"
+          },
+          "retrieval_handles": {
+            "description": "Handles for the fragments that were externalized, not emitted.",
+            "items": {
+              "description": "A not-emitted fragment the caller can fetch back on demand.",
+              "properties": {
+                "estimated_tokens": {
+                  "description": "Estimated token cost of re-injecting the full original.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "fragment_id": {
+                  "description": "The fragment behind the handle.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "handle": {
+                  "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "handle",
+                "fragment_id",
+                "estimated_tokens"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "risk": {
+            "description": "Overall fidelity risk (the max over all decisions).",
+            "oneOf": [
+              {
+                "const": "low",
+                "description": "Nothing was lost: everything fit, only exact duplicates were dropped.",
+                "type": "string"
+              },
+              {
+                "const": "medium",
+                "description": "Recoverable reductions happened: abstractions, or non-critical\nfragments externalized behind retrieval handles.",
+                "type": "string"
+              },
+              {
+                "const": "high",
+                "description": "Critical content (a preserve-classified fragment) could not be packed\n— the caller should consider retrieving it or raising the budget.",
+                "type": "string"
+              }
+            ]
+          },
+          "sections": {
+            "description": "The output split into ordered blocks (cache prefix first). Emptied by\n[`CompilePolicy::slim_response`].",
+            "items": {
+              "description": "One contiguous block of the assembled output.",
+              "properties": {
+                "content": {
+                  "description": "The block's text (verbatim slice of [`CompiledContext::content`]).",
+                  "type": "string"
+                },
+                "fragment_ids": {
+                  "description": "Ids of the fragments emitted into this block, in emission order.",
+                  "items": {
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "string"
+                    ]
+                  },
+                  "type": "array"
+                },
+                "kind": {
+                  "description": "Which block this is.",
+                  "oneOf": [
+                    {
+                      "const": "cache",
+                      "description": "The stable, cache-marked prefix.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "body",
+                      "description": "The main compiled body.",
+                      "type": "string"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "content",
+                "fragment_ids"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "sources": {
+            "description": "One source pointer per distinct fragment.",
+            "items": {
+              "description": "A pointer from a compiled output back to one original fragment.",
+              "properties": {
+                "fragment_id": {
+                  "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "handle": {
+                  "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                  "type": "string"
+                },
+                "memory_id": {
+                  "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "fragment_id",
+                "handle"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "warnings": {
+            "default": [],
+            "description": "Mechanical, low-noise heads-up over `decisions` (V2a-2 quick win):\nevery externalized fragment relevant enough to the query that a\ncaller should double-check it was not needed. `#[serde(default)]` so\na pre-0.10.0 caller reading an older stored/replayed response still\ndeserializes (defaults to empty).",
+            "items": {
+              "description": "A mechanical heads-up over one decision, surfaced in\n[`CompiledContext::warnings`] so a caller can check \"was anything\nrelevant cut?\" without scanning every entry of `decisions` by hand\n(V2a-2 quick win). Only [`ContextAction::Retrieve`] decisions at or\nabove the relevance threshold qualify — a [`ContextAction::Drop`] in\nthis compiler is always a byte-identical duplicate whose content\nsurvives through its kept twin (see `dup_verdict`), so it is never a\nreal loss and never warns.",
+              "properties": {
+                "action": {
+                  "description": "What happened to it (always [`ContextAction::Retrieve`] today).",
+                  "oneOf": [
+                    {
+                      "const": "preserve",
+                      "description": "Emitted verbatim — critical content (code, constraints, exact values).",
+                      "type": "string"
+                    },
+                    {
+                      "const": "abstract",
+                      "description": "Emitted as a deterministic structured reduction (never a generative\nsummary) — e.g. repeated log lines collapsed with a count.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "retrieve",
+                      "description": "Not emitted, but recoverable through its `ctx://source/<id>` handle.",
+                      "type": "string"
+                    },
+                    {
+                      "const": "drop",
+                      "description": "Not emitted and not externalized — redundant content (duplicates).",
+                      "type": "string"
+                    },
+                    {
+                      "const": "cache",
+                      "description": "Emitted verbatim at the front of the output, forming a stable prefix\nthat maximizes provider prompt-cache hits across compilations.",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "fragment_id": {
+                  "description": "The fragment this warning is about.",
+                  "minimum": 0,
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                },
+                "reason": {
+                  "description": "The matching `decisions` entry's `reason`, copied verbatim.",
+                  "type": "string"
+                },
+                "relevance": {
+                  "description": "Lexical relevance to the request query, in `[0, 1]` — the same value\nas the matching `decisions` entry.",
+                  "format": "float",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "fragment_id",
+                "action",
+                "relevance",
+                "reason"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "content",
+          "sections",
+          "decisions",
+          "sources",
+          "retrieval_handles",
+          "insights",
+          "risk"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "One-call shortcut over compile_context for a raw agent-session transcript: deterministically segments it into turns (plain marker-based — System:/User:/Human:/Assistant:/AI:/Tool:/### User/### Assistant — or JSONL, one line per turn) and, within each turn, into code/log/body sub-segments (fenced code blocks stay atomic; runs of 8+ log-like lines collapse the same way abstract.log_dedup would), then compiles the result exactly like compile_context. Exactly one of `transcript` (inline) or `path` (an absolute filesystem path, same VELESDB_MEMORY_INGEST_ROOTS allowlist as compile_context's `path` fragments but capped at 8 MiB) must be set. `segmentation.format` forces plain or jsonl instead of auto-detecting; a forced jsonl format that fails to parse is a hard error, never a silent fallback. The first turn is tagged cache-eligible when it looks like a system prompt (segmentation.cache_system_turn, default true). Returns `context` (byte-compatible with compile_context's output) plus `segmentation` — the detected format and one audit entry (turn, role, kind, byte range, fragment_id) per segment, so a caller can see exactly how the transcript was cut before trusting the compiled result.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "path": {
+            "description": "Read the transcript from this absolute filesystem path instead of\ninline `transcript` — the same `VELESDB_MEMORY_INGEST_ROOTS`\nallowlist and security pipeline as a `compile_context` fragment's\n`path` (V2b-1), except capped at\n[`crate::limits::MAX_TRANSCRIPT_BYTES`] (8 MiB) instead of the\nordinary 1 MiB fragment ceiling — the transcript is segmented into\nsub-1-MiB pieces immediately after this read.",
+            "type": "string"
+          },
+          "policy": {
+            "description": "Per-request compile policy override, same as `compile_context`'s\n`policy`.",
+            "properties": {
+              "chunk": {
+                "default": {
+                  "boundary": "paragraph",
+                  "max_chunk_bytes": 2048,
+                  "overlap_bytes": 0
+                },
+                "description": "How oversized fragments are split before packing. Only\n[`ChunkPolicy::max_chunk_bytes`] and [`ChunkPolicy::boundary`] apply\nhere — the compiler forces `overlap_bytes` to `0`, since it emits\npieces by concatenation and an overlap prefix would duplicate content\nreported as verbatim. `overlap_bytes` is honoured only by the\nstandalone [`crate::context::chunk::chunk_text`] API.",
+                "properties": {
+                  "boundary": {
+                    "default": "paragraph",
+                    "description": "Preferred cut points.\n- \"paragraph\": Cut at blank lines (`\\n\\n`), falling back to hard splits inside an\noversized paragraph.\n- \"sentence\": Cut after sentence enders (`.`, `!`, `?` followed by whitespace).\n- \"fixed\": Cut at the byte ceiling only (char-aligned).",
+                    "enum": [
+                      "paragraph",
+                      "sentence",
+                      "fixed"
+                    ],
+                    "type": "string"
+                  },
+                  "max_chunk_bytes": {
+                    "default": 2048,
+                    "description": "Soft byte ceiling per chunk (fences may exceed it, see module doc).",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "overlap_bytes": {
+                    "default": 0,
+                    "description": "Bytes of the previous chunk to repeat at the start of the next one\n(char-aligned). `0` keeps chunks disjoint.",
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "disabled_rules": {
+                "default": [],
+                "description": "Rule ids to disable (e.g. `\"abstract.log_dedup\"`). Disabled rules are\nskipped during classification; their fragments fall through to the\nnext matching rule.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "event_ttl_seconds": {
+                "description": "TTL applied to compilation events (`None` keeps them).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "ids_as_strings": {
+                "default": false,
+                "description": "Wire-compat opt-in for the MCP context tools (`compile_context`,\n`explain_compilation`): when `true`, every [`super::wire::ID_KEYS`]\nfield of the RESPONSE (`fragment_id`, `content_hash`, `memory_id`,\n`fragment_ids`) is rewritten into its decimal-string form, through\nthe exact same tree walk the Node and WASM bindings already apply on\nevery response ([`super::wire::stringify_id_fields`]). A raw MCP\nclient — one that talks JSON-RPC directly, without either binding —\nparses ids as JS `number`s (IEEE-754 doubles), which silently lose\nprecision above 2^53; string ids round-trip exactly. Default\n`false`: existing MCP clients keep today's byte-identical numeric\nresponse unless they opt in.",
+                "type": "boolean"
+              },
+              "importance": {
+                "default": {
+                  "confidence": 0.2,
+                  "recency": 0.1
+                },
+                "description": "Memory bridge only: usage-driven importance blend over the pulled\nmemories (RL confidence + batch-relative recency). The struct-level\n`#[serde(default)]` keeps 0.8.0 requests wire-compatible.",
+                "properties": {
+                  "confidence": {
+                    "default": 0.2,
+                    "description": "Weight of the learned RL confidence (`_veles_rl_*`, fed by\n[`feedback`](crate::MemoryService::feedback)). A memory with no\nfeedback history counts as the neutral `0.5`, contributing exactly\n`0`. Default `0.2`.",
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "recency": {
+                    "default": 0.1,
+                    "description": "Weight of the batch-relative recency term. Inert unless\n[`Self::recency_field`] is also set. Default `0.1`.",
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "recency_field": {
+                    "description": "Caller metadata key holding each memory's **numeric** timestamp-like\nvalue. `None` (the default) disables the recency term completely —\nthere is no standard key to guess. The scale must be monotone and\nhomogeneous across the batch (e.g. `YYYYMMDD` integers as in\n[`crate::format_dated_context`], or an epoch); it is documented, not\nverified at run time. Values are min-max normalised over the pulled\nmemories that carry the key; a memory without the key contributes `0`\n(never penalised), and a degenerate batch (`max == min`) contributes\n`0` for all.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "near_dup_dedup": {
+                "default": true,
+                "description": "Collapse near-duplicates (case/whitespace variants) in addition to\nexact duplicates. Default `true`.",
+                "type": "boolean"
+              },
+              "normalize_log_timestamps": {
+                "default": false,
+                "description": "Opt-in, deterministic: before `abstract.log_dedup` groups a `kind =\n\"log\"` fragment's repeated lines, mask each line's volatile prefix\n(ISO/syslog timestamps, bracketed hex/pid counters) with **fixed**\npatterns — never a caller-supplied regex, so the collapse stays\nreproducible — so lines identical modulo timestamp collapse into one\nannotated line instead of surviving as distinct entries. The emitted\nline is still the first occurrence's exact bytes; only the grouping\nkey changes. Default `false`: masking is opt-in because it changes\nwhat \"duplicate\" means for logs, so callers who rely on the previous\nbyte-exact grouping keep it unless they ask. See the crate README's\n\"Normalizing timestamped logs\" section for the exact patterns.",
+                "type": "boolean"
+              },
+              "pricing": {
+                "description": "Caller-supplied pricing table so the insights also report the\nestimated cost avoided for [`super::model::CompileRequest::target_model`] — the\n**wire channel** for cost accounting (MCP and the bindings cannot\nreach the Rust-only [`super::ContextCompiler::with_pricing`] builder).\nTakes precedence over a builder-injected table. `None` (default)\nreports tokens only.",
+                "properties": {
+                  "currency": {
+                    "description": "ISO-4217 currency code of every rate in the table (e.g. `\"EUR\"`).",
+                    "type": "string"
+                  },
+                  "models": {
+                    "additionalProperties": {
+                      "description": "Pricing of one model, in integer micro-units per **million** input tokens\n(e.g. a `3 USD / 1M tokens` rate is `3_000_000`).",
+                      "properties": {
+                        "input_micros_per_million_tokens": {
+                          "description": "Micro-units of the table's currency per million input tokens.",
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "input_micros_per_million_tokens"
+                      ],
+                      "type": "object"
+                    },
+                    "description": "Rates keyed by model name (a `BTreeMap` so iteration — and therefore\nevery serialized output — is deterministically ordered).",
+                    "type": "object"
+                  },
+                  "version": {
+                    "description": "Caller-side version tag of this table (recorded in insights so a cost\nfigure is always traceable to the prices that produced it).",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "version",
+                  "currency",
+                  "models"
+                ],
+                "type": "object"
+              },
+              "record_events": {
+                "default": true,
+                "description": "Memory bridge only: record a compilation event (metadata and hashes,\n**never fragment content**) so savings stay aggregatable. Default\n`true`; set `false` to opt out entirely.",
+                "type": "boolean"
+              },
+              "response_reserve_tokens": {
+                "default": 0,
+                "description": "Tokens kept aside for the model's answer; the compiler packs into\n`token_budget − response_reserve_tokens`. Default `0`: the caller\nknows their generation length, the compiler does not guess it.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "slim_response": {
+                "default": false,
+                "description": "Quick win (V2a-2): when `true`, `sections` and `decisions` are\nemptied out of the response after compilation — `content`,\n`insights`, `risk`, `warnings`, `sources`, and `retrieval_handles`\nare unaffected. The full audit trail (`sections`/`decisions`) is\nstill recoverable: re-compile the same request without\n`slim_response` (compilation is deterministic, so nothing is lost,\nonly not sent this time). Default `false`.",
+                "type": "boolean"
+              },
+              "source_ttl_seconds": {
+                "description": "TTL applied to stored sources (`None` keeps them until forgotten).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "store_sources": {
+                "default": true,
+                "description": "Memory bridge only: store each distinct fragment's original (as an\ninternal system fact, invisible to normal recall) so its\n`ctx://source/<hash>` handle round-trips. Default `true`.",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "project": {
+            "description": "Project facet, recorded in provenance.",
+            "type": "string"
+          },
+          "query": {
+            "description": "What the agent is working on — drives relevance scoring, exactly like\n`compile_context`'s `query`.",
+            "type": "string"
+          },
+          "segmentation": {
+            "description": "Tuning knobs for the transcript segmentation step itself (format,\nmerge threshold, system-turn caching). `None` uses\n[`SegmentationPolicy::default`].",
+            "properties": {
+              "cache_system_turn": {
+                "default": true,
+                "description": "When `true` (the default) and [`SegmentationPolicy::format`]\ndetermines the FIRST turn's role is `\"system\"` (case-insensitive),\nevery segment of that turn is marked `metadata.cache = true` — the\nsame signal `compile_context`'s `cache.stable_prefix` rule reads, so\na system prompt turn becomes the compiled output's stable,\ncache-friendly prefix without the caller hand-annotating it.",
+                "type": "boolean"
+              },
+              "format": {
+                "default": "auto",
+                "description": "Which format to assume (see [`SegmentFormat`]). Default [`SegmentFormat::Auto`].\n- \"auto\": Detect `jsonl` vs `plain` from the transcript itself (the default).\n- \"plain\": Force plain-text, marker-based turn splitting — a transcript that\nhappens to also be valid JSONL is still segmented as plain text.\n- \"jsonl\": Force one-line-one-turn JSONL parsing — a line that does not parse as\na `{role, content}` object is a hard error, never a silent fallback.",
+                "enum": [
+                  "auto",
+                  "plain",
+                  "jsonl"
+                ],
+                "type": "string"
+              },
+              "min_segment_bytes": {
+                "default": 256,
+                "description": "Segments under this many bytes merge into an adjacent segment of the\nsame turn and kind (see the module docs' step 4). Default `256`.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "target_model": {
+            "description": "Target model name, for cost insights.",
+            "type": "string"
+          },
+          "token_budget": {
+            "description": "Hard token ceiling for the assembled content, same as\n`compile_context`'s `token_budget`.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "transcript": {
+            "description": "The raw transcript text (plain, marker-based, or JSONL). Exactly one\nof `transcript` or `path` must be set.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query",
+          "token_budget"
+        ],
+        "type": "object"
+      },
+      "name": "compile_transcript",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "context": {
+            "description": "The compiled context — byte-compatible with `compile_context`'s\noutput.",
+            "properties": {
+              "content": {
+                "description": "The assembled context, ready to inject into a prompt.",
+                "type": "string"
+              },
+              "decisions": {
+                "description": "One decision per input fragment (duplicates included). Emptied by\n[`CompilePolicy::slim_response`].",
+                "items": {
+                  "description": "The auditable record of what happened to one fragment and why.",
+                  "properties": {
+                    "action": {
+                      "description": "What was done.",
+                      "oneOf": [
+                        {
+                          "const": "preserve",
+                          "description": "Emitted verbatim — critical content (code, constraints, exact values).",
+                          "type": "string"
+                        },
+                        {
+                          "const": "abstract",
+                          "description": "Emitted as a deterministic structured reduction (never a generative\nsummary) — e.g. repeated log lines collapsed with a count.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "retrieve",
+                          "description": "Not emitted, but recoverable through its `ctx://source/<id>` handle.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "drop",
+                          "description": "Not emitted and not externalized — redundant content (duplicates).",
+                          "type": "string"
+                        },
+                        {
+                          "const": "cache",
+                          "description": "Emitted verbatim at the front of the output, forming a stable prefix\nthat maximizes provider prompt-cache hits across compilations.",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "content_hash": {
+                      "description": "Content hash of the *original* fragment text (FNV-1a 64, the crate's\n[`stable id`](super::fragment_id)) — lets an auditor prove which exact\nbytes the decision covered even when the caller supplied its own id.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "fragment_id": {
+                      "description": "The fragment this decision is about (caller id, or content-derived).",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "handle": {
+                      "description": "Recoverable address of the original content, when not fully emitted.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "memory_id": {
+                      "description": "The memory backing this fragment, when it came from recall (US-002).",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "reason": {
+                      "description": "Human-readable explanation of the decision.",
+                      "type": "string"
+                    },
+                    "relevance": {
+                      "description": "Lexical relevance of the fragment to the request query, in `[0, 1]`.",
+                      "format": "float",
+                      "type": "number"
+                    },
+                    "risk": {
+                      "description": "Fidelity risk this single decision contributes.",
+                      "oneOf": [
+                        {
+                          "const": "low",
+                          "description": "Nothing was lost: everything fit, only exact duplicates were dropped.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "medium",
+                          "description": "Recoverable reductions happened: abstractions, or non-critical\nfragments externalized behind retrieval handles.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "high",
+                          "description": "Critical content (a preserve-classified fragment) could not be packed\n— the caller should consider retrieving it or raising the budget.",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "rule_id": {
+                      "description": "The stable id of the rule that decided (e.g. `\"preserve.code_fence\"`).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "fragment_id",
+                    "content_hash",
+                    "action",
+                    "rule_id",
+                    "relevance",
+                    "risk",
+                    "reason"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "insights": {
+                "description": "Token (and optional cost) savings of this compilation.",
+                "properties": {
+                  "currency": {
+                    "description": "Currency of the cost figure, from the pricing table.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "estimated_cost_saved_micros": {
+                    "description": "Estimated cost avoided, in micro-units of [`Self::currency`] — only\nwhen a pricing table was injected *and* it prices the target model.",
+                    "minimum": 0,
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "pricing_version": {
+                    "description": "Version tag of the pricing table that produced the cost figure.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "tokens_in": {
+                    "description": "Estimated tokens of all input fragments combined.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tokens_out": {
+                    "description": "Estimated tokens of the assembled output.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tokens_saved": {
+                    "description": "`tokens_in − tokens_out` (saturating) — the local *estimate* of what\nthis compilation avoided sending; not billed tokens.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "tokens_saved_by_rule": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "description": "Tokens saved attributed to the rule that saved them, keyed by rule id\n(`BTreeMap` for deterministic serialization order).",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "tokens_in",
+                  "tokens_out",
+                  "tokens_saved",
+                  "tokens_saved_by_rule"
+                ],
+                "type": "object"
+              },
+              "retrieval_handles": {
+                "description": "Handles for the fragments that were externalized, not emitted.",
+                "items": {
+                  "description": "A not-emitted fragment the caller can fetch back on demand.",
+                  "properties": {
+                    "estimated_tokens": {
+                      "description": "Estimated token cost of re-injecting the full original.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "fragment_id": {
+                      "description": "The fragment behind the handle.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "handle": {
+                      "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "handle",
+                    "fragment_id",
+                    "estimated_tokens"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "risk": {
+                "description": "Overall fidelity risk (the max over all decisions).",
+                "oneOf": [
+                  {
+                    "const": "low",
+                    "description": "Nothing was lost: everything fit, only exact duplicates were dropped.",
+                    "type": "string"
+                  },
+                  {
+                    "const": "medium",
+                    "description": "Recoverable reductions happened: abstractions, or non-critical\nfragments externalized behind retrieval handles.",
+                    "type": "string"
+                  },
+                  {
+                    "const": "high",
+                    "description": "Critical content (a preserve-classified fragment) could not be packed\n— the caller should consider retrieving it or raising the budget.",
+                    "type": "string"
+                  }
+                ]
+              },
+              "sections": {
+                "description": "The output split into ordered blocks (cache prefix first). Emptied by\n[`CompilePolicy::slim_response`].",
+                "items": {
+                  "description": "One contiguous block of the assembled output.",
+                  "properties": {
+                    "content": {
+                      "description": "The block's text (verbatim slice of [`CompiledContext::content`]).",
+                      "type": "string"
+                    },
+                    "fragment_ids": {
+                      "description": "Ids of the fragments emitted into this block, in emission order.",
+                      "items": {
+                        "minimum": 0,
+                        "type": [
+                          "integer",
+                          "string"
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "kind": {
+                      "description": "Which block this is.",
+                      "oneOf": [
+                        {
+                          "const": "cache",
+                          "description": "The stable, cache-marked prefix.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "body",
+                          "description": "The main compiled body.",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "content",
+                    "fragment_ids"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "sources": {
+                "description": "One source pointer per distinct fragment.",
+                "items": {
+                  "description": "A pointer from a compiled output back to one original fragment.",
+                  "properties": {
+                    "fragment_id": {
+                      "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "handle": {
+                      "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                      "type": "string"
+                    },
+                    "memory_id": {
+                      "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "fragment_id",
+                    "handle"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "warnings": {
+                "default": [],
+                "description": "Mechanical, low-noise heads-up over `decisions` (V2a-2 quick win):\nevery externalized fragment relevant enough to the query that a\ncaller should double-check it was not needed. `#[serde(default)]` so\na pre-0.10.0 caller reading an older stored/replayed response still\ndeserializes (defaults to empty).",
+                "items": {
+                  "description": "A mechanical heads-up over one decision, surfaced in\n[`CompiledContext::warnings`] so a caller can check \"was anything\nrelevant cut?\" without scanning every entry of `decisions` by hand\n(V2a-2 quick win). Only [`ContextAction::Retrieve`] decisions at or\nabove the relevance threshold qualify — a [`ContextAction::Drop`] in\nthis compiler is always a byte-identical duplicate whose content\nsurvives through its kept twin (see `dup_verdict`), so it is never a\nreal loss and never warns.",
+                  "properties": {
+                    "action": {
+                      "description": "What happened to it (always [`ContextAction::Retrieve`] today).",
+                      "oneOf": [
+                        {
+                          "const": "preserve",
+                          "description": "Emitted verbatim — critical content (code, constraints, exact values).",
+                          "type": "string"
+                        },
+                        {
+                          "const": "abstract",
+                          "description": "Emitted as a deterministic structured reduction (never a generative\nsummary) — e.g. repeated log lines collapsed with a count.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "retrieve",
+                          "description": "Not emitted, but recoverable through its `ctx://source/<id>` handle.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "drop",
+                          "description": "Not emitted and not externalized — redundant content (duplicates).",
+                          "type": "string"
+                        },
+                        {
+                          "const": "cache",
+                          "description": "Emitted verbatim at the front of the output, forming a stable prefix\nthat maximizes provider prompt-cache hits across compilations.",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "fragment_id": {
+                      "description": "The fragment this warning is about.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "reason": {
+                      "description": "The matching `decisions` entry's `reason`, copied verbatim.",
+                      "type": "string"
+                    },
+                    "relevance": {
+                      "description": "Lexical relevance to the request query, in `[0, 1]` — the same value\nas the matching `decisions` entry.",
+                      "format": "float",
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "fragment_id",
+                    "action",
+                    "relevance",
+                    "reason"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "content",
+              "sections",
+              "decisions",
+              "sources",
+              "retrieval_handles",
+              "insights",
+              "risk"
+            ],
+            "type": "object"
+          },
+          "segmentation": {
+            "description": "How the transcript was cut into fragments before compilation.",
+            "properties": {
+              "format_detected": {
+                "description": "`\"plain\"` or `\"jsonl\"` — the format actually used, never `\"auto\"`\neven when the request asked for it.",
+                "oneOf": [
+                  {
+                    "const": "auto",
+                    "description": "Detect `jsonl` vs `plain` from the transcript itself (the default).",
+                    "type": "string"
+                  },
+                  {
+                    "const": "plain",
+                    "description": "Force plain-text, marker-based turn splitting — a transcript that\nhappens to also be valid JSONL is still segmented as plain text.",
+                    "type": "string"
+                  },
+                  {
+                    "const": "jsonl",
+                    "description": "Force one-line-one-turn JSONL parsing — a line that does not parse as\na `{role, content}` object is a hard error, never a silent fallback.",
+                    "type": "string"
+                  }
+                ]
+              },
+              "merged_segments": {
+                "description": "How many segments [`SegmentationPolicy::min_segment_bytes`] merging\neliminated.",
+                "format": "uint",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "segments": {
+                "description": "Every segment, in transcript order, with byte ranges that partition\nthe transcript exactly — no gaps, no overlaps, even for a `jsonl`\nline whose decoded `content` alone exceeds\n[`crate::limits::MAX_FRAGMENT_BYTES`] (1 MiB) and gets re-split into\nseveral segments (`compile_context` still gets sub-1-MiB fragments):\neach child's range is a proportional, non-overlapping share of the\noriginal JSON line's raw span rather than a byte-exact one, since a\nJSONL line's decoded text has no byte-aligned mapping back into the\nraw (JSON-escaped) source bytes (see `resplit_body` in\n`context::segment`). An extreme edge case (one transcript line over\n1 MiB of decoded content), but even then every segment keeps a\ndistinct, non-overlapping range.",
+                "items": {
+                  "description": "One entry of [`SegmentationReport::segments`] — the audit trail of how\n`compile_transcript` cut the transcript up, independent of what\n`compile_context` then did with the resulting fragments.",
+                  "properties": {
+                    "byte_end": {
+                      "description": "End byte offset (exclusive) in the original transcript. Same caveat\nas `byte_start`.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "byte_start": {
+                      "description": "Start byte offset (inclusive) in the original transcript. For a\n`jsonl` transcript this is a slice of the raw JSON line's span, not\nan offset into the decoded `content` — a JSONL line's decoded text\nhas no byte-exact mapping back into the raw (JSON-escaped) source\nbytes, so when a single line's decoded content is re-split (over\n[`crate::limits::MAX_FRAGMENT_BYTES`]) each child's range is a\nproportional, non-overlapping share of the line's raw range rather\nthan a byte-precise one. Every segment's range is still distinct and\nnon-overlapping (see [`SegmentationReport::segments`]'s struct docs).",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "fragment_id": {
+                      "description": "The id this segment's fragment carries into `context.decisions` —\ncontent-addressed, same formula as every other `compile_context`\nfragment with no caller-supplied `id`.",
+                      "minimum": 0,
+                      "type": [
+                        "integer",
+                        "string"
+                      ]
+                    },
+                    "index": {
+                      "description": "Position of this segment in `segmentation.segments`, in transcript\norder.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "kind": {
+                      "description": "`\"body\"`, `\"code\"`, or `\"log\"`.",
+                      "oneOf": [
+                        {
+                          "const": "body",
+                          "description": "Ordinary text — [`ContextFragment::kind`] stays `None`, so the\nexisting classification rules (code fence, URL, negative constraint,\nvalue density, …) decide its fate exactly as for `compile_context`.",
+                          "type": "string"
+                        },
+                        {
+                          "const": "code",
+                          "description": "A triple-backtick-fenced block, cut out atomically by\n[`super::chunk::fence_segments`]. Tagged `kind = \"code\"` so\n[`super::classify::classify`]'s `preserve.code_fence` rule matches\neven for a fence whose content does not itself literally contain\n`` ``` `` (defense in depth; it usually does).",
+                          "type": "string"
+                        },
+                        {
+                          "const": "log",
+                          "description": "A run of at least [`MIN_LOG_RUN_LINES`] log-like lines. Tagged\n`kind = \"log\"` so `abstract.log_dedup` can consider it for\nrepeated-line collapsing exactly like a caller-declared `kind: \"log\"`\nfragment in `compile_context`.",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "role": {
+                      "description": "The turn's role, when one was determined. `null` for a `plain`\ntranscript with no matching marker at all.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "turn": {
+                      "description": "Which turn (0-based) this segment belongs to.",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "turn",
+                    "kind",
+                    "byte_start",
+                    "byte_end",
+                    "fragment_id"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "format_detected",
+              "segments",
+              "merged_segments"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "context",
+          "segmentation"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Aggregate the token (and cost) savings of past compile_context calls, optionally per project. Figures are local estimates recorded per compilation (metadata only, never content); `truncated` reports when the sweep hit the recall cap.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "project": {
+            "description": "Restrict the aggregation to this project facet.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "name": "context_savings",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "cost_saved_micros_by_currency": {
+            "additionalProperties": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "description": "Estimated cost avoided, in micro-units, keyed by currency (events\npriced under different pricing tables never silently mix).",
+            "type": "object"
+          },
+          "events": {
+            "description": "Number of compilation events aggregated.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "tokens_in": {
+            "description": "Sum of estimated input tokens across events.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "tokens_out": {
+            "description": "Sum of estimated output tokens across events.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "tokens_saved": {
+            "description": "Sum of estimated tokens saved across events.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "truncated": {
+            "description": "`true` when the aggregation hit the recall cap\n([`crate::limits::MAX_RECALL_LIMIT`]) — older events beyond the cap\nwere not folded in.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "events",
+          "tokens_in",
+          "tokens_out",
+          "tokens_saved",
+          "cost_saved_micros_by_currency",
+          "truncated"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Look up everything the memory graph knows about a NAMED ENTITY (a person, a place, an organisation): the attributes it carries and the typed edges leaving it. Use this for questions ABOUT a thing rather than about a sentence — \"how old is Theo\", \"who is Theo's father\", \"where does he live\" — where `recall` would only return sentences that happen to mention the name. Entities and their edges are built automatically by `remember_extracted`, which reads relationships (`X is the father of Y`) and properties (`Y is 15`) out of plain text; attributes land in ColumnStore metadata with their JSON type preserved, so a number stays a number. The name is matched case-insensitively, so `\"Theo Durand\"` and `\"theo durand\"` are the same entity — the id is content-addressed, so it is stable across sessions. Returns `found: false` when nothing has ever mentioned that name; `name` is echoed back in its canonical (trimmed, lowercased) form either way, so several lookups can be told apart. Ids exceed 2^53 — always relay them as strings (`id_str`).",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "name": {
+            "description": "Entity name to look up. Matched case-insensitively.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "name": "entity",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "attributes": {
+            "additionalProperties": true,
+            "description": "Attributes learned about this entity, reserved keys stripped.",
+            "type": "object"
+          },
+          "found": {
+            "description": "Whether an entity is known under that name at all.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Stable, content-addressed id of the entity (`0` when not found).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id_str": {
+            "description": "Decimal-string twin of `id` (issue #1468).",
+            "type": "string"
+          },
+          "name": {
+            "description": "Canonical (trimmed, lowercased) entity name. Always filled in — on a\nMISS it echoes the *queried* name, canonicalized exactly as a hit's\nwould be, so a caller running several lookups can pair each response\nwith its question (issue #1654).",
+            "type": "string"
+          },
+          "relations": {
+            "description": "Typed edges leaving this entity.",
+            "items": {
+              "description": "Wire shape of one typed edge leaving an entity, with the `target_id_str`\ntwin (issue #1468).",
+              "properties": {
+                "predicate": {
+                  "description": "The edge label the passage stated (e.g. `\"pere de\"`, `\"soeur de\"`).",
+                  "type": "string"
+                },
+                "target": {
+                  "description": "Stored content of the far end — for an entity, `Entity: <name>`.",
+                  "type": "string"
+                },
+                "target_id": {
+                  "description": "Stable id of the entity (or fact) on the far end.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "target_id_str": {
+                  "description": "Decimal-string twin of `target_id` (issue #1468).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "predicate",
+                "target_id",
+                "target_id_str",
+                "target"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "relations_in": {
+            "description": "Typed edges pointing AT this entity, each naming its SOURCE.\n\nWithout these, a question is only answerable from one side: the graph\nholds `camille --soeur de--> theo`, so asking what Theo's outgoing\nedges say never finds Camille. The edge exists, it simply leaves the\nother node. Nothing is inferred here — the converse of a kinship\nlabel needs the gender, which the graph does not hold; this reports\nonly what is stored.",
+            "items": {
+              "description": "Wire shape of one typed edge leaving an entity, with the `target_id_str`\ntwin (issue #1468).",
+              "properties": {
+                "predicate": {
+                  "description": "The edge label the passage stated (e.g. `\"pere de\"`, `\"soeur de\"`).",
+                  "type": "string"
+                },
+                "target": {
+                  "description": "Stored content of the far end — for an entity, `Entity: <name>`.",
+                  "type": "string"
+                },
+                "target_id": {
+                  "description": "Stable id of the entity (or fact) on the far end.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "target_id_str": {
+                  "description": "Decimal-string twin of `target_id` (issue #1468).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "predicate",
+                "target_id",
+                "target_id_str",
+                "target"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "found",
+          "id",
+          "id_str",
+          "name",
+          "attributes",
+          "relations",
+          "relations_in"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Explain why one fragment of a compile_context request was preserved, abstracted, externalized, dropped, or cached. Compilation is deterministic, so the request is re-compiled (with event/source recording off) and the fragment's exact decision (rule id, reason, relevance, risk, handle) is returned — no server-side state needed. Caveat: with a memory_scope the re-compile recalls from CURRENT memory, so decisions about pulled memories reflect the memory as it is now, not as it was; a `path` fragment is likewise re-read from disk, so the decision reflects the file's CURRENT content, not necessarily what the original compile_context call saw. Pass `fragment_index` (0-based position in request.fragments) instead of relying on `fragment_id` alone when fragments are byte-identical — a shared content-addressed id otherwise always resolves to the deduplication survivor's decision. `policy.ids_as_strings` on the request rewrites the response's id fields into decimal strings, like compile_context.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "fragment_id": {
+            "description": "The fragment whose decision to return. Looked up by matching\n`ContextDecision::fragment_id`, UNLESS `fragment_index` is also\ngiven (see there) — still required even then, since it is the only\ndisambiguator when `fragment_index` is absent. Accepts a JSON number\nOR a decimal string, so a `fragment_id` received under\n[`CompilePolicy::ids_as_strings`] can be relayed back unchanged.",
+            "type": "string"
+          },
+          "fragment_index": {
+            "description": "Optional, 0-based position of the fragment in `request.fragments`.\nWhen given, TAKES PRIORITY over `fragment_id` for locating the\ndecision: `compile_context` records exactly one decision per input\nfragment, in order, so `decisions[fragment_index]` is unambiguous\neven when several fragments are byte-identical and therefore share\nthe same content-addressed `fragment_id` — a plain `fragment_id`\nlookup always returns the FIRST such decision (the deduplication\nsurvivor), never a dropped twin's. Absent (the default): behavior is\nunchanged, the decision is found by `fragment_id` alone.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "request": {
+            "description": "The compile request to explain (compilation is deterministic, so\nre-submitting the request reproduces the exact decisions).",
+            "properties": {
+              "fragments": {
+                "description": "The context fragments to compile.",
+                "items": {
+                  "description": "One unit of caller-supplied context to compile.",
+                  "properties": {
+                    "content": {
+                      "default": "",
+                      "description": "The fragment text. `#[serde(default)]` (V2b-1): a `path` fragment\ncarries no `content` on the wire — the adapter resolves `path` into\n`content` in a pre-pass before the pure compiler core ever sees the\nrequest, so this stays the only field the core reads.",
+                      "type": "string"
+                    },
+                    "id": {
+                      "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n[`super::wire::deserialize_optional_id`]) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Free-form kind hint (`\"code\"`, `\"log\"`, `\"prose\"`, …) — classification\nworks without it, but honors it when present.",
+                      "type": "string"
+                    },
+                    "media": {
+                      "description": "Inline media payload (US-009, PR1). `None` (the default) keeps every\npre-0.9.0 request wire-compatible. When set, the fragment packs as one\natomic piece — see [`MediaRef`].",
+                      "properties": {
+                        "bytes_b64": {
+                          "description": "The raw media bytes, base64-encoded (standard alphabet, padded).\nCapped at [`crate::limits::MAX_MEDIA_BYTES`] and validated for\nwell-formedness at compile time — a request carrying an oversized or\nmalformed payload is rejected before any other work.",
+                          "type": "string"
+                        },
+                        "mime": {
+                          "description": "Declared MIME type (e.g. `\"image/png\"`, `\"image/jpeg\"`). Only PNG and\nJPEG headers are sniffed for dimensions; any other value (or an\nunreadable header) falls back to a deterministic, safe over-count\n(see [`super::estimator::ImageTokenEstimator`]) — never rejected for\nan unrecognized mime alone.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mime",
+                        "bytes_b64"
+                      ],
+                      "type": "object"
+                    },
+                    "metadata": {
+                      "additionalProperties": true,
+                      "description": "Caller metadata. Recognized keys: `\"verbatim\": true` forces\n[`ContextAction::Preserve`]; `\"cache\": true` forces\n[`ContextAction::Cache`].",
+                      "type": "object"
+                    },
+                    "path": {
+                      "description": "Read this file's content from disk in place of an inline `content`\n(V2b-1 path ingestion): exactly one of `path`, non-empty `content`,\nor `media` is accepted — a fragment carrying `path` together with\n`content` or `media` is rejected. Requires the server to be started\nwith `VELESDB_MEMORY_INGEST_ROOTS` set (a colon/semicolon-separated\nallowlist of directories, platform `PATH`-list syntax); otherwise\nevery `path` fragment fails with an explicit \"ingestion disabled\"\nerror. The path must be absolute and resolve (after following\nsymlinks) to a plain file under one of the configured roots, no\nlarger than [`crate::limits::MAX_INGEST_FILE_BYTES`] and valid UTF-8.\nThe **pure compiler core never reads this field** — resolution is an\nadapter-side I/O pre-pass (see the crate's `context::ingest`\nmodule); a `path` fragment that reaches [`super::ContextCompiler`]\nunresolved is rejected with\n[`crate::error::MemoryError::IngestDisabled`].",
+                      "type": "string"
+                    },
+                    "priority": {
+                      "description": "Caller priority, higher packs first (default `0`).",
+                      "maximum": 255,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "memory_scope": {
+                "description": "Which memories may be pulled in (US-002; ignored by the memoryless core).",
+                "properties": {
+                  "graph_boost": {
+                    "description": "Fusion weight added to graph-reached memories (default 0.15). Raise\nit (e.g. `0.5`–`0.8`) when pulling from curated fact chains built\nwith `relate`: evidence that shares **no vocabulary** with the query\ncan then out-rank lexically-noisy near-misses — the tri-engine's\nanswer to the purely lexical relevance of caller fragments.",
+                    "format": "double",
+                    "type": "number"
+                  },
+                  "hops": {
+                    "description": "Graph-walk depth of the fused recall (default 2). Deeper hops reach\nlonger cause/fix chains from the vector seed.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "k": {
+                    "description": "How many memories to consider (adapter-clamped).",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "project": {
+                    "description": "Restrict recalled memories to this project facet.",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "policy": {
+                "description": "Per-request policy override; `None` uses the compiler's policy.",
+                "properties": {
+                  "chunk": {
+                    "default": {
+                      "boundary": "paragraph",
+                      "max_chunk_bytes": 2048,
+                      "overlap_bytes": 0
+                    },
+                    "description": "How oversized fragments are split before packing. Only\n[`ChunkPolicy::max_chunk_bytes`] and [`ChunkPolicy::boundary`] apply\nhere — the compiler forces `overlap_bytes` to `0`, since it emits\npieces by concatenation and an overlap prefix would duplicate content\nreported as verbatim. `overlap_bytes` is honoured only by the\nstandalone [`crate::context::chunk::chunk_text`] API.",
+                    "properties": {
+                      "boundary": {
+                        "default": "paragraph",
+                        "description": "Preferred cut points.\n- \"paragraph\": Cut at blank lines (`\\n\\n`), falling back to hard splits inside an\noversized paragraph.\n- \"sentence\": Cut after sentence enders (`.`, `!`, `?` followed by whitespace).\n- \"fixed\": Cut at the byte ceiling only (char-aligned).",
+                        "enum": [
+                          "paragraph",
+                          "sentence",
+                          "fixed"
+                        ],
+                        "type": "string"
+                      },
+                      "max_chunk_bytes": {
+                        "default": 2048,
+                        "description": "Soft byte ceiling per chunk (fences may exceed it, see module doc).",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "overlap_bytes": {
+                        "default": 0,
+                        "description": "Bytes of the previous chunk to repeat at the start of the next one\n(char-aligned). `0` keeps chunks disjoint.",
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "disabled_rules": {
+                    "default": [],
+                    "description": "Rule ids to disable (e.g. `\"abstract.log_dedup\"`). Disabled rules are\nskipped during classification; their fragments fall through to the\nnext matching rule.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "event_ttl_seconds": {
+                    "description": "TTL applied to compilation events (`None` keeps them).",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "ids_as_strings": {
+                    "default": false,
+                    "description": "Wire-compat opt-in for the MCP context tools (`compile_context`,\n`explain_compilation`): when `true`, every [`super::wire::ID_KEYS`]\nfield of the RESPONSE (`fragment_id`, `content_hash`, `memory_id`,\n`fragment_ids`) is rewritten into its decimal-string form, through\nthe exact same tree walk the Node and WASM bindings already apply on\nevery response ([`super::wire::stringify_id_fields`]). A raw MCP\nclient — one that talks JSON-RPC directly, without either binding —\nparses ids as JS `number`s (IEEE-754 doubles), which silently lose\nprecision above 2^53; string ids round-trip exactly. Default\n`false`: existing MCP clients keep today's byte-identical numeric\nresponse unless they opt in.",
+                    "type": "boolean"
+                  },
+                  "importance": {
+                    "default": {
+                      "confidence": 0.2,
+                      "recency": 0.1
+                    },
+                    "description": "Memory bridge only: usage-driven importance blend over the pulled\nmemories (RL confidence + batch-relative recency). The struct-level\n`#[serde(default)]` keeps 0.8.0 requests wire-compatible.",
+                    "properties": {
+                      "confidence": {
+                        "default": 0.2,
+                        "description": "Weight of the learned RL confidence (`_veles_rl_*`, fed by\n[`feedback`](crate::MemoryService::feedback)). A memory with no\nfeedback history counts as the neutral `0.5`, contributing exactly\n`0`. Default `0.2`.",
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "recency": {
+                        "default": 0.1,
+                        "description": "Weight of the batch-relative recency term. Inert unless\n[`Self::recency_field`] is also set. Default `0.1`.",
+                        "format": "double",
+                        "type": "number"
+                      },
+                      "recency_field": {
+                        "description": "Caller metadata key holding each memory's **numeric** timestamp-like\nvalue. `None` (the default) disables the recency term completely —\nthere is no standard key to guess. The scale must be monotone and\nhomogeneous across the batch (e.g. `YYYYMMDD` integers as in\n[`crate::format_dated_context`], or an epoch); it is documented, not\nverified at run time. Values are min-max normalised over the pulled\nmemories that carry the key; a memory without the key contributes `0`\n(never penalised), and a degenerate batch (`max == min`) contributes\n`0` for all.",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "near_dup_dedup": {
+                    "default": true,
+                    "description": "Collapse near-duplicates (case/whitespace variants) in addition to\nexact duplicates. Default `true`.",
+                    "type": "boolean"
+                  },
+                  "normalize_log_timestamps": {
+                    "default": false,
+                    "description": "Opt-in, deterministic: before `abstract.log_dedup` groups a `kind =\n\"log\"` fragment's repeated lines, mask each line's volatile prefix\n(ISO/syslog timestamps, bracketed hex/pid counters) with **fixed**\npatterns — never a caller-supplied regex, so the collapse stays\nreproducible — so lines identical modulo timestamp collapse into one\nannotated line instead of surviving as distinct entries. The emitted\nline is still the first occurrence's exact bytes; only the grouping\nkey changes. Default `false`: masking is opt-in because it changes\nwhat \"duplicate\" means for logs, so callers who rely on the previous\nbyte-exact grouping keep it unless they ask. See the crate README's\n\"Normalizing timestamped logs\" section for the exact patterns.",
+                    "type": "boolean"
+                  },
+                  "pricing": {
+                    "description": "Caller-supplied pricing table so the insights also report the\nestimated cost avoided for [`super::model::CompileRequest::target_model`] — the\n**wire channel** for cost accounting (MCP and the bindings cannot\nreach the Rust-only [`super::ContextCompiler::with_pricing`] builder).\nTakes precedence over a builder-injected table. `None` (default)\nreports tokens only.",
+                    "properties": {
+                      "currency": {
+                        "description": "ISO-4217 currency code of every rate in the table (e.g. `\"EUR\"`).",
+                        "type": "string"
+                      },
+                      "models": {
+                        "additionalProperties": {
+                          "description": "Pricing of one model, in integer micro-units per **million** input tokens\n(e.g. a `3 USD / 1M tokens` rate is `3_000_000`).",
+                          "properties": {
+                            "input_micros_per_million_tokens": {
+                              "description": "Micro-units of the table's currency per million input tokens.",
+                              "minimum": 0,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "input_micros_per_million_tokens"
+                          ],
+                          "type": "object"
+                        },
+                        "description": "Rates keyed by model name (a `BTreeMap` so iteration — and therefore\nevery serialized output — is deterministically ordered).",
+                        "type": "object"
+                      },
+                      "version": {
+                        "description": "Caller-side version tag of this table (recorded in insights so a cost\nfigure is always traceable to the prices that produced it).",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "version",
+                      "currency",
+                      "models"
+                    ],
+                    "type": "object"
+                  },
+                  "record_events": {
+                    "default": true,
+                    "description": "Memory bridge only: record a compilation event (metadata and hashes,\n**never fragment content**) so savings stay aggregatable. Default\n`true`; set `false` to opt out entirely.",
+                    "type": "boolean"
+                  },
+                  "response_reserve_tokens": {
+                    "default": 0,
+                    "description": "Tokens kept aside for the model's answer; the compiler packs into\n`token_budget − response_reserve_tokens`. Default `0`: the caller\nknows their generation length, the compiler does not guess it.",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "slim_response": {
+                    "default": false,
+                    "description": "Quick win (V2a-2): when `true`, `sections` and `decisions` are\nemptied out of the response after compilation — `content`,\n`insights`, `risk`, `warnings`, `sources`, and `retrieval_handles`\nare unaffected. The full audit trail (`sections`/`decisions`) is\nstill recoverable: re-compile the same request without\n`slim_response` (compilation is deterministic, so nothing is lost,\nonly not sent this time). Default `false`.",
+                    "type": "boolean"
+                  },
+                  "source_ttl_seconds": {
+                    "description": "TTL applied to stored sources (`None` keeps them until forgotten).",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "store_sources": {
+                    "default": true,
+                    "description": "Memory bridge only: store each distinct fragment's original (as an\ninternal system fact, invisible to normal recall) so its\n`ctx://source/<hash>` handle round-trips. Default `true`.",
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              },
+              "project": {
+                "description": "Project facet, recorded in provenance and used by the memory bridge.",
+                "type": "string"
+              },
+              "query": {
+                "description": "What the agent is working on — drives relevance scoring.",
+                "type": "string"
+              },
+              "target_model": {
+                "description": "Target model name — selects the row of the pricing table\n([`CompilePolicy::pricing`] on the wire, or the Rust\n[`super::ContextCompiler::with_pricing`] builder) for cost insights.\nWithout a table, insights report tokens only.",
+                "type": "string"
+              },
+              "token_budget": {
+                "description": "Hard token ceiling for the assembled content.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "query",
+              "fragments",
+              "token_budget"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "request",
+          "fragment_id"
+        ],
+        "type": "object"
+      },
+      "name": "explain_compilation",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "action": {
+            "description": "What was done.",
+            "oneOf": [
+              {
+                "const": "preserve",
+                "description": "Emitted verbatim — critical content (code, constraints, exact values).",
+                "type": "string"
+              },
+              {
+                "const": "abstract",
+                "description": "Emitted as a deterministic structured reduction (never a generative\nsummary) — e.g. repeated log lines collapsed with a count.",
+                "type": "string"
+              },
+              {
+                "const": "retrieve",
+                "description": "Not emitted, but recoverable through its `ctx://source/<id>` handle.",
+                "type": "string"
+              },
+              {
+                "const": "drop",
+                "description": "Not emitted and not externalized — redundant content (duplicates).",
+                "type": "string"
+              },
+              {
+                "const": "cache",
+                "description": "Emitted verbatim at the front of the output, forming a stable prefix\nthat maximizes provider prompt-cache hits across compilations.",
+                "type": "string"
+              }
+            ]
+          },
+          "content_hash": {
+            "description": "Content hash of the *original* fragment text (FNV-1a 64, the crate's\n[`stable id`](super::fragment_id)) — lets an auditor prove which exact\nbytes the decision covered even when the caller supplied its own id.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "fragment_id": {
+            "description": "The fragment this decision is about (caller id, or content-derived).",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "string"
+            ]
+          },
+          "handle": {
+            "description": "Recoverable address of the original content, when not fully emitted.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "memory_id": {
+            "description": "The memory backing this fragment, when it came from recall (US-002).",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "description": "Human-readable explanation of the decision.",
+            "type": "string"
+          },
+          "relevance": {
+            "description": "Lexical relevance of the fragment to the request query, in `[0, 1]`.",
+            "format": "float",
+            "type": "number"
+          },
+          "risk": {
+            "description": "Fidelity risk this single decision contributes.",
+            "oneOf": [
+              {
+                "const": "low",
+                "description": "Nothing was lost: everything fit, only exact duplicates were dropped.",
+                "type": "string"
+              },
+              {
+                "const": "medium",
+                "description": "Recoverable reductions happened: abstractions, or non-critical\nfragments externalized behind retrieval handles.",
+                "type": "string"
+              },
+              {
+                "const": "high",
+                "description": "Critical content (a preserve-classified fragment) could not be packed\n— the caller should consider retrieving it or raising the budget.",
+                "type": "string"
+              }
+            ]
+          },
+          "rule_id": {
+            "description": "The stable id of the rule that decided (e.g. `\"preserve.code_fence\"`).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "fragment_id",
+          "content_hash",
+          "action",
+          "rule_id",
+          "relevance",
+          "risk",
+          "reason"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Reinforce a recalled memory with an outcome: `success=true` if the fact was useful, `false` if it was noise. This durably updates the fact's learned confidence, which `recall` uses to re-rank future results — over repeated feedback, useful facts drift up and noise drifts down, so the memory improves with use without retraining the model. Returns the fact's new confidence in [0,1].",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "id": {
+            "description": "Id of the recalled memory to reinforce (as returned by\n`recall`/`remember`). Accepts a JSON number or a decimal string —\nrelay `id_str` to avoid float-precision loss above 2^53 (issue\n#1468).",
+            "type": "string"
+          },
+          "success": {
+            "description": "`true` if the memory was useful (reinforce it), `false` if it was noise\n(weaken it).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "success"
+        ],
+        "type": "object"
+      },
+      "name": "feedback",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "confidence": {
+            "description": "The memory's new learned confidence in `[0.0, 1.0]` after this feedback.",
+            "format": "float",
+            "type": "number"
+          },
+          "id": {
+            "description": "Id of the reinforced memory.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id_str": {
+            "description": "Decimal-string twin of `id` (issue #1468) — see\n[`RememberResult::id_str`].",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "id_str",
+          "confidence"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Permanently delete a memory by its `id` (as returned by `remember` or `recall`), removing the fact and its graph links. The deletion is durable and cannot be undone — use it to retract or correct stored knowledge. For automatic time-based expiry instead, set a TTL when calling `remember`. Returns the requested id plus `found`: `true` if a memory actually existed and was deleted, `false` if nothing was stored under that id (a stale id or a typo) — a no-op, not an error, but distinguishable from a real deletion.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "id": {
+            "description": "Id of the memory to permanently delete (as returned by `remember` or\n`recall`). Accepts a JSON number or a decimal string — relay `id_str`\nto avoid float-precision loss above 2^53 (issue #1468).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "name": "forget",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "found": {
+            "description": "Whether a memory actually existed under `id` and was deleted.\n`false` means nothing was stored there — a stale id or a typo, not a\nsecond successful deletion — so a caller can tell the two apart.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Id that was requested for deletion.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id_str": {
+            "description": "Decimal-string twin of `id` (issue #1468) — see\n[`RememberResult::id_str`].",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "id_str",
+          "found"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "List every session saved under a project via save_working_context, most-recently-saved first — so an agent can discover what is resumable before guessing a session id at load_working_context, or recover from a typo. Empty (not an error) when the project never saved anything.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "project": {
+            "description": "Project facet to list saved working-context sessions for (same\nconvention as `save_working_context`'s `project`).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "project"
+        ],
+        "type": "object"
+      },
+      "name": "list_working_contexts",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "sessions": {
+            "description": "Every session saved under this project, most-recently-saved first.\nEmpty (not an error) when the project never saved anything.",
+            "items": {
+              "description": "One session recorded in a project's working-context index (V2a-1's\n`list_working_contexts` quick win).",
+              "properties": {
+                "saved_at": {
+                  "description": "Unix seconds this session was last saved — updated on every\n`save_working_context` call under this project + session, not just\nthe first (a resave never duplicates the entry).",
+                  "format": "uint64",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "session": {
+                  "description": "The session id, as passed to `save_working_context`.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "session",
+                "saved_at"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sessions"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Resume a session: load back the working context previously saved by save_working_context under the same project + session id — the goal, constraints, verified facts, open hypotheses, decisions, exact evidence, and pending actions a PRIOR session left off with. Call this at the START of a new session before doing anything else, so work continues instead of restarting. `found: false` (with `working: null`) means nothing was ever saved under that exact project + session — not an error, but check `other_sessions`: if it lists a similarly-named session, `session` was likely a typo, not a genuinely fresh start. `other_sessions` is always filled in, on a hit too: if it lists a session that looks more like the one you meant, you may have just resumed the WRONG session. Use `list_working_contexts` to browse a project's sessions up front.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "project": {
+            "description": "Project facet the working context was saved under.",
+            "type": "string"
+          },
+          "session": {
+            "description": "Session identifier the working context was saved under.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "project",
+          "session"
+        ],
+        "type": "object"
+      },
+      "name": "load_working_context",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "found": {
+            "description": "`true` when a working context was found under this exact project +\nsession. Wire-additive alongside `working` (added V2a-1): a client\nthat only reads `working` sees no change.",
+            "type": "boolean"
+          },
+          "other_sessions": {
+            "default": [],
+            "description": "The OTHER sessions saved under this SAME project (never the requested\none) — helps recover from a typo in `session` instead of silently\nstarting fresh (e.g. `\"task-1234\"` saved, `\"task-1235\"` requested by\nmistake). Populated on a hit as well as on a miss: a typo that lands\non another real session is the case the caller can least detect on its\nown. Empty only when the project has no other session.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "working": {
+            "anyOf": [
+              {
+                "description": "The distilled working state of an agent session — small enough to carry\nacross sessions, structured enough to resume from. Persisted and reloaded\nby the memory bridge (US-002) under `type = working_context` metadata.",
+                "properties": {
+                  "active_constraints": {
+                    "default": [],
+                    "description": "Constraints currently in force (never compressed away).",
+                    "items": {
+                      "description": "One asserted fact inside a [`WorkingContext`].",
+                      "properties": {
+                        "source": {
+                          "anyOf": [
+                            {
+                              "description": "A pointer from a compiled output back to one original fragment.",
+                              "properties": {
+                                "fragment_id": {
+                                  "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string"
+                                  ]
+                                },
+                                "handle": {
+                                  "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                                  "type": "string"
+                                },
+                                "memory_id": {
+                                  "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fragment_id",
+                                "handle"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Where the fact came from, when known."
+                        },
+                        "text": {
+                          "description": "The fact text.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "decisions": {
+                    "default": [],
+                    "description": "Decisions taken so far.",
+                    "items": {
+                      "description": "A lightweight pointer to a past [`ContextDecision`].",
+                      "properties": {
+                        "fragment_id": {
+                          "description": "The fragment the decision was about. Accepts a JSON number OR a\ndecimal string on input, for the same reason as\n[`SourceReference::fragment_id`].",
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "string"
+                          ]
+                        },
+                        "rule_id": {
+                          "description": "The rule that decided.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fragment_id",
+                        "rule_id"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "exact_evidence": {
+                    "default": [],
+                    "description": "Exact evidence the session relies on (verbatim, addressable).",
+                    "items": {
+                      "description": "A pointer from a compiled output back to one original fragment.",
+                      "properties": {
+                        "fragment_id": {
+                          "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "string"
+                          ]
+                        },
+                        "handle": {
+                          "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                          "type": "string"
+                        },
+                        "memory_id": {
+                          "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                          "minimum": 0,
+                          "type": [
+                            "integer",
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "fragment_id",
+                        "handle"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "goal": {
+                    "description": "What the session is trying to achieve.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "open_hypotheses": {
+                    "default": [],
+                    "description": "Hypotheses still open.",
+                    "items": {
+                      "description": "One asserted fact inside a [`WorkingContext`].",
+                      "properties": {
+                        "source": {
+                          "anyOf": [
+                            {
+                              "description": "A pointer from a compiled output back to one original fragment.",
+                              "properties": {
+                                "fragment_id": {
+                                  "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string"
+                                  ]
+                                },
+                                "handle": {
+                                  "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                                  "type": "string"
+                                },
+                                "memory_id": {
+                                  "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fragment_id",
+                                "handle"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Where the fact came from, when known."
+                        },
+                        "text": {
+                          "description": "The fact text.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "pending_actions": {
+                    "default": [],
+                    "description": "Actions still to do.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "verified_facts": {
+                    "default": [],
+                    "description": "Facts that were verified, with their sources.",
+                    "items": {
+                      "description": "One asserted fact inside a [`WorkingContext`].",
+                      "properties": {
+                        "source": {
+                          "anyOf": [
+                            {
+                              "description": "A pointer from a compiled output back to one original fragment.",
+                              "properties": {
+                                "fragment_id": {
+                                  "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string"
+                                  ]
+                                },
+                                "handle": {
+                                  "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                                  "type": "string"
+                                },
+                                "memory_id": {
+                                  "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                                  "minimum": 0,
+                                  "type": [
+                                    "integer",
+                                    "string",
+                                    "null"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fragment_id",
+                                "handle"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ],
+                          "description": "Where the fact came from, when known."
+                        },
+                        "text": {
+                          "description": "The fact text.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "text"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The previously saved working context, or `null` when nothing was ever\nsaved under that project + session (a fresh start, not an error)."
+          }
+        },
+        "required": [
+          "found"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "filter": {
+            "additionalProperties": true,
+            "description": "Optional exact-match metadata filter (e.g.\n`{\"project\": \"veles\", \"status\": \"resolved\"}`).",
+            "type": "object"
+          },
+          "limit": {
+            "description": "Maximum number of memories to return (default 10).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "description": "Natural-language query to match semantically.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "recall",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "memories": {
+            "description": "Recalled memories, most similar first.",
+            "items": {
+              "description": "Wire shape of one recalled memory: [`Recollection`] plus the `id_str`\ntwin (issue #1468). Built via `From<Recollection>` at the serialization\nboundary so the domain type itself stays untouched.",
+              "properties": {
+                "content": {
+                  "description": "Stored fact content.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Stable id of the memory.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id_str": {
+                  "description": "Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/\n`feedback`, never `id` itself: a u64 above 2^53 loses precision\nthrough a float-lossy JSON client (issue #1468). Additive: `id` is\nunchanged and stays present for 0.9.x callers.",
+                  "type": "string"
+                },
+                "metadata": {
+                  "additionalProperties": true,
+                  "description": "Caller-supplied structured metadata stored with the fact, reserved\nsystem keys excluded — the exact field [`Recollection::metadata`]\ncarries, forwarded unchanged.",
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "score": {
+                  "description": "Similarity score (higher is closer).",
+                  "format": "float",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "id_str",
+                "score",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "memories"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Fused vector + graph recall: like `recall`, but also walks the graph from the top vector hit and folds any connected fact into the ranking — the tri-engine ranking (vector similarity + ColumnStore filter + graph reach) measured on multi-hop and temporal benchmarks. Reach for this when an answer needs a fact the query doesn't mention directly but a stored `relate`/extracted link connects (multi-hop reasoning, temporal chains). `hops`/`graph_boost` tune the graph reach and `pool` the depth of the vector candidate pool fusion re-ranks; omit them for the proven defaults. Optionally narrow with an exact-match `filter`. Set `date_field` (the metadata key holding a YYYYMMDD date) to also get a `dated_context` timeline and a `now` anchor for temporal questions. Most relevant first.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "date_field": {
+            "description": "Name of the metadata field holding each fact's date as a `YYYYMMDD`\ninteger (e.g. `\"ts\"`, `\"occurred_at\"`). When set, the result adds a\n`dated_context` timeline (facts date-prefixed and ordered oldest-first)\nplus a `now` anchor — the representation that lifts temporal reasoning.\nOmit for plain results.",
+            "type": "string"
+          },
+          "filter": {
+            "additionalProperties": true,
+            "description": "Optional exact-match metadata filter (e.g.\n`{\"project\": \"veles\", \"status\": \"resolved\"}`).",
+            "type": "object"
+          },
+          "graph_boost": {
+            "description": "Weight added to a graph-reached fact's normalised vector score\n(default 0.15). Raise to trust the graph more, lower to trust vector\nsimilarity more.",
+            "format": "double",
+            "type": "number"
+          },
+          "hops": {
+            "description": "Graph hops walked from the top vector hit (default 2). Higher reaches\nfurther but adds noise; capped at the `why` hop ceiling.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "limit": {
+            "description": "Maximum number of memories to return (default 10). Multi-hop reasoning\nbenefits from a larger budget (~32-64); simple and temporal recall\nsaturate early, where a larger budget only adds tokens.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pool": {
+            "description": "Depth of the oversampled vector candidate pool fusion re-ranks before\nthe `limit` cutoff (default: `limit` scaled up, floored at 64). That\ndefault is already deep enough for a graph-reached fact to surface;\nwiden it to give a reranker more to work with, narrow it to confine\nfusion to the strongest vector hits. Capped at 1000, the same ceiling\n`limit` carries — NOT the one `hops` carries, which is 10.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "description": "Natural-language query to match semantically.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "recall_fused",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "dated_context": {
+            "description": "Chronological, date-prefixed rendering of `memories` (`- [YYYY-MM-DD]\ncontent` per line, oldest first, undated facts last). Present only when\n`date_field` was set.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "memories": {
+            "description": "Recalled memories, most relevant first.",
+            "items": {
+              "description": "Wire shape of one recalled memory: [`Recollection`] plus the `id_str`\ntwin (issue #1468). Built via `From<Recollection>` at the serialization\nboundary so the domain type itself stays untouched.",
+              "properties": {
+                "content": {
+                  "description": "Stored fact content.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Stable id of the memory.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id_str": {
+                  "description": "Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/\n`feedback`, never `id` itself: a u64 above 2^53 loses precision\nthrough a float-lossy JSON client (issue #1468). Additive: `id` is\nunchanged and stays present for 0.9.x callers.",
+                  "type": "string"
+                },
+                "metadata": {
+                  "additionalProperties": true,
+                  "description": "Caller-supplied structured metadata stored with the fact, reserved\nsystem keys excluded — the exact field [`Recollection::metadata`]\ncarries, forwarded unchanged.",
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "score": {
+                  "description": "Similarity score (higher is closer).",
+                  "format": "float",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "id_str",
+                "score",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "now": {
+            "description": "The most recent date across `memories` (`YYYY-MM-DD`), the \"now\" anchor.\nPresent only when `date_field` was set and at least one fact is dated.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "memories"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Fused recall: semantically similar memories (vector) constrained by structured ColumnStore predicates over metadata — ranges and comparisons, not just equality. Each filter is {field, op (eq/ne/lt/le/gt/ge), value}, ANDed. Use for time-windowed or numeric-scoped recall, e.g. facts about a topic with `ts` in a date range. Comparisons are TYPE-STRICT, with no runtime coercion: a filter value of 20230601 (a JSON number) never matches a fact stored with metadata {\"ts\": \"20230601\"} (a JSON string) — same value, different JSON type, no match, no error. Store comparable values like dates NUMERICALLY at `remember` time (e.g. 20230601, not \"20230601\") so `recall_where` filters actually match them. Most similar first.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "filters": {
+            "description": "Structured `ColumnStore` predicates (ranges/comparisons) combined with AND,\ne.g. a date window `[{\"field\":\"ts\",\"op\":\"ge\",\"value\":20230101},\n{\"field\":\"ts\",\"op\":\"le\",\"value\":20231231}]`. Each `op` is one of\n`eq`/`ne`/`lt`/`le`/`gt`/`ge`. **Type-strict, no coercion** (issue\n#1473): `value` is compared to the stored metadata's JSON type\nas-is — a numeric `20230101` never matches a fact stored with\n`{\"ts\": \"20230101\"}` (a string). Store comparable values (dates,\ncounters) NUMERICALLY at `remember` time so these filters match them.",
+            "items": {
+              "description": "A structured predicate over a memory's metadata column, for the fused\nvector+`ColumnStore` recall\n[`MemoryService::recall_where`](crate::service::MemoryService::recall_where).\nUnlike the exact-match filter on\n[`MemoryService::recall`](crate::service::MemoryService::recall), this supports\nranges and comparisons (e.g. `timestamp >= …`), so temporal and numeric facets\nbecome queryable, not just equal-matchable.",
+              "properties": {
+                "field": {
+                  "description": "Metadata field name (alphanumeric/underscore).",
+                  "type": "string"
+                },
+                "op": {
+                  "description": "Comparison operator.\n- \"eq\": `=`\n- \"ne\": `!=`\n- \"lt\": `<`\n- \"le\": `<=`\n- \"gt\": `>`\n- \"ge\": `>=`",
+                  "enum": [
+                    "eq",
+                    "ne",
+                    "lt",
+                    "le",
+                    "gt",
+                    "ge"
+                  ],
+                  "type": "string"
+                },
+                "value": {
+                  "description": "Value to compare against.\n\nThe comparison is TYPE-STRICT with no coercion, so the JSON type sent\nhere is part of the query: `20260601` (number) never matches a fact\nstored as `\"20260601\"` (string) — same value, no match, and **no\nerror**. A wrong type here is therefore the one mistake this API\ncannot report; it just returns nothing.\n\nWhich is why the advertised type is spelled out rather than left as\nthe empty schema `serde_json::Value` would produce. `{}` says \"send\nanything\", on the single field where sending the wrong thing fails\nsilently.",
+                  "type": [
+                    "number",
+                    "string",
+                    "boolean"
+                  ]
+                }
+              },
+              "required": [
+                "field",
+                "op",
+                "value"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "limit": {
+            "description": "Maximum number of memories to return (default 10).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "query": {
+            "description": "Natural-language query to match semantically.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "name": "recall_where",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "memories": {
+            "description": "Recalled memories, most similar first.",
+            "items": {
+              "description": "Wire shape of one recalled memory: [`Recollection`] plus the `id_str`\ntwin (issue #1468). Built via `From<Recollection>` at the serialization\nboundary so the domain type itself stays untouched.",
+              "properties": {
+                "content": {
+                  "description": "Stored fact content.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Stable id of the memory.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id_str": {
+                  "description": "Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/\n`feedback`, never `id` itself: a u64 above 2^53 loses precision\nthrough a float-lossy JSON client (issue #1468). Additive: `id` is\nunchanged and stays present for 0.9.x callers.",
+                  "type": "string"
+                },
+                "metadata": {
+                  "additionalProperties": true,
+                  "description": "Caller-supplied structured metadata stored with the fact, reserved\nsystem keys excluded — the exact field [`Recollection::metadata`]\ncarries, forwarded unchanged.",
+                  "type": [
+                    "object",
+                    "null"
+                  ]
+                },
+                "score": {
+                  "description": "Similarity score (higher is closer).",
+                  "format": "float",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "id_str",
+                "score",
+                "content"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "memories"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Create a typed, directional link between two memories (`from` → `to`) labeled by `relation`. These links are the graph edges that `why` and `recall_fused` later traverse to surface connected facts that share no words with the query — build the graph with `relate` so multi-hop reasoning works (e.g. link a decision to its cause, a fact to its source, a task to the person it concerns). Direction matters: traversal follows OUTGOING edges only, so point `from` at the memory you will later ask `why` about and `to` at its evidence (decision → cause, fact → source) — an edge pointing INTO a memory is invisible to `why(that memory)`. Idempotent per (from, relation, to); `from` and `to` must be DIFFERENT memories — a self-loop states nothing and only adds noise to `why`'s evidence trail, so it is refused. Returns the new edge id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "from": {
+            "description": "Source memory id — the link points FROM here (as returned by\n`remember`/`recall`). Accepts a JSON number or a decimal string:\nalways relay a previous response's `id_str` here — a plain JSON\nnumber above 2^53 loses precision on a float-lossy client (issue\n#1468).",
+            "type": "string"
+          },
+          "relation": {
+            "description": "Directional relationship label, read as `from` <relation> `to`.\nExamples: `caused_by`, `depends_on`, `authored_by`, `supersedes`.",
+            "type": "string"
+          },
+          "to": {
+            "description": "Target memory id — the link points TO here (as returned by\n`remember`/`recall`). Same string-or-number contract as `from`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "relation"
+        ],
+        "type": "object"
+      },
+      "name": "relate",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "edge_id": {
+            "description": "Id of the created edge.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "edge_id_str": {
+            "description": "Decimal-string twin of `edge_id` (issue #1468) — see\n[`RememberResult::id_str`].",
+            "type": "string"
+          }
+        },
+        "required": [
+          "edge_id",
+          "edge_id_str"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Store a fact in durable local memory. Optionally link it to existing memories (graph) and tag it with structured metadata like project/author/type/status/date (ColumnStore) for later filtering — metadata is capped at 64 KiB serialized. A fact is capped at 2048 bytes: that is roughly what the embedding model's context window holds, and a longer one is REFUSED with its size, not silently mangled — split a long passage into several atomic facts, or compile it with `compile_context` and remember a summary. Set `ttl_seconds` to make the fact expire after a delay (a durable TTL that survives restarts); omit it for a permanent memory — `ttl_seconds: 0` is refused, not read as \"never\". Returns the fact's stable id. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "fact": {
+            "description": "The fact to store in memory.",
+            "type": "string"
+          },
+          "links": {
+            "description": "Optional typed links from this fact to existing memories.",
+            "items": {
+              "description": "A typed link from a freshly remembered fact to an existing memory.",
+              "properties": {
+                "relation": {
+                  "description": "Relationship label (e.g. `\"decided_in\"`, `\"references\"`, `\"depends_on\"`).",
+                  "type": "string"
+                },
+                "target": {
+                  "description": "Id of the memory being linked to. Accepts a JSON number or a decimal\nstring — ids can exceed 2^53, where float-lossy JSON clients (JS\n`number`) round a plain integer, so a caller relaying an `id_str`\nvalue straight from a previous response must be able to resubmit it\nas-is (see issue #1468).",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target",
+                "relation"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Optional structured metadata for later filtering (e.g.\n`{\"project\": \"veles\", \"author\": \"julien\", \"status\": \"open\"}`).",
+            "type": "object"
+          },
+          "ttl_seconds": {
+            "description": "Optional time-to-live in seconds. When set, the fact expires (and stops\nbeing recalled) after this many seconds — a durable TTL that survives a\nrestart. Omit for a permanent memory. Falls back to the server's\n`VELESDB_MEMORY_DEFAULT_TTL` when unset.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "fact"
+        ],
+        "type": "object"
+      },
+      "name": "remember",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "id": {
+            "description": "Stable id assigned to the remembered fact.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id_str": {
+            "description": "Decimal-string twin of `id` — always relay THIS to `relate`/`forget`/\n`feedback`, never `id` itself: a u64 above 2^53 loses precision\nthrough a float-lossy JSON client (issue #1468). Additive: `id` is\nunchanged, so 0.9.x callers are unaffected.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "id_str"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns the stored facts' ids.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Optional structured metadata applied to every extracted fact.",
+            "type": "object"
+          },
+          "text": {
+            "description": "Raw text to extract atomic facts from and store as a connected graph.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "name": "remember_extracted",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "ids": {
+            "description": "Stable ids of the stored facts, in extraction order.",
+            "items": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "ids_str": {
+            "description": "Decimal-string twins of `ids`, same order (issue #1468) — see\n[`RememberResult::id_str`].",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skipped_over_cap": {
+            "description": "Extracted facts DROPPED for exceeding the embeddable text cap\n(2048 bytes). Additive and always present: a skip the caller cannot\nsee is indistinguishable from the model extracting fewer facts, and\nthis tool exists precisely so the caller does not have to verify what\nit stored.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ids",
+          "ids_str",
+          "skipped_over_cap"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Fetch back the exact original content behind a ctx://source/<hash> handle from a compiled context — what compile_context externalized or partially packed is recoverable, not lost.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "handle": {
+            "description": "A `ctx://source/<hash>` handle from a compiled context.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "handle"
+        ],
+        "type": "object"
+      },
+      "name": "retrieve_context_source",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "content": {
+            "description": "The original fragment content, byte for byte.",
+            "type": "string"
+          },
+          "handle": {
+            "description": "The handle that was resolved.",
+            "type": "string"
+          },
+          "media": {
+            "anyOf": [
+              {
+                "description": "Inline media payload attached to a [`ContextFragment`] (US-009, PR1:\nscreenshots/images only). `ContextFragment::content` stays the\ntext/caption — often empty for a bare screenshot — while the pixels live\nhere, base64-encoded so the JSON wire never needs a binary frame.\n\nThe fragment packs atomically (see [`super::pieces`] in the compiler)\nand its token cost comes from [`super::estimator::ImageTokenEstimator`].\nA media fragment that cannot fit the budget is externalized behind a\n`ctx://source` handle exactly like text (US-009, PR2: the memory bridge\npersists the bytes behind it — see\n[`crate::MemoryService::retrieve_context_source`]); the memoryless core\ncompiler mints the same handle either way, since it never knows whether\na resolver is attached. See the crate README's \"media fragments\"\nsection.",
+                "properties": {
+                  "bytes_b64": {
+                    "description": "The raw media bytes, base64-encoded (standard alphabet, padded).\nCapped at [`crate::limits::MAX_MEDIA_BYTES`] and validated for\nwell-formedness at compile time — a request carrying an oversized or\nmalformed payload is rejected before any other work.",
+                    "type": "string"
+                  },
+                  "mime": {
+                    "description": "Declared MIME type (e.g. `\"image/png\"`, `\"image/jpeg\"`). Only PNG and\nJPEG headers are sniffed for dimensions; any other value (or an\nunreadable header) falls back to a deterministic, safe over-count\n(see [`super::estimator::ImageTokenEstimator`]) — never rejected for\nan unrecognized mime alone.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "mime",
+                  "bytes_b64"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The original media payload, when the fragment carried one (US-009,\nPR2). Absent for every text-only source — the exact pre-PR2 shape."
+          }
+        },
+        "required": [
+          "handle",
+          "content"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Persist this session's distilled working state (goal, active constraints, verified facts, open hypotheses, decisions, exact evidence, pending actions) under a project + session id — so a LATER session (a fresh agent run, a new conversation, a resumed process) can pick up exactly where this one left off instead of re-deriving context from scratch. Call this near the end of a session, or whenever the working state changes meaningfully. Saving again under the same project+session replaces the previous state (idempotent upsert) — so an entirely empty `working` is REFUSED rather than allowed to wipe what a previous save stored; fill at least one field. Serialized size is capped at 1 MiB. Returns the stored fact's id.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "project": {
+            "description": "Project facet this working context belongs to (matches `remember`'s\n`project` metadata convention).",
+            "type": "string"
+          },
+          "session": {
+            "description": "Session identifier — pick something stable for the agent run you want\nto resume later (e.g. a conversation id).",
+            "type": "string"
+          },
+          "working": {
+            "description": "The distilled state to persist: goal, active constraints, verified\nfacts, open hypotheses, decisions taken, exact evidence, and pending\nactions.",
+            "properties": {
+              "active_constraints": {
+                "default": [],
+                "description": "Constraints currently in force (never compressed away).",
+                "items": {
+                  "description": "One asserted fact inside a [`WorkingContext`].",
+                  "properties": {
+                    "source": {
+                      "description": "Where the fact came from, when known.",
+                      "properties": {
+                        "fragment_id": {
+                          "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                          "type": "string"
+                        },
+                        "handle": {
+                          "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                          "type": "string"
+                        },
+                        "memory_id": {
+                          "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fragment_id",
+                        "handle"
+                      ],
+                      "type": "object"
+                    },
+                    "text": {
+                      "description": "The fact text.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "decisions": {
+                "default": [],
+                "description": "Decisions taken so far.",
+                "items": {
+                  "description": "A lightweight pointer to a past [`ContextDecision`].",
+                  "properties": {
+                    "fragment_id": {
+                      "description": "The fragment the decision was about. Accepts a JSON number OR a\ndecimal string on input, for the same reason as\n[`SourceReference::fragment_id`].",
+                      "type": "string"
+                    },
+                    "rule_id": {
+                      "description": "The rule that decided.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "fragment_id",
+                    "rule_id"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "exact_evidence": {
+                "default": [],
+                "description": "Exact evidence the session relies on (verbatim, addressable).",
+                "items": {
+                  "description": "A pointer from a compiled output back to one original fragment.",
+                  "properties": {
+                    "fragment_id": {
+                      "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                      "type": "string"
+                    },
+                    "handle": {
+                      "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                      "type": "string"
+                    },
+                    "memory_id": {
+                      "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "fragment_id",
+                    "handle"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "goal": {
+                "description": "What the session is trying to achieve.",
+                "type": "string"
+              },
+              "open_hypotheses": {
+                "default": [],
+                "description": "Hypotheses still open.",
+                "items": {
+                  "description": "One asserted fact inside a [`WorkingContext`].",
+                  "properties": {
+                    "source": {
+                      "description": "Where the fact came from, when known.",
+                      "properties": {
+                        "fragment_id": {
+                          "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                          "type": "string"
+                        },
+                        "handle": {
+                          "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                          "type": "string"
+                        },
+                        "memory_id": {
+                          "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fragment_id",
+                        "handle"
+                      ],
+                      "type": "object"
+                    },
+                    "text": {
+                      "description": "The fact text.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "pending_actions": {
+                "default": [],
+                "description": "Actions still to do.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "verified_facts": {
+                "default": [],
+                "description": "Facts that were verified, with their sources.",
+                "items": {
+                  "description": "One asserted fact inside a [`WorkingContext`].",
+                  "properties": {
+                    "source": {
+                      "description": "Where the fact came from, when known.",
+                      "properties": {
+                        "fragment_id": {
+                          "description": "The fragment this source refers to. Accepts a JSON number OR a\ndecimal string on input: a `fragment_id` is an FNV-1a 64 content hash\n(see [`ContextDecision::content_hash`]), so it is almost always above\n2^53 — a float-lossy JSON client that reads one back from a compiled\ncontext and resubmits it inside a working context would otherwise\ncorrupt it silently. Same accepted-forms rule as issue #1468's ids;\nthe serialized (output) shape is unchanged.",
+                          "type": "string"
+                        },
+                        "handle": {
+                          "description": "Recoverable address of the original content (`ctx://source/<id>`).",
+                          "type": "string"
+                        },
+                        "memory_id": {
+                          "description": "The memory backing this source, when it came from recall (US-002).\nAccepts a JSON number OR a decimal string on input, exactly like\n`fragment_id` just above.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fragment_id",
+                        "handle"
+                      ],
+                      "type": "object"
+                    },
+                    "text": {
+                      "description": "The fact text.",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "text"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "project",
+          "session",
+          "working"
+        ],
+        "type": "object"
+      },
+      "name": "save_working_context",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "id": {
+            "description": "Id of the stored system fact backing this working context.",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "id_str": {
+            "description": "Decimal-string twin of `id`, same contract as\n[`crate::mcp::dto::RememberResult::id_str`]: the id is content-addressed\n(FNV-1a 64), so it is past 2^53 and a float-lossy JSON client rounds\n`id` on arrival. This was the ONE tool handing back an id without its\ntwin while `forget`/`feedback` accept only the decimal string — the\ncaller had no way to build the form the schema demands.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "id_str"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Suggest a starting token_budget for compile_context, for a named target model — looked up in a static, committed model-name to context-window table (dated \"as of\", NEVER a network call). Pass `reserve_tokens` (default 0) to reserve room for the response, mirroring compile_context's own `policy.response_reserve_tokens`. `window`/`suggested_budget` come back null when the model is not in the table — an honest \"unknown\", never a guess; extend the table in a new release instead of relying on this for an unlisted model.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "reserve_tokens": {
+            "description": "Tokens to reserve for the response, subtracted from the model's\nwindow (default `0`) — mirrors\n[`CompilePolicy::response_reserve_tokens`].",
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "target_model": {
+            "description": "The model name to look up in the static window table (e.g.\n`\"claude-sonnet-4-5\"`). Matched case-insensitively.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_model"
+        ],
+        "type": "object"
+      },
+      "name": "suggest_budget",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "source": {
+            "description": "Always the static table's provenance, dated — never \"measured\" or\n\"fetched\": this is a committed snapshot, not a live lookup.",
+            "type": "string"
+          },
+          "suggested_budget": {
+            "description": "`window - reserve_tokens` (saturating at 0) — `None` when `window`\nis `None`. Mirrors the role of\n[`CompilePolicy::response_reserve_tokens`](super::CompilePolicy::response_reserve_tokens)\non `compile_context`'s own budget.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "window": {
+            "description": "The model's context window, in tokens — `None` when `target_model`\nis not in the static table.",
+            "format": "uint64",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Remove the typed link `from` -relation-> `to` — `relate`'s exact undo, so a mistaken edge no longer costs the facts at its endpoints. Only the edge is removed: the two memories, and any entity, are untouched. Idempotent: removing an absent edge answers `found: false` instead of erroring, so a cleanup can be replayed safely; `removed` counts the edges actually deleted. It refuses exactly what `relate` refuses (empty relation, `from` == `to`). Scope: the store does not distinguish a link you created with `relate` from one auto-derived from a passage, so `unrelate` removes both alike — to correct an auto-derived link, prefer `forget` + `remember` of the source fact, otherwise remembering the same passage again can rebuild the edge removed here. Same id wire contract as `relate`: pass ids as decimal strings (`id_str`) — a JSON-number id above 2^53 loses precision on float-lossy clients.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "from": {
+            "description": "Source memory id of the link to remove — the side it points FROM.\nAccepts a JSON number or a decimal string: always relay a previous\nresponse's `id_str` here (issue #1468).",
+            "type": "string"
+          },
+          "relation": {
+            "description": "Directional relationship label of the link to remove, exactly as it\nwas given to `relate`.",
+            "type": "string"
+          },
+          "to": {
+            "description": "Target memory id of the link to remove — the side it points TO. Same\nstring-or-number contract as `from`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to",
+          "relation"
+        ],
+        "type": "object"
+      },
+      "name": "unrelate",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "found": {
+            "description": "Whether at least one matching edge existed and was removed. `false`\nmeans no such edge — a replayed cleanup or a typo, not an error.",
+            "type": "boolean"
+          },
+          "removed": {
+            "description": "How many matching edges were removed.",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "found",
+          "removed"
+        ],
+        "type": "object"
+      }
+    },
+    {
+      "description": "Explain a decision: find the best-matching memory (optionally scoped by a metadata `filter`, e.g. the current project) and return the connected subgraph of related memories reachable through typed links — fusing vector, ColumnStore, and graph to surface context a plain similarity search misses.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "decision": {
+            "description": "The decision (or fact) to explain.",
+            "type": "string"
+          },
+          "filter": {
+            "additionalProperties": true,
+            "description": "Optional exact-match metadata filter to scope the seed (e.g.\n`{\"project\": \"veles\"}`).",
+            "type": "object"
+          },
+          "max_hops": {
+            "description": "How many hops of typed links to follow (default 2).",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "type": "object"
+      },
+      "name": "why",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "edges": {
+            "description": "Typed edges connecting the nodes.",
+            "items": {
+              "description": "Wire shape of one edge in a `why` subgraph: [`MemoryEdge`] plus the\n`from_str`/`to_str` twins (issue #1468).",
+              "properties": {
+                "from": {
+                  "description": "Source memory id.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "from_str": {
+                  "description": "Decimal-string twin of `from` (issue #1468) — see\n[`RecollectionDto::id_str`].",
+                  "type": "string"
+                },
+                "relation": {
+                  "description": "Relationship label.",
+                  "type": "string"
+                },
+                "to": {
+                  "description": "Target memory id.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "to_str": {
+                  "description": "Decimal-string twin of `to` (issue #1468) — see\n[`RecollectionDto::id_str`].",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "from",
+                "from_str",
+                "to",
+                "to_str",
+                "relation"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "nodes": {
+            "description": "Memories in the subgraph, seed first.",
+            "items": {
+              "description": "Wire shape of one node in a `why` subgraph: [`MemoryNode`] plus the\n`id_str` twin (issue #1468).",
+              "properties": {
+                "content": {
+                  "description": "Stored fact content.",
+                  "type": "string"
+                },
+                "hop": {
+                  "description": "Distance in hops from the seed memory (the seed is hop `0`).",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id": {
+                  "description": "Stable id of the memory.",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "id_str": {
+                  "description": "Decimal-string twin of `id` (issue #1468) — see\n[`RecollectionDto::id_str`].",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "id_str",
+                "content",
+                "hop"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "nodes",
+          "edges"
+        ],
+        "type": "object"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Le probleme, et pourquoi il revenait

Quatre fois, un defaut de schema MCP a ete diagnostique en lisant le schema **tel qu'un harnais client le rendait**, et non tel que le serveur l'emettait. Deux de ces diagnostics etaient faux — `mcp_schema_bdd.rs` porte deja la retractation de l'un d'eux dans ses propres commentaires.

La cause racine n'etait aucun bug de schema. C'etait que **le fil n'avait aucune representation qu'on puisse designer** : la verite n'existait qu'a l'interieur d'une execution de test, donc chaque campagne devait la re-deduire, et pouvait la re-deduire faux.

`docs/reference/mcp-tools.json` donne un corps au fil. Capture JSON-RPC brute des 20 outils depuis le serveur vivant, sans bibliotheque cliente entre les octets et l'assertion. Meme patron que `openapi-drift` pour la surface REST : on regenere depuis le code, on compare a ce qui est versionne, on echoue sur la derive.

Ce que cet artefact prouve immediatement :

| Slot | Rendu par le client | Emis par le serveur |
|---|---|---|
| `save_working_context.required` | `["working"]` | `["project","session","working"]` |
| `feedback.id` | `{}` | `type: ["integer","string"]` |
| `working.goal` | `{}` | `type: ["string","null"]` |
| `$schema` | `draft-07` | `draft/2020-12` |

Le serveur n'a jamais eu tort. Le harnais aplatit toute union en `{}`. On ne peut pas corriger les harnais — donc on n'emet plus d'union sur une **entree**, et il n'y a plus rien a aplatir.

## Ce qui change

- **Entree scalarisee.** `scalarize_slot_types` effondre les unions d'entree, et seulement quand la branche promue porte deja un type direct — un `$ref` laisse par le garde de cycle ne doit jamais devenir un slot orphelin. Il reste **exactement une** union d'entree, declaree avec sa raison : `recall_where.filters[].value`, dont la comparaison ColumnStore est type-stricte sans coercition.
- **Sortie jamais touchee.** Les SDK MCP valident `structuredContent` contre l'`outputSchema` : une union nullable y est legitime, et **66 y survivent**. `reharden_tool_input` ne prend plus le schema de sortie en parametre, et deux gardes verifient la regle.
- **Point de passage unique.** `combined_router()` reecrit chaque route et valide la post-condition sur place. **10 outils sur 20 n'avaient aucun `input_schema` declare** : un durcissement par-outil laissait toute route future non protegee.
- **Les ids d'entree annoncent `string`**, le serveur reste tolerant. On change ce que le client **lit**, jamais ce qu'il peut **envoyer**.
- **Le garde exige un type scalaire unique**, et les exemptions portent une raison ecrite et **perissent** si elles ne correspondent plus a rien.

## Defauts trouves par ces gardes, pas par une relecture

- `explain_compilation.fragment_id` etait un `u64` **strict** : il refusait la chaine decimale qu'un client float-lossy doit relayer au-dessus de 2^53. Reproduit — `invalid type: string "9007199254740993", expected u64`.
- `SourceReference.memory_id` etait emis en chaine et refuse en entree.
- `load_working_context` rendait des ids que `save_working_context` n'acceptait plus. Le test de round-trip **epinglait** le defaut : il asserait `as_u64()` et appelait cela un aller-retour survecu.
- `policy.pricing.models` publiait un `$ref` irresolvable derriere `additionalProperties`, que la marche generique traversait sans inliner.
- `save_working_context` rendait le seul id sans son jumeau `_str`.

La regle d'ensemble des ids n'est plus une liste ecrite a la main : elle se **derive des schemas de sortie**, ou `widen_id_properties` designe deja les champs concernes.

## Verification

Chaque garde ajoute a ete **vu refuser** avant d'etre declare utile — injection deliberee, puis retrait. `cargo test -p velesdb-memory` : 27 suites, 0 echec. `clippy --all-targets -D warnings` et `fmt --check` : propres. Boucle d'isolation par feature avec cible neuve : verte. `lizard -C 8 -a 8` sur les fichiers de production touches : 0 warning.

## Dette ouverte, pas enfouie

- #1685 — la liste des cles d'id est encore declaree deux fois, separee par un feature gate. Meme famille que ce qui est corrige ici, hors perimetre.
- #1686 — `mcp::wire::lenient` rend intestable la moitie negative du contrat de type.