### PR TITLE
fix(gardes): six gardes recoivent le vecteur de refus qu'ils n'avaient pas

### DIFF
--- a/scripts/check-feature-claims.py
+++ b/scripts/check-feature-claims.py
@@ -7,15 +7,21 @@ documentation claims, and flags roadmap items misrepresented as delivered.
 Exit codes:
   0 — no gaps or misrepresentations found
   1 — at least one MISSING, UNDOC, or ROADMAP gap detected
+  2 — the audit could not run (unreadable tree); NOT a refusal
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import sys
 from pathlib import Path
 from typing import NamedTuple
+
+#: Default tree to audit. `--root` overrides it so the guard can be pointed at a
+#: fixture tree and be SEEN refusing (#1715); the default keeps CI byte-identical.
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
 # Capability taxonomy
@@ -478,9 +484,7 @@ def _format_crate_report(result: AuditResult) -> tuple[list[str], int]:
 # Main
 # ---------------------------------------------------------------------------
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent
-
+def run(root: Path) -> int:
     print("=== VelesDB Feature Claims Audit ===")
     print()
 
@@ -523,6 +527,19 @@ def main() -> int:
     print(f"Audit {verdict}")
 
     return 0 if overall_ok else 1
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit feature claims against the code.")
+    parser.add_argument("--root", default=str(REPO_ROOT), help="repository root to scan")
+    args = parser.parse_args(argv)
+    # An unreadable tree answers 2, never 1: a guard that COULD NOT RUN is not a
+    # guard that refused, and the refusal-vector harness asserts exactly 1.
+    try:
+        return run(Path(args.root).resolve())
+    except (OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -29,13 +29,26 @@ Three independent gates run here:
 
 from __future__ import annotations
 
+import argparse
 import json
 import pathlib
 import re
 import subprocess
+import sys
 
+#: Default tree to check. `--root` overrides it so the guard can be pointed at a
+#: fixture tree and be SEEN refusing (#1715); the default keeps CI byte-identical.
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-REGISTRY = ROOT / "docs/reference/promise-contract.json"
+REGISTRY_REL = "docs/reference/promise-contract.json"
+
+
+def registry_path(root: pathlib.Path) -> pathlib.Path:
+    """The claims registry inside `root`.
+
+    This used to be a module constant derived from `ROOT` and frozen at import,
+    which is precisely why no `--root` could reach it.
+    """
+    return root / REGISTRY_REL
 
 # Docs that document the storage/quantization modes at the point of choice.
 # These are the surfaces pinned by Requirement 10 (see design section 10).
@@ -103,19 +116,20 @@ def _scan_line(line: str) -> bool:
     return False
 
 
-def check_registry() -> list[str]:
+def check_registry(root: pathlib.Path) -> list[str]:
     """Validate every registry claim still appears in its target file."""
-    if not REGISTRY.exists():
-        return [f"Missing registry file: {REGISTRY}"]
+    registry = registry_path(root)
+    if not registry.exists():
+        return [f"Missing registry file: {registry}"]
 
-    data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    data = json.loads(registry.read_text(encoding="utf-8"))
     claims = data.get("claims", [])
     if not claims:
         return ["Registry has no claims"]
 
     failed = []
     for claim in claims:
-        file_path = ROOT / claim["file"]
+        file_path = root / claim["file"]
         needle = claim["must_contain"]
         claim_id = claim["id"]
 
@@ -206,9 +220,9 @@ def stale_claims(claims: list[dict], workspace_version: str) -> list[str]:
     return stale
 
 
-def workspace_version() -> str:
+def workspace_version(root: pathlib.Path) -> str:
     """The `[workspace.package]` version, the single source of truth."""
-    manifest = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    manifest = (root / "Cargo.toml").read_text(encoding="utf-8")
     match = re.search(
         r'(?ms)^\[workspace\.package\].*?^version\s*=\s*"([^"]+)"', manifest
     )
@@ -226,11 +240,11 @@ def unsourced_claims(claims: list[dict]) -> list[str]:
     ]
 
 
-def check_capacity_mode_overclaim() -> list[str]:
+def check_capacity_mode_overclaim(root: pathlib.Path) -> list[str]:
     """Requirement 10.4: sq8/binary docs must not promise search throughput."""
     failed = []
     for rel_path in CAPACITY_MODE_DOCS:
-        file_path = ROOT / rel_path
+        file_path = root / rel_path
         if not file_path.exists():
             failed.append(f"[capacity-mode] missing file: {rel_path}")
             continue
@@ -247,6 +261,7 @@ def check_capacity_mode_overclaim() -> list[str]:
 
 def run_validation_commands(
     claims: list[dict],
+    root: pathlib.Path,
 ) -> tuple[list[str], list[str], list[str]]:
     """Execute ``validation_command`` for every claim marked executable.
 
@@ -283,7 +298,7 @@ def run_validation_commands(
             result = subprocess.run(
                 command,
                 shell=True,
-                cwd=ROOT,
+                cwd=root,
                 capture_output=True,
                 text=True,
                 timeout=EXECUTABLE_CLAIM_TIMEOUT_SECONDS,
@@ -309,52 +324,46 @@ def run_validation_commands(
     return executed, skipped, failures
 
 
-def main() -> int:
-    registry_failures = check_registry()
-    overclaim_failures = check_capacity_mode_overclaim()
+def _report(title: str, messages: "list[str]") -> None:
+    """Print a findings block, or nothing when there is nothing to say.
 
-    data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    Seven copies of this three-line shape are what pushed the caller past the
+    complexity ceiling; the output is byte-identical to what they printed.
+    """
+    if not messages:
+        return
+    print(title)
+    for msg in messages:
+        print(f"  - {msg}")
+
+
+def run(root: pathlib.Path) -> int:
+    registry_failures = check_registry(root)
+    overclaim_failures = check_capacity_mode_overclaim(root)
+
+    # Read the registry only if it is there. This used to be an unconditional
+    # `json.loads(REGISTRY.read_text())`, which raised FileNotFoundError before
+    # check_registry's own "Missing registry file" line could ever be printed —
+    # so its graceful path at the top was unreachable, and a missing registry
+    # exited 1 through a traceback. Exit 1 by crashing is not a refusal.
+    registry = registry_path(root)
+    data = json.loads(registry.read_text(encoding="utf-8")) if registry.exists() else {}
     claims = data.get("claims", [])
     provenance_failures = check_provenance(claims)
-    executed, skipped, execution_failures = run_validation_commands(claims)
+    executed, skipped, execution_failures = run_validation_commands(claims, root)
 
-    if provenance_failures:
-        print("Provenance check failed — every claim must record its measurement:")
-        for msg in provenance_failures:
-            print(f"  - {msg}")
-
-    if registry_failures:
-        print("Promise contract check failed:")
-        for msg in registry_failures:
-            print(f"  - {msg}")
-
-    if overclaim_failures:
-        print("Anti-overclaim check failed (Requirement 10.4):")
-        for msg in overclaim_failures:
-            print(f"  - {msg}")
-
-    if execution_failures:
-        print("Executable validation_command check failed:")
-        for msg in execution_failures:
-            print(f"  - {msg}")
-
-    if skipped:
-        print("Documentary claims not auto-verified:")
-        for msg in skipped:
-            print(f"  - {msg}")
+    _report("Provenance check failed — every claim must record its measurement:", provenance_failures)
+    _report("Promise contract check failed:", registry_failures)
+    _report("Anti-overclaim check failed (Requirement 10.4):", overclaim_failures)
+    _report("Executable validation_command check failed:", execution_failures)
+    _report("Documentary claims not auto-verified:", skipped)
 
     unsourced = unsourced_claims(claims)
-    if unsourced:
-        print("Claims with no sourced measurement (honest debt, not a failure):")
-        for msg in unsourced:
-            print(f"  - {msg}")
+    _report("Claims with no sourced measurement (honest debt, not a failure):", unsourced)
 
-    version = workspace_version()
+    version = workspace_version(root)
     stale = stale_claims(claims, version)
-    if stale:
-        print(f"Claims measured on an older release than {version} (re-measure):")
-        for msg in stale:
-            print(f"  - {msg}")
+    _report(f"Claims measured on an older release than {version} (re-measure):", stale)
 
     if (
         registry_failures
@@ -372,6 +381,21 @@ def main() -> int:
         f"{len(CAPACITY_MODE_DOCS)} capacity-mode docs clean)."
     )
     return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description="Check the promise contract registry.")
+    parser.add_argument("--root", default=str(ROOT), help="repository root to scan")
+    args = parser.parse_args(argv)
+    # A tree this guard cannot read answers 2, never 1: `Cargo.toml` is read
+    # unguarded by workspace_version, and a malformed registry raises a
+    # ValueError. Both exit 1 through a traceback otherwise, which the refusal
+    # harness cannot tell apart from a refusal.
+    try:
+        return run(pathlib.Path(args.root).resolve())
+    except (OSError, RuntimeError, ValueError, KeyError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check-python.sh
+++ b/scripts/check-python.sh
@@ -75,7 +75,11 @@ echo -e "\n${YELLOW}3️⃣  Running security checks...${NC}"
 
 if command -v bandit &> /dev/null; then
     for dir in $PYTHON_DIRS; do
-        if [ -d "$dir" ]; then
+        # Guard the directory bandit is actually GIVEN. The test was on "$dir"
+        # while the scan was on "$dir/src", so an integration laid out without a
+        # src/ made bandit error out and counted as a finding — a refusal the
+        # tree never earned.
+        if [ -d "$dir/src" ]; then
             echo -e "   Scanning $dir..."
             if ! bandit -r "$dir/src" -ll -q 2>/dev/null; then
                 ERRORS=$((ERRORS + 1))
@@ -93,8 +97,24 @@ fi
 # =============================================================================
 echo -e "\n${YELLOW}4️⃣  Checking cyclomatic complexity (CC <= 8)...${NC}"
 
-if command -v flake8 &> /dev/null; then
-    COMPLEXITY_ISSUES=$(flake8 $PYTHON_DIRS integrations/common --select=C901 --max-complexity=8 2>/dev/null || true)
+# Only hand flake8 directories that exist. `integrations/common` used to be
+# passed unconditionally, and on a tree without it flake8 answers E902 on
+# stdout — which --select=C901 does not suppress, so it counted as a complexity
+# finding no function had caused.
+COMPLEXITY_TARGETS=""
+for dir in $PYTHON_DIRS integrations/common; do
+    if [ -d "$dir" ]; then
+        COMPLEXITY_TARGETS="$COMPLEXITY_TARGETS $dir"
+    fi
+done
+
+if ! command -v flake8 &> /dev/null; then
+    echo -e "${YELLOW}⚠️  flake8 not installed, skipping complexity check${NC}"
+    echo -e "   Install with: pip install flake8 mccabe"
+elif [ -z "$COMPLEXITY_TARGETS" ]; then
+    echo -e "${YELLOW}⚠️  no Python integration directory present, nothing to measure${NC}"
+else
+    COMPLEXITY_ISSUES=$(flake8 $COMPLEXITY_TARGETS --select=C901 --max-complexity=8 2>/dev/null || true)
     if [ -n "$COMPLEXITY_ISSUES" ]; then
         echo -e "${RED}❌ Functions exceeding complexity threshold (CC > 8):${NC}"
         echo "$COMPLEXITY_ISSUES"
@@ -102,9 +122,6 @@ if command -v flake8 &> /dev/null; then
     else
         echo -e "${GREEN}✅ All functions within complexity limit (CC <= 8)${NC}"
     fi
-else
-    echo -e "${YELLOW}⚠️  flake8 not installed, skipping complexity check${NC}"
-    echo -e "   Install with: pip install flake8 mccabe"
 fi
 
 # =============================================================================

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Verify that all package manifests share the same version as the Cargo workspace."""
 
+import argparse
 import json
 import re
 import sys
@@ -194,8 +195,8 @@ MEMORY_TARGETS: "list[tuple[str, str]]" = [
 ]
 
 
-def _read_memory_crate_version() -> str:
-    cargo_toml = (REPO_ROOT / "crates/velesdb-memory/Cargo.toml").read_text(encoding="utf-8")
+def _read_memory_crate_version(root: Path) -> str:
+    cargo_toml = (root / "crates/velesdb-memory/Cargo.toml").read_text(encoding="utf-8")
     match = re.search(r"^version\s*=\s*\"([^\"]+)\"", cargo_toml, re.MULTILINE)
     if not match:
         raise RuntimeError("Could not find version field in crates/velesdb-memory/Cargo.toml")
@@ -216,8 +217,8 @@ def _read_mcp_server_json_versions(path: Path) -> str:
     return versions[0] if len(uniq) == 1 else "/".join(versions)
 
 
-def _read_cargo_version() -> str:
-    cargo_toml = (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+def _read_cargo_version(root: Path) -> str:
+    cargo_toml = (root / "Cargo.toml").read_text(encoding="utf-8")
     section_idx = cargo_toml.find("[workspace.package]")
     if section_idx == -1:
         raise RuntimeError("Could not find [workspace.package] section in Cargo.toml")
@@ -590,13 +591,23 @@ _READERS = {
 }
 
 
-def main() -> int:
-    expected = _read_cargo_version()
-    print(f"Workspace version (Cargo.toml): {expected}")
+def _compare_targets(
+    root: Path,
+    targets: "list[tuple[str, str]]",
+    expected: str,
+    mismatches: "list[str]",
+) -> None:
+    """Compare every stamp in `targets` against `expected`, appending findings.
 
-    mismatches: list[str] = []
-    for rel_path, fmt in TARGETS:
-        path = REPO_ROOT / rel_path
+    The two sweeps were the same loop written twice, which is how they drifted:
+    the workspace sweep resolved its reader through `_READERS.get` and raised a
+    RuntimeError on an unknown format, while the memory sweep indexed
+    `_READERS[fmt]` directly and raised a KeyError — an uncaught KeyError exits
+    1 through a traceback, which is indistinguishable from a refusal. One loop,
+    one behaviour.
+    """
+    for rel_path, fmt in targets:
+        path = root / rel_path
         if not path.exists():
             print(f"  SKIP  {rel_path} (file not found)")
             continue
@@ -614,20 +625,17 @@ def main() -> int:
                 f"{rel_path} [{fmt}]: expected {expected}, found {actual}"
             )
 
-    memory_expected = _read_memory_crate_version()
+
+def run(root: Path) -> int:
+    expected = _read_cargo_version(root)
+    print(f"Workspace version (Cargo.toml): {expected}")
+
+    mismatches: list[str] = []
+    _compare_targets(root, TARGETS, expected, mismatches)
+
+    memory_expected = _read_memory_crate_version(root)
     print(f"\nvelesdb-memory version (crates/velesdb-memory/Cargo.toml): {memory_expected}")
-    for rel_path, fmt in MEMORY_TARGETS:
-        path = REPO_ROOT / rel_path
-        if not path.exists():
-            print(f"  SKIP  {rel_path} (file not found)")
-            continue
-        actual = _READERS[fmt](path)
-        status = "OK   " if actual == memory_expected else "MISMATCH"
-        print(f"  {status}  {rel_path} [{fmt}]: {actual}")
-        if actual != memory_expected:
-            mismatches.append(
-                f"{rel_path} [{fmt}]: expected {memory_expected}, found {actual}"
-            )
+    _compare_targets(root, MEMORY_TARGETS, memory_expected, mismatches)
 
     if mismatches:
         print("\nVersion mismatch(es) detected:")
@@ -637,6 +645,21 @@ def main() -> int:
 
     print("\nAll versions match.")
     return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description="Check version stamps stay in sync.")
+    parser.add_argument("--root", default=str(REPO_ROOT), help="repository root to scan")
+    args = parser.parse_args(argv)
+    # A tree this guard cannot read answers 2, never 1. Both anchor files are
+    # read unguarded (`Cargo.toml`, the memory crate manifest), and a missing
+    # one used to surface as a FileNotFoundError traceback — which also exits 1
+    # and would have passed for a refusal it never made.
+    try:
+        return run(Path(args.root).resolve())
+    except (OSError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -27,7 +27,7 @@
     "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required",
     "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the same tree repaired. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
     "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent.",
-    "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make.",
+    "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make. Two further keys, both optional and both keyed like the trees: `author` (`Name <email>`) and `message`. Without them a guard that reads WHO authored a commit could not be handed two trees differing in the only field it looks at; they default to the harness identity, so vectors written before they existed are unchanged.",
     "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green.",
     "not_a_gate": "scripts a workflow runs that CANNOT refuse — no non-zero exit path. Surfaced by the reverse sweep (workflows -> registry) and kept out of `guards` so the registry never overstates what it covers. The `reason` is mandatory and the no-failure-path claim is verified against the source."
   },
@@ -164,7 +164,25 @@
         "issue": null,
         "summary": "None known. Its self-test is reached by gate-contracts.yml's `unittest discover`, which the fold made required through the `gate-contracts` caller job."
       },
-      "refusal_untested": "No CLI surface: same rooted-at-REPO_ROOT shape. Its self-test proves the comparison in-process, never the process. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a manifest stamped 9.9.9 against a 1.0.0 workspace — the drift this guard exists for",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
+            "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
+            "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"9.9.9\"\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n\n[workspace.dependencies]\nvelesdb-core = { path = \"crates/velesdb-core\", version = \"1.0.0\" }\n",
+            "crates/velesdb-memory/Cargo.toml": "version = \"1.0.0\"\n",
+            "crates/velesdb-python/pyproject.toml": "[project]\nversion = \"1.0.0\"\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/check-feature-claims.py",
@@ -179,7 +197,21 @@
         "issue": null,
         "summary": "Breaks (reports column_store MISSING) if any string literal in velesdb-python/src uses a backslash line-continuation."
       },
-      "refusal_untested": "No CLI surface: same rooted-at-REPO_ROOT shape. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a roadmap entry still marked in-progress, which the audit must not let a README present as shipped",
+          "files": {
+            "ROADMAP.md": "## EPIC-010 Agent Memory SDK — in progress\n"
+          },
+          "accepts": {
+            "ROADMAP.md": "## EPIC-010 Agent Memory SDK — delivered\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/check-perf-claims.py",
@@ -312,11 +344,33 @@
         "summary": "None known. Folded into CI Success's needs and chain via the `promise-contract` caller job, so a failure now blocks the merge."
       },
       "required_via": "promise-contract",
-      "refusal_untested": "No CLI surface: the registry path is rooted at REPO_ROOT. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a capacity-mode doc promising sq8 buys search throughput — the overclaim Requirement 10.4 exists to refuse",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ]\n}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ]\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/check-python.sh",
-      "purpose": "Python integration checks (dangerous hash(), bandit, mypy).",
+      "purpose": "Python integration checks (dangerous hash(), non-determinism, bandit, flake8 complexity).",
       "workflow": ".github/workflows/propagation-guard.yml",
       "job": "integrations-python",
       "required": true,
@@ -325,10 +379,21 @@
       "self_test_required": false,
       "blind_spot": {
         "issue": null,
-        "summary": "None known. Folded into CI Success's needs and chain via the `propagation-guard` caller job, so a failure now blocks the merge."
+        "summary": "Entirely cwd-relative (PYTHON_DIRS) with no --root and no cd of its own: run from a subdirectory it scans nothing and exits 0 — measured from docs/. Harmless in CI, which runs it from the root, and it is what lets the refusal harness drive it with an empty argv. Only checks 1, 3 and 4 can raise ERRORS; 2 and 5 warn and can never refuse."
       },
       "required_via": "propagation-guard",
-      "refusal_untested": "No CLI surface: the shell guard cds to the repository root itself. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a builtin hash() used to derive a token — non-deterministic across processes, which is the whole point of check 1",
+          "files": {
+            "integrations/langchain/src/velesdb_langchain/store.py": "def token_for(doc):\n    return hash(doc)\n"
+          },
+          "accepts": {
+            "integrations/langchain/src/velesdb_langchain/store.py": "import hashlib\n\n\ndef token_for(doc):\n    return hashlib.sha256(doc).hexdigest()\n"
+          },
+          "argv": []
+        }
+      ]
     },
     {
       "script": "scripts/check_binary_size.py",
@@ -341,10 +406,27 @@
       "self_test_required": false,
       "blind_spot": {
         "issue": null,
-        "summary": "None known. Folded into CI Success's needs and chain via the `binary-size` caller job, so a failure now blocks the merge."
+        "summary": "The vector below proves the MISSING half only. The OVER-CEILING half is not vector-testable: the smallest ceiling is 9 MiB, so a fixture exceeding one would mean carrying 9 MiB of literal bytes in this registry. That half is exercised for real on every release, against the binaries the release build produced."
       },
       "required_via": "binary-size",
-      "refusal_untested": "No CLI surface, and a vector would have to produce real release binaries to weigh. Tracked by #1715."
+      "must_refuse": [
+        {
+          "vector": "a release that built only two of its three binaries — the gate must not pass on a binary it never weighed",
+          "files": {
+            "velesdb-server": "stub\n",
+            "velesdb": "stub\n"
+          },
+          "accepts": {
+            "velesdb-server": "stub\n",
+            "velesdb": "stub\n",
+            "velesdb-migrate": "stub\n"
+          },
+          "argv": [
+            "--target-dir",
+            "{root}"
+          ]
+        }
+      ]
     },
     {
       "script": "scripts/run-production-gates.sh",
@@ -360,7 +442,7 @@
         "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
       },
       "required_via": "production-gates",
-      "refusal_untested": "A meta-runner: it chains the other guards, so its refusal is theirs. It gets a vector once the guards it chains have one. Tracked by #1715."
+      "refusal_untested": "Measured, and NOT for the reason previously written here. Under the harness (cwd = a temp tree) its first line, `bash scripts/check-doc-contract.sh`, cannot be found and the runner exits 127 — not 1, so it would fail the vector contract even though it did stop. And the positive control is out of reach in principle: gates 3 to 5 are `cargo test` invocations against velesdb-core (velesql_planner_golden, crash_recovery_tests, wal_recovery_tests), so exit 0 requires a real crate and a full build, not a materialised tree. Its refusal is genuinely its members'; each of those now carries its own vector. Tracked by #1715."
     },
     {
       "script": ".github/workflows/pr-governance.yml",
@@ -381,7 +463,7 @@
         "summary": "No self-test materialises a PR these steps must reject: Git Flow and branch freshness read a pull_request payload no local tree reproduces. The attribution check is no longer inline — it moved to scripts/check-ai-attribution.py, which is tested (#1699 closed)."
       },
       "required_via": "pr-governance",
-      "refusal_untested": "Git Flow and branch freshness read a pull_request payload that no local tree reproduces, so neither can be handed a vector. Tracked by #1715."
+      "refusal_untested": "Not a script but three inline steps, and the two that remain here read a `pull_request` payload — the source branch name and its merge-base with the base branch — that no materialised tree reproduces: there is no pull request to describe. The third check, AI attribution, is no longer inline (it moved to scripts/check-ai-attribution.py) and now carries an executable vector of its own. Tracked by #1715."
     },
     {
       "script": "scripts/check-ai-attribution.py",
@@ -392,7 +474,34 @@
       "mode": "strict",
       "self_test": "scripts.tests.test_check_ai_attribution",
       "self_test_required": true,
-      "refusal_untested": "Its vectors need a git repository with authored commits, which `must_refuse`'s file-tree shape cannot materialise. scripts/tests/test_check_ai_attribution.py pins 21 cases in-process instead, refusals AND the admissions that decide (dependabot[bot], a person named Claudette, prose describing a trailer). Giving the harness a `repo` vector shape is tracked by #1715.",
+      "must_refuse": [
+        {
+          "vector": "a commit whose author identity is an assistant, against the same tree authored by a person whose name merely starts the same way",
+          "files": {
+            "NOTES.md": "placeholder\n"
+          },
+          "accepts": {
+            "NOTES.md": "placeholder\n"
+          },
+          "repo": {
+            "files": [
+              "NOTES.md"
+            ],
+            "accepts": [
+              "NOTES.md"
+            ],
+            "author": {
+              "files": "Claude <claude@anthropic.com>",
+              "accepts": "Claudette <claudette@example.com>"
+            }
+          },
+          "argv": [
+            "HEAD",
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
         "summary": "Reads the RAW identity (%an <%ae>, never %aN): a .mailmap line in this repository already maps anthropic to the maintainer, and the mapped name would launder the case being looked for. Admission is by whole identity, so an impostor of an admitted bot does not inherit it."

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -258,7 +258,7 @@
         "issue": 1695,
         "summary": "POLICED_TOOLS holds 1 of the 20 published tools, and SURFACE_GLOBS misses the Python and WASM binding sources. Attribution rests on alias proximity within 500 characters."
       },
-      "refusal_untested": "Takes --root, so a vector is possible; not written yet because the tree it needs is a whole tools capture plus a policed surface. Tracked by #1715.",
+      "refusal_untested": "Takes --root, so a vector is possible, and the shape is known: _structural_failures short-circuits before the drift check, so the tree must carry the tools capture PLUS all 16 pinned surfaces, each with a declaration the attribution rule credits to the tool — 17 files. It is deliberately NOT written here: #1695 replaces that attribution rule (nearest-alias within 500 characters, measured at 6 percent precision when widened) with attribution by section title, which changes what counts as a credited declaration in every one of the 16 fixture files. Writing the fixture against the rule being replaced means writing it twice. It lands with the rule, in #1695. Tracked by #1715.",
       "subguards": [
         "return-shape"
       ]

--- a/scripts/tests/test_check_promise_contract.py
+++ b/scripts/tests/test_check_promise_contract.py
@@ -56,7 +56,7 @@ class RunValidationCommandsTests(unittest.TestCase):
                 "validation_command": "true",
             }
         ]
-        executed, skipped, failures = cpc.run_validation_commands(claims)
+        executed, skipped, failures = cpc.run_validation_commands(claims, cpc.ROOT)
         self.assertEqual(executed, ["fake_passing_claim"])
         self.assertEqual(skipped, [])
         self.assertEqual(failures, [])
@@ -73,7 +73,7 @@ class RunValidationCommandsTests(unittest.TestCase):
                 "validation_command": "grep -qF 'this-string-does-not-exist' /dev/null",
             }
         ]
-        executed, skipped, failures = cpc.run_validation_commands(claims)
+        executed, skipped, failures = cpc.run_validation_commands(claims, cpc.ROOT)
         self.assertEqual(executed, ["fake_failing_claim"])
         self.assertEqual(skipped, [])
         self.assertEqual(len(failures), 1)
@@ -87,7 +87,7 @@ class RunValidationCommandsTests(unittest.TestCase):
                 "validation_command": "cargo bench -p velesdb-core --bench some_bench",
             }
         ]
-        executed, skipped, failures = cpc.run_validation_commands(claims)
+        executed, skipped, failures = cpc.run_validation_commands(claims, cpc.ROOT)
         self.assertEqual(executed, [])
         self.assertEqual(failures, [])
         self.assertEqual(len(skipped), 1)
@@ -105,7 +105,7 @@ class RunValidationCommandsTests(unittest.TestCase):
                 "validation_command": "true",
             }
         ]
-        executed, skipped, failures = cpc.run_validation_commands(claims)
+        executed, skipped, failures = cpc.run_validation_commands(claims, cpc.ROOT)
         self.assertEqual(executed, [])
         self.assertEqual(len(skipped), 1)
         self.assertEqual(failures, [])
@@ -122,9 +122,9 @@ class RealRegistryExecutableClaimsTests(unittest.TestCase):
         """
         import json
 
-        data = json.loads(cpc.REGISTRY.read_text(encoding="utf-8"))
+        data = json.loads(cpc.registry_path(cpc.ROOT).read_text(encoding="utf-8"))
         claims = data.get("claims", [])
-        executed, _skipped, failures = cpc.run_validation_commands(claims)
+        executed, _skipped, failures = cpc.run_validation_commands(claims, cpc.ROOT)
         self.assertGreater(
             len(executed), 0, "expected at least one claim to be marked executable"
         )
@@ -133,7 +133,7 @@ class RealRegistryExecutableClaimsTests(unittest.TestCase):
     def test_real_registry_has_both_executable_and_documentary_claims(self) -> None:
         import json
 
-        data = json.loads(cpc.REGISTRY.read_text(encoding="utf-8"))
+        data = json.loads(cpc.registry_path(cpc.ROOT).read_text(encoding="utf-8"))
         claims = data.get("claims", [])
         executable_count = sum(1 for c in claims if c.get("executable") is True)
         documentary_count = sum(1 for c in claims if c.get("executable") is False)

--- a/scripts/tests/test_guard_refusal_vectors.py
+++ b/scripts/tests/test_guard_refusal_vectors.py
@@ -71,7 +71,24 @@ def materialise(tree: "dict[str, str]", root: Path) -> None:
         path.write_text(content, encoding="utf-8")
 
 
-def make_repository(root: Path, tracked: "list[str]") -> None:
+#: Identity and message a `repo` vector gets unless it names its own. Local to
+#: the tree, so the harness never depends on the machine's git configuration.
+DEFAULT_IDENTITY = "refusal-vector-harness <harness@velesdb.invalid>"
+DEFAULT_MESSAGE = "vector"
+
+
+def split_identity(identity: str) -> "tuple[str, str]":
+    """`Name <email>` -> `(name, email)`, the form git config wants."""
+    name, _, email = identity.partition("<")
+    return name.strip(), email.rstrip(">").strip()
+
+
+def make_repository(
+    root: Path,
+    tracked: "list[str]",
+    identity: str = DEFAULT_IDENTITY,
+    message: str = DEFAULT_MESSAGE,
+) -> None:
     """Turn the materialised tree into a git work tree, tracking `tracked`.
 
     Some guards do not ask the filesystem, they ask **git** — is this path
@@ -81,18 +98,23 @@ def make_repository(root: Path, tracked: "list[str]") -> None:
     erases: a file that exists and a file a clone would receive are not the
     same file.
 
-    The commit identity is fixed and local to the tree, so the harness never
-    depends on the machine's git configuration.
+    `identity` and `message` were hardcoded here, which left one whole class of
+    guard still unable to receive a vector: the ones that read WHO authored a
+    commit, or WHAT the message says, cannot be handed a tree that differs in
+    the only field they look at. A vector names them per tree, like the tracked
+    paths; both default to the values this harness always used, so every vector
+    written before this stays byte-identical.
     """
     run = lambda *args: subprocess.run(  # noqa: E731 - local shorthand
         ["git", "-C", str(root), *args], capture_output=True, text=True, check=True
     )
+    name, email = split_identity(identity)
     run("init", "-q")
-    run("config", "user.email", "harness@velesdb.invalid")
-    run("config", "user.name", "refusal-vector-harness")
+    run("config", "user.email", email)
+    run("config", "user.name", name)
     for relative in tracked:
         run("add", "--", relative)
-    run("commit", "-q", "-m", "vector")
+    run("commit", "-q", "-m", message)
 
 
 def run_guard(script: str, argv: "list[str]", root: Path) -> "subprocess.CompletedProcess[str]":
@@ -123,7 +145,12 @@ class RefusalVectorTests(unittest.TestCase):
         # untracked, which is the whole point for a guard that asks git.
         repo = vector.get("repo")
         if repo is not None:
-            make_repository(tmp, repo.get(key, []))
+            make_repository(
+                tmp,
+                repo.get(key, []),
+                repo.get("author", {}).get(key, DEFAULT_IDENTITY),
+                repo.get("message", {}).get(key, DEFAULT_MESSAGE),
+            )
         return run_guard(entry["script"], vector["argv"], tmp)
 
     def test_every_declared_vector_is_refused(self) -> None:
@@ -179,8 +206,24 @@ class RefusalVectorTests(unittest.TestCase):
             for vector in entry["must_refuse"]:
                 with self.subTest(script=entry["script"], vector=vector["vector"]):
                     repo = vector.get("repo") or {}
-                    refused = (vector["files"], sorted(repo.get("files", [])))
-                    accepted = (vector["accepts"], sorted(repo.get("accepts", [])))
+                    author = repo.get("author", {})
+                    message = repo.get("message", {})
+                    # The state is the tree, what git tracks of it, AND who
+                    # authored it — a vector for the attribution guard differs
+                    # in the identity alone, and comparing trees and tracked
+                    # sets only would have rejected it as "identical".
+                    refused = (
+                        vector["files"],
+                        sorted(repo.get("files", [])),
+                        author.get("files"),
+                        message.get("files"),
+                    )
+                    accepted = (
+                        vector["accepts"],
+                        sorted(repo.get("accepts", [])),
+                        author.get("accepts"),
+                        message.get("accepts"),
+                    )
                     self.assertNotEqual(
                         refused,
                         accepted,


### PR DESCRIPTION
Ferme #1715.

## Cause racine

Un garde resolvait son perimetre depuis `__file__`, donc il ne pouvait etre
execute que contre le depot ou il vit. C'est pour cela qu'aucun vecteur ne
pouvait lui etre donne -- pas parce que les vecteurs etaient durs a ecrire.

Le patron maison existait deja dans cinq scripts (`check-doc-freshness.py:522`
+ `:529` + l'enveloppe de sortie 2 de `:540-543`) ; il est propage ici.

**6 gardes vus refuser -> 12 sur 16.**

| garde | ce qui a change |
|---|---|
| `check-feature-claims.py` | `--root` + vecteur roadmap |
| `check-version-sync.py` | `--root` + vecteur de derive 9.9.9 vs 1.0.0 |
| `check-promise-contract.py` | `--root` + vecteur de surpromesse sq8 |
| `check-python.sh` | deux defauts corriges + vecteur `hash()` |
| `check-ai-attribution.py` | vecteur d'identite, via une extension du harnais |
| `check_binary_size.py` | vecteur de binaire manquant (il etait declare exempt a tort) |

La CI ne change pas d'un octet : `--root` a pour defaut la racine actuelle, et
la sortie des trois scripts est **byte-identique a develop**, verifiee par diff.

## L'enveloppe de sortie 2

Chaque garde retouche gagne `except (...): return 2`. C'est la distinction qui
porte tout le reste : **une traceback Python sort AUSSI en 1**, et le harnais
assert exactement 1. Sans elle un plantage se serait fait passer pour un refus.

## Trois defauts trouves en chemin, corriges plutot que contournes

- **`check-promise-contract.py` lisait le registre deux fois**, la seconde sans
  garde : un registre absent levait `FileNotFoundError` avant que le retour
  gracieux `Missing registry file` ne puisse s'afficher. Sa branche gracieuse
  etait donc inatteignable.
- **`check-version-sync.py` balayait ses deux listes avec la meme boucle ecrite
  deux fois**, et elles avaient derive : l'une resolvait son lecteur par
  `_READERS.get` et levait `RuntimeError`, l'autre indexait `_READERS[fmt]` et
  levait `KeyError` -- non attrapee, elle sort en 1 par traceback.
- **`check-python.sh` testait `[ -d "$dir" ]` mais scannait `"$dir/src"`**, et
  passait `integrations/common` a flake8 sans le garder : sur un arbre sans ces
  repertoires, les deux comptaient une erreur que rien n'avait causee.

En prime, deux violations de complexite **preexistantes sur develop** sont
resorbees : `check-version-sync.py:main` (CCN 12) et
`check-promise-contract.py:main` (CCN 19) etaient la meme boucle recopiee.
`lizard -C 8` sort maintenant 0 sur les deux.

## Extension du harnais : `repo.author` et `repo.message`

Toute une classe de gardes restait sans vecteur possible : ceux qui lisent QUI
a signe un commit ne peuvent pas recevoir deux arbres qui different sur le seul
champ qu'ils regardent -- `make_repository` codait l'identite en dur.

Un vecteur les nomme desormais par arbre. L'invariant "les deux etats different"
s'elargit au meme triplet, sans quoi un vecteur qui ne differe que par
l'identite serait rejete comme identique. Les defauts reproduisent l'identite
utilisee jusqu'ici : **les vecteurs anterieurs sont inchanges**.

## Deux affirmations du registre etaient fausses

- `check-python.sh` ne "cd vers la racine" pas : il ne `cd` nulle part. Depuis
  `docs/` il ne scanne rien et sort **0** -- mesure. Son `purpose` annoncait
  aussi mypy, qui n'est jamais invoque (ligne 8, un commentaire).
- `run-production-gates.sh` n'aurait pas un vecteur "quand les gardes qu'il
  chaine en auront" : sous cwd temporaire il sort **127**, pas 1, et son
  controle positif exige trois suites cargo contre un vrai crate. Mesure : 127.

## Les exemptions restantes disent la verite

`run-production-gates.sh` et `pr-governance.yml` restent exemptes, avec des
raisons mesurees. `check-mcp-doc-contract.py` aussi, mais pour une raison de
sequencement explicite : sa regle d'attribution est remplacee par #1695, et son
gabarit de 17 fichiers depend de cette regle. L'ecrire maintenant reviendrait a
l'ecrire deux fois ; il arrive avec la regle.

## Verification

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` :
  **203 tests, exit 0**
- Chaque vecteur a ete **desarme structurellement** (JSON charge, jamais un
  replace textuel) et **vu rougir en nommant son vecteur** -- y compris
  `repo.author`, dont le desarmement fait repondre 0 la ou 1 est exige.
- Sortie des trois scripts retouches : `diff` vide contre develop.