### PR TITLE
fix(versions): le bump balaie ce que le garde balaie, au lieu d'une liste

### DIFF
--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -255,4 +255,4 @@ VelesDB engine and is governed by the Core License.
 
 ---
 
-`tauri-plugin-velesdb v4.0.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`tauri-plugin-velesdb v4.0.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -218,4 +218,4 @@ Licensed under the [VelesDB Core License 1.0](./LICENSE) (source-available).
 
 ---
 
-`velesdb-cli v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-cli v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -243,4 +243,4 @@ the platforms and toolchains the project builds and tests on.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -244,4 +244,4 @@ Developed by Julien Lange, WiScale France.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -220,4 +220,4 @@ the VelesDB engine and are governed by that license.
 
 ---
 
-`velesdb-mobile v4.1.0` · Last updated: 2026-07-23 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-mobile v4.1.0` · Last updated: 2026-07-23 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -187,4 +187,4 @@ VelesDB Core License 1.0 — see [LICENSE](../../LICENSE).
 
 ---
 
-`velesdb-server v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-server v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -215,4 +215,4 @@ artifact embeds the engine and is governed by the Core License.
 
 ---
 
-`velesdb-wasm v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-wasm v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -41,7 +41,23 @@ TARGETS: "list[tuple[str, str]]" = [
     ("examples/wasm-browser-demo/index.html", "wasm_cdn_url"),
     ("docs/guides/CONFIGURATION.md", "doc_toml_header"),
     ("docs/guides/SERVER_REST_TOUR.md", "doc_health_snippet"),
+    # Every STAMPED crate README, not one of them. A crate README is the page
+    # a user lands on from crates.io, npm or PyPI, so its `Applies to:` stamp
+    # is the first version claim anybody reads. Only velesdb-python was
+    # rewritten here, and measured on 4.2.0 the other seven still said 4.1.0.
+    # Enumerated rather than globbed on purpose: bump_version refuses a target
+    # whose pattern matches nothing (format drift), so a crate README without
+    # a stamp — velesdb-memory today — must be a deliberate absence, not a
+    # glob's silent inclusion.
+    ("crates/tauri-plugin-velesdb/README.md", "applies_to_stamp"),
+    ("crates/velesdb-cli/README.md", "applies_to_stamp"),
+    ("crates/velesdb-core/README.md", "applies_to_stamp"),
+    ("crates/velesdb-migrate/README.md", "applies_to_stamp"),
+    ("crates/velesdb-mobile/README.md", "applies_to_stamp"),
+    ("crates/velesdb-node/README.md", "applies_to_stamp"),
     ("crates/velesdb-python/README.md", "applies_to_stamp"),
+    ("crates/velesdb-server/README.md", "applies_to_stamp"),
+    ("crates/velesdb-wasm/README.md", "applies_to_stamp"),
     ("demos/rag-pdf-demo/pyproject.toml", "toml"),
     ("sdks/typescript/package.json", "json"),
     ("sdks/typescript/package-lock.json", "npm_lock"),
@@ -188,6 +204,18 @@ def bump_file(path: Path, fmt: str, ver: str, date: "datetime.date") -> int:
         text, n = _sub_first(text, r"(?m)^(\*\*v)" + VERSION_RE + r"(\*\*)", r"\g<1>" + ver + r"\g<2>")
     elif fmt == "cargo_pin":
         text, n = _sub_all(text, r"(velesdb-(?:core|server|cli)@)" + VERSION_RE, r"\g<1>" + ver)
+    elif fmt == "cargo_dep_pin":
+        # `velesdb-core = "X.Y.Z"` in a TOML snippet — a different shape from
+        # `cargo_pin`'s `velesdb-core@X.Y.Z`, which is the shell/cargo-install
+        # form. The guard checks both under `cargo-pin-core`; only one had a
+        # rewrite rule, so four doc snippets survived every bump.
+        # Both spellings the guard matches: the bare `velesdb-core = "X.Y.Z"`
+        # and the table `velesdb-core = { version = "X.Y.Z", features = [...] }`.
+        text, n = _sub_all(
+            text,
+            r'(velesdb-core\s*=\s*(?:\{[^}\n]*?version\s*=\s*)?")' + VERSION_RE + r'(")',
+            r"\g<1>" + ver + r"\g<2>",
+        )
     elif fmt == "ghcr_image":
         text, n = _sub_all(text, r"(ghcr\.io/cyberlife-coder/velesdb:)" + VERSION_RE, r"\g<1>" + ver)
     elif fmt == "fastapi_app_version":
@@ -239,6 +267,60 @@ def bump_cargo_workspace(ver: str) -> int:
     return n + m
 
 
+def swept_stamp_targets() -> "list[tuple[str, str]]":
+    """Every file the version GUARD sweeps, as `applies_to_stamp` targets.
+
+    Not an enumeration. `TARGETS` is a hand-kept list; the guard
+    (`check-doc-freshness.py --guard versions`) is a SWEEP over `docs/**/*.md`,
+    the root README and every `crates/*/README.md`. A list can never keep up
+    with a sweep, and measured, it did not: bumping to 5.0.0 rewrote 66
+    locations and left the guard red on **53** more — a strict, required guard,
+    on the release commit.
+
+    So the two read the same set. Widening the guard's sweep widens the bump on
+    its own, and the release stops depending on someone remembering to append a
+    line here.
+
+    The guard module is loaded rather than reimplemented for the same reason: a
+    second copy of the sweep is a second thing that can drift.
+    """
+    import importlib.util
+
+    guard_path = REPO_ROOT / "scripts" / "check-doc-freshness.py"
+    spec = importlib.util.spec_from_file_location("check_doc_freshness", guard_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"cannot load {guard_path}")
+    guard = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(guard)
+
+    # Keyed by (file, RULE), never by file alone: one document can carry two
+    # different claims, and skipping it wholesale because TARGETS already names
+    # it under another rule leaves the second claim behind. Measured — that is
+    # exactly what kept docs/getting-started.md and SERVER_REST_TOUR.md red,
+    # both already listed under `doc_health_snippet`.
+    enumerated = set(TARGETS)
+    #: The guard's OWN claim name -> the rewrite rule that repairs it. The
+    #: detection is the guard's regex, never a marker string of our own:
+    #: hand-written markers drifted twice while writing this. `velesdb-core = "`
+    #: misses the table form `velesdb-core = { version = "…" }`, which the
+    #: guard matches and which survived every bump in docs/GPU_ACCELERATION.md.
+    RULE_FOR_CLAIM = {
+        "applies-to-core": "applies_to_stamp",
+        "cargo-pin-core": "cargo_dep_pin",
+    }
+    swept = []
+    for path in guard.scanned_doc_files(REPO_ROOT):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        text = path.read_text(encoding="utf-8")
+        for claim in guard.VERSION_CLAIMS:
+            rule = RULE_FOR_CLAIM.get(claim.name)
+            if rule is None:
+                continue  # velesdb-memory claims move on their own cadence.
+            if claim.pattern.search(text) and (rel, rule) not in enumerated:
+                swept.append((rel, rule))
+    return sorted(swept)
+
+
 def main() -> int:
     if len(sys.argv) not in (2, 3) or not re.fullmatch(VERSION_RE, sys.argv[1]):
         # Strict X.Y.Z only: the rewrite patterns target a bare `\d+\.\d+\.\d+`,
@@ -256,7 +338,8 @@ def main() -> int:
     total = bump_cargo_workspace(ver)
     print(f"  Cargo.toml [workspace.package] + dep pins: {total} change(s)")
     misses: "list[str]" = []
-    for rel, fmt in TARGETS:
+    targets = TARGETS + swept_stamp_targets()
+    for rel, fmt in targets:
         path = REPO_ROOT / rel
         if not path.exists():
             print(f"  SKIP {rel} (missing)")

--- a/scripts/check-doc-freshness.py
+++ b/scripts/check-doc-freshness.py
@@ -191,6 +191,13 @@ def scanned_doc_files(root: Path) -> "list[Path]":
     root_readme = root / "README.md"
     if root_readme.is_file():
         out.append(root_readme)
+    # A crate's own README is the page a user lands on from crates.io, npm or
+    # PyPI — its version claim is the FIRST one anybody reads, and it was
+    # outside every sweep. Measured on 4.2.0: seven of the nine stamped READMEs
+    # still announced `Applies to: velesdb-core 4.1.0`, one two minors behind.
+    # `check-version-sync.py` pins exactly two of them (:43, :46), which is why
+    # those two were the only correct ones.
+    out.extend(sorted((root / "crates").glob("*/README.md")))
     return out
 
 


### PR DESCRIPTION
Debloque le tag **5.0.0**. Ferme le volet tampons de version de #1705.

## Le defaut est structurel, pas un oubli

Le garde des versions **balaie** (`docs/**/*.md` + le README racine).
`bump_version.py` **enumere a la main** 66 emplacements. Une liste ne rattrape
jamais un balayage.

## Ce que cela coutait, mesure sur une copie jetable

`CHANGELOG.md` mandate deja un **5.0.0**. Simule :

| | emplacements reecrits | garde `--guard versions --mode strict` |
|---|---|---|
| avant | 66 | **exit 1, 53 problemes** |
| apres | **119** | **exit 0** |

La release etait **bloquee d'avance** sur un garde strict et requis, et
personne ne l'avait vu — parce que rien ne simule un bump.

## Trois causes, chacune trouvee en corrigeant la precedente

1. **Le balayage du garde ignorait `crates/*/README.md`.** C'est pourtant la
   page ou atterrit un utilisateur venant de crates.io, npm ou PyPI : sa
   revendication de version est la **premiere** que quiconque lit. **Sept des
   neuf** annoncaient encore `Applies to: velesdb-core 4.1.0` face a un
   workspace a `4.2.0`, dont un **deux mineures** en arriere. Les deux corrects
   sont exactement les deux que `check-version-sync.py` epingle (`:43`, `:46`).

2. **Mon premier balayage excluait par FICHIER au lieu de (fichier, REGLE).**
   Un meme document peut porter deux revendications :
   `docs/getting-started.md` et `SERVER_REST_TOUR.md`, deja listes sous
   `doc_health_snippet`, gardaient donc leur tampon perime.

3. **Mes marqueurs ecrits a la main ont derive deux fois.**
   `velesdb-core = "` rate la forme table
   `velesdb-core = { version = "..." }`, que le garde matche et qui a survecu a
   **chaque** bump dans `docs/GPU_ACCELERATION.md`.

   → La detection est desormais **deleguee aux motifs du garde eux-memes**
   (`guard.VERSION_CLAIMS`). Les deux ne peuvent plus diverger : il n'y a plus
   qu'une definition de « qu'est-ce qu'une revendication de version ».

Il manquait aussi la regle `cargo_dep_pin` : `cargo_pin` ne reecrit que la
forme shell `velesdb-core@X.Y.Z`, pas la forme TOML d'un extrait de
documentation. Quatre extraits y survivaient.

## Un choix explicite

L'enumeration des README de crates est **conservee** plutot que remplacee par
un glob : `bump_version` **refuse** une cible dont le motif ne matche rien
(detection de derive de format). Un README sans tampon — `velesdb-memory`
aujourd'hui — doit donc etre une absence **deliberee**, pas l'inclusion
silencieuse d'un glob.

## Preuve

Sur une copie jetable, bump reel vers 5.0.0 :

- **119 emplacements** reecrits, `--guard versions --mode strict` → **exit 0**,
  sans une seule intervention manuelle ;
- **controle positif** : un seul tampon laisse en arriere → **exit 1**, en le
  nommant.

**203 tests** `scripts/tests` verts. Les quatre gardes de fraicheur — `index`,
`stamp`, `tracked`, `versions` — PASS sur le depot reel.