### PR TITLE
fix(gardes): index cede a tracked, et perd exactement ce point-la

### DIFF
--- a/scripts/check-doc-freshness.py
+++ b/scripts/check-doc-freshness.py
@@ -168,13 +168,35 @@ def read_memory_version(root: Path) -> str:
 
 
 def root_docs(root: Path) -> "list[Path]":
-    """Markdown files directly under docs/, excluding structural exemptions."""
+    """TRACKED markdown files directly under docs/, minus structural exemptions.
+
+    Tracked, not on disk — and that distinction is the arbitration of the
+    guard-against-guard conflict on `docs/CORE_PREMIUM_SPLIT.md`.
+
+    This guard used to glob the filesystem. It therefore demanded that
+    `docs/README.md` link a document that existed on exactly one machine: for
+    every clone and every CI run, obeying it meant publishing a BROKEN LINK.
+    A guard that reasons about untracked files reasons about a state nobody
+    else can observe, and it was actively enforcing the lie that
+    `--guard tracked` correctly refused.
+
+    So `index` yields: existence precedes navigation. A document has to be in
+    the repository before there is any sense in demanding it be in the table
+    of contents. Fall back to the filesystem outside a work tree, where the
+    question has no answer — an empty sweep would pass vacuously.
+    """
     docs_dir = root / DOCS_DIRNAME
-    return sorted(
-        p
-        for p in docs_dir.glob("*.md")
-        if p.name not in ROOT_DOC_EXEMPTIONS
+    on_disk = sorted(
+        path for path in docs_dir.glob("*.md")
+        if path.name not in ROOT_DOC_EXEMPTIONS
     )
+    tracked = tracked_files(root)
+    if tracked is None:
+        return on_disk
+    return [
+        path for path in on_disk
+        if path.relative_to(root).as_posix() in tracked
+    ]
 
 
 def scanned_doc_files(root: Path) -> "list[Path]":
@@ -337,7 +359,17 @@ def guard_versions(root: Path) -> "tuple[list[str], list[str]]":
 #:
 #: Root-level, not under docs/: these are the entry points a reader meets
 #: before any documentation index.
-ENTRY_DOCUMENTS = ("AGENTS.md", "CLAUDE.md", "CONTRIBUTING.md", "README.md")
+#: `docs/README.md` is here for the other half of the same arbitration: it is
+#: the index `guard_index` fills, so it is the document most likely to be
+#: pointed at an untracked file by someone obeying that guard. Leaving it out
+#: is what let the original conflict exist at all.
+ENTRY_DOCUMENTS = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "README.md",
+    "docs/README.md",
+)
 
 #: A relative markdown link, minus anchors, mail and network schemes.
 ENTRY_LINK_RE = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:|#)([^)#\s]+)")


### PR DESCRIPTION
L'arbitrage que #1718 avait evite.

## Ce que #1718 a fait, et ce qu'elle n'a pas fait

Deux gardes requis s'opposaient frontalement sur `docs/CORE_PREMIUM_SPLIT.md` :
`index` exigeait que `docs/README.md` le lie, `tracked` refusait un lien vers un
fichier non suivi.

#1718 a rendu le fichier suivi. Les deux gardes se sont tus — mais **la
collision est restee vivante pour le prochain fichier**, et rien ne disait
lequel avait raison.

Reveillee pour le prouver : un simple `.md` local depose dans `docs/` fait
rougir `index` (`exit 1`), et lui obeir revient a lier un fichier qu'aucun
clone ne possede.

## Verdict : `tracked` a raison

**L'existence precede la navigation.** Un document doit etre dans le depot
avant qu'il y ait le moindre sens a exiger qu'il figure dans la table des
matieres.

Le defaut de `index` n'est pas sa regle, c'est sa **portee** : `root_docs()`
globait le **systeme de fichiers**. Il reclamait donc un lien vers un document
qui n'existait que sur une machine — pour tout clone et toute CI, lui obeir
signifiait **publier un lien casse**. Un garde qui raisonne sur des fichiers non
suivis raisonne sur un etat que personne d'autre ne peut observer, et celui-ci
imposait activement le mensonge que l'autre refusait.

`index` balaie desormais le **depot**. Repli sur le disque hors arbre de
travail, ou la question n'a pas de reponse : un balayage vide passerait a vide.

## Deuxieme moitie — et c'est un trou dans mon propre travail

`tracked` ne balayait que les documents d'entree **racine**, donc
`docs/README.md` lui echappait. C'est-a-dire **l'index meme que `index` fait
remplir**, donc le document le plus expose a se voir pointer vers un fichier non
suivi par quelqu'un qui obeit a `index`.

Sans lui, la collision d'origine n'aurait pas pu etre attrapee du tout. Il entre
dans `ENTRY_DOCUMENTS`.

## Preuve

Dans les trois sens :

| situation | verdict |
|---|---|
| `.md` local **non suivi** depose dans `docs/` | `index` **exit 0** — il cede |
| quelqu'un le lie quand meme depuis l'index | `tracked` **exit 1** — il refuse |
| document **suivi** non lie | `index` **exit 1** — dents intactes |

Et les deux moities sont **portantes**, mutation a l'appui :

| mutation | consequence mesuree |
|---|---|
| `index` redevient un balayage du disque | la collision **renait** (`exit 1`) |
| `docs/README.md` sort du perimetre de `tracked` | le lien mort **passe** (`exit 0`) |

`index` perd exactement le point de conflit, et rien d'autre.

**203 tests** `scripts/tests` verts. Les quatre gardes de fraicheur PASS.