### PR TITLE
feat(memory): brancher les backends d'inference enfichables (#1751, lot 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`velesdb-memory`: an OpenAI-compatible backend for both inference roles
+  (#1751).** `VELESDB_MEMORY_EMBEDDER=openai` and
+  `VELESDB_MEMORY_EXTRACTOR=openai` reach oMLX, llama.cpp's server, LM Studio,
+  vLLM or a hosted provider. The value names a **protocol, not a vendor** — a
+  different server is a different URL, never a new backend name — and the two
+  roles are configured independently, so embedding on a local Ollama while
+  extracting on an OpenAI-compatible server is a supported combination.
+  Tokens live in the environment only (`..._API_TOKEN`); no token means no
+  `Authorization` header at all, and an `api_token` written into
+  `velesdb-memory.toml` is refused at startup. The MCP daemon is the only
+  surface that changes here — Python, Node and WASM keep their current
+  enumeration, and their parity is a lot of its own. Full detail in
+  `crates/velesdb-memory/CHANGELOG.md`.
+
 ### Changed
 
 - **BREAKING (`velesdb-memory` 0.12.0, and the Node/Python/WASM bindings +

--- a/crates/velesdb-memory/ARCHITECTURE.md
+++ b/crates/velesdb-memory/ARCHITECTURE.md
@@ -184,8 +184,12 @@ scaffolding: marked with the reserved `_veles_hub` key and **excluded from
 - **Feature gates** keep the default build tiny:
   - `ollama` → real semantic recall via a local embedding model.
   - `extract` → the `OllamaExtractor` backend for `remember_extracted` (HTTP).
-- **Env config**: `VELESDB_MEMORY_PATH`, `VELESDB_MEMORY_EMBEDDER` (`hash`|`ollama`),
-  `VELESDB_MEMORY_EXTRACTOR` (`ollama`) + model/URL vars. The `Extractor` trait
+- **Env config**: `VELESDB_MEMORY_PATH`, `VELESDB_MEMORY_EMBEDDER`
+  (`hash`|`ollama`|`openai`), `VELESDB_MEMORY_EXTRACTOR`
+  (`outline`|`ollama`|`openai`) + role-named `_URL`/`_MODEL`/`_API_TOKEN` vars
+  (`VELESDB_MEMORY_OLLAMA_URL`/`_MODEL` stay supported as aliases of the
+  embedding role's). `openai` names a protocol, not a vendor: a different
+  server is a different URL, never a new backend name. The `Extractor` trait
   is dependency-free, so the tool is always present and reports "not configured"
   when no backend is attached.
 

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -11,6 +11,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`openai`: an OpenAI-compatible backend for BOTH roles (#1751).** Set
+  `VELESDB_MEMORY_EMBEDDER=openai` or `VELESDB_MEMORY_EXTRACTOR=openai` to
+  reach oMLX, llama.cpp's server, LM Studio, vLLM or a hosted provider. The
+  value names a **protocol, not a vendor**: reaching a different server is a
+  different URL, never a new backend name — which is what stops the selector
+  from growing a vendor list.
+
+  Neither the URL nor the model has a default here, deliberately: guessing
+  either would pick one of those servers for the operator. Both roles are
+  configured independently — embedding on a local Ollama while extracting on
+  an OpenAI-compatible server is a supported combination.
+
+  The daemon now dispatches on the backend name the library hands it. It
+  previously matched `NeedsRemoteConfig(_)` and built an Ollama client
+  regardless, in **two** places (`attach_extractor` and the autograph path),
+  so a second backend would have been selected and then silently ignored —
+  asking for `openai` answered `VELESDB_MEMORY_EXTRACTOR=ollama requires …`.
+
+- **Role-named configuration for the embedding role.** `VELESDB_MEMORY_EMBEDDER_URL`,
+  `_MODEL` and `_API_TOKEN` mirror the extraction role's variables, which were
+  role-named from the start. `VELESDB_MEMORY_OLLAMA_URL` / `_MODEL` keep
+  working as aliases, so no existing setup changes; when both names are set to
+  **different** values the role-named one wins and the daemon says so **once**
+  at startup. `velesdb-memory.toml`'s `[embedder]` section now writes the
+  role-named variables.
+
+- **API tokens, environment-only.** `VELESDB_MEMORY_EMBEDDER_API_TOKEN` /
+  `VELESDB_MEMORY_EXTRACTOR_API_TOKEN`. No token means **no `Authorization`
+  header at all** — not an empty one, which a server rejects as a bad
+  credential rather than a missing one; a token set to an empty string is
+  refused at startup for the same reason. There is deliberately **no
+  `api_token` field in the config file**, and one written there is refused:
+  a credential at rest in a versionable file is one `git add .` away from a
+  public history. The refusal is rewritten rather than passed through, because
+  the TOML parser quotes the offending line back — which would have printed
+  the secret to stderr.
+
+- **The store records which embedding model filled it.**
+  `embedding-provenance.json`, beside the store. `velesdb-core` already refuses
+  a collection whose dimension differs, which catches the loud half of the
+  problem; two different models of the **same** width open fine and return
+  noise (this crate's `hash` embedder is 384-dimensional, and so is
+  `all-minilm`). The **backend is not recorded** — it is a transport, and the
+  same model served by Ollama, oMLX or a hosted API produces the same vectors,
+  so refusing on it would block a valid migration. The record is written only
+  for a store holding **no facts**, never over existing data where one open
+  with the wrong model would carve a provenance every later check would trust.
+  A store created before this stays unrecorded, and its check degrades to the
+  dimension alone — saying so explicitly rather than letting a successful open
+  read as a verified match. Deleting the file is safe; the store is untouched.
+
 - **`OutlineExtractor`: a deterministic, network-free extraction backend.**
   Until now `OllamaExtractor` was the crate's only `Extractor`, so every
   contract `remember_extracted` publishes was reachable only through a
@@ -41,6 +92,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TypeScript SDK gains `entity`, `unrelate` and `rememberExtracted`**, the
   methods it had been missing for its whole life (#1721), and enters a
   guard's perimeter for the first time.
+
+### Fixed
+
+- **A base URL carrying the `/v1` prefix no longer doubles it (#1751).**
+  Servers advertise their OpenAI-compatible endpoint *with* the version prefix
+  — oMLX's console shows `http://127.0.0.1:8019/v1` beside a copy button — and
+  concatenating `/v1/embeddings` onto that produced `/v1/v1/embeddings` and a
+  `404` whose cause was invisible from the message. Both spellings now reach
+  the same endpoint. A trailing `/v1` is stripped only when something precedes
+  it, so a host genuinely named `v1` is not truncated to `http:/`.
 
 ### Changed
 

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -102,7 +102,7 @@ agent can read the full thing whenever the summary is not enough.
 |---|---|---|
 | Rust | 1.90 | Only to install or build. The binary itself has no runtime dependency. |
 | An MCP client | — | Claude Code, Claude Desktop, Codex CLI, Cursor, Cline, Zed, opencode, Windsurf, Devin CLI. |
-| Ollama | any | **Optional** — only for real semantic recall (`--features ollama`). The default embedder is offline and dependency-free. |
+| Ollama, **or any OpenAI-compatible server** | any | **Optional** — only for real semantic recall and for model-based extraction (`--features ollama` / `--features extract`). The default embedder is offline and dependency-free. `openai` names a protocol, not a vendor: oMLX, llama.cpp, LM Studio, vLLM and hosted providers all speak it, and each is reached by URL rather than by a backend name of its own. See [MCP_SERVER_SETUP.md](../../docs/guides/MCP_SERVER_SETUP.md#embedding-backend). |
 | Node.js | any LTS | **Optional** — only for the Claude Desktop stdio→HTTPS bridge. |
 
 ## Installation

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -235,6 +235,33 @@ launched with:
 - **`ollama`:** real on-device semantic recall. Requires a build with
   `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
   `VELESDB_MEMORY_EMBEDDER=ollama`.
+- **`openai`:** any OpenAI-compatible server — oMLX, llama.cpp, LM Studio,
+  vLLM, or a hosted provider. Same `--features ollama` build (that feature
+  carries the HTTP dependency for the embedding role, and its name predates
+  the protocol split). `openai` names a **protocol, not a vendor**: reaching a
+  different server is a different URL, never a new backend name. It therefore
+  has **no default URL and no default model** — set
+  `VELESDB_MEMORY_EMBEDDER_URL` and `_MODEL` yourself.
+
+The extraction role takes the same three-way choice — `outline`, `ollama`,
+`openai` — under `VELESDB_MEMORY_EXTRACTOR`, and **the two roles are
+configured independently**: nothing requires them to share a backend, a server
+or a token. Embedding on a local Ollama while extracting on an
+OpenAI-compatible server is a supported combination.
+
+The base URL may be written **with or without** the `/v1` suffix. Server
+consoles advertise the version-prefixed form (`http://127.0.0.1:8019/v1`)
+beside a copy button, so pasting it works instead of producing
+`/v1/v1/embeddings` and a `404`.
+
+**A store is fixed to one embedding MODEL, not to one backend.** The store
+records the model that filled it (`embedding-provenance.json`) and refuses to
+open under a different one — including a different model of the same width,
+which the dimension check alone cannot see. Changing only the *transport* is
+safe: the same model over Ollama or over an OpenAI-compatible API produces the
+same vectors, so the backend is deliberately not part of the record. A store
+created before this recording existed stays unrecorded and is checked on the
+dimension alone, and says so.
 
 ### Configure it in a file, not in a plist
 
@@ -249,10 +276,18 @@ default_ttl = 0                # seconds; 0 = permanent
 [embedder]
 backend = "ollama"             # `hash` is lexical, not semantic — see above
 model = "bge-m3"
+# url = "http://127.0.0.1:8019"  # required by "openai"; defaulted by "ollama"
 
 [extractor]
-backend = "ollama"             # or "outline" — infers vs reads directives, see above
-model = "qwen3.6:35b-mlx"      # "ollama" only; "outline" needs no model
+backend = "ollama"             # or "outline"/"openai" — see above
+model = "qwen3.6:35b-mlx"      # required by "ollama" and "openai"; "outline" needs none
+# url = "http://127.0.0.1:8019"  # required by "openai"; defaulted by "ollama"
+
+# There is deliberately NO api_token field, in either section. A token is read
+# from VELESDB_MEMORY_EMBEDDER_API_TOKEN / VELESDB_MEMORY_EXTRACTOR_API_TOKEN
+# and from nowhere else — a credential at rest in a versionable file is one
+# `git add .` away from a public history. Writing one here is refused at
+# startup, and the refusal does not echo the line back.
 
 [graph]
 autograph = false              # true = every `remember` also wires entities

--- a/crates/velesdb-memory/src/config.rs
+++ b/crates/velesdb-memory/src/config.rs
@@ -132,30 +132,41 @@ pub struct HttpConfig {
 }
 
 /// `[embedder]` — how text becomes vectors.
+///
+/// **No `api_token` field, deliberately** — see [`TOKEN_HINT`]. The two roles
+/// carry the same four settings under the same names on purpose: an operator
+/// who has configured one has configured the other.
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EmbedderConfig {
-    /// `hash` or `ollama` (`VELESDB_MEMORY_EMBEDDER`).
+    /// `hash`, `ollama` or `openai` (`VELESDB_MEMORY_EMBEDDER`).
     pub backend: Option<String>,
-    /// Ollama model (`VELESDB_MEMORY_OLLAMA_MODEL`).
+    /// Embedding model (`VELESDB_MEMORY_EMBEDDER_MODEL`).
     pub model: Option<String>,
-    /// Ollama base URL (`VELESDB_MEMORY_OLLAMA_URL`).
+    /// Base URL, origin and port, no path (`VELESDB_MEMORY_EMBEDDER_URL`).
     pub url: Option<String>,
     /// How long Ollama keeps the model resident
     /// (`VELESDB_MEMORY_OLLAMA_KEEP_ALIVE`).
+    ///
+    /// The one setting here that keeps a product name, and legitimately: it is
+    /// a field of Ollama's own wire protocol, not a role-level knob an
+    /// OpenAI-compatible server would know what to do with.
     pub keep_alive: Option<String>,
 }
 
 /// `[extractor]` — the backend that reads facts, relations and attributes out
 /// of raw text for `remember_extracted`.
+///
+/// **No `api_token` field, deliberately** — see [`TOKEN_HINT`].
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExtractorConfig {
-    /// `ollama`, or absent for none (`VELESDB_MEMORY_EXTRACTOR`).
+    /// `outline`, `ollama`, `openai`, or absent for none
+    /// (`VELESDB_MEMORY_EXTRACTOR`).
     pub backend: Option<String>,
     /// Generative model (`VELESDB_MEMORY_EXTRACTOR_MODEL`).
     pub model: Option<String>,
-    /// Base URL (`VELESDB_MEMORY_EXTRACTOR_URL`).
+    /// Base URL, origin and port, no path (`VELESDB_MEMORY_EXTRACTOR_URL`).
     pub url: Option<String>,
 }
 
@@ -217,12 +228,99 @@ pub fn load(path: &Path) -> Result<LoadedConfig, ConfigError> {
     })?;
     let file: ConfigFile = toml::from_str(&text).map_err(|err| ConfigError::Parse {
         path: path.to_path_buf(),
-        message: err.to_string(),
+        message: describe_parse_failure(&err.to_string()),
     })?;
     Ok(LoadedConfig {
         path: path.to_path_buf(),
         values: file.into_env(path)?,
     })
+}
+
+/// Where an API token belongs, quoted verbatim by the refusal that rejects one
+/// found in the file.
+///
+/// `deny_unknown_fields` already refuses an `api_token` key, since no section
+/// declares one. What it cannot do is say where the operator should put the
+/// token they legitimately have — so the refusal is rewritten to carry this.
+pub const TOKEN_HINT: &str = "an API token is read from the environment only, never from a \
+     file: set VELESDB_MEMORY_EMBEDDER_API_TOKEN or \
+     VELESDB_MEMORY_EXTRACTOR_API_TOKEN instead. A credential in a TOML is one \
+     `git add .` away from a public history, and no pre-commit secret scan can \
+     police a file it has never seen.";
+
+/// Render a TOML parse failure, redacting it when it concerns a credential.
+///
+/// `toml`'s own error quotes the offending source line back — which is exactly
+/// the right thing for `mdoel = "bge-m3"` and exactly the wrong thing for
+/// `api_token = "sk-…"`: the daemon would print the secret to stderr, where a
+/// launch agent's log file keeps it. So a failure naming `api_token` loses the
+/// snippet and gains [`TOKEN_HINT`]; every other failure is untouched.
+fn describe_parse_failure(rendered: &str) -> String {
+    if rendered.contains("api_token") {
+        return format!("unknown field `api_token` — {TOKEN_HINT}");
+    }
+    rendered.to_owned()
+}
+
+/// One setting reachable under two environment-variable names: the canonical,
+/// role-named one and a legacy alias kept working for compatibility.
+///
+/// See [`resolve_alias`] for the precedence rule.
+pub struct AliasResolution {
+    /// The value to use, or `None` when neither name is set.
+    pub value: Option<String>,
+    /// Both names are set to **different** values. The caller is expected to
+    /// gather these and emit a single [`alias_conflict_notice`].
+    pub conflicting: bool,
+}
+
+/// Resolve a setting the caller can name two ways: canonical wins, the legacy
+/// alias is the fallback (C1).
+///
+/// The embedding role's URL and model were named after a *product*
+/// (`VELESDB_MEMORY_OLLAMA_URL`) while the extraction role's were named after
+/// the *role* (`VELESDB_MEMORY_EXTRACTOR_URL`). Once a non-Ollama backend can
+/// serve either role, a variable that says `OLLAMA` while pointing at oMLX is
+/// a lie the operator has to hold in their head. This closes the asymmetry
+/// without breaking a single existing setup: the alias keeps working, and only
+/// a genuine disagreement between the two is worth a word.
+///
+/// Canonical wins **whatever the source** — including a role-named value that
+/// came from the config file against a legacy one exported by the shell, which
+/// is the one case where this rule and [`apply`]'s "environment outranks the
+/// file" point different ways. That case is not silent: it is precisely what
+/// [`alias_conflict_notice`] reports.
+#[must_use]
+pub fn resolve_alias(canonical: Option<&str>, legacy: Option<&str>) -> AliasResolution {
+    AliasResolution {
+        conflicting: matches!((canonical, legacy), (Some(role), Some(old)) if role != old),
+        value: canonical.or(legacy).map(str::to_owned),
+    }
+}
+
+/// One line naming every variable whose legacy alias disagrees with it, or
+/// `None` when nothing disagrees.
+///
+/// **One notice, however many settings conflict.** A warning per variable is
+/// how a startup log becomes noise an operator learns to scroll past, and the
+/// operator's next action is the same for all of them. This is also
+/// deliberately not a deprecation warning: the aliases are supported, and
+/// shouting at someone whose setup works is how a message gets filtered out
+/// before the day it finally matters.
+#[must_use]
+pub fn alias_conflict_notice(conflicts: &[(&str, &str)]) -> Option<String> {
+    if conflicts.is_empty() {
+        return None;
+    }
+    let pairs = conflicts
+        .iter()
+        .map(|(canonical, legacy)| format!("{canonical} over {legacy}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "[velesdb-memory] set under two names with different values — using {pairs}. \
+         The role-named variable wins; unset the other to silence this."
+    ))
 }
 
 /// Export `values` into the process environment, skipping any variable that is
@@ -278,8 +376,12 @@ impl ConfigFile {
         set("VELESDB_MEMORY_TLS_DIR", self.http.tls_dir);
 
         set("VELESDB_MEMORY_EMBEDDER", self.embedder.backend);
-        set("VELESDB_MEMORY_OLLAMA_MODEL", self.embedder.model);
-        set("VELESDB_MEMORY_OLLAMA_URL", self.embedder.url);
+        // The role-named variables, not the `VELESDB_MEMORY_OLLAMA_*` aliases:
+        // the section is named after the role, so what it writes should be too.
+        // The aliases stay readable from the environment (see
+        // [`resolve_alias`]) for setups that already export them.
+        set("VELESDB_MEMORY_EMBEDDER_MODEL", self.embedder.model);
+        set("VELESDB_MEMORY_EMBEDDER_URL", self.embedder.url);
         set("VELESDB_MEMORY_OLLAMA_KEEP_ALIVE", self.embedder.keep_alive);
 
         set("VELESDB_MEMORY_EXTRACTOR", self.extractor.backend);

--- a/crates/velesdb-memory/src/config_tests.rs
+++ b/crates/velesdb-memory/src/config_tests.rs
@@ -52,8 +52,16 @@ url = "http://localhost:11434"
     assert_eq!(v["VELESDB_MEMORY_HTTP_MAX_SESSIONS"], "64");
     assert_eq!(v["VELESDB_MEMORY_TLS_DIR"], "/tmp/tls");
     assert_eq!(v["VELESDB_MEMORY_EMBEDDER"], "ollama");
-    assert_eq!(v["VELESDB_MEMORY_OLLAMA_MODEL"], "bge-m3");
-    assert_eq!(v["VELESDB_MEMORY_OLLAMA_URL"], "http://localhost:11434");
+    // The file is role-named (`[embedder]`), so it writes the role-named
+    // variables. The `VELESDB_MEMORY_OLLAMA_*` pair survives as an environment
+    // alias for anyone who set it in a shell or a launch plist, but nothing
+    // written here produces it — a file that emitted a product name for a
+    // section named after a role is the asymmetry #1751 exists to close.
+    assert_eq!(v["VELESDB_MEMORY_EMBEDDER_MODEL"], "bge-m3");
+    assert_eq!(v["VELESDB_MEMORY_EMBEDDER_URL"], "http://localhost:11434");
+    // `keep_alive` keeps the product name, and legitimately: it is a field of
+    // Ollama's own wire protocol, not a role-level setting an OpenAI-compatible
+    // server would know what to do with.
     assert_eq!(v["VELESDB_MEMORY_OLLAMA_KEEP_ALIVE"], "30m");
     assert_eq!(v["VELESDB_MEMORY_EXTRACTOR"], "ollama");
     assert_eq!(v["VELESDB_MEMORY_EXTRACTOR_MODEL"], "qwen3.6:35b-mlx");
@@ -107,8 +115,8 @@ autograph = true
         "VELESDB_MEMORY_HTTP_MAX_SESSIONS",
         "VELESDB_MEMORY_TLS_DIR",
         "VELESDB_MEMORY_EMBEDDER",
-        "VELESDB_MEMORY_OLLAMA_MODEL",
-        "VELESDB_MEMORY_OLLAMA_URL",
+        "VELESDB_MEMORY_EMBEDDER_MODEL",
+        "VELESDB_MEMORY_EMBEDDER_URL",
         "VELESDB_MEMORY_OLLAMA_KEEP_ALIVE",
         "VELESDB_MEMORY_EXTRACTOR",
         "VELESDB_MEMORY_EXTRACTOR_MODEL",
@@ -140,6 +148,129 @@ fn an_empty_file_sets_nothing_and_is_not_an_error() {
     assert!(load(&path).expect("empty is valid").values.is_empty());
 }
 
+// --- C1: the role-named variable and its legacy alias ----------------------
+
+#[test]
+fn the_role_named_variable_wins_over_its_legacy_alias() {
+    let resolved = resolve_alias(Some("http://role"), Some("http://legacy"));
+    assert_eq!(resolved.value.as_deref(), Some("http://role"));
+    assert!(
+        resolved.conflicting,
+        "two different values is exactly the case the operator must be told about"
+    );
+}
+
+#[test]
+fn the_legacy_alias_is_used_when_the_role_named_one_is_unset() {
+    let resolved = resolve_alias(None, Some("http://legacy"));
+    assert_eq!(
+        resolved.value.as_deref(),
+        Some("http://legacy"),
+        "an existing setup must keep working untouched — that is the whole \
+         point of keeping the alias"
+    );
+    assert!(
+        !resolved.conflicting,
+        "using the alias as intended is not a conflict"
+    );
+}
+
+#[test]
+fn the_same_value_under_both_names_is_silent() {
+    let resolved = resolve_alias(Some("http://same"), Some("http://same"));
+    assert_eq!(resolved.value.as_deref(), Some("http://same"));
+    assert!(
+        !resolved.conflicting,
+        "a migration that sets both to the same thing is correct, not suspicious \
+         — warning about it would train the operator to ignore the warning"
+    );
+}
+
+#[test]
+fn neither_name_set_resolves_to_nothing() {
+    let resolved = resolve_alias(None, None);
+    assert!(resolved.value.is_none());
+    assert!(!resolved.conflicting);
+}
+
+#[test]
+fn conflicts_are_reported_in_one_notice_naming_both_variables() {
+    assert!(
+        alias_conflict_notice(&[]).is_none(),
+        "no conflict must produce no output at all"
+    );
+    let notice = alias_conflict_notice(&[
+        ("VELESDB_MEMORY_EMBEDDER_URL", "VELESDB_MEMORY_OLLAMA_URL"),
+        (
+            "VELESDB_MEMORY_EMBEDDER_MODEL",
+            "VELESDB_MEMORY_OLLAMA_MODEL",
+        ),
+    ])
+    .expect("two conflicts must produce a notice");
+    for name in [
+        "VELESDB_MEMORY_EMBEDDER_URL",
+        "VELESDB_MEMORY_OLLAMA_URL",
+        "VELESDB_MEMORY_EMBEDDER_MODEL",
+        "VELESDB_MEMORY_OLLAMA_MODEL",
+    ] {
+        assert!(
+            notice.contains(name),
+            "the notice must name {name} so the operator can find it, got: {notice}"
+        );
+    }
+    assert_eq!(
+        notice.lines().count(),
+        1,
+        "ONE notice, however many variables disagree: a warning per variable is \
+         how a startup log becomes noise, got: {notice}"
+    );
+}
+
+// --- B1: a credential never lives in the file ------------------------------
+
+#[test]
+fn an_api_token_in_the_file_is_refused_for_both_roles() {
+    // The rule, and the reason: a token at rest in a TOML is a secret one
+    // `git add .` away from a public history, and this repo's pre-commit
+    // secret guard cannot police a file it has never seen. Tokens are read
+    // from the environment ONLY. `deny_unknown_fields` is what makes that
+    // structural rather than a convention — the field does not exist, so it
+    // cannot be silently accepted and ignored either, which would be worse:
+    // the operator would believe the daemon authenticates when it does not.
+    for role in ["embedder", "extractor"] {
+        let (_dir, path) = config_file(&format!("[{role}]\napi_token = \"sk-secret\"\n"));
+        let Err(err) = load(&path) else {
+            panic!("[{role}] api_token must be refused, not accepted");
+        };
+        let ConfigError::Parse { message, .. } = &err else {
+            panic!("[{role}]: expected a parse refusal, got {err:?}");
+        };
+        assert!(
+            message.contains("api_token"),
+            "[{role}]: the refusal must name the offending key, got: {message}"
+        );
+    }
+}
+
+#[test]
+fn refusing_an_api_token_says_where_the_token_belongs() {
+    // "Unknown field" alone leaves an operator with a working token and
+    // nowhere to put it; the whole point of failing at boot is to hand back
+    // the next step. The hint names the role's own variable, so it is
+    // actionable without a trip to the README.
+    let (_dir, path) = config_file("[extractor]\napi_token = \"sk-secret\"\n");
+    let err = load(&path).expect_err("api_token must be refused");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("VELESDB_MEMORY_EXTRACTOR_API_TOKEN"),
+        "the refusal must name the variable to use instead, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("sk-secret"),
+        "the refusal must never echo the credential back, got: {rendered}"
+    );
+}
+
 #[test]
 fn a_typo_is_rejected_rather_than_silently_dropped() {
     let (_dir, path) = config_file("[embedder]\nmdoel = \"bge-m3\"\n");
@@ -147,6 +278,17 @@ fn a_typo_is_rejected_rather_than_silently_dropped() {
     assert!(
         matches!(err, ConfigError::Parse { .. }),
         "got {err:?} — a typo'd key must not be silently ignored"
+    );
+    // POSITIVE CONTROL for the redaction above. `toml` quotes the offending
+    // source line back, which is a gift here — the operator sees exactly what
+    // to fix — and a credential leak on the `api_token` line. If this
+    // assertion ever fails, `toml` stopped echoing the source and
+    // `describe_parse_failure`'s redaction has become a guard with nothing
+    // left to catch: check before deleting it, do not assume.
+    assert!(
+        err.to_string().contains("bge-m3"),
+        "the parser is expected to quote the offending line verbatim — that is \
+         WHY the api_token failure has to be rewritten. Got: {err}"
     );
 }
 

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -273,7 +273,7 @@ impl OpenAiEmbedder {
         auth: crate::http_client::Auth,
     ) -> Result<Self, EmbedError> {
         let client = crate::http_client::HttpJsonClient::new(
-            base_url,
+            crate::openai::base_url(&base_url.into()),
             auth,
             embed_agent(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS)),
         );

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -160,9 +160,17 @@ pub fn select_embedder(backend: Option<&str>) -> Result<EmbedderSelection, Strin
             Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION)),
         )),
         Some("ollama") => Ok(EmbedderSelection::NeedsRemoteConfig("ollama")),
+        // A protocol, not a vendor: oMLX, llama.cpp's server, LM Studio, vLLM
+        // and the hosted providers all speak it. Reaching a new one is a
+        // different URL — never a new name here. That is what stops this
+        // `match` from growing a vendor list (#1730).
+        Some("openai") => Ok(EmbedderSelection::NeedsRemoteConfig("openai")),
         Some(other) => Err(format!(
             "unknown embedding backend '{other}' (expected 'hash' for the \
-             offline deterministic embedder, or 'ollama' for a local model)"
+             offline deterministic embedder, 'ollama' for a local model, or \
+             'openai' for any OpenAI-compatible server — oMLX, llama.cpp, LM \
+             Studio, vLLM or a hosted provider, selected by URL rather than by \
+             name)"
         )),
     }
 }

--- a/crates/velesdb-memory/src/embedder_selection_tests.rs
+++ b/crates/velesdb-memory/src/embedder_selection_tests.rs
@@ -47,6 +47,17 @@ fn ollama_defers_to_the_caller_for_url_and_model() {
 }
 
 #[test]
+fn openai_defers_to_the_caller_for_url_and_model() {
+    let selection = select_embedder(Some("openai")).expect("`openai` is an accepted backend");
+    assert!(
+        matches!(selection, EmbedderSelection::NeedsRemoteConfig("openai")),
+        "the name must reach the caller intact: it is what the daemon dispatches \
+         on, and a backend that came back as `ollama` would be silently served by \
+         the wrong protocol"
+    );
+}
+
+#[test]
 fn an_empty_value_is_refused_like_any_other_unknown_name() {
     // Distinct from `None` ON PURPOSE, and preserved from the behaviour that
     // predates this seam: an *unset* variable means "no preference" and takes
@@ -59,20 +70,24 @@ fn an_empty_value_is_refused_like_any_other_unknown_name() {
     // is a real choice, "no embedder" is not.
     let err = select_embedder(Some("")).expect_err("an empty backend name is not a selection");
     assert!(
-        err.contains("hash") && err.contains("ollama"),
+        err.contains("hash") && err.contains("ollama") && err.contains("openai"),
         "the refusal must name the accepted forms, got: {err}"
     );
 }
 
 #[test]
 fn an_unknown_backend_names_the_accepted_forms() {
-    let err = select_embedder(Some("openai")).expect_err("`openai` is not wired yet");
+    // A vendor name on purpose. `openai` is now a real backend, and the point
+    // of the whole protocol split is that reaching a new server is a different
+    // URL rather than a new name here — so the refusal must steer a user who
+    // typed their vendor towards the protocol they actually speak.
+    let err = select_embedder(Some("lmstudio")).expect_err("`lmstudio` is not a backend name");
     assert!(
-        err.contains("openai"),
+        err.contains("lmstudio"),
         "the refusal must quote what was asked for, got: {err}"
     );
     assert!(
-        err.contains("hash") && err.contains("ollama"),
+        err.contains("hash") && err.contains("ollama") && err.contains("openai"),
         "the refusal must name the accepted forms, got: {err}"
     );
 }

--- a/crates/velesdb-memory/src/embedding_provenance.rs
+++ b/crates/velesdb-memory/src/embedding_provenance.rs
@@ -1,0 +1,160 @@
+//! What embedder filled this store, and whether the configured one can still
+//! read it (#1751, arbitration A1).
+//!
+//! # The problem this exists for
+//!
+//! A store's vectors are only comparable to vectors from the **same embedding
+//! model**. `velesdb-core` already refuses to open a collection whose
+//! dimension differs from the embedder's, which catches the loud half of the
+//! problem — `bge-m3` (1024) against `all-minilm` (384) fails immediately and
+//! clearly.
+//!
+//! It does not catch the quiet half. Two different models of the *same*
+//! dimension open perfectly and then return nonsense: this crate's own `hash`
+//! embedder is 384-dimensional, and so is `all-minilm`. Recall degrades to
+//! noise with nothing anywhere reporting a fault. Recording the model closes
+//! that gap.
+//!
+//! # What is recorded, and what deliberately is not
+//!
+//! The model identifier and the dimension. **Not the backend.** A backend is a
+//! *transport*: the same model served by Ollama, by oMLX or by a hosted
+//! OpenAI-compatible API produces the same vectors, so refusing an open
+//! because the transport changed would block a valid migration — precisely the
+//! migration #1751 exists to enable.
+//!
+//! # When it is recorded
+//!
+//! Only when the store holds **no facts**. Never retroactively over data: a
+//! single open with the wrong model would carve a false provenance into the
+//! store, and every later check would trust it. A store that predates this
+//! record therefore stays unrecorded for good, and its check degrades to the
+//! dimension alone — with [`unrecorded_model_note`] saying so rather than
+//! letting a successful open read as a verified match.
+
+use std::path::Path;
+
+/// Name of the record inside the store directory.
+///
+/// Sits beside the engine's own files rather than inside them: this is
+/// `velesdb-memory`'s knowledge about its embedder, not something
+/// `velesdb-core` — which only ever sees raw `&[f32]` — has any business
+/// carrying.
+pub const PROVENANCE_FILE: &str = "embedding-provenance.json";
+
+/// The embedder a store was filled by.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EmbeddingProvenance {
+    /// The model identifier as configured — `bge-m3`, `all-minilm`, or `hash`
+    /// for this crate's built-in offline embedder.
+    pub model: String,
+    /// The vector width that model produces.
+    pub dimension: usize,
+}
+
+impl EmbeddingProvenance {
+    /// Record `model` at `dimension`.
+    #[must_use]
+    pub fn new(model: impl Into<String>, dimension: usize) -> Self {
+        Self {
+            model: model.into(),
+            dimension,
+        }
+    }
+}
+
+/// Read the record from `store_dir`, or `None` when there is none.
+///
+/// An absent record is a normal outcome — every store created before this
+/// existed has none — and is deliberately distinct from a failure to read one,
+/// because the two lead to opposite actions: the first degrades the check, the
+/// second stops the daemon.
+///
+/// # Errors
+/// A record that exists but cannot be read or parsed. Treating that as
+/// "absent" would silently disable the guard on exactly the store whose
+/// metadata is already damaged; the message names the file so the operator can
+/// delete it and let the check degrade knowingly.
+pub fn read(store_dir: &Path) -> Result<Option<EmbeddingProvenance>, String> {
+    let path = store_dir.join(PROVENANCE_FILE);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(format!("cannot read {PROVENANCE_FILE}: {err}")),
+    };
+    // Unknown fields are IGNORED on purpose (no `deny_unknown_fields` here,
+    // unlike the operator-facing config file): a store stamped by a newer
+    // version must stay readable by an older binary, which can still run the
+    // check it does understand. A typo is impossible — nobody writes this file
+    // by hand.
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|err| format!("cannot parse {PROVENANCE_FILE}: {err} — delete it to reset the embedding record (the store's own data is untouched)"))
+}
+
+/// Write the record into `store_dir`.
+///
+/// # Errors
+/// The directory is unwritable, or serialisation fails.
+pub fn write(store_dir: &Path, provenance: &EmbeddingProvenance) -> Result<(), String> {
+    let body = serde_json::to_string_pretty(provenance)
+        .map_err(|err| format!("cannot serialise the embedding record: {err}"))?;
+    std::fs::write(store_dir.join(PROVENANCE_FILE), body)
+        .map_err(|err| format!("cannot write {PROVENANCE_FILE}: {err}"))
+}
+
+/// Compare what the store recorded against what the daemon is configured for.
+///
+/// `stored` is `None` for a store that predates the record; there is then
+/// nothing to compare and the core's own dimension check remains the only
+/// guard — see [`unrecorded_model_note`].
+///
+/// # Errors
+/// A message naming **both** configurations and what can be done about them.
+/// Naming only the mismatch would leave the operator guessing which side to
+/// change.
+pub fn check(
+    stored: Option<&EmbeddingProvenance>,
+    model: &str,
+    dimension: usize,
+) -> Result<(), String> {
+    let Some(stored) = stored else {
+        return Ok(());
+    };
+    if stored.model == model && stored.dimension == dimension {
+        return Ok(());
+    }
+    // The dimension is stated on both sides even when only the name differs:
+    // it is what tells an operator whether a re-index is a re-embed or a
+    // rebuild, and a served model can change what its own name means.
+    Err(format!(
+        "this store was filled with the embedding model '{}' ({} dimensions), and the daemon is \
+         configured for '{}' ({} dimensions). Vectors from two different models are not \
+         comparable, so recall would silently return nonsense. Either point \
+         VELESDB_MEMORY_EMBEDDER_MODEL back at '{}', or re-index the store against the new model \
+         (re-indexing is not implemented yet — see #1751). Which backend serves the model does \
+         not matter and is not recorded: the same model over Ollama, oMLX or an \
+         OpenAI-compatible API produces the same vectors.",
+        stored.model, stored.dimension, model, dimension, stored.model
+    ))
+}
+
+/// What to say when the store carries no model record.
+///
+/// The disclosure is the point. A store created before this record existed
+/// opens on a dimension match alone, and an operator reading that as "my model
+/// matches" would be reading something nobody verified.
+#[must_use]
+pub fn unrecorded_model_note(model: &str) -> String {
+    format!(
+        "[velesdb-memory] this store predates embedding-model recording, so only the vector \
+         dimension could be compared against '{model}' — not the model itself. Two different \
+         models of the same width would pass this check. The record is written only for a store \
+         with no facts in it, never over existing data, because a wrong stamp would be trusted \
+         forever."
+    )
+}
+
+#[cfg(test)]
+#[path = "embedding_provenance_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/embedding_provenance_tests.rs
+++ b/crates/velesdb-memory/src/embedding_provenance_tests.rs
@@ -1,0 +1,140 @@
+//! What the store records about the embedder that filled it, and what it
+//! refuses when the two stop matching (#1751, arbitration A1).
+
+use super::*;
+
+fn store_dir() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+#[test]
+fn a_record_round_trips_through_the_store_directory() {
+    let dir = store_dir();
+    let written = EmbeddingProvenance::new("bge-m3", 1024);
+    write(dir.path(), &written).expect("write provenance");
+    let read_back = read(dir.path()).expect("read provenance");
+    assert_eq!(read_back.as_ref(), Some(&written));
+}
+
+#[test]
+fn an_absent_record_is_not_an_error() {
+    // The normal state of every store created before this existed. It has to
+    // be distinguishable from a failure, because the two lead to opposite
+    // actions: one degrades the check, the other stops the daemon.
+    let dir = store_dir();
+    assert_eq!(
+        read(dir.path()).expect("an absent record is a normal outcome"),
+        None
+    );
+}
+
+#[test]
+fn the_backend_is_not_part_of_the_record() {
+    // The correction that shaped this whole design: a backend is a TRANSPORT.
+    // The same model served by Ollama, by oMLX or by a hosted OpenAI-compatible
+    // API produces the same vectors, so recording who served them would refuse
+    // a perfectly valid open for the sole reason that the transport changed —
+    // which is exactly the migration #1751 exists to allow.
+    let dir = store_dir();
+    write(dir.path(), &EmbeddingProvenance::new("bge-m3", 1024)).expect("write");
+    let raw = std::fs::read_to_string(dir.path().join(PROVENANCE_FILE)).expect("read raw");
+    assert!(
+        !raw.contains("backend") && !raw.contains("ollama") && !raw.contains("openai"),
+        "the record must carry the model and the dimension and nothing else, got: {raw}"
+    );
+    assert!(raw.contains("bge-m3") && raw.contains("1024"), "got: {raw}");
+}
+
+#[test]
+fn the_same_model_at_the_same_dimension_opens() {
+    let stored = EmbeddingProvenance::new("bge-m3", 1024);
+    assert!(check(Some(&stored), "bge-m3", 1024).is_ok());
+}
+
+#[test]
+fn a_different_model_is_refused_naming_both_configurations() {
+    let stored = EmbeddingProvenance::new("bge-m3", 1024);
+    let err = check(Some(&stored), "all-minilm", 384)
+        .expect_err("a store filled with one model cannot be searched with another");
+    for expected in ["bge-m3", "1024", "all-minilm", "384"] {
+        assert!(
+            err.contains(expected),
+            "the refusal must name BOTH configurations — the operator has to know \
+             which one to change. Missing {expected} in: {err}"
+        );
+    }
+    assert!(
+        err.contains("VELESDB_MEMORY_EMBEDDER_MODEL"),
+        "and it must name the variable that changes it, got: {err}"
+    );
+}
+
+#[test]
+fn the_same_model_at_a_different_dimension_is_refused() {
+    // Edge case, and a real one: a served model can change what its name means
+    // (a quantisation swap, a provider re-pointing an alias). The name matching
+    // is then a false reassurance, so the dimension is checked on its own.
+    let stored = EmbeddingProvenance::new("bge-m3", 1024);
+    let err = check(Some(&stored), "bge-m3", 768).expect_err("same name, different vectors");
+    assert!(
+        err.contains("1024") && err.contains("768"),
+        "the refusal must name both dimensions, got: {err}"
+    );
+}
+
+#[test]
+fn an_unrecorded_model_discloses_that_only_the_dimension_was_compared() {
+    // A store created before this record existed cannot be checked fully, and
+    // saying nothing about that would be the worse failure: the operator would
+    // read a successful open as "my model matches", which was never verified.
+    let note = unrecorded_model_note("bge-m3");
+    assert!(
+        note.contains("bge-m3"),
+        "the note must name what the daemon is configured for, got: {note}"
+    );
+    assert!(
+        note.contains("dimension"),
+        "and it must say the comparison was dimension-only, got: {note}"
+    );
+}
+
+#[test]
+fn nothing_recorded_means_nothing_to_refuse() {
+    assert!(
+        check(None, "any-model", 1).is_ok(),
+        "an unrecorded model is not a mismatch — it is an unknown, and the \
+         dimension check in the core still applies underneath"
+    );
+}
+
+#[test]
+fn a_corrupt_record_is_an_error_rather_than_a_silent_pass() {
+    // Treating an unreadable record as "absent" would silently disable the
+    // guard on exactly the store whose metadata is already damaged.
+    let dir = store_dir();
+    std::fs::write(dir.path().join(PROVENANCE_FILE), "{not json").expect("write junk");
+    let err = read(dir.path()).expect_err("a damaged record must be reported");
+    assert!(
+        err.contains(PROVENANCE_FILE),
+        "the error must name the file to delete, got: {err}"
+    );
+}
+
+#[test]
+fn a_record_from_a_newer_version_still_reads_its_known_fields() {
+    // Forward compatibility, deliberately: an older binary opening a store
+    // stamped by a newer one must still be able to run the check it does
+    // understand, rather than refuse the store outright.
+    let dir = store_dir();
+    std::fs::write(
+        dir.path().join(PROVENANCE_FILE),
+        r#"{"model":"bge-m3","dimension":1024,"future_field":"whatever"}"#,
+    )
+    .expect("write");
+    let read_back = read(dir.path()).expect("unknown fields must not break the read");
+    assert_eq!(
+        read_back,
+        Some(EmbeddingProvenance::new("bge-m3", 1024)),
+        "the fields this version knows must survive an unknown one"
+    );
+}

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -905,11 +905,17 @@ pub fn select_extractor(backend: &str) -> Result<ExtractorSelection, String> {
             OutlineExtractor,
         ))),
         "ollama" => Ok(ExtractorSelection::NeedsRemoteConfig("ollama")),
+        // A protocol, not a vendor — see [`crate::select_embedder`]'s own
+        // `openai` arm. The two roles accept the same names on purpose: an
+        // operator who learned one has learned the other.
+        "openai" => Ok(ExtractorSelection::NeedsRemoteConfig("openai")),
         "none" | "" => Ok(ExtractorSelection::Disabled),
         other => Err(format!(
             "unknown extraction backend '{other}' (expected 'outline' for the \
              offline deterministic reader, 'ollama' for a local generative \
-             model, or 'none')"
+             model, 'openai' for any OpenAI-compatible server — oMLX, \
+             llama.cpp, LM Studio, vLLM or a hosted provider, selected by URL \
+             rather than by name — or 'none')"
         )),
     }
 }
@@ -1503,6 +1509,10 @@ fn step_string(escaped: &mut bool, byte: u8) -> bool {
         (false, _) => true,
     }
 }
+
+#[cfg(test)]
+#[path = "extractor_selection_tests.rs"]
+mod selection_tests;
 
 #[cfg(all(test, feature = "extract"))]
 mod tests {

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -1109,7 +1109,11 @@ impl OpenAiExtractor {
             .timeout(timeout)
             .build();
         Self {
-            client: crate::http_client::HttpJsonClient::new(base_url, auth, agent),
+            client: crate::http_client::HttpJsonClient::new(
+                crate::openai::base_url(&base_url.into()),
+                auth,
+                agent,
+            ),
             model: model.into(),
         }
     }

--- a/crates/velesdb-memory/src/extractor_selection_tests.rs
+++ b/crates/velesdb-memory/src/extractor_selection_tests.rs
@@ -1,0 +1,79 @@
+//! Tests for [`super::select_extractor`] — the seam that resolves an extraction
+//! backend name to what the caller must do about it.
+//!
+//! Deliberately NOT gated on `feature = "extract"`, and that absence is the
+//! point: `outline` and `none` must resolve in every build, including the
+//! published one that has no HTTP backend compiled in. #1734 is exactly what
+//! happens when the only code that can *choose* a dependency-free backend sits
+//! behind an unrelated HTTP feature — two published tools went dead by default.
+//! A test living inside `extract.rs`'s own `cfg(feature = "extract")` module
+//! would have been compiled away alongside the defect.
+//!
+//! Its counterpart is `embedder_selection_tests.rs`; the two roles are kept
+//! deliberately symmetric, down to the shape of the refusals.
+
+use super::*;
+
+#[test]
+fn outline_is_ready_with_no_configuration_and_no_network() {
+    let selection = select_extractor("outline").expect("`outline` is an accepted backend");
+    assert!(
+        matches!(selection, ExtractorSelection::Ready(_)),
+        "the offline deterministic reader needs no URL and no model, so it comes \
+         back ready to use — in every build"
+    );
+}
+
+#[test]
+fn ollama_defers_to_the_caller_for_url_and_model() {
+    let selection = select_extractor("ollama").expect("`ollama` is an accepted backend");
+    assert!(
+        matches!(selection, ExtractorSelection::NeedsRemoteConfig("ollama")),
+        "only the caller knows the URL and model, so the library names the \
+         backend and stops there"
+    );
+}
+
+#[test]
+fn openai_defers_to_the_caller_for_url_and_model() {
+    let selection = select_extractor("openai").expect("`openai` is an accepted backend");
+    assert!(
+        matches!(selection, ExtractorSelection::NeedsRemoteConfig("openai")),
+        "the name must reach the caller intact: it is what the daemon dispatches \
+         on, and a backend that came back as `ollama` would be silently served by \
+         the wrong protocol"
+    );
+}
+
+#[test]
+fn none_and_the_empty_value_both_mean_no_extraction() {
+    for backend in ["none", ""] {
+        let selection =
+            select_extractor(backend).unwrap_or_else(|err| panic!("`{backend}`: {err}"));
+        assert!(
+            matches!(selection, ExtractorSelection::Disabled),
+            "`{backend}` must disable extraction rather than pick a backend"
+        );
+    }
+    // Where this role legitimately diverges from the embedding one: "no
+    // extraction" is a real choice — the graph simply does not build — while a
+    // memory store cannot exist without an embedder, so `select_embedder`
+    // refuses `""` instead.
+}
+
+#[test]
+fn an_unknown_backend_names_the_accepted_forms() {
+    // A vendor name on purpose. `openai` is now a real backend, and the point
+    // of the whole protocol split is that reaching a new server is a different
+    // URL rather than a new name here — so the refusal must steer a user who
+    // typed their vendor towards the protocol they actually speak.
+    let err = select_extractor("lmstudio").expect_err("`lmstudio` is not a backend name");
+    assert!(
+        err.contains("lmstudio"),
+        "the refusal must quote what was asked for, got: {err}"
+    );
+    assert!(
+        err.contains("outline") && err.contains("ollama") && err.contains("openai"),
+        "the refusal must name the accepted forms, got: {err}"
+    );
+}

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -45,6 +45,12 @@ pub mod context;
 /// question answering, shipped as product behavior rather than a harness prompt.
 pub mod dated_context;
 pub mod embedder;
+/// Which embedding model filled a store, and whether the configured one can
+/// still read it. Gated on `persistence` because an unrecorded store is a
+/// directory on disk — see the module docs for why the *backend* is
+/// deliberately not part of the record.
+#[cfg(feature = "persistence")]
+pub mod embedding_provenance;
 pub mod error;
 pub mod extract;
 /// Vector+graph score fusion — the ranking layer behind

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -386,20 +386,46 @@ const LOCK_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// (#1448).
 fn open_store_with_actionable_lock_error(
     store_path: &str,
-    embedder: DynEmbedder,
+    configured: ConfiguredEmbedder,
 ) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
     use velesdb_memory::MemoryError;
 
+    let ConfiguredEmbedder { embedder, model } = configured;
     let dimension = embedder.dimension();
+    // Read BEFORE the store is opened, so a mismatch is refused instead of
+    // being reported after the daemon has taken the store's single-writer
+    // `flock` — and so `recorded` below genuinely means "recorded before this
+    // process touched anything".
+    let store_dir = std::path::Path::new(store_path);
+    let recorded = velesdb_memory::embedding_provenance::read(store_dir)?;
+    velesdb_memory::embedding_provenance::check(recorded.as_ref(), &model, dimension)?;
+    let unrecorded = recorded.is_none();
+
     let mut last_locked_path: Option<String> = None;
     for attempt in 0..LOCK_RETRY_ATTEMPTS {
         match NativeStore::open(store_path, dimension) {
-            Ok(store) => return Ok(MemoryService::with_store(store, embedder)),
+            Ok(store) => {
+                if unrecorded {
+                    record_embedding_model(store_dir, &store, &model, dimension);
+                }
+                return Ok(MemoryService::with_store(store, embedder));
+            }
             Err(MemoryError::Storage(velesdb_core::Error::DatabaseLocked(locked_path))) => {
                 last_locked_path = Some(locked_path);
                 if attempt + 1 < LOCK_RETRY_ATTEMPTS {
                     std::thread::sleep(LOCK_RETRY_DELAY);
                 }
+            }
+            // A dimension mismatch surfaces here, from the core. When the store
+            // carries no model record, that dimension was the ONLY thing that
+            // could be compared, and saying so is what stops a caller reading
+            // the core's message as a full compatibility verdict.
+            Err(other) if unrecorded => {
+                return Err(format!(
+                    "{other}\n{}",
+                    velesdb_memory::embedding_provenance::unrecorded_model_note(&model)
+                )
+                .into())
             }
             Err(other) => return Err(other.into()),
         }
@@ -411,6 +437,44 @@ fn open_store_with_actionable_lock_error(
          kill it (pkill velesdb-memory) or point VELESDB_MEMORY_PATH elsewhere"
     );
     std::process::exit(1);
+}
+
+/// Record which embedding model filled this store — **only when it holds no
+/// facts**.
+///
+/// The emptiness test is what makes the record trustworthy, and it is
+/// semantic rather than filesystem-shaped on purpose: "the directory looks
+/// new" is defeated by a config file sitting beside the store, or by a
+/// `.DS_Store` a file browser dropped in it. "No fact is stored" is the thing
+/// that actually matters — with zero vectors, there is nothing that could have
+/// come from a different model, so writing the record states something true.
+/// Over existing data it would not: one open with the wrong model would carve
+/// a false provenance that every later check would trust.
+///
+/// A failed write is a warning, never fatal. The daemon runs perfectly without
+/// the record — it only loses the model half of the check — and refusing to
+/// start because a metadata file could not be written would cost more than the
+/// gap it guards.
+fn record_embedding_model(
+    store_dir: &std::path::Path,
+    store: &NativeStore,
+    model: &str,
+    dimension: usize,
+) {
+    use velesdb_memory::embedding_provenance::{write, EmbeddingProvenance};
+    use velesdb_memory::MemoryStore as _;
+
+    if store.count() != 0 {
+        return;
+    }
+    if let Err(err) = write(store_dir, &EmbeddingProvenance::new(model, dimension)) {
+        if std::env::var_os("VELESDB_MEMORY_QUIET").is_none() {
+            eprintln!(
+                "[velesdb-memory] could not record the embedding model ({err}) — the store works, \
+                 but a later model change will only be checked against the vector dimension"
+            );
+        }
+    }
 }
 
 /// Default store location when `VELESDB_MEMORY_PATH` is unset: `~/.velesdb-memory`
@@ -431,11 +495,25 @@ fn build_configured_service(
 ) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
     apply_config_file(args)?;
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
-    let embedder = build_embedder()?;
+    let configured = build_embedder()?;
     apply_autograph(open_store_with_actionable_lock_error(
         &store_path,
-        embedder,
+        configured,
     )?)
+}
+
+/// An embedder together with the identifier of the model behind it.
+///
+/// The model travels with the embedder because only the code that *built* it
+/// knows its name: the [`velesdb_memory::Embedder`] trait exposes a dimension
+/// and nothing else, deliberately — a trait implemented by callers should not
+/// have to answer questions about a configuration it may not have. Carrying
+/// the name here keeps [`velesdb_memory::embedding_provenance`] usable without
+/// widening that trait for every implementor, in this crate and out of it.
+struct ConfiguredEmbedder {
+    embedder: DynEmbedder,
+    /// As configured: `bge-m3`, `all-minilm`, or `hash` for the built-in.
+    model: String,
 }
 
 /// Cancel `ct` on the signals a supervisor actually sends.
@@ -893,7 +971,7 @@ fn build_openai_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
 /// `.ok()` maps an unset variable to `None`, which the library reads as "no
 /// preference". A variable that IS set keeps its value — including an empty
 /// one, which stays a caller error rather than collapsing into the default.
-fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+fn build_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     let backend = std::env::var("VELESDB_MEMORY_EMBEDDER");
     // The library message is transport-neutral; the daemon adds the name of the
     // thing the reader actually has to edit.
@@ -905,9 +983,17 @@ fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
         // must not inherit it silently.
         velesdb_memory::EmbedderSelection::Ready("hash", embedder) => {
             warn_hash_embedder_not_semantic();
-            Ok(embedder)
+            Ok(ConfiguredEmbedder {
+                embedder,
+                model: "hash".to_owned(),
+            })
         }
-        velesdb_memory::EmbedderSelection::Ready(_, embedder) => Ok(embedder),
+        // For a backend that needs no configuration, the backend name IS the
+        // model: there is no separate identifier to carry.
+        velesdb_memory::EmbedderSelection::Ready(name, embedder) => Ok(ConfiguredEmbedder {
+            embedder,
+            model: name.to_owned(),
+        }),
         // The name, not a wildcard — see `attach_extractor` for the defect
         // this shape removes on the extraction side. The embedding side never
         // had a second backend to get wrong, which is exactly why it was the
@@ -925,7 +1011,7 @@ fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 /// to one and not the other must say so rather than fall back to whichever
 /// client happens to be first.
 #[cfg(feature = "ollama")]
-fn build_remote_embedder(backend: &str) -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+fn build_remote_embedder(backend: &str) -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     match backend {
         "ollama" => build_ollama_embedder(),
         "openai" => build_openai_embedder(),
@@ -938,7 +1024,7 @@ fn build_remote_embedder(backend: &str) -> Result<DynEmbedder, Box<dyn std::erro
 /// split and now under-describes what it carries — it is this crate's HTTP
 /// dependency for the embedding role, not a vendor.
 #[cfg(not(feature = "ollama"))]
-fn build_remote_embedder(backend: &str) -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+fn build_remote_embedder(backend: &str) -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     Err(format!(
         "the '{backend}' embedder requires building with `--features ollama` \
          (that feature carries the HTTP dependency for both remote embedding \
@@ -970,7 +1056,7 @@ fn warn_hash_embedder_not_semantic() {
 /// unchanged behaviour, now reached through the role-named variables with the
 /// `VELESDB_MEMORY_OLLAMA_*` pair kept working as aliases.
 #[cfg(feature = "ollama")]
-fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+fn build_ollama_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 
     let endpoint = embedder_endpoint()?;
@@ -980,17 +1066,23 @@ fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
     let model = endpoint
         .model
         .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
-    Ok(Box::new(OllamaEmbedder::new(url, model)?))
+    Ok(ConfiguredEmbedder {
+        embedder: Box::new(OllamaEmbedder::new(&url, &model)?),
+        model,
+    })
 }
 
 /// Build the OpenAI-compatible embedder. Both the URL and the model are
 /// required — see [`RemoteEndpoint::require`].
 #[cfg(feature = "ollama")]
-fn build_openai_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+fn build_openai_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::OpenAiEmbedder;
 
     let (url, model, auth) = embedder_endpoint()?.require("VELESDB_MEMORY_EMBEDDER")?;
-    Ok(Box::new(OpenAiEmbedder::new(url, model, auth)?))
+    Ok(ConfiguredEmbedder {
+        embedder: Box::new(OpenAiEmbedder::new(url, &model, auth)?),
+        model,
+    })
 }
 
 /// Default token budget of `compile-stdin` when `--budget` is omitted.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -4,11 +4,19 @@
 //! Cline, Zed, …) can use it locally. The store never leaves the machine.
 //! Configure the store directory with `VELESDB_MEMORY_PATH` (default
 //! `~/.velesdb-memory`) and the embedding
-//! backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama`). Set
+//! backend with `VELESDB_MEMORY_EMBEDDER` (`hash` | `ollama` | `openai`). Set
 //! `VELESDB_MEMORY_EXTRACTOR` to enable the `remember_extracted` tool (text →
 //! fact↔topic graph): `outline` reads directives you write explicitly and needs
-//! no model and no extra feature, while `ollama` infers them with a local
-//! generative model and needs `--features extract`. Set
+//! no model and no extra feature, while `ollama` and `openai` infer them with a
+//! generative model and need `--features extract`.
+//!
+//! Each role carries its own `_URL`, `_MODEL` and `_API_TOKEN`, and the two are
+//! configured independently — embedding on a local Ollama while extracting on
+//! an OpenAI-compatible server is a supported combination. `openai` names a
+//! *protocol* (oMLX, llama.cpp, LM Studio, vLLM, hosted providers all speak
+//! it), so it has no default URL and no default model: reaching a different
+//! server is a different URL, never a new backend name. Tokens are read from
+//! the environment only, never from the config file. Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
 //! Set `VELESDB_MEMORY_INGEST_ROOTS` (a `PATH`-list of directories) to let
 //! `compile_context`/`explain_compilation` fragments reference a file by
@@ -496,8 +504,13 @@ fn apply_autograph(
                 .into(),
         ),
         ExtractorSelection::Ready(extractor) => Ok(service.with_autograph(extractor)),
-        ExtractorSelection::NeedsRemoteConfig(_) => {
-            Ok(service.with_autograph(build_ollama_extractor()?))
+        // Dispatches on the NAME, exactly like `attach_extractor`. This arm
+        // used to ignore it and build Ollama unconditionally; leaving it that
+        // way would mean autograph silently talked to a different server than
+        // `remember_extracted` on the very same daemon — the contradiction the
+        // comment above says an operator cannot resolve.
+        ExtractorSelection::NeedsRemoteConfig(backend) => {
+            Ok(service.with_autograph(build_remote_extractor(backend)?))
         }
     }
 }
@@ -634,10 +647,205 @@ fn attach_extractor(
     match velesdb_memory::select_extractor(backend)? {
         ExtractorSelection::Disabled => Ok(server),
         ExtractorSelection::Ready(extractor) => Ok(server.with_extractor(extractor)),
-        ExtractorSelection::NeedsRemoteConfig(_) => {
-            Ok(server.with_extractor(build_ollama_extractor()?))
+        // **This is the seam #1751 turns on.** The arm used to read
+        // `NeedsRemoteConfig(_)` and call `build_ollama_extractor()`: the
+        // library named the backend the operator asked for, and the daemon
+        // threw the name away and built the only client it knew. Adding a
+        // second protocol to `select_extractor` would have changed nothing
+        // observable — the wrong client would have been built, silently, for
+        // every name.
+        ExtractorSelection::NeedsRemoteConfig(backend) => {
+            Ok(server.with_extractor(build_remote_extractor(backend)?))
         }
     }
+}
+
+/// Build the remote extraction backend named `backend`.
+///
+/// The `other` arm is not decoration. `select_extractor` is the single place
+/// that knows which names exist, and it lives in the library while this
+/// dispatch lives in the binary — so the two CAN drift. When they do, the
+/// operator gets a message naming the gap instead of an Ollama client quietly
+/// pointed at a server that speaks something else.
+#[cfg(feature = "extract")]
+fn build_remote_extractor(
+    backend: &str,
+) -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
+    match backend {
+        "ollama" => build_ollama_extractor(),
+        "openai" => build_openai_extractor(),
+        other => Err(unwired_backend("extraction", other).into()),
+    }
+}
+
+/// Without the `extract` feature there is no HTTP backend to build, whichever
+/// one was asked for. The error names the offline alternative rather than only
+/// what is missing: since #1734, `outline` is a real answer in **every** build,
+/// so a user who only wanted a graph is one setting away instead of one
+/// rebuild away.
+#[cfg(not(feature = "extract"))]
+fn build_remote_extractor(
+    backend: &str,
+) -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
+    Err(format!(
+        "VELESDB_MEMORY_EXTRACTOR={backend} needs a build with `--features extract`; \
+         for an offline deterministic graph with no rebuild, set \
+         VELESDB_MEMORY_EXTRACTOR=outline instead"
+    )
+    .into())
+}
+
+// --- Where a remote backend's URL, model and credential come from -----------
+//
+// One shape for both roles, on purpose. The two were configured differently
+// for historical reasons only — extraction by role, embedding by product —
+// and an operator who has configured one should not have to learn the other
+// (#1751, arbitration C1).
+
+/// A remote backend's configuration, read from one role's environment.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+struct RemoteEndpoint {
+    /// Server origin and port, no path. `None` when unset.
+    url: Option<String>,
+    /// Model identifier the server expects. `None` when unset.
+    model: Option<String>,
+    /// The credential, already resolved to what the transport puts on the wire.
+    auth: velesdb_memory::Auth,
+}
+
+#[cfg(any(feature = "ollama", feature = "extract"))]
+impl RemoteEndpoint {
+    /// The URL and model, both **required** — the `openai` shape.
+    ///
+    /// Neither has a default, and that is the design rather than an omission:
+    /// `openai` names a *protocol*, spoken by oMLX, llama.cpp, LM Studio, vLLM
+    /// and a dozen hosted providers. Guessing a URL would pick one of them for
+    /// the operator, and guessing a model would send a name no server on that
+    /// list is obliged to know. Ollama keeps its defaults because it genuinely
+    /// has one canonical local address.
+    ///
+    /// # Errors
+    /// A message naming the exact variable that is missing, per role.
+    fn require(self, prefix: &str) -> Result<(String, String, velesdb_memory::Auth), String> {
+        let url = self.url.ok_or_else(|| {
+            format!(
+                "{prefix}=openai requires {prefix}_URL — the server's origin and port, \
+                 no path (e.g. http://localhost:8020). There is no default: `openai` \
+                 is a protocol, and only you know which server speaks it here."
+            )
+        })?;
+        let model = self.model.ok_or_else(|| {
+            format!(
+                "{prefix}=openai requires {prefix}_MODEL — the model identifier the server expects"
+            )
+        })?;
+        Ok((url, model, self.auth))
+    }
+}
+
+/// The embedding role's endpoint, honouring the legacy
+/// `VELESDB_MEMORY_OLLAMA_*` aliases (C1).
+///
+/// # Errors
+/// An `_API_TOKEN` that is set but empty.
+#[cfg(feature = "ollama")]
+fn embedder_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
+    use velesdb_memory::config::{alias_conflict_notice, resolve_alias};
+
+    let url = resolve_alias(
+        env_opt("VELESDB_MEMORY_EMBEDDER_URL").as_deref(),
+        env_opt("VELESDB_MEMORY_OLLAMA_URL").as_deref(),
+    );
+    let model = resolve_alias(
+        env_opt("VELESDB_MEMORY_EMBEDDER_MODEL").as_deref(),
+        env_opt("VELESDB_MEMORY_OLLAMA_MODEL").as_deref(),
+    );
+    let mut conflicts = Vec::new();
+    if url.conflicting {
+        conflicts.push(("VELESDB_MEMORY_EMBEDDER_URL", "VELESDB_MEMORY_OLLAMA_URL"));
+    }
+    if model.conflicting {
+        conflicts.push((
+            "VELESDB_MEMORY_EMBEDDER_MODEL",
+            "VELESDB_MEMORY_OLLAMA_MODEL",
+        ));
+    }
+    // Once, at startup, and only when the two genuinely disagree. Called from
+    // `build_remote_embedder`, which runs exactly once per process.
+    if let Some(notice) = alias_conflict_notice(&conflicts) {
+        if std::env::var_os("VELESDB_MEMORY_QUIET").is_none() {
+            eprintln!("{notice}");
+        }
+    }
+    Ok(RemoteEndpoint {
+        url: url.value,
+        model: model.value,
+        auth: role_auth("VELESDB_MEMORY_EMBEDDER_API_TOKEN")?,
+    })
+}
+
+/// The extraction role's endpoint. No aliases to resolve: these variables were
+/// role-named from the start, which is the naming the embedding side is being
+/// brought in line with.
+///
+/// # Errors
+/// An `_API_TOKEN` that is set but empty.
+#[cfg(feature = "extract")]
+fn extractor_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
+    Ok(RemoteEndpoint {
+        url: env_opt("VELESDB_MEMORY_EXTRACTOR_URL"),
+        model: env_opt("VELESDB_MEMORY_EXTRACTOR_MODEL"),
+        auth: role_auth("VELESDB_MEMORY_EXTRACTOR_API_TOKEN")?,
+    })
+}
+
+/// A variable's value, or `None` when it is unset.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
+/// Read a role's API token and turn it into what the transport will send.
+///
+/// The token lives in the environment and **nowhere else** — never in the TOML
+/// (arbitration B1, enforced by `velesdb_memory::config`'s
+/// `deny_unknown_fields` and its redacted refusal).
+///
+/// Note for the Ollama backends: they take no credential, so a token set
+/// alongside `backend = "ollama"` is read here and then goes unused. That is
+/// harmless — Ollama authenticates nothing — and refusing it would reject a
+/// configuration that works.
+///
+/// # Errors
+/// A variable that is set to an empty or blank value. That is not the same as
+/// unset: unset means "send no credential", while empty is a caller whose
+/// shell expansion produced nothing, and silently sending no credential would
+/// surface as a `401` they cannot explain.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+fn role_auth(name: &str) -> Result<velesdb_memory::Auth, Box<dyn std::error::Error>> {
+    match env_opt(name) {
+        None => Ok(velesdb_memory::Auth::None),
+        Some(token) if token.trim().is_empty() => Err(format!(
+            "{name} is set but empty — unset it entirely to send no credential. An \
+             empty token would go out as `Authorization: Bearer `, which a server \
+             rejects as a bad credential rather than a missing one."
+        )
+        .into()),
+        Some(token) => Ok(velesdb_memory::Auth::Bearer(token)),
+    }
+}
+
+/// A backend name the library accepts but this binary has no builder for.
+///
+/// Reachable only if `select_*` gains a name and the dispatch below is not
+/// updated with it — the exact drift a wildcard arm used to hide.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+fn unwired_backend(role: &str, backend: &str) -> String {
+    format!(
+        "the {role} backend '{backend}' is accepted by velesdb-memory's selector but \
+         the daemon has no builder wired for it — this is a bug in velesdb-memory, \
+         not a configuration error; please report it quoting this message"
+    )
 }
 
 /// Build the Ollama-backed extractor from `VELESDB_MEMORY_EXTRACTOR_URL`
@@ -648,27 +856,28 @@ fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
     use velesdb_memory::extract::DEFAULT_OLLAMA_URL;
     use velesdb_memory::OllamaExtractor;
 
-    let url = std::env::var("VELESDB_MEMORY_EXTRACTOR_URL")
-        .unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_owned());
-    let model = std::env::var("VELESDB_MEMORY_EXTRACTOR_MODEL").map_err(|_| {
+    let endpoint = extractor_endpoint()?;
+    // A default URL is right HERE and wrong for `openai`: Ollama has one
+    // canonical local address, an OpenAI-compatible server has none.
+    let url = endpoint
+        .url
+        .unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
+    let model = endpoint.model.ok_or(
         "VELESDB_MEMORY_EXTRACTOR=ollama requires VELESDB_MEMORY_EXTRACTOR_MODEL \
-         (e.g. qwen3.6:35b-mlx)"
-    })?;
+         (e.g. qwen3.6:35b-mlx)",
+    )?;
     Ok(Arc::new(OllamaExtractor::new(url, model)))
 }
 
-/// Without the `extract` feature there is no HTTP backend to build. The error
-/// names the offline alternative rather than only what is missing: since
-/// #1734, `outline` is a real answer in **every** build, so a user who only
-/// wanted a graph is one setting away instead of one rebuild away.
-#[cfg(not(feature = "extract"))]
-fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
-    Err(
-        "VELESDB_MEMORY_EXTRACTOR=ollama needs a build with `--features extract`; \
-         for an offline deterministic graph with no rebuild, set \
-         VELESDB_MEMORY_EXTRACTOR=outline instead"
-            .into(),
-    )
+/// Build the OpenAI-compatible extractor from the extraction role's own
+/// `VELESDB_MEMORY_EXTRACTOR_URL`, `_MODEL` and optional `_API_TOKEN`.
+#[cfg(feature = "extract")]
+fn build_openai_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
+    use std::sync::Arc;
+    use velesdb_memory::OpenAiExtractor;
+
+    let (url, model, auth) = extractor_endpoint()?.require("VELESDB_MEMORY_EXTRACTOR")?;
+    Ok(Arc::new(OpenAiExtractor::new(url, model, auth)))
 }
 
 /// Select the embedding backend from `VELESDB_MEMORY_EMBEDDER`: `hash`
@@ -699,8 +908,43 @@ fn build_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
             Ok(embedder)
         }
         velesdb_memory::EmbedderSelection::Ready(_, embedder) => Ok(embedder),
-        velesdb_memory::EmbedderSelection::NeedsRemoteConfig(_) => build_ollama_embedder(),
+        // The name, not a wildcard — see `attach_extractor` for the defect
+        // this shape removes on the extraction side. The embedding side never
+        // had a second backend to get wrong, which is exactly why it was the
+        // easier of the two to leave broken.
+        velesdb_memory::EmbedderSelection::NeedsRemoteConfig(backend) => {
+            build_remote_embedder(backend)
+        }
     }
+}
+
+/// Build the remote embedding backend named `backend`.
+///
+/// Mirrors [`build_remote_extractor`], down to the `other` arm: the selector
+/// lives in the library and this dispatch lives in the binary, so a name added
+/// to one and not the other must say so rather than fall back to whichever
+/// client happens to be first.
+#[cfg(feature = "ollama")]
+fn build_remote_embedder(backend: &str) -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    match backend {
+        "ollama" => build_ollama_embedder(),
+        "openai" => build_openai_embedder(),
+        other => Err(unwired_backend("embedding", other).into()),
+    }
+}
+
+/// Without the `ollama` feature this crate has no HTTP embedding backend at
+/// all, whichever one was asked for. The feature's name predates the protocol
+/// split and now under-describes what it carries — it is this crate's HTTP
+/// dependency for the embedding role, not a vendor.
+#[cfg(not(feature = "ollama"))]
+fn build_remote_embedder(backend: &str) -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    Err(format!(
+        "the '{backend}' embedder requires building with `--features ollama` \
+         (that feature carries the HTTP dependency for both remote embedding \
+         backends); VELESDB_MEMORY_EMBEDDER=hash needs no rebuild"
+    )
+    .into())
 }
 
 /// Warn (on **stderr**, never stdout — that carries the MCP JSON-RPC stream)
@@ -722,20 +966,31 @@ fn warn_hash_embedder_not_semantic() {
     );
 }
 
+/// Build the Ollama-backed embedder, defaulting both the URL and the model —
+/// unchanged behaviour, now reached through the role-named variables with the
+/// `VELESDB_MEMORY_OLLAMA_*` pair kept working as aliases.
 #[cfg(feature = "ollama")]
 fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 
-    let url = std::env::var("VELESDB_MEMORY_OLLAMA_URL")
-        .unwrap_or_else(|_| DEFAULT_OLLAMA_URL.to_owned());
-    let model = std::env::var("VELESDB_MEMORY_OLLAMA_MODEL")
-        .unwrap_or_else(|_| DEFAULT_OLLAMA_MODEL.to_owned());
+    let endpoint = embedder_endpoint()?;
+    let url = endpoint
+        .url
+        .unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
+    let model = endpoint
+        .model
+        .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
     Ok(Box::new(OllamaEmbedder::new(url, model)?))
 }
 
-#[cfg(not(feature = "ollama"))]
-fn build_ollama_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
-    Err("the 'ollama' embedder requires building with `--features ollama`".into())
+/// Build the OpenAI-compatible embedder. Both the URL and the model are
+/// required — see [`RemoteEndpoint::require`].
+#[cfg(feature = "ollama")]
+fn build_openai_embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
+    use velesdb_memory::OpenAiEmbedder;
+
+    let (url, model, auth) = embedder_endpoint()?.require("VELESDB_MEMORY_EMBEDDER")?;
+    Ok(Box::new(OpenAiEmbedder::new(url, model, auth)?))
 }
 
 /// Default token budget of `compile-stdin` when `--budget` is omitted.

--- a/crates/velesdb-memory/src/openai.rs
+++ b/crates/velesdb-memory/src/openai.rs
@@ -14,6 +14,32 @@
 
 use serde_json::{json, Value};
 
+/// The base URL to concatenate this protocol's paths onto, from whatever the
+/// operator configured.
+///
+/// **Both spellings of the same endpoint are accepted**, and that is not
+/// leniency for its own sake: servers advertise their OpenAI-compatible
+/// endpoint WITH the version prefix. oMLX's own console shows
+/// `http://127.0.0.1:8019/v1` beside a copy button, and LM Studio and vLLM do
+/// the same. Concatenating [`EMBEDDINGS_PATH`] onto a copied URL would produce
+/// `/v1/v1/embeddings` and a `404` whose cause is invisible from the message —
+/// the operator sees a URL they copied from the vendor's own UI being refused.
+///
+/// The `/v1` prefix belongs to this protocol, so recognising it in the base
+/// URL belongs here too, and nowhere else: [`crate::http_client`] must keep
+/// concatenating a path onto a string it knows nothing about.
+///
+/// A trailing `/v1` is stripped only when something precedes it, so a host
+/// genuinely called `v1` (`http://v1`) is left alone.
+#[cfg(any(feature = "ollama", feature = "extract"))]
+pub(crate) fn base_url(configured: &str) -> String {
+    let trimmed = configured.trim().trim_end_matches('/');
+    match trimmed.strip_suffix("/v1") {
+        Some(base) if !base.is_empty() && !base.ends_with('/') => base.to_owned(),
+        _ => trimmed.to_owned(),
+    }
+}
+
 /// Embeddings endpoint, relative to the caller's base URL.
 #[cfg(feature = "ollama")]
 pub(crate) const EMBEDDINGS_PATH: &str = "/v1/embeddings";

--- a/crates/velesdb-memory/src/openai_tests.rs
+++ b/crates/velesdb-memory/src/openai_tests.rs
@@ -102,3 +102,48 @@ fn a_long_payload_is_previewed_not_pasted_whole() {
     );
     assert!(err.contains('…'), "the preview must say it was cut: {err}");
 }
+
+// --- The base URL an operator actually copies --------------------------------
+
+#[test]
+fn a_base_url_carrying_the_version_prefix_is_not_doubled() {
+    // The exact string oMLX's console shows beside a copy button. Left as-is,
+    // it would produce `/v1/v1/embeddings` and a 404 the operator cannot
+    // explain — they pasted the vendor's own URL.
+    assert_eq!(
+        base_url("http://127.0.0.1:8019/v1"),
+        "http://127.0.0.1:8019"
+    );
+    assert_eq!(
+        base_url("http://127.0.0.1:8019/v1/"),
+        "http://127.0.0.1:8019",
+        "a trailing slash on the copied URL must not defeat it either"
+    );
+}
+
+#[test]
+fn a_bare_origin_is_left_alone() {
+    assert_eq!(base_url("http://localhost:8020"), "http://localhost:8020");
+    assert_eq!(
+        base_url("  http://localhost:8020/  "),
+        "http://localhost:8020",
+        "surrounding whitespace comes free with a shell variable"
+    );
+}
+
+#[test]
+fn a_server_mounted_under_a_path_keeps_its_path() {
+    assert_eq!(
+        base_url("https://gateway.example/models/v1"),
+        "https://gateway.example/models",
+        "stripping the protocol's own prefix must not eat the mount point"
+    );
+}
+
+#[test]
+fn a_host_genuinely_named_v1_is_not_truncated() {
+    // Edge case with a sharp failure mode: a blind `strip_suffix("/v1")` turns
+    // `http://v1` into `http:/`, which fails as a malformed URL rather than as
+    // an unreachable host.
+    assert_eq!(base_url("http://v1"), "http://v1");
+}

--- a/crates/velesdb-memory/tests/backend_dispatch_bdd.rs
+++ b/crates/velesdb-memory/tests/backend_dispatch_bdd.rs
@@ -1,0 +1,240 @@
+//! Process-level proof that the daemon dispatches on the backend NAME the
+//! library handed it (#1751, lot 3).
+//!
+//! Why a spawned process rather than a unit test: the defect being closed was
+//! not in the selector — `select_extractor` has carried the backend's name
+//! since #1734 — it was in `main.rs` throwing that name away:
+//!
+//! ```ignore
+//! ExtractorSelection::NeedsRemoteConfig(_) => build_ollama_extractor()
+//! ```
+//!
+//! An in-process test of the selector stays green against that line. Only
+//! running the real binary shows which client it actually built.
+//!
+//! **How each test tells the two apart, without any server running.** The two
+//! backends disagree about what a URL default means: Ollama has one canonical
+//! local address and defaults to it, while `openai` names a protocol a dozen
+//! servers speak and therefore refuses to guess. So the startup refusal names
+//! `..._URL` for one and only `..._MODEL` for the other — a difference that
+//! exists only if the dispatch read the name. The pair is the point: either
+//! test alone would pass on a daemon hard-wired to the backend it happens to
+//! assert.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+#![cfg(all(feature = "extract", feature = "ollama"))]
+
+use std::process::{Command, Output};
+
+/// Generous ceiling for "the daemon refused its configuration and exited".
+/// This path opens the store and then fails before serving anything, so it is
+/// bounded by process startup, not by any network call.
+const STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Spawn the real binary with `VELESDB_MEMORY_EXTRACTOR=<backend>` on a
+/// throwaway store, and return what it did.
+///
+/// Every other `VELESDB_MEMORY_*` variable is cleared: the developer running
+/// this suite may well have a real daemon configured, and inheriting their
+/// `VELESDB_MEMORY_EXTRACTOR_MODEL` would make the refusal under test vanish.
+fn start_with_extractor(backend: &str) -> Output {
+    let store = tempfile::tempdir().expect("tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env_clear()
+        // `HOME` survives because the config-file lookup and the default store
+        // path both read it; pointing it at the throwaway directory keeps this
+        // test off the developer's own `~/.velesdb-memory`.
+        .env("HOME", store.path())
+        .env("VELESDB_MEMORY_PATH", store.path())
+        .env("VELESDB_MEMORY_EXTRACTOR", backend)
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn velesdb-memory");
+
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(_status) = child.try_wait().expect("wait on velesdb-memory") {
+            return child.wait_with_output().expect("collect output");
+        }
+        assert!(
+            start.elapsed() < STARTUP_TIMEOUT,
+            "velesdb-memory did not exit within {STARTUP_TIMEOUT:?} — it should \
+             have refused its extractor configuration at startup"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn stderr_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn openai_refuses_without_a_url_because_it_has_no_default_server() {
+    let output = start_with_extractor("openai");
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "a backend missing its required configuration must not start; got {output:?}"
+    );
+    assert!(
+        stderr.contains("VELESDB_MEMORY_EXTRACTOR_URL"),
+        "the refusal must name the variable to set. An `openai` request served \
+         by the Ollama builder would have defaulted the URL and never mentioned \
+         it — which is precisely the bug. Got: {stderr}"
+    );
+}
+
+#[test]
+fn ollama_still_defaults_its_url_and_asks_only_for_the_model() {
+    // The other half of the pair, and the compatibility guarantee: routing by
+    // name must not have changed what `ollama` does.
+    let output = start_with_extractor("ollama");
+    let stderr = stderr_of(&output);
+    assert!(!output.status.success(), "no model configured, so no start");
+    assert!(
+        stderr.contains("VELESDB_MEMORY_EXTRACTOR_MODEL"),
+        "Ollama's own refusal is about the model, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("VELESDB_MEMORY_EXTRACTOR_URL"),
+        "Ollama defaults its URL to the canonical local address and must keep \
+         doing so — naming the URL here would mean the `openai` builder answered \
+         for it. Got: {stderr}"
+    );
+}
+
+#[test]
+fn an_unknown_backend_is_refused_before_any_client_is_built() {
+    let output = start_with_extractor("lmstudio");
+    let stderr = stderr_of(&output);
+    assert!(!output.status.success(), "an unknown name must not start");
+    assert!(
+        stderr.contains("lmstudio") && stderr.contains("openai"),
+        "the refusal must quote what was asked for and name the accepted forms, \
+         got: {stderr}"
+    );
+}
+
+/// Spawn the binary configured for the EMBEDDING role, with `extra` variables
+/// on top. Unlike [`start_with_extractor`] this leaves `VELESDB_MEMORY_QUIET`
+/// unset, because some of what is asserted here is written to stderr at
+/// startup.
+fn start_with_embedder(backend: &str, extra: &[(&str, &str)]) -> Output {
+    let store = tempfile::tempdir().expect("tempdir");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"));
+    command
+        .env_clear()
+        .env("HOME", store.path())
+        .env("VELESDB_MEMORY_PATH", store.path())
+        .env("VELESDB_MEMORY_EMBEDDER", backend);
+    for (name, value) in extra {
+        command.env(name, value);
+    }
+    command
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to spawn velesdb-memory")
+}
+
+#[test]
+fn the_embedding_role_refuses_openai_without_a_url_too() {
+    // The symmetry is the contract: an operator who has configured one role
+    // has configured the other. This role had no second backend to get wrong
+    // before #1751, which is exactly why its `_` was the easier one to leave.
+    let output = start_with_embedder("openai", &[]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "no URL configured, so no start");
+    assert!(
+        stderr.contains("VELESDB_MEMORY_EMBEDDER_URL"),
+        "the refusal must name the embedding role's own variable, got: {stderr}"
+    );
+}
+
+#[test]
+fn the_role_named_url_wins_over_the_legacy_alias_and_says_so_once() {
+    // Port 1 and port 2 both refuse instantly, so this needs no server: what
+    // matters is WHICH address the daemon tried, which the connection failure
+    // names verbatim.
+    let output = start_with_embedder(
+        "openai",
+        &[
+            ("VELESDB_MEMORY_EMBEDDER_URL", "http://127.0.0.1:1"),
+            ("VELESDB_MEMORY_OLLAMA_URL", "http://127.0.0.1:2"),
+            ("VELESDB_MEMORY_EMBEDDER_MODEL", "bge-m3"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("127.0.0.1:1"),
+        "the role-named URL must be the one actually called, got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("127.0.0.1:2"),
+        "the legacy alias must not be what was called, got: {stderr}"
+    );
+    let notices = stderr
+        .lines()
+        .filter(|line| line.contains("VELESDB_MEMORY_OLLAMA_URL"))
+        .count();
+    assert_eq!(
+        notices, 1,
+        "exactly ONE notice about the disagreement — not one per read, not none. \
+         Got: {stderr}"
+    );
+}
+
+#[test]
+fn the_legacy_alias_alone_still_configures_the_embedder() {
+    // The compatibility guarantee, stated as a test: a setup that predates the
+    // role-named variables must keep working with nothing changed.
+    let output = start_with_embedder(
+        "openai",
+        &[
+            ("VELESDB_MEMORY_OLLAMA_URL", "http://127.0.0.1:2"),
+            ("VELESDB_MEMORY_OLLAMA_MODEL", "bge-m3"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("127.0.0.1:2"),
+        "the legacy alias must still be honoured when it is the only one set, \
+         got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("VELESDB_MEMORY_OLLAMA_URL is set under two names"),
+        "using the alias as intended is not a conflict, got: {stderr}"
+    );
+}
+
+#[test]
+fn an_empty_api_token_is_refused_rather_than_sent_as_a_blank_bearer() {
+    // Edge case with teeth: `VELESDB_MEMORY_EXTRACTOR_API_TOKEN=` is what a
+    // shell produces when an expansion yields nothing. Sending
+    // `Authorization: Bearer ` gets rejected as a BAD credential, sending
+    // nothing gets rejected as a MISSING one, and the operator debugs the
+    // wrong half of their setup either way.
+    let store = tempfile::tempdir().expect("tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env_clear()
+        .env("HOME", store.path())
+        .env("VELESDB_MEMORY_PATH", store.path())
+        .env("VELESDB_MEMORY_EXTRACTOR", "openai")
+        .env("VELESDB_MEMORY_EXTRACTOR_URL", "http://localhost:8028")
+        .env("VELESDB_MEMORY_EXTRACTOR_MODEL", "ornith")
+        .env("VELESDB_MEMORY_EXTRACTOR_API_TOKEN", "")
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("failed to spawn velesdb-memory");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "an empty token must not start");
+    assert!(
+        stderr.contains("VELESDB_MEMORY_EXTRACTOR_API_TOKEN"),
+        "the refusal must name the variable, got: {stderr}"
+    );
+}

--- a/crates/velesdb-memory/tests/embedding_provenance_bdd.rs
+++ b/crates/velesdb-memory/tests/embedding_provenance_bdd.rs
@@ -1,0 +1,211 @@
+//! End-to-end behaviour of the embedding-model record (#1751, arbitration A1).
+//!
+//! The unit tests next to `src/embedding_provenance.rs` prove the comparison;
+//! these prove the daemon actually runs it, and — the part no pure test can
+//! reach — that the record is written for a store with no facts and **never**
+//! over one that has them.
+//!
+//! Why the same-dimension case is the one that matters: `velesdb-core` already
+//! refuses a collection whose dimension differs, so `bge-m3` (1024) against
+//! `all-minilm` (384) was never the silent failure. Two *different* models of
+//! the *same* width open fine and return nonsense — this crate's own `hash`
+//! embedder is 384-dimensional, and so is `all-minilm`. That is the gap under
+//! test here.
+//!
+//! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
+
+#![cfg(feature = "persistence")]
+
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// The daemon opens the store, answers, and exits on EOF; nothing here waits
+/// on a network call.
+const EXIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+const PROVENANCE_FILE: &str = "embedding-provenance.json";
+
+/// Run the daemon against `store`, optionally sending `requests` over stdio,
+/// then close stdin and return `(exit_ok, stderr)`.
+///
+/// `env_clear` for the same reason as the dispatch suite: a developer running
+/// this with a real `VELESDB_MEMORY_EMBEDDER` exported would otherwise test
+/// their own configuration instead of the default one.
+fn run_daemon(store: &Path, requests: &[String]) -> (bool, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env_clear()
+        .env("HOME", store)
+        .env("VELESDB_MEMORY_PATH", store)
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn velesdb-memory");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        let mut stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        for request in requests {
+            writeln!(stdin, "{request}").expect("write request");
+            stdin.flush().expect("flush");
+            // One reply per request, read before sending the next: the server
+            // answers concurrently, so a batched write lets a later reply
+            // overtake an earlier one.
+            if request.contains("\"id\"") {
+                let mut line = String::new();
+                stdout.read_line(&mut line).expect("read reply");
+                // BOTH failure shapes. A refused tool call comes back as a
+                // perfectly successful JSON-RPC *result* carrying
+                // `isError: true`, so checking only for a JSON-RPC `error`
+                // reads a failed `remember` as a stored fact — which is how
+                // this very harness first "proved" that a seeded store had
+                // nothing in it.
+                assert!(
+                    !line.contains("\"error\"") && !line.contains("\"isError\":true"),
+                    "the daemon refused a request: {line}"
+                );
+            }
+        }
+    }
+    child.stdin.take();
+
+    let start = std::time::Instant::now();
+    loop {
+        if child.try_wait().expect("wait").is_some() {
+            let output = child.wait_with_output().expect("collect");
+            return (
+                output.status.success(),
+                String::from_utf8_lossy(&output.stderr).into_owned(),
+            );
+        }
+        assert!(
+            start.elapsed() < EXIT_TIMEOUT,
+            "the daemon did not exit within {EXIT_TIMEOUT:?}"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
+fn initialize() -> String {
+    r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"provenance_bdd","version":"0"}}}"#.to_owned()
+}
+
+fn initialized() -> String {
+    r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_owned()
+}
+
+/// The argument is `fact`, not `content` — `content` belongs to the context
+/// compiler's fragments, and passing it here returns `isError: true` inside an
+/// otherwise successful frame.
+fn remember(text: &str) -> String {
+    format!(
+        r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"remember","arguments":{{"fact":"{text}"}}}}}}"#
+    )
+}
+
+fn record_of(store: &Path) -> Option<serde_json::Value> {
+    let raw = std::fs::read_to_string(store.join(PROVENANCE_FILE)).ok()?;
+    Some(serde_json::from_str(&raw).expect("the record must be valid JSON"))
+}
+
+#[test]
+fn a_fresh_store_records_the_model_it_was_created_with() {
+    let store = tempfile::tempdir().expect("tempdir");
+    let (ok, stderr) = run_daemon(store.path(), &[initialize()]);
+    assert!(ok, "a fresh store must open cleanly; stderr: {stderr}");
+
+    let record = record_of(store.path()).expect("a fresh store must be stamped");
+    assert_eq!(record["model"], "hash", "the default embedder is `hash`");
+    assert_eq!(
+        record["dimension"], 384,
+        "and `hash` is 384-dimensional — the same width as `all-minilm`, which \
+         is exactly why the model has to be recorded alongside it"
+    );
+    assert!(
+        record.get("backend").is_none(),
+        "the backend is a transport and must not be recorded: the same model \
+         over Ollama or over an OpenAI-compatible API yields the same vectors"
+    );
+}
+
+#[test]
+fn a_recorded_model_is_refused_by_a_different_one_of_the_same_width() {
+    // THE case the record exists for. 384 on both sides, so `velesdb-core`'s
+    // dimension check passes and would have let this open silently.
+    let store = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        store.path().join(PROVENANCE_FILE),
+        r#"{"model":"all-minilm","dimension":384}"#,
+    )
+    .expect("pre-stamp the store");
+
+    let (ok, stderr) = run_daemon(store.path(), &[]);
+    assert!(!ok, "a model change must not open the store");
+    assert!(
+        stderr.contains("all-minilm") && stderr.contains("hash"),
+        "the refusal must name both configurations, got: {stderr}"
+    );
+}
+
+#[test]
+fn a_store_that_already_holds_facts_is_never_stamped_retroactively() {
+    // A store created before this record existed. Simulated the only honest
+    // way: let the daemon create one, put a fact in it, then remove the record
+    // so the next open sees data with no provenance.
+    let store = tempfile::tempdir().expect("tempdir");
+    let (ok, stderr) = run_daemon(
+        store.path(),
+        &[initialize(), initialized(), remember("un fait durable")],
+    );
+    assert!(ok, "the seeding run must succeed; stderr: {stderr}");
+    std::fs::remove_file(store.path().join(PROVENANCE_FILE)).expect("remove the record");
+
+    let (ok, stderr) = run_daemon(store.path(), &[initialize()]);
+    assert!(
+        ok,
+        "a store with no record must still open — the compatibility guarantee; \
+         stderr: {stderr}"
+    );
+    assert!(
+        record_of(store.path()).is_none(),
+        "stamping a store that already holds vectors would carve a provenance \
+         nobody verified, and every later check would trust it"
+    );
+}
+
+#[test]
+fn an_empty_store_with_no_record_is_stamped_on_the_next_open() {
+    // The edge that makes the rule "no facts", not "new directory": a store
+    // that exists but holds nothing has no vector that could have come from
+    // another model, so recording states something true. A directory-shaped
+    // test would also be defeated by the config file the docs put right here.
+    let store = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        store.path().join("velesdb-memory.toml"),
+        "# a config file living beside the store, exactly as documented\n",
+    )
+    .expect("write config");
+
+    let (ok, stderr) = run_daemon(store.path(), &[initialize()]);
+    assert!(ok, "must open; stderr: {stderr}");
+    assert!(
+        record_of(store.path()).is_some(),
+        "a config file sitting in the store directory must not be mistaken for \
+         stored data"
+    );
+}
+
+#[test]
+fn a_damaged_record_stops_the_daemon_instead_of_silently_skipping_the_check() {
+    let store = tempfile::tempdir().expect("tempdir");
+    std::fs::write(store.path().join(PROVENANCE_FILE), "{ truncated").expect("write junk");
+
+    let (ok, stderr) = run_daemon(store.path(), &[]);
+    assert!(!ok, "an unreadable record must not be treated as absent");
+    assert!(
+        stderr.contains(PROVENANCE_FILE),
+        "the refusal must name the file to delete, got: {stderr}"
+    );
+}

--- a/crates/velesdb-memory/tests/openai_auth_bdd.rs
+++ b/crates/velesdb-memory/tests/openai_auth_bdd.rs
@@ -258,3 +258,46 @@ fn debug_never_prints_the_secret() {
          provider is still diagnosable: {custom}"
     );
 }
+
+// --- The request LINE, not just its headers ---------------------------------
+
+#[test]
+fn a_base_url_copied_with_its_version_prefix_still_hits_the_right_path() {
+    // Byte-level, for the same reason the header tests are: only the socket
+    // shows whether the path was doubled. The URL under test is the literal
+    // string an oMLX console offers to copy — `http://127.0.0.1:8019/v1` —
+    // which a naive concatenation turns into `/v1/v1/chat/completions`.
+    let (addr, server) = capture_one_request(CHAT_RESPONSE);
+    let extractor = OpenAiExtractor::new(format!("http://{addr}/v1"), "ornith-35b", Auth::None);
+    let _ = extractor.extract("peu importe le texte");
+    let captured = server.join().expect("stub thread");
+    let request_line = captured.lines().next().unwrap_or_default();
+
+    assert!(
+        request_line.contains("/v1/chat/completions"),
+        "the protocol path must be reached exactly once, got: {request_line}"
+    );
+    assert!(
+        !request_line.contains("/v1/v1/"),
+        "a base URL that already carries the version prefix must not double it \
+         — that is a 404 whose cause is invisible. Got: {request_line}"
+    );
+}
+
+#[test]
+fn an_origin_without_the_prefix_reaches_the_same_path() {
+    // The control: both spellings must land on one identical request line, or
+    // the normalisation above traded one surprise for another.
+    let (addr, server) = capture_one_request(CHAT_RESPONSE);
+    let extractor = OpenAiExtractor::new(format!("http://{addr}"), "ornith-35b", Auth::None);
+    let _ = extractor.extract("peu importe le texte");
+    let captured = server.join().expect("stub thread");
+    assert!(
+        captured
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .contains("/v1/chat/completions"),
+        "got: {captured}"
+    );
+}

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -235,6 +235,33 @@ launched with:
 - **`ollama`:** real on-device semantic recall. Requires a build with
   `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
   `VELESDB_MEMORY_EMBEDDER=ollama`.
+- **`openai`:** any OpenAI-compatible server — oMLX, llama.cpp, LM Studio,
+  vLLM, or a hosted provider. Same `--features ollama` build (that feature
+  carries the HTTP dependency for the embedding role, and its name predates
+  the protocol split). `openai` names a **protocol, not a vendor**: reaching a
+  different server is a different URL, never a new backend name. It therefore
+  has **no default URL and no default model** — set
+  `VELESDB_MEMORY_EMBEDDER_URL` and `_MODEL` yourself.
+
+The extraction role takes the same three-way choice — `outline`, `ollama`,
+`openai` — under `VELESDB_MEMORY_EXTRACTOR`, and **the two roles are
+configured independently**: nothing requires them to share a backend, a server
+or a token. Embedding on a local Ollama while extracting on an
+OpenAI-compatible server is a supported combination.
+
+The base URL may be written **with or without** the `/v1` suffix. Server
+consoles advertise the version-prefixed form (`http://127.0.0.1:8019/v1`)
+beside a copy button, so pasting it works instead of producing
+`/v1/v1/embeddings` and a `404`.
+
+**A store is fixed to one embedding MODEL, not to one backend.** The store
+records the model that filled it (`embedding-provenance.json`) and refuses to
+open under a different one — including a different model of the same width,
+which the dimension check alone cannot see. Changing only the *transport* is
+safe: the same model over Ollama or over an OpenAI-compatible API produces the
+same vectors, so the backend is deliberately not part of the record. A store
+created before this recording existed stays unrecorded and is checked on the
+dimension alone, and says so.
 
 ### Configure it in a file, not in a plist
 
@@ -249,10 +276,18 @@ default_ttl = 0                # seconds; 0 = permanent
 [embedder]
 backend = "ollama"             # `hash` is lexical, not semantic — see above
 model = "bge-m3"
+# url = "http://127.0.0.1:8019"  # required by "openai"; defaulted by "ollama"
 
 [extractor]
-backend = "ollama"             # or "outline" — infers vs reads directives, see above
-model = "qwen3.6:35b-mlx"      # "ollama" only; "outline" needs no model
+backend = "ollama"             # or "outline"/"openai" — see above
+model = "qwen3.6:35b-mlx"      # required by "ollama" and "openai"; "outline" needs none
+# url = "http://127.0.0.1:8019"  # required by "openai"; defaulted by "ollama"
+
+# There is deliberately NO api_token field, in either section. A token is read
+# from VELESDB_MEMORY_EMBEDDER_API_TOKEN / VELESDB_MEMORY_EXTRACTOR_API_TOKEN
+# and from nowhere else — a credential at rest in a versionable file is one
+# `git add .` away from a public history. Writing one here is refused at
+# startup, and the refusal does not echo the line back.
 
 [graph]
 autograph = false              # true = every `remember` also wires entities

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -530,24 +530,56 @@ quality, and `why`'s seed match, depend on it.
 |---|---|---|---|
 | `hash` (default) | keyword-ish, deterministic | tiny, **fully offline, zero-dep** | nothing |
 | `ollama` | real semantic | tiny binary + your local model | a running Ollama; build `--features ollama` |
+| `openai` | real semantic | tiny binary + whatever serves the model | any OpenAI-compatible server; build `--features ollama` |
 
 The default keeps the *single tiny offline binary* promise intact. For real
 semantic recall, build with the `ollama` feature and point it at a local model
-— the model runs in your own Ollama, so memory still never leaves the machine:
+— the model runs on your own machine, so memory still never leaves it:
 
 ```bash
 cargo build --release -p velesdb-memory --features ollama
 ollama pull all-minilm
 VELESDB_MEMORY_EMBEDDER=ollama \
-VELESDB_MEMORY_OLLAMA_MODEL=all-minilm \
+VELESDB_MEMORY_EMBEDDER_MODEL=all-minilm \
   /path/to/velesdb-memory
 ```
 
-Env vars: `VELESDB_MEMORY_OLLAMA_URL` (default `http://localhost:11434`),
-`VELESDB_MEMORY_OLLAMA_MODEL` (default `all-minilm`).
+Env vars: `VELESDB_MEMORY_EMBEDDER_URL` (default `http://localhost:11434` for
+`ollama`, **required** for `openai`), `VELESDB_MEMORY_EMBEDDER_MODEL` (default
+`all-minilm` for `ollama`, **required** for `openai`),
+`VELESDB_MEMORY_EMBEDDER_API_TOKEN` (optional; when unset, **no**
+`Authorization` header is sent).
+
+`VELESDB_MEMORY_OLLAMA_URL` and `VELESDB_MEMORY_OLLAMA_MODEL` remain supported
+as aliases of the two role-named variables above, so an existing setup keeps
+working unchanged. If both names are set to *different* values, the role-named
+one wins and the daemon says so once at startup.
+
+### `openai` is a protocol, not a vendor
+
+The `openai` value selects the OpenAI-compatible HTTP shape (`/v1/embeddings`,
+`/v1/chat/completions`), which oMLX, llama.cpp's server, LM Studio, vLLM and
+the hosted providers all speak. Reaching a different server is a **different
+URL**, never a new backend name — which is why neither the URL nor the model
+has a default here: guessing either would pick one of those servers for you.
+
+```bash
+VELESDB_MEMORY_EMBEDDER=openai \
+VELESDB_MEMORY_EMBEDDER_URL=http://localhost:8020 \
+VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
+  /path/to/velesdb-memory
+```
+
+**API tokens are read from the environment only.** There is deliberately no
+`api_token` field in `velesdb-memory.toml`, and putting one there is refused at
+startup: a credential at rest in a versionable file is one `git add .` away
+from a public history.
 
 **The embedding dimension is probed from the model, so a store is fixed to one
-embedder** — do not switch embedders on an existing store.
+embedder** — do not switch embedding *models* on an existing store. Switching
+the *transport* is safe: the same model served by Ollama or by an
+OpenAI-compatible server produces the same vectors, and the daemon compares the
+model and the dimension rather than which backend served them.
 
 ## Auto-extraction backend (opt-in)
 
@@ -564,11 +596,28 @@ VELESDB_MEMORY_EXTRACTOR_MODEL=qwen3.6:35b-mlx \
   /path/to/velesdb-memory
 ```
 
-Env vars: `VELESDB_MEMORY_EXTRACTOR` (`ollama` or `outline`),
-`VELESDB_MEMORY_EXTRACTOR_URL` (default `http://localhost:11434`, `ollama`
-only), `VELESDB_MEMORY_EXTRACTOR_MODEL` (a generative model — required for
-`ollama`, unused by `outline`). Without a backend the tool returns a clear
-"not configured" error.
+Env vars: `VELESDB_MEMORY_EXTRACTOR` (`outline`, `ollama` or `openai`),
+`VELESDB_MEMORY_EXTRACTOR_URL` (default `http://localhost:11434` for `ollama`,
+**required** for `openai`, unused by `outline`),
+`VELESDB_MEMORY_EXTRACTOR_MODEL` (a generative model — required for `ollama`
+and `openai`, unused by `outline`), `VELESDB_MEMORY_EXTRACTOR_API_TOKEN`
+(optional; when unset, **no** `Authorization` header is sent). Without a
+backend the tool returns a clear "not configured" error.
+
+`openai` is the same OpenAI-compatible protocol described under
+[Embedding backend](#embedding-backend), reached over
+`/v1/chat/completions`:
+
+```bash
+VELESDB_MEMORY_EXTRACTOR=openai \
+VELESDB_MEMORY_EXTRACTOR_URL=http://localhost:8028 \
+VELESDB_MEMORY_EXTRACTOR_MODEL=your-model \
+  /path/to/velesdb-memory
+```
+
+**The two roles are configured independently** — nothing requires them to share
+a backend, a server or a token. Embedding on a local Ollama while extracting on
+an OpenAI-compatible server is a supported combination, not an accident.
 
 The two backends are **not** interchangeable:
 

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -565,10 +565,15 @@ has a default here: guessing either would pick one of those servers for you.
 
 ```bash
 VELESDB_MEMORY_EMBEDDER=openai \
-VELESDB_MEMORY_EMBEDDER_URL=http://localhost:8020 \
+VELESDB_MEMORY_EMBEDDER_URL=http://127.0.0.1:8019 \
 VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
   /path/to/velesdb-memory
 ```
+
+The URL may be written **with or without** the `/v1` suffix — both reach the
+same endpoint. Server consoles advertise the version-prefixed form
+(`http://127.0.0.1:8019/v1`) next to a copy button, so pasting it must work
+rather than silently produce `/v1/v1/embeddings` and a `404`.
 
 **API tokens are read from the environment only.** There is deliberately no
 `api_token` field in `velesdb-memory.toml`, and putting one there is refused at
@@ -610,14 +615,23 @@ backend the tool returns a clear "not configured" error.
 
 ```bash
 VELESDB_MEMORY_EXTRACTOR=openai \
-VELESDB_MEMORY_EXTRACTOR_URL=http://localhost:8028 \
+VELESDB_MEMORY_EXTRACTOR_URL=http://127.0.0.1:8019 \
 VELESDB_MEMORY_EXTRACTOR_MODEL=your-model \
   /path/to/velesdb-memory
 ```
 
 **The two roles are configured independently** — nothing requires them to share
 a backend, a server or a token. Embedding on a local Ollama while extracting on
-an OpenAI-compatible server is a supported combination, not an accident.
+an OpenAI-compatible server is a supported combination, not an accident:
+
+```bash
+VELESDB_MEMORY_EMBEDDER=ollama \
+VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
+VELESDB_MEMORY_EXTRACTOR=openai \
+VELESDB_MEMORY_EXTRACTOR_URL=http://127.0.0.1:8019 \
+VELESDB_MEMORY_EXTRACTOR_MODEL=your-model \
+  /path/to/velesdb-memory
+```
 
 The two backends are **not** interchangeable:
 

--- a/scripts/prove-openai-memory-write.py
+++ b/scripts/prove-openai-memory-write.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Prove that a velesdb-memory daemon can WRITE against its configured embedder.
+
+Runs a throwaway daemon over stdio on a TEMPORARY store, so the operator's own
+daemon is never restarted and their real memory is never touched.
+
+Requests are sent one at a time, each waiting for its own response: the server
+answers concurrently, so a batch of lines would let `load` overtake `save` and
+report `found: false` on a store that was written correctly.
+
+Usage:
+    python3 scripts/prove-openai-memory-write.py path/to/velesdb-memory
+
+Every VELESDB_MEMORY_* variable in the environment is passed through, which is
+how the embedder under test is selected.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PROTOCOL_VERSION = "2024-11-05"
+GOAL = "preuve d'ecriture sur le backend configure"
+
+
+def send(proc, message):
+    """Write one JSON-RPC message, then block for the reply carrying its id."""
+    proc.stdin.write(json.dumps(message) + "\n")
+    proc.stdin.flush()
+    if "id" not in message:
+        return None
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            raise SystemExit("the daemon closed its output before answering")
+        try:
+            reply = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # not a JSON-RPC frame
+        if reply.get("id") == message["id"]:
+            return reply
+
+
+def call(proc, call_id, tool, arguments):
+    return send(proc, {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": arguments},
+    })
+
+
+def report(label, reply):
+    """Print the raw result, and say plainly whether it succeeded."""
+    payload = reply.get("result") or reply.get("error")
+    print(f"\n=== {label} ===")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    failed = "error" in reply or (reply.get("result") or {}).get("isError")
+    print(f"--> {'ECHEC' if failed else 'OK'}")
+    return not failed
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(f"usage: {sys.argv[0]} path/to/velesdb-memory")
+    binary = sys.argv[1]
+
+    with tempfile.TemporaryDirectory() as store:
+        env = dict(os.environ)
+        env["VELESDB_MEMORY_PATH"] = store
+        env["VELESDB_MEMORY_QUIET"] = "1"
+        print("Variables VELESDB_MEMORY_* en vigueur :")
+        for key in sorted(k for k in env if k.startswith("VELESDB_MEMORY_")):
+            shown = "<redacted>" if "TOKEN" in key or "KEY" in key else env[key]
+            print(f"  {key}={shown}")
+
+        proc = subprocess.Popen(
+            [binary],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            text=True,
+            env=env,
+        )
+        try:
+            send(proc, {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "preuve-openai", "version": "0"},
+                },
+            })
+            send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+            saved = report("save_working_context", call(proc, 2, "save_working_context", {
+                "project": "preuve",
+                "session": "omlx",
+                "working": {"goal": GOAL},
+            }))
+            loaded = report("load_working_context", call(proc, 3, "load_working_context", {
+                "project": "preuve",
+                "session": "omlx",
+            }))
+        finally:
+            proc.stdin.close()
+            proc.wait(timeout=30)
+
+    print("\n=== VERDICT ===")
+    print(f"save_working_context : {'OK' if saved else 'ECHEC'}")
+    print(f"load_working_context : {'OK' if loaded else 'ECHEC'}")
+    raise SystemExit(0 if saved and loaded else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.json
+++ b/server.json
@@ -26,7 +26,7 @@
         },
         {
           "name": "VELESDB_MEMORY_EMBEDDER",
-          "description": "Embedding backend: 'hash' (default, offline, zero-dep) or 'ollama' (real semantic recall via a local model; binary must be built --features ollama).",
+          "description": "Embedding backend: 'hash' (default, offline, zero-dep), 'ollama' (real semantic recall via a local model), or 'openai' (any OpenAI-compatible server — oMLX, llama.cpp, LM Studio, vLLM, a hosted provider — set VELESDB_MEMORY_EMBEDDER_URL and _MODEL). Both remote backends need a binary built --features ollama.",
           "isRequired": false,
           "default": "hash"
         }


### PR DESCRIPTION
Ferme le lot 3 de #1751 : les deux rôles d'inférence acceptent un backend
`openai`, et le démon aiguille enfin sur le nom que la bibliothèque lui donne.

## Le défaut central, mesuré

`select_extractor` porte le nom du backend depuis #1734. Le démon le jetait :

```rust
ExtractorSelection::NeedsRemoteConfig(_) => build_ollama_extractor()
```

Demander `openai` répondait donc `VELESDB_MEMORY_EXTRACTOR=ollama requires
VELESDB_MEMORY_EXTRACTOR_MODEL` — sortie capturée en remettant le `_` en place,
et c'est ce que `tests/backend_dispatch_bdd.rs` refuse désormais. Le **même**
wildcard vivait dans `apply_autograph` : l'autographe et `remember_extracted`
auraient parlé à deux serveurs différents sur un seul démon.

## Ce que le lot contient

- `openai` accepté par `select_embedder` et `select_extractor`. Un protocole,
  pas un fournisseur : joindre un autre serveur est une URL différente, jamais
  un nom de plus. Donc **ni URL ni modèle par défaut**.
- Variables role-nommées côté embedding (`_URL`, `_MODEL`, `_API_TOKEN`), les
  `VELESDB_MEMORY_OLLAMA_*` restant des alias. Valeurs différentes sous les deux
  noms : **un seul** avertissement, le nom de rôle gagne.
- Token en environnement uniquement. Pas de header du tout sans token ; un token
  vide est refusé. `api_token` dans le TOML est refusé — et le refus est réécrit,
  car le parseur cite la ligne fautive et aurait imprimé le secret sur stderr.
- Le magasin enregistre le **modèle** d'embedding. `velesdb-core` attrape déjà
  les dimensions différentes ; deux modèles de même largeur s'ouvraient et
  rendaient du bruit (`hash` fait 384, `all-minilm` aussi). Le **backend n'est
  pas enregistré** : c'est un transport. Estampille uniquement sur un magasin
  sans aucun fait, jamais sur des données existantes. Magasin antérieur =
  contrôle dégradé à la dimension, et le message le dit.
- Une URL de base portant déjà `/v1` ne double plus le préfixe : les consoles
  serveur affichent la forme préfixée à côté d'un bouton copier. Mesuré au
  niveau des octets — `POST /v1/v1/chat/completions` avant, une seule fois après.

## Portes

489 (462+27) · 442 (419+23) · wasm 656 inchangé · clippy workspace et crate
pedantic · matrice de 6 features · `Ran 211 ... OK` · doc-contract · bindings.
Le décompte des +27 : 1 embedder, 5 extracteur, 7 config, 10 provenance, 4 URL.

## Hors périmètre, décidé

#1752, la ré-indexation (#1762), le renommage des features (#1766), les 48
erreurs `--all-targets` (#1765). Python, Node et WASM gardent leur énumération :
leur parité est un lot dédié.

## Non prouvable en CI

Qu'un serveur oMLX réel réponde. `scripts/prove-openai-memory-write.py` le
vérifie sur la machine de l'opérateur, sur un démon jetable et un magasin
temporaire.

Refs #1751