### PR TITLE
fix(context): explain_compilation cesse de perdre sa reponse sous slim_response

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -659,8 +659,22 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         }
         let mut request = request.clone();
         let mut policy = request.policy.take().unwrap_or_default();
+        // Three options neutralised for one reason: an explanation must not
+        // inherit the side effects, nor the presentation, of the compilation it
+        // explains. The caller asked "why this fragment?", not "compile this".
         policy.record_events = false;
         policy.store_sources = false;
+        // `slim_response` empties `sections` and `decisions` to save tokens
+        // (see `apply_slim`). Applied here it would not trim the answer, it
+        // would DELETE it: `decisions` is cleared, the lookup below finds
+        // nothing, and the caller is told `FragmentNotFound` about a fragment
+        // that compiled perfectly well (#1745).
+        //
+        // The option exists to save tokens, so a caller under a tight budget
+        // turns it on by default — and lost the audit tool exactly when they
+        // most needed it, with a message that sent them looking for a typo in
+        // an id that was correct.
+        policy.slim_response = false;
         request.policy = Some(policy);
         let compiled =
             self.compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)?;

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -455,6 +455,91 @@ fn test_explain_compilation_fragment_index_out_of_bounds_is_rejected() {
     ));
 }
 
+/// #1745. `slim_response` empties `sections` and `decisions` from a
+/// `compile_context` response — a PRESENTATION option, for a caller who wants
+/// the compiled content without its audit trail.
+///
+/// `explain_compilation` asks for exactly ONE decision. Letting that option
+/// through does not trim its answer, it deletes it: `apply_slim` clears
+/// `decisions`, the lookup then finds nothing, and the caller gets
+/// `FragmentNotFound` for a fragment that was compiled perfectly well.
+///
+/// The message is what makes this worse than a limitation. A caller told
+/// "fragment not found" reasonably concludes they passed the wrong id and
+/// goes looking in the wrong place.
+///
+/// And the option exists to SAVE TOKENS, so a caller under a tight budget
+/// turns it on by default — losing the audit tool exactly when they most need
+/// it.
+#[test]
+fn test_explain_compilation_ignores_slim_response() {
+    let (_dir, svc) = open_service();
+    let wanted = fragment_id("a fact");
+    let slim = CompilePolicy {
+        slim_response: true,
+        ..CompilePolicy::default()
+    };
+    let req = explain_request(vec![fragment("a fact"), fragment("other")], Some(slim));
+
+    let decision = svc
+        .explain_compilation(&req, wanted, None)
+        .expect("slim_response is a presentation option; it must not hide the decision");
+
+    // Not merely "no error": the decision must be the one that was ASKED for,
+    // and it must carry the explanation. An empty reason or a neighbour's
+    // decision would satisfy `is_ok()` while telling the caller nothing.
+    assert_eq!(
+        decision.fragment_id, wanted,
+        "the decision must belong to the fragment that was asked about"
+    );
+    assert!(matches!(decision.action, ContextAction::Preserve));
+    assert!(
+        !decision.reason.is_empty(),
+        "an explanation with no reason explains nothing"
+    );
+    assert!(
+        !decision.rule_id.is_empty(),
+        "the rule that produced the decision is half the explanation"
+    );
+}
+
+/// The other half of the same guard. The fix works by FORCING a policy field,
+/// so this pins that the nominal path — the one every caller already uses —
+/// is untouched: same decision, same action, same rule, whether the option is
+/// absent or explicitly off.
+#[test]
+fn test_explain_compilation_without_slim_response_is_unchanged() {
+    let (_dir, svc) = open_service();
+    let wanted = fragment_id("a fact");
+    let explicit_off = CompilePolicy {
+        slim_response: false,
+        ..CompilePolicy::default()
+    };
+
+    let baseline = svc
+        .explain_compilation(
+            &explain_request(vec![fragment("a fact"), fragment("other")], None),
+            wanted,
+            None,
+        )
+        .expect("explain_compilation with no policy at all");
+    let with_flag_off = svc
+        .explain_compilation(
+            &explain_request(
+                vec![fragment("a fact"), fragment("other")],
+                Some(explicit_off),
+            ),
+            wanted,
+            None,
+        )
+        .expect("explain_compilation with slim_response explicitly false");
+
+    assert_eq!(with_flag_off.fragment_id, baseline.fragment_id);
+    assert_eq!(with_flag_off.action, baseline.action);
+    assert_eq!(with_flag_off.rule_id, baseline.rule_id);
+    assert_eq!(with_flag_off.reason, baseline.reason);
+}
+
 #[test]
 fn test_explain_compilation_fragment_index_disambiguates_byte_identical_twins() {
     // Two byte-identical fragments share the same content-addressed


### PR DESCRIPTION
Ferme #1745.

`explain_compilation` rendait `FragmentNotFound` pour un fragment **qui existe**, des que la requete portait `policy.slim_response: true`.

## La chaine, verifiee ligne a ligne

`slim_response` vide `sections` et `decisions` de la reponse de `compile_context` (`context.rs:1010-1016`) : c'est une option de **presentation**, pour un appelant qui veut le contenu compile sans son journal d'audit.

`explain_compilation` demande exactement **une** decision. La laisser passer ne reduit pas sa reponse, elle la **supprime** : `apply_slim` vide `decisions`, la recherche ne trouve plus rien, et l'appelant recoit `decision.ok_or(FragmentNotFound(id))` pour un fragment qui s'est compile parfaitement.

## Pourquoi c'est pire qu'une limitation

**Le message est FAUX.** Un appelant a qui l'on dit « fragment not found » conclut raisonnablement qu'il s'est trompe d'identifiant, et va chercher au mauvais endroit.

Et l'option existe pour **economiser des tokens**, donc un appelant sous budget serre l'active par defaut — et perdait l'outil d'audit exactement quand il en avait le plus besoin.

## La correction : une ligne

A cote de deux qui existaient deja et qui disent la meme chose — une explication n'herite ni des effets de bord, ni de la presentation, de la compilation qu'elle explique. `record_events` et `store_sources` etaient deja neutralises pour ce motif ; `slim_response` appartient a cette famille, et son absence de la liste etait un **oubli**, pas une decision.

## Une correction, quatre surfaces, zero binding touche

| surface | site |
|---|---|
| MCP | `mcp/context_tools.rs:575` |
| Node | `node/src/lib.rs:460` |
| Python | `python/src/agent_memory_service.rs:813` |
| WASM | `wasm/src/memory_service.rs:880` |

Les quatre appellent la **meme signature** `.explain_compilation(&request, fragment_id, fragment_index)` et n'implementent aucune logique propre.

**Mesure** : `git grep 'slim_response\|slimResponse'` sur les quatre sources de binding rend **zero resultat**. L'option voyage dans le JSON de `policy` ; aucun binding ne la connait. Corriger le pont les corrige donc tous les quatre **sans en modifier un seul**.

## Le rouge-d'abord, authentique

Joue sur `develop` **avant** toute modification de production :

```
test_explain_compilation_ignores_slim_response ... FAILED
panicked at memory_bridge_tests.rs:486:
slim_response is a presentation option; it must not hide the decision:
FragmentNotFound(15545792975496669522)
```

Un fragment qui existe, declare introuvable.

**Le test exige plus que l'absence d'erreur** : que la decision appartienne au fragment **exact** demande (`fragment_id == wanted`), et qu'elle porte son action, sa `reason` non vide et son `rule_id` non vide. Une decision voisine ou une explication creuse satisferait `is_ok()` sans rien apprendre a l'appelant.

**Le garde-fou** compare deux appels — politique absente contre `slim_response = false` explicite — sur les quatre champs. Il passait deja avant le correctif, et c'est son role : la correction **force** un champ de politique, sans lui rien ne prouverait que le chemin nominal est intact.

## Verification

Codes captures **avant tout pipe** :

| gate | code | detail |
|---|---|---|
| `cargo test -p velesdb-memory --lib` | **0** | 414 passes, 0 echec |
| 4 suites d'integration | **0** | 84 passes, 0 echec |
| `python3 -m unittest discover -s scripts/tests` | **0** | `Ran 211 ... OK` (verdict sur **stderr**) |
| `check-mcp-doc-contract.py` | **0** | `MCP doc-contract guards passed.` |
| clippy workspace (commande exacte de `ci.yml:216-219`) | **0** | |
| clippy `velesdb-node --lib` | **0** | |
| `cargo fmt --all --check` | **0** | |

Aucune autre option de `policy` touchee. Aucun artefact epingle a regenerer.
