### PR TITLE
ci(gardes): balayer des workflows vers le registre, pas du nom des fichiers

### DIFF
--- a/docs/guides/INSTALL_OPTIONS.md
+++ b/docs/guides/INSTALL_OPTIONS.md
@@ -48,8 +48,13 @@ equivalent for "one command, no toolchain."
 
 ## Known gap
 
-`scripts/setup-hooks.ps1` (Windows: configures `git config core.hooksPath
-.githooks` for local CI validation) has **no shell-script counterpart** —
-`scripts/setup-hooks.sh` does not exist in this repository. This is a
-contributor-tooling gap, not an end-user installation path, so it is not
-represented in the table above; it is called out here so it is not lost.
+`scripts/setup-hooks.ps1` (Windows) and `scripts/setup-hooks.sh` (Linux /
+macOS) both configure `git config core.hooksPath .githooks` so the pre-commit
+and pre-push validation runs locally, before CI has to say no. This is
+contributor tooling, not an end-user installation path, so it is not
+represented in the table above.
+
+The shell counterpart landed in `4c089789`; this page went on saying it "does
+not exist in this repository" for every contributor who read it afterwards, and
+cost them their local hooks. Nothing confronts a documented path against the
+filesystem yet — tracked by #1705.

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -28,7 +28,8 @@
     "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the same tree repaired. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
     "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent.",
     "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make.",
-    "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green."
+    "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green.",
+    "not_a_gate": "scripts a workflow runs that CANNOT refuse — no non-zero exit path. Surfaced by the reverse sweep (workflows -> registry) and kept out of `guards` so the registry never overstates what it covers. The `reason` is mandatory and the no-failure-path claim is verified against the source."
   },
   "_json_not_yaml": [
     "gate-contracts.yml runs these suites with a bare actions/setup-python and",
@@ -397,6 +398,41 @@
         "summary": "Reads the RAW identity (%an <%ae>, never %aN): a .mailmap line in this repository already maps anthropic to the maintainer, and the mapped name would launder the case being looked for. Admission is by whole identity, so an impostor of an admitted bot does not inherit it."
       },
       "required_via": "pr-governance"
+    },
+    {
+      "script": "scripts/compare_perf.py",
+      "purpose": "A benchmark that regresses past its threshold fails the build (perf-smoke).",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "perf-smoke",
+      "required": true,
+      "mode": "strict",
+      "self_test": null,
+      "self_test_required": false,
+      "must_refuse": [
+        {
+          "vector": "a benchmark 3x slower than its baseline, past the declared threshold",
+          "files": {
+            "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 120000\n    }\n  }\n}\n",
+            "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
+          },
+          "accepts": {
+            "current.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 39000\n    }\n  }\n}\n",
+            "baseline.json": "{\n  \"benchmarks\": {\n    \"hnsw_search_k10\": {\n      \"mean_ns\": 38600\n    }\n  },\n  \"threshold_percent\": 15\n}\n"
+          },
+          "argv": [
+            "--current",
+            "{root}/current.json",
+            "--baseline",
+            "{root}/baseline.json",
+            "--threshold",
+            "15"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "Found by the reverse sweep, not by the name pattern: it exits 1 on a regression and runs in the required perf-smoke job, yet matched no guard-shaped name and was absent from this registry entirely. A benchmark absent from `current` is not compared — an empty result set exits 0 (compare_perf.py:119)."
+      }
     }
   ],
   "unwired": [
@@ -409,6 +445,19 @@
       "script": "scripts/perf_phase_gate.py",
       "reason": "Invoked by no workflow. QUALITY_BAR.md:220 and docs/contributing/BENCHMARKING_GUIDE.md:274-289 describe it as if it were active, which is the defect: either wire it or say in both documents that it is a manual tool.",
       "issue": 1708
+    },
+    {
+      "script": "scripts/bump_version.py",
+      "reason": "Release-time only, by design: release.yml:124 runs it to rewrite the version stamps before publishing. There is nothing for it to assert on a pull request. Same class as check-crates-io-versions.sh.",
+      "issue": null
+    }
+  ],
+  "not_a_gate": [
+    {
+      "script": "scripts/export_smoke_criterion.py",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "perf-smoke",
+      "reason": "Produces the artefact compare_perf.py then judges (ci.yml:1108, one step before). It has no non-zero exit path at all — measured — so it cannot refuse anything, and declaring it a guard would overstate the registry. The claim is checked: the suite reads its source and fails this entry if a failure path ever appears."
     }
   ]
 }

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -155,6 +155,47 @@ def discovered_guard_scripts() -> "set[str]":
     return found
 
 
+#: A repo-relative script path as a workflow spells it.
+WORKFLOW_SCRIPT_RE = re.compile(r"(?<![\w./-])(scripts/[\w./-]+\.(?:py|sh|ps1))")
+
+
+def scripts_invoked_by_workflows() -> "dict[str, list[str]]":
+    """Every `scripts/…` path any workflow runs, to `file:line` sites.
+
+    The mirror of :func:`discovered_guard_scripts`, and the half that closes
+    the class. That one asks the filesystem "which files LOOK like guards?",
+    through a name pattern (:44) — and a name pattern is forever guessable.
+    Measured: `scripts/compare_perf.py` exits 1 on a performance regression,
+    runs in the required `perf-smoke` job, and matched no pattern, so the
+    registry never knew it existed.
+
+    Lines inside the `on:` block are skipped: a `paths:` filter NAMES scripts
+    it never runs, and reading those would demand registry entries for files
+    the workflow only watches.
+    """
+    found: "dict[str, list[str]]" = {}
+    for workflow in sorted(WORKFLOW_DIR.glob("*.yml")):
+        inside_triggers = False
+        for number, line in enumerate(
+            workflow.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if COMMENT_LINE_RE.match(line):
+                continue
+            if re.match(r"^on:", line):
+                inside_triggers = True
+                continue
+            if inside_triggers:
+                if re.match(r"^[a-z]", line):
+                    inside_triggers = False
+                else:
+                    continue
+            for match in WORKFLOW_SCRIPT_RE.finditer(line):
+                found.setdefault(match.group(1), []).append(
+                    f"{workflow.name}:{number}"
+                )
+    return found
+
+
 def script_mentions_in_job(workflow_text: str, job: str, script: str) -> "list[str]":
     """Live (comment-stripped) lines of ``job`` that name ``script``.
 
@@ -566,6 +607,51 @@ class GuardRegistryShapeTests(unittest.TestCase):
                     r"#\d+",
                     "an untested refusal must name the issue that will close it, "
                     "else the gap has no owner",
+                )
+
+    def test_every_script_a_workflow_runs_is_accounted_for(self) -> None:
+        # The sweep in the other direction, and the one that closes the class.
+        # `test_every_guard_shaped_script_on_disk_is_accounted_for` asks the
+        # filesystem which files LOOK like guards, through a name pattern —
+        # forever guessable. This one starts from what CI actually RUNS, which
+        # cannot be guessed wrong.
+        #
+        # It found `scripts/compare_perf.py`: exits 1 on a performance
+        # regression, runs in the required `perf-smoke` job, matched no
+        # pattern, and was therefore a required guard the registry did not
+        # know existed.
+        declared = {entry["script"] for entry in self.guards}
+        declared |= {entry["script"] for entry in self.unwired}
+        declared |= {entry["script"] for entry in self.registry.get("not_a_gate", [])}
+        invoked = scripts_invoked_by_workflows()
+        unaccounted = sorted(set(invoked) - declared)
+        self.assertEqual(
+            unaccounted,
+            [],
+            "script(s) a workflow runs and the registry never mentions: "
+            + ", ".join(f"{name} ({', '.join(invoked[name][:2])})" for name in unaccounted)
+            + ". Add each under `guards`, `unwired` or `not_a_gate`.",
+        )
+
+    def test_a_not_a_gate_entry_says_why_it_cannot_refuse(self) -> None:
+        # The escape hatch has to cost something, or every awkward script ends
+        # up in it. A script declared here must have no failure path at all —
+        # the claim is checkable, so it is checked.
+        for entry in self.registry.get("not_a_gate", []):
+            with self.subTest(script=entry["script"]):
+                self.assertTrue(
+                    (entry.get("reason") or "").strip(),
+                    "a `not_a_gate` entry must say why it cannot refuse",
+                )
+                source = (REPO_ROOT / entry["script"]).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+                self.assertNotRegex(
+                    source,
+                    r"sys\.exit\(\s*[1-9]|raise SystemExit\(\s*[1-9]|^\s*exit 1\b",
+                    f"{entry['script']} is declared as unable to refuse, but it "
+                    "carries a non-zero exit path — it is a guard, and it belongs "
+                    "under `guards`.",
                 )
 
     def test_no_guard_is_declared_twice(self) -> None:

--- a/scripts/tests/test_guard_refusal_vectors.py
+++ b/scripts/tests/test_guard_refusal_vectors.py
@@ -139,6 +139,18 @@ class RefusalVectorTests(unittest.TestCase):
                         f"could not run, which is not the same thing.\n"
                         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}",
                     )
+                    # An uncaught Python exception ALSO exits 1, so the code
+                    # alone cannot tell a refusal from a crash. Measured while
+                    # writing the compare_perf vector: a malformed benchmark
+                    # shape raised ValueError, exited 1, and would have passed
+                    # the assertion above as a refusal that never happened.
+                    self.assertNotIn(
+                        "Traceback (most recent call last)",
+                        result.stderr,
+                        f"{entry['script']} exited 1 by CRASHING on this vector, not by "
+                        f"refusing it. The vector is malformed, or the guard is.\n"
+                        f"--- stderr ---\n{result.stderr}",
+                    )
 
     def test_every_vector_declares_a_tree_the_guard_accepts(self) -> None:
         for entry in guards_with_vectors():


### PR DESCRIPTION
Ferme le volet « perimetre du registre » de #1706.

## Le defaut

Le registre se declare « The declared set of repository guards ». Sa moitie
anti-retrecissement demande au **systeme de fichiers** quels fichiers
*ressemblent* a des gardes, via un motif de nom :

```
GUARD_SCRIPT_RE = ^scripts/[^/]*(?:check|verify|gate)[^/]*\.(py|sh)$
```

**Un motif de nom est devinable a jamais.** Elargir le motif ne ferme rien : il
restera toujours un garde nomme autrement. La correction racine est de partir
de ce que la CI **execute**, qui ne se devine pas.

## Ce que le balayage inverse trouve, des sa premiere execution

18 scripts invoques par les 21 workflows. **Trois absents du registre.**

| script | verdict |
|---|---|
| `scripts/compare_perf.py` | **un garde requis que le registre ne connaissait pas** |
| `scripts/bump_version.py` | release-only → `unwired` |
| `scripts/export_smoke_criterion.py` | aucun chemin de sortie non nul → `not_a_gate` |

`compare_perf.py` sort **1** sur une regression de performance (`:165`), tourne
dans `ci.yml:1112`, job `perf-smoke` — lequel est **a la fois dans le `needs` et
lu par la chaine de `CI Success`**. Il n'avait echappe a aucun controle : il ne
*ressemblait* simplement pas a un garde.

La section `not_a_gate` a un prix, sinon tout script genant y atterrit : la
`reason` est obligatoire, **et l'affirmation est verifiee contre la source**.
Declarer un vrai garde « incapable de refuser » fait rougir la suite.

## Le harnais apprend qu'une traceback n'est pas un refus

Mesure faite **en ecrivant le vecteur de `compare_perf`** : ma premiere forme
de benchmark portait `time_ns` la ou `get_mean_ns` lit `mean_ns` (`:25-31`). Le
garde a leve une `ValueError`, Python est sorti en **1**, et l'assertion
« exit 1 = refus » passait au vert sur **un refus qui n'a jamais eu lieu**.

C'est le controle positif qui l'a attrape. Le harnais exige desormais l'absence
de traceback : **le code de sortie seul ne distingue pas un refus d'un
plantage**, et la regle « 1 et pas non-nul » que j'avais ecrite ce matin etait
donc encore trop faible.

## Aussi

`docs/guides/INSTALL_OPTIONS.md` affirmait que `scripts/setup-hooks.sh`
« does not exist in this repository ». **Il existe, suivi, depuis `4c089789`** —
et la page a coute ses hooks locaux a chaque contributeur qui l'a lue depuis.
Corrigee, en nommant la dette : rien ne confronte encore un chemin documente au
systeme de fichiers (#1705).

## Preuve

Cinq desarmements rejoues sur les **vrais** artefacts, tous rouges :

| desarmement | detecte par |
|---|---|
| `compare_perf` sort du registre | `test_every_script_a_workflow_runs_is_accounted_for` |
| la section `not_a_gate` disparait | idem |
| un **vrai** garde est declare incapable de refuser | `test_a_not_a_gate_entry_says_why_it_cannot_refuse` |
| une entree `not_a_gate` sans raison ecrite | idem |
| un vecteur qui **plante** au lieu de refuser | `test_every_declared_vector_is_refused` |

**202 tests** `scripts/tests` verts (201 avant).

## Ce que cette PR ne fait pas

Elle ne declare **pas** les gardes qui sont des tests cargo
(`binding_parity_bdd.rs`, `mcp_tools_drift.rs`, `velesql_error_code_conformance.rs`…).
Mesure : ils tournent dans **deux** jobs requis (`test` a `ci.yml:389-393` et
`lint` a `:163-164`), et rien ne pinne leur execution — `script_mentions_in_job`
rend 0 pour chacun. Les couvrir demande un discriminant `kind` dans le schema et
une forme de vecteur par mutation de source, ce qui double la taille de cette
PR. C'est le residu de #1706, mesure et documente plutot que tu.