### PR TITLE
fix(skill): la signature datee publiee sur npm prenait ses arguments dans le mauvais ordre

### DIFF
--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -58,8 +58,9 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
      `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
      it, so `recall_fused(date_field="_veles_date")` gives you a chronological
      `dated_context` timeline (plus a `now` anchor) with zero setup on your part
-     (Node binding: the dated variant is its own method,
-     `recallFusedDated(query, k, filter, opts, "_veles_date")`).
+     (Node binding: the dated variant is its own method, and it takes the date
+     field SECOND, not last:
+     `recallFusedDated(query, "_veles_date", k, filter, opts)`).
      Set `_veles_date` explicitly only to override the default — e.g. to date a
      fact by when an incident actually happened, not when you recorded it; once
      set, the server never overwrites it. Store any OTHER comparable value

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -499,6 +499,41 @@ test('recallFusedDated leaves now unset and the timeline undated when no fact ca
   }
 })
 
+// The bundled skill (skills/velesdb-memory/SKILL.md) promises zero-setup dating:
+// remember auto-stamps `_veles_date`, so the dated variant works with no metadata
+// of your own. It shipped on npm with the arguments in the WRONG ORDER — the core
+// Rust order (date field last) transcribed onto the JS name, where the field comes
+// SECOND. Nothing caught it because the tests above pass their own `ts` field, so
+// neither the auto-stamp nor the documented call was ever executed. This test is
+// the documented call, verbatim.
+test('recallFusedDated dates a plain remember through the auto-stamped _veles_date', async () => {
+  const { store, cleanup } = freshStore()
+  try {
+    await store.remember('the invoice service started rejecting refunds')
+
+    const res = await store.recallFusedDated(
+      'invoice service refunds',
+      '_veles_date',
+      10,
+    )
+
+    assert.ok(res.memories.length >= 1, 'the recall half returns the memory')
+    assert.match(
+      res.now ?? '',
+      /^\d{4}-\d{2}-\d{2}$/,
+      'a plain remember must carry a date the timeline can anchor on, with no metadata from the caller',
+    )
+    assert.ok(
+      res.datedContext.includes(
+        `- [${res.now}] the invoice service started rejecting refunds`,
+      ),
+      `the timeline must date the fact with the stamp itself, got: ${res.datedContext}`,
+    )
+  } finally {
+    cleanup()
+  }
+})
+
 test('feedback reinforces a fact, weakens on failure, NOT_FOUND on unknown id', async () => {
   const { store, cleanup } = freshStore()
   try {

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -58,8 +58,9 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
      `_veles_date` — today's date as a `YYYYMMDD` integer — unless you already set
      it, so `recall_fused(date_field="_veles_date")` gives you a chronological
      `dated_context` timeline (plus a `now` anchor) with zero setup on your part
-     (Node binding: the dated variant is its own method,
-     `recallFusedDated(query, k, filter, opts, "_veles_date")`).
+     (Node binding: the dated variant is its own method, and it takes the date
+     field SECOND, not last:
+     `recallFusedDated(query, "_veles_date", k, filter, opts)`).
      Set `_veles_date` explicitly only to override the default — e.g. to date a
      fact by when an incident actually happened, not when you recorded it; once
      set, the server never overwrites it. Store any OTHER comparable value


### PR DESCRIPTION
Ferme l'item 1 de #1705 -- le plus grave, parce qu'il est deja livre sur npm.

## Le defaut

`SKILL.md:62` documentait :

```js
recallFusedDated(query, k, filter, opts, "_veles_date")
```

Les trois surfaces JS prennent le champ de date en **deuxieme** position :

| surface | signature |
|---|---|
| `crates/velesdb-node/src/lib.rs:237-244` | `recall_fused_dated(query, date_field, k, filter, opts)` |
| `crates/velesdb-wasm/src/memory_service.rs:563-569` | idem |
| `sdks/typescript/src/memory.ts:436-442` | `recallFusedDated(query, dateField, k, filter, opts)` |

C'est l'ordre du core Rust (`fused_recall.rs:107-114`, ou le champ vient en
dernier) recopie sur le nom JS. Le doc est seul contre les trois.

`crates/velesdb-node/package.json:41` declare `"skills/"` dans `files`, donc
le paquet `@wiscale/velesdb-memory-node` publiait cette signature.

## Le defaut est mesure, pas suppose

Avec l'ordre documente, l'appel meurt au marshalling :

```
Error: Failed to convert JavaScript value `Number 10 ` into rust type `String`
code: 'StringExpected'
```

Un agent qui suivait ce skill produisait un appel qui ne pouvait pas aboutir.

## Pourquoi rien ne l'avait vu

Les deux tests existants (`index.spec.mjs:456`, `:477`) passent leur propre
champ `ts` avec des metadonnees posees a la main. Ni l'estampille automatique
`_veles_date` ni l'ordre documente n'etaient donc jamais executes.

Le test ajoute est l'appel documente, verbatim, sur un `remember` nu. Il
verifie la promesse reelle du skill : le datage sans aucune configuration.
Controle execute dans les deux sens -- il echoue sur l'ancien ordre
(`StringExpected`) et passe sur le nouveau.

## Verification

- `npm test` dans `crates/velesdb-node` apres `npx napi build --platform` :
  **62 tests, 61 passes, 1 skip** (celui gate par `VELESDB_OLLAMA_TESTS`), 0 echec
- `python3 -m unittest scripts.tests.test_skill_copies_are_identical` : **11 tests, OK**

Les deux copies de `SKILL.md` bougent dans le meme commit : elles sont gardees
octet-identiques par `test_skill_copies_are_identical` et par
`__test__/skills-sync.spec.mjs`.