### PR TITLE
refactor(memory): declarer WIRE_ID_KEYS une seule fois, context::wire la reexporte

### DIFF
--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -19,7 +19,14 @@ use serde_json::Value;
 /// Object keys whose `u64` values (or arrays of them) must cross to JS as
 /// decimal strings. Token counts stay numbers: they are bounded far below
 /// 2^53 by the budget caps.
-pub const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+///
+/// Re-exported from [`crate::schema::WIRE_ID_KEYS`] rather than redeclared
+/// (#1685): the two used to be independent constants with identical
+/// contents, so a future id field added to one could silently miss the
+/// other. `schema.rs` holds the single declaration because it compiles
+/// unconditionally, while this module only compiles under the `context`
+/// feature.
+pub use crate::schema::WIRE_ID_KEYS as ID_KEYS;
 
 /// Recursively rewrite every [`ID_KEYS`] field of a serialized `context`
 /// wire value into its decimal-string form.

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -441,13 +441,20 @@ fn is_rust_int_format(format: &str) -> bool {
 mod tests;
 
 /// Les champs d'id qui traversent le fil sous forme entiere OU chaine
-/// decimale. Definis ici et non dans `context::wire` : `schema.rs` est gate
-/// sur `mcp`, alors que `context::wire` l'est sur `context` — et les outils
-/// de `mcp.rs` en ont besoin meme quand `context` est absente, ce qui est le
-/// cas de `--features http`.
-#[cfg(feature = "mcp")]
-pub(crate) const WIRE_ID_KEYS: &[&str] =
-    &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+/// decimale.
+///
+/// Seule declaration (#1685) : [`crate::context::wire::ID_KEYS`] la
+/// reexporte telle quelle plutot que de la redeclarer. Vit ici et non dans
+/// `context::wire` parce que `schema.rs` n'est jamais gate par une feature
+/// (voir `mod schema;` dans `lib.rs`), alors que le module `context` entier
+/// l'est sur `context` — et les outils de `mcp.rs` en ont besoin meme quand
+/// `context` est absente, ce qui est le cas de `--features http`. Gatee sur
+/// `any(mcp, context)` et non laissee inconditionnelle : un build
+/// `--features persistence` seule (verifie en isolation par la CI, voir
+/// `ci.yml`) n'a besoin d'aucune des deux, et `-D warnings` transformerait
+/// la constante alors inutilisee en echec de build.
+#[cfg(any(feature = "mcp", feature = "context"))]
+pub const WIRE_ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
 
 /// Le schema de sortie ANNONCE d'un outil : ids elargis, puis `$ref` inlines
 /// et `$defs` inatteignables elagues.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

This branch name (`claude/funny-fermat-sb9i0r`) is assigned by the scheduled-task harness that produced this PR and does not match the `PR Governance` workflow's allowed prefixes (`fix/*`, `refactor/*`, …); the commit is also authored under the harness's Claude identity, which the same workflow's "Reject AI-attributed commits" check explicitly forbids. Both checks exist to force a human re-authoring step before merge, so I have **not** tried to rename the branch or spoof a different author identity to route around them — that decision belongs to a maintainer. **Before merging**, please cherry-pick the single commit below onto a `refactor/*` branch and re-author it as yourself, or otherwise satisfy those two governance checks. The code change itself is independently verified (see below) and ready for review.

## Description

Closes #1685. `context::wire::ID_KEYS` and `schema::WIRE_ID_KEYS` were two independent constants with identical contents (`["fragment_id", "content_hash", "memory_id", "fragment_ids"]`), kept apart by a feature-gate mismatch (`schema.rs` gated on `mcp`, `context::wire` gated on `context`) that the code's own comment said prevented one from referencing the other. Nothing compared them, so a future id field added to one could silently diverge from the other while each stayed internally consistent — the exact class of bug the sibling PR #1687 fixed for the per-tool id-key lists (deriving them from output schemas instead of hand-written lists).

**Fix:** `schema.rs`'s `mod schema;` declaration in `lib.rs` is never itself feature-gated (only individual items inside it are), so it can hold the single declaration. `WIRE_ID_KEYS` there is now `pub` (was `pub(crate)`) and gated on `#[cfg(any(feature = "mcp", feature = "context"))]` — needed by both consumers, absent (so no `dead_code` under `-D warnings`) when neither is active, which the CI's per-feature isolation loop (`--features persistence` alone, etc.) already exercises. `context::wire::ID_KEYS` becomes `pub use crate::schema::WIRE_ID_KEYS as ID_KEYS;` — same public path, so the existing intra-doc links in `velesdb-node`/`velesdb-wasm` (`velesdb_memory::context::wire::ID_KEYS`) keep resolving unchanged.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Ran locally (not yet through this repo's CI, given the governance caveat above):
- Each of `velesdb-memory`'s six features in isolation (`mcp`, `http`, `context`, `persistence`, `ollama`, `extract,ollama`) via `cargo check --no-default-features --features <feat>`
- `RUSTFLAGS="-Dwarnings" cargo check -p velesdb-memory --no-default-features --features persistence` — confirms no `dead_code` regression on the exact combination that motivated the `any(mcp, context)` gate
- `cargo test -p velesdb-memory` (default features) and `cargo test -p velesdb-memory --features extract,ollama,persistence` — all green, including `tests/mcp_schema_bdd.rs`
- `cargo clippy -p velesdb-memory --all-targets -- -D warnings -D clippy::pedantic` (mirrors the workspace clippy CI gate) — clean
- `cargo fmt -p velesdb-memory -- --check` — clean
- `cargo check -p velesdb-node -p velesdb-wasm` — both still build (doc-link consumers of `context::wire::ID_KEYS`)
- `cargo doc -p velesdb-memory --no-deps --features context,mcp` — no new broken intra-doc links (diffed against the same command on `develop`)
- `python3 scripts/check_prod_unwraps.py` — passes (Gate 3)

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: workspace-pinned (`rust-version = "1.90"`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — no public-facing docs describe this internal duplication)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (existing coverage — `tests/mcp_schema_bdd.rs`, `context/wire.rs`'s own unit tests, and the `velesdb-node`/`velesdb-wasm` doc-link references — already exercises both paths; this is a pure duplication removal with no new behavior to test)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Open follow-up in the same family, deliberately left out of scope: #1686 (`mcp::wire::lenient` makes the negative half of the scalar-type contract untestable) — unrelated to this constant-deduplication change.
