### PR TITLE
ci(gardes): declarer l'ensemble des gardes, et le confronter au disque

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,15 @@ All new/modified code must satisfy these limits (enforced by Codacy and CI):
 | Code duplication | **< 2%** | jscpd |
 | Unsafe blocks | Must have `// SAFETY:` comment | CI (`verify_unsafe_safety_template.py`) |
 | TODO format | Must carry an issue tag: `[EPIC-XXX/US-YYY]`, `(PREFIX-NNN)`, `#123`, or `#issue` | CI (`check-todo-annotations.py`) |
-| `.unwrap()` | Forbidden in production code | Code review |
+| `.unwrap()` | Forbidden in production code | CI (`check_prod_unwraps.py`) |
 | Recall@10 | **>= 0.95** (if search path modified) | CI + local validation |
+
+Every guard script this repository runs is declared in
+[`scripts/guards.json`](scripts/guards.json): which workflow and job invokes it,
+whether its failure blocks a merge, and whether it runs strict or advisory. Adding
+a `scripts/check-*.py` (or `verify-`/`gate-`) without an entry there fails
+`scripts/tests/test_ci_gate_reachability.py` — the registry is checked against the
+workflows *and* against the filesystem, so it cannot quietly shrink.
 
 ### Concurrency Rules
 

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1,0 +1,233 @@
+{
+  "_purpose": [
+    "The declared set of repository guards. Before this file existed, the set was",
+    "implicit in the YAML text of .github/workflows/ and in GitHub's branch",
+    "protection settings, and the two were never confronted: removing a guard's",
+    "`run:` line from ci.yml turned nothing red (issue #1702), and a guard that",
+    "runs in a workflow nobody requires is decorative at merge time (#1698).",
+    "",
+    "scripts/tests/test_ci_gate_reachability.py confronts this file with the",
+    "workflows AND with the filesystem. The filesystem half is what makes the",
+    "registry impossible to shrink silently: every guard-shaped script under",
+    "scripts/ must appear here, either under `guards` or under `unwired` with a",
+    "written reason. Deleting an entry does not remove the obligation — the script",
+    "is still on disk, so the suite demands an accounting for it."
+  ],
+  "_schema": {
+    "script": "repo-relative path, the identity of the guard",
+    "workflow": "the workflow file whose job invokes it",
+    "job": "the job key inside that workflow",
+    "required": "true when a failure of `job` must fail the single required check (CI Success)",
+    "mode": "strict = a finding fails the build; warn = it does not (see exit_condition)",
+    "exit_condition": "mandatory when mode is warn: what has to happen for it to become strict",
+    "self_test": "unittest module that proves the guard refuses; null when none exists",
+    "self_test_required": "true when that module runs inside a required job",
+    "blind_spot": "known limit of the guard's reach, with the issue tracking it"
+  },
+  "_json_not_yaml": [
+    "gate-contracts.yml runs these suites with a bare actions/setup-python and",
+    "installs nothing, so importing PyYAML here would be an ImportError in CI — a",
+    "guard that cannot run. json is stdlib everywhere. Same reasoning that keeps",
+    "the workflow parsers in test_ci_gate_reachability.py regex-based."
+  ],
+
+  "guards": [
+    {
+      "script": "scripts/check_prod_unwraps.py",
+      "purpose": "No .unwrap()/.expect() in production code (QUALITY_BAR Gate 3).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_prod_unwraps",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": 1700,
+        "summary": "scan_file() stops at the first #[cfg(test)] marker, and does so BEFORE block-comment tracking: 33914 lines are never read, and a marker quoted inside /* */ blinds the whole file."
+      }
+    },
+    {
+      "script": "scripts/verify_unsafe_safety_template.py",
+      "purpose": "Every unsafe block carries a // SAFETY: comment (Gate 4).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Runs only on production .rs files changed by the PR, so it never re-reads unsafe blocks that predate it."
+      }
+    },
+    {
+      "script": "scripts/check-todo-annotations.py",
+      "purpose": "TODO/FIXME/HACK follow the // TODO(EPIC-XXX): governance format.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Diff-scoped to changed velesdb-core production files, like the unsafe guard."
+      }
+    },
+    {
+      "script": "scripts/check-version-sync.py",
+      "purpose": "Version equality across policed manifests (REL-07), at PR time.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_version_sync",
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Its self-test runs only via gate-contracts.yml's unittest discover, which is NOT in CI Success's needs — so the proof that this guard refuses does not block a merge. Fixed by the fold of #1698."
+      }
+    },
+    {
+      "script": "scripts/check-feature-claims.py",
+      "purpose": "Documented feature claims match real exports.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_feature_claims",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": null,
+        "summary": "Breaks (reports column_store MISSING) if any string literal in velesdb-python/src uses a backslash line-continuation."
+      }
+    },
+    {
+      "script": "scripts/check-perf-claims.py",
+      "purpose": "Performance numbers stay consistent across documents.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "lint",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1701,
+        "summary": "Cannot go red as wired: the grouping label contains the measured value, so two claims never share a group and the only exit-1 path is unreachable. The Criterion front is disabled by --no-criterion and never feeds the exit code."
+      }
+    },
+    {
+      "script": "scripts/check-mcp-doc-contract.py",
+      "purpose": "Documented MCP return shapes match the published outputSchema.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "mcp-doc-contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_mcp_doc_contract",
+      "self_test_required": true,
+      "blind_spot": {
+        "issue": 1695,
+        "summary": "POLICED_TOOLS holds 1 of the 20 published tools, and SURFACE_GLOBS misses the Python and WASM binding sources. Attribution rests on alias proximity within 500 characters."
+      }
+    },
+    {
+      "script": "scripts/check-doc-contract.sh",
+      "purpose": "Every runtime route of the server is documented in the root README.",
+      "workflow": ".github/workflows/doc-contract.yml",
+      "job": "contract",
+      "required": false,
+      "mode": "warn",
+      "exit_condition": "Document the four routes named in the script header (/collections/{name}/compact, points/raw, stream/enable, vacuum) in README.md, then flip DOC_CONTRACT_MODE's default to strict in the same commit. Tracked by #1707.",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1707,
+        "summary": "Measured: exit 0 in the default warn mode with 4 undocumented routes, exit 1 under DOC_CONTRACT_MODE=strict. The guard works; nothing asks it to."
+      }
+    },
+    {
+      "script": "scripts/check-doc-freshness.py",
+      "purpose": "Doc stamps, index and version references stay fresh (three guards).",
+      "workflow": ".github/workflows/doc-contract.yml",
+      "job": "freshness",
+      "required": false,
+      "mode": "warn",
+      "exit_condition": "The `stamp` and `versions` guards already run with --mode strict; only `index` runs with --mode warn (doc-contract.yml:94). Either bring `index` to strict or record here why it cannot be. The whole job is unrequired until the fold of #1698.",
+      "self_test": "scripts.tests.test_check_doc_freshness",
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1698,
+        "summary": "Lives in doc-contract.yml, which is not in CI Success's needs: all three guards can be red while the merge button stays green."
+      }
+    },
+    {
+      "script": "scripts/check-promise-contract.py",
+      "purpose": "The promise-contract registry stays valid.",
+      "workflow": ".github/workflows/promise-contract.yml",
+      "job": "contract",
+      "required": false,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_promise_contract",
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1698,
+        "summary": "promise-contract.yml is not in CI Success's needs, and its self-test is reachable only from gate-contracts.yml, which is not either."
+      }
+    },
+    {
+      "script": "scripts/check-python.sh",
+      "purpose": "Python integration checks (dangerous hash(), bandit, mypy).",
+      "workflow": ".github/workflows/propagation-guard.yml",
+      "job": "integrations-python",
+      "required": false,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1698,
+        "summary": "propagation-guard.yml is not in CI Success's needs."
+      }
+    },
+    {
+      "script": "scripts/check_binary_size.py",
+      "purpose": "Release binaries stay within their size ceilings.",
+      "workflow": ".github/workflows/binary-size.yml",
+      "job": "binary-size",
+      "required": false,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1698,
+        "summary": "binary-size.yml is not in CI Success's needs."
+      }
+    },
+    {
+      "script": "scripts/run-production-gates.sh",
+      "purpose": "Meta-runner chaining the production gates.",
+      "workflow": ".github/workflows/production-gates.yml",
+      "job": "gates",
+      "required": false,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1698,
+        "summary": "production-gates.yml is not in CI Success's needs. It re-invokes check-doc-contract.sh, which is warn by default, so part of this chain is advisory too."
+      }
+    }
+  ],
+
+  "unwired": [
+    {
+      "script": "scripts/check-crates-io-versions.sh",
+      "reason": "Release-time only, by design: it checks a version collision on crates.io before publishing (release.yml:345, release-memory.yml:187). There is nothing for it to assert on a pull request.",
+      "issue": null
+    },
+    {
+      "script": "scripts/perf_phase_gate.py",
+      "reason": "Invoked by no workflow. QUALITY_BAR.md:220 and docs/contributing/BENCHMARKING_GUIDE.md:274-289 describe it as if it were active, which is the defect: either wire it or say in both documents that it is a manual tool.",
+      "issue": 1708
+    }
+  ]
+}

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -26,12 +26,27 @@ below before being pointed at the real file.
 
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+GUARDS_REGISTRY = REPO_ROOT / "scripts" / "guards.json"
+
+# Which scripts count as guards for the exhaustiveness check below. Deliberately
+# a name pattern over the filesystem and not a list: a list is the thing that
+# was missing, so bootstrapping the fix from another list would reproduce the
+# defect one level up. Adding `scripts/check-foo.py` makes this suite red until
+# the registry accounts for it.
+GUARD_SCRIPT_RE = re.compile(r"^scripts/[^/]*(?:check|verify|gate)[^/]*\.(?:py|sh)$")
+
+# Tokens that turn a finding into a report. Only ever applied to entries whose
+# declared mode is `strict` — a `warn` entry declares its own leniency and
+# carries an `exit_condition` instead.
+DISARM_TOKENS = ("--mode warn", "|| true", "continue-on-error")
 
 # Jobs allowed in `needs` without being read by the chain, and why. Keep this
 # as short as it is: each entry is a job whose failure cannot block a merge.
@@ -118,6 +133,49 @@ def job_block(text: str, job: str) -> str:
 def guard_invocations(text: str, script: str) -> "list[str]":
     """Every `run:` line invoking ``script``."""
     return [line for line in GUARD_INVOCATION_RE.findall(text) if script in line]
+
+
+def load_guard_registry() -> dict:
+    """``scripts/guards.json`` — the declared set of repository guards."""
+    return json.loads(GUARDS_REGISTRY.read_text(encoding="utf-8"))
+
+
+def discovered_guard_scripts() -> "set[str]":
+    """Guard-shaped scripts present on disk, repo-relative.
+
+    The filesystem, not the registry, answers "what guards exist". That is what
+    makes the registry unable to shrink quietly: dropping an entry leaves the
+    script on disk, and the script still has to be accounted for.
+    """
+    found = set()
+    for path in sorted((REPO_ROOT / "scripts").glob("*")):
+        rel = f"scripts/{path.name}"
+        if path.is_file() and GUARD_SCRIPT_RE.match(rel):
+            found.add(rel)
+    return found
+
+
+def script_mentions_in_job(workflow_text: str, job: str, script: str) -> "list[str]":
+    """Live (comment-stripped) lines of ``job`` that name ``script``.
+
+    Not GUARD_INVOCATION_RE: that one only matches a single-line
+    ``run: python3 scripts/…``, and two required guards are invoked from inside
+    a multi-line ``run: |`` block (ci.yml:271 and :296). A guard whose
+    invocation shape the regex cannot see would have looked unwired.
+    """
+    block = strip_comments(job_block(workflow_text, job))
+    return [line.strip() for line in block.split("\n") if script in line]
+
+
+def required_ci_jobs() -> "set[str]":
+    """ci.yml jobs whose failure actually fails the one required check.
+
+    Both halves are needed: `needs` makes the job run, the chain makes its
+    failure count. CHAIN_EXEMPT jobs are in `needs` and deliberately unread,
+    so they are NOT required.
+    """
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    return set(ci_success_needs(text)) & chain_checked_jobs(text)
 
 
 SYNTHETIC = """\
@@ -334,6 +392,237 @@ class DisarmTests(unittest.TestCase):
         broken = self.text.replace(invocation, invocation + " --mode warn")
         self.assertIn(
             "--mode warn", guard_invocations(broken, "check-mcp-doc-contract.py")[0]
+        )
+
+
+class GuardRegistryShapeTests(unittest.TestCase):
+    """``scripts/guards.json`` is well-formed and exhaustive.
+
+    Everything below this class checks that each declared guard is wired. This
+    class checks the prior question the repository had no answer to: *which
+    guards are we even claiming to have?* The set used to live only in the YAML
+    text and in GitHub's branch-protection settings, so removing an invocation
+    was invisible (#1702) and a guard nobody required was decorative (#1698).
+    """
+
+    def setUp(self) -> None:
+        self.registry = load_guard_registry()
+        self.guards = self.registry["guards"]
+        self.unwired = self.registry["unwired"]
+
+    def test_every_guard_declares_the_fields_the_wiring_tests_read(self) -> None:
+        required_fields = ("script", "purpose", "workflow", "job", "required", "mode")
+        for entry in self.guards:
+            with self.subTest(script=entry.get("script")):
+                for field in required_fields:
+                    self.assertIn(field, entry, f"missing `{field}`")
+                self.assertIn(entry["mode"], ("strict", "warn"))
+                self.assertIsInstance(entry["required"], bool)
+
+    def test_a_warn_guard_states_what_would_make_it_strict(self) -> None:
+        # A `warn` without a way out is not a guard, it is a log. This is the
+        # rule check-doc-contract.sh needed and did not have: its own header
+        # prescribed the flip to strict, and nothing carried the obligation.
+        for entry in self.guards:
+            if entry["mode"] != "warn":
+                continue
+            with self.subTest(script=entry["script"]):
+                self.assertTrue(
+                    (entry.get("exit_condition") or "").strip(),
+                    "a `warn` guard must declare its exit_condition",
+                )
+
+    def test_no_guard_is_declared_twice(self) -> None:
+        scripts = [entry["script"] for entry in self.guards]
+        duplicates = sorted({s for s in scripts if scripts.count(s) > 1})
+        self.assertEqual(duplicates, [], f"duplicate registry entries: {duplicates}")
+
+    def test_every_declared_script_exists_on_disk(self) -> None:
+        for entry in self.guards + self.unwired:
+            with self.subTest(script=entry["script"]):
+                self.assertTrue(
+                    (REPO_ROOT / entry["script"]).is_file(),
+                    "registry names a script that is not there",
+                )
+
+    def test_every_guard_shaped_script_on_disk_is_accounted_for(self) -> None:
+        # The anti-shrink half. A registry that only had to agree with itself
+        # could be emptied one entry at a time; this makes the filesystem the
+        # source of truth for the SET, and the registry answerable to it.
+        declared = {entry["script"] for entry in self.guards}
+        declared |= {entry["script"] for entry in self.unwired}
+        unaccounted = sorted(discovered_guard_scripts() - declared)
+        self.assertEqual(
+            unaccounted,
+            [],
+            f"guard-shaped script(s) missing from scripts/guards.json: {unaccounted}. "
+            "Add each one under `guards` with its workflow and job, or under "
+            "`unwired` with a written reason.",
+        )
+
+    def test_an_unwired_guard_states_why(self) -> None:
+        for entry in self.unwired:
+            with self.subTest(script=entry["script"]):
+                self.assertTrue(
+                    (entry.get("reason") or "").strip(),
+                    "an unwired guard must say why it is not wired",
+                )
+
+    def test_at_least_one_guard_is_required(self) -> None:
+        self.assertTrue(
+            [entry for entry in self.guards if entry["required"]],
+            "no guard in the registry is required at merge — the registry gates nothing",
+        )
+
+
+class GuardWiringTests(unittest.TestCase):
+    """Each declared guard is invoked where the registry says it is."""
+
+    def setUp(self) -> None:
+        self.guards = load_guard_registry()["guards"]
+        self.required_jobs = required_ci_jobs()
+
+    def _workflow_text(self, entry: dict) -> str:
+        path = REPO_ROOT / entry["workflow"]
+        self.assertTrue(path.is_file(), f"no such workflow: {entry['workflow']}")
+        return path.read_text(encoding="utf-8")
+
+    def test_every_guard_is_invoked_in_the_job_the_registry_names(self) -> None:
+        for entry in self.guards:
+            with self.subTest(script=entry["script"]):
+                mentions = script_mentions_in_job(
+                    self._workflow_text(entry), entry["job"], entry["script"]
+                )
+                self.assertTrue(
+                    mentions,
+                    f"{entry['workflow']} job `{entry['job']}` never runs "
+                    f"{entry['script']} — the invocation was removed, or the "
+                    "registry entry is stale.",
+                )
+
+    def test_a_required_guard_lives_in_a_job_that_blocks_the_merge(self) -> None:
+        for entry in self.guards:
+            if not entry["required"]:
+                continue
+            with self.subTest(script=entry["script"]):
+                self.assertEqual(
+                    entry["workflow"],
+                    ".github/workflows/ci.yml",
+                    "only ci.yml feeds the single required check (CI Success)",
+                )
+                self.assertIn(
+                    entry["job"],
+                    self.required_jobs,
+                    f"`{entry['job']}` is not both in CI Success's needs and read "
+                    "by its chain, so this guard cannot block a merge",
+                )
+
+    def test_a_strict_guard_is_not_disarmed_at_its_invocation(self) -> None:
+        for entry in self.guards:
+            if entry["mode"] != "strict":
+                continue
+            text = self._workflow_text(entry)
+            for line in script_mentions_in_job(text, entry["job"], entry["script"]):
+                for token in DISARM_TOKENS:
+                    with self.subTest(script=entry["script"], token=token):
+                        self.assertNotIn(
+                            token,
+                            line,
+                            f"strict guard disarmed at its invocation: {line!r}",
+                        )
+
+    def test_the_self_test_declaration_is_true(self) -> None:
+        # Both directions: a `true` that is not backed by a required job
+        # overstates coverage, and a `false` that IS backed understates it and
+        # goes stale the day the wiring improves.
+        ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
+        required_blocks = "\n".join(
+            job_block(ci_text, job) for job in sorted(self.required_jobs)
+        )
+        for entry in self.guards:
+            module = entry.get("self_test")
+            if not module:
+                continue
+            actually_required = module in required_blocks
+            with self.subTest(script=entry["script"], module=module):
+                self.assertEqual(
+                    entry.get("self_test_required"),
+                    actually_required,
+                    f"`self_test_required` for {module} says "
+                    f"{entry.get('self_test_required')}, the workflow says "
+                    f"{actually_required}",
+                )
+
+
+class GuardRegistryDisarmTests(unittest.TestCase):
+    """Every way to quietly widen the hole, replayed — each must be RED.
+
+    Same discipline as DisarmTests above: the registry is worth exactly what it
+    refuses. These mutate in-memory copies, so nothing on disk changes.
+    """
+
+    def setUp(self) -> None:
+        self.registry = load_guard_registry()
+        self.ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    def _required_entry(self) -> dict:
+        for entry in self.registry["guards"]:
+            if entry["required"] and entry["workflow"] == ".github/workflows/ci.yml":
+                return entry
+        raise AssertionError("no required ci.yml guard to mutate")
+
+    def test_removing_an_invocation_from_ci_yml_is_detected(self) -> None:
+        entry = self._required_entry()
+        before = script_mentions_in_job(self.ci_text, entry["job"], entry["script"])
+        self.assertTrue(before, "fixture precondition: the guard is invoked today")
+        broken = self.ci_text.replace(entry["script"], "scripts/removed-guard.py")
+        self.assertEqual(
+            script_mentions_in_job(broken, entry["job"], entry["script"]),
+            [],
+            "dropping the invocation must leave nothing for the wiring test to find",
+        )
+
+    def test_deleting_a_registry_entry_is_detected_by_the_disk_sweep(self) -> None:
+        entry = self._required_entry()
+        declared = {
+            e["script"] for e in self.registry["guards"] if e["script"] != entry["script"]
+        }
+        declared |= {e["script"] for e in self.registry["unwired"]}
+        self.assertIn(
+            entry["script"],
+            discovered_guard_scripts() - declared,
+            "a deleted entry must resurface as an unaccounted script on disk",
+        )
+
+    def test_an_unregistered_new_guard_script_is_detected(self) -> None:
+        declared = {e["script"] for e in self.registry["guards"]}
+        declared |= {e["script"] for e in self.registry["unwired"]}
+        self.assertNotIn("scripts/check-newcomer.py", declared)
+        self.assertRegex(
+            "scripts/check-newcomer.py",
+            GUARD_SCRIPT_RE,
+            "a check-*.py file must be seen as guard-shaped, else the sweep is blind",
+        )
+
+    def test_warn_mode_on_a_strict_guard_is_detected(self) -> None:
+        entry = self._required_entry()
+        line = script_mentions_in_job(self.ci_text, entry["job"], entry["script"])[0]
+        broken = self.ci_text.replace(line, line + " --mode warn")
+        disarmed = [
+            candidate
+            for candidate in script_mentions_in_job(broken, entry["job"], entry["script"])
+            if "--mode warn" in candidate
+        ]
+        self.assertTrue(disarmed, "the disarm must be visible on the invocation line")
+
+    def test_moving_a_required_guard_to_an_unrequired_job_is_detected(self) -> None:
+        # The subtler disarm: the guard still runs, still strict, still in
+        # ci.yml — just in a job whose result the chain does not read.
+        exempt = sorted(CHAIN_EXEMPT)[0]
+        self.assertNotIn(
+            exempt,
+            required_ci_jobs(),
+            f"`{exempt}` is chain-exempt, so a guard parked there blocks nothing",
         )
 
 


### PR DESCRIPTION
Premiere piece de la campagne decrite dans #1706 : l'ensemble des gardes du
depot n'existait nulle part **comme donnee**. Il etait implicite dans le texte
YAML des workflows et dans les reglages de protection de branche, et les deux
n'etaient jamais confrontes.

Consequences mesurees : retirer la ligne `run:` d'un garde de `ci.yml` ne
rougissait rien (#1702), et seuls `mcp-doc-contract` et
`check-mcp-doc-contract.py` etaient epingles par leur nom — les quatre autres
gardes du job `lint` etaient retirables en une ligne.

## Ce que fait cette PR

`scripts/guards.json` declare les **15** scripts de garde du depot : quel
workflow et quel job les invoque, si leur echec bloque le merge, s'ils tournent
en `strict` ou en advisory, quelle suite prouve qu'ils refusent, et quel angle
mort les limite (avec l'issue qui le suit). Treize sous `guards`, deux sous
`unwired` avec leur raison ecrite.

`scripts/tests/test_ci_gate_reachability.py` le confronte au YAML **et au
disque**.

**La moitie disque est ce qui ferme la cause racine.** Le systeme de fichiers est
la source de verite de « quels gardes existent » : supprimer une entree du
registre ne supprime pas l'obligation, puisque le script est toujours la et qu'il
faut en rendre compte. Amorcer le correctif depuis une seconde liste aurait
reproduit exactement le defaut qu'il corrige.

Trois regles nouvelles :

- **un garde en `warn` doit declarer sa condition de sortie.** Un `warn` sans
  sortie n'est pas un garde, c'est un journal. C'est la regle qui manquait a
  `check-doc-contract.sh`, dont l'en-tete prescrivait lui-meme le passage en
  `strict` sans que rien ne porte l'obligation (#1707) ;
- **un garde `required` doit vivre dans un job present dans le `needs` ET lu par
  la chaine** de `CI Success` — les deux moities, sinon il ne bloque rien ;
- **`self_test_required` doit etre vrai dans les deux sens** : une declaration
  qui surestime la couverture est refusee, une qui la sous-estime aussi (sinon
  elle devient perimee le jour ou le cablage s'ameliore).

## Vu refuser

Six desarmements reels, rejoues sur l'arbre puis restaures. Chacun produit un
refus **nomme** :

| desarmement | test qui refuse |
|---|---|
| invocation retiree de `ci.yml` | `test_every_guard_is_invoked_in_the_job_the_registry_names` |
| entree supprimee du registre | `test_every_guard_shaped_script_on_disk_is_accounted_for` |
| garde ajoute sans etre enregistre | `test_every_guard_shaped_script_on_disk_is_accounted_for` |
| garde `strict` passe en `--mode warn` | `test_a_strict_guard_is_not_disarmed_at_its_invocation` |
| `self_test_required` mensonger | `test_the_self_test_declaration_is_true` |
| `warn` sans `exit_condition` | `test_a_warn_guard_states_what_would_make_it_strict` |

## Deux verites corrigees au passage

- `GUARD_INVOCATION_RE` ne matche que les `run:` sur **une** ligne.
  `verify_unsafe_safety_template.py` (`ci.yml:271`) et
  `check-todo-annotations.py` (`ci.yml:296`) sont invoques depuis un `run: |`
  multi-ligne : sans `script_mentions_in_job()`, qui lit le bloc de job
  comment-strippe, ces deux gardes requis paraissaient non cables.
- `CONTRIBUTING.md` attribuait l'interdiction de `.unwrap()` a la relecture,
  alors que `check_prod_unwraps.py` la garde en CI. Laisser la doc contredire le
  registre ajoute dans la meme PR aurait ete de la dette auto-infligee.

## Ce que cette PR ne fait pas

Le **repli** des six workflows orphelins (`gate-contracts`, `doc-contract`,
`promise-contract`, `production-gates`, `propagation-guard`, `binary-size`) dans
le `needs` et la chaine de `CI Success` fait l'objet d'une PR distincte : il
change la topologie CI et doit etre valide sur une vraie PR. Le registre les
declare deja `required: false` avec l'issue qui les suit, donc l'ecart est ecrit
plutot que tu.

## Verification

```bash
python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .
```

164 tests, exit 0 (38 dans le fichier touche). Gardes documentaires relances
apres le dernier changement : `check-doc-freshness.py --guard stamp/versions
--mode strict` verts, `check-doc-contract.sh` inchange.

Refs #1702, #1706
