### PR TITLE
refactor(memory): declarer WIRE_ID_KEYS une seule fois, context::wire la reexporte

### DIFF
--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -19,7 +19,14 @@ use serde_json::Value;
 /// Object keys whose `u64` values (or arrays of them) must cross to JS as
 /// decimal strings. Token counts stay numbers: they are bounded far below
 /// 2^53 by the budget caps.
-pub const ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+///
+/// Re-exported from [`crate::schema::WIRE_ID_KEYS`] rather than redeclared
+/// (#1685): the two used to be independent constants with identical
+/// contents, so a future id field added to one could silently miss the
+/// other. `schema.rs` holds the single declaration because it compiles
+/// unconditionally, while this module only compiles under the `context`
+/// feature.
+pub use crate::schema::WIRE_ID_KEYS as ID_KEYS;
 
 /// Recursively rewrite every [`ID_KEYS`] field of a serialized `context`
 /// wire value into its decimal-string form.

--- a/crates/velesdb-memory/src/schema.rs
+++ b/crates/velesdb-memory/src/schema.rs
@@ -949,13 +949,20 @@ fn is_rust_int_format(format: &str) -> bool {
 mod tests;
 
 /// Les champs d'id qui traversent le fil sous forme entiere OU chaine
-/// decimale. Definis ici et non dans `context::wire` : `schema.rs` est gate
-/// sur `mcp`, alors que `context::wire` l'est sur `context` — et les outils
-/// de `mcp.rs` en ont besoin meme quand `context` est absente, ce qui est le
-/// cas de `--features http`.
-#[cfg(feature = "mcp")]
-pub(crate) const WIRE_ID_KEYS: &[&str] =
-    &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
+/// decimale.
+///
+/// Seule declaration (#1685) : [`crate::context::wire::ID_KEYS`] la
+/// reexporte telle quelle plutot que de la redeclarer. Vit ici et non dans
+/// `context::wire` parce que `schema.rs` n'est jamais gate par une feature
+/// (voir `mod schema;` dans `lib.rs`), alors que le module `context` entier
+/// l'est sur `context` — et les outils de `mcp.rs` en ont besoin meme quand
+/// `context` est absente, ce qui est le cas de `--features http`. Gatee sur
+/// `any(mcp, context)` et non laissee inconditionnelle : un build
+/// `--features persistence` seule (verifie en isolation par la CI, voir
+/// `ci.yml`) n'a besoin d'aucune des deux, et `-D warnings` transformerait
+/// la constante alors inutilisee en echec de build.
+#[cfg(any(feature = "mcp", feature = "context"))]
+pub const WIRE_ID_KEYS: &[&str] = &["fragment_id", "content_hash", "memory_id", "fragment_ids"];
 
 // --- Les deux surfaces du fil, separees par le TYPE -------------------------
 //


### PR DESCRIPTION
Ferme #1685.

La liste des champs qui portent le contrat d'id existait en **deux constantes au contenu identique**, `context::wire::ID_KEYS` et `schema::WIRE_ID_KEYS`, que rien ne comparait. Une verite declaree a deux endroits derive, et la derive aurait ete silencieuse puisque chaque copie est correcte de son cote — la meme forme de defaut que celle corrigee dans #1687.

Une seule declaration desormais, dans `schema.rs` : c'est le module qui compile inconditionnellement, alors que `context` entier est derriere sa feature — et `mcp.rs` en a besoin meme quand `context` est absente, ce qui est le cas de `--features http`. `context::wire::ID_KEYS` devient une reexportation.

La constante est gatee sur `any(mcp, context)` plutot que laissee inconditionnelle : un build `--features persistence` seule, que la CI verifie en isolation, n'a besoin d'aucune des deux, et `-D warnings` transformerait la constante alors inutilisee en echec de build.

---

Cette PR **remplace #1688**, dont le commit etait authored par une identite non humaine sur une branche `claude/*`. Les deux gardes du depot l'ont correctement rejetee : `Git Flow & Freshness Checks` sur le prefixe de branche, `cla-assistant` sur l'auteur. Le contenu etait bon et est repris ici tel quel, sous la bonne signature.