### PR TITLE
test(gardes): executer les vecteurs de refus, et exiger un refus, pas un plantage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,17 +549,22 @@ jobs:
   # captured in docs/reference/mcp-tools.json.
   #
   # It lives HERE, in ci.yml, and not in doc-contract.yml or
-  # gate-contracts.yml, for one reason: neither of those is in "CI Success"'s
-  # needs, and "CI Success" is the only required check on develop and main —
-  # so nothing they find can block a merge. doc-contract.yml's path filter
-  # was ALSO blind to crates/velesdb-memory/src, sdks/, integrations/ and
-  # skills/, the very directories this guard reads. A gate that is never
-  # triggered, or triggered but not required, protects nothing. (That filter
-  # is widened in the same change, so the doc-contract workflow stops missing
-  # those paths on push too.)
+  # gate-contracts.yml, for a reason that WAS decisive and no longer is:
+  # neither of those was in "CI Success"'s needs, and "CI Success" is the only
+  # required check on develop and main — so nothing they found could block a
+  # merge. doc-contract.yml's path filter was ALSO blind to
+  # crates/velesdb-memory/src, sdks/, integrations/ and skills/, the very
+  # directories this guard reads. A gate that is never triggered, or triggered
+  # but not required, protects nothing. (That filter is widened in the same
+  # change, so the doc-contract workflow stops missing those paths on push
+  # too.)
   #
-  # Every python suite this job runs is therefore run HERE and not only under
-  # gate-contracts.yml's `unittest discover`, which is not required.
+  # Since the fold of #1698 and #1710, BOTH of those workflows are called from
+  # ci.yml and read by the "CI Success" chain, so `gate-contracts.yml`'s
+  # `unittest discover -s scripts/tests` IS required — every suite under that
+  # directory now blocks a merge, including the ones no job names. This job
+  # stays as it is: naming its suites explicitly costs seconds and survives
+  # someone narrowing the discover.
   #
   # No toolchain, no build: pure Python over committed text, seconds.
   # ===========================================================================

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -24,7 +24,9 @@
     "self_test": "unittest module that proves the guard refuses; null when none exists",
     "self_test_required": "true when that module runs inside a required job",
     "blind_spot": "known limit of the guard's reach, with the issue tracking it",
-    "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required"
+    "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required",
+    "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the same tree repaired. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
+    "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent."
   },
   "_json_not_yaml": [
     "gate-contracts.yml runs these suites with a bare actions/setup-python and",
@@ -45,7 +47,8 @@
       "blind_spot": {
         "issue": 1700,
         "summary": "scan_file() stops at the first #[cfg(test)] marker, and does so BEFORE block-comment tracking: 33914 lines are never read, and a marker quoted inside /* */ blinds the whole file."
-      }
+      },
+      "refusal_untested": "No CLI surface: the scan is rooted at REPO_ROOT derived from the script path, so no tree can be handed to it as a process. Its self-test exercises the internal functions, which leaves everything between main() and the exit code unproven. Tracked by #1715."
     },
     {
       "script": "scripts/verify_unsafe_safety_template.py",
@@ -56,6 +59,21 @@
       "mode": "strict",
       "self_test": null,
       "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "an unsafe block with no SAFETY comment in front of it",
+          "files": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - `target` is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases `target` for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
         "summary": "Runs only on production .rs files changed by the PR, so it never re-reads unsafe blocks that predate it."
@@ -70,6 +88,34 @@
       "mode": "strict",
       "self_test": null,
       "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "a TODO carrying no EPIC/US tag and no issue number",
+          "files": {
+            "src/lib.rs": "// TODO: rewrite this once the index lands\npub fn f() {}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "// TODO(EPIC-042): rewrite this once the index lands\npub fn f() {}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        },
+        {
+          "vector": "a FIXME carrying no tag — the verb changes, the obligation does not",
+          "files": {
+            "src/lib.rs": "// FIXME: the cast overflows above 2^53\npub fn f() {}\n"
+          },
+          "accepts": {
+            "src/lib.rs": "// FIXME(#1468): the cast overflows above 2^53\npub fn f() {}\n"
+          },
+          "argv": [
+            "--files",
+            "{root}/src/lib.rs"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
         "summary": "Diff-scoped to changed velesdb-core production files, like the unsafe guard."
@@ -87,7 +133,8 @@
       "blind_spot": {
         "issue": null,
         "summary": "None known. Its self-test is reached by gate-contracts.yml's `unittest discover`, which the fold made required through the `gate-contracts` caller job."
-      }
+      },
+      "refusal_untested": "No CLI surface: same rooted-at-REPO_ROOT shape. Its self-test proves the comparison in-process, never the process. Tracked by #1715."
     },
     {
       "script": "scripts/check-feature-claims.py",
@@ -101,7 +148,8 @@
       "blind_spot": {
         "issue": null,
         "summary": "Breaks (reports column_store MISSING) if any string literal in velesdb-python/src uses a backslash line-continuation."
-      }
+      },
+      "refusal_untested": "No CLI surface: same rooted-at-REPO_ROOT shape. Tracked by #1715."
     },
     {
       "script": "scripts/check-perf-claims.py",
@@ -115,7 +163,8 @@
       "blind_spot": {
         "issue": 1701,
         "summary": "Cannot go red as wired: the grouping label contains the measured value, so two claims never share a group and the only exit-1 path is unreachable. The Criterion front is disabled by --no-criterion and never feeds the exit code."
-      }
+      },
+      "refusal_untested": "No CLI surface AND, per #1701, structurally unable to reach its own exit 1: a vector would be refused by the guard for the wrong reason, or not at all. Fix #1701 first, then #1715."
     },
     {
       "script": "scripts/check-mcp-doc-contract.py",
@@ -129,7 +178,8 @@
       "blind_spot": {
         "issue": 1695,
         "summary": "POLICED_TOOLS holds 1 of the 20 published tools, and SURFACE_GLOBS misses the Python and WASM binding sources. Attribution rests on alias proximity within 500 characters."
-      }
+      },
+      "refusal_untested": "Takes --root, so a vector is possible; not written yet because the tree it needs is a whole tools capture plus a policed surface. Tracked by #1715."
     },
     {
       "script": "scripts/check-doc-contract.sh",
@@ -176,7 +226,8 @@
         "issue": null,
         "summary": "None known. Folded into CI Success's needs and chain via the `promise-contract` caller job, so a failure now blocks the merge."
       },
-      "required_via": "promise-contract"
+      "required_via": "promise-contract",
+      "refusal_untested": "No CLI surface: the registry path is rooted at REPO_ROOT. Tracked by #1715."
     },
     {
       "script": "scripts/check-python.sh",
@@ -191,7 +242,8 @@
         "issue": null,
         "summary": "None known. Folded into CI Success's needs and chain via the `propagation-guard` caller job, so a failure now blocks the merge."
       },
-      "required_via": "propagation-guard"
+      "required_via": "propagation-guard",
+      "refusal_untested": "No CLI surface: the shell guard cds to the repository root itself. Tracked by #1715."
     },
     {
       "script": "scripts/check_binary_size.py",
@@ -206,7 +258,8 @@
         "issue": null,
         "summary": "None known. Folded into CI Success's needs and chain via the `binary-size` caller job, so a failure now blocks the merge."
       },
-      "required_via": "binary-size"
+      "required_via": "binary-size",
+      "refusal_untested": "No CLI surface, and a vector would have to produce real release binaries to weigh. Tracked by #1715."
     },
     {
       "script": "scripts/run-production-gates.sh",
@@ -221,7 +274,8 @@
         "issue": null,
         "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
       },
-      "required_via": "production-gates"
+      "required_via": "production-gates",
+      "refusal_untested": "A meta-runner: it chains the other guards, so its refusal is theirs. It gets a vector once the guards it chains have one. Tracked by #1715."
     },
     {
       "script": ".github/workflows/pr-governance.yml",
@@ -242,7 +296,8 @@
         "issue": 1699,
         "summary": "No self-test materialises a PR these steps must reject, so none of the three is known to refuse. The attribution step greps identities for `claude|anthropic` only, so Codex, Copilot and other assistant identities pass; #1699 replaces it with a two-compartment allowlist (dependabot[bot] has 149 legitimate commits and must keep passing)."
       },
-      "required_via": "pr-governance"
+      "required_via": "pr-governance",
+      "refusal_untested": "An inline guard: its steps run in a GitHub runner against a pull_request payload, which no local tree reproduces. #1699 replaces the attribution step and brings its own vectors, including the positive control (dependabot[bot] must keep passing)."
     }
   ],
   "unwired": [

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -539,6 +539,35 @@ class GuardRegistryShapeTests(unittest.TestCase):
                     "declares a guard the wiring test cannot read",
                 )
 
+    def test_a_strict_required_guard_has_been_seen_refusing_or_says_why_not(self) -> None:
+        # The question under this whole registry. `guards.json` answered
+        # "which guards exist" (#1702), and the fold of #1698 made them block a
+        # merge; neither answers "can this one refuse at all?".
+        # `check-perf-claims.py` satisfies both today and is structurally
+        # unable to reach its own `exit 1` (#1701). So a strict, required guard
+        # either carries executable vectors — run by
+        # scripts/tests/test_guard_refusal_vectors.py — or states in writing
+        # why it has none yet, naming the issue that will give it one.
+        for entry in self.guards:
+            if entry["mode"] != "strict" or not entry["required"]:
+                continue
+            with self.subTest(script=entry["script"]):
+                if entry.get("must_refuse"):
+                    continue
+                reason = (entry.get("refusal_untested") or "").strip()
+                self.assertTrue(
+                    reason,
+                    "declares no `must_refuse` vector and no `refusal_untested` "
+                    "reason: nothing has ever seen this guard refuse, and nothing "
+                    "says why not",
+                )
+                self.assertRegex(
+                    reason,
+                    r"#\d+",
+                    "an untested refusal must name the issue that will close it, "
+                    "else the gap has no owner",
+                )
+
     def test_no_guard_is_declared_twice(self) -> None:
         scripts = [entry["script"] for entry in self.guards]
         duplicates = sorted({s for s in scripts if scripts.count(s) > 1})

--- a/scripts/tests/test_guard_refusal_vectors.py
+++ b/scripts/tests/test_guard_refusal_vectors.py
@@ -1,0 +1,162 @@
+"""Every declared refusal vector is executed, and the guard must refuse it.
+
+``scripts/guards.json`` said which guards exist (#1702) and the fold of #1698
+made them block a merge. Neither answers the question underneath: *can this
+guard refuse at all?* A guard that exits 0 on everything satisfies both — it
+is declared, it is required, and it protects nothing. ``check-perf-claims.py``
+is that guard today (#1701): wired, strict, required, and structurally unable
+to reach its own ``exit 1``.
+
+So a guard declares its refusals as DATA, and this module runs them:
+
+  * every vector in ``must_refuse`` is materialised under a temp directory and
+    the guard is invoked on it — it must exit **1**;
+  * every vector's ``accepts`` tree is materialised the same way — it must
+    exit **0**.
+
+**Exit 1, not "non-zero".** A guard that crashes exits 2, and a crash is not a
+refusal: reading any non-zero code as success would let a guard broken by a
+typo pass this suite as if it were doing its job. The distinction is not
+theoretical — ``check-mcp-doc-contract.py`` returns 2 when its capture file is
+missing, which is exactly the shape a careless vector would produce.
+
+**The accepted control is not optional.** A guard that refuses everything
+passes the refusal half perfectly, and would break the build on every PR. The
+control is what tells "it can say no" apart from "it can only say no". Same
+reason ``dependabot[bot]`` has to keep passing the attribution guard of #1699:
+149 legitimate commits are the positive control there.
+
+The vectors live in the registry rather than here so that adding a guard and
+declaring what it refuses are one act, in one file, confronted by
+``test_ci_gate_reachability.py``'s shape rule.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GUARDS_REGISTRY = REPO_ROOT / "scripts" / "guards.json"
+
+#: What the guard is expected to answer, by tree.
+REFUSED, ACCEPTED = 1, 0
+
+
+def load_guard_registry() -> dict:
+    return json.loads(GUARDS_REGISTRY.read_text(encoding="utf-8"))
+
+
+def guards_with_vectors() -> "list[dict]":
+    return [entry for entry in load_guard_registry()["guards"] if entry.get("must_refuse")]
+
+
+def materialise(tree: "dict[str, str]", root: Path) -> None:
+    """Write ``{relative path: content}`` under ``root``, parents included."""
+    for relative, content in tree.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def run_guard(script: str, argv: "list[str]", root: Path) -> "subprocess.CompletedProcess[str]":
+    """Invoke ``script`` on the materialised tree.
+
+    ``{root}`` in an argument is replaced by the temp directory, so a vector
+    names paths without knowing where they will land.
+    """
+    resolved = [argument.replace("{root}", str(root)) for argument in argv]
+    interpreter = [sys.executable] if script.endswith(".py") else ["bash"]
+    return subprocess.run(  # noqa: S603 - fixed interpreter, registry-declared script
+        [*interpreter, str(REPO_ROOT / script), *resolved],
+        capture_output=True,
+        text=True,
+        cwd=root,
+        check=False,
+    )
+
+
+class RefusalVectorTests(unittest.TestCase):
+    """Each declared vector, executed against the real guard."""
+
+    def _run_tree(self, entry: dict, vector: dict, key: str) -> "subprocess.CompletedProcess[str]":
+        tmp = Path(tempfile.mkdtemp(prefix="guard-vector-"))
+        self.addCleanup(shutil.rmtree, tmp, True)
+        materialise(vector[key], tmp)
+        return run_guard(entry["script"], vector["argv"], tmp)
+
+    def test_every_declared_vector_is_refused(self) -> None:
+        for entry in guards_with_vectors():
+            for vector in entry["must_refuse"]:
+                with self.subTest(script=entry["script"], vector=vector["vector"]):
+                    result = self._run_tree(entry, vector, "files")
+                    self.assertEqual(
+                        result.returncode,
+                        REFUSED,
+                        f"{entry['script']} answered {result.returncode} to a tree it must "
+                        f"refuse ({vector['vector']}). 1 is a refusal; 2 is a guard that "
+                        f"could not run, which is not the same thing.\n"
+                        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+                    )
+
+    def test_every_vector_declares_a_tree_the_guard_accepts(self) -> None:
+        for entry in guards_with_vectors():
+            for vector in entry["must_refuse"]:
+                with self.subTest(script=entry["script"], vector=vector["vector"]):
+                    result = self._run_tree(entry, vector, "accepts")
+                    self.assertEqual(
+                        result.returncode,
+                        ACCEPTED,
+                        f"{entry['script']} refused its own positive control "
+                        f"({vector['vector']}) with {result.returncode}. A guard that "
+                        f"refuses everything passes the vector above and breaks every "
+                        f"PR.\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
+                    )
+
+    def test_the_refused_and_accepted_trees_differ(self) -> None:
+        # Two identical trees cannot both be refused and accepted, so a pair
+        # that is equal means one of them was pasted over the other and the
+        # vector proves nothing.
+        for entry in guards_with_vectors():
+            for vector in entry["must_refuse"]:
+                with self.subTest(script=entry["script"], vector=vector["vector"]):
+                    self.assertNotEqual(
+                        vector["files"],
+                        vector["accepts"],
+                        "a vector whose two trees are identical asserts nothing",
+                    )
+
+
+class VectorShapeTests(unittest.TestCase):
+    """The vectors themselves are well-formed."""
+
+    def test_every_vector_declares_what_it_needs(self) -> None:
+        for entry in guards_with_vectors():
+            for vector in entry["must_refuse"]:
+                with self.subTest(script=entry["script"]):
+                    for field in ("vector", "files", "argv", "accepts"):
+                        self.assertIn(field, vector, f"missing `{field}`")
+                    self.assertTrue(vector["files"], "an empty tree exercises nothing")
+                    self.assertTrue(vector["accepts"], "an empty control proves nothing")
+                    self.assertTrue(
+                        (vector["vector"] or "").strip(),
+                        "a vector must say in words what it materialises",
+                    )
+
+    def test_at_least_one_guard_has_been_seen_refusing(self) -> None:
+        # The suite would be vacuously green with an empty registry — the same
+        # "iterated over an empty array" failure scripts/check-doc-contract.sh
+        # documents in its own header.
+        self.assertTrue(
+            guards_with_vectors(),
+            "no guard declares a refusal vector: this suite proves nothing",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ouvre #1715.

## La question du dessous

Le registre disait quels gardes existent (#1702) et le repli de #1698 les a
rendus bloquants. Ni l'un ni l'autre ne repond a la question suivante : **ce
garde sait-il refuser ?** Un garde qui sort 0 sur tout satisfait les deux — il
est declare, il est requis, et il ne protege rien. `check-perf-claims.py` est
exactement cela aujourd'hui (#1701) : cable, strict, requis, et
structurellement incapable d'atteindre son propre `exit 1`.

Un garde declare donc ses refus en **donnees**, dans `scripts/guards.json`, et
`scripts/tests/test_guard_refusal_vectors.py` les execute : chaque vecteur est
materialise sous un tmp, le garde est invoque dessus, et doit sortir 1.

## Deux exigences qui ne sont pas des details

**`exit 1`, pas « non nul ».** Un garde qui plante sort 2, et un plantage
n'est pas un refus. Lire n'importe quel code non nul comme un succes
laisserait passer un garde casse par une faute de frappe comme s'il faisait
son travail. Ce n'est pas theorique : `check-mcp-doc-contract.py` sort 2 quand
sa capture manque — exactement la forme qu'un vecteur negligent produirait.

**Le controle positif est obligatoire.** Un garde qui refuse tout passe la
moitie « refus » parfaitement, et casse chaque PR. Le controle est ce qui
distingue « il sait dire non » de « il ne sait dire que non ». Il a d'ailleurs
servi immediatement : mon premier arbre accepte pour le garde SAFETY etait
faux, et le controle l'a dit tout de suite — le gabarit exige un en-tete, des
puces de condition **et** une ligne `Reason:`, pas une ligne `// SAFETY:`.
C'est la meme raison qui fait que `dependabot[bot]` devra continuer de passer
le garde d'attribution de #1699 : 149 commits legitimes sont son controle.

## Ce que la mesure a change par rapport au plan

Le plan annoncait « un garde qui n'accepte pas de racine gagne `--root` ».
Mesure : `verify_unsafe_safety_template.py` et `check-todo-annotations.py`
acceptent deja `--files`, donc **aucun des deux n'avait besoin de `--root`**.
Ce sont aussi les deux seuls gardes stricts et requis dont personne n'avait
jamais vu un refus et qui pouvaient en recevoir un. Ils gagnent trois vecteurs
reels.

Les **dix autres** gardes stricts et requis lisent une racine codee en dur :
aucun arbre ne peut leur etre remis en tant que processus. Ils gagnent un
`refusal_untested` qui dit pourquoi et **nomme l'issue #1715**. La regle de
forme exige desormais l'un ou l'autre, avec un numero d'issue : un `null` ne
passe plus, et le trou a un proprietaire au lieu d'etre absent.

A noter, parce que c'est le genre de nuance qui se perd : les quatre gardes
qui ont un module de self-test le prouvent en appelant leurs fonctions
internes. Tout ce qui se passe entre `main()` et le code de sortie reste hors
preuve. C'est pour cela que `refusal_untested` est ecrit meme la ou un
self-test existe.

## Corrige au passage

Un commentaire de `ci.yml` devenu faux : il affirmait que le
`unittest discover` de `gate-contracts.yml` « n'est pas requis ». Ca a cesse
d'etre vrai avec #1710, et c'est precisement pourquoi la nouvelle suite bloque
un merge sans qu'aucun job ait a la nommer.

## Preuve

Cinq desarmements rejoues sur le **vrai** registre, tous rouges :

| desarmement | detecte par |
|---|---|
| la raison `refusal_untested` est retiree | `test_a_strict_required_guard_has_been_seen_refusing_or_says_why_not` |
| la raison ne nomme aucune issue | idem |
| l'arbre refuse est remplace par l'accepte | `test_every_declared_vector_is_refused` + `test_the_refused_and_accepted_trees_differ` |
| le controle positif est remplace par l'arbre refuse | `test_every_vector_declares_a_tree_the_guard_accepts` + idem |
| tous les vecteurs sont supprimes | `test_at_least_one_guard_has_been_seen_refusing` |

`python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` :
**176 tests verts** (170 avant).