### PR TITLE
ci(gardes): replier pr-governance, le dernier garde hors du check requis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ on:
   # path-filtered.
   pull_request:
     branches: [main, develop]
+    # `ready_for_review` is NOT in the default set ([opened, synchronize,
+    # reopened]). pr-governance.yml declared it before being folded in below,
+    # so leaving `types:` implicit here would have silently narrowed it: a
+    # draft turned "ready" with no new commit would never be re-governed.
+    # Pinned by scripts/tests/test_ci_gate_reachability.py.
+    types: [opened, synchronize, reopened, ready_for_review]
   # Manual trigger so coverage can be refreshed on demand (e.g. after a
   # config-only commit to main that skipped the path-filtered CI, leaving the
   # Codacy coverage badge stale).
@@ -1219,13 +1225,29 @@ jobs:
     name: Binary Size Gate
     uses: ./.github/workflows/binary-size.yml
 
+  # Last of the fold, and the one #1698 named: Git Flow, branch freshness and
+  # the AI-attribution guard ran beside the required check, so none of them
+  # could block a merge. Freshness matters most — it is the in-house
+  # replacement for branch protection's `strict` (decision #1639), which is
+  # off, so until this job existed nothing at all held a PR to its base.
+  #
+  # `permissions:` is explicit because a called workflow cannot exceed its
+  # caller: ci.yml grants `contents: read` at the top level, and
+  # pr-governance.yml declares `pull-requests: read` too.
+  pr-governance:
+    name: PR Governance
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/pr-governance.yml
+
   # ===========================================================================
   # Summary (léger)
   # ===========================================================================
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, sonarcloud]
+    needs: [lint, test, security, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
     if: always()
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -1251,5 +1273,6 @@ jobs:
           [[ "${{ needs.production-gates.result }}" == "success" ]] && \
           [[ "${{ needs.propagation-guard.result }}" == "success" ]] && \
           [[ "${{ needs.binary-size.result }}" == "success" ]] && \
+          [[ "${{ needs.pr-governance.result }}" == "success" ]] && \
           [[ "${{ needs.security.result }}" == "success" ]] && \
           echo "✅ CI passed" || { echo "❌ CI failed"; exit 1; }

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,7 +1,21 @@
 name: PR Governance
 
+# Called by ci.yml on pull requests (see the note in gate-contracts.yml). Its
+# three checks — Git Flow, branch freshness, AI attribution — used to report
+# BESIDE the only required check instead of inside it, so none of them could
+# block a merge (#1698). Branch freshness in particular is this repository's
+# replacement for branch protection's `strict` (decision #1639), and was
+# therefore protected by nobody.
+#
+# `branches-ignore` rather than no `pull_request:` at all: ci.yml is filtered
+# to `branches: [main, develop]`, so folding without this would have silently
+# dropped the "PR targets '<x>', which is not a valid Git Flow integration
+# branch" refusal for every other target. Fold + this filter = the same
+# coverage as before, with the main/develop half now required.
 on:
+  workflow_call:
   pull_request:
+    branches-ignore: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -13,8 +27,20 @@ jobs:
     name: Git Flow & Freshness Checks
     runs-on: ubuntu-latest
     steps:
+      # ci.yml also runs on `push` and `workflow_dispatch`, where there is no
+      # pull_request payload at all: every step below would then read an empty
+      # base ref and fail on nothing. Conditioning the steps (rather than the
+      # caller job) keeps the job's result `success` instead of `skipped` —
+      # `CI Success` demands `== "success"` exactly, and a skip would fail the
+      # chain on every push to develop.
+      - name: No pull request to govern
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          echo "event '${{ github.event_name }}' carries no pull_request payload:"
+          echo "Git Flow, branch freshness and attribution have nothing to assert."
+
       - name: Block archive branches as PR source
-        if: ${{ startsWith(github.event.pull_request.head.ref, 'archive/') }}
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'archive/') }}
         env:
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
@@ -22,6 +48,7 @@ jobs:
           exit 1
 
       - name: Enforce Git Flow branch rules
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           SOURCE_REF: ${{ github.event.pull_request.head.ref }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -81,12 +108,14 @@ jobs:
           fi
 
       - name: Checkout head branch
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Verify branch includes latest base branch
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
@@ -99,6 +128,7 @@ jobs:
           fi
 
       - name: Reject AI-attributed commits
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -14,7 +14,8 @@
     "is still on disk, so the suite demands an accounting for it."
   ],
   "_schema": {
-    "script": "repo-relative path, the identity of the guard",
+    "script": "repo-relative path, the identity of the guard — the workflow itself when the guard is inline steps (see `inline_steps`)",
+    "inline_steps": "present when the guard is written as steps inside `workflow` rather than as a script under scripts/: the exact `- name:` of each step that must exist in `job`. The wiring test then reads those steps instead of hunting for a `run:` line naming a script. Without it, the three checks of pr-governance.yml — Git Flow, branch freshness, AI attribution — were real guards that the declared set simply did not mention.",
     "workflow": "the workflow file whose job invokes it",
     "job": "the job key inside that workflow",
     "required": "true when a failure of `job` must fail the single required check (CI Success)",
@@ -221,6 +222,27 @@
         "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
       },
       "required_via": "production-gates"
+    },
+    {
+      "script": ".github/workflows/pr-governance.yml",
+      "inline_steps": [
+        "Block archive branches as PR source",
+        "Enforce Git Flow branch rules",
+        "Verify branch includes latest base branch",
+        "Reject AI-attributed commits"
+      ],
+      "purpose": "Git Flow branch rules, freshness of the branch against its base, and no AI-attributed commit.",
+      "workflow": ".github/workflows/pr-governance.yml",
+      "job": "governance",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "blind_spot": {
+        "issue": 1699,
+        "summary": "No self-test materialises a PR these steps must reject, so none of the three is known to refuse. The attribution step greps identities for `claude|anthropic` only, so Codex, Copilot and other assistant identities pass; #1699 replaces it with a two-compartment allowlist (dependabot[bot] has 149 legitimate commits and must keep passing)."
+      },
+      "required_via": "pr-governance"
     }
   ],
   "unwired": [

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -167,6 +167,42 @@ def script_mentions_in_job(workflow_text: str, job: str, script: str) -> "list[s
     return [line.strip() for line in block.split("\n") if script in line]
 
 
+def inline_step_blocks(workflow_text: str, job: str, steps: "list[str]") -> "dict[str, str]":
+    """The live YAML of each named step of ``job``, keyed by step name.
+
+    A guard need not be a script: pr-governance.yml writes Git Flow, branch
+    freshness and the AI-attribution check as steps. They were real guards that
+    the registry could not even name, because every wiring test looked for a
+    `run:` line mentioning a path under scripts/. Missing steps are simply
+    absent from the mapping, which is what makes their removal detectable.
+    """
+    block = strip_comments(job_block(workflow_text, job))
+    found = {}
+    for step in steps:
+        start = block.find(f"- name: {step}\n")
+        if start == -1:
+            continue
+        rest = block[start:]
+        following = re.search(r"^      - name: ", rest[1:], re.MULTILINE)
+        found[step] = rest if following is None else rest[: 1 + following.start()]
+    return found
+
+
+def step_attributes(step_block: str) -> str:
+    """A step's own YAML keys, without the shell body of its `run:`.
+
+    Where a step can be disarmed. Scanning the whole block instead would read
+    the shell too, and `ident=$(git log … | grep -iE … || true)` is a `grep`
+    that found nothing, not a guard that gave up — DISARM_TOKENS applied to the
+    body flagged it, which is a false positive on a line doing its job.
+    """
+    return "\n".join(
+        line
+        for line in step_block.split("\n")
+        if re.match(r"^ {8}[A-Za-z][\w-]*:", line)
+    )
+
+
 def trigger_block(text: str, trigger: str) -> str:
     """The `on:` sub-block of one trigger, up to the next trigger or top key."""
     on_match = re.search(r"^on:$", strip_comments(text), re.MULTILINE)
@@ -322,6 +358,20 @@ class RealWorkflowTests(unittest.TestCase):
                     "jobs instead, never the workflow.",
                 )
 
+    def test_ci_still_runs_when_a_draft_becomes_ready(self) -> None:
+        # pr-governance.yml declared `ready_for_review` before it was folded
+        # into ci.yml. The default type set is [opened, synchronize, reopened],
+        # so folding without spelling the types out here would have narrowed
+        # that guard's reach without a single line saying so — exactly the
+        # class of silent coverage loss this campaign exists to close.
+        block = trigger_block(CI_WORKFLOW.read_text(encoding="utf-8"), "pull_request")
+        self.assertIn(
+            "ready_for_review",
+            block,
+            "ci.yml's pull_request types must keep `ready_for_review`: it is not "
+            "in the default set, and pr-governance now runs only from here.",
+        )
+
 
 class BlockingBehaviourTests(unittest.TestCase):
     """Presence is not blocking, and only blocking blocks.
@@ -475,6 +525,20 @@ class GuardRegistryShapeTests(unittest.TestCase):
                     "a `warn` guard must declare its exit_condition",
                 )
 
+    def test_an_inline_guard_names_the_steps_that_are_the_guard(self) -> None:
+        # `inline_steps: []` would satisfy the wiring test vacuously — an entry
+        # claiming a guard while pointing at nothing.
+        for entry in self.guards:
+            if "inline_steps" not in entry:
+                continue
+            with self.subTest(script=entry["script"]):
+                self.assertIsInstance(entry["inline_steps"], list)
+                self.assertTrue(
+                    entry["inline_steps"],
+                    "an inline guard must name at least one step, else it "
+                    "declares a guard the wiring test cannot read",
+                )
+
     def test_no_guard_is_declared_twice(self) -> None:
         scripts = [entry["script"] for entry in self.guards]
         duplicates = sorted({s for s in scripts if scripts.count(s) > 1})
@@ -533,6 +597,19 @@ class GuardWiringTests(unittest.TestCase):
     def test_every_guard_is_invoked_in_the_job_the_registry_names(self) -> None:
         for entry in self.guards:
             with self.subTest(script=entry["script"]):
+                steps = entry.get("inline_steps")
+                if steps:
+                    present = inline_step_blocks(
+                        self._workflow_text(entry), entry["job"], steps
+                    )
+                    self.assertEqual(
+                        sorted(present),
+                        sorted(steps),
+                        f"{entry['workflow']} job `{entry['job']}` no longer has "
+                        f"step(s) {sorted(set(steps) - set(present))} — the check "
+                        "was removed or renamed, or the registry entry is stale.",
+                    )
+                    continue
                 mentions = script_mentions_in_job(
                     self._workflow_text(entry), entry["job"], entry["script"]
                 )
@@ -583,7 +660,16 @@ class GuardWiringTests(unittest.TestCase):
             if entry["mode"] != "strict":
                 continue
             text = self._workflow_text(entry)
-            for line in script_mentions_in_job(text, entry["job"], entry["script"]):
+            steps = entry.get("inline_steps")
+            invocations = (
+                [
+                    step_attributes(block)
+                    for block in inline_step_blocks(text, entry["job"], steps).values()
+                ]
+                if steps
+                else script_mentions_in_job(text, entry["job"], entry["script"])
+            )
+            for line in invocations:
                 for token in DISARM_TOKENS:
                     with self.subTest(script=entry["script"], token=token):
                         self.assertNotIn(
@@ -693,6 +779,65 @@ class GuardRegistryDisarmTests(unittest.TestCase):
             if "--mode warn" in candidate
         ]
         self.assertTrue(disarmed, "the disarm must be visible on the invocation line")
+
+    def _inline_entry(self) -> dict:
+        for entry in self.registry["guards"]:
+            if entry.get("inline_steps"):
+                return entry
+        raise AssertionError("no inline guard in the registry to mutate")
+
+    def test_deleting_an_inline_step_from_its_workflow_is_detected(self) -> None:
+        entry = self._inline_entry()
+        text = (REPO_ROOT / entry["workflow"]).read_text(encoding="utf-8")
+        steps = entry["inline_steps"]
+        self.assertEqual(
+            sorted(inline_step_blocks(text, entry["job"], steps)),
+            sorted(steps),
+            "fixture precondition: every declared step is there today",
+        )
+        victim = steps[-1]
+        broken = text.replace(f"- name: {victim}\n", "- name: Something else\n")
+        self.assertNotIn(
+            victim,
+            inline_step_blocks(broken, entry["job"], steps),
+            "renaming a declared step away must leave the wiring test nothing to find",
+        )
+
+    def test_continue_on_error_on_an_inline_step_is_detected(self) -> None:
+        # The inline equivalent of `--mode warn`: the step still runs, still
+        # exits 1, and the job stays green.
+        entry = self._inline_entry()
+        text = (REPO_ROOT / entry["workflow"]).read_text(encoding="utf-8")
+        victim = entry["inline_steps"][-1]
+        today = [
+            step_attributes(block)
+            for block in inline_step_blocks(
+                text, entry["job"], entry["inline_steps"]
+            ).values()
+        ]
+        self.assertEqual(
+            [token for attrs in today for token in DISARM_TOKENS if token in attrs],
+            [],
+            "fixture precondition: no declared step is disarmed today",
+        )
+        broken = text.replace(
+            f"- name: {victim}\n", f"- name: {victim}\n        continue-on-error: true\n"
+        )
+        attributes = step_attributes(
+            inline_step_blocks(broken, entry["job"], [victim])[victim]
+        )
+        self.assertTrue(
+            any(token in attributes for token in DISARM_TOKENS),
+            "a disarmed inline step must be visible among the step's own YAML keys",
+        )
+
+    def test_dropping_ready_for_review_from_ci_is_detected(self) -> None:
+        text = CI_WORKFLOW.read_text(encoding="utf-8")
+        broken = text.replace(
+            "    types: [opened, synchronize, reopened, ready_for_review]\n", "", 1
+        )
+        self.assertIn("ready_for_review", trigger_block(text, "pull_request"))
+        self.assertNotIn("ready_for_review", trigger_block(broken, "pull_request"))
 
     def test_moving_a_required_guard_to_an_unrequired_job_is_detected(self) -> None:
         # The subtler disarm: the guard still runs, still strict, still in


### PR DESCRIPTION
Ferme le volet code de #1698.

## Le manque

`pr-governance.yml` etait **absent de `ci.yml`** — ni job, ni `needs`. Le repli
de #1710 a pris six workflows et laisse celui-la, alors que #1698 le nommait
explicitement. Il porte trois choses qui ne gardaient donc rien :

1. le Git Flow (prefixes de branche et cible autorisee) ;
2. le garde anti-attribution IA ;
3. **la fraicheur de branche** — `git merge-base --is-ancestor origin/BASE HEAD`,
   le remplacant maison de `strict` (decision #1639).

`strict` est a `false` et le job maison n'etait pas requis : **la fraicheur de
branche n'etait protegee par personne.**

## Les deux pieges du repli, traites

- **`ready_for_review`.** `pr-governance` le declarait ; le `pull_request` de
  `ci.yml` n'avait aucun `types`, donc le defaut `[opened, synchronize,
  reopened]`. Replier tel quel retrecissait la portee du garde sans qu'une
  ligne le dise. `ci.yml` epelle desormais ses quatre types — au passage, la CI
  se relance quand un brouillon devient pret.
- **Les permissions.** Un workflow appele ne peut pas exceder son appelant, et
  `ci.yml` n'a que `contents: read` au niveau global. Le job appelant accorde
  explicitement `pull-requests: read`.

## Deux choix a expliciter

- **`branches-ignore: [main, develop]` plutot que plus de `pull_request` du
  tout.** `ci.yml` est filtre sur ces deux branches : la suppression seche
  aurait perdu le refus « cette PR ne vise pas une branche d'integration »
  pour toute autre cible. Couverture identique a avant, moitie main/develop
  desormais requise, aucun double run.
- **Les etapes sont conditionnees a l'evenement, pas le job appelant.**
  `ci.yml` tourne aussi sur `push` et `workflow_dispatch`, ou il n'y a aucune
  charge utile de PR — les etapes echoueraient sur une base vide. Conditionner
  le job l'aurait rendu `skipped`, que la chaine de `CI Success` (`== "success"`
  exactement) refuse : rouge sur chaque push vers `develop`.

## Le registre savait nommer un script, pas une etape

Les trois gardes de `pr-governance` sont ecrits en YAML inline. `guards.json`
etait ancre sur les chemins sous `scripts/`, donc ces trois gardes reels
etaient absents de l'ensemble declare — le defaut de #1706 en miniature.
`inline_steps` les y fait entrer, et les tests de cablage lisent les etapes
nommees au lieu de chercher une ligne `run:`.

Effet de bord attrape en chemin : applique tel quel, `DISARM_TOKENS` lisait le
corps du shell et prenait le `|| true` de `grep` (aucune correspondance n'est
pas un echec) pour un desarmement. La detection porte maintenant sur les cles
YAML de l'etape, la ou `continue-on-error` se pose.

## Preuve

Sept desarmements rejoues sur les vrais fichiers, **tous rouges**, chacun en
nommant le test :

| Desarmement | Detecte par |
|---|---|
| perte de `ready_for_review` | `test_ci_still_runs_when_a_draft_becomes_ready` |
| etape renommee | `test_every_guard_is_invoked_in_the_job_the_registry_names` |
| `continue-on-error` sur une etape | `test_a_strict_guard_is_not_disarmed_at_its_invocation` |
| sortie du `needs` | `test_a_required_guard_lives_in_a_job_that_blocks_the_merge` |
| sortie de la chaine | idem + `test_every_needed_job_is_checked_by_the_chain` |
| `required_via` pointe ailleurs | idem |
| job appelant supprime | idem + `test_every_needed_job_is_actually_declared` |

`python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` : **170
tests verts** (165 avant).

Ce que cette PR ne peut pas prouver localement : que le repli tourne bien sous
`workflow_call` avec le contexte de PR. **C'est son propre run CI qui tranche**
— les six etapes doivent apparaitre dans le job `PR Governance` de ce run.

## Reste de #1698

`enforce_admins` (aujourd'hui `false` : le seul check requis est contournable
par la seule personne qui merge) sera bascule apres ce merge. `strict` reste
`false`, decide et mesure : 16 a 19 PR mergees par jour contre une CI a ~30 min,
et le controle equivalent est desormais requis par cette PR.