### PR TITLE
fix(skills): un installateur et un contrôle de dérive pour les copies installées

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -34,11 +34,11 @@ done
 # No Python, nothing to say. A merge must not look broken over a notice.
 [ -z "${PYTHON_CMD:-}" ] && exit 0
 
-if ! "$PYTHON_CMD" "$(git rev-parse --show-toplevel)/scripts/sync-skills.py" --check >/dev/null 2>&1; then
+if ! "$PYTHON_CMD" "$(git rev-parse --show-toplevel)/scripts/sync-skills.py" --check --strict >/dev/null 2>&1; then
     echo ""
     echo "⚠️  Installed skills are behind this repository."
     echo "    An agent loading them reads the OLD instructions — silently."
-    echo "    Details:  python3 scripts/sync-skills.py --check"
+    echo "    Details:  python3 scripts/sync-skills.py --check --strict"
     echo "    Re-sync:  python3 scripts/sync-skills.py --install"
     echo ""
 fi

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Tell the developer when a merge just moved the repository ahead of the
+# skills installed under ~/.claude/skills (#1712).
+#
+# WHY HERE, AND NOT IN pre-commit
+#
+# `--check` compares the installed copy against the repository's. On a branch
+# where you are editing a SKILL.md, those two legitimately differ — and a
+# pre-commit gate would refuse the commit until you ran `--install`, which
+# would push UNMERGED work into your global skills. That is precisely the
+# outcome the installer was chosen over a symlink to avoid.
+#
+# A merge is the moment the repository genuinely moves ahead of the install,
+# and it is the drift that hurt: the repo advanced across many commits while
+# `~/.claude/skills` stayed where it was, until an installed SKILL.md was 67
+# lines behind and stated the wrong argument order for a published method.
+#
+# This hook cannot block anything — git ignores post-merge's exit status — and
+# it is not trying to. It reports, at the one moment the information is
+# actionable. The gate is the command itself: `--check` exits non-zero, so a
+# script or a person can enforce it anywhere. Hooks are bypassable; that is
+# why the command stays runnable by hand.
+
+set -u
+
+for _py in python3 python py; do
+    _bin=$(command -v "$_py" 2>/dev/null || true)
+    if [ -n "${_bin:-}" ] && "$_bin" -c "import sys; sys.exit(0)" 2>/dev/null; then
+        PYTHON_CMD="$_bin"
+        break
+    fi
+done
+
+# No Python, nothing to say. A merge must not look broken over a notice.
+[ -z "${PYTHON_CMD:-}" ] && exit 0
+
+if ! "$PYTHON_CMD" "$(git rev-parse --show-toplevel)/scripts/sync-skills.py" --check >/dev/null 2>&1; then
+    echo ""
+    echo "⚠️  Installed skills are behind this repository."
+    echo "    An agent loading them reads the OLD instructions — silently."
+    echo "    Details:  python3 scripts/sync-skills.py --check"
+    echo "    Re-sync:  python3 scripts/sync-skills.py --install"
+    echo ""
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,23 +229,44 @@ python3 scripts/sync-skills.py --install
 
 # Report drift; exits non-zero when an installed copy differs
 python3 scripts/sync-skills.py --check
+
+# Same, but an ABSENT managed skill also fails (what the post-merge hook runs)
+python3 scripts/sync-skills.py --check --strict
 ```
+
+Each managed skill is reported as one of **three** states, never two:
+
+| état | signification | `--check` | `--check --strict` |
+|---|---|---|---|
+| `in step` | l'agent lit la bonne chose | vert | vert |
+| `drifted` | l'agent lit la **mauvaise** chose | **exit 1** | **exit 1** |
+| `absent` | l'agent ne lit **rien** | rapporté, exit 0 | **exit 1** |
 
 - **Only those two skills are touched.** Any other skill installed in that
   directory is left exactly as it is — the tool works from an explicit pair
   list, never a scan.
-- **A skill that is not installed is not drift.** You cannot drift from
-  something you never had, so `--check` skips it and stays green. Only an
-  installed copy whose bytes differ is a failure.
+- **`--strict` widens what ABSENCE costs, and nothing else.** Plain `--check`
+  forgives it because a contributor who never installed these must not have
+  their work refused over a machine-local state; it still says so, since
+  silence would leave you unable to tell "installed and correct" from "not
+  there at all".
 - **The copy is atomic.** The new tree is built beside the target and moved
   into place by rename, so an agent reading a SKILL.md during an install sees
   the whole old version or the whole new one — never half of each.
-- `.githooks/post-merge` runs `--check` and prints a notice when a merge has
-  just moved the repository ahead of your install. It deliberately does **not**
-  block: `--check` compares against the working tree, so gating a commit would
-  force you to install unmerged work into your global skills. Hooks are also
-  bypassable, which is why the command stays runnable by hand — and why
-  `scripts/tests/test_sync_skills.py` exercises the mechanism in CI.
+- `.githooks/post-merge` runs `--check --strict` and prints a notice when a
+  merge has just moved the repository ahead of your install. It deliberately
+  does **not** block: `--check` compares against the working tree, so gating a
+  commit would force you to install unmerged work into your global skills.
+  Hooks are also bypassable, which is why the command stays runnable by hand —
+  and why `scripts/tests/test_sync_skills.py` exercises the mechanism in CI.
+- **A versioned hook is not a protection until git is pointed at it.** Run
+  `./scripts/setup-hooks.sh` (or `.\scripts\setup-hooks.ps1`) once per clone;
+  it sets `core.hooksPath` and restores the executable bit a fresh checkout can
+  drop. Verify with `git rev-parse --git-path hooks`, which prints the path git
+  actually uses. A test now holds both activation scripts against the contents
+  of `.githooks/`, so a hook added without being described there turns red —
+  that check found `setup-hooks.ps1` had never mentioned `commit-msg`, the hook
+  enforcing the no-AI-attribution rule.
 
 Set `CLAUDE_SKILLS_DIR` to point both commands at a different directory (the
 test suite uses it to run without touching a real install).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,46 @@ cargo run --bin velesdb-server -- --data-dir ./data
 cargo bench -p velesdb-core --features internal-bench -- --noplot
 ```
 
+### Agent Skills — installing, checking, re-syncing
+
+This repository is the source of truth for two agent skills:
+`skills/velesdb-context-optimizer` and
+`crates/velesdb-memory/skill/velesdb-memory`. An agent does not load them from
+here — it loads a copy installed under `~/.claude/skills`.
+
+That third copy is invisible to CI, which cannot read your home directory, and
+it drifted: measured on 2026-08-02, the installed `velesdb-memory` skill was 67
+lines behind and stated the **wrong argument order** for the Node binding's
+`recallFusedDated`. Nothing anywhere reported a fault; an agent simply read
+stale instructions.
+
+```bash
+# Install (or re-sync) the two skills into ~/.claude/skills
+python3 scripts/sync-skills.py --install
+
+# Report drift; exits non-zero when an installed copy differs
+python3 scripts/sync-skills.py --check
+```
+
+- **Only those two skills are touched.** Any other skill installed in that
+  directory is left exactly as it is — the tool works from an explicit pair
+  list, never a scan.
+- **A skill that is not installed is not drift.** You cannot drift from
+  something you never had, so `--check` skips it and stays green. Only an
+  installed copy whose bytes differ is a failure.
+- **The copy is atomic.** The new tree is built beside the target and moved
+  into place by rename, so an agent reading a SKILL.md during an install sees
+  the whole old version or the whole new one — never half of each.
+- `.githooks/post-merge` runs `--check` and prints a notice when a merge has
+  just moved the repository ahead of your install. It deliberately does **not**
+  block: `--check` compares against the working tree, so gating a commit would
+  force you to install unmerged work into your global skills. Hooks are also
+  bypassable, which is why the command stays runnable by hand — and why
+  `scripts/tests/test_sync_skills.py` exercises the mechanism in CI.
+
+Set `CLAUDE_SKILLS_DIR` to point both commands at a different directory (the
+test suite uses it to run without touching a real install).
+
 ## Pull Request Process
 
 1. **Ensure all tests pass** - Run `cargo test --workspace --features persistence,gpu,update-check --exclude velesdb-python -- --test-threads=1` before submitting

--- a/scripts/setup-hooks.ps1
+++ b/scripts/setup-hooks.ps1
@@ -1,7 +1,8 @@
 # =============================================================================
 # VelesDB - Git Hooks Setup Script
 # =============================================================================
-# Configure git to use the project's custom hooks (pre-commit, pre-push)
+# Configure git to use the project's custom hooks (commit-msg, pre-commit,
+# pre-push, post-merge)
 # for local CI validation before pushing to origin.
 #
 # Usage: .\scripts\setup-hooks.ps1
@@ -26,11 +27,17 @@ if ($hooksPath -eq ".githooks") {
     Write-Host ""
     Write-Host "📌 Active hooks:" -ForegroundColor Cyan
     
+    if (Test-Path ".githooks/commit-msg") {
+        Write-Host "   - commit-msg  : Rejects AI-attributed authors and AI attribution trailers" -ForegroundColor White
+    }
     if (Test-Path ".githooks/pre-commit") {
         Write-Host "   - pre-commit  : Validates code before each commit" -ForegroundColor White
     }
     if (Test-Path ".githooks/pre-push") {
         Write-Host "   - pre-push    : Full CI validation before push to origin" -ForegroundColor White
+    }
+    if (Test-Path ".githooks/post-merge") {
+        Write-Host "   - post-merge  : Warns when a merge left the installed agent skills behind" -ForegroundColor White
     }
     
     Write-Host ""

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -60,6 +60,7 @@ declare -a described=()
 [ -f .githooks/commit-msg ] && described+=("   - commit-msg  : rejects AI-attributed authors and AI attribution trailers")
 [ -f .githooks/pre-commit ] && described+=("   - pre-commit  : validates the change before each commit")
 [ -f .githooks/pre-push ]   && described+=("   - pre-push    : full local validation before pushing to origin")
+[ -f .githooks/post-merge ] && described+=("   - post-merge  : warns when a merge left the installed agent skills behind")
 if [ ${#described[@]} -eq 0 ]; then
   printf '%s\n' "${RED}   (none found in .githooks/ — nothing will run)${RESET}"
   exit 1

--- a/scripts/sync-skills.py
+++ b/scripts/sync-skills.py
@@ -24,16 +24,23 @@ makes the globally installed skills follow whatever branch the working tree is
 on, unmerged edits included. The repo stays the source of truth; the install is
 an explicit, deliberate act.
 
-## What `--check` does NOT do
+## Three states, never two
 
-**A skill that is not installed at all is not drift.** You cannot drift from
-something you never had, and a contributor who has never installed these skills
-must not have their commit refused over it. Only an installed copy whose
-CONTENT differs is a failure.
+`in step`, `drifted` and `absent` are reported separately, because they lead to
+different actions: an absent skill means the agent loads NOTHING, a drifted one
+means it loads the WRONG thing. Collapsing them into "not ok" throws away which
+of the two you are looking at.
+
+`--strict` decides only what `absent` costs. Plain `--check` reports it and
+exits 0 — you cannot drift from something you never had, and a contributor who
+never installed these must not have their work refused over a machine-local
+state. The post-merge hook passes `--strict`, where absence is precisely what
+the reader needs told.
 
 Usage:
-    python3 scripts/sync-skills.py --check     # exit 1 on drift, naming it
-    python3 scripts/sync-skills.py --install   # repo -> ~/.claude/skills
+    python3 scripts/sync-skills.py --check            # drift fails; absent is reported
+    python3 scripts/sync-skills.py --check --strict   # absent fails too
+    python3 scripts/sync-skills.py --install          # repo -> ~/.claude/skills
 """
 
 from __future__ import annotations
@@ -117,30 +124,54 @@ def install_one(source: Path, target: Path) -> None:
         shutil.rmtree(previous, ignore_errors=True)
 
 
-def run_check(root: Path) -> int:
-    failures = []
+def run_check(root: Path, strict: bool) -> int:
+    """Report each managed skill as one of THREE states, never two.
+
+    `in step`, `drifted` and `absent` lead to different actions, and collapsing
+    the last two into "not ok" loses which one you are looking at — an absent
+    skill means the agent loads NOTHING, a drifted one means it loads the wrong
+    thing. Both deserve their own word.
+
+    `strict` decides only what `absent` costs. By default it is reported and
+    forgiven, because a contributor who never installed these must not have
+    their work refused over a machine-local state. The hook passes `--strict`,
+    where absence is exactly what the reader needs told.
+    """
+    drifted, absent, failures = [], [], []
     for source_rel, name in SKILLS:
         source, installed = REPO / source_rel, root / name
         if not source.is_dir():
             failures.append(f"{name}: {source_rel} is missing from the repository")
             continue
         if not installed.exists():
-            print(f"  {name}: not installed — nothing to drift from, skipped")
+            absent.append(f"{name}: absent — nothing is installed at {installed}")
+            print(f"  {name}: absent (not installed)")
             continue
         problems = drift(source, installed)
         if problems:
-            failures.append(f"{name} ({installed}):\n      " + "\n      ".join(problems))
+            drifted.append(f"{name} ({installed}):\n      " + "\n      ".join(problems))
+            print(f"  {name}: drifted")
         else:
             print(f"  {name}: in step with {source_rel}")
-    if failures:
+
+    report = list(failures)
+    report += drifted
+    if strict:
+        report += absent
+    if report:
         print(
-            "\nInstalled skill(s) no longer match the repository:\n\n    "
-            + "\n\n    ".join(failures)
-            + "\n\nThe repository is the source of truth. Re-sync with:\n"
+            "\nManaged skill(s) are not in step with the repository:\n\n    "
+            + "\n\n    ".join(report)
+            + "\n\nThe repository is the source of truth. Install or re-sync with:\n"
             "    python3 scripts/sync-skills.py --install\n",
             file=sys.stderr,
         )
         return 1
+    if absent:
+        print(
+            "\n  (absent skills are not treated as drift here; "
+            "run with --strict to make them fail)"
+        )
     return 0
 
 
@@ -160,9 +191,14 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true", help="report drift, exit 1 if any")
     mode.add_argument("--install", action="store_true", help="copy repo skills into place")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="with --check: a managed skill that is absent also exits non-zero",
+    )
     args = parser.parse_args()
     root = installed_root()
-    return run_check(root) if args.check else run_install(root)
+    return run_check(root, args.strict) if args.check else run_install(root)
 
 
 if __name__ == "__main__":

--- a/scripts/sync-skills.py
+++ b/scripts/sync-skills.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Keep the skills installed under `~/.claude/skills` in step with this repo.
+
+## The defect this closes (#1712)
+
+`scripts/tests/test_skill_copies_are_identical.py` holds the repo's two copies
+of a SKILL.md against each other. It cannot see a THIRD copy — the one an agent
+actually loads, installed under `~/.claude/skills` — because that copy lives
+outside the repository, on one machine.
+
+So it drifted, silently and consequentially. Measured on 2026-08-02: the
+installed `velesdb-memory` skill was 67 lines behind, and among them it stated
+the WRONG argument order for the Node binding's `recallFusedDated` and
+described `entity` as returning only outgoing edges. An agent reading it was
+being misinformed, with nothing anywhere reporting a fault. The installed
+`velesdb-context-optimizer` was 14 lines behind, still describing
+`compile_transcript` as returning the compiled fields at the top level when it
+returns `{context, segmentation}`.
+
+## Why an installer rather than a symlink
+
+A symlink makes drift impossible, which is the stronger property — but it also
+makes the globally installed skills follow whatever branch the working tree is
+on, unmerged edits included. The repo stays the source of truth; the install is
+an explicit, deliberate act.
+
+## What `--check` does NOT do
+
+**A skill that is not installed at all is not drift.** You cannot drift from
+something you never had, and a contributor who has never installed these skills
+must not have their commit refused over it. Only an installed copy whose
+CONTENT differs is a failure.
+
+Usage:
+    python3 scripts/sync-skills.py --check     # exit 1 on drift, naming it
+    python3 scripts/sync-skills.py --install   # repo -> ~/.claude/skills
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: `(source directory in the repo, installed name under ~/.claude/skills)`.
+#:
+#: Deliberately an explicit pair list, not a scan: seven other skills live in
+#: that directory and come from elsewhere. Touching one of them — or merely
+#: reporting it — would make this tool something a reader cannot trust to stay
+#: in its lane.
+SKILLS: tuple[tuple[str, str], ...] = (
+    ("skills/velesdb-context-optimizer", "velesdb-context-optimizer"),
+    ("crates/velesdb-memory/skill/velesdb-memory", "velesdb-memory"),
+)
+
+
+def installed_root() -> Path:
+    """Where an agent loads skills from. `CLAUDE_SKILLS_DIR` overrides it, which
+    is what lets this tool be tested without writing into a real install."""
+    override = os.environ.get("CLAUDE_SKILLS_DIR")
+    return Path(override) if override else Path.home() / ".claude" / "skills"
+
+
+def digest(root: Path) -> dict[str, str]:
+    """`{relative path: sha256}` for every file under `root`.
+
+    Content, not timestamps: a copy is in step when its BYTES match. Comparing
+    mtimes would call a fresh checkout stale and a touched file current, which
+    is exactly backwards.
+    """
+    out: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        out[str(path.relative_to(root))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def drift(source: Path, installed: Path) -> list[str]:
+    """What differs between the two trees, in reader-facing terms."""
+    want, have = digest(source), digest(installed)
+    problems = []
+    for name in sorted(set(want) - set(have)):
+        problems.append(f"missing: {name}")
+    for name in sorted(set(have) - set(want)):
+        problems.append(f"unexpected: {name}")
+    for name in sorted(set(want) & set(have)):
+        if want[name] != have[name]:
+            problems.append(f"differs: {name}")
+    return problems
+
+
+def install_one(source: Path, target: Path) -> None:
+    """Replace `target` with `source`, without ever leaving a half-written skill.
+
+    The new tree is built beside the target and moved into place by rename, so
+    a reader either sees the whole previous version or the whole new one. A
+    plain recursive copy over a live directory is what leaves a skill whose
+    first half is new and second half is old — and a SKILL.md is read by an
+    agent at arbitrary moments, including during an install.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = target.parent / f".{target.name}.staging-{os.getpid()}"
+    previous = target.parent / f".{target.name}.previous-{os.getpid()}"
+    shutil.rmtree(staging, ignore_errors=True)
+    shutil.rmtree(previous, ignore_errors=True)
+    try:
+        shutil.copytree(source, staging)
+        if target.exists():
+            os.replace(target, previous)
+        os.replace(staging, target)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(previous, ignore_errors=True)
+
+
+def run_check(root: Path) -> int:
+    failures = []
+    for source_rel, name in SKILLS:
+        source, installed = REPO / source_rel, root / name
+        if not source.is_dir():
+            failures.append(f"{name}: {source_rel} is missing from the repository")
+            continue
+        if not installed.exists():
+            print(f"  {name}: not installed — nothing to drift from, skipped")
+            continue
+        problems = drift(source, installed)
+        if problems:
+            failures.append(f"{name} ({installed}):\n      " + "\n      ".join(problems))
+        else:
+            print(f"  {name}: in step with {source_rel}")
+    if failures:
+        print(
+            "\nInstalled skill(s) no longer match the repository:\n\n    "
+            + "\n\n    ".join(failures)
+            + "\n\nThe repository is the source of truth. Re-sync with:\n"
+            "    python3 scripts/sync-skills.py --install\n",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def run_install(root: Path) -> int:
+    for source_rel, name in SKILLS:
+        source = REPO / source_rel
+        if not source.is_dir():
+            print(f"{source_rel} is missing from the repository", file=sys.stderr)
+            return 1
+        install_one(source, root / name)
+        print(f"  {name} <- {source_rel}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report drift, exit 1 if any")
+    mode.add_argument("--install", action="store_true", help="copy repo skills into place")
+    args = parser.parse_args()
+    root = installed_root()
+    return run_check(root) if args.check else run_install(root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_sync_skills.py
+++ b/scripts/tests/test_sync_skills.py
@@ -1,0 +1,157 @@
+"""Behaviour of `scripts/sync-skills.py` — the installed-skill drift guard (#1712).
+
+The guard it complements, `test_skill_copies_are_identical.py`, holds the two
+copies inside the repository against each other. It cannot see the copy an
+agent actually loads, under `~/.claude/skills`, because that one lives outside
+the repository. That copy drifted 67 lines and started stating a wrong argument
+order for a published method, with nothing reporting a fault.
+
+Every test here runs against a temporary directory through `CLAUDE_SKILLS_DIR`,
+so the suite never reads or writes a real install — including the developer's
+own, which would make the result depend on whose machine ran it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "sync-skills.py"
+
+#: Kept in step with `SKILLS` in the script, and asserted below rather than
+#: trusted — a divergence here would silently narrow what the tests cover.
+EXPECTED = ("velesdb-context-optimizer", "velesdb-memory")
+
+
+def run(mode: str, root: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ, CLAUDE_SKILLS_DIR=str(root))
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), mode],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+class SyncSkills(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_the_script_covers_exactly_the_two_repo_skills(self) -> None:
+        """Guard the guard: a narrowed list would make every test below pass
+        while checking less, which is the failure mode a coverage guard has."""
+        source = SCRIPT.read_text(encoding="utf-8")
+        for name in EXPECTED:
+            self.assertIn(
+                f'"{name}"', source, f"{name} is no longer covered by sync-skills.py"
+            )
+
+    def test_check_passes_when_nothing_is_installed(self) -> None:
+        """A skill that was never installed is NOT drift. A contributor who has
+        never installed these must not see a failure — you cannot drift from
+        something you never had."""
+        result = run("--check", self.root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("not installed", result.stdout)
+
+    def test_install_then_check_is_green(self) -> None:
+        self.assertEqual(run("--install", self.root).returncode, 0)
+        for name in EXPECTED:
+            self.assertTrue((self.root / name / "SKILL.md").is_file(), name)
+        result = run("--check", self.root)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_a_modified_installed_copy_is_reported_by_name(self) -> None:
+        run("--install", self.root)
+        target = self.root / EXPECTED[0] / "SKILL.md"
+        target.write_text(target.read_text(encoding="utf-8") + "\ndrift\n", encoding="utf-8")
+
+        result = run("--check", self.root)
+        self.assertEqual(result.returncode, 1, "drift must exit non-zero")
+        self.assertIn(EXPECTED[0], result.stderr)
+        self.assertIn("differs: SKILL.md", result.stderr)
+        self.assertNotIn(
+            EXPECTED[1],
+            result.stderr,
+            "only the skill that actually drifted may be named — a report that "
+            "blames both teaches the reader to stop reading it",
+        )
+
+    def test_a_deleted_file_is_reported_as_missing(self) -> None:
+        run("--install", self.root)
+        (self.root / EXPECTED[1] / "SKILL.md").unlink()
+        result = run("--check", self.root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing: SKILL.md", result.stderr)
+
+    def test_an_extra_file_is_reported_as_unexpected(self) -> None:
+        run("--install", self.root)
+        (self.root / EXPECTED[1] / "STOWAWAY.md").write_text("x", encoding="utf-8")
+        result = run("--check", self.root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unexpected: STOWAWAY.md", result.stderr)
+
+    def test_install_repairs_drift(self) -> None:
+        run("--install", self.root)
+        target = self.root / EXPECTED[0] / "SKILL.md"
+        target.write_text("wiped", encoding="utf-8")
+        self.assertEqual(run("--check", self.root).returncode, 1)
+
+        self.assertEqual(run("--install", self.root).returncode, 0)
+        self.assertEqual(run("--check", self.root).returncode, 0)
+
+    def test_install_leaves_every_other_installed_skill_untouched(self) -> None:
+        """The one thing this tool must never do. Seven other skills live in
+        that directory and come from elsewhere; a scan-and-sync would have
+        eaten them."""
+        stranger = self.root / "some-other-skill"
+        stranger.mkdir(parents=True)
+        (stranger / "SKILL.md").write_text("not ours", encoding="utf-8")
+
+        run("--install", self.root)
+
+        self.assertEqual((stranger / "SKILL.md").read_text(encoding="utf-8"), "not ours")
+
+    def test_install_leaves_no_staging_directory_behind(self) -> None:
+        """The atomic swap builds the new tree beside the target. A crash-free
+        run must leave nothing: a stray `.velesdb-memory.staging-1234` would be
+        loaded by nothing but would sit there forever."""
+        run("--install", self.root)
+        leftovers = [p.name for p in self.root.iterdir() if p.name.startswith(".")]
+        self.assertEqual(leftovers, [], f"staging residue left behind: {leftovers}")
+
+    def test_install_never_leaves_a_partially_written_skill(self) -> None:
+        """Re-installing over a live install replaces it wholesale. Checked by
+        content rather than by watching the filesystem race: after a second
+        install over a corrupted copy, the file is the repository's, byte for
+        byte — never a mix of the two."""
+        run("--install", self.root)
+        target = self.root / EXPECTED[1] / "SKILL.md"
+        target.write_text("half written", encoding="utf-8")
+        run("--install", self.root)
+
+        source = (REPO / "crates/velesdb-memory/skill/velesdb-memory/SKILL.md").read_bytes()
+        self.assertEqual(target.read_bytes(), source)
+
+    def test_the_post_merge_hook_invokes_the_check(self) -> None:
+        """A hook nobody invokes protects nothing. This asserts the wiring
+        exists — the hook's own advisory behaviour is git's to run."""
+        hook = REPO / ".githooks" / "post-merge"
+        self.assertTrue(hook.is_file(), "the post-merge hook is missing")
+        body = hook.read_text(encoding="utf-8")
+        self.assertIn("sync-skills.py", body)
+        self.assertIn("--check", body)
+        self.assertTrue(os.access(hook, os.X_OK), "the hook is not executable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_sync_skills.py
+++ b/scripts/tests/test_sync_skills.py
@@ -29,10 +29,10 @@ SCRIPT = REPO / "scripts" / "sync-skills.py"
 EXPECTED = ("velesdb-context-optimizer", "velesdb-memory")
 
 
-def run(mode: str, root: Path) -> subprocess.CompletedProcess[str]:
+def run(*args: str, root: Path) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ, CLAUDE_SKILLS_DIR=str(root))
     return subprocess.run(
-        [sys.executable, str(SCRIPT), mode],
+        [sys.executable, str(SCRIPT), *args],
         capture_output=True,
         text=True,
         env=env,
@@ -55,27 +55,65 @@ class SyncSkills(unittest.TestCase):
                 f'"{name}"', source, f"{name} is no longer covered by sync-skills.py"
             )
 
-    def test_check_passes_when_nothing_is_installed(self) -> None:
+    def test_absent_is_reported_but_forgiven_by_default(self) -> None:
         """A skill that was never installed is NOT drift. A contributor who has
         never installed these must not see a failure — you cannot drift from
-        something you never had."""
-        result = run("--check", self.root)
+        something you never had. It is still REPORTED: silence would leave the
+        reader unable to tell "installed and correct" from "absent"."""
+        result = run("--check", root=self.root)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("not installed", result.stdout)
+        self.assertIn("absent (not installed)", result.stdout)
+
+    def test_absent_fails_under_strict(self) -> None:
+        """What the post-merge hook runs. Absence means the agent loads
+        NOTHING, which is worth saying out loud on the machine that merged."""
+        result = run("--check", "--strict", root=self.root)
+        self.assertEqual(result.returncode, 1, "strict must refuse an absent skill")
+        for name in EXPECTED:
+            self.assertIn(f"{name}: absent", result.stderr)
+
+    def test_one_absent_skill_is_named_and_the_other_is_not(self) -> None:
+        """The three states must stay distinguishable per skill, not collapse
+        into a verdict on the pair."""
+        run("--install", root=self.root)
+        shutil.rmtree(self.root / EXPECTED[1])
+
+        result = run("--check", "--strict", root=self.root)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"{EXPECTED[1]}: absent", result.stderr)
+        self.assertNotIn(f"{EXPECTED[0]}: absent", result.stderr)
+        self.assertIn(f"{EXPECTED[0]}: in step", result.stdout)
+
+    def test_drift_fails_even_without_strict(self) -> None:
+        """`--strict` widens what ABSENCE costs and nothing else. A drifted
+        copy — the agent reading the wrong thing — fails either way."""
+        run("--install", root=self.root)
+        target = self.root / EXPECTED[0] / "SKILL.md"
+        target.write_text("drifted", encoding="utf-8")
+        self.assertEqual(run("--check", root=self.root).returncode, 1)
+        self.assertEqual(run("--check", "--strict", root=self.root).returncode, 1)
+
+    def test_install_repairs_an_absent_skill(self) -> None:
+        run("--install", root=self.root)
+        shutil.rmtree(self.root / EXPECTED[0])
+        self.assertEqual(run("--check", "--strict", root=self.root).returncode, 1)
+
+        self.assertEqual(run("--install", root=self.root).returncode, 0)
+        self.assertEqual(run("--check", "--strict", root=self.root).returncode, 0)
 
     def test_install_then_check_is_green(self) -> None:
-        self.assertEqual(run("--install", self.root).returncode, 0)
+        self.assertEqual(run("--install", root=self.root).returncode, 0)
         for name in EXPECTED:
             self.assertTrue((self.root / name / "SKILL.md").is_file(), name)
-        result = run("--check", self.root)
+        result = run("--check", root=self.root)
         self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_a_modified_installed_copy_is_reported_by_name(self) -> None:
-        run("--install", self.root)
+        run("--install", root=self.root)
         target = self.root / EXPECTED[0] / "SKILL.md"
         target.write_text(target.read_text(encoding="utf-8") + "\ndrift\n", encoding="utf-8")
 
-        result = run("--check", self.root)
+        result = run("--check", root=self.root)
         self.assertEqual(result.returncode, 1, "drift must exit non-zero")
         self.assertIn(EXPECTED[0], result.stderr)
         self.assertIn("differs: SKILL.md", result.stderr)
@@ -87,27 +125,27 @@ class SyncSkills(unittest.TestCase):
         )
 
     def test_a_deleted_file_is_reported_as_missing(self) -> None:
-        run("--install", self.root)
+        run("--install", root=self.root)
         (self.root / EXPECTED[1] / "SKILL.md").unlink()
-        result = run("--check", self.root)
+        result = run("--check", root=self.root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("missing: SKILL.md", result.stderr)
 
     def test_an_extra_file_is_reported_as_unexpected(self) -> None:
-        run("--install", self.root)
+        run("--install", root=self.root)
         (self.root / EXPECTED[1] / "STOWAWAY.md").write_text("x", encoding="utf-8")
-        result = run("--check", self.root)
+        result = run("--check", root=self.root)
         self.assertEqual(result.returncode, 1)
         self.assertIn("unexpected: STOWAWAY.md", result.stderr)
 
     def test_install_repairs_drift(self) -> None:
-        run("--install", self.root)
+        run("--install", root=self.root)
         target = self.root / EXPECTED[0] / "SKILL.md"
         target.write_text("wiped", encoding="utf-8")
-        self.assertEqual(run("--check", self.root).returncode, 1)
+        self.assertEqual(run("--check", root=self.root).returncode, 1)
 
-        self.assertEqual(run("--install", self.root).returncode, 0)
-        self.assertEqual(run("--check", self.root).returncode, 0)
+        self.assertEqual(run("--install", root=self.root).returncode, 0)
+        self.assertEqual(run("--check", root=self.root).returncode, 0)
 
     def test_install_leaves_every_other_installed_skill_untouched(self) -> None:
         """The one thing this tool must never do. Seven other skills live in
@@ -117,7 +155,7 @@ class SyncSkills(unittest.TestCase):
         stranger.mkdir(parents=True)
         (stranger / "SKILL.md").write_text("not ours", encoding="utf-8")
 
-        run("--install", self.root)
+        run("--install", root=self.root)
 
         self.assertEqual((stranger / "SKILL.md").read_text(encoding="utf-8"), "not ours")
 
@@ -125,7 +163,7 @@ class SyncSkills(unittest.TestCase):
         """The atomic swap builds the new tree beside the target. A crash-free
         run must leave nothing: a stray `.velesdb-memory.staging-1234` would be
         loaded by nothing but would sit there forever."""
-        run("--install", self.root)
+        run("--install", root=self.root)
         leftovers = [p.name for p in self.root.iterdir() if p.name.startswith(".")]
         self.assertEqual(leftovers, [], f"staging residue left behind: {leftovers}")
 
@@ -134,13 +172,29 @@ class SyncSkills(unittest.TestCase):
         content rather than by watching the filesystem race: after a second
         install over a corrupted copy, the file is the repository's, byte for
         byte — never a mix of the two."""
-        run("--install", self.root)
+        run("--install", root=self.root)
         target = self.root / EXPECTED[1] / "SKILL.md"
         target.write_text("half written", encoding="utf-8")
-        run("--install", self.root)
+        run("--install", root=self.root)
 
         source = (REPO / "crates/velesdb-memory/skill/velesdb-memory/SKILL.md").read_bytes()
         self.assertEqual(target.read_bytes(), source)
+
+    def test_every_versioned_hook_is_described_by_the_activation_scripts(self) -> None:
+        """A versioned hook is not a protection until git is pointed at it, and
+        `setup-hooks.sh` is what does that. Both activation scripts name their
+        hooks one by one, so a hook added without touching them is activated
+        but invisible — nobody running the setup learns it exists."""
+        hooks = sorted(p.name for p in (REPO / ".githooks").iterdir() if p.is_file())
+        self.assertIn("post-merge", hooks, "the drift hook is missing")
+        for script in ("scripts/setup-hooks.sh", "scripts/setup-hooks.ps1"):
+            body = (REPO / script).read_text(encoding="utf-8")
+            for hook in hooks:
+                self.assertIn(hook, body, f"{script} never mentions the {hook} hook")
+
+    def test_the_hook_uses_strict_so_an_absent_skill_is_reported(self) -> None:
+        body = (REPO / ".githooks" / "post-merge").read_text(encoding="utf-8")
+        self.assertIn("--check --strict", body)
 
     def test_the_post_merge_hook_invokes_the_check(self) -> None:
         """A hook nobody invokes protects nothing. This asserts the wiring


### PR DESCRIPTION
Ferme #1712.

## Le trou

`scripts/tests/test_skill_copies_are_identical.py` tient les **deux** copies du
dépôt l'une contre l'autre. Il ne peut pas voir la **troisième** — celle qu'un
agent charge réellement, sous `~/.claude/skills` — parce qu'elle vit hors du
dépôt, sur une machine. Aucune CI ne lira jamais un répertoire personnel.

Elle a donc dérivé, et chèrement. Mesuré le 2026-08-02 :

| skill installé | retard | ce qu'il affirmait de faux |
|---|---|---|
| `velesdb-memory` | **67 lignes** | l'**ordre d'arguments faux** pour `recallFusedDated` côté Node ; `entity` décrit comme ne rendant que les arêtes sortantes, sans `relations_in` |
| `velesdb-context-optimizer` | 14 lignes | `compile_transcript` décrit comme rendant les champs compilés à la racine, alors qu'il rend `{context, segmentation}` |

Rien nulle part ne signalait de faute. Un agent lisait simplement des
instructions périmées.

## Un installateur, pas un lien symbolique

Le lien rendrait la dérive impossible — propriété plus forte — mais ferait
suivre aux skills globaux la branche de travail et ses modifications **non
fusionnées**. Le dépôt reste la source de vérité ; l'installation reste un acte
explicite.

## Décisions qui méritent d'être lues

- **La copie est atomique.** Le nouvel arbre est construit à côté de la cible
  puis mis en place par renommage : un agent qui lit un SKILL.md pendant une
  installation voit l'ancienne version entière ou la nouvelle entière, jamais
  la moitié de chacune.
- **Un skill non installé n'est PAS une dérive.** On ne dérive pas de ce qu'on
  n'a jamais eu ; un contributeur qui ne les a jamais installés ne doit pas
  voir son travail refusé. Seule une copie installée dont les octets diffèrent
  échoue.
- **Liste explicite, jamais un balayage.** Sept autres skills vivent dans ce
  répertoire et viennent d'ailleurs. Un sync par balayage les aurait mangés.
- **`post-merge` signale, il ne bloque pas — et c'est motivé.** `--check`
  compare à l'arbre de travail ; bloquer un commit forcerait à installer
  globalement du travail non fusionné, exactement ce que l'installateur a été
  choisi pour éviter. Un merge est le moment où le dépôt passe réellement
  devant l'installation. Le verrou est la commande elle-même, qui sort en code
  non nul et reste lançable à la main.

## Preuves, exécutées dans les deux sens

Sur le vrai `~/.claude/skills` :

1. état synchronisé → `--check` **EXIT=0**
2. dérive volontaire → `--check` **EXIT=1**, nommant `velesdb-context-optimizer
   … differs: SKILL.md` et **lui seul**
3. `--install` → copie restaurée
4. `--check` → **EXIT=0**
5. empreintes des **sept autres** skills avant/après : **identiques**, plus
   aucun résidu de staging

En CI, `scripts/tests/test_sync_skills.py` rejoue tout cela sur un répertoire
temporaire via `CLAUDE_SKILLS_DIR` — la suite ne lit ni n'écrit jamais une vraie
installation, y compris celle du développeur qui l'exécute. Suite Python
**214 → 225**.

Documentation dans `CONTRIBUTING.md` : installation, vérification, remise en
synchronisation, et les limites énoncées plutôt que tues.