### PR TITLE
refactor(memory): la selection d'embedder rejoint la bibliotheque

### DIFF
--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -89,6 +89,84 @@ impl<T: Embedder + ?Sized> Embedder for Box<T> {
     }
 }
 
+// --- Backend selection -------------------------------------------------------
+
+/// What a caller must do about a named embedding backend.
+///
+/// Two variants, not three: unlike [`crate::ExtractorSelection`] there is no
+/// `Disabled`. "No extraction" is a real choice — the graph simply does not
+/// build — while a memory store cannot exist without an embedder. Every
+/// accepted name therefore resolves to something usable.
+pub enum EmbedderSelection {
+    /// Ready to use as-is: needs no configuration, no network, and no optional
+    /// dependency.
+    ///
+    /// Carries the backend's name, which [`ExtractorSelection::Ready`] does
+    /// not. The daemon prints a startup notice that belongs to one specific
+    /// backend (`hash` is deterministic but not semantic), and a library must
+    /// not write to stderr on a caller's behalf. Naming the backend here lets
+    /// the binary decide, instead of inferring "ready implies hash" — an
+    /// inference a second offline backend would silently break.
+    ///
+    /// [`ExtractorSelection::Ready`]: crate::ExtractorSelection::Ready
+    Ready(&'static str, DynEmbedder),
+    /// A network-backed backend the caller must build itself, because only the
+    /// caller knows its URL and model. Carries the backend's name so the caller
+    /// can dispatch without re-parsing the string.
+    NeedsRemoteConfig(&'static str),
+}
+
+/// Hand-written because [`DynEmbedder`] is a trait object and [`Embedder`] does
+/// not require `Debug` — a backend is identified by its shape here, never by
+/// dumping its innards (an HTTP-backed one holds a URL, and a panic message is
+/// not the place for it). Mirrors [`crate::ExtractorSelection`]'s own impl.
+impl std::fmt::Debug for EmbedderSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ready(name, _) => write!(f, "Ready({name}, <embedder>)"),
+            Self::NeedsRemoteConfig(name) => write!(f, "NeedsRemoteConfig({name})"),
+        }
+    }
+}
+
+/// Resolve an embedding backend name to what the caller must do about it.
+///
+/// `backend` is `None` when the selecting variable is **unset**, and
+/// `Some(value)` for whatever it was set to. The distinction is load-bearing
+/// and predates this seam: an unset variable means "no preference" and takes
+/// the offline default, while an empty or misspelled value is a caller who
+/// asked for something and got it wrong. Reading both as "unset" — the shape
+/// an `unwrap_or_default()` at the call site would produce — would turn that
+/// mistake into a silent default.
+///
+/// # Why this exists, and why it is in the library rather than the binary
+///
+/// The embedding selection used to be a bare `match` inside `main.rs`, so
+/// nothing could exercise it without starting the daemon and reading its
+/// stderr. Its counterpart [`crate::select_extractor`] already lives here for
+/// the reasons #1734 made expensive; keeping the two apart meant only one of
+/// the two roles was testable, and only one could gain a backend without
+/// touching the binary.
+///
+/// # Errors
+/// A human-readable message naming the accepted forms, for an unknown backend.
+pub fn select_embedder(backend: Option<&str>) -> Result<EmbedderSelection, String> {
+    match backend {
+        // No `#[cfg]` on this arm, deliberately: `hash` is linked into every
+        // build, including the published one that has no HTTP backend at all,
+        // and it is what an unconfigured daemon runs on.
+        None | Some("hash") => Ok(EmbedderSelection::Ready(
+            "hash",
+            Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION)),
+        )),
+        Some("ollama") => Ok(EmbedderSelection::NeedsRemoteConfig("ollama")),
+        Some(other) => Err(format!(
+            "unknown embedding backend '{other}' (expected 'hash' for the \
+             offline deterministic embedder, or 'ollama' for a local model)"
+        )),
+    }
+}
+
 // --- Optional real-recall backend: a local Ollama embeddings endpoint --------
 //
 // Enabled with `--features ollama`. The default build omits this backend (and
@@ -377,3 +455,7 @@ fn request_embedding(
 #[cfg(all(test, feature = "ollama"))]
 #[path = "embedder_tests.rs"]
 mod ollama_tests;
+
+#[cfg(test)]
+#[path = "embedder_selection_tests.rs"]
+mod selection_tests;

--- a/crates/velesdb-memory/src/embedder_selection_tests.rs
+++ b/crates/velesdb-memory/src/embedder_selection_tests.rs
@@ -1,0 +1,78 @@
+//! Tests for [`super::select_embedder`] — the seam that resolves an embedding
+//! backend name to what the caller must do about it.
+//!
+//! Deliberately NOT gated on `feature = "ollama"` (unlike `embedder_tests.rs`,
+//! which tests the Ollama client itself): the `hash` arm must resolve in every
+//! build, including the default one that has no HTTP backend compiled in. A
+//! test that only ran under `--features ollama` would leave the shipped
+//! binary's own path unexercised.
+
+use super::*;
+
+#[test]
+fn an_unset_variable_takes_the_offline_default() {
+    let selection = select_embedder(None).expect("an unset variable is not a caller error");
+    match selection {
+        EmbedderSelection::Ready(name, embedder) => {
+            assert_eq!(name, "hash", "the default backend is the offline one");
+            assert_eq!(
+                embedder.dimension(),
+                crate::DEFAULT_DIMENSION,
+                "the default embedder is built at the crate's default dimension"
+            );
+        }
+        other @ EmbedderSelection::NeedsRemoteConfig(_) => {
+            panic!("an unset variable must resolve to a ready embedder, got {other:?}")
+        }
+    }
+}
+
+#[test]
+fn hash_is_ready_with_no_configuration_and_no_network() {
+    let selection = select_embedder(Some("hash")).expect("`hash` is an accepted backend");
+    assert!(
+        matches!(selection, EmbedderSelection::Ready("hash", _)),
+        "`hash` needs no URL and no model, so it comes back ready to use"
+    );
+}
+
+#[test]
+fn ollama_defers_to_the_caller_for_url_and_model() {
+    let selection = select_embedder(Some("ollama")).expect("`ollama` is an accepted backend");
+    assert!(
+        matches!(selection, EmbedderSelection::NeedsRemoteConfig("ollama")),
+        "only the caller knows the URL and model, so the library names the \
+         backend and stops there"
+    );
+}
+
+#[test]
+fn an_empty_value_is_refused_like_any_other_unknown_name() {
+    // Distinct from `None` ON PURPOSE, and preserved from the behaviour that
+    // predates this seam: an *unset* variable means "no preference" and takes
+    // the offline default, while `VELESDB_MEMORY_EMBEDDER=` is a caller who
+    // set something and set it wrong. Collapsing the two (an `unwrap_or_default`
+    // at the call site) would silently turn that mistake into a default.
+    //
+    // This is also where the embedder legitimately diverges from
+    // [`crate::select_extractor`], which reads `""` as `none`: "no extraction"
+    // is a real choice, "no embedder" is not.
+    let err = select_embedder(Some("")).expect_err("an empty backend name is not a selection");
+    assert!(
+        err.contains("hash") && err.contains("ollama"),
+        "the refusal must name the accepted forms, got: {err}"
+    );
+}
+
+#[test]
+fn an_unknown_backend_names_the_accepted_forms() {
+    let err = select_embedder(Some("openai")).expect_err("`openai` is not wired yet");
+    assert!(
+        err.contains("openai"),
+        "the refusal must quote what was asked for, got: {err}"
+    );
+    assert!(
+        err.contains("hash") && err.contains("ollama"),
+        "the refusal must name the accepted forms, got: {err}"
+    );
+}

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -121,7 +121,9 @@ const _: () = assert!(
 #[cfg(feature = "context")]
 pub use context::ContextCompiler;
 pub use dated_context::{format_dated_context, DatedContext};
-pub use embedder::{DynEmbedder, EmbedError, Embedder, HashEmbedder};
+pub use embedder::{
+    select_embedder, DynEmbedder, EmbedError, Embedder, EmbedderSelection, HashEmbedder,
+};
 #[cfg(feature = "ollama")]
 pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::{ErrorCategory, MemoryError};

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -35,9 +35,7 @@ use std::time::Duration;
 
 use rmcp::ServiceExt;
 use velesdb_memory::mcp::McpServer;
-use velesdb_memory::{
-    DynEmbedder, ExtractorSelection, HashEmbedder, MemoryService, NativeStore, DEFAULT_DIMENSION,
-};
+use velesdb_memory::{DynEmbedder, ExtractorSelection, MemoryService, NativeStore};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
@@ -676,17 +674,32 @@ fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
 /// Select the embedding backend from `VELESDB_MEMORY_EMBEDDER`: `hash`
 /// (default) is deterministic and fully offline; `ollama` gives real on-device
 /// semantic recall and requires building with `--features ollama`.
+///
+/// A thin read of the environment on top of
+/// [`velesdb_memory::select_embedder`], mirroring what [`build_server`] does
+/// for the extraction side. The choice itself lives in the library so the
+/// daemon and the tests exercise the same function instead of a seam written
+/// for the test.
+///
+/// `.ok()` maps an unset variable to `None`, which the library reads as "no
+/// preference". A variable that IS set keeps its value — including an empty
+/// one, which stays a caller error rather than collapsing into the default.
 fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
-    match std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() {
-        Ok("ollama") => build_ollama_embedder(),
-        Ok("hash") | Err(_) => {
+    let backend = std::env::var("VELESDB_MEMORY_EMBEDDER");
+    // The library message is transport-neutral; the daemon adds the name of the
+    // thing the reader actually has to edit.
+    let selection = velesdb_memory::select_embedder(backend.as_deref().ok())
+        .map_err(|err| format!("VELESDB_MEMORY_EMBEDDER: {err}"))?;
+    match selection {
+        // Matched by name rather than by "ready implies hash": the startup
+        // notice belongs to this one backend, and a future offline backend
+        // must not inherit it silently.
+        velesdb_memory::EmbedderSelection::Ready("hash", embedder) => {
             warn_hash_embedder_not_semantic();
-            Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION)))
+            Ok(embedder)
         }
-        Ok(other) => Err(format!(
-            "unknown VELESDB_MEMORY_EMBEDDER '{other}' (expected 'hash' or 'ollama')"
-        )
-        .into()),
+        velesdb_memory::EmbedderSelection::Ready(_, embedder) => Ok(embedder),
+        velesdb_memory::EmbedderSelection::NeedsRemoteConfig(_) => build_ollama_embedder(),
     }
 }
 


### PR DESCRIPTION
Premier lot de #1751. **Refactor pur** : aucun comportement change, seule la couture commune aux lots suivants est posee.

## Pourquoi

La selection d'embedder etait un `match` dans `main.rs` — intestable sans demarrer le demon. Son pendant `select_extractor` vit dans la bibliotheque depuis #1734. Un seul des deux roles etait donc couvert, et un seul pouvait gagner un backend sans toucher au binaire.

## Ce que ca fait

`select_embedder` + `EmbedderSelection` dans `embedder.rs`. Deux divergences assumees avec le miroir `ExtractorSelection`, chacune pour une raison :

- **Deux variantes, pas trois.** Un extracteur peut etre `Disabled` — « pas d'extraction » est un choix reel. « Pas d'embedder » n'en est pas un.
- **`Ready` porte le nom du backend.** Le demon imprime un avertissement propre a `hash` (deterministe mais pas semantique) ; une bibliotheque n'ecrit pas sur stderr a la place de l'appelant. Nommer le backend laisse le binaire decider, au lieu d'inferer « ready donc hash » — inference qu'un second backend hors ligne casserait en silence.

**`Option<&str>` et non `&str`** : variable absente = pas de preference, variable posee a vide = erreur d'appelant. Un `unwrap_or_default()` au point d'appel aurait confondu les deux et transforme la faute en defaut silencieux. C'est aussi la ou l'embedder diverge legitimement de `select_extractor`, qui lit `""` comme `none`.

## Preuves

Rouge d'abord — mais soyons exacts : le rouge est une **erreur de compilation** (la couture n'existe pas), pas un echec d'assertion. Les 5 tests ne sont pas gates sur `feature = "ollama"`, contrairement a `embedder_tests.rs` : l'arme `hash` doit se resoudre dans la build publiee, qui n'a aucun backend HTTP compile.

Le comportement identique n'est pas deduit de la suite, il est **mesure sur le binaire** :

| `VELESDB_MEMORY_EMBEDDER` | exit | resultat |
|---|---|---|
| `=` (vide) | 1 | refus nommant la variable et les formes acceptees |
| `bogus` | 1 | idem |
| `hash` | 1 | selection passee, echoue plus loin sur `ConnectionClosed("initialize request")` (EOF stdio) |
| absent | 1 | idem |

| porte | resultat |
|---|---|
| `cargo test -p velesdb-memory` | EXIT=0, **419** `--lib` (414 + 5) |
| `cargo test -p velesdb-wasm` | EXIT=0, 656 |
| clippy strict (`ci.yml:216-219`) | EXIT=0 |
| `unittest scripts/tests` | EXIT=0, Ran 211, OK |
| `check-mcp-doc-contract.py` | EXIT=0, PASS |
| `cargo check` node + python | EXIT=0 |

## Note

Le message d'erreur change de forme : la bibliotheque le rend transport-neutre, le demon y prefixe `VELESDB_MEMORY_EMBEDDER:` — le lecteur garde le nom de ce qu'il doit editer. Aucun test ne l'epinglait. Memes entrees, memes succes et memes echecs.

Prepare #1751.