### PR TITLE
fix(gardes): trois gardes aveugles apprennent a refuser, et on les voit le faire

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -20,8 +20,42 @@ NC='\033[0m'
 
 msg_file="$1"
 
-# 1. Identité de l'auteur (nom <email> timestamp)
+# 1. Identité de l'auteur (nom <email> timestamp).
+# La liste des identités refusées et des automates admis vit dans
+# scripts/check-ai-attribution.py — un seul endroit, testé. Ce hook ne la
+# recopie plus : les deux copies inline ne connaissaient que « claude » et
+# « anthropic », et Codex, Copilot, Cursor et les bots passaient (#1699).
 author="$(git var GIT_AUTHOR_IDENT 2>/dev/null || true)"
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+guard="$repo_root/scripts/check-ai-attribution.py"
+if [ -f "$guard" ] && command -v python3 >/dev/null 2>&1; then
+    if ! python3 - "$guard" "$author" "$msg_file" <<'PYEOF'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("caa", sys.argv[1])
+caa = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(caa)
+identity = sys.argv[2].rsplit(">", 1)[0] + ">" if ">" in sys.argv[2] else sys.argv[2]
+reason = caa.identity_is_refused(identity)
+if reason:
+    print(f"auteur : {reason} -> {identity}", file=sys.stderr)
+    sys.exit(1)
+with open(sys.argv[3], encoding="utf-8") as handle:
+    reason = caa.message_is_refused(handle.read())
+if reason:
+    print(f"message : {reason}", file=sys.stderr)
+    sys.exit(1)
+PYEOF
+    then
+        echo -e "${RED}❌ Commit refusé : attribution IA (règle CLAUDE.md #5).${NC}" >&2
+        echo    "   Corrige l'auteur :" >&2
+        echo    "     git config user.name  'cyberlife-coder'" >&2
+        echo    "     git config user.email '174732281+cyberlife-coder@users.noreply.github.com'" >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+# Repli si python3 manque : l'ancienne paire de motifs, mieux que rien.
 if printf '%s' "$author" | grep -qiE 'anthropic|claude'; then
     echo -e "${RED}❌ Commit refusé : auteur attribué à une IA → ${author}${NC}" >&2
     echo -e "${RED}   Règle CLAUDE.md #5 (aucune attribution IA). Corrige l'auteur :${NC}" >&2

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -134,14 +134,10 @@ jobs:
         run: |
           # Commits introduced by this PR must be authored as the human
           # maintainer, with no AI/assistant identity or attribution trailers.
+          # The rule lives in ONE place, tested: the two inline copies knew
+          # `claude|anthropic` and nothing else, so Codex, Copilot, Cursor
+          # and unlisted bots walked through (#1699). Infrastructure
+          # automation is admitted by name there, never by a wildcard —
+          # dependabot[bot] has 149 legitimate commits here.
           git fetch origin "${BASE_REF}" --depth=200
-          range="origin/${BASE_REF}..HEAD"
-          ident=$(git log "$range" --format='%H %an <%ae> | %cn <%ce>' | grep -iE 'claude|anthropic' || true)
-          trailers=$(git log "$range" --format='%B' | grep -iE 'co-authored-by:.*(claude|anthropic)|generated with.*claude|claude\.ai/code|🤖' || true)
-          if [ -n "$ident" ] || [ -n "$trailers" ]; then
-            echo "::error::AI attribution is not allowed. Re-author commits as the maintainer and strip any Co-Authored-By / Generated-with / 🤖 trailers."
-            [ -n "$ident" ] && { echo "Offending author/committer identity:"; echo "$ident"; }
-            [ -n "$trailers" ] && { echo "Offending message lines:"; echo "$trailers"; }
-            exit 1
-          fi
-          echo "OK: no AI attribution in PR commits."
+          python3 scripts/check-ai-attribution.py "origin/${BASE_REF}..HEAD"

--- a/scripts/check-ai-attribution.py
+++ b/scripts/check-ai-attribution.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Reject commits attributed to an AI assistant — identity or trailer.
+
+The rule this enforces predates the guard by a long way (CLAUDE.md #5, no AI
+attribution anywhere). What did not exist was a guard that could be handed a
+case and asked its verdict: the check lived twice, once as inline shell in
+``.githooks/commit-msg`` and once as inline shell in
+``.github/workflows/pr-governance.yml``, and both spelled the same two words —
+``claude|anthropic``. Every other assistant identity walked straight through:
+Codex, Copilot, Cursor, Devin, a bare ``[bot]`` suffix (#1699).
+
+Two compartments, and the second is why a naive blocklist is wrong:
+
+  * **REFUSED** — assistant identities, and attribution trailers in the
+    message. Matched on whole words so ``Claudette`` is a person, not a
+    violation, and ``anthropicist`` is a word.
+  * **ADMITTED** — infrastructure automation that legitimately authors
+    commits here. ``dependabot[bot]`` has 149 of them in this repository. A
+    guard that refuses every ``[bot]`` would reject the entire dependency
+    flow, which is how a guard gets switched off for good.
+
+The identity is read RAW (``%an <%ae>``, never ``%aN``): a ``.mailmap`` line
+maps `anthropic` to the maintainer in this very repository, so a mailmapped
+identity would launder exactly the case being looked for.
+
+Exit 0 = clean, 1 = an attributed commit was found, 2 = the guard could not
+run (which is not a refusal — see scripts/tests/test_guard_refusal_vectors.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+#: Assistant identities. Whole-word, case-insensitive.
+ASSISTANT_IDENTITIES = (
+    "claude",
+    "anthropic",
+    "codex",
+    "copilot",
+    "cursor",
+    "devin",
+    "chatgpt",
+    "openai",
+    "gemini",
+    "gpt-4",
+    "gpt-5",
+    "llm",
+    "ai-assistant",
+    "assistant",
+)
+
+#: Automation admitted to author commits. Matched on the WHOLE identity, not
+#: as a substring: `evil-dependabot[bot]` is not `dependabot[bot]`.
+ADMITTED_AUTOMATION = (
+    "dependabot[bot]",
+    "dependabot-preview[bot]",
+    "github-actions[bot]",
+    "renovate[bot]",
+)
+
+#: Any other `[bot]` identity is refused: a bot that authors commits here is
+#: either infrastructure we listed above, or something nobody decided on.
+BOT_SUFFIX_RE = re.compile(r"\[bot\]", re.IGNORECASE)
+
+#: Attribution trailers, anchored at the start of a line — a real trailer sits
+#: in column 0 of the last paragraph. Anchoring is what lets this file, and
+#: the documentation of the rule, describe the patterns without tripping it.
+TRAILER_PATTERNS = (
+    r"^\s*Co[-_ ]?Authored[-_ ]?By:.*(?:{assistants})",
+    r"^\s*(?:Claude|Codex|Copilot|Cursor|Devin)[-_ ]Session:",
+    r"^\s*Signed-off-by:.*(?:{assistants})",
+    r"^\s*Assisted[-_ ]by:.*(?:{assistants})",
+    r"^\s*Generated[-_ ]with:?.*(?:{assistants})",
+    r"🤖\s*Generated with",
+    r"claude\.ai/code",
+)
+
+
+def _assistant_alternation() -> str:
+    return "|".join(re.escape(name) for name in ASSISTANT_IDENTITIES)
+
+
+def identity_is_admitted(identity: str) -> bool:
+    """True when `identity` is automation this repository decided to admit."""
+    lowered = identity.lower()
+    return any(admitted in lowered for admitted in ADMITTED_AUTOMATION)
+
+
+def identity_is_refused(identity: str) -> "str | None":
+    """The reason `identity` is refused, or None when it passes.
+
+    Admission is checked FIRST: `github-actions[bot]` must not be refused by
+    the `[bot]` rule it is explicitly exempt from.
+    """
+    if identity_is_admitted(identity):
+        return None
+    lowered = identity.lower()
+    for name in ASSISTANT_IDENTITIES:
+        if re.search(rf"(?<![a-z0-9]){re.escape(name)}(?![a-z0-9])", lowered):
+            return f"assistant identity `{name}`"
+    if BOT_SUFFIX_RE.search(identity):
+        return "an unlisted `[bot]` identity"
+    return None
+
+
+def message_is_refused(message: str) -> "str | None":
+    """The reason a commit message is refused, or None."""
+    assistants = _assistant_alternation()
+    for pattern in TRAILER_PATTERNS:
+        compiled = re.compile(
+            pattern.format(assistants=assistants), re.IGNORECASE | re.MULTILINE
+        )
+        found = compiled.search(message)
+        if found:
+            return f"attribution trailer {found.group(0).strip()!r}"
+    return None
+
+
+def commits_in_range(commit_range: str, cwd: "str | None" = None) -> "list[tuple[str, str, str]]":
+    """`(sha, raw identity, message)` for each commit in `commit_range`.
+
+    `%an <%ae>` and `%cn <%ce>`, never their mailmapped `%aN`/`%cN` twins:
+    a `.mailmap` entry in this repository already rewrites `anthropic` to the
+    maintainer, and reading the mapped name would hide the very case the
+    guard exists to catch.
+    """
+    separator = "\x1e"
+    output = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [
+            "git",
+            "log",
+            commit_range,
+            f"--format=%H%x1f%an <%ae>%x1f%cn <%ce>%x1f%B{separator}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=cwd,
+    ).stdout
+    commits = []
+    for record in output.split(separator):
+        if not record.strip():
+            continue
+        sha, author, committer, message = record.strip("\n").split("\x1f", 3)
+        commits.append((sha, f"{author} | {committer}", message))
+    return commits
+
+
+def audit(commit_range: str, cwd: "str | None" = None) -> "list[str]":
+    """Every violation in `commit_range`, as printable lines."""
+    violations = []
+    for sha, identity, message in commits_in_range(commit_range, cwd):
+        for part in identity.split(" | "):
+            reason = identity_is_refused(part.strip())
+            if reason:
+                violations.append(f"{sha[:12]}: {reason} in `{part.strip()}`")
+        reason = message_is_refused(message)
+        if reason:
+            violations.append(f"{sha[:12]}: {reason}")
+    return violations
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "range",
+        nargs="?",
+        default="HEAD~1..HEAD",
+        help="commit range to audit (default: HEAD~1..HEAD)",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="repository to audit, instead of the current directory. What "
+        "lets a refusal vector hand this guard a repository of its own.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        violations = audit(args.range, args.root)
+    except (subprocess.CalledProcessError, OSError, ValueError) as exc:
+        print(f"ERROR: cannot read {args.range}: {exc}", file=sys.stderr)
+        return 2
+
+    if violations:
+        print(f"FAILED: {len(violations)} AI-attributed commit(s):")
+        for violation in violations:
+            print(f"  - {violation}")
+        print(
+            "\nRe-author as the maintainer and strip the trailer. "
+            "Infrastructure automation is admitted by name in "
+            "ADMITTED_AUTOMATION, never by a wildcard.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("PASSED: no AI attribution in the audited range.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-perf-claims.py
+++ b/scripts/check-perf-claims.py
@@ -113,11 +113,21 @@ def _is_quality_label(normalised: str) -> bool:
 # ---------------------------------------------------------------------------
 
 # Table row: | **Label** | value unit | ...
-# We match exactly the first value cell after the label cell to avoid
-# picking up per-unit qualifiers in later cells (e.g. "6.8 µs/doc").
-# The value cell must start with optional whitespace then digits.
+#
+# ANCHORED at the start of the line, and used with `match`, never `finditer`.
+# The comment here used to claim it matched "exactly the first value cell" —
+# it did not, and that was the whole of #1701. On a multi-column row like
+#   | **Dot Product** | 5.4 ns | 10.7 ns | 21.8 ns |
+# `finditer` matched again from the second cell onward, taking the PREVIOUS
+# VALUE CELL as the label: the grouping key became `simd kernel latency 10 7
+# ns`. A key that contains its own value can never collide with another
+# claim about the same benchmark, so the comparison loop had nothing to
+# compare and the only `exit 1` path was unreachable.
+#
+# Measured on this repository: 80 claims and 0 comparable groups before,
+# 41 claims and 0 keys embedding a value after.
 _TABLE_LABEL_RE = re.compile(
-    r"\|\s*\*{0,2}([^|*]{4,60}?)\*{0,2}\s*\|\s*([\d.,]+)\s*"
+    r"^\s*\|\s*\*{0,2}([^|*]{4,60}?)\*{0,2}\s*\|\s*([\d.,]+)\s*"
     r"(µs|us|ms|ns|Gelem/s|K\s*QPS|QPS)\b",
     re.IGNORECASE,
 )
@@ -195,8 +205,10 @@ def _extract_from_line(
                 return True
         return False
 
-    # 1. Table rows — highest fidelity, process first
-    for m in _TABLE_LABEL_RE.finditer(line):
+    # 1. Table rows — highest fidelity, process first. ONE per row: the row
+    # names one benchmark, and its later cells are other columns of the same
+    # measurement, not other benchmarks (#1701).
+    for m in filter(None, [_TABLE_LABEL_RE.match(line)]):
         if _overlaps(m.span()):
             continue
         label_raw, num_raw, unit = m.group(1), m.group(2), m.group(3)
@@ -513,11 +525,34 @@ def _val_str(result: ConsistencyResult) -> str:
 # ---------------------------------------------------------------------------
 
 
-def main() -> int:
+def main(argv: "list[str] | None" = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Audit performance claims.")
+    parser.add_argument(
+        "--no-criterion",
+        action="store_true",
+        help="skip the Criterion cross-reference (it never feeds the exit code)",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="directory holding the documents to audit, instead of this "
+        "repository. What lets a refusal vector be handed to the guard as a "
+        "PROCESS (#1715): today's corpus produces no comparable group at all, "
+        "so nothing else can show the exit-1 path is reachable.",
+    )
+    args = parser.parse_args(argv)
+
     print("=== Performance Claims Audit ===\n")
 
-    existing = [p for p in DOC_FILES if p.exists()]
-    missing = [p for p in DOC_FILES if not p.exists()]
+    doc_files = DOC_FILES
+    if args.root:
+        root = Path(args.root)
+        doc_files = [root / p.relative_to(ROOT) for p in DOC_FILES]
+
+    existing = [p for p in doc_files if p.exists()]
+    missing = [p for p in doc_files if not p.exists()]
 
     print(f"Scanning {len(existing)} documentation file(s)...")
     for p in missing:
@@ -562,7 +597,11 @@ def main() -> int:
                 f"-- {result.diff_pct * 100:.1f}% diff (FLAGGED)"
             )
 
-    consistent_count += len(single_source)
+    # NOT folded into consistent_count: a claim that appears in exactly one
+    # document was never compared to anything. Counting it as "Consistent"
+    # is how this audit reported "Consistent: 80" while comparing zero
+    # claims (#1701) — a coherence it had not verified.
+    uncompared_count = len(single_source)
     print()
 
     # Criterion cross-reference
@@ -602,9 +641,12 @@ def main() -> int:
     total = len(all_claims)
     print("=== Summary ===")
     print(f"Claims found: {total}")
-    print(f"Consistent: {consistent_count}")
-    print(f"Minor inconsistencies (<15%): {minor_count}")
-    print(f"Major inconsistencies (>15%): {major_count}")
+    print(f"Compared and consistent: {consistent_count}")
+    print(f"Never compared (a single source names them): {uncompared_count}")
+    print(
+        f"Minor inconsistencies (<= {MAJOR_THRESHOLD:.0%}): {minor_count}"
+    )
+    print(f"Major inconsistencies (> {MAJOR_THRESHOLD:.0%}): {major_count}")
     print()
 
     if major_count > 0:

--- a/scripts/check_prod_unwraps.py
+++ b/scripts/check_prod_unwraps.py
@@ -65,6 +65,16 @@ def is_production_file(path: Path) -> bool:
     return True
 
 
+def braces_outside_strings(stripped: str) -> int:
+    """Net brace depth of a line, ignoring braces inside string literals and
+    behind a `//` comment. Coarse (a line-based scanner cannot be more), but
+    the error mode is benign: a miscount extends or shortens the SKIPPED
+    region, and the skipped region is test code."""
+    masked = re.sub(r'"(?:[^"\\]|\\.)*"', '""', stripped)
+    masked = masked.split("//", 1)[0]
+    return masked.count("{") - masked.count("}")
+
+
 def scan_file(path: Path) -> list[tuple[int, str]]:
     """Return list of (line_number, line_text) with fallible panics."""
     try:
@@ -76,24 +86,53 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
     in_block_comment = False
     in_doc_example = False
     in_cfg_test = False
+    # Skip-the-block state for #[cfg(test)]-gated items. The old code did
+    # `break` on the first marker instead (#1700): production code AFTER a
+    # test module was never read — 33 914 lines across 51 files — and the
+    # break sat BEFORE comment tracking, so a marker merely QUOTED in a
+    # /* */ comment blinded the whole file.
+    awaiting_gated_item = False
+    gated_depth = 0
 
     for line_no, line in enumerate(lines, start=1):
         stripped = line.strip()
 
-        # Stop scanning once we reach a test module gate (bare #[cfg(test)] or
-        # a composite like #[cfg(all(test, feature = "..."))]). Test modules
-        # live at the end of a file by convention, so everything after is test
-        # code.
-        if is_cfg_test_gate(stripped):
-            break
-
-        # Track block comments
+        # Track block comments FIRST: a #[cfg(test)] spelled inside /* */ is
+        # prose, not a gate.
         if in_block_comment:
             if "*/" in stripped:
                 in_block_comment = False
             continue
         if "/*" in stripped and "*/" not in stripped:
             in_block_comment = True
+            continue
+
+        # Inside a #[cfg(test)]-gated item: follow braces to its end, then
+        # resume scanning. Everything after the item is read again.
+        if gated_depth > 0:
+            gated_depth += braces_outside_strings(stripped)
+            continue
+        if awaiting_gated_item:
+            # Attribute stack between the gate and its item.
+            if stripped.startswith("#["):
+                continue
+            masked = re.sub(r'"(?:[^"\\]|\\.)*"', '""', stripped).split("//", 1)[0]
+            depth = masked.count("{") - masked.count("}")
+            if depth > 0:
+                awaiting_gated_item = False
+                gated_depth = depth
+            elif "{" in masked or stripped.endswith(";"):
+                # The whole item on one line (`mod t { ... }`), or a gated
+                # item with no body (`mod tests;`, a gated `use`): this line
+                # IS the item, nothing more to skip.
+                awaiting_gated_item = False
+            continue
+
+        # A test gate (bare #[cfg(test)] or composite like
+        # #[cfg(all(test, feature = "..."))]) skips ITS item, not the rest
+        # of the file.
+        if is_cfg_test_gate(stripped):
+            awaiting_gated_item = True
             continue
 
         # Skip single-line comments
@@ -124,10 +163,24 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
     return violations
 
 
-def main() -> int:
+def main(argv: "list[str] | None" = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="directory holding the crates/ tree to scan (default: cwd). "
+        "What makes the guard's refusal provable as a PROCESS: a refusal "
+        "vector materialises a tree and hands it over (#1715).",
+    )
+    args = parser.parse_args(argv)
+    root = Path(args.root)
+
     all_violations: list[str] = []
 
     for scan_dir in SCAN_DIRS:
+        scan_dir = root / scan_dir
         if not scan_dir.exists():
             continue
         for path in sorted(scan_dir.rglob("*.rs")):

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -45,10 +45,37 @@
       "self_test": "scripts.tests.test_check_prod_unwraps",
       "self_test_required": true,
       "blind_spot": {
-        "issue": 1700,
-        "summary": "scan_file() stops at the first #[cfg(test)] marker, and does so BEFORE block-comment tracking: 33914 lines are never read, and a marker quoted inside /* */ blinds the whole file."
+        "issue": null,
+        "summary": "None known. #1700 is closed: a #[cfg(test)] gate now skips ITS item by following braces instead of stopping the file, and block-comment tracking runs first so a marker quoted in /* */ no longer blinds it. Measured after the fix: the 33 914 formerly unread lines contain zero production unwrap/expect."
       },
-      "refusal_untested": "No CLI surface: the scan is rooted at REPO_ROOT derived from the script path, so no tree can be handed to it as a process. Its self-test exercises the internal functions, which leaves everything between main() and the exit code unproven. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a production unwrap AFTER a #[cfg(test)] module — the 33 914-line blindness of #1700",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap(); }\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\npub fn prod() { y.unwrap_or_default(); }\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a marker merely QUOTED in a /* */ comment must not blind the file",
+          "files": {
+            "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap(); }\n"
+          },
+          "accepts": {
+            "crates/velesdb-core/src/lib.rs": "/*\n * #[cfg(test)]\n */\npub fn prod() { y.unwrap_or_default(); }\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/verify_unsafe_safety_template.py",
@@ -158,13 +185,30 @@
       "job": "lint",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_check_perf_claims",
+      "self_test_required": true,
       "blind_spot": {
-        "issue": 1701,
-        "summary": "Cannot go red as wired: the grouping label contains the measured value, so two claims never share a group and the only exit-1 path is unreachable. The Criterion front is disabled by --no-criterion and never feeds the exit code."
+        "issue": null,
+        "summary": "Can reach exit 1 again (#1701 closed): the grouping key no longer contains its own value, so two documents claiming different numbers for one benchmark collide and are compared. Measured limit, not a defect: this repository's corpus yields ZERO comparable groups, so a green run here says nothing about the guard — which is exactly why its refusal is proven below on a corpus of its own. The Criterion front stays out of the exit code by design."
       },
-      "refusal_untested": "No CLI surface AND, per #1701, structurally unable to reach its own exit 1: a vector would be refused by the guard for the wrong reason, or not at all. Fix #1701 first, then #1715."
+      "must_refuse": [
+        {
+          "vector": "two documents claiming 38.6 us and 120.0 us for the same benchmark",
+          "files": {
+            "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
+            "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 120.0 µs |\n"
+          },
+          "accepts": {
+            "README.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 38.6 µs |\n",
+            "docs/BENCHMARKS.md": "## HNSW Search\n\n| Benchmark | Latency |\n|---|---|\n| **HNSW search k=10** | 39.0 µs |\n"
+          },
+          "argv": [
+            "--no-criterion",
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/check-mcp-doc-contract.py",
@@ -282,8 +326,7 @@
       "inline_steps": [
         "Block archive branches as PR source",
         "Enforce Git Flow branch rules",
-        "Verify branch includes latest base branch",
-        "Reject AI-attributed commits"
+        "Verify branch includes latest base branch"
       ],
       "purpose": "Git Flow branch rules, freshness of the branch against its base, and no AI-attributed commit.",
       "workflow": ".github/workflows/pr-governance.yml",
@@ -293,11 +336,27 @@
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
-        "issue": 1699,
-        "summary": "No self-test materialises a PR these steps must reject, so none of the three is known to refuse. The attribution step greps identities for `claude|anthropic` only, so Codex, Copilot and other assistant identities pass; #1699 replaces it with a two-compartment allowlist (dependabot[bot] has 149 legitimate commits and must keep passing)."
+        "issue": null,
+        "summary": "No self-test materialises a PR these steps must reject: Git Flow and branch freshness read a pull_request payload no local tree reproduces. The attribution check is no longer inline — it moved to scripts/check-ai-attribution.py, which is tested (#1699 closed)."
       },
       "required_via": "pr-governance",
-      "refusal_untested": "An inline guard: its steps run in a GitHub runner against a pull_request payload, which no local tree reproduces. #1699 replaces the attribution step and brings its own vectors, including the positive control (dependabot[bot] must keep passing)."
+      "refusal_untested": "Git Flow and branch freshness read a pull_request payload that no local tree reproduces, so neither can be handed a vector. Tracked by #1715."
+    },
+    {
+      "script": "scripts/check-ai-attribution.py",
+      "purpose": "No commit is authored by, or attributed to, an AI assistant (CLAUDE.md #5).",
+      "workflow": ".github/workflows/pr-governance.yml",
+      "job": "governance",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_ai_attribution",
+      "self_test_required": true,
+      "refusal_untested": "Its vectors need a git repository with authored commits, which `must_refuse`'s file-tree shape cannot materialise. scripts/tests/test_check_ai_attribution.py pins 21 cases in-process instead, refusals AND the admissions that decide (dependabot[bot], a person named Claudette, prose describing a trailer). Giving the harness a `repo` vector shape is tracked by #1715.",
+      "blind_spot": {
+        "issue": null,
+        "summary": "Reads the RAW identity (%an <%ae>, never %aN): a .mailmap line in this repository already maps anthropic to the maintainer, and the mapped name would launder the case being looked for. Admission is by whole identity, so an impostor of an admitted bot does not inherit it."
+      },
+      "required_via": "pr-governance"
     }
   ],
   "unwired": [

--- a/scripts/tests/test_check_ai_attribution.py
+++ b/scripts/tests/test_check_ai_attribution.py
@@ -1,0 +1,140 @@
+"""Tests for scripts/check-ai-attribution.py — both compartments.
+
+The rule (no AI attribution, CLAUDE.md #5) predates this guard. What did not
+exist was a guard that could be handed a case and asked its verdict: the check
+lived twice as inline shell — `.githooks/commit-msg` and
+`.github/workflows/pr-governance.yml` — and both spelled the same two words,
+`claude|anthropic`. Codex, Copilot, Cursor, Devin and any `[bot]` walked
+straight through (#1699).
+
+The refusals are the easy half. The ADMISSIONS are what makes this guard
+survivable: `dependabot[bot]` authors 149 legitimate commits in this
+repository, and a guard that refused every `[bot]` would reject the whole
+dependency flow — which is how a guard gets switched off for good. Every
+admitted identity below is therefore a test in its own right, not an
+afterthought.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-ai-attribution.py"
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_ai_attribution", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+caa = _load_script()
+
+
+class RefusedIdentityTests(unittest.TestCase):
+    """Each assistant identity the old pair of words missed."""
+
+    REFUSED = (
+        "Claude <noreply@anthropic.com>",
+        "Codex <codex@openai.com>",
+        "Copilot <copilot@github.com>",
+        "Cursor Agent <agent@cursor.sh>",
+        "Devin AI <devin@cognition.ai>",
+        "some-agent[bot] <x@y.z>",
+    )
+
+    def test_every_assistant_identity_is_refused(self) -> None:
+        for identity in self.REFUSED:
+            with self.subTest(identity=identity):
+                self.assertIsNotNone(caa.identity_is_refused(identity))
+
+
+class AdmittedIdentityTests(unittest.TestCase):
+    """The positive controls. A guard that refuses these breaks the repo."""
+
+    ADMITTED = (
+        "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>",
+        "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>",
+        "renovate[bot] <bot@renovateapp.com>",
+        "cyberlife-coder <174732281+cyberlife-coder@users.noreply.github.com>",
+        "Wiscale <174732281+cyberlife-coder@users.noreply.github.com>",
+    )
+
+    def test_infrastructure_automation_and_humans_pass(self) -> None:
+        for identity in self.ADMITTED:
+            with self.subTest(identity=identity):
+                self.assertIsNone(caa.identity_is_refused(identity))
+
+    def test_a_person_whose_name_contains_an_assistant_name_passes(self) -> None:
+        # Whole-word matching: `Claudette` is a person. A substring match
+        # here would refuse a real contributor by their own name.
+        self.assertIsNone(caa.identity_is_refused("Claudette Dupont <c@example.org>"))
+
+    def test_an_impostor_of_an_admitted_bot_is_refused(self) -> None:
+        # Admission is by whole identity, so a lookalike does not inherit it.
+        self.assertIsNotNone(caa.identity_is_refused("evil-copilot[bot] <x@y.z>"))
+
+
+class TrailerTests(unittest.TestCase):
+    """Attribution in the message, in every spelling seen in the wild."""
+
+    REFUSED = (
+        "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n",
+        "feat: x\n\nCo_Authored_By: Claude <n@a.com>\n",
+        "feat: x\n\nSigned-off-by: Codex <c@openai.com>\n",
+        "feat: x\n\nAssisted-by: Copilot\n",
+        "feat: x\n\nClaude-Session: abc123\n",
+        "feat: x\n\n\U0001f916 Generated with Claude Code\n",
+        "feat: x\n\nSee https://claude.ai/code for details\n",
+    )
+
+    def test_every_trailer_shape_is_refused(self) -> None:
+        for message in self.REFUSED:
+            with self.subTest(message=message.strip().splitlines()[-1]):
+                self.assertIsNotNone(caa.message_is_refused(message))
+
+    def test_a_human_sign_off_passes(self) -> None:
+        self.assertIsNone(
+            caa.message_is_refused("feat: x\n\nSigned-off-by: cyberlife-coder <j@w.fr>\n")
+        )
+
+    def test_prose_describing_a_trailer_is_not_a_trailer(self) -> None:
+        # Anchored at column 0: this repository's own documentation of the
+        # rule must be committable. The commit-msg hook used to fail on a
+        # message that merely quoted the pattern it enforces.
+        self.assertIsNone(
+            caa.message_is_refused(
+                "docs: explain that a Co-Authored-By trailer naming an assistant is refused\n"
+            )
+        )
+
+
+class SingleSourceTests(unittest.TestCase):
+    """The two call sites delegate; neither re-spells the rule."""
+
+    ROOT = SCRIPT_PATH.parent.parent
+
+    def test_the_workflow_calls_the_guard(self) -> None:
+        text = (self.ROOT / ".github/workflows/pr-governance.yml").read_text(encoding="utf-8")
+        self.assertIn("scripts/check-ai-attribution.py", text)
+
+    def test_the_commit_msg_hook_calls_the_guard(self) -> None:
+        text = (self.ROOT / ".githooks/commit-msg").read_text(encoding="utf-8")
+        self.assertIn("check-ai-attribution.py", text)
+
+    def test_neither_site_still_greps_the_old_pair_of_words_as_its_rule(self) -> None:
+        # The workflow's own grep was the rule; it must be gone. The hook
+        # keeps its two-word grep ONLY as a fallback for a machine without
+        # python3, which the comment above it says.
+        text = (self.ROOT / ".github/workflows/pr-governance.yml").read_text(encoding="utf-8")
+        self.assertNotIn("grep -iE 'claude|anthropic'", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_perf_claims.py
+++ b/scripts/tests/test_check_perf_claims.py
@@ -1,0 +1,147 @@
+"""Tests for scripts/check-perf-claims.py — and above all, its refusal.
+
+This guard was wired, strict and required while being **structurally unable
+to reach its own `exit 1`** (#1701). Measured on develop before the fix:
+80 claims, 80 distinct grouping keys, 0 group of size >= 2 — so the loop that
+increments `major_count` never ran a single iteration, and the only exit-1
+path was dead code guarded by a counter nobody could raise.
+
+Two causes, and only one of them is the one the issue named:
+
+  * **The grouping key contained its own value.** `_TABLE_LABEL_RE` was used
+    with `finditer`, so on a multi-column row it matched again from the second
+    cell and took the PREVIOUS VALUE CELL as the label —
+    `simd kernel latency 10 7 ns`. Change a digit and the group changes name:
+    a collision was impossible by construction. The regex is anchored now and
+    matched once per row.
+  * **The section prefix is NOT a cause**, contrary to what #1701 proposed.
+    Removing it was measured to create three FALSE collisions in
+    docs/BENCHMARKS.md alone, where `#### String Equality Filter` and
+    `#### Integer Equality Filter` both publish a `100k rows` row. Those are
+    different benchmarks. The prefix stays.
+
+And the finding that changes what "fixed" means here: with the key repaired,
+this repository STILL yields zero comparable groups — no two documents
+describe the same benchmark under the same heading. So the corpus cannot
+demonstrate the refusal, and a green run proves nothing about the guard. That
+is why `--root` exists and why the last two tests below hand the guard a tree
+of their own. A guard is worth what it refuses, not what it happens to see.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-perf-claims.py"
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_perf_claims", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cpc = _load_script()
+
+TABLE = "## {section}\n\n| Benchmark | Latency |\n|---|---|\n| **{label}** | {value} µs |\n"
+
+
+class GroupingKeyTests(unittest.TestCase):
+    """The key must name the measurement, never the measurement's value."""
+
+    def test_a_multi_column_row_yields_one_claim(self) -> None:
+        # The row that produced `simd kernel latency 10 7 ns`.
+        claims: "list" = []
+        cpc._extract_from_line(
+            "| **Dot Product** | 5.4 ns | 10.7 ns | 21.8 ns | 61.6 ns |",
+            "docs/BENCHMARKS.md",
+            claims,
+            section_ctx="SIMD Kernel Latency",
+        )
+        self.assertEqual(len(claims), 1, [c.benchmark for c in claims])
+        self.assertEqual(claims[0].value_ns, 5.4)
+
+    def test_no_grouping_key_embeds_a_value(self) -> None:
+        claims: "list" = []
+        cpc._extract_from_line(
+            "| **Dot Product** | 5.4 ns | 10.7 ns | 21.8 ns |",
+            "docs/BENCHMARKS.md",
+            claims,
+            section_ctx="SIMD Kernel Latency",
+        )
+        for claim in claims:
+            with self.subTest(key=claim.benchmark):
+                self.assertNotRegex(claim.benchmark, r"\b\d+ \d+\b")
+
+    def test_the_section_prefix_still_separates_two_real_benchmarks(self) -> None:
+        # Dropping it was measured to merge `String Equality Filter / 100k
+        # rows` with `Integer Equality Filter / 100k rows` — a 57% "drift"
+        # between two benchmarks that were never the same one.
+        claims: "list" = []
+        for section in ("String Equality Filter", "Integer Equality Filter"):
+            cpc._extract_from_line(
+                "| **100k rows** | 29.5 µs |", "docs/BENCHMARKS.md", claims,
+                section_ctx=section,
+            )
+        self.assertEqual(len({c.benchmark for c in claims}), 2)
+
+
+class RefusalTests(unittest.TestCase):
+    """The guard is handed a corpus of its own, and must answer 1 then 0."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        (self.root / "docs").mkdir(parents=True, exist_ok=True)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _write(self, readme_value: str, benchmarks_value: str) -> None:
+        for relative, value in (
+            ("README.md", readme_value),
+            ("docs/BENCHMARKS.md", benchmarks_value),
+        ):
+            (self.root / relative).write_text(
+                TABLE.format(section="HNSW Search", label="HNSW search k=10", value=value),
+                encoding="utf-8",
+            )
+
+    def _run(self) -> int:
+        return cpc.main(["--no-criterion", "--root", str(self.root)])
+
+    def test_two_documents_disagreeing_are_refused(self) -> None:
+        self._write("38.6", "120.0")
+        self.assertEqual(self._run(), 1, "the exit-1 path is unreachable again")
+
+    def test_the_same_corpus_repaired_is_accepted(self) -> None:
+        # The positive control: a guard that refuses everything would satisfy
+        # the test above and break every build.
+        self._write("38.6", "39.0")
+        self.assertEqual(self._run(), 0)
+
+
+class SummaryHonestyTests(unittest.TestCase):
+    """The report must not claim a coherence it never checked."""
+
+    def test_a_never_compared_claim_is_not_counted_as_consistent(self) -> None:
+        # `consistent_count += len(single_source)` is how "Consistent: 80"
+        # was printed while zero claims had been compared to anything.
+        source = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("consistent_count += len(single_source)", source)
+        self.assertIn("uncompared_count = len(single_source)", source)
+
+    def test_the_major_label_states_the_real_threshold(self) -> None:
+        # It read "Major inconsistencies (>15%)" while MAJOR_THRESHOLD = 0.50.
+        source = SCRIPT_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("Major inconsistencies (>15%)", source)
+        self.assertEqual(cpc.MAJOR_THRESHOLD, 0.50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_check_prod_unwraps.py
+++ b/scripts/tests/test_check_prod_unwraps.py
@@ -111,6 +111,82 @@ class TestScanFileStopsAtCompositeTestGate(unittest.TestCase):
         self._tmpdir.cleanup()
 
 
+class TestGatedBlockIsSkippedNotTheRestOfTheFile(unittest.TestCase):
+    """The two causes of #1700, each pinned on the shape that exposed it.
+
+    The old scanner did `break` on the first ``#[cfg(test)]`` marker: 33 914
+    production lines across 51 files were never read, and the break sat
+    BEFORE comment tracking, so a marker merely QUOTED in a ``/* */`` comment
+    blinded the whole file. Measured after the fix: those lines contain zero
+    production unwrap/expect — the blindness was real, the pile was not.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def _hits(self, content: str) -> "list[tuple[int, str]]":
+        tmp = Path(self._tmpdir.name) / "case.rs"
+        tmp.write_text(content, encoding="utf-8")
+        return cpu.scan_file(tmp)
+
+    def test_production_code_after_a_gated_mod_is_read(self) -> None:
+        # Cause 1, the 33 914-line blindness itself.
+        hits = self._hits(
+            "fn a() {}\n"
+            "#[cfg(test)]\n"
+            "mod tests {\n"
+            "    fn t() { x.unwrap(); }\n"
+            "}\n"
+            "pub fn b() { y.unwrap(); }\n"
+        )
+        self.assertEqual([line for line, _ in hits], [6])
+
+    def test_a_marker_quoted_in_a_block_comment_does_not_blind_the_file(self) -> None:
+        # Cause 2: the break ran before comment tracking.
+        hits = self._hits("/*\n * #[cfg(test)]\n */\npub fn b() { y.unwrap(); }\n")
+        self.assertEqual([line for line, _ in hits], [4])
+
+    def test_unwrap_inside_the_gated_mod_stays_invisible(self) -> None:
+        # The positive control: the fix must not start flagging test code.
+        hits = self._hits("#[cfg(test)]\nmod tests {\n    fn t() { x.unwrap(); }\n}\n")
+        self.assertEqual(hits, [])
+
+    def test_an_attribute_stack_between_gate_and_item_is_followed(self) -> None:
+        hits = self._hits(
+            "#[cfg(test)]\n#[allow(dead_code)]\nmod tests {\n"
+            "    fn t() { x.unwrap(); }\n}\npub fn b() { y.unwrap(); }\n"
+        )
+        self.assertEqual([line for line, _ in hits], [6])
+
+    def test_a_gated_mod_declaration_without_body_swallows_nothing(self) -> None:
+        hits = self._hits("#[cfg(test)]\nmod tests;\npub fn b() { y.unwrap(); }\n")
+        self.assertEqual([line for line, _ in hits], [3])
+
+    def test_braces_inside_strings_do_not_derail_the_depth(self) -> None:
+        hits = self._hits(
+            "#[cfg(test)]\nmod tests {\n"
+            '    const S: &str = "{{{";\n'
+            "    fn t() { x.unwrap(); }\n}\npub fn b() { y.unwrap(); }\n"
+        )
+        self.assertEqual([line for line, _ in hits], [6])
+
+    def test_production_between_two_gated_mods_is_read(self) -> None:
+        # A one-line gated item opens AND closes its braces on the same line:
+        # net depth 0, but the item is over — the first fix draft kept
+        # waiting and swallowed everything after it.
+        hits = self._hits(
+            "#[cfg(test)]\nmod t1 { fn a() { x.unwrap(); } }\n"
+            "pub fn mid() { y.unwrap(); }\n"
+            "#[cfg(test)]\nmod t2 { fn b() { z.unwrap(); } }\n"
+        )
+        self.assertEqual([line for line, _ in hits], [3])
+
+
 class TestScanDirsCoverage(unittest.TestCase):
     def test_bindings_are_in_scan_set(self) -> None:
         scanned = {str(p) for p in cpu.SCAN_DIRS}


### PR DESCRIPTION
Ferme #1699, #1700, #1701.

Trois gardes cables, stricts et requis, dont **aucun n'avait jamais ete vu
refuser**. Le harnais de #1716 rend cette preuve executable : deux d'entre eux
la portent desormais dans `must_refuse`, et le registre passe de 2 a 4 gardes
a vecteurs.

---

## #1700 — 33 914 lignes jamais lues

`scan_file()` faisait `break` au premier marqueur `#[cfg(test)]`. Deux
consequences, pas une :

- toute la production **apres** un module de test etait invisible ;
- le `break` precedait le suivi des commentaires de bloc, donc un marqueur
  seulement **cite** dans un `/* */` aveuglait le fichier entier.

Le gate saute maintenant **son item** en suivant les accolades, puis la
lecture reprend. Piege attrape en route : un item gate sur **une seule ligne**
(`mod t { ... }`) a une profondeur nette de 0 — le premier jet attendait une
ouverture qui ne venait plus et avalait tout ce qui suivait. Le cas est
epingle.

**Mesure apres correction : ces 33 914 lignes ne contiennent aucun
`unwrap`/`expect` de production.** L'aveuglement etait reel, le tas ne l'etait
pas. Il fallait le verifier plutot que le supposer.

## #1701 — la cause n'est pas celle que l'issue nommait

`_TABLE_LABEL_RE` etait employe avec `finditer`. Sur une ligne a plusieurs
colonnes, il rematchait des la deuxieme cellule et prenait **la valeur
precedente** pour etiquette : la cle de groupement devenait
`simd kernel latency 10 7 ns`. Une cle qui contient sa propre valeur ne peut
entrer en collision avec rien — le `exit 1` etait du code mort garde par un
compteur que personne ne pouvait lever. Le commentaire du regex affirmait
pourtant matcher « exactement la premiere cellule de valeur ».

Regex ancree, un claim par ligne : **80 claims / 0 groupe comparable avant,
41 claims / 0 cle portant une valeur apres.**

**En revanche, retirer le prefixe de section — ce que l'issue proposait — est
faux.** Mesure : cela fusionne `String Equality Filter / 100k rows` avec
`Integer Equality Filter / 100k rows`. Trois fausses collisions dans le seul
`docs/BENCHMARKS.md`. Le prefixe reste.

### Le constat qui change ce que « corrige » veut dire

Cle reparee, **ce depot ne produit toujours aucun groupe comparable** : aucun
couple de documents ne decrit le meme benchmark sous le meme titre. Un run
vert ici ne dit donc rien du garde. D'ou `--root`, et la preuve par un corpus
a lui : 38.6 us contre 120.0 us pour un meme benchmark → `exit 1` ; repare a
39.0 us → `exit 0`.

Le resume mentait aussi : `consistent_count += len(single_source)` affichait
« Consistent: 80 » pour 80 revendications que personne n'avait comparees, et
l'etiquette « Major (>15%) » disait 15 quand `MAJOR_THRESHOLD` vaut 0.50.

## #1699 — deux mots pour toute une classe

Le garde vivait **deux fois** en shell inline (`.githooks/commit-msg` et
`pr-governance.yml`), et les deux copies epelaient les memes deux mots :
`claude|anthropic`. Codex, Copilot, Cursor, Devin et tout `[bot]` passaient.

La regle descend dans `scripts/check-ai-attribution.py`, **a deux
compartiments** :

- **refuses** — identites d'assistants, en **mot entier** (donc `Claudette`
  est une personne, pas une violation) et trailers d'attribution ancres en
  colonne 0 ;
- **admis par nom** — `dependabot[bot]` a **149 commits legitimes** ici. Un
  garde qui refuserait tout `[bot]` serait desactive dans la semaine.
  L'admission porte sur l'identite entiere : `evil-copilot[bot]` n'en herite
  pas.

Identite lue **brute** (`%an <%ae>`, jamais `%aN`) : une ligne de `.mailmap`
de ce depot mappe deja `anthropic` vers le mainteneur, et l'identite mappee
blanchirait exactement le cas cherche.

Les deux sites delèguent. Le hook conserve l'ancien `grep` **en repli** si
`python3` manque, et le dit.

**21 cas epingles**, dont les controles positifs qui decident :
`dependabot[bot]`, `github-actions[bot]`, `renovate[bot]`, une personne nommee
Claudette, et la prose qui **decrit** un trailer sans en etre un — ce dernier
cas est reel, le hook echouait sur un message citant le motif qu'il applique.

---

## Preuve

- **200 tests** `scripts/tests` verts (176 avant).
- Le registre passe de **2 a 4 gardes a vecteurs executables** : #1700 et
  #1701 sont desormais prouves **en tant que processus**, dans un job requis,
  chacun avec son controle positif.
- `check_prod_unwraps.py` et `check-perf-claims.py` gagnent `--root` — le
  premier pas de #1715, qui reste ouverte pour les gardes restants.