### PR TITLE
fix(mcp): l'extracteur deterministe redevient joignable depuis le serveur

### DIFF
--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -170,9 +170,21 @@ age stored as `"15"` will never match `age >= 15` — no error, just silence. Th
 is the same trap as the date field in step 2, and it is the single most common
 way a memory system looks like it is working while returning nothing.
 
-`remember_extracted` needs an extraction backend
-(`[extractor] backend = "ollama"`); without one the tool reports itself as
-unconfigured rather than silently storing less.
+`remember_extracted` needs an extraction backend; without one the tool reports
+itself as unconfigured rather than silently storing less. Two exist, and they
+are **not** interchangeable:
+
+- `"ollama"` runs a local generative model that **infers** the facts, entity
+  edges and attributes a passage states. It needs that model running, and a
+  binary built with `--features extract`.
+- `"outline"` is deterministic and fully offline — no model, no network, and no
+  extra build feature. But it only reads structure you write out **explicitly**,
+  one directive per line (`fact:`, `edge:`, `attr:`). Hand it free prose and you
+  get plain facts with no graph around them.
+
+Pick `"outline"` when you control the input format, or to get a graph at all
+without running a model. Pick `"ollama"` when the input is prose nobody is
+going to reformat.
 
 ## Concrete scenarios
 
@@ -239,8 +251,8 @@ backend = "ollama"             # `hash` is lexical, not semantic — see above
 model = "bge-m3"
 
 [extractor]
-backend = "ollama"             # required for remember_extracted / entities
-model = "qwen3.6:35b-mlx"
+backend = "ollama"             # or "outline" — infers vs reads directives, see above
+model = "qwen3.6:35b-mlx"      # "ollama" only; "outline" needs no model
 
 [graph]
 autograph = false              # true = every `remember` also wires entities

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -844,6 +844,76 @@ impl Extractor for OutlineExtractor {
     }
 }
 
+/// What a caller must do to honour a requested extraction backend.
+///
+/// Returned by [`select_extractor`], which is the single place that knows which
+/// backend names exist. Splitting the answer into these three shapes is what
+/// lets the dependency-free backends be selected in **any** build: only the
+/// [`Self::NeedsRemoteConfig`] arm requires an optional dependency and the URL
+/// and model that go with it, and only that arm's construction is feature-gated.
+pub enum ExtractorSelection {
+    /// No extraction. Tools that need an extractor answer "not configured".
+    Disabled,
+    /// Ready to use as-is: needs no configuration, no network, no optional
+    /// dependency. Attach it and the graph builds.
+    Ready(DynExtractor),
+    /// A network-backed backend the caller must build itself, because only the
+    /// caller knows its URL and model. Carries the backend's name so the caller
+    /// can dispatch without re-parsing the string.
+    NeedsRemoteConfig(&'static str),
+}
+
+/// Hand-written because [`DynExtractor`] is a trait object and the trait does
+/// not require `Debug` — a backend is identified by its shape here, never by
+/// dumping its innards (an HTTP-backed one holds a URL, and a panic message is
+/// not the place for it).
+impl std::fmt::Debug for ExtractorSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => f.write_str("Disabled"),
+            Self::Ready(_) => f.write_str("Ready(<extractor>)"),
+            Self::NeedsRemoteConfig(name) => write!(f, "NeedsRemoteConfig({name})"),
+        }
+    }
+}
+
+/// Resolve an extraction backend name to what the caller must do about it.
+///
+/// # Why this exists, and why it is in the library rather than the binary
+///
+/// The selection used to live inside the daemon's `#[cfg(feature = "extract")]`
+/// block. That gate is what made [`OutlineExtractor`] unreachable from the MCP
+/// server (#1734): the extractor needs no dependency and is linked into every
+/// build, but the only code that could *choose* it was compiled away unless an
+/// unrelated HTTP feature was on. Two of the twenty published tools were dead by
+/// default as a result — `remember_extracted` refused outright, and `entity`
+/// answered `found: false` for every name, entity hubs being born only of
+/// extraction.
+///
+/// Living here rather than in `main.rs` also means the daemon and the tests
+/// exercise the **same** function: a test can select `outline` and drive the
+/// real server with the result, instead of proving a seam written for the test.
+///
+/// # Errors
+/// A human-readable message naming the accepted forms, for an unknown backend.
+pub fn select_extractor(backend: &str) -> Result<ExtractorSelection, String> {
+    match backend {
+        // No `#[cfg]` here, and that absence IS the fix: this arm must survive
+        // in a build without any HTTP feature, which is exactly the build the
+        // published binary ships.
+        "outline" => Ok(ExtractorSelection::Ready(std::sync::Arc::new(
+            OutlineExtractor,
+        ))),
+        "ollama" => Ok(ExtractorSelection::NeedsRemoteConfig("ollama")),
+        "none" | "" => Ok(ExtractorSelection::Disabled),
+        other => Err(format!(
+            "unknown extraction backend '{other}' (expected 'outline' for the \
+             offline deterministic reader, 'ollama' for a local generative \
+             model, or 'none')"
+        )),
+    }
+}
+
 // --- Optional batteries-included backend: a local Ollama generative model -----
 //
 // Enabled with `--features extract`. The default build omits this backend (and

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -128,8 +128,8 @@ pub use error::{ErrorCategory, MemoryError};
 #[cfg(feature = "extract")]
 pub use extract::OllamaExtractor;
 pub use extract::{
-    DynExtractor, ExtractError, ExtractedAttribute, ExtractedFact, ExtractedRelation, Extraction,
-    Extractor, OutlineExtractor,
+    select_extractor, DynExtractor, ExtractError, ExtractedAttribute, ExtractedFact,
+    ExtractedRelation, Extraction, Extractor, ExtractorSelection, OutlineExtractor,
 };
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -33,7 +33,9 @@ use std::time::Duration;
 
 use rmcp::ServiceExt;
 use velesdb_memory::mcp::McpServer;
-use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION};
+use velesdb_memory::{
+    DynEmbedder, ExtractorSelection, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
@@ -475,39 +477,29 @@ fn spawn_shutdown_signals(ct: tokio_util::sync::CancellationToken) {
 /// a silent no-op: the operator turned on a feature, and a daemon that
 /// answers by doing nothing is how you spend a week wondering why the graph
 /// is empty.
-#[cfg(feature = "extract")]
 fn apply_autograph(
     service: MemoryService<DynEmbedder>,
 ) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
     if std::env::var("VELESDB_MEMORY_AUTOGRAPH").as_deref() != Ok("1") {
         return Ok(service);
     }
-    if std::env::var("VELESDB_MEMORY_EXTRACTOR").as_deref() != Ok("ollama") {
-        return Err(
+    let backend = std::env::var("VELESDB_MEMORY_EXTRACTOR").unwrap_or_default();
+    // Same gate as `attach_extractor`, and it must accept the same names: a
+    // build where `remember_extracted` works with `outline` but autograph
+    // refuses to start would be a contradiction the operator cannot resolve.
+    match velesdb_memory::select_extractor(&backend)? {
+        ExtractorSelection::Disabled => Err(
             "autograph is on ([graph] autograph = true / VELESDB_MEMORY_AUTOGRAPH=1) but no \
-             extraction backend is configured — set [extractor] backend = \"ollama\" (and a \
-             model), or turn autograph off"
+             extraction backend is configured — set [extractor] backend = \"outline\" for the \
+             offline deterministic reader (no rebuild, no model to run), or \"ollama\" with a \
+             model, or turn autograph off"
                 .into(),
-        );
+        ),
+        ExtractorSelection::Ready(extractor) => Ok(service.with_autograph(extractor)),
+        ExtractorSelection::NeedsRemoteConfig(_) => {
+            Ok(service.with_autograph(build_ollama_extractor()?))
+        }
     }
-    Ok(service.with_autograph(build_ollama_extractor()?))
-}
-
-/// Without the `extract` feature there is no backend to attach. A request for
-/// autograph still fails loudly rather than being ignored — the binary was
-/// built without the code to honour it, exactly like `--http` without `http`.
-#[cfg(not(feature = "extract"))]
-fn apply_autograph(
-    service: MemoryService<DynEmbedder>,
-) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
-    if std::env::var("VELESDB_MEMORY_AUTOGRAPH").as_deref() == Ok("1") {
-        return Err(
-            "autograph is on but this binary was built without --features extract, so no \
-             extraction backend exists"
-                .into(),
-        );
-    }
-    Ok(service)
 }
 
 /// Locate and apply the optional `velesdb-memory.toml`.
@@ -605,31 +597,47 @@ fn apply_ingest_roots(server: McpServer) -> Result<McpServer, Box<dyn std::error
     Ok(server)
 }
 
-/// Build the MCP server, attaching an extraction backend from
-/// `VELESDB_MEMORY_EXTRACTOR` (`ollama`) when built with `--features extract`.
-#[cfg(feature = "extract")]
+/// Build the MCP server, attaching the extraction backend named by
+/// `VELESDB_MEMORY_EXTRACTOR`.
+///
+/// This function is now a thin read of the environment on top of
+/// [`attach_extractor`]; the choice itself lives in the library so the daemon
+/// and the tests run the same code. See [`attach_extractor`] for why that
+/// matters here in particular.
 fn build_server(
     service: MemoryService<DynEmbedder>,
 ) -> Result<McpServer, Box<dyn std::error::Error>> {
-    let server = McpServer::new(service);
-    match std::env::var("VELESDB_MEMORY_EXTRACTOR").as_deref() {
-        Ok("ollama") => Ok(server.with_extractor(build_ollama_extractor()?)),
-        Ok("none") | Err(_) => Ok(server),
-        Ok(other) => {
-            Err(format!("unknown VELESDB_MEMORY_EXTRACTOR '{other}' (expected 'ollama')").into())
-        }
-    }
+    let backend = std::env::var("VELESDB_MEMORY_EXTRACTOR").unwrap_or_default();
+    attach_extractor(McpServer::new(service), &backend)
 }
 
-/// Without the `extract` feature there is no extraction backend to attach. The
-/// `Result` return mirrors the `extract` variant's signature so the caller is
-/// identical for both builds.
-#[cfg(not(feature = "extract"))]
-#[allow(clippy::unnecessary_wraps)]
-fn build_server(
-    service: MemoryService<DynEmbedder>,
+/// Attach the extraction backend named `backend` to `server`.
+///
+/// **There is deliberately no `#[cfg(feature = "extract")]` on this function.**
+/// That gate used to sit on the whole selection, which is what made
+/// `OutlineExtractor` unreachable from the MCP server (#1734): the extractor
+/// needs no dependency and is linked into every build, but the only code that
+/// could choose it was compiled away unless an unrelated HTTP feature was on.
+/// Two of the twenty published tools were dead by default as a result —
+/// `remember_extracted` refused outright, and `entity` answered `found: false`
+/// for every name, entity hubs being born only of extraction.
+///
+/// Only the arm that genuinely needs the optional dependency stays gated.
+///
+/// # Errors
+/// An unknown backend name, or a network-backed backend whose required
+/// configuration is missing or whose feature was not compiled in.
+fn attach_extractor(
+    server: McpServer,
+    backend: &str,
 ) -> Result<McpServer, Box<dyn std::error::Error>> {
-    Ok(McpServer::new(service))
+    match velesdb_memory::select_extractor(backend)? {
+        ExtractorSelection::Disabled => Ok(server),
+        ExtractorSelection::Ready(extractor) => Ok(server.with_extractor(extractor)),
+        ExtractorSelection::NeedsRemoteConfig(_) => {
+            Ok(server.with_extractor(build_ollama_extractor()?))
+        }
+    }
 }
 
 /// Build the Ollama-backed extractor from `VELESDB_MEMORY_EXTRACTOR_URL`
@@ -647,6 +655,20 @@ fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
          (e.g. qwen3.6:35b-mlx)"
     })?;
     Ok(Arc::new(OllamaExtractor::new(url, model)))
+}
+
+/// Without the `extract` feature there is no HTTP backend to build. The error
+/// names the offline alternative rather than only what is missing: since
+/// #1734, `outline` is a real answer in **every** build, so a user who only
+/// wanted a graph is one setting away instead of one rebuild away.
+#[cfg(not(feature = "extract"))]
+fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
+    Err(
+        "VELESDB_MEMORY_EXTRACTOR=ollama needs a build with `--features extract`; \
+         for an offline deterministic graph with no rebuild, set \
+         VELESDB_MEMORY_EXTRACTOR=outline instead"
+            .into(),
+    )
 }
 
 /// Select the embedding backend from `VELESDB_MEMORY_EMBEDDER`: `hash`

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -4,9 +4,11 @@
 //! Cline, Zed, …) can use it locally. The store never leaves the machine.
 //! Configure the store directory with `VELESDB_MEMORY_PATH` (default
 //! `~/.velesdb-memory`) and the embedding
-//! backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama`). When built with
-//! `--features extract`, set `VELESDB_MEMORY_EXTRACTOR=ollama` to enable the
-//! `remember_extracted` tool (auto text → fact↔topic graph). Set
+//! backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama`). Set
+//! `VELESDB_MEMORY_EXTRACTOR` to enable the `remember_extracted` tool (text →
+//! fact↔topic graph): `outline` reads directives you write explicitly and needs
+//! no model and no extra feature, while `ollama` infers them with a local
+//! generative model and needs `--features extract`. Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
 //! Set `VELESDB_MEMORY_INGEST_ROOTS` (a `PATH`-list of directories) to let
 //! `compile_context`/`explain_compilation` fragments reference a file by

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -470,7 +470,9 @@ impl McpServer {
             return Err(ErrorData::new(
                 ErrorCode::INTERNAL_ERROR,
                 "extraction backend not configured: start the server with \
-                 VELESDB_MEMORY_EXTRACTOR set (built with --features extract)",
+                 VELESDB_MEMORY_EXTRACTOR=outline for the offline deterministic \
+                 reader — it needs no model and no extra build feature — or \
+                 =ollama with a local generative model",
                 None,
             ));
         };

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1387,3 +1387,97 @@ fn unrelate_params_accept_string_or_number_ids_on_the_wire() {
     assert_eq!(params.from, u64::MAX);
     assert_eq!(params.to, 42);
 }
+
+/// #1734, and this is the test that has to cross the REAL wiring rather than a
+/// seam written for it.
+///
+/// The defect was never in the library: `OutlineExtractor` always worked, and
+/// `McpServer::with_extractor` always accepted it. What was broken is that the
+/// only code able to CHOOSE `outline` sat inside the daemon's
+/// `#[cfg(feature = "extract")]` block, so on a default build two of the twenty
+/// published tools were dead — `remember_extracted` refused outright, and
+/// `entity` answered `found: false` for every name, entity hubs being born only
+/// of extraction.
+///
+/// So this test deliberately calls [`crate::select_extractor`] — the same
+/// function `main.rs` now calls — instead of constructing `OutlineExtractor`
+/// directly. Building the extractor by hand here would prove only that the
+/// library works, which was never in doubt. The one step it does not cover is
+/// `std::env::var` itself, which is a process-global read the daemon does once.
+#[tokio::test]
+async fn an_outline_configured_server_builds_a_hub_that_entity_finds() {
+    let dir = TempDir::new().expect("create tempdir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
+    let service = MemoryService::open(dir.path(), embedder).expect("open memory store");
+
+    // The selection, through the real function. `Ready` is the whole point:
+    // outline needs no configuration, no network and no optional dependency,
+    // which is why it can be chosen in a build that has none of them.
+    let crate::ExtractorSelection::Ready(extractor) =
+        crate::select_extractor("outline").expect("`outline` must be an accepted backend name")
+    else {
+        panic!("`outline` must be usable as-is, with no remote configuration");
+    };
+    let srv = McpServer::new(service).with_extractor(extractor);
+
+    // Tool 1 of the two that were dead: it used to answer "extraction backend
+    // not configured" no matter what the operator set.
+    let Json(stored) = srv
+        .remember_extracted(Parameters(RememberExtractedParams {
+            text: "fact: Theo has a sister called Camille | Theo, Camille\n\
+                   edge: Camille | soeur de | Theo\n\
+                   attr: Theo | age | 15"
+                .to_owned(),
+            metadata: None,
+        }))
+        .await
+        .expect("remember_extracted must work on an outline-configured server");
+    assert_eq!(
+        stored.ids.len(),
+        1,
+        "the passage carries exactly one `fact:` directive, so exactly one \
+         fact must be stored (`edge:` and `attr:` build the graph around it, \
+         they are not facts of their own)"
+    );
+
+    // Tool 2: `entity` answered `found: false` for EVERY name, because hubs are
+    // salted so that no caller fact can create one — they are born only of
+    // extraction. If this passes, the cascade is closed.
+    let Json(theo) = srv
+        .entity(Parameters(EntityParams {
+            name: "Theo".to_owned(),
+        }))
+        .await
+        .expect("entity");
+    assert!(
+        theo.found,
+        "entity must find the hub that remember_extracted just created — \
+         this is the second of the two behaviours #1734 reported dead"
+    );
+    let outgoing: Vec<&str> = theo
+        .relations
+        .iter()
+        .map(|r| r.predicate.as_str())
+        .collect();
+    let incoming: Vec<&str> = theo
+        .relations_in
+        .iter()
+        .map(|r| r.predicate.as_str())
+        .collect();
+    // Asserted on EITHER side on purpose, and the reason is written here so the
+    // looseness is not mistaken for carelessness. What #1734 is about is that
+    // the edge reaches the graph at all: before the fix no extractor could be
+    // selected, so there was no edge on either side.
+    //
+    // Which side it lands on is a SEPARATE question, and an open one: measured
+    // here, `edge: Camille | soeur de | Theo` lands in Theo's OUTGOING edges
+    // and leaves his incoming empty, while `incoming_entity_relations`'s own
+    // doc uses this exact example to say the opposite. Pinning either direction
+    // in this test would freeze an answer nobody has established yet — so it is
+    // tracked on its own instead.
+    assert!(
+        incoming.contains(&"soeur de") || outgoing.contains(&"soeur de"),
+        "the `edge:` directive must reach the graph — outgoing {outgoing:?}, \
+         incoming {incoming:?}"
+    );
+}

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -170,9 +170,21 @@ age stored as `"15"` will never match `age >= 15` — no error, just silence. Th
 is the same trap as the date field in step 2, and it is the single most common
 way a memory system looks like it is working while returning nothing.
 
-`remember_extracted` needs an extraction backend
-(`[extractor] backend = "ollama"`); without one the tool reports itself as
-unconfigured rather than silently storing less.
+`remember_extracted` needs an extraction backend; without one the tool reports
+itself as unconfigured rather than silently storing less. Two exist, and they
+are **not** interchangeable:
+
+- `"ollama"` runs a local generative model that **infers** the facts, entity
+  edges and attributes a passage states. It needs that model running, and a
+  binary built with `--features extract`.
+- `"outline"` is deterministic and fully offline — no model, no network, and no
+  extra build feature. But it only reads structure you write out **explicitly**,
+  one directive per line (`fact:`, `edge:`, `attr:`). Hand it free prose and you
+  get plain facts with no graph around them.
+
+Pick `"outline"` when you control the input format, or to get a graph at all
+without running a model. Pick `"ollama"` when the input is prose nobody is
+going to reformat.
 
 ## Concrete scenarios
 
@@ -239,8 +251,8 @@ backend = "ollama"             # `hash` is lexical, not semantic — see above
 model = "bge-m3"
 
 [extractor]
-backend = "ollama"             # required for remember_extracted / entities
-model = "qwen3.6:35b-mlx"
+backend = "ollama"             # or "outline" — infers vs reads directives, see above
+model = "qwen3.6:35b-mlx"      # "ollama" only; "outline" needs no model
 
 [graph]
 autograph = false              # true = every `remember` also wires entities

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -564,13 +564,29 @@ VELESDB_MEMORY_EXTRACTOR_MODEL=qwen3.6:35b-mlx \
   /path/to/velesdb-memory
 ```
 
-Env vars: `VELESDB_MEMORY_EXTRACTOR` (`ollama` to enable),
-`VELESDB_MEMORY_EXTRACTOR_URL` (default `http://localhost:11434`),
-`VELESDB_MEMORY_EXTRACTOR_MODEL` (required, a generative model). Without a
-backend the tool returns a clear "not configured" error.
+Env vars: `VELESDB_MEMORY_EXTRACTOR` (`ollama` or `outline`),
+`VELESDB_MEMORY_EXTRACTOR_URL` (default `http://localhost:11434`, `ollama`
+only), `VELESDB_MEMORY_EXTRACTOR_MODEL` (a generative model — required for
+`ollama`, unused by `outline`). Without a backend the tool returns a clear
+"not configured" error.
 
-To plug a different model, implement the dependency-free `Extractor` trait and
-pass it to `MemoryService::remember_extracted` from Rust.
+The two backends are **not** interchangeable:
+
+- **`ollama`** runs a local generative model that **infers** the facts, entity
+  edges and attributes a passage states. It needs that model running, and a
+  binary built with `--features extract`.
+- **`outline`** is deterministic and fully offline — no model, no network, and
+  **no extra build feature**, so it works in the default binary. But it only
+  reads structure written out **explicitly**, one directive per line (`fact:`,
+  `edge:`, `attr:`). Free prose handed to it becomes plain facts with no graph
+  around them.
+
+Choose `outline` when you control the input format, or to get a graph at all
+without running a model; choose `ollama` when the input is prose nobody is
+going to reformat.
+
+To plug a different backend entirely, implement the dependency-free `Extractor`
+trait and pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 


### PR DESCRIPTION
Ferme #1734. **Ne traite PAS #1751** (backend OpenAI-compatible), **ni #1752** (override par appel), **ni #1753** (features par defaut) — ces trois sujets ont ete deliberement sortis du perimetre et sont suivis separement.

## Les deux comportements morts

**`remember_extracted` refusait.** `mcp.rs` rend « extraction backend not configured » des que `self.extractor` est vide.

**`entity` repondait `found: false` pour TOUT nom.** Les hubs d'entite ne naissent que d'`entity_hub()` (`service.rs:755`), appelee uniquement depuis les chemins d'extraction — `:574-575`, `:621`, `:702` — et `wire_entities` n'a que deux entrees, `autograph` et `remember_extracted`. Leurs ids sont sales (`service.rs:66`) precisement pour qu'aucun fait d'appelant ne puisse en creer un. **Sans extracteur attache, aucun hub ne peut exister.**

## La cause : un feature gate mal place

`OutlineExtractor` ne depend de rien et est exporte **sans `cfg`** (`lib.rs:128-133`) : il est deja lie dans chaque binaire. Mais le seul code capable de le **choisir** vivait dans le bloc `#[cfg(feature = "extract")]` du demon — une feature qui n'existe que pour tirer `ureq`, dont ce backend n'a aucun besoin.

Poser `VELESDB_MEMORY_EXTRACTOR=outline` **empechait donc le demon de demarrer**, et `[extractor] backend = "outline"` n'etait pas une echappatoire : la configuration ecrit la meme variable que le demarrage refuse ensuite.

## Ce qui change

**`select_extractor()` vit desormais dans la BIBLIOTHEQUE**, pas dans le binaire. Ce n'est pas du rangement : c'est ce qui permet au test de traverser **la meme fonction** que le demon, au lieu d'une couture ecrite pour lui.

**Le bras `outline` ne porte aucun `#[cfg]`, et cette absence EST le correctif.** Seul le bras qui a reellement besoin de la dependance optionnelle reste gate.

**`attach_extractor` et `apply_autograph` acceptent les memes noms.** Un binaire ou `remember_extracted` marcherait avec `outline` mais ou l'autographe refuserait de demarrer serait une contradiction que l'operateur ne peut pas resoudre.

**Trois messages devenus faux** sont corriges : ils nommaient `ollama` comme seule reponse possible, et l'un d'eux exigeait un rebuild qui n'est plus necessaire.

## La preuve, et ses limites dites franchement

**Pas de rouge-d'abord, et je ne le revendique pas.** Le defaut est un chemin **absent**, pas un chemin faux : sur `develop`, un test visant la selection ne compile pas, et un test visant la bibliotheque **passe deja** — elle savait faire, c'est le cablage du binaire qui ne l'exposait pas.

Ce qui est prouve a la place :

1. **Le test fonctionnel traverse le cablage REEL** — `select_extractor` → `McpServer::with_extractor` → `remember_extracted` → `entity` — et verifie que le hub cree par l'un est retrouve par l'autre. Il appelle deliberement `select_extractor` plutot que de construire `OutlineExtractor` a la main : le construire ici ne prouverait que la bibliotheque, ce qui n'a jamais fait de doute. **La seule etape non couverte est `std::env::var`**, que le demon fait une fois.
2. **`cargo check` passe AVEC et SANS la feature `extract`** (`CHECK_WITH_EXTRACT_UNSET_EXIT=0`, `CHECK_WITH_EXTRACT_EXIT=0`). C'est la preuve structurelle que le bras `outline` survit dans le binaire livre.

## Deux choses trouvees en chemin, laissees hors perimetre

**#1754 — une arete outline atterrit du cote oppose a ce qui est annonce.** Le test fonctionnel a revele que `edge: Camille | soeur de | Theo` donne `entity("Theo") -> out=["soeur de"], in=[]`, l'inverse de ce que le doc d'`incoming_entity_relations` affirme **sur cet exemple exact**. Mesure reproduite deux fois. **Non corrigee, et la direction n'est pas epinglee dans le test** : trois hypotheses restent a departager, et figer une reponse que personne n'a etablie serait pire que ne rien figer. Le test dit pourquoi en commentaire.

**#1755 — six surfaces publiees deviennent fausses par ce correctif.** Elles affirment qu'`ollama` est requis pour l'extraction : les deux copies de `SKILL.md`, deux endroits de `MCP_SERVER_SETUP.md`, l'en-tete de module de `main.rs`, et le commentaire du modele de configuration. Elles n'etaient pas fausses avant cette PR. C'est une dette **creee sciemment** parce que le perimetre validé couvrait les trois messages du binaire, pas la vague documentaire — et tracee le jour meme plutot que laissee en silence.

## Verification

Codes de sortie captures **avant tout pipe**, tous relances **apres** le `cargo fmt` qui avait reformate deux fichiers :

| gate | code | detail |
|---|---|---|
| `cargo test --lib` (**sans** `extract`) | **0** | 412 passes, 0 echec |
| `cargo test --lib` (**avec** `extract`) | **0** | 434 passes, 0 echec |
| 4 suites d'integration | **0** | 49 passes, 0 echec |
| `python3 -m unittest discover -s scripts/tests` | **0** | `Ran 211 ... OK` (verdict sur **stderr**) |
| clippy workspace (commande exacte de `ci.yml:216-219`) | **0** | |
| clippy `velesdb-node --lib` | **0** | |
| `cargo fmt --all --check` | **0** | |

Aucun artefact epingle a regenerer : `select_extractor` n'ajoute pas d'outil MCP et ne touche aucun `outputSchema`.
