### PR TITLE
fix(sdk): le fragment TypeScript déclare enfin priority

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -95,6 +95,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TypeScript SDK: `CompileContextFragment` gains `priority`.** The wire has
+  accepted it since the context compiler shipped, and this SDK never declared
+  it — so a TypeScript caller could reach `compileContext` and not express the
+  one input that controls what a tight budget drops. Found by deriving both
+  field lists from source rather than reading either one.
+
+  A new parity check in `tests/binding_parity_bdd.rs` holds the SDK's fragment
+  against the canonical `ContextFragment`, so a field added to one and not the
+  other turns red. Method parity already proved a tool was *reachable*; this
+  proves its *input* can be expressed.
+
+  **`path` stays undeclared, on every binding, by decision.** Resolving a path
+  fragment is a server-side I/O pre-pass gated on `VELESDB_MEMORY_INGEST_ROOTS`,
+  an operator-configured allowlist — the WASM binding has neither a filesystem
+  nor that setting, and neither `velesdb-node` nor `velesdb-python` resolves
+  paths. Declaring it would publish a field that always fails. The exemption is
+  written down next to the check, with its reason, because an absence by
+  decision and an absence by oversight look identical from the outside.
+
 - **A base URL carrying the `/v1` prefix no longer doubles it (#1751).**
   Servers advertise their OpenAI-compatible endpoint *with* the version prefix
   — oMLX's console shows `http://127.0.0.1:8019/v1` beside a copy button — and

--- a/crates/velesdb-memory/tests/binding_parity_bdd.rs
+++ b/crates/velesdb-memory/tests/binding_parity_bdd.rs
@@ -1407,3 +1407,140 @@ fn the_sdk_check_distinguishes_the_class_from_the_interface() {
     let gaps = sdk_gaps(&tools, &upstream, &absent, &present);
     assert!(gaps[0].contains("NOT the class"), "got: {}", gaps[0]);
 }
+
+// --- Field parity: the context compiler's fragment ---------------------------
+//
+// Method parity, above, proves a tool is REACHABLE from the SDK. It says
+// nothing about whether the SDK can express the tool's input — and that is a
+// second way to publish a promise nobody can use.
+//
+// Measured on 2026-08-02: `CompileContextFragment` in the TypeScript SDK was
+// missing `path` (file ingestion, V2b-1 — advertised by the server and by both
+// SKILL.md copies) and `priority` ("higher packs first", the knob that decides
+// what survives a token budget). A TypeScript caller could reach
+// `compileContext` and still not use half of what it accepts.
+//
+// Both lists are read from source, never written down here: adding a field to
+// the canonical fragment without adding it to the SDK turns this red on the
+// spot, which a hard-coded expectation could not do.
+
+/// Where the canonical wire shape of a context fragment is declared.
+const FRAGMENT_SOURCE: &str = "crates/velesdb-memory/src/context/model.rs";
+const FRAGMENT_STRUCT: &str = "pub struct ContextFragment {";
+
+/// Where the TypeScript SDK declares the same fragment.
+const SDK_FRAGMENT: &str = "export interface CompileContextFragment {";
+
+/// Field names of the `struct` opened by `opening`, up to the next column-0 `}`.
+fn rust_struct_fields(source_path: &str, opening: &str) -> BTreeSet<String> {
+    let path = workspace_root().join(source_path);
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("read {source_path} ({}): {err}", path.display()));
+    let mut lines = source.lines().skip_while(|l| l.trim() != opening);
+    assert!(
+        lines.next().is_some(),
+        "{source_path} no longer contains `{opening}` — point the constant at the renamed struct",
+    );
+    lines
+        .take_while(|l| *l != "}")
+        .filter_map(|line| {
+            let declaration = line.trim().strip_prefix("pub ")?;
+            let (name, _) = declaration.split_once(':')?;
+            name.chars()
+                .all(|c| c.is_alphanumeric() || c == '_')
+                .then(|| name.to_owned())
+        })
+        .collect()
+}
+
+/// Field names of the TypeScript interface opened by `opening`.
+fn typescript_interface_fields(opening: &str) -> BTreeSet<String> {
+    let path = workspace_root().join(SDK_SOURCE);
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("read {SDK_SOURCE} ({}): {err}", path.display()));
+    let mut lines = source.lines().skip_while(|l| l.trim() != opening);
+    assert!(
+        lines.next().is_some(),
+        "{SDK_SOURCE} no longer contains `{opening}` — point the constant at the renamed interface",
+    );
+    lines
+        .take_while(|l| *l != "}")
+        .filter_map(|line| {
+            let declaration = line.trim();
+            let (name, _) = declaration.split_once(':')?;
+            let name = name.trim_end_matches('?');
+            name.chars()
+                .all(|c| c.is_alphanumeric() || c == '_')
+                .then(|| name.to_owned())
+        })
+        .collect()
+}
+
+#[test]
+fn the_fragment_scans_read_something_on_both_sides() {
+    // Guard the guard: an empty scan on either side would make the parity
+    // assertion below pass (or fail) for reasons that have nothing to do with
+    // the SDK.
+    let canonical = rust_struct_fields(FRAGMENT_SOURCE, FRAGMENT_STRUCT);
+    assert!(
+        canonical.contains("content") && canonical.contains("id"),
+        "the canonical fragment scan parsed {canonical:?} — the scan is broken, not the struct",
+    );
+    let sdk = typescript_interface_fields(SDK_FRAGMENT);
+    assert!(
+        sdk.contains("content") && sdk.contains("id"),
+        "the SDK fragment scan parsed {sdk:?} — the scan is broken, not the SDK",
+    );
+}
+
+/// Fields the SDK deliberately does NOT declare, each with the reason.
+///
+/// Same shape as this file's tool-level exemptions, and for the same reason: a
+/// field that is absent by decision and a field that is absent by oversight
+/// look identical from the outside, and only a written reason tells them
+/// apart.
+const SDK_FRAGMENT_EXEMPTIONS: &[(&str, &str)] = &[(
+    "path",
+    "resolving a `path` fragment is a server-side I/O pre-pass gated on \
+     VELESDB_MEMORY_INGEST_ROOTS, an operator-configured allowlist of \
+     directories. This SDK runs on the WASM binding, which has neither a \
+     filesystem nor that setting. NO binding declares it — velesdb-node and \
+     velesdb-python do not resolve paths either; the MCP daemon is the only \
+     surface that can honour one, so declaring it here would be a field that \
+     always fails.",
+)];
+
+#[test]
+fn every_fragment_exemption_names_a_field_that_actually_exists() {
+    // An exemption for a field the canonical fragment no longer has would sit
+    // here forever, silently excusing nothing — and would hide the day a real
+    // field takes that name.
+    let canonical = rust_struct_fields(FRAGMENT_SOURCE, FRAGMENT_STRUCT);
+    for (field, _) in SDK_FRAGMENT_EXEMPTIONS {
+        assert!(
+            canonical.contains(*field),
+            "`{field}` is exempted from the SDK fragment but is not a field of the canonical \
+             fragment any more — delete the exemption",
+        );
+    }
+}
+
+#[test]
+fn the_typescript_fragment_declares_every_field_the_wire_accepts() {
+    let canonical = rust_struct_fields(FRAGMENT_SOURCE, FRAGMENT_STRUCT);
+    let mut sdk = typescript_interface_fields(SDK_FRAGMENT);
+    sdk.extend(
+        SDK_FRAGMENT_EXEMPTIONS
+            .iter()
+            .map(|(field, _)| (*field).to_owned()),
+    );
+    let missing: Vec<&String> = canonical.difference(&sdk).collect();
+    assert!(
+        missing.is_empty(),
+        "the TypeScript SDK's `CompileContextFragment` is missing {missing:?}, so a TypeScript \
+         caller cannot express input the server accepts. The tool is reachable and half of its \
+         contract is not — declare the field in {SDK_SOURCE}, or, if it is deliberately withheld, \
+         say so where a reader will see it rather than leaving the absence to look like an \
+         oversight.",
+    );
+}

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -13,6 +13,23 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 - **Compiler read tools in the browser**: `retrieveContextSource` retrieves the exact original content behind a compiled fragment (externalized sources included), directly from the WASM engine.
 - **Since 3.6.0 (3.7–3.11 recap)**: `compileContext` on the `MemoryService` (deterministic context compression, media fragments included), working-context `save`/`load`/`list` for cross-session resumption, `bulkDelete` over `POST points/delete`, and automatic retry with exponential backoff on 429/503 (idempotent methods only, capped `Retry-After`).
 
+### What a fragment carries, and the one field that is daemon-only
+
+`CompileContextFragment` accepts `id`, `content`, `kind`, `priority`,
+`metadata` and `media`. **`priority` is the knob that decides what survives a
+tight budget** — relevance ordering anchors on the query, and a higher
+`priority` packs a fragment ahead of it.
+
+The MCP wire also accepts a **`path`** field, reading a fragment's content from
+a file instead of sending it inline. **No SDK declares it, and that is
+deliberate**: resolving a path is a server-side I/O pre-pass gated on
+`VELESDB_MEMORY_INGEST_ROOTS`, an operator-configured allowlist of directories.
+This SDK runs on the WASM binding, which has neither a filesystem nor that
+setting — and neither `@wiscale/velesdb-memory-node` nor the Python binding
+resolves paths either. Path ingestion is a capability of the `velesdb-memory`
+**daemon**, reachable over MCP; from an SDK, read the file yourself and pass
+its text as `content`.
+
 ## What's New in v3.6.0
 
 - **Memory wedge, running in-browser via WASM**: new `MemoryService` class (`remember`/`recall`/`recallWhere`/`recallFused`/`relate`/`forget`/`why`) — the same local-first agent memory as `@wiscale/velesdb-memory-node` and the Python binding, now reachable without a server. In-memory only in this release (no filesystem access under WASM); see [Memory Wedge](#memory-wedge-agent-memory) below. Requires `@wiscale/velesdb-wasm` >= 3.6.0 — fresh installs resolve it automatically; on an upgrade, refresh the dependency in your lockfile (`init()` reports the exact cause otherwise).

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -79,6 +79,26 @@ export interface CompileContextFragment {
   content: string;
   /** Classification hint (`"code"`, `"log"`, `"screenshot"`, …). */
   kind?: string;
+  /**
+   * Caller priority; higher packs first. Defaults to `0`.
+   *
+   * The knob that decides what survives a tight budget: relevance ordering
+   * anchors on the query, and this overrides it for fragments the caller
+   * already knows must be kept ahead of the rest.
+   *
+   * The wire has accepted it since the compiler shipped; this SDK simply never
+   * declared it, so a TypeScript caller could reach `compileContext` and not
+   * express the one input that controls what it drops.
+   */
+  priority?: number;
+  // No `path` here, and its absence is a DECISION, not an oversight — see the
+  // note on the canonical fragment in
+  // `crates/velesdb-memory/src/context/model.rs`. Resolving a `path` fragment
+  // is a server-side I/O pre-pass gated on `VELESDB_MEMORY_INGEST_ROOTS`, an
+  // operator-configured allowlist of directories. This SDK runs on the WASM
+  // binding, which has neither a filesystem nor that setting, so a declared
+  // `path` would be a field that always fails. No binding declares it — the
+  // MCP daemon is the only surface that can honour one.
   /** Fragment flags, e.g. `{ verbatim: true }` or `{ cache: true }`. */
   metadata?: Record<string, unknown>;
   /**


### PR DESCRIPTION
Lot C des suites de #1751 : la parité du compilateur de contexte côté SDK.

## Ce que la parité existante ne voyait pas

`binding_parity_bdd.rs` prouvait qu'un outil est **atteignable** depuis le SDK.
Il ne disait rien de sa capacité à exprimer l'**entrée** de cet outil — seconde
façon de publier une promesse inutilisable.

Les deux listes de champs, dérivées des sources (jamais écrites en dur) :

| canonique `ContextFragment` | SDK TypeScript |
|---|---|
| `id`, `content`, `path`, `kind`, **`priority`**, `metadata`, `media` | `id`, `content`, `kind`, `metadata`, `media` |

**`priority` manquait.** C'est le levier qui décide de ce qu'un budget serré
laisse tomber : l'ordre par pertinence s'ancre sur la requête, `priority` passe
devant. Le fil l'accepte depuis la sortie du compilateur ; le SDK ne l'avait
jamais déclaré.

## Une correction de ma propre analyse

J'ai d'abord annoncé `path` comme un second écart de parité. **C'était faux**,
et je le corrige ici plutôt que de le livrer :

- `velesdb-wasm` ne contient **aucune** mention d'ingestion — il ne résout pas
  les fragments `path` ;
- `velesdb-node` et `velesdb-python` non plus (0 mention chacun) ;
- seul le serveur MCP le fait.

Résoudre un `path` est une pré-passe d'E/S **côté serveur**, gatée sur
`VELESDB_MEMORY_INGEST_ROOTS` — une liste blanche de répertoires configurée par
l'opérateur. C'est une capacité de **démon**, pas de bibliothèque : le SDK
TypeScript tourne sur WASM, qui n'a ni système de fichiers ni ce réglage.
Déclarer `path` aurait publié un champ qui échoue toujours.

L'absence est donc correcte. Ce qui manquait, c'est que **personne ne le
disait** — elle se lisait comme un oubli. L'exemption est désormais écrite à
côté du contrôle, avec sa raison, exactement comme ce fichier le fait déjà pour
`feedback` sur WASM.

## Preuves, exécutées

- **Rouge** : le contrôle a nommé `["path", "priority"]` avant correction.
- **Rouge après exemption** : `priority` retiré du SDK → rouge nommant
  `["priority"]` ; remis → vert. L'exemption n'a donc pas transformé le garde
  en passe-droit.
- Le contrôle porte **ses propres gardes** : les deux scans doivent lire
  quelque chose, et une exemption qui ne nomme plus un champ existant est
  refusée.
- `binding_parity_bdd` 15 → **18** · `tsc --noEmit` exit 0 · suite TS **37
  fichiers / 927 tests** · `unittest scripts/tests` **214 OK** ·
  `check-mcp-doc-contract.py` passé · `velesdb-memory` **489**.

## Documentation

Le README du SDK dit maintenant ce que porte un fragment, ce que `priority`
contrôle, et pourquoi `path` est réservé au démon — avec le contournement
(lire le fichier soi-même et passer son texte en `content`).