### PR TITLE
feat(memory): un client OpenAI-compatible partage par les deux roles

### DIFF
--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -229,6 +229,97 @@ impl Embedder for OllamaEmbedder {
     }
 }
 
+/// Embeds through any **OpenAI-compatible** `/v1/embeddings` endpoint — oMLX,
+/// llama.cpp's server, LM Studio, vLLM, or a hosted provider.
+///
+/// A sibling of [`OllamaEmbedder`], not a layer over it: each sits directly on
+/// its own protocol, both over the same transport. Reaching a new server is a
+/// different base URL, never a new backend name.
+///
+/// Gated on `feature = "ollama"` because that feature carries this crate's
+/// HTTP dependency for the embedding role. The name predates the protocol
+/// split and now under-describes what it enables.
+#[cfg(feature = "ollama")]
+#[derive(Debug)]
+pub struct OpenAiEmbedder {
+    client: crate::http_client::HttpJsonClient,
+    model: String,
+    dimension: usize,
+}
+
+#[cfg(feature = "ollama")]
+impl OpenAiEmbedder {
+    /// Connect to the server at `base_url` using `model`, probing the
+    /// embedding dimension once so it adapts to whatever model is configured.
+    ///
+    /// `base_url` is the server's origin, port included and path excluded
+    /// (`http://localhost:8020`): the `/v1/embeddings` suffix belongs to the
+    /// protocol, not to the caller.
+    ///
+    /// # Errors
+    /// [`EmbedError`] if the server is unreachable, refuses the request, or
+    /// answers with no vector.
+    pub fn new(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        auth: crate::http_client::Auth,
+    ) -> Result<Self, EmbedError> {
+        let client = crate::http_client::HttpJsonClient::new(
+            base_url,
+            auth,
+            embed_agent(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS)),
+        );
+        let probing = Self {
+            client,
+            model: model.into(),
+            dimension: 0,
+        };
+        let dimension = probing.request("dimension probe")?.len();
+        if dimension == 0 {
+            return Err(EmbedError::Empty);
+        }
+        Ok(Self {
+            dimension,
+            ..probing
+        })
+    }
+
+    /// One embeddings call. The protocol layer builds the body and reads the
+    /// answer back; this method supplies only the model and renders the
+    /// failure — the two things the protocol has no business knowing.
+    fn request(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        let body = crate::openai::embeddings_body(&self.model, text);
+        let payload = self
+            .client
+            .post_json(crate::openai::EMBEDDINGS_PATH, &body)
+            .map_err(|failure| {
+                EmbedError::Backend(crate::http_retry::actionable_openai_failure(
+                    "embeddings",
+                    &failure.url,
+                    &self.model,
+                    failure.attempts,
+                    &failure.cause,
+                    Some(
+                        "fall back to the fully-offline embedder with \
+                         VELESDB_MEMORY_EMBEDDER=hash",
+                    ),
+                ))
+            })?;
+        crate::openai::parse_embeddings_response(&payload).map_err(EmbedError::Backend)
+    }
+}
+
+#[cfg(feature = "ollama")]
+impl Embedder for OpenAiEmbedder {
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        self.request(text)
+    }
+}
+
 /// Build the JSON request body for the embeddings endpoint.
 /// How long Ollama keeps a model resident after a request. `-1` means "for as
 /// long as the server runs", which is what a daemon wants: the model loads once
@@ -374,20 +465,19 @@ enum OllamaCall {
 #[cfg(feature = "ollama")]
 fn call_is_retryable(err: &OllamaCall) -> bool {
     match err {
-        OllamaCall::Transport(inner) => crate::ollama_retry::is_retryable(inner),
-        OllamaCall::Body(inner) => crate::ollama_retry::io_is_retryable(inner),
+        OllamaCall::Transport(inner) => crate::http_retry::is_retryable(inner),
+        OllamaCall::Body(inner) => crate::http_retry::io_is_retryable(inner),
         OllamaCall::Payload(_) => false,
     }
 }
 
 /// The knobs that actually configure this backend, named in its failures.
 #[cfg(feature = "ollama")]
-const EMBED_LEVERS: crate::ollama_retry::OllamaLevers<'static> =
-    crate::ollama_retry::OllamaLevers {
-        url_var: "VELESDB_MEMORY_OLLAMA_URL",
-        model_var: "VELESDB_MEMORY_OLLAMA_MODEL",
-        fallback: Some("fall back to the fully-offline embedder with VELESDB_MEMORY_EMBEDDER=hash"),
-    };
+const EMBED_LEVERS: crate::http_retry::FailureLevers<'static> = crate::http_retry::FailureLevers {
+    url_var: "VELESDB_MEMORY_OLLAMA_URL",
+    model_var: "VELESDB_MEMORY_OLLAMA_MODEL",
+    fallback: Some("fall back to the fully-offline embedder with VELESDB_MEMORY_EMBEDDER=hash"),
+};
 
 /// Perform one embeddings request against a local Ollama, replaying it when the
 /// failure is transient.
@@ -422,15 +512,15 @@ fn request_embedding(
         parse_embedding_response(&payload).map_err(OllamaCall::Payload)
     };
 
-    match crate::ollama_retry::with_retry(
-        &crate::ollama_retry::OLLAMA_RETRIES,
+    match crate::http_retry::with_retry(
+        &crate::http_retry::HTTP_RETRIES,
         call_is_retryable,
         attempt,
     ) {
         Ok(vector) => Ok(vector),
         Err((OllamaCall::Payload(err), _)) => Err(err),
         Err((OllamaCall::Transport(err), attempts)) => Err(EmbedError::Backend(
-            crate::ollama_retry::actionable_failure(
+            crate::http_retry::actionable_ollama_failure(
                 "embeddings",
                 &url,
                 model,
@@ -440,7 +530,7 @@ fn request_embedding(
             ),
         )),
         Err((OllamaCall::Body(err), attempts)) => Err(EmbedError::Backend(
-            crate::ollama_retry::actionable_failure(
+            crate::http_retry::actionable_ollama_failure(
                 "embeddings",
                 &url,
                 model,

--- a/crates/velesdb-memory/src/embedder_tests.rs
+++ b/crates/velesdb-memory/src/embedder_tests.rs
@@ -103,7 +103,7 @@ fn a_silent_ollama_is_bounded_instead_of_hanging_forever() {
 /// The server here accepts, never reads, and closes: the kernel answers
 /// unread bytes in the receive queue with an RST — the portable stand-in for
 /// `SO_LINGER=0`, which would need a dependency this crate does not carry.
-/// 1 initial attempt + the 2 replays of `OLLAMA_RETRIES`.
+/// 1 initial attempt + the 2 replays of `HTTP_RETRIES`.
 const EXPECTED_ATTEMPTS: usize = 3;
 
 /// A listener that accepts `EXPECTED_ATTEMPTS` connections and closes each one

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -950,8 +950,8 @@ const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// is no offline fallback to offer either: extraction is opt-in, and running
 /// without it is simply not passing an extractor.
 #[cfg(feature = "extract")]
-const EXTRACT_LEVERS: crate::ollama_retry::OllamaLevers<'static> =
-    crate::ollama_retry::OllamaLevers {
+const EXTRACT_LEVERS: crate::http_retry::FailureLevers<'static> =
+    crate::http_retry::FailureLevers {
         url_var: "VELESDB_MEMORY_EXTRACTOR_URL",
         model_var: "VELESDB_MEMORY_EXTRACTOR_MODEL",
         fallback: None,
@@ -972,8 +972,8 @@ enum GenerateCall {
 #[cfg(feature = "extract")]
 fn generate_is_retryable(err: &GenerateCall) -> bool {
     match err {
-        GenerateCall::Transport(inner) => crate::ollama_retry::is_retryable(inner),
-        GenerateCall::Body(inner) => crate::ollama_retry::io_is_retryable(inner),
+        GenerateCall::Transport(inner) => crate::http_retry::is_retryable(inner),
+        GenerateCall::Body(inner) => crate::http_retry::io_is_retryable(inner),
     }
 }
 
@@ -985,7 +985,7 @@ fn describe_generate_failure(url: &str, model: &str, err: &GenerateCall, attempt
         GenerateCall::Transport(inner) => inner.to_string(),
         GenerateCall::Body(inner) => format!("reading the response failed: {inner}"),
     };
-    crate::ollama_retry::actionable_failure(
+    crate::http_retry::actionable_ollama_failure(
         "generate",
         url,
         model,
@@ -1038,20 +1038,107 @@ impl OllamaExtractor {
     }
 }
 
+/// Read a model's reply as the flat fact list [`Extractor::extract`] promises.
+///
+/// A free function because every generative backend produces the same reply
+/// and reads it the same way — only the transport differs. Leaving a copy in
+/// each `impl` would let two backends drift on what counts as a valid answer.
+#[cfg(feature = "extract")]
+fn facts_from_reply(reply: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+    let raw =
+        json_slice::<Vec<RawFact>>(reply).ok_or_else(|| ExtractError::Parse(truncate(reply)))?;
+    Ok(raw.into_iter().filter_map(RawFact::into_fact).collect())
+}
+
+/// [`facts_from_reply`]'s counterpart for [`Extractor::extract_graph`].
+#[cfg(feature = "extract")]
+fn extraction_from_reply(reply: &str) -> Result<Extraction, ExtractError> {
+    let raw = json_slice_object::<RawExtraction>(reply)
+        .ok_or_else(|| ExtractError::Parse(truncate(reply)))?;
+    Ok(raw.into_extraction())
+}
+
 #[cfg(feature = "extract")]
 impl Extractor for OllamaExtractor {
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
-        let reply = self.generate(&build_prompt(text))?;
-        let raw = json_slice::<Vec<RawFact>>(&reply)
-            .ok_or_else(|| ExtractError::Parse(truncate(&reply)))?;
-        Ok(raw.into_iter().filter_map(RawFact::into_fact).collect())
+        facts_from_reply(&self.generate(&build_prompt(text))?)
     }
 
     fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
-        let reply = self.generate(&build_graph_prompt(text))?;
-        let raw = json_slice_object::<RawExtraction>(&reply)
-            .ok_or_else(|| ExtractError::Parse(truncate(&reply)))?;
-        Ok(raw.into_extraction())
+        extraction_from_reply(&self.generate(&build_graph_prompt(text))?)
+    }
+}
+
+/// Extracts through any **OpenAI-compatible** `/v1/chat/completions` endpoint.
+///
+/// A sibling of [`OllamaExtractor`], not a layer over it — the same shape the
+/// embedding role takes. The prompt stays here, on the role side: it is what
+/// this crate wants said, not something the protocol knows about.
+#[cfg(feature = "extract")]
+#[derive(Debug)]
+pub struct OpenAiExtractor {
+    client: crate::http_client::HttpJsonClient,
+    model: String,
+}
+
+#[cfg(feature = "extract")]
+impl OpenAiExtractor {
+    /// Build an extractor targeting `model` on the server at `base_url`
+    /// (origin and port, no path).
+    ///
+    /// Bounded on the same four axes as [`OllamaExtractor::new`], with the
+    /// same generous [`REQUEST_TIMEOUT_SECS`]: generation is slow wherever it
+    /// runs, and the ceiling belongs to the role, not to the transport.
+    #[must_use]
+    pub fn new(
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        auth: crate::http_client::Auth,
+    ) -> Self {
+        let timeout = std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS);
+        let agent = ureq::AgentBuilder::new()
+            .timeout_connect(CONNECT_TIMEOUT)
+            .timeout_write(WRITE_TIMEOUT)
+            .timeout_read(timeout)
+            .timeout(timeout)
+            .build();
+        Self {
+            client: crate::http_client::HttpJsonClient::new(base_url, auth, agent),
+            model: model.into(),
+        }
+    }
+
+    /// POST one prompt and return the assistant's reply.
+    fn generate(&self, prompt: &str) -> Result<String, ExtractError> {
+        let body = crate::openai::chat_body(&self.model, prompt);
+        let payload = self
+            .client
+            .post_json(crate::openai::CHAT_COMPLETIONS_PATH, &body)
+            .map_err(|failure| {
+                ExtractError::Backend(crate::http_retry::actionable_openai_failure(
+                    "chat/completions",
+                    &failure.url,
+                    &self.model,
+                    failure.attempts,
+                    &failure.cause,
+                    Some(
+                        "use the offline deterministic reader with \
+                         VELESDB_MEMORY_EXTRACTOR=outline",
+                    ),
+                ))
+            })?;
+        crate::openai::parse_chat_response(&payload).map_err(ExtractError::Backend)
+    }
+}
+
+#[cfg(feature = "extract")]
+impl Extractor for OpenAiExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        facts_from_reply(&self.generate(&build_prompt(text))?)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        extraction_from_reply(&self.generate(&build_graph_prompt(text))?)
     }
 }
 
@@ -1090,8 +1177,8 @@ impl OllamaExtractor {
             response.into_string().map_err(GenerateCall::Body)
         };
 
-        let payload = crate::ollama_retry::with_retry(
-            &crate::ollama_retry::OLLAMA_RETRIES,
+        let payload = crate::http_retry::with_retry(
+            &crate::http_retry::HTTP_RETRIES,
             generate_is_retryable,
             attempt,
         )

--- a/crates/velesdb-memory/src/http_client.rs
+++ b/crates/velesdb-memory/src/http_client.rs
@@ -1,0 +1,193 @@
+//! Authenticated JSON over HTTP — the transport layer under every remote
+//! inference backend.
+//!
+//! # What this module deliberately does NOT know
+//!
+//! Not which *role* is calling: nothing here mentions embedding or extraction,
+//! and the caller supplies its own [`ureq::Agent`] precisely because the two
+//! roles need different ceilings (an embedding answers in a moment, a
+//! generation can take minutes). A client that built its own agent would have
+//! to know which of the two it was serving.
+//!
+//! Not which *vendor* is answering either. Once the path, the body and the
+//! auth scheme all come from the caller, nothing OpenAI-specific is left —
+//! which is the honest reason this is not called an "OpenAI client". The
+//! OpenAI protocol lives one layer up, in [`crate::openai`]; Azure, Gemini or
+//! Anthropic would each get their own protocol module over this same
+//! transport.
+//!
+//! Not `velesdb-server`'s [`crate::http`] either, despite the neighbouring
+//! name: that module *serves* MCP over HTTP, this one *calls* a model.
+
+use crate::http_retry;
+
+/// How a request proves who it is.
+///
+/// An enum rather than an `Option<String>` bearer token, because the shape
+/// varies by provider and was already known to vary before the first
+/// non-OpenAI one landed: Azure `OpenAI` authenticates with `api-key`, a local
+/// server wants nothing at all, and a future provider will want something
+/// else again. Widening an `Option<String>` later would break every caller;
+/// adding a variant here does not.
+pub enum Auth {
+    /// Send no credential header at all.
+    ///
+    /// The default for a model running on the caller's own machine. "No
+    /// token" must mean **no header**, not an empty one: a server that
+    /// validates the header's *presence* rejects `Authorization: Bearer `
+    /// with an error that reads like a bad credential rather than a missing
+    /// one.
+    None,
+    /// `Authorization: Bearer <token>` — the `OpenAI` convention.
+    Bearer(String),
+    /// A verbatim `name: value` header, for a provider that authenticates
+    /// some other way. No bearer is added alongside it.
+    Header {
+        /// Header name (e.g. `api-key`).
+        name: String,
+        /// Header value. Treated as a secret.
+        value: String,
+    },
+}
+
+/// Hand-written so a credential never reaches a log or a panic message
+/// through the derive. The same reflex [`crate::ExtractorSelection`] applies
+/// to a backend's URL, applied to something that matters more.
+///
+/// The header NAME survives: it is not a secret, and printing it is what
+/// makes a provider misconfigured with the wrong scheme diagnosable at all.
+impl std::fmt::Debug for Auth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => f.write_str("None"),
+            Self::Bearer(_) => f.write_str("Bearer(<redacted>)"),
+            Self::Header { name, .. } => {
+                write!(f, "Header {{ name: {name:?}, value: <redacted> }}")
+            }
+        }
+    }
+}
+
+/// Everything a failed call can say WITHOUT knowing what it was for.
+///
+/// The role-specific half of a good error message — which model was asked,
+/// which environment variables repoint it — belongs to the caller, which is
+/// why this carries only transport facts and leaves the rendering to the
+/// provider-appropriate renderer in [`http_retry`].
+pub(crate) struct HttpFailure {
+    /// Full URL that was called, for the message the caller renders.
+    pub url: String,
+    /// How many attempts were spent before giving up.
+    pub attempts: u32,
+    /// Why the last attempt failed.
+    pub cause: String,
+}
+
+/// A JSON-over-HTTP caller bound to one base URL and one credential.
+pub struct HttpJsonClient {
+    base_url: String,
+    auth: Auth,
+    agent: ureq::Agent,
+}
+
+/// Hand-written rather than derived: `ureq::Agent` is not `Debug`, and the
+/// credential must go through [`Auth`]'s own redacting impl rather than
+/// whatever a derive would have produced. The agent is omitted entirely —
+/// its timeouts belong to the caller that built it.
+impl std::fmt::Debug for HttpJsonClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpJsonClient")
+            .field("base_url", &self.base_url)
+            .field("auth", &self.auth)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HttpJsonClient {
+    /// Bind a client to `base_url`, authenticating with `auth`.
+    ///
+    /// `base_url` is kept verbatim and only concatenated with the caller's
+    /// path, so a non-standard port (`http://localhost:8020`) needs no special
+    /// handling — it is already part of the string.
+    ///
+    /// `agent` is the caller's, not this module's: see the module docs.
+    #[must_use]
+    pub fn new(base_url: impl Into<String>, auth: Auth, agent: ureq::Agent) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            auth,
+            agent,
+        }
+    }
+
+    /// The URL `path` resolves to. Exposed for the caller's error messages,
+    /// which name the endpoint they failed against.
+    pub(crate) fn url_for(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    /// POST `body` as JSON to `path`, retrying transient transport failures,
+    /// and return the raw response body.
+    ///
+    /// # Errors
+    /// [`HttpFailure`] carrying the URL, the attempt count and the cause —
+    /// never a rendered sentence, since only the caller knows the levers that
+    /// would change the outcome.
+    pub(crate) fn post_json(&self, path: &str, body: &str) -> Result<String, HttpFailure> {
+        let url = self.url_for(path);
+        let attempt = || {
+            let response = self
+                .authenticated(self.agent.post(&url))
+                .set("Content-Type", "application/json")
+                .send_string(body)
+                .map_err(|err| Call::Transport(Box::new(err)))?;
+            response.into_string().map_err(Call::Body)
+        };
+
+        http_retry::with_retry(&http_retry::HTTP_RETRIES, call_is_retryable, attempt).map_err(
+            |(err, attempts)| HttpFailure {
+                url,
+                attempts,
+                cause: match err {
+                    Call::Transport(inner) => inner.to_string(),
+                    Call::Body(inner) => format!("reading the response failed: {inner}"),
+                },
+            },
+        )
+    }
+
+    /// Apply the credential — or, for [`Auth::None`], apply nothing.
+    ///
+    /// The `None` arm returns the request UNTOUCHED. That is the whole point
+    /// of the variant and the thing the wire-level tests assert: not an empty
+    /// header, not a header with an empty value, no header.
+    fn authenticated(&self, request: ureq::Request) -> ureq::Request {
+        match &self.auth {
+            Auth::None => request,
+            Auth::Bearer(token) => request.set("Authorization", &format!("Bearer {token}")),
+            Auth::Header { name, value } => request.set(name, value),
+        }
+    }
+}
+
+/// How one attempt failed, kept apart just long enough to classify it —
+/// mirrors the shape both role-specific backends already use.
+enum Call {
+    /// The request never completed (reset, refusal, timeout, error status).
+    /// Boxed: `ureq::Error::Status` carries a whole `Response`.
+    Transport(Box<ureq::Error>),
+    /// The response arrived but its body could not be read.
+    Body(std::io::Error),
+}
+
+/// Replay a transport hiccup; never replay a body the server finished sending.
+fn call_is_retryable(err: &Call) -> bool {
+    match err {
+        Call::Transport(inner) => http_retry::is_retryable(inner),
+        Call::Body(inner) => http_retry::io_is_retryable(inner),
+    }
+}
+
+#[cfg(test)]
+#[path = "http_client_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/http_client_tests.rs
+++ b/crates/velesdb-memory/src/http_client_tests.rs
@@ -1,0 +1,73 @@
+//! Tests for the transport layer's own behaviour.
+//!
+//! What goes on the wire is proved in `tests/openai_auth_bdd.rs`, against a
+//! real socket. What is proved here is what can be checked without one: URL
+//! assembly, and that a credential never leaks through `Debug`.
+
+use super::*;
+
+fn client(base_url: &str, auth: Auth) -> HttpJsonClient {
+    HttpJsonClient::new(base_url, auth, ureq::AgentBuilder::new().build())
+}
+
+#[test]
+fn a_non_standard_port_survives_into_the_url() {
+    // oMLX serves on 8020/8028/8030. The base URL is kept verbatim precisely
+    // so a port needs no special handling — it is already part of the string.
+    let client = client("http://localhost:8020", Auth::None);
+    assert_eq!(
+        client.url_for("/v1/embeddings"),
+        "http://localhost:8020/v1/embeddings"
+    );
+}
+
+#[test]
+fn a_trailing_slash_does_not_double_up() {
+    let client = client("http://localhost:8020/", Auth::None);
+    assert_eq!(
+        client.url_for("/v1/embeddings"),
+        "http://localhost:8020/v1/embeddings",
+        "a base URL copied from a browser usually ends in a slash"
+    );
+}
+
+#[test]
+fn a_base_path_is_preserved() {
+    // A provider behind a reverse proxy is reached at a prefix, not at the
+    // origin. Concatenation rather than URL joining is what keeps this working.
+    let client = client("https://gateway.example/inference", Auth::None);
+    assert_eq!(
+        client.url_for("/v1/embeddings"),
+        "https://gateway.example/inference/v1/embeddings"
+    );
+}
+
+#[test]
+fn debug_redacts_a_bearer_token() {
+    let printed = format!("{:?}", Auth::Bearer("sk-must-not-appear".to_owned()));
+    assert!(
+        !printed.contains("sk-must-not-appear"),
+        "a token reaches logs through Debug far more often than through a \
+         deliberate print, got: {printed}"
+    );
+}
+
+#[test]
+fn debug_redacts_a_custom_header_value_but_keeps_its_name() {
+    let printed = format!(
+        "{:?}",
+        Auth::Header {
+            name: "api-key".to_owned(),
+            value: "azure-must-not-appear".to_owned(),
+        }
+    );
+    assert!(
+        !printed.contains("azure-must-not-appear"),
+        "the value is the secret, got: {printed}"
+    );
+    assert!(
+        printed.contains("api-key"),
+        "the NAME is not a secret, and printing it is what makes a provider \
+         configured with the wrong scheme diagnosable at all: {printed}"
+    );
+}

--- a/crates/velesdb-memory/src/http_retry.rs
+++ b/crates/velesdb-memory/src/http_retry.rs
@@ -45,7 +45,7 @@ pub(crate) struct RetryConfig {
 /// is already struggling, and would inflate the worst case of
 /// `remember_extracted`, which issues one embed per fact *and* one per entity
 /// hub. Total added latency on a hard failure: ~300 ms.
-pub(crate) const OLLAMA_RETRIES: RetryConfig = RetryConfig {
+pub(crate) const HTTP_RETRIES: RetryConfig = RetryConfig {
     max_retries: 2,
     initial_delay: Duration::from_millis(100),
     max_delay: Duration::from_secs(1),
@@ -159,7 +159,7 @@ pub(crate) fn with_retry<T, E>(
 /// `VELESDB_MEMORY_EXTRACTOR_URL`/`_MODEL` (see `main.rs`). Naming the wrong
 /// pair would send the user to edit a setting that has no effect — worse than
 /// saying nothing.
-pub(crate) struct OllamaLevers<'a> {
+pub(crate) struct FailureLevers<'a> {
     /// Variable that repoints the base URL.
     pub url_var: &'a str,
     /// Variable that selects the model.
@@ -172,13 +172,13 @@ pub(crate) struct OllamaLevers<'a> {
 /// model, how many times it was tried, why it failed, and which knobs change
 /// the outcome. Modelled on `main.rs`'s hash-embedder notice, which already
 /// states a trade-off and points at its opt-in.
-pub(crate) fn actionable_failure(
+pub(crate) fn actionable_ollama_failure(
     endpoint: &str,
     url: &str,
     model: &str,
     attempts: u32,
     cause: &str,
-    levers: &OllamaLevers<'_>,
+    levers: &FailureLevers<'_>,
 ) -> String {
     let plural = if attempts == 1 { "attempt" } else { "attempts" };
     let mut message = format!(
@@ -190,6 +190,40 @@ pub(crate) fn actionable_failure(
     if let Some(fallback) = levers.fallback {
         message.push_str(", or ");
         message.push_str(fallback);
+    }
+    message.push('.');
+    message
+}
+
+/// The same job for an OpenAI-compatible server, with none of the Ollama
+/// advice.
+///
+/// A separate function rather than a flag on [`actionable_ollama_failure`],
+/// because that one does not merely *name* Ollama — it tells the reader to run
+/// `ollama pull`. Pointed at an oMLX or llama.cpp server, its remedy would be
+/// confidently wrong, which costs more than no remedy at all. Renaming this
+/// module to `http_retry` is what made the hard-coded text visible.
+///
+/// `hint` is the caller's escape hatch (e.g. the fully-offline embedder), or
+/// `None` when it has none to offer.
+#[cfg_attr(not(any(feature = "ollama", feature = "extract")), allow(dead_code))]
+pub(crate) fn actionable_openai_failure(
+    endpoint: &str,
+    url: &str,
+    model: &str,
+    attempts: u32,
+    cause: &str,
+    hint: Option<&str>,
+) -> String {
+    let plural = if attempts == 1 { "attempt" } else { "attempts" };
+    let mut message = format!(
+        "openai-compatible {endpoint} call failed after {attempts} {plural}: \
+         POST {url} (model '{model}'): {cause}. Check a server is listening at \
+         that base URL and serves that model"
+    );
+    if let Some(hint) = hint {
+        message.push_str(", or ");
+        message.push_str(hint);
     }
     message.push('.');
     message
@@ -293,7 +327,7 @@ mod tests {
     fn with_retry_stops_early_on_a_non_retryable_error() {
         let mut calls = 0_u32;
         let outcome: Result<(), (&str, u32)> = with_retry(
-            &OLLAMA_RETRIES,
+            &HTTP_RETRIES,
             |_| false,
             || {
                 calls += 1;
@@ -307,7 +341,7 @@ mod tests {
     #[test]
     fn with_retry_reports_the_attempt_count() {
         let outcome: Result<(), (&str, u32)> =
-            with_retry(&OLLAMA_RETRIES, |_| true, || Err("transient"));
+            with_retry(&HTTP_RETRIES, |_| true, || Err("transient"));
         assert!(
             matches!(outcome, Err((_, 3))),
             "one attempt plus two replays, and the count must reach the caller"
@@ -316,31 +350,31 @@ mod tests {
 
     #[test]
     fn the_backoff_grows_and_stays_capped() {
-        assert_eq!(OLLAMA_RETRIES.delay_for_attempt(0), Duration::ZERO);
+        assert_eq!(HTTP_RETRIES.delay_for_attempt(0), Duration::ZERO);
         assert_eq!(
-            OLLAMA_RETRIES.delay_for_attempt(1),
+            HTTP_RETRIES.delay_for_attempt(1),
             Duration::from_millis(100)
         );
         assert_eq!(
-            OLLAMA_RETRIES.delay_for_attempt(2),
+            HTTP_RETRIES.delay_for_attempt(2),
             Duration::from_millis(200)
         );
         assert_eq!(
-            OLLAMA_RETRIES.delay_for_attempt(99),
-            OLLAMA_RETRIES.max_delay,
+            HTTP_RETRIES.delay_for_attempt(99),
+            HTTP_RETRIES.max_delay,
             "the schedule must not drift into a long sleep"
         );
     }
 
     #[test]
     fn the_failure_message_names_the_levers_of_its_own_call_site() {
-        let message = actionable_failure(
+        let message = actionable_ollama_failure(
             "embeddings",
             "http://localhost:11434/api/embeddings",
             "all-minilm",
             3,
             "Network Error: Connection reset by peer (os error 54)",
-            &OllamaLevers {
+            &FailureLevers {
                 url_var: "VELESDB_MEMORY_OLLAMA_URL",
                 model_var: "VELESDB_MEMORY_OLLAMA_MODEL",
                 fallback: Some(

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -58,6 +58,11 @@ mod fusion;
 /// the crate README's "HTTP transport (multi-client)" section.
 #[cfg(feature = "http")]
 pub mod http;
+/// Synchronous retry + actionable failure reporting shared by the two blocking
+/// Ollama call sites ([`embedder`] and [`extract`]). Internal: it exists to make
+/// those two backends resilient, not to be a general-purpose retry API.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+mod http_retry;
 /// Content-addressed memory ids — internal; ids surface through the service API.
 pub(crate) mod id;
 /// Resource caps (DoS limits) shared by every adapter — the single source of
@@ -72,11 +77,16 @@ pub mod mcp;
 /// (`Link`, `Recollection`, `ColumnFilter`, `Explanation`, …), separate from the
 /// service that computes them.
 pub mod model;
-/// Synchronous retry + actionable failure reporting shared by the two blocking
-/// Ollama call sites ([`embedder`] and [`extract`]). Internal: it exists to make
-/// those two backends resilient, not to be a general-purpose retry API.
+
+/// Authenticated JSON over HTTP: the transport under every remote inference
+/// backend, with no knowledge of role or vendor.
 #[cfg(any(feature = "ollama", feature = "extract"))]
-mod ollama_retry;
+pub mod http_client;
+
+/// The OpenAI-compatible protocol — paths, bodies, responses — over
+/// [`http_client`].
+#[cfg(any(feature = "ollama", feature = "extract"))]
+mod openai;
 /// Optional second-stage re-scoring of a fused recall pool (bring your own
 /// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].
 pub mod rerank;
@@ -125,14 +135,16 @@ pub use embedder::{
     select_embedder, DynEmbedder, EmbedError, Embedder, EmbedderSelection, HashEmbedder,
 };
 #[cfg(feature = "ollama")]
-pub use embedder::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
+pub use embedder::{OllamaEmbedder, OpenAiEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::{ErrorCategory, MemoryError};
-#[cfg(feature = "extract")]
-pub use extract::OllamaExtractor;
 pub use extract::{
     select_extractor, DynExtractor, ExtractError, ExtractedAttribute, ExtractedFact,
     ExtractedRelation, Extraction, Extractor, ExtractorSelection, OutlineExtractor,
 };
+#[cfg(feature = "extract")]
+pub use extract::{OllamaExtractor, OpenAiExtractor};
+#[cfg(any(feature = "ollama", feature = "extract"))]
+pub use http_client::{Auth, HttpJsonClient};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
 pub use model::{

--- a/crates/velesdb-memory/src/openai.rs
+++ b/crates/velesdb-memory/src/openai.rs
@@ -15,12 +15,15 @@
 use serde_json::{json, Value};
 
 /// Embeddings endpoint, relative to the caller's base URL.
+#[cfg(feature = "ollama")]
 pub(crate) const EMBEDDINGS_PATH: &str = "/v1/embeddings";
 
 /// Chat-completions endpoint, relative to the caller's base URL.
+#[cfg(feature = "extract")]
 pub(crate) const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
 
 /// Body of an embeddings request.
+#[cfg(feature = "ollama")]
 pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
     json!({ "model": model, "input": input }).to_string()
 }
@@ -30,6 +33,7 @@ pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
 /// `temperature: 0` for the same reason the Ollama backend pins it: a backend
 /// that answers differently to the same text turns one stored fact into two
 /// on a re-run.
+#[cfg(feature = "extract")]
 pub(crate) fn chat_body(model: &str, prompt: &str) -> String {
     json!({
         "model": model,
@@ -46,6 +50,7 @@ pub(crate) fn chat_body(model: &str, prompt: &str) -> String {
 /// own `{"error":{"message":...}}` envelope when the server sent one — a
 /// server that answers `200` with an error body is common enough that reading
 /// past it would report "malformed response" for a perfectly clear refusal.
+#[cfg(feature = "ollama")]
 pub(crate) fn parse_embeddings_response(payload: &str) -> Result<Vec<f32>, String> {
     let value = parse_json(payload)?;
     // Deserialized into a typed `Vec<f32>` rather than walked as `Value` and
@@ -71,11 +76,13 @@ pub(crate) fn parse_embeddings_response(payload: &str) -> Result<Vec<f32>, Strin
 }
 
 /// `{"data":[{"embedding":[...]}]}` — only the field this crate reads.
+#[cfg(feature = "ollama")]
 #[derive(serde::Deserialize)]
 struct EmbeddingsResponse {
     data: Vec<EmbeddingDatum>,
 }
 
+#[cfg(feature = "ollama")]
 #[derive(serde::Deserialize)]
 struct EmbeddingDatum {
     embedding: Vec<f32>,
@@ -86,6 +93,7 @@ struct EmbeddingDatum {
 ///
 /// # Errors
 /// As [`parse_embeddings_response`].
+#[cfg(feature = "extract")]
 pub(crate) fn parse_chat_response(payload: &str) -> Result<String, String> {
     let value = parse_json(payload)?;
     value

--- a/crates/velesdb-memory/src/openai.rs
+++ b/crates/velesdb-memory/src/openai.rs
@@ -1,0 +1,139 @@
+//! The OpenAI-compatible protocol: which paths exist, what a request body
+//! looks like, and how to read an answer back.
+//!
+//! Sits between [`crate::http_client`] (which knows only how to post JSON with
+//! a credential) and the two backends that use it. It knows both endpoints of
+//! the protocol because the protocol has both — that is not role logic, no
+//! more than an HTTP library knowing about `GET` and `POST` is. What it does
+//! NOT know: the [`crate::Embedder`] trait, dimension probing, extraction
+//! prompts, or anything else that belongs to a caller.
+//!
+//! "OpenAI-compatible" is a protocol, not a vendor. oMLX, llama.cpp's server,
+//! LM Studio, vLLM and the hosted providers all speak it, and reaching a new
+//! one means a different base URL — never a new value to add here.
+
+use serde_json::{json, Value};
+
+/// Embeddings endpoint, relative to the caller's base URL.
+pub(crate) const EMBEDDINGS_PATH: &str = "/v1/embeddings";
+
+/// Chat-completions endpoint, relative to the caller's base URL.
+pub(crate) const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
+
+/// Body of an embeddings request.
+pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
+    json!({ "model": model, "input": input }).to_string()
+}
+
+/// Body of a single-turn chat-completions request.
+///
+/// `temperature: 0` for the same reason the Ollama backend pins it: a backend
+/// that answers differently to the same text turns one stored fact into two
+/// on a re-run.
+pub(crate) fn chat_body(model: &str, prompt: &str) -> String {
+    json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+        "temperature": 0,
+    })
+    .to_string()
+}
+
+/// The vector out of an embeddings response: `{"data":[{"embedding":[...]}]}`.
+///
+/// # Errors
+/// A message naming what was wrong with the payload, including the protocol's
+/// own `{"error":{"message":...}}` envelope when the server sent one — a
+/// server that answers `200` with an error body is common enough that reading
+/// past it would report "malformed response" for a perfectly clear refusal.
+pub(crate) fn parse_embeddings_response(payload: &str) -> Result<Vec<f32>, String> {
+    let value = parse_json(payload)?;
+    // Deserialized into a typed `Vec<f32>` rather than walked as `Value` and
+    // cast: serde narrows each component, so there is no hand-written
+    // `as f32` to justify — the same shape the Ollama backend already uses.
+    let response: EmbeddingsResponse = serde_json::from_value(value).map_err(|err| {
+        format!(
+            "response has no `data[0].embedding` array ({err}): {}",
+            preview(payload)
+        )
+    })?;
+    response
+        .data
+        .into_iter()
+        .next()
+        .map(|datum| datum.embedding)
+        .ok_or_else(|| {
+            format!(
+                "response has no `data[0].embedding` array: {}",
+                preview(payload)
+            )
+        })
+}
+
+/// `{"data":[{"embedding":[...]}]}` — only the field this crate reads.
+#[derive(serde::Deserialize)]
+struct EmbeddingsResponse {
+    data: Vec<EmbeddingDatum>,
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingDatum {
+    embedding: Vec<f32>,
+}
+
+/// The assistant message out of a chat-completions response:
+/// `{"choices":[{"message":{"content":"..."}}]}`.
+///
+/// # Errors
+/// As [`parse_embeddings_response`].
+pub(crate) fn parse_chat_response(payload: &str) -> Result<String, String> {
+    let value = parse_json(payload)?;
+    value
+        .get("choices")
+        .and_then(|choices| choices.get(0))
+        .and_then(|first| first.get("message"))
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            format!(
+                "response has no `choices[0].message.content` string: {}",
+                preview(payload)
+            )
+        })
+}
+
+/// Parse a payload, surfacing the protocol's error envelope as the message
+/// when there is one.
+fn parse_json(payload: &str) -> Result<Value, String> {
+    let value: Value = serde_json::from_str(payload)
+        .map_err(|err| format!("response is not JSON ({err}): {}", preview(payload)))?;
+    if let Some(message) = value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+    {
+        return Err(format!("the server refused the request: {message}"));
+    }
+    Ok(value)
+}
+
+/// First 200 bytes of a payload, on a char boundary — enough to recognise what
+/// came back without pasting a whole model response into an error.
+fn preview(payload: &str) -> String {
+    let cut = payload
+        .char_indices()
+        .map(|(at, _)| at)
+        .take_while(|at| *at <= 200)
+        .last()
+        .unwrap_or(0);
+    if cut < payload.len() {
+        format!("{}…", &payload[..cut])
+    } else {
+        payload.to_owned()
+    }
+}
+
+#[cfg(test)]
+#[path = "openai_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/openai_tests.rs
+++ b/crates/velesdb-memory/src/openai_tests.rs
@@ -1,0 +1,93 @@
+//! Tests for the OpenAI-compatible protocol layer: what goes into a request
+//! body, and what comes back out of a response.
+//!
+//! Wire-level authentication is proved elsewhere, in
+//! `tests/openai_auth_bdd.rs` — headers belong to the transport, and asserting
+//! them here would only prove what this layer *intended*.
+
+use super::*;
+
+#[test]
+fn an_embeddings_body_carries_the_model_and_the_input() {
+    let body = embeddings_body("text-embedding-3-small", "hello world");
+    let json: Value = serde_json::from_str(&body).expect("valid json");
+    assert_eq!(json["model"], "text-embedding-3-small");
+    assert_eq!(json["input"], "hello world");
+}
+
+#[test]
+fn a_chat_body_pins_temperature_to_zero() {
+    // Same reason the Ollama backend pins it: a backend that answers
+    // differently to the same text turns one stored fact into two on a re-run.
+    let body = chat_body("qwen3", "extract facts");
+    let json: Value = serde_json::from_str(&body).expect("valid json");
+    assert_eq!(json["model"], "qwen3");
+    assert_eq!(json["messages"][0]["role"], "user");
+    assert_eq!(json["messages"][0]["content"], "extract facts");
+    assert_eq!(json["temperature"], 0);
+}
+
+#[test]
+fn an_embeddings_response_yields_its_vector() {
+    let vector =
+        parse_embeddings_response(r#"{"data":[{"embedding":[0.25,-0.5]}]}"#).expect("parsed");
+    assert_eq!(vector, vec![0.25, -0.5]);
+}
+
+#[test]
+fn a_chat_response_yields_the_assistant_message() {
+    let content =
+        parse_chat_response(r#"{"choices":[{"message":{"content":"[]"}}]}"#).expect("parsed");
+    assert_eq!(content, "[]");
+}
+
+// --- Negative ----------------------------------------------------------------
+
+#[test]
+fn an_error_envelope_is_reported_as_a_refusal_not_a_malformed_response() {
+    // A server that answers 200 with `{"error":{...}}` is common enough that
+    // reading past the envelope would report "no data[0].embedding" for a
+    // perfectly clear refusal, sending the reader to look for the wrong bug.
+    let err = parse_embeddings_response(r#"{"error":{"message":"model not found"}}"#)
+        .expect_err("an error envelope is not a vector");
+    assert!(
+        err.contains("model not found"),
+        "the server's own words must survive into the message, got: {err}"
+    );
+    assert!(
+        err.contains("refused"),
+        "and it must read as a refusal, got: {err}"
+    );
+}
+
+#[test]
+fn a_non_json_response_names_what_came_back() {
+    let err = parse_chat_response("<html>502 Bad Gateway</html>")
+        .expect_err("HTML is not a chat completion");
+    assert!(
+        err.contains("not JSON") && err.contains("502"),
+        "the reader must see what actually arrived, got: {err}"
+    );
+}
+
+#[test]
+fn a_missing_field_is_reported_rather_than_silently_empty() {
+    let err = parse_embeddings_response(r#"{"data":[]}"#)
+        .expect_err("an empty data array carries no vector");
+    assert!(
+        err.contains("data[0].embedding"),
+        "the message must name the field it looked for, got: {err}"
+    );
+}
+
+#[test]
+fn a_long_payload_is_previewed_not_pasted_whole() {
+    let payload = format!(r#"{{"junk":"{}"}}"#, "x".repeat(5_000));
+    let err = parse_chat_response(&payload).expect_err("no content field");
+    assert!(
+        err.len() < 400,
+        "a whole model response must not land in an error message, got {} chars",
+        err.len()
+    );
+    assert!(err.contains('…'), "the preview must say it was cut: {err}");
+}

--- a/crates/velesdb-memory/src/openai_tests.rs
+++ b/crates/velesdb-memory/src/openai_tests.rs
@@ -5,9 +5,13 @@
 //! `tests/openai_auth_bdd.rs` — headers belong to the transport, and asserting
 //! them here would only prove what this layer *intended*.
 
+// Each test is gated on the feature that keeps its half of the protocol
+// alive: CI checks every feature IN ISOLATION, so a test referring to the
+// other half would be a compile error there, not merely dead code.
 use super::*;
 
 #[test]
+#[cfg(feature = "ollama")]
 fn an_embeddings_body_carries_the_model_and_the_input() {
     let body = embeddings_body("text-embedding-3-small", "hello world");
     let json: Value = serde_json::from_str(&body).expect("valid json");
@@ -16,6 +20,7 @@ fn an_embeddings_body_carries_the_model_and_the_input() {
 }
 
 #[test]
+#[cfg(feature = "extract")]
 fn a_chat_body_pins_temperature_to_zero() {
     // Same reason the Ollama backend pins it: a backend that answers
     // differently to the same text turns one stored fact into two on a re-run.
@@ -28,6 +33,7 @@ fn a_chat_body_pins_temperature_to_zero() {
 }
 
 #[test]
+#[cfg(feature = "ollama")]
 fn an_embeddings_response_yields_its_vector() {
     let vector =
         parse_embeddings_response(r#"{"data":[{"embedding":[0.25,-0.5]}]}"#).expect("parsed");
@@ -35,6 +41,7 @@ fn an_embeddings_response_yields_its_vector() {
 }
 
 #[test]
+#[cfg(feature = "extract")]
 fn a_chat_response_yields_the_assistant_message() {
     let content =
         parse_chat_response(r#"{"choices":[{"message":{"content":"[]"}}]}"#).expect("parsed");
@@ -44,6 +51,7 @@ fn a_chat_response_yields_the_assistant_message() {
 // --- Negative ----------------------------------------------------------------
 
 #[test]
+#[cfg(feature = "ollama")]
 fn an_error_envelope_is_reported_as_a_refusal_not_a_malformed_response() {
     // A server that answers 200 with `{"error":{...}}` is common enough that
     // reading past the envelope would report "no data[0].embedding" for a
@@ -61,6 +69,7 @@ fn an_error_envelope_is_reported_as_a_refusal_not_a_malformed_response() {
 }
 
 #[test]
+#[cfg(feature = "extract")]
 fn a_non_json_response_names_what_came_back() {
     let err = parse_chat_response("<html>502 Bad Gateway</html>")
         .expect_err("HTML is not a chat completion");
@@ -71,6 +80,7 @@ fn a_non_json_response_names_what_came_back() {
 }
 
 #[test]
+#[cfg(feature = "ollama")]
 fn a_missing_field_is_reported_rather_than_silently_empty() {
     let err = parse_embeddings_response(r#"{"data":[]}"#)
         .expect_err("an empty data array carries no vector");
@@ -81,6 +91,7 @@ fn a_missing_field_is_reported_rather_than_silently_empty() {
 }
 
 #[test]
+#[cfg(feature = "extract")]
 fn a_long_payload_is_previewed_not_pasted_whole() {
     let payload = format!(r#"{{"junk":"{}"}}"#, "x".repeat(5_000));
     let err = parse_chat_response(&payload).expect_err("no content field");

--- a/crates/velesdb-memory/tests/openai_auth_bdd.rs
+++ b/crates/velesdb-memory/tests/openai_auth_bdd.rs
@@ -1,0 +1,260 @@
+//! BDD integration tests for #1751: what the OpenAI-compatible backends
+//! actually put on the wire when authenticating.
+//!
+//! **These assert on BYTES, not on an in-process request object.** A mock that
+//! inspects a builder proves what the code meant to send; only reading the
+//! socket proves what it sent. The rule under test has a negative half — "no
+//! `Authorization` header AT ALL when no token is configured" — and a negative
+//! is exactly what a builder-level assertion is worst at: it cannot distinguish
+//! "never set" from "set and dropped in transit".
+//!
+//! Both roles are covered, not the shared client twice. The client is
+//! role-agnostic by construction, but each adapter builds its own request, and
+//! an adapter is free to add or lose a header on the way. Testing only the
+//! client would leave that gap open on both sides.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+#![cfg(all(feature = "ollama", feature = "extract"))]
+
+use std::io::{Read as _, Write as _};
+use std::net::{SocketAddr, TcpListener};
+use std::thread::JoinHandle;
+
+use velesdb_memory::extract::Extractor as _;
+use velesdb_memory::{Auth, OpenAiEmbedder, OpenAiExtractor};
+
+/// A well-formed `OpenAI` embeddings response — two dimensions is enough for the
+/// constructor's dimension probe to succeed.
+const EMBEDDINGS_RESPONSE: &str = r#"{"data":[{"embedding":[0.5,0.5]}]}"#;
+
+/// A well-formed `OpenAI` chat-completions response whose `content` is the strict
+/// JSON array the extraction prompt asks the model for. Empty on purpose: this
+/// suite is about headers, not about what was extracted.
+const CHAT_RESPONSE: &str = r#"{"choices":[{"message":{"content":"[]"}}]}"#;
+
+/// Accept exactly one connection, capture the raw request bytes, answer
+/// `body`, and hand the captured text back through the join handle.
+///
+/// Bounded to a single connection so the thread ends on its own — no join
+/// timeout, no orphan left behind if an assertion panics first.
+fn capture_one_request(body: &'static str) -> (SocketAddr, JoinHandle<String>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let handle = std::thread::spawn(move || {
+        let Ok((mut socket, _)) = listener.accept() else {
+            return String::new();
+        };
+        // Read the WHOLE request before answering. A single read is a race:
+        // the extraction prompt is several kilobytes, so the request arrives
+        // in more than one chunk, and answering after the first one closes the
+        // socket while the client is still writing — which surfaces as an
+        // opaque transport error instead of the assertion under test.
+        let captured = read_full_request(&mut socket);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = socket.write_all(response.as_bytes());
+        let _ = socket.flush();
+        captured
+    });
+    (addr, handle)
+}
+
+/// Read one complete HTTP request: headers, then exactly `Content-Length`
+/// bytes of body.
+///
+/// Bounded on both ends — a total ceiling and a read timeout — so a client
+/// that stops mid-request ends this thread instead of wedging the suite.
+fn read_full_request(socket: &mut std::net::TcpStream) -> String {
+    const CEILING: usize = 256 * 1024;
+    let _ = socket.set_read_timeout(Some(std::time::Duration::from_secs(5)));
+    let mut raw: Vec<u8> = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let Ok(read) = socket.read(&mut chunk) else {
+            break;
+        };
+        if read == 0 {
+            break;
+        }
+        raw.extend_from_slice(&chunk[..read]);
+        if raw.len() >= CEILING {
+            break;
+        }
+        let text = String::from_utf8_lossy(&raw);
+        let Some(head_end) = text.find("\r\n\r\n") else {
+            continue; // headers still incomplete
+        };
+        let declared = content_length(&text[..head_end]);
+        if raw.len() >= head_end + 4 + declared {
+            break;
+        }
+    }
+    String::from_utf8_lossy(&raw).into_owned()
+}
+
+/// The `Content-Length` a header block declares, or `0` when it declares none.
+fn content_length(head: &str) -> usize {
+    head.lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().ok())?
+        })
+        .unwrap_or(0)
+}
+
+/// The header lines of a captured request, lowercased for a case-insensitive
+/// search — HTTP header names are case-insensitive, so a test that only looked
+/// for `Authorization` could be fooled by `authorization`.
+fn header_block(captured: &str) -> String {
+    captured
+        .split("\r\n\r\n")
+        .next()
+        .unwrap_or_default()
+        .to_lowercase()
+}
+
+// --- Nominal: no token configured -------------------------------------------
+
+#[test]
+fn embedder_sends_no_authorization_header_when_no_token_is_configured() {
+    let (addr, server) = capture_one_request(EMBEDDINGS_RESPONSE);
+
+    let embedder = OpenAiEmbedder::new(
+        format!("http://{addr}"),
+        "text-embedding-3-small",
+        Auth::None,
+    );
+    let captured = server.join().expect("server thread");
+    embedder.expect("the probe response is well-formed");
+
+    let headers = header_block(&captured);
+    assert!(
+        !headers.contains("authorization"),
+        "a local server needs no credential: with no token configured the \
+         request must carry NO `Authorization` header at all, got:\n{captured}"
+    );
+}
+
+#[test]
+fn extractor_sends_no_authorization_header_when_no_token_is_configured() {
+    let (addr, server) = capture_one_request(CHAT_RESPONSE);
+
+    let extractor = OpenAiExtractor::new(format!("http://{addr}"), "qwen3", Auth::None);
+    extractor
+        .extract("Alice ships the parser.")
+        .expect("extract");
+    let captured = server.join().expect("server thread");
+
+    let headers = header_block(&captured);
+    assert!(
+        !headers.contains("authorization"),
+        "the rule is shared with the embedder, and must hold on this role too, \
+         got:\n{captured}"
+    );
+}
+
+// --- Nominal: a token IS configured -----------------------------------------
+
+#[test]
+fn embedder_sends_the_exact_bearer_header_when_a_token_is_configured() {
+    let (addr, server) = capture_one_request(EMBEDDINGS_RESPONSE);
+
+    let embedder = OpenAiEmbedder::new(
+        format!("http://{addr}"),
+        "text-embedding-3-small",
+        Auth::Bearer("sk-test-123".to_owned()),
+    );
+    let captured = server.join().expect("server thread");
+    embedder.expect("the probe response is well-formed");
+
+    assert!(
+        captured.contains("Authorization: Bearer sk-test-123"),
+        "the header must be exactly `Authorization: Bearer <token>`, got:\n{captured}"
+    );
+}
+
+#[test]
+fn extractor_sends_the_exact_bearer_header_when_a_token_is_configured() {
+    let (addr, server) = capture_one_request(CHAT_RESPONSE);
+
+    let extractor = OpenAiExtractor::new(
+        format!("http://{addr}"),
+        "qwen3",
+        Auth::Bearer("sk-test-123".to_owned()),
+    );
+    extractor
+        .extract("Alice ships the parser.")
+        .expect("extract");
+    let captured = server.join().expect("server thread");
+
+    assert!(
+        captured.contains("Authorization: Bearer sk-test-123"),
+        "the header must be exactly `Authorization: Bearer <token>`, got:\n{captured}"
+    );
+}
+
+// --- Edge: a provider that authenticates by another header ------------------
+
+#[test]
+fn a_custom_auth_header_is_sent_verbatim_and_no_bearer_is_added() {
+    // Azure OpenAI authenticates with `api-key`, not `Authorization`. This is
+    // why `Auth` is an enum rather than an `Option<String>` token: the shape
+    // was already known to vary before the first non-OpenAI provider landed.
+    let (addr, server) = capture_one_request(EMBEDDINGS_RESPONSE);
+
+    let embedder = OpenAiEmbedder::new(
+        format!("http://{addr}"),
+        "text-embedding-3-small",
+        Auth::Header {
+            name: "api-key".to_owned(),
+            value: "azure-secret".to_owned(),
+        },
+    );
+    let captured = server.join().expect("server thread");
+    embedder.expect("the probe response is well-formed");
+
+    assert!(
+        captured.contains("api-key: azure-secret"),
+        "the caller's header must go out verbatim, got:\n{captured}"
+    );
+    assert!(
+        !header_block(&captured).contains("authorization"),
+        "naming another header must not ALSO add a bearer, got:\n{captured}"
+    );
+}
+
+// --- Negative: the secret must not leak through Debug -----------------------
+
+#[test]
+fn debug_never_prints_the_secret() {
+    // A token reaches logs and panic messages through `Debug` far more often
+    // than through a deliberate print. The same reflex the crate already
+    // applies to `ExtractorSelection`, which refuses to dump a backend's URL.
+    let bearer = format!("{:?}", Auth::Bearer("sk-must-not-appear".to_owned()));
+    assert!(
+        !bearer.contains("sk-must-not-appear"),
+        "a bearer token must be redacted in Debug, got: {bearer}"
+    );
+
+    let custom = format!(
+        "{:?}",
+        Auth::Header {
+            name: "api-key".to_owned(),
+            value: "azure-must-not-appear".to_owned(),
+        }
+    );
+    assert!(
+        !custom.contains("azure-must-not-appear"),
+        "a custom header VALUE must be redacted in Debug, got: {custom}"
+    );
+    assert!(
+        custom.contains("api-key"),
+        "the header NAME is not a secret and stays visible, so a misconfigured \
+         provider is still diagnosable: {custom}"
+    );
+}


### PR DESCRIPTION
Deuxieme lot de #1751 : la fondation partagee, avant tout binding.

## Les couches

```
http_client      transport + Auth — ne sait ni le role, ni le fournisseur
     │
openai           chemins /v1/*, corps, reponses, enveloppe d'erreur
     │
 ┌───┴───┐
Embedder Extractor      freres, jamais empiles
```

Le decoupage en **deux** couches et non une vient d'appliquer le critere « le client ignore le role » jusqu'au bout : une fois le chemin, le corps, le schema d'auth **et l'agent HTTP** fournis par l'appelant, il ne reste rien d'OpenAI dans le transport. L'appeler `OpenAiClient` aurait ete le meme mensonge de nom que `ollama_retry`.

L'agent vient de l'appelant pour une raison verifiable : un embedding a un plafond de 60 s, une generation de 300 s. Un client qui construisait le sien saurait lequel des deux roles il sert.

## `Auth` en enum

`None` / `Bearer` / `Header { name, value }`, pas `api_key: Option<String>`. Azure authentifie par `api-key` : elargir un `Option<String>` aurait casse tous les appelants des le premier fournisseur non-OpenAI.

`Debug` redige a la main — un secret fuit par `Debug` bien plus souvent que par un print delibere. Le **nom** du header survit : il n'est pas secret, et c'est lui qui rend diagnosticable un fournisseur configure avec le mauvais schema.

## La preuve

Au niveau **octet**, contre un vrai socket, sur les **deux** roles. Pas un mock de builder : la moitie negative de la regle — « aucun header du tout » — est exactement ce qu'une assertion sur un builder sait le moins prouver, elle ne distingue pas « jamais pose » de « pose puis perdu ».

Et surtout **falsifiable**. Neutralisation de chaque moitie, verifiee :

| sabotage | tests qui tombent |
|---|---|
| `Auth::None` pose un bearer VIDE (le bug classique) | exactement les 2 « aucun header », embedder ET extracteur |
| `Auth::Bearer` ne pose plus rien | exactement les 2 « bearer exact », les deux roles |

Ces tests tournent en CI : `ci.yml:164` lance deja `--features extract,ollama,persistence`.

| porte | resultat |
|---|---|
| `cargo test -p velesdb-memory --features extract,ollama,persistence` | EXIT=0, **462** |
| `cargo test -p velesdb-memory --features persistence,context` | EXIT=0, 419 (inchange) |
| `cargo test -p velesdb-wasm` | EXIT=0, 656 |
| clippy strict, defaut + combinaison OpenAI | EXIT=0 |
| `unittest scripts/tests` | EXIT=0, Ran 211, OK |
| `check-mcp-doc-contract.py` | EXIT=0 |
| `cargo check` node + python | EXIT=0 |

## Ce que le renommage a revele

`ollama_retry` → `http_retry` (E1) devait etre cosmetique. Il ne l'etait pas : `actionable_failure` ne **nommait** pas seulement Ollama, il conseillait « Check Ollama is running » et `ollama pull <model>`. Pointe vers un serveur oMLX, chaque phrase du remede aurait ete fausse — et un remede confidemment faux coute plus cher que pas de remede. Scinde en `actionable_ollama_failure` et `actionable_openai_failure`.

## Notes

- Les deux nouveaux backends sont **constructibles**, pas encore **selectionnables** : la config et les variables sont le lot 3.
- Aucune dependance ajoutee : `ureq` est deja tire par les features `ollama` et `extract`.
- Ces deux noms de feature sous-decrivent maintenant ce qu'ils activent (ils portent « ce role sait parler HTTP »). Non renommes ici pour garder le lot au perimetre.
- `impl Extractor` factorise en `facts_from_reply` / `extraction_from_reply` : deux backends generatifs lisent la meme reponse, une copie par `impl` les laisserait diverger sur ce qui compte comme reponse valide.

Prepare #1751.