### PR TITLE
fix(doc): flip DOC_CONTRACT_MODE to strict, close the 4-route gap

### DIFF
--- a/.github/workflows/doc-contract.yml
+++ b/.github/workflows/doc-contract.yml
@@ -41,9 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Blocking on the pinned endpoints (/query/explain, /aggregate); the
-      # full 34-route sweep reports as warnings until the four routes named in
-      # the script header are documented, then set DOC_CONTRACT_MODE=strict.
+      # Blocking on the pinned endpoints (/query/explain, /aggregate) and,
+      # since #1707, on the full 34-route sweep too (DOC_CONTRACT_MODE
+      # defaults to strict in the script).
       - name: Check README/runtime contract
         run: bash scripts/check-doc-contract.sh
 

--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ Tool parity per surface is published honestly — including where a surface is s
 | Category | Key Endpoints |
 |----------|--------------|
 | **Collections** | `POST /collections`, `GET /collections`, `GET/DELETE /collections/{name}` |
-| **Points** | `/collections/{name}/points`, `/collections/{name}/points/scroll`, `/collections/{name}/stream/insert`, `/collections/{name}/points/{id}/relations`, `/collections/{name}/points/{id}/ttl`, `/collections/{name}/relations` |
+| **Points** | `/collections/{name}/points`, `/collections/{name}/points/raw`, `/collections/{name}/points/scroll`, `/collections/{name}/stream/insert`, `/collections/{name}/stream/enable`, `/collections/{name}/points/{id}/relations`, `/collections/{name}/points/{id}/ttl`, `/collections/{name}/relations` |
 | **Search** | `/collections/{name}/search`, `/collections/{name}/search/batch`, `/collections/{name}/search/hybrid`, `/collections/{name}/search/text`, `/collections/{name}/search/multi`, `/collections/{name}/search/ids`, `/collections/{name}/match` |
 | **Graph** | `/collections/{name}/graph/edges`, `/collections/{name}/graph/edges/{id}`, `/collections/{name}/graph/edges/count`, `/collections/{name}/graph/traverse`, `/collections/{name}/graph/traverse/stream`, `/collections/{name}/graph/traverse/parallel`, `/collections/{name}/graph/nodes`, `/collections/{name}/graph/nodes/{id}/degree`, `/collections/{name}/graph/nodes/{id}/edges`, `/collections/{name}/graph/nodes/{id}/payload`, `/collections/{name}/graph/search` |
 | **Indexes** | `GET/POST /collections/{name}/indexes`, `DELETE /collections/{name}/indexes/{label}/{property}`, `/collections/{name}/index/rebuild` |
 | **VelesQL** | `/query`, `/aggregate`, `/query/explain` |
-| **Admin** | `/health`, `/ready`, `/metrics`, `/guardrails`, `/collections/{name}/stats`, `/collections/{name}/config`, `/collections/{name}/flush`, `/collections/{name}/analyze`, `/collections/{name}/empty`, `/collections/{name}/sanity` |
+| **Admin** | `/health`, `/ready`, `/metrics`, `/guardrails`, `/collections/{name}/stats`, `/collections/{name}/config`, `/collections/{name}/flush`, `/collections/{name}/analyze`, `/collections/{name}/empty`, `/collections/{name}/sanity`, `/collections/{name}/compact`, `/collections/{name}/vacuum` |
 
 > **Full API reference:** [docs/reference/api-reference.md](docs/reference/api-reference.md) | **OpenAPI spec:** [docs/openapi.yaml](docs/openapi.yaml) | **Server security:** [docs/guides/SERVER_SECURITY.md](docs/guides/SERVER_SECURITY.md)
 

--- a/scripts/check-doc-contract.sh
+++ b/scripts/check-doc-contract.sh
@@ -16,14 +16,14 @@
 #     main.rs, so restoring the full sweep cannot change the verdict on any
 #     tree that was green yesterday.
 #   * FULL sweep of every `.route("...")` in the server crate — governed by
-#     DOC_CONTRACT_MODE, default `warn`. It is red on develop today (4 routes
-#     were added without a README entry while the sweep was disarmed). Flip
-#     the default to `strict` in the same commit that documents them:
+#     DOC_CONTRACT_MODE, default `strict` since #1707. The four routes that
+#     were previously undocumented while the sweep was disarmed are now in
+#     README.md:
 #       /collections/{name}/compact  /collections/{name}/points/raw
 #       /collections/{name}/stream/enable  /collections/{name}/vacuum
 set -euo pipefail
 
-DOC_CONTRACT_MODE="${DOC_CONTRACT_MODE:-warn}"
+DOC_CONTRACT_MODE="${DOC_CONTRACT_MODE:-strict}"
 if [[ "$DOC_CONTRACT_MODE" != "strict" && "$DOC_CONTRACT_MODE" != "warn" ]]; then
   echo "ERROR: DOC_CONTRACT_MODE must be 'strict' or 'warn' (got '$DOC_CONTRACT_MODE')"
   exit 2

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -237,14 +237,27 @@
       "workflow": ".github/workflows/doc-contract.yml",
       "job": "contract",
       "required": true,
-      "mode": "warn",
-      "exit_condition": "Document the four routes named in the script header (/collections/{name}/compact, points/raw, stream/enable, vacuum) in README.md, then flip DOC_CONTRACT_MODE's default to strict in the same commit. Tracked by #1707. The fold made this gate required, so the flip now has teeth.",
+      "mode": "strict",
       "self_test": null,
       "self_test_required": false,
       "blind_spot": {
-        "issue": 1707,
-        "summary": "Measured: exit 0 in the default warn mode with 4 undocumented routes, exit 1 under DOC_CONTRACT_MODE=strict. The guard works; nothing asks it to."
+        "issue": null,
+        "summary": "None known. #1707 is closed: the four routes (/collections/{name}/compact, points/raw, stream/enable, vacuum) are now documented in README.md, and DOC_CONTRACT_MODE's default flipped to strict in the same commit, so a full-sweep finding fails the build like the pinned routes always did."
       },
+      "must_refuse": [
+        {
+          "vector": "a route added under the server crate without a matching README backtick entry — the four-route gap of #1707",
+          "files": {
+            "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
+            "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`\n"
+          },
+          "accepts": {
+            "crates/velesdb-server/src/routes.rs": "pub fn build_router() {\n    Router::new()\n        .route(\"/query/explain\", post(explain))\n        .route(\"/aggregate\", post(aggregate))\n        .route(\"/collections/{name}/vacuum\", post(vacuum_collection));\n}\n",
+            "README.md": "# Test fixture\n\nAPI: `/query/explain`, `/aggregate`, `/collections/{name}/vacuum`\n"
+          },
+          "argv": []
+        }
+      ],
       "required_via": "doc-contract"
     },
     {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`scripts/check-doc-contract.sh` sweeps every `.route("...")` declared under the server crate against `README.md`, but the full sweep was gated behind `DOC_CONTRACT_MODE`, defaulting to `warn`. Four routes added since 2026-07-25 (`/collections/{name}/compact`, `/collections/{name}/points/raw`, `/collections/{name}/stream/enable`, `/collections/{name}/vacuum`) slipped in undocumented, and — because the default never carried an expiry — nothing pushed the guard back to `strict`.

This PR:
- Documents the four routes in `README.md`'s endpoint table.
- Flips `DOC_CONTRACT_MODE`'s default to `strict` in `scripts/check-doc-contract.sh`, in the same commit, so a future undocumented route fails the build like the two pinned endpoints already do.
- Updates `scripts/guards.json`'s entry for this guard: `mode` is now `strict`, the stale `exit_condition`/`blind_spot` describing the warn gap is replaced with a "resolved" note, and a `must_refuse` vector is added (exercised by `scripts/tests/test_guard_refusal_vectors.py`) so a route added without a README entry is proven to fail the build, and the regression cannot silently reopen.
- Refreshes a stale comment in `.github/workflows/doc-contract.yml` that still described the warn-mode behavior.

Fixes #1707

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring
- [ ] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- `bash scripts/check-doc-contract.sh` → passes in the new strict default (all 34 routes documented).
- `python3 -m unittest scripts.tests.test_ci_gate_reachability` → 48 tests pass.
- `python3 -m unittest scripts.tests.test_guard_refusal_vectors` → 5 tests pass, including the new vector for this guard.
- `python3 scripts/check-doc-freshness.py` → unaffected, passes.
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` → passes.

**Test Configuration:**
- OS: Linux (CI runner)
- Rust version: n/a (no Rust source changed)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (refusal vector)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

No Rust source changed — this is scoped to the doc-contract guard, README, and its CI wiring/registry entry, per the surgical-change principle in AGENTS.md.
