### PR TITLE
test(ci): PREUVE JETABLE - ne pas merger - le repli bloque-t-il le merge ?

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -11,19 +11,12 @@ name: Binary Size Gate
 # absorb the Linux x86_64 build delta this CI runner produces. They catch a
 # real regression (a multi-MB dependency, a bundled asset), not exact bytes.
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml). The
+# `pull_request` trigger is gone so the ceiling reports inside `CI Success`, the
+# only required check. The `push` filter below still applies on develop/main.
 on:
+  workflow_call:
   push:
-    branches: [develop, main]
-    paths:
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/velesdb-core/**"
-      - "crates/velesdb-server/**"
-      - "crates/velesdb-cli/**"
-      - "crates/velesdb-migrate/**"
-      - "scripts/check_binary_size.py"
-      - ".github/workflows/binary-size.yml"
-  pull_request:
     branches: [develop, main]
     paths:
       - "Cargo.toml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1179,12 +1179,53 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
 
   # ===========================================================================
+  # Gates folded in from their own workflows
+  #
+  # These six ran as standalone workflows on `pull_request`, and `CI Success` is
+  # the ONLY required check on develop — so each could be red while the merge
+  # button stayed green. Requiring them through GitHub's branch-protection list
+  # instead would keep the required set unversioned and unreadable by any guard,
+  # which is the defect one level up. Calling them from here puts the required
+  # set in reviewable YAML, and scripts/guards.json holds them to it.
+  #
+  # `workflow_call` ignores the callee's own `paths:` filters, so these now run
+  # on every PR. Measured cost: 0.2 to 5.5 min each, against CI's ~29 min
+  # critical path — they finish long before this job can start, so the wait is
+  # unchanged. Filtering them conditionally instead would make a skipped job
+  # report `skipped`, forcing the chain below to accept anything other than
+  # `success` — the "skipped = green" ambiguity this fold exists to remove.
+  # ===========================================================================
+  gate-contracts:
+    name: Gate Contracts
+    uses: ./.github/workflows/gate-contracts.yml
+
+  doc-contract:
+    name: Doc Contract
+    uses: ./.github/workflows/doc-contract.yml
+
+  promise-contract:
+    name: Promise Contract
+    uses: ./.github/workflows/promise-contract.yml
+
+  production-gates:
+    name: Production Gates
+    uses: ./.github/workflows/production-gates.yml
+
+  propagation-guard:
+    name: Propagation Guard
+    uses: ./.github/workflows/propagation-guard.yml
+
+  binary-size:
+    name: Binary Size Gate
+    uses: ./.github/workflows/binary-size.yml
+
+  # ===========================================================================
   # Summary (léger)
   # ===========================================================================
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, sonarcloud]
+    needs: [lint, test, security, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, sonarcloud]
     if: always()
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -1204,5 +1245,11 @@ jobs:
           [[ "${{ needs.python-integrations.result }}" == "success" ]] && \
           [[ "${{ needs.node-binding-tests.result }}" == "success" ]] && \
           [[ "${{ needs.node-binding-tests-windows.result }}" == "success" ]] && \
+          [[ "${{ needs.gate-contracts.result }}" == "success" ]] && \
+          [[ "${{ needs.doc-contract.result }}" == "success" ]] && \
+          [[ "${{ needs.promise-contract.result }}" == "success" ]] && \
+          [[ "${{ needs.production-gates.result }}" == "success" ]] && \
+          [[ "${{ needs.propagation-guard.result }}" == "success" ]] && \
+          [[ "${{ needs.binary-size.result }}" == "success" ]] && \
           [[ "${{ needs.security.result }}" == "success" ]] && \
           echo "✅ CI passed" || { echo "❌ CI failed"; exit 1; }

--- a/.github/workflows/doc-contract.yml
+++ b/.github/workflows/doc-contract.yml
@@ -1,32 +1,12 @@
 name: Doc Contract
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml). The
+# `pull_request` trigger is deliberately gone: `CI Success` is the only required
+# check, so this contract now reports inside it rather than beside it. The
+# `push` filter below still applies to direct pushes on main/develop.
 on:
+  workflow_call:
   push:
-    branches: [main, develop]
-    paths:
-      - 'README.md'
-      - 'docs/**'
-      - 'Cargo.toml'
-      - 'crates/velesdb-memory/Cargo.toml'
-      # The MCP tools themselves. Editing context_tools.rs alone triggered
-      # NOTHING here, which is exactly how a return contract changes while
-      # every page describing it stays behind.
-      - 'crates/velesdb-memory/src/**'
-      - 'crates/velesdb-node/README.md'
-      - 'crates/velesdb-node/skills/**'
-      - 'crates/velesdb-server/src/**'
-      # Surfaces that republish the same contract to the same model, and
-      # were outside this filter entirely.
-      - 'sdks/**'
-      - 'integrations/**'
-      - 'skills/**'
-      - 'scripts/check-doc-contract.sh'
-      - 'scripts/check-doc-freshness.py'
-      - 'scripts/check-mcp-doc-contract.py'
-      - 'scripts/tests/test_check_doc_freshness.py'
-      - 'scripts/tests/test_check_mcp_doc_contract.py'
-      - '.github/workflows/doc-contract.yml'
-  pull_request:
     branches: [main, develop]
     paths:
       - 'README.md'

--- a/.github/workflows/gate-contracts.yml
+++ b/.github/workflows/gate-contracts.yml
@@ -9,10 +9,13 @@ name: Gate Contracts
 # Deliberately not path-filtered. A filter is how a gate quietly stops
 # running: these suites cost seconds, so they run on every change.
 
+# On a pull request this runs as a job of ci.yml, not on its own: `CI Success`
+# is the only required check, so a gate outside its `needs` could be red while
+# the merge button stayed green. The `pull_request` trigger is deliberately
+# absent — keeping it would run every suite twice per PR.
 on:
+  workflow_call:
   push:
-    branches: [main, develop]
-  pull_request:
     branches: [main, develop]
 
 permissions:

--- a/.github/workflows/production-gates.yml
+++ b/.github/workflows/production-gates.yml
@@ -1,16 +1,11 @@
 name: Production Gates
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml). The
+# `pull_request` trigger is gone: this gate now reports inside `CI Success`,
+# the only required check, instead of beside it.
 on:
+  workflow_call:
   workflow_dispatch:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'scripts/run-production-gates.sh'
-      - 'scripts/check-doc-contract.sh'
-      - 'scripts/check-promise-contract.py'
-      - 'crates/velesdb-core/tests/velesql_planner_golden.rs'
-      - 'crates/velesdb-core/tests/crash_recovery/**'
-      - 'crates/velesdb-core/src/storage/wal_recovery_tests.rs'
 
 permissions:
   contents: read

--- a/.github/workflows/promise-contract.yml
+++ b/.github/workflows/promise-contract.yml
@@ -25,5 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: PREUVE TEMPORAIRE - echec volontaire du garde replie
+        run: exit 1
       - name: Validate promise contract registry
         run: python3 scripts/check-promise-contract.py

--- a/.github/workflows/promise-contract.yml
+++ b/.github/workflows/promise-contract.yml
@@ -1,16 +1,11 @@
 name: Promise Contract
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml): the
+# `pull_request` trigger is gone so the gate reports inside the only required
+# check instead of beside it. The `push` path filter below still applies to
+# direct pushes on main/develop.
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'README.md'
-      - 'crates/velesdb-core/README.md'
-      - 'crates/velesdb-core/src/quantization/mod.rs'
-      - 'docs/guides/QUANTIZATION.md'
-      - 'docs/VELESQL_SPEC.md'
-      - 'docs/reference/promise-contract.json'
-      - 'scripts/check-promise-contract.py'
+  workflow_call:
   push:
     branches: [main, develop]
     paths:

--- a/.github/workflows/propagation-guard.yml
+++ b/.github/workflows/propagation-guard.yml
@@ -1,22 +1,11 @@
 name: Propagation Guard
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml). The
+# `pull_request` trigger is gone so this guard reports inside `CI Success`, the
+# only required check. The `push` filter below still applies on main/develop.
 on:
+  workflow_call:
   push:
-    branches: [main, develop]
-    paths:
-      - "crates/**"
-      - "sdks/typescript/**"
-      - "integrations/**"
-      - "demos/**"
-      - "examples/**"
-      - "conformance/**"
-      - "docs/**"
-      - "scripts/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".cargo/config.toml"
-      - ".github/workflows/propagation-guard.yml"
-  pull_request:
     branches: [main, develop]
     paths:
       - "crates/**"

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -22,7 +22,8 @@
     "exit_condition": "mandatory when mode is warn: what has to happen for it to become strict",
     "self_test": "unittest module that proves the guard refuses; null when none exists",
     "self_test_required": "true when that module runs inside a required job",
-    "blind_spot": "known limit of the guard's reach, with the issue tracking it"
+    "blind_spot": "known limit of the guard's reach, with the issue tracking it",
+    "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required"
   },
   "_json_not_yaml": [
     "gate-contracts.yml runs these suites with a bare actions/setup-python and",
@@ -30,7 +31,6 @@
     "guard that cannot run. json is stdlib everywhere. Same reasoning that keeps",
     "the workflow parsers in test_ci_gate_reachability.py regex-based."
   ],
-
   "guards": [
     {
       "script": "scripts/check_prod_unwraps.py",
@@ -82,10 +82,10 @@
       "required": true,
       "mode": "strict",
       "self_test": "scripts.tests.test_check_version_sync",
-      "self_test_required": false,
+      "self_test_required": true,
       "blind_spot": {
         "issue": null,
-        "summary": "Its self-test runs only via gate-contracts.yml's unittest discover, which is NOT in CI Success's needs — so the proof that this guard refuses does not block a merge. Fixed by the fold of #1698."
+        "summary": "None known. Its self-test is reached by gate-contracts.yml's `unittest discover`, which the fold made required through the `gate-contracts` caller job."
       }
     },
     {
@@ -135,89 +135,94 @@
       "purpose": "Every runtime route of the server is documented in the root README.",
       "workflow": ".github/workflows/doc-contract.yml",
       "job": "contract",
-      "required": false,
+      "required": true,
       "mode": "warn",
-      "exit_condition": "Document the four routes named in the script header (/collections/{name}/compact, points/raw, stream/enable, vacuum) in README.md, then flip DOC_CONTRACT_MODE's default to strict in the same commit. Tracked by #1707.",
+      "exit_condition": "Document the four routes named in the script header (/collections/{name}/compact, points/raw, stream/enable, vacuum) in README.md, then flip DOC_CONTRACT_MODE's default to strict in the same commit. Tracked by #1707. The fold made this gate required, so the flip now has teeth.",
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
         "issue": 1707,
         "summary": "Measured: exit 0 in the default warn mode with 4 undocumented routes, exit 1 under DOC_CONTRACT_MODE=strict. The guard works; nothing asks it to."
-      }
+      },
+      "required_via": "doc-contract"
     },
     {
       "script": "scripts/check-doc-freshness.py",
       "purpose": "Doc stamps, index and version references stay fresh (three guards).",
       "workflow": ".github/workflows/doc-contract.yml",
       "job": "freshness",
-      "required": false,
+      "required": true,
       "mode": "warn",
       "exit_condition": "The `stamp` and `versions` guards already run with --mode strict; only `index` runs with --mode warn (doc-contract.yml:94). Either bring `index` to strict or record here why it cannot be. The whole job is unrequired until the fold of #1698.",
       "self_test": "scripts.tests.test_check_doc_freshness",
-      "self_test_required": false,
+      "self_test_required": true,
       "blind_spot": {
-        "issue": 1698,
-        "summary": "Lives in doc-contract.yml, which is not in CI Success's needs: all three guards can be red while the merge button stays green."
-      }
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `doc-contract` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "doc-contract"
     },
     {
       "script": "scripts/check-promise-contract.py",
       "purpose": "The promise-contract registry stays valid.",
       "workflow": ".github/workflows/promise-contract.yml",
       "job": "contract",
-      "required": false,
+      "required": true,
       "mode": "strict",
       "self_test": "scripts.tests.test_check_promise_contract",
-      "self_test_required": false,
+      "self_test_required": true,
       "blind_spot": {
-        "issue": 1698,
-        "summary": "promise-contract.yml is not in CI Success's needs, and its self-test is reachable only from gate-contracts.yml, which is not either."
-      }
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `promise-contract` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "promise-contract"
     },
     {
       "script": "scripts/check-python.sh",
       "purpose": "Python integration checks (dangerous hash(), bandit, mypy).",
       "workflow": ".github/workflows/propagation-guard.yml",
       "job": "integrations-python",
-      "required": false,
+      "required": true,
       "mode": "strict",
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
-        "issue": 1698,
-        "summary": "propagation-guard.yml is not in CI Success's needs."
-      }
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `propagation-guard` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "propagation-guard"
     },
     {
       "script": "scripts/check_binary_size.py",
       "purpose": "Release binaries stay within their size ceilings.",
       "workflow": ".github/workflows/binary-size.yml",
       "job": "binary-size",
-      "required": false,
+      "required": true,
       "mode": "strict",
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
-        "issue": 1698,
-        "summary": "binary-size.yml is not in CI Success's needs."
-      }
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `binary-size` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "binary-size"
     },
     {
       "script": "scripts/run-production-gates.sh",
       "purpose": "Meta-runner chaining the production gates.",
       "workflow": ".github/workflows/production-gates.yml",
       "job": "gates",
-      "required": false,
+      "required": true,
       "mode": "strict",
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
-        "issue": 1698,
-        "summary": "production-gates.yml is not in CI Success's needs. It re-invokes check-doc-contract.sh, which is warn by default, so part of this chain is advisory too."
-      }
+        "issue": null,
+        "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
+      },
+      "required_via": "production-gates"
     }
   ],
-
   "unwired": [
     {
       "script": "scripts/check-crates-io-versions.sh",

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -167,6 +167,32 @@ def script_mentions_in_job(workflow_text: str, job: str, script: str) -> "list[s
     return [line.strip() for line in block.split("\n") if script in line]
 
 
+def trigger_block(text: str, trigger: str) -> str:
+    """The `on:` sub-block of one trigger, up to the next trigger or top key."""
+    on_match = re.search(r"^on:$", strip_comments(text), re.MULTILINE)
+    if on_match is None:
+        raise AssertionError("no top-level `on:` block found")
+    rest = strip_comments(text)[on_match.end():]
+    end = re.search(r"^[a-z]", rest, re.MULTILINE)
+    on_block = rest[: end.start()] if end else rest
+    start = re.search(rf"^  {re.escape(trigger)}:", on_block, re.MULTILINE)
+    if start is None:
+        raise AssertionError(f"ci.yml has no `{trigger}:` trigger")
+    tail = on_block[start.end():]
+    following = re.search(r"^  [a-z_]+:", tail, re.MULTILINE)
+    return tail[: following.start()] if following else tail
+
+
+def called_workflow(ci_text: str, job: str) -> "str | None":
+    """The workflow a ci.yml job delegates to via ``uses: ./…``, if any."""
+    match = re.search(
+        r"^\s*uses:\s*\./(\.github/workflows/[\w.-]+)\s*$",
+        strip_comments(job_block(ci_text, job)),
+        re.MULTILINE,
+    )
+    return match.group(1) if match else None
+
+
 def required_ci_jobs() -> "set[str]":
     """ci.yml jobs whose failure actually fails the one required check.
 
@@ -278,6 +304,23 @@ class RealWorkflowTests(unittest.TestCase):
 
     def test_the_needs_list_is_not_empty(self) -> None:
         self.assertTrue(self.needs, "`CI Success` needs nothing — it gates nothing")
+
+    def test_ci_runs_on_every_pull_request(self) -> None:
+        # Load-bearing since the gate fold: six guards gave up their own
+        # `pull_request` triggers to report inside `CI Success`. A `paths:`
+        # filter here would silently stop ALL of them — plus the thirteen jobs
+        # that were already required — on any PR touching only unlisted files.
+        # The `push` trigger keeps its filter; each folded workflow kept its own.
+        block = trigger_block(CI_WORKFLOW.read_text(encoding="utf-8"), "pull_request")
+        for key in ("paths:", "paths-ignore:"):
+            with self.subTest(key=key):
+                self.assertNotIn(
+                    key,
+                    block,
+                    "ci.yml's pull_request trigger must stay unfiltered: every "
+                    "required gate now reports through it. Filter individual "
+                    "jobs instead, never the workflow.",
+                )
 
 
 class BlockingBehaviourTests(unittest.TestCase):
@@ -501,20 +544,38 @@ class GuardWiringTests(unittest.TestCase):
                 )
 
     def test_a_required_guard_lives_in_a_job_that_blocks_the_merge(self) -> None:
+        ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
         for entry in self.guards:
             if not entry["required"]:
                 continue
+            caller = entry.get("required_via")
             with self.subTest(script=entry["script"]):
-                self.assertEqual(
-                    entry["workflow"],
-                    ".github/workflows/ci.yml",
-                    "only ci.yml feeds the single required check (CI Success)",
-                )
+                if caller is None:
+                    # Invoked directly by a ci.yml job.
+                    self.assertEqual(
+                        entry["workflow"],
+                        ".github/workflows/ci.yml",
+                        "a guard required without `required_via` must live in ci.yml",
+                    )
+                    self.assertIn(
+                        entry["job"],
+                        self.required_jobs,
+                        f"`{entry['job']}` is not both in CI Success's needs and "
+                        "read by its chain, so this guard cannot block a merge",
+                    )
+                    continue
+                # Invoked in its own workflow, made required by a caller job.
+                # Both links are checked: pointing `required_via` at some
+                # unrelated required job would otherwise pass.
                 self.assertIn(
-                    entry["job"],
+                    caller,
                     self.required_jobs,
-                    f"`{entry['job']}` is not both in CI Success's needs and read "
-                    "by its chain, so this guard cannot block a merge",
+                    f"caller job `{caller}` is not required by CI Success",
+                )
+                self.assertEqual(
+                    called_workflow(ci_text, caller),
+                    entry["workflow"],
+                    f"ci.yml job `{caller}` does not call {entry['workflow']}",
                 )
 
     def test_a_strict_guard_is_not_disarmed_at_its_invocation(self) -> None:
@@ -531,19 +592,37 @@ class GuardWiringTests(unittest.TestCase):
                             f"strict guard disarmed at its invocation: {line!r}",
                         )
 
+    def _required_test_surface(self) -> str:
+        """Everything a required job can run, including through a called workflow.
+
+        A caller job's own block is three lines of `uses:`; the suites it runs
+        live in the callee. Reading only ci.yml would report every folded gate's
+        self-test as unreached.
+        """
+        ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
+        parts = []
+        for job in sorted(self.required_jobs):
+            parts.append(job_block(ci_text, job))
+            callee = called_workflow(ci_text, job)
+            if callee:
+                parts.append((REPO_ROOT / callee).read_text(encoding="utf-8"))
+        return "\n".join(parts)
+
     def test_the_self_test_declaration_is_true(self) -> None:
         # Both directions: a `true` that is not backed by a required job
         # overstates coverage, and a `false` that IS backed understates it and
         # goes stale the day the wiring improves.
-        ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
-        required_blocks = "\n".join(
-            job_block(ci_text, job) for job in sorted(self.required_jobs)
+        surface = self._required_test_surface()
+        # `unittest discover -s scripts/tests` runs every module under that
+        # directory, so it covers each one by name without naming any.
+        discovers_all = bool(
+            re.search(r"unittest\s+discover\s+-s\s+scripts/tests", surface)
         )
         for entry in self.guards:
             module = entry.get("self_test")
             if not module:
                 continue
-            actually_required = module in required_blocks
+            actually_required = discovers_all or module in surface
             with self.subTest(script=entry["script"], module=module):
                 self.assertEqual(
                     entry.get("self_test_required"),


### PR DESCRIPTION
Branche jetable, **a ne jamais merger**, fermee des que la reponse est lue.

Elle casse volontairement le plus court des six gardes replies par #1710
(`promise-contract`, mediane 0,2 min) avec un `run: exit 1` insere apres le
checkout.

## La question

Le repli de #1710 met six workflows dans le `needs` et la chaine de
`CI Success`. Le YAML le montre, les tests l'epinglent — mais aucun des deux ne
peut prouver qu'un job `uses:` **propage son echec**. C'est la seule inconnue,
et c'est celle dont depend tout #1706 : si le repli ne bloque pas, chaque garde
ajoute ensuite reste contournable au merge.

## Attendu

`CI Success` **rouge**, sur la ligne
`[[ "\${{ needs.promise-contract.result }}" == "success" ]]`.

Si `CI Success` ressort vert avec `Promise Contract` rouge, le repli est
decoratif et #1710 doit etre repense.