### PR TITLE
fix(mcp): remember_extracted cesse de taire les faits qu'il a jetes

### DIFF
--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -453,7 +453,7 @@ impl McpServer {
         // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
         // or les SDK MCP valident structuredContent contre ce schema.
         output_schema = crate::schema::wire_safe_output_schema::<RememberExtractedResult>(),
-        description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns the stored facts' ids."
+        description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts."
     )]
     async fn remember_extracted(
         &self,

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1157,6 +1157,85 @@ fn test_recall_where_description_documents_type_strict_comparisons() {
     );
 }
 
+/// Whether `haystack` names `field` as a WORD, not as an accidental substring.
+///
+/// A plain `contains` is not enough, and the measurement says so: across the
+/// twenty published tools it lets `feedback`'s `id` pass on the strength of
+/// "con-f-**id**-ence", and `entity`'s `relations` on "relation-ships". A
+/// guard weaker than its own statement is worse than none, because it reads
+/// as coverage.
+///
+/// Backticks, spaces and punctuation are all boundaries here; only ASCII
+/// alphanumerics and `_` continue a word — so `ids` does NOT match inside
+/// `ids_str`, and each field has to be named on its own.
+fn description_names_field(haystack: &str, field: &str) -> bool {
+    let continues_word = |byte: u8| byte.is_ascii_alphanumeric() || byte == b'_';
+    let bytes = haystack.as_bytes();
+    haystack.match_indices(field).any(|(start, _)| {
+        let end = start + field.len();
+        let opens = start == 0 || !continues_word(bytes[start - 1]);
+        let closes = end == bytes.len() || !continues_word(bytes[end]);
+        opens && closes
+    })
+}
+
+/// #1747. `remember_extracted`'s published `outputSchema` carries three root
+/// fields, and one of them — `skipped_over_cap` — exists PRECISELY to make a
+/// silent loss visible: facts the extractor produced and this tool dropped for
+/// exceeding the per-fact text cap. Its own doc-comment argues the point: "a
+/// skip the caller cannot see is indistinguishable from the model extracting
+/// fewer facts".
+///
+/// The description used to say only "Returns the stored facts' ids". So the
+/// one surface a model reads BEFORE deciding to call never mentioned the field
+/// whose whole purpose is to be read — the omission defeated the reason the
+/// field was added (#1692).
+///
+/// The field names are DERIVED from the published schema rather than kept as a
+/// second hard-coded list here: a root field added tomorrow is caught without
+/// anyone remembering this test exists.
+///
+/// Scope, stated so it is not overclaimed: this pins ONE tool. Fourteen of the
+/// twenty published tools would fail the same check today, and closing that
+/// class is its own piece of work (#1695).
+#[test]
+fn test_remember_extracted_description_names_every_published_output_field() {
+    let tool = McpServer::remember_extracted_tool_attr();
+    let description = tool
+        .description
+        .clone()
+        .expect("remember_extracted must declare a description");
+    let schema = tool
+        .output_schema
+        .as_ref()
+        .expect("remember_extracted declares an explicit output_schema");
+    let properties = schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .expect("its output schema is an object schema carrying `properties`");
+
+    assert!(
+        !properties.is_empty(),
+        "the published output schema must expose root properties, else this \
+         test would pass vacuously"
+    );
+
+    let missing: Vec<&str> = properties
+        .keys()
+        .filter(|field| !description_names_field(&description, field))
+        .map(String::as_str)
+        .collect();
+
+    assert!(
+        missing.is_empty(),
+        "remember_extracted's description must name every root field of its \
+         published outputSchema. Missing: {missing:?}. A field the description \
+         omits is a field the model never learns to read, and `skipped_over_cap` \
+         omitted is a silent data loss — the caller believes everything it sent \
+         was stored. Description was: {description}"
+    );
+}
+
 /// Issue: real MCP client harnesses (observed 2026-07-24 with Claude Code)
 /// degrade a parameter whose advertised schema carries no DIRECT `type`
 /// keyword — `anyOf`-wrapped optionals and `$ref`-only structs both come out

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -2821,7 +2821,7 @@
       }
     },
     {
-      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns the stored facts' ids.",
+      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {


### PR DESCRIPTION
Ferme #1747.

L'`outputSchema` publie de `remember_extracted` porte **trois** champs racine. La description n'en nommait **qu'un** :

> Returns the stored facts' ids.

## Le champ tu existe pour rendre visible une perte

`skipped_over_cap`, et son propre doc-comment (`crates/velesdb-memory/src/mcp/dto.rs:563-567`) explique exactement pourquoi il a ete ajoute :

> Extracted facts **DROPPED** for exceeding the embeddable text cap. Additive and always present: **a skip the caller cannot see is indistinguishable from the model extracting fewer facts**, and this tool exists precisely so the caller does not have to verify what it stored.

Le champ existe donc **pour etre lu**. Et la description — la seule surface qu'un modele lit AVANT de decider d'appeler — ne le mentionnait pas. **L'omission defaisait la raison d'etre du champ.**

`ids_str` manquait aussi, et ce n'est pas cosmetique : les ids depassent 2^53, donc un client sans lecture JSON u64-sure doit lire `ids_str`. Tous les autres outils le disent.

### Le scenario

Un agent envoie un long passage. Trois faits extraits depassent le plafond par fait et sont **jetes**. La reponse porte `skipped_over_cap: 3`. L'agent, qui a lu « Returns the stored facts' ids », lit `ids`, y trouve 7 identifiants, et poursuit en croyant avoir stocke tout ce qui comptait. Les faits perdus sont les plus longs — donc souvent les plus riches.

## La derive etait unilaterale, et mesuree

**Toutes** les autres surfaces declarent deja l'enveloppe complete, et expliquent meme pourquoi elle existe :

| surface | ligne |
|---|---|
| `docs/reference/MCP_TOOLS.md` | `:319-320` |
| `crates/velesdb-python/python/velesdb/__init__.pyi` | `:2606` |
| `sdks/typescript/src/memory.ts` | `:858` |
| `docs/guides/WASM_API.md` | `:277-285` |
| JSDoc du binding Node | `lib.rs:672-676` |

Cette derniere dit meme, verbatim :

> The envelope is the breaking change that ends that silence (issue #1692).

**Le silence que #1692 avait ete ouverte pour finir a survecu exactement la ou il coute le plus cher.** Cinq surfaces a jour, une oubliee — le meme motif que #1748, dans l'autre sens.

## Le test derive les noms, il ne les recopie pas

`test_remember_extracted_description_names_every_published_output_field` lit les cles racine de l'`output_schema` **publie** (via `McpServer::remember_extracted_tool_attr()`) et les confronte a la description.

**Aucune seconde liste codee en dur** : un champ racine ajoute demain est attrape sans que personne ait a se souvenir que ce test existe. C'est la difference entre epingler un contrat et recopier un etat.

La correspondance est **a frontieres de mot**, pas un `contains`. La mesure sur les vingt outils publies dit pourquoi : un `contains` laisserait passer le champ `id` de `feedback` sur la seule force de « con-f-**id**-ence », et le champ `relations` d'`entity` sur « relation-ships ». Un garde plus faible que son propre enonce est pire que pas de garde, parce qu'il se lit comme de la couverture.

La frontiere fait aussi que `ids` ne matche **pas** a l'interieur de `ids_str` : chaque champ doit etre nomme pour lui-meme.

### Desarmement joue

Sur la description d'origine, le test rougit **en nommant son vecteur**, et ce vecteur est derive du schema, pas ecrit a la main :

```
remember_extracted's description must name every root field of its published
outputSchema. Missing: ["ids_str", "skipped_over_cap"]. A field the description
omits is a field the model never learns to read, and `skipped_over_cap` omitted
is a silent data loss — the caller believes everything it sent was stored.
```

## Ce que ce lot ne pretend PAS faire

Ce test epingle **un** outil. **Quatorze des vingt** outils publies echoueraient le meme controle aujourd'hui — 26 champs racine non nommes sur 66, en correspondance a frontieres de mot. Fermer cette classe est un travail a part, suivi par #1695. Rien ici ne le pretend.

`remember_extracted` n'est pas dans `POLICED_TOOLS`, donc aucune surface epinglee n'avait a etre resynchronisee.

## Verification

Codes de sortie captures **avant tout pipe** :

| gate | code | detail |
|---|---|---|
| `cargo test -p velesdb-memory --lib` | **0** | 411 passes, 0 echec |
| les 5 suites d'integration | **0** | 102 passes, 0 echec |
| `python3 -m unittest discover -s scripts/tests` | **0** | `Ran 211 ... OK` (verdict sur **stderr**) |
| `check-mcp-doc-contract.py` | **0** | `MCP doc-contract guards passed.` |
| clippy workspace (commande exacte de `ci.yml:216-219`) | **0** | |
| clippy `velesdb-node --lib` | **0** | |
| `cargo fmt --all --check` | **0** | |

`docs/reference/mcp-tools.json` regenere via `UPDATE_MCP_TOOLS_SNAPSHOT=1` — **une seule ligne changee**, et les trois champs y sont verifies nommes.

Pas de changement de comportement : la description et son test, rien d'autre.
