### PR TITLE
fix(core)!: une expiration ne s'herite plus d'un remember a l'autre

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -199,13 +199,34 @@ impl SemanticMemory {
         Ok(())
     }
 
-    /// Copies the reserved system keys (`_veles_*`: durable TTL, RL confidence,
-    /// entity tags) of the live prior version of `id` into `payload`, so a
-    /// content re-store (`remember`) does not silently wipe learned state.
+    /// Copies the reserved system keys (`_veles_*`: RL confidence, entity
+    /// tags) of the live prior version of `id` into `payload`, so a content
+    /// re-store (`remember`) does not silently wipe LEARNED state.
     ///
     /// Only keys `payload` does not already carry are copied — that guard,
     /// and it alone, is what keeps a carried-forward value from shadowing
     /// something the caller meant.
+    ///
+    /// # The durable TTL is deliberately NOT carried forward
+    ///
+    /// [`EXPIRES_AT_KEY`] is excluded, and that exclusion is the whole point
+    /// of the distinction this function draws. An RL confidence and an entity
+    /// tag are state the SYSTEM learned; an expiry is an intent the CALLER
+    /// expressed. Only the properties the current call supplies are applied,
+    /// so a historical expiry is never inherited implicitly.
+    ///
+    /// It used to be carried forward, which left no published way to promote
+    /// a TTL'd fact back to permanent: `remember` without `ttl_seconds` — the
+    /// exact call five binding surfaces document as "omit it for a permanent
+    /// memory" — quietly reinstated the old expiry, and the only escape was
+    /// `forget` plus a re-create, which mints a new id and breaks every edge
+    /// pointing at it.
+    ///
+    /// That is the same betrayal of intent [`crate::agent`]'s zero-TTL refusal
+    /// was introduced to stop, read in the other direction: there, an explicit
+    /// `0` silently became permanent; here, an omitted TTL silently stayed
+    /// temporary. Both are the caller's stated intent being overridden without
+    /// a signal.
     ///
     /// The ordering with `attach_expiry` is deliberately NOT part of the
     /// argument: `attach_expiry` is a no-op on `None` and an unconditional
@@ -239,6 +260,13 @@ impl SemanticMemory {
             return;
         };
         for (k, v) in prior {
+            // The expiry is a caller intent, not learned state: see this
+            // function's docs. Excluding it here is what makes `remember`
+            // without a TTL mean "permanent" on an existing fact, exactly as
+            // every binding surface documents it.
+            if k == memory_helpers::EXPIRES_AT_KEY {
+                continue;
+            }
             if k.starts_with("_veles_") && !obj.contains_key(k) {
                 obj.insert(k.clone(), v.clone());
             }

--- a/crates/velesdb-core/tests/bdd/agent_memory.rs
+++ b/crates/velesdb-core/tests/bdd/agent_memory.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use tempfile::TempDir;
 use velesdb_core::agent::AgentMemory;
-use velesdb_core::{velesql::Parser, Database, SearchResult};
+use velesdb_core::{velesql::Parser, Database, SearchResult, EXPIRES_AT_KEY};
 
 // ============================================================================
 // Helpers
@@ -348,5 +348,141 @@ fn test_expired_ttl_is_reclaimed_by_auto_expire_after_reopen() {
         collection.len(),
         0,
         "the expired point's storage must be physically reclaimed"
+    );
+}
+
+// ============================================================================
+// A re-store applies only what the CURRENT call supplies
+// ============================================================================
+//
+// The rule, stated once for the three tests below: on a re-store, only the
+// properties the current call supplies are applied. A historical expiry is
+// never inherited implicitly.
+//
+// An RL confidence and an entity tag are state the SYSTEM learned, and
+// `carry_forward_reserved_keys` rightly preserves them. An expiry is an intent
+// the CALLER expressed, and it must not outlive the call that expressed it.
+//
+// Carrying it forward left no published way to promote a TTL'd fact back to
+// permanent: the very call five binding surfaces document as "omit it for a
+// permanent memory" quietly reinstated the old expiry, and the only escape was
+// delete-and-recreate, which mints a new id and breaks every edge pointing at
+// it.
+//
+// These assert on the reserved `_veles_expires_at` payload key rather than
+// waiting for a TTL to lapse: the claim is about what the write PERSISTS, and
+// a sleeping test would pin the clock instead of the contract.
+
+/// Case 1 — existing TTL + re-store WITHOUT a TTL must become permanent.
+/// This is the one that used to fail: the expiry was carried forward.
+#[test]
+fn restoring_without_a_ttl_clears_an_existing_expiry() {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: create AgentMemory");
+
+    // GIVEN a fact stored with a durable TTL
+    memory
+        .semantic()
+        .store_with_ttl(1, "temporary at first", &[1.0, 0.0, 0.0, 0.0], 3600)
+        .expect("store with ttl");
+    let before = memory
+        .semantic()
+        .get_metadata(1)
+        .expect("read metadata")
+        .expect("the fact exists");
+    assert!(
+        before.contains_key(EXPIRES_AT_KEY),
+        "precondition: the fact must actually carry an expiry, else this test proves nothing"
+    );
+
+    // WHEN it is re-stored without any TTL
+    memory
+        .semantic()
+        .store(1, "temporary at first", &[1.0, 0.0, 0.0, 0.0])
+        .expect("re-store without ttl");
+
+    // THEN it is permanent
+    let after = memory
+        .semantic()
+        .get_metadata(1)
+        .expect("read metadata")
+        .expect("the fact still exists");
+    assert!(
+        !after.contains_key(EXPIRES_AT_KEY),
+        "a re-store without a TTL must clear the expiry — five binding surfaces \
+         document this exact call as storing a permanent memory, and inheriting \
+         the old expiry silently overrides the caller's intent"
+    );
+}
+
+/// Case 2 — existing TTL + re-store WITH a TTL must take the NEW one.
+/// Guards the other direction: clearing must not have become unconditional.
+#[test]
+fn restoring_with_a_ttl_replaces_the_previous_expiry() {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: create AgentMemory");
+
+    memory
+        .semantic()
+        .store_with_ttl(1, "short lived", &[1.0, 0.0, 0.0, 0.0], 60)
+        .expect("store with a short ttl");
+    let first = memory
+        .semantic()
+        .get_metadata(1)
+        .expect("read metadata")
+        .expect("the fact exists");
+    let first_expiry = first
+        .get(EXPIRES_AT_KEY)
+        .and_then(serde_json::Value::as_u64)
+        .expect("the first write persisted an expiry");
+
+    memory
+        .semantic()
+        .store_with_ttl(1, "short lived", &[1.0, 0.0, 0.0, 0.0], 86_400)
+        .expect("re-store with a longer ttl");
+
+    let second = memory
+        .semantic()
+        .get_metadata(1)
+        .expect("read metadata")
+        .expect("the fact still exists");
+    let second_expiry = second
+        .get(EXPIRES_AT_KEY)
+        .and_then(serde_json::Value::as_u64)
+        .expect("an explicit TTL must still persist an expiry");
+    assert!(
+        second_expiry > first_expiry,
+        "the NEW ttl must win: expected an expiry later than {first_expiry}, got {second_expiry}"
+    );
+}
+
+/// Case 3 — already permanent + re-store WITHOUT a TTL stays permanent.
+/// The unremarkable case, pinned so a future "helpful" default cannot make a
+/// plain re-store start expiring things.
+#[test]
+fn restoring_a_permanent_fact_without_a_ttl_keeps_it_permanent() {
+    let dir = TempDir::new().expect("test: create temp dir");
+    let db = Arc::new(Database::open(dir.path()).expect("test: open database"));
+    let memory = AgentMemory::with_dimension(Arc::clone(&db), 4).expect("test: create AgentMemory");
+
+    memory
+        .semantic()
+        .store(1, "permanent from the start", &[1.0, 0.0, 0.0, 0.0])
+        .expect("store permanently");
+    memory
+        .semantic()
+        .store(1, "permanent from the start", &[1.0, 0.0, 0.0, 0.0])
+        .expect("re-store permanently");
+
+    let after = memory
+        .semantic()
+        .get_metadata(1)
+        .expect("read metadata")
+        .expect("the fact exists");
+    assert!(
+        !after.contains_key(EXPIRES_AT_KEY),
+        "a permanent fact re-stored without a TTL must stay permanent"
     );
 }

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -132,8 +132,10 @@ impl MemoryStore {
     /// Store a fact; resolves to its decimal-string id. `links` are
     /// `{target, relation}` edges to existing memories; `metadata` is an optional
     /// object for later filtering. `ttlSeconds` makes the fact expire after that
-    /// many seconds (a durable TTL that survives restarts); omit it (or `0`) for
-    /// a permanent memory.
+    /// many seconds (a durable TTL that survives restarts); omit it for a
+    /// permanent memory, including when re-storing a fact that already had an
+    /// expiry — only what this call supplies is applied. An explicit `0` is
+    /// REFUSED, because a caller writing `0` means "expire now", not "never".
     #[napi(ts_return_type = "Promise<string>")]
     pub fn remember(
         &self,

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2329,7 +2329,10 @@ class MemoryService:
                 Keys starting with ``_veles_`` are reserved.
             ttl_seconds: Optional durable time-to-live in seconds. The fact
                 expires (and stops being recalled) after this delay, surviving a
-                restart. Omit (or ``0``) for a permanent memory.
+                restart. Omit for a permanent memory, including when re-storing a
+                fact that already had an expiry — only what this call supplies is
+                applied. An explicit ``0`` is REFUSED, because a caller writing
+                ``0`` means "expire now", not "never".
 
         Returns:
             Stable integer id for the stored fact.

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -380,7 +380,10 @@ impl PyMemoryService {
     /// Store a fact; returns its stable id. `links` is a list of `(target_id,
     /// relation)` tuples; `metadata` is an optional dict for later filtering.
     /// `ttl_seconds` makes the fact expire after that many seconds (a durable TTL
-    /// that survives restarts); omit it (or `0`) for a permanent memory.
+    /// that survives restarts); omit it for a permanent memory, including when
+    /// re-storing a fact that already had an expiry — only what this call
+    /// supplies is applied. An explicit `0` is REFUSED, because a caller
+    /// writing `0` means "expire now", not "never".
     #[pyo3(signature = (fact, links = None, metadata = None, ttl_seconds = None))]
     fn remember(
         &self,

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -498,7 +498,10 @@ impl WasmMemoryService {
     /// Store a fact; resolves to its decimal-string id. `links` is an array
     /// of `{target, relation}` edges to existing memories; `metadata` is an
     /// optional plain object; `ttlSeconds` makes the fact expire after that
-    /// many seconds (omit, or `0`, for a permanent memory).
+    /// many seconds. Omit it for a permanent memory, including when re-storing
+    /// a fact that already had an expiry — only what this call supplies is
+    /// applied. An explicit `0` is REFUSED, because a caller writing `0` means
+    /// "expire now", not "never".
     #[wasm_bindgen(js_name = remember)]
     pub fn remember(
         &self,

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -687,7 +687,10 @@ export class MemoryService {
    * Store a fact; resolves to its decimal-string id (idempotent on
    * identical content). `links` are edges to existing memories; `metadata`
    * is optional structured data for later filtering; `ttlSeconds` makes the
-   * fact expire after that many seconds (omit, or `0`, for permanent).
+   * fact expire after that many seconds. Omit it for a permanent memory,
+   * including when re-storing a fact that already had an expiry — only what
+   * this call supplies is applied. An explicit `0` is REFUSED, because a
+   * caller writing `0` means "expire now", not "never".
    */
   remember(
     fact: string,


### PR DESCRIPTION
Ferme #1735 et #1736. Deux issues, mais **une seule phrase**, repetee sur cinq surfaces, qui ment **deux fois** :

> `ttl_seconds` ... **omit it (or `0`) for a permanent memory**

- `0` est **refuse** (`MemoryError::ZeroTtl`)
- **omettre**, sur un fait deja TTL'e, reconduisait l'ancienne echeance au lieu de le rendre permanent

## L'origine, et pourquoi la derive n'est pas discutable

Le refus de `0` est **delibere**. #1654 l'a introduit parce qu'un appelant qui ecrit `0` veut « expire tout de suite », et le normaliser en « permanent » etait l'intention exactement inverse, sans signal. Le message d'erreur dit deja la bonne chose, et **la description MCP a ete corrigee a l'epoque** :

> omit it for a permanent memory — `ttl_seconds: 0` is refused, not read as "never"

Les cinq surfaces de binding, elles, n'ont jamais suivi. Une surface mise a jour, cinq oubliees : la derive est unilaterale et mesurable, ce n'est pas une opinion sur ce qui aurait du etre.

| surface | ligne |
|---|---|
| `crates/velesdb-node/src/lib.rs` | `:135` |
| `crates/velesdb-python/python/velesdb/__init__.pyi` | `:2332` |
| `crates/velesdb-python/src/agent_memory_service.rs` | `:383` |
| `crates/velesdb-wasm/src/memory_service.rs` | `:501` |
| `sdks/typescript/src/memory.ts` | `:690` |

## Le second mensonge, et la regle qui le corrige

`carry_forward_reserved_keys` recopiait les cles reservees `_veles_*` de la version precedente d'un fait, **dont la TTL durable**. Un `remember` sans TTL reconduisait donc l'echeance, et il n'existait **aucun chemin publie** pour promouvoir un fait a TTL en fait permanent : la seule sortie etait `forget` puis re-creation, ce qui donne un id neuf et casse toute arete qui pointait dessus.

**La regle retenue, et sa PORTEE EXACTE :** lors d'un `remember`, seules les proprietes explicitement fournies par l'appel courant s'appliquent — **pour l'expiration**. `EXPIRES_AT_KEY` n'est plus heritee.

La distinction qui la porte : **un etat APPRIS se conserve, une intention d'APPELANT ne s'herite pas.** Une confiance RL et un tag d'entite sont de l'etat que le systeme a appris ; une expiration est une intention que l'appelant a exprimee.

**La regle n'est PAS generalisee aux autres cles reservees.** La confiance RL et les tags d'entite gardent leur comportement de report actuel. Les etendre casserait la boucle `feedback`, et c'est une decision distincte qui n'a pas ete prise.

C'est le meme raisonnement que #1654, lu dans l'autre sens : la-bas un `0` explicite devenait silencieusement permanent, ici une TTL omise restait silencieusement temporaire. Les deux sont l'intention de l'appelant ecrasee sans signal.

## Ce que les tests prouvent, et ce qu'ils ne prouvent pas

Trois cas nommes dans `crates/velesdb-core/tests/bdd/agent_memory.rs` :

| cas | attendu |
|---|---|
| TTL existante + re-store **sans** TTL | permanent |
| TTL existante + re-store **avec** TTL | la nouvelle TTL gagne |
| deja permanent + re-store **sans** TTL | reste permanent |

**Desarmement joue.** Sur le source d'origine (`git stash` du seul `semantic_memory.rs`, les tests neufs restant en place), **seul le premier rougit**, en nommant son vecteur :

```
---- agent_memory::restoring_without_a_ttl_clears_an_existing_expiry stdout ----
panicked at crates/velesdb-core/tests/bdd/agent_memory.rs:411:5:
a re-store without a TTL must clear the expiry — five binding surfaces document
this exact call as storing a permanent memory, and inheriting the old expiry
silently overrides the caller's intent
```

Les deux autres passaient deja : ce sont des **garde-fous de non-regression, pas des preuves de correctif**, et je ne les compte pas comme telles.

Ils assertent sur la cle `_veles_expires_at` plutot que d'attendre qu'une TTL s'ecoule : la promesse porte sur ce que l'ecriture **persiste**, et un test qui dort epinglerait l'horloge au lieu du contrat.

## Un fait qui merite d'etre dit

La suite `velesdb-core` complete passe avec ce changement **sans qu'un seul test existant ait du etre touche**. Autrement dit : **aucun test n'epinglait l'ancien report d'expiration.** Le comportement qui produisait #1736 n'etait protege par rien.

## Verification

Codes de sortie captures **avant tout pipe**, apres rebase sur `develop@70c12c9e` :

| gate | code | detail |
|---|---|---|
| `cargo test -p velesdb-core --test bdd` | **0** | 635 passes, 0 echec |
| `cargo test -p velesdb-memory --lib` | **0** | 410 passes, 0 echec |
| `python3 -m unittest discover -s scripts/tests` | **0** | `Ran 211 ... OK` (verdict sur **stderr**) |
| `check-mcp-doc-contract.py` | **0** | `MCP doc-contract guards passed.` |
| clippy workspace (commande exacte de `ci.yml:216-219`) | **0** | |
| clippy `velesdb-node --lib` | **0** | |
| `cargo fmt --all --check` | **0** | |

La suite `velesdb-core` complete (58 suites) a tourne deux fois : une fois avant rebase, et une fois via le hook `pre-commit`.

## BREAKING CHANGE

Un `remember` sans `ttl_seconds` sur un fait qui portait deja une expiration la **supprime** desormais, au lieu de la reconduire. C'est ce que les cinq surfaces publiees documentaient deja ; le code s'y conforme enfin.
