### PR TITLE
feat(skills): version the learning-loop skill and guard what a skill may ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,6 +621,17 @@ jobs:
       - name: Bundled skill copies are byte-identical
         run: python3 -m unittest scripts.tests.test_skill_copies_are_identical
 
+      # A skill ships twice: in this repository and inside the npm package.
+      # Whoever loads it has the open core and nothing else, so a passage
+      # pointing at something only the closed repository holds is unactionable
+      # where it is read. Self-test first, RED-then-GREEN on a synthetic tree,
+      # same order as the guard above it.
+      - name: Self-test the private-reference guard
+        run: python3 -m unittest scripts.tests.test_check_skill_private_references
+
+      - name: Versioned skills carry no private reference
+        run: python3 scripts/check-skill-private-references.py
+
       # BLOCKING. Verified green on the whole tree (16 pinned surfaces, 20
       # declarations of load_working_context's envelope — including the three
       # agent session hooks and the napi `ts_return_type` shipped as the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,14 +253,22 @@ jobs:
         # One folder per skill at the archive root, so
         # `tar -xz -C ~/.claude/skills/` drops each skill straight into
         # place — the one-line install README documents. Staged in a temp
-        # dir first (the two skills live under different source trees) so
-        # the tar entries carry no leading path noise.
+        # dir first (the skills live under different source trees) so the
+        # tar entries carry no leading path noise.
+        #
+        # This list is held against `SKILLS` in scripts/sync-skills.py by
+        # `scripts.tests.test_sync_skills.ReleaseArchive`. It was the fifth
+        # hand-written copy of that registry and the only one pinned against
+        # nothing: a skill could be versioned, installed, bundled into npm and
+        # guarded twice while silently missing from the archive the README
+        # tells people to install from.
         run: |
           set -euo pipefail
           stage="$(mktemp -d)"
           cp -r crates/velesdb-memory/skill/velesdb-memory "$stage/"
           cp -r skills/velesdb-context-optimizer "$stage/"
-          tar -czf velesdb-skills.tar.gz -C "$stage" velesdb-memory velesdb-context-optimizer
+          cp -r skills/velesdb-learning-loop "$stage/"
+          tar -czf velesdb-skills.tar.gz -C "$stage" velesdb-memory velesdb-context-optimizer velesdb-learning-loop
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A third versioned agent skill, `velesdb-learning-loop`.** It ships in
+  `skills/`, in the npm package and in `velesdb-skills.tar.gz`, and it is the
+  discipline over the other two: recall before designing, check whether a fix
+  is a *recurrence* before storing it, correct a wrong memory instead of adding
+  one beside it, and treat writing to memory as a decision rather than a
+  reflex. `sync-skills.py --bundle` now **generates** the npm-bundled copies
+  from the same registry the installer uses, and the release archive's skill
+  list is held against that registry by a test — it was the fifth hand-written
+  copy of the list and the only one pinned against nothing.
+- **`scripts/check-skill-private-references.py`** — a versioned skill may not
+  point at something only the closed repository holds. A skill is loaded on
+  machines that have the open core and nothing else, so such a passage is
+  unactionable where it is read. Strict and required, with three executed
+  refusal vectors.
+- **A machine-local layer for installed skills.** `LOCAL.md` beside an
+  installed `SKILL.md` is preserved across `--install` and never reported as
+  drift. It used to be deleted by the atomic swap and flagged `unexpected` by
+  the check — silently destroying the only copy of a file the design invites
+  you to write.
+
 - **`velesdb-memory`: an OpenAI-compatible backend for both inference roles
   (#1751).** `VELESDB_MEMORY_EMBEDDER=openai` and
   `VELESDB_MEMORY_EXTRACTOR=openai` reach oMLX, llama.cpp's server, LM Studio,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,8 +212,8 @@ cargo bench -p velesdb-core --features internal-bench -- --noplot
 
 ### Agent Skills — installing, checking, re-syncing
 
-This repository is the source of truth for two agent skills:
-`skills/velesdb-context-optimizer` and
+This repository is the source of truth for three agent skills:
+`skills/velesdb-context-optimizer`, `skills/velesdb-learning-loop` and
 `crates/velesdb-memory/skill/velesdb-memory`. An agent does not load them from
 here — it loads a copy installed under `~/.claude/skills`.
 
@@ -224,7 +224,7 @@ lines behind and stated the **wrong argument order** for the Node binding's
 stale instructions.
 
 ```bash
-# Install (or re-sync) the two skills into ~/.claude/skills
+# Install (or re-sync) the managed skills into ~/.claude/skills
 python3 scripts/sync-skills.py --install
 
 # Report drift; exits non-zero when an installed copy differs
@@ -232,6 +232,9 @@ python3 scripts/sync-skills.py --check
 
 # Same, but an ABSENT managed skill also fails (what the post-merge hook runs)
 python3 scripts/sync-skills.py --check --strict
+
+# Regenerate the copies bundled into the npm package after editing a source
+python3 scripts/sync-skills.py --bundle
 ```
 
 Each managed skill is reported as one of **three** states, never two:
@@ -242,9 +245,16 @@ Each managed skill is reported as one of **three** states, never two:
 | `drifted` | l'agent lit la **mauvaise** chose | **exit 1** | **exit 1** |
 | `absent` | l'agent ne lit **rien** | rapporté, exit 0 | **exit 1** |
 
-- **Only those two skills are touched.** Any other skill installed in that
+- **Only the managed skills are touched.** Any other skill installed in that
   directory is left exactly as it is — the tool works from an explicit pair
   list, never a scan.
+- **`LOCAL.md` is yours.** A managed skill may hold a machine-local layer under
+  that name: never committed, never a copy of the shipped `SKILL.md`. It is
+  preserved across an `--install` and never reported as drift. Nothing else
+  extra is forgiven — a stale file from an older version is still `unexpected`.
+- **The npm copies are generated.** `crates/velesdb-node/skills/` ships inside
+  the package; `--bundle` rewrites it from the same registry. Two byte-identity
+  guards stay red until you run it.
 - **`--strict` widens what ABSENCE costs, and nothing else.** Plain `--check`
   forgives it because a contributor who never installed these must not have
   their work refused over a machine-local state; it still says so, since

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -237,14 +237,17 @@ compiler surface, media fragments, working contexts, resource caps) is in the
 ## Bundled agent skills
 
 Wiring the API gives your agent the *methods*; it does not tell it *when* to
-use them. Two skills ship inside the package for that — `velesdb-memory` (the
-recall → remember → relate → why → feedback loop) and
-`velesdb-context-optimizer` (the compression workflow, including when *not* to
-compress):
+use them. Three skills ship inside the package for that — `velesdb-memory` (the
+recall → remember → relate → why → feedback loop), `velesdb-context-optimizer`
+(the compression workflow, including when *not* to compress) and
+`velesdb-learning-loop` (the discipline that makes those two compound: recall
+before designing, check recurrence before storing a fix, and never write to
+memory by reflex):
 
 ```bash
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory ~/.claude/skills/
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-learning-loop ~/.claude/skills/
 ```
 
 That `cp` is a snapshot, not a live link: re-run it after every `npm update`.

--- a/crates/velesdb-node/__test__/skills-sync.spec.mjs
+++ b/crates/velesdb-node/__test__/skills-sync.spec.mjs
@@ -1,10 +1,10 @@
 // Guards the skills bundled into the @wiscale/velesdb-memory-node npm package
-// (package.json "files": ["skills/"]) against silent drift from their
-// sources of truth elsewhere in the repo. There is no build step, symlink,
-// or CI check that keeps these copies in sync — they are committed,
-// hand-copied duplicates (velesdb-memory added in PR #1496) — so this test
-// is the only thing that notices when a source SKILL.md changes but the
-// bundled copy does not.
+// (package.json "files": ["skills/"]) against silent drift from their sources
+// of truth elsewhere in the repo. The copies are committed artefacts, produced
+// by `python3 scripts/sync-skills.py --bundle` from the same skill registry
+// the installer uses — no symlink, and nothing regenerates them on build, so
+// this test is what notices when a source SKILL.md changes and the bundled
+// copy does not.
 //
 // Pure Node fs, no napi addon needed: `node --test __test__/skills-sync.spec.mjs`
 // runs standalone without `napi build` first.
@@ -46,6 +46,11 @@ const PAIRS = [
     copy: join(NODE_SKILLS_DIR, 'velesdb-context-optimizer'),
   },
   {
+    name: 'velesdb-learning-loop',
+    source: join(REPO_ROOT, 'skills', 'velesdb-learning-loop'),
+    copy: join(NODE_SKILLS_DIR, 'velesdb-learning-loop'),
+  },
+  {
     name: 'velesdb-memory',
     source: join(REPO_ROOT, 'crates', 'velesdb-memory', 'skill', 'velesdb-memory'),
     copy: join(NODE_SKILLS_DIR, 'velesdb-memory'),
@@ -66,7 +71,7 @@ for (const { name, source, copy } of PAIRS) {
     const sourceFiles = listFiles(source)
     const copyFiles = listFiles(copy)
 
-    const resync = `cp -r ${relative(REPO_ROOT, source)}/. ${relative(REPO_ROOT, copy)}/`
+    const resync = 'python3 scripts/sync-skills.py --bundle'
 
     const onlyInSource = sourceFiles.filter((f) => !copyFiles.includes(f))
     const onlyInCopy = copyFiles.filter((f) => !sourceFiles.includes(f))

--- a/crates/velesdb-node/skills/velesdb-learning-loop/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-learning-loop/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: velesdb-learning-loop
+description: >
+  Turn every velesdb design / implement / verify cycle into durable, connected
+  memory so the SAME mistake is never repeated and later decisions build on
+  what was already learned, instead of re-deriving it or silently colliding
+  with it. Trigger BEFORE starting a design or implementation on
+  velesdb / velesdb-core / velesdb-memory (recall prior decisions and known
+  anti-patterns for this area first — don't propose an approach blind).
+  Trigger AFTER a bug is found and fixed, a review finding is confirmed, or a
+  non-trivial decision is made (check whether this failure mode was already
+  recorded before storing it — a match means RECURRENCE, not a fresh fact).
+  Trigger BEFORE declaring a change verified (cross-check the four adversarial
+  axes — OOM, performance, data loss, vulnerabilities — instead of closing on a
+  green suite or a coverage number). Trigger when a stored memory turns out to
+  be WRONG (correct it with forget plus a replacement; a stale fact outranks no
+  fact and keeps being recalled). Complements the velesdb-memory skill's
+  generic recall / recall_fused / remember / relate / entity / why / feedback
+  loop with a stricter, project-specific discipline: no design starts blind, no
+  fix ships without a recurrence check, no verification closes on coverage
+  alone, and writing to memory is never automatic.
+---
+
+# velesdb-learning-loop — don't repeat a mistake twice
+
+This skill is not a new set of tools — it's a **discipline on top of**
+`velesdb-memory`'s `remember`/`recall`/`recall_fused`/`relate`/`entity`/`why`/
+`feedback`, aimed specifically at making design → implementation →
+verification on velesdb *compound*: each cycle should make the next one faster
+and safer, not just add another isolated fact.
+
+## Writing is never systematic — sort first
+
+Most of what happens in a session must NOT be written. A memory store that
+accumulates everything stops being a memory and becomes a log: recall returns
+the noise ahead of the fact, and the discipline below quietly stops working
+because nothing useful surfaces.
+
+Before storing anything, sort it into one of five:
+
+| It is | What to do |
+|---|---|
+| **Durable** — a decision, an incident, a measured fact, an anti-pattern that will still be true next month | `remember`, with the metadata convention below, and `relate` it to what it touches |
+| **Temporary working state** — where you are in a task, what is next | not `remember`. It belongs to the working-context tools, which are the resumption mechanism, not durable memory |
+| **Ephemeral** — a command output, a path you just read, a number you are about to use once | nothing. Re-derive it if you need it again |
+| **A secret** — token, credential, private URL, personal data | never, under any framing. Not in a fact, not in metadata, not "temporarily" |
+| **An existing memory that is now wrong** | correct it (below). Adding the new version beside the old one leaves both in recall, and the reader cannot tell which is current |
+
+When in doubt, ask whether a *later* session reaching this fact would act on
+it. If not, it is noise.
+
+## The three checkpoints
+
+### 1. Before design/implementation — recall, don't assume
+
+Before proposing an approach or writing code for a feature/module/area, run:
+
+```
+recall_fused("<area> design decisions and known pitfalls", filter={"project":"velesdb"})
+```
+
+Read what comes back for:
+
+- **decisions already taken** in this area (don't re-litigate or silently
+  contradict one — if you must deviate, say so explicitly and `relate` the
+  new decision to the old one with `supersedes`).
+- **anti-patterns / incidents** tied to this area (a past bug, a rejected
+  design, a race condition class). Treat these as constraints, not trivia.
+
+When the area is a **named thing** rather than a topic — a crate, a module, a
+tool, a workflow — ask about the thing itself instead of about the sentences
+that mention it:
+
+```
+entity("velesdb-core")        # what is known ABOUT it, and what it connects to
+```
+
+`recall` ranks passages; `entity` returns the node and its edges. Asking
+`recall("velesdb-core")` for "what do we know about this crate" gets you the
+paragraphs where the name appears, which is a different and usually worse
+answer.
+
+If recall returns nothing, say so and proceed — never invent a memory to
+fill the gap.
+
+### 2. After a bug is found and fixed — check recurrence BEFORE remembering
+
+This is the step most likely to be skipped, and the one that matters most.
+When you fix a bug, a race, a silent data-loss path, or a review finding:
+
+1. **Recall first**, using the *failure signature* (symptom + mechanism, not
+   just the file name) — e.g. `recall("write path deadlocks under concurrent
+   compaction")`, not `recall("bug in wal.rs")`.
+2. **Score the match.** A close semantic match (same mechanism, same class of
+   trigger — concurrency, boundary, resource exhaustion) is a candidate
+   recurrence even if the surface symptom or the file differs.
+3. **If it's a likely recurrence:**
+   - Say so explicitly to the user — *"this looks like the same root cause as
+     <prior incident>, not a new bug"* — don't bury it in a routine commit
+     message.
+   - `relate(new_incident_id, prior_incident_id, "same_root_cause_as")`
+     instead of leaving two disconnected facts that `why` can't join.
+   - `remember` a **generalized** anti-pattern fact (the class of mistake,
+     not just this instance) if one doesn't already exist, and link both
+     incidents to it (`caused_by` → the anti-pattern).
+4. **If it's genuinely new:**
+   - `remember("<what broke, what the fix was, why>", metadata={"type":
+     "incident", "project": "velesdb", "area": "<area>", "date": <YYYYMMDD
+     numeric>})`.
+   - `relate` it to the fix (PR/commit description as a fact if durable
+     enough), the module it concerns, and any design decision it invalidates.
+
+Skipping step 1 is how the same class of bug gets fixed twice under two
+different names, two years apart, with nothing connecting them.
+
+### 3. Before closing verification — cross-check the adversarial standard
+
+Before marking a change "tested" or a PR "ready", recall the project's own
+test standard rather than trusting a green suite or a coverage number:
+
+```
+recall_fused("test standard adversarial axes", filter={"project":"velesdb","topic":"test-standard"})
+```
+
+Confirm, for the change at hand, that the four axes were exercised — not
+merely that lines were covered:
+
+- **OOM** — unbounded allocations, giant payloads, index and cache growth,
+  leaks under a long-running process.
+- **Performance** — regressions, lock contention, cost under concurrency.
+- **Data loss** — WAL, snapshots, compaction, retention and purge, restore
+  that is not atomic, anything that rewrites a file in place.
+- **Vulnerabilities** — input reaching a query or a path without validation,
+  an unauthenticated route, isolation between callers.
+
+A green suite is evidence about the cases someone thought to write. It is not
+evidence about these four, and it never becomes evidence about them by being
+greener. If a change ships without one of the axes exercised, say which one
+and why, before declaring it done — the point of saying it out loud is that a
+reader six months later can tell an axis was *considered and skipped* from an
+axis that was never looked at.
+
+## Correcting a memory that turned out to be wrong
+
+A stale fact is worse than a missing one: it outranks nothing, it keeps
+surfacing, and the reader has no way to know it has been superseded. When a
+stored memory is contradicted by something you have just proven:
+
+1. `why(<id>)` first — read what it was based on. Sometimes the fact is right
+   and the *conclusion* drawn from it was wrong, which is a different repair.
+2. If it is genuinely wrong, `forget(<id>)`, then `remember` the corrected
+   version. Two calls, in that order. Leaving the old one and adding the new
+   one beside it is the failure this step exists to prevent.
+3. If it is not wrong but no longer *current* — a decision that has since been
+   superseded — keep both and `relate(new_id, old_id, "supersedes")`. The
+   history is worth having; the ambiguity is not.
+4. Say which you did. "I corrected a memory" and "I recorded that a decision
+   changed" mean different things to whoever reads the trail.
+
+Use `feedback(id, false)` on a memory that surfaced and misled you, and
+`feedback(id, true)` on one that actually helped. Ranking only improves if the
+outcome comes back; skipping it leaves confidence flat forever.
+
+## Metadata convention (so recall/recurrence-check actually work)
+
+Use these consistently or the recurrence check in step 2 has nothing to match
+against:
+
+- `type`: `"decision" | "fact" | "incident" | "anti-pattern" | "milestone" |
+  "measurement"`
+- `project`: `"velesdb"`
+- `area`: the subsystem (`"raft"`, `"wal"`, `"hnsw"`, `"context-compiler"`,
+  `"velesql"`, …) — this is what makes an area-scoped `recall_fused` filter
+  useful before a design.
+- `date`: numeric `YYYYMMDD` (`recall_where`'s comparisons are type-strict —
+  see the velesdb-memory skill's date-format note).
+
+## Worked example
+
+A crash-recovery test finds that a compaction mid-write can leave a torn WAL
+tail (already fixed once, PR #1011).
+
+- Before writing a NEW compaction-adjacent fix, `recall_fused("compaction
+  torn WAL tail write path")` — this should surface PR #1011's fix and its
+  reasoning *before* re-deriving the same analysis or, worse, reintroducing
+  the same gap in a different code path.
+- If a second, distinct torn-tail bug shows up in a different subsystem later,
+  the recurrence check surfaces #1011 as `same_root_cause_as`, and a
+  generalized anti-pattern ("compaction-adjacent writes need X invariant")
+  gets remembered once instead of two unlinked incident facts nobody connects
+  six months later.
+
+## Anti-patterns
+
+- **Remembering the fix without checking for its predecessor first.** This is
+  the single most valuable step and the easiest to skip under time pressure.
+- **Storing the incident but not the generalized anti-pattern.** A recall hit
+  on the exact same bug is useful; a recall hit on the *same class* of bug in
+  a new file is what actually prevents repeats — that only works if the
+  anti-pattern fact exists and is linked.
+- **Writing every turn to memory.** The store fills with session chatter, and
+  the facts that matter stop being the ones that come back.
+- **Adding a corrected fact without removing the wrong one.** Now recall
+  returns both and the reader has to guess which is current.
+- **Treating coverage % as the verification checkpoint.** It's a floor, not a
+  substitute for the 4-axis check.
+- **Skipping this loop under time pressure "just this once."** The failure
+  mode this skill exists to prevent happens under exactly that pressure —
+  a suite that was green while three deterministic blockers sat behind it.
+
+## Where the tool contract lives
+
+This file holds the discipline. The tools' own contract — argument shapes,
+return envelopes, embedder and extractor setup, the date-format rule, and the
+working-context calls that resume a session — belongs to the **velesdb-memory
+skill**, which is the single source of truth for them. Read it there rather
+than trusting a paraphrase here: a duplicated contract is a contract that
+drifts.
+
+At the start of a session, load the previous working context before
+re-deriving anything; at the end, save it. If you do not know the session
+name, list the project's sessions before concluding that no earlier work
+exists — an empty result for a mistyped name looks exactly like a fresh start.
+
+## A machine-local layer, if one exists
+
+Everything above is generic and ships with the repository. A machine may add
+a personal layer beside this file, in `LOCAL.md`, in the same directory as
+this `SKILL.md`. It is never versioned and never a copy of what is above.
+
+If that file exists, **read it after** these rules and treat it as a
+complement, never a replacement — the generic rules resolve first, the local
+layer refines them. The harness does not load it for you.
+
+It must never contain a token, a credential, or personal data.

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -181,9 +181,20 @@ cp -r skills/velesdb-context-optimizer ~/.claude/skills/
 → [`skills/velesdb-context-optimizer/SKILL.md`](../../skills/velesdb-context-optimizer/SKILL.md)
 and the [Context compiler guide](CONTEXT_COMPILER.md).
 
+A third, **`velesdb-learning-loop`**, is the discipline over the other two —
+recall before designing, check whether a fix is a *recurrence* before storing
+it, correct a wrong memory rather than adding beside it, and treat writing to
+memory as a decision, never a reflex:
+
+```bash
+cp -r skills/velesdb-learning-loop ~/.claude/skills/
+```
+
+→ [`skills/velesdb-learning-loop/SKILL.md`](../../skills/velesdb-learning-loop/SKILL.md)
+
 **No repo clone needed.** Every
 [GitHub Release](https://github.com/cyberlife-coder/VelesDB/releases/latest)
-attaches `velesdb-skills.tar.gz` — both skills, one folder per skill at the
+attaches `velesdb-skills.tar.gz` — every skill, one folder per skill at the
 archive root — so a one-liner installs them straight from the release:
 
 ```bash

--- a/docs/guides/NODE_ADDON.md
+++ b/docs/guides/NODE_ADDON.md
@@ -250,10 +250,12 @@ methods — wiring the API alone gives it the verbs, not the loop:
 |---|---|
 | `skills/velesdb-memory` | recall before acting → remember decisions with metadata **and** links → `relate` as relationships appear → `why` to explain → `feedback` to reinforce |
 | `skills/velesdb-context-optimizer` | the full compression workflow, including when *not* to compress |
+| `skills/velesdb-learning-loop` | the discipline over both: recall before designing, check recurrence before storing a fix, correct a wrong memory instead of adding beside it, and never write by reflex |
 
 ```bash
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-memory ~/.claude/skills/
 cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-context-optimizer ~/.claude/skills/
+cp -r node_modules/@wiscale/velesdb-memory-node/skills/velesdb-learning-loop ~/.claude/skills/
 ```
 
 **Keep them fresh.** That `cp` is a snapshot, not a live link — re-run it

--- a/scripts/check-skill-private-references.py
+++ b/scripts/check-skill-private-references.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""No versioned skill may point at something only the private repository holds.
+
+## Why this exists
+
+A skill is public twice over. It lives in the open-core repository, and
+`crates/velesdb-node/package.json` ships `skills/` inside the npm package —
+so the copy an agent loads may have arrived from npm, on a machine that has
+never seen this repository and never will see the private one.
+
+`AGENTS.md` already draws the line: *core must never reference any premium
+crate, type, or symbol*, and CI enforces it on Rust. Skills sat outside that
+reach. It showed the moment one was versioned: the learning-loop skill arrived
+carrying four `premium` mentions and three citations of a pull request that
+exists only in the private repository, instructing an agent to cross-check a
+test standard it cannot open. Nothing anywhere reported a fault — the same
+shape as #1712, one surface over.
+
+## What it refuses, and what it deliberately does not
+
+Two markers, declared with their reason in `MARKERS`. Both are about the
+READER: a shipped skill must be actionable from the open core alone.
+
+It does not refuse issue or PR numbers. `skills/velesdb-context-optimizer`
+cites `issue #1455` and the memory skill cites `#1473`, both public and both
+useful; nothing in the text of `#147` distinguishes a private number from a
+public one, and a guard that guessed would either block those two or catch
+nothing. That half of the leak is closed by the content, not by this guard —
+stated here rather than left for a reader to discover it never fired.
+
+## Anti-disarm
+
+A sweep that reads no file exits 1. Deleting `skills/` is otherwise the
+cheapest way to retire a guard while leaving it green in the workflow.
+
+Usage:
+    python3 scripts/check-skill-private-references.py            # this repository
+    python3 scripts/check-skill-private-references.py --verbose  # list what was read
+    python3 scripts/check-skill-private-references.py --root DIR # a tree under test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: `(marker, why a shipped skill must not carry it)`. Matched case-insensitively
+#: on a leading word boundary, so `Premium` and `premium-only` are the same
+#: finding and `premiums` is not a way through.
+MARKERS: "tuple[tuple[str, str], ...]" = (
+    (
+        "velesdb-private",
+        "the private repository — whoever loads this skill cannot open it",
+    ),
+    (
+        "premium",
+        "premium surfaces live in the private repository; AGENTS.md forbids core "
+        "from referencing any premium crate, type or symbol, and a shipped skill "
+        "is core's surface too",
+    ),
+)
+
+
+def skill_roots(root: Path) -> "list[Path]":
+    """Directories whose whole contents ship as a versioned skill.
+
+    Globbed, never listed. A hand-maintained list is one more registry to keep
+    in step, and the failure mode of a stale one is silence.
+    """
+    candidates = [root / "skills"]
+    candidates += sorted((root / "crates").glob("*/skill"))
+    candidates += sorted((root / "crates").glob("*/skills"))
+    return [path for path in candidates if path.is_dir()]
+
+
+def skill_files(root: Path) -> "list[Path]":
+    """Every file under every skill root, deduplicated and ordered."""
+    found: "set[Path]" = set()
+    for base in skill_roots(root):
+        found.update(path for path in base.rglob("*") if path.is_file())
+    return sorted(found)
+
+
+def findings(path: Path, name: str) -> "list[str]":
+    """Every offending line in one file, reported with its number and text.
+
+    Every line, not the first: stopping at one hit turns a single fix into N
+    runs, and the reader believes the run that finally goes quiet.
+    """
+    reports = []
+    body = path.read_text(encoding="utf-8", errors="replace")
+    for number, line in enumerate(body.splitlines(), 1):
+        for marker, reason in MARKERS:
+            if re.search(rf"\b{re.escape(marker)}", line, re.IGNORECASE):
+                reports.append(f"{name}:{number}: {marker} — {reason}\n      {line.strip()}")
+    return reports
+
+
+def check(root: Path, verbose: bool) -> int:
+    files = skill_files(root)
+    if not files:
+        print(
+            f"no versioned skill found under {root} — this guard read nothing, "
+            "which is never a pass",
+            file=sys.stderr,
+        )
+        return 1
+
+    problems: "list[str]" = []
+    for path in files:
+        name = str(path.relative_to(root))
+        if verbose:
+            print(f"  scanned {name}")
+        problems += findings(path, name)
+
+    if problems:
+        print(
+            "A versioned skill references something only the private repository "
+            "holds:\n\n    " + "\n\n    ".join(problems) + "\n\n"
+            "A skill ships to npm and is loaded on machines that have the open "
+            "core and nothing else. Rewrite the passage so it is actionable "
+            "there, or drop it.\n",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  {len(files)} versioned skill file(s) carry no private reference")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default=str(REPO), help="tree to scan (default: this repo)")
+    parser.add_argument("--verbose", action="store_true", help="name every file read")
+    args = parser.parse_args(argv)
+    return check(Path(args.root), args.verbose)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -264,6 +264,62 @@
       ]
     },
     {
+      "script": "scripts/check-skill-private-references.py",
+      "purpose": "No versioned skill points at something only the private repository holds.",
+      "workflow": ".github/workflows/ci.yml",
+      "job": "mcp-doc-contract",
+      "required": true,
+      "mode": "strict",
+      "self_test": "scripts.tests.test_check_skill_private_references",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "a versioned skill sending the reader to a standard held in the closed repository",
+          "files": {
+            "skills/demo/SKILL.md": "# Demo\n\nBefore declaring premium coverage done, cross-check the axes.\n"
+          },
+          "accepts": {
+            "skills/demo/SKILL.md": "# Demo\n\nBefore declaring coverage done, cross-check the axes.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "the bundled npm copy naming the private repository — that copy is the one that leaves the machine",
+          "files": {
+            "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee velesdb-private for the enforcing policy.\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/skills/demo/SKILL.md": "# Demo\n\nSee the architecture reference for the boundary.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "a tree holding no versioned skill at all — deleting skills/ is the cheapest way to retire this guard while leaving it in the workflow",
+          "files": {
+            "docs/README.md": "nothing to scan here\n"
+          },
+          "accepts": {
+            "docs/README.md": "nothing to scan here\n",
+            "skills/demo/SKILL.md": "# Demo\n\nUse recall before proposing an approach.\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
+      "blind_spot": {
+        "issue": null,
+        "summary": "Reads the two declared markers and nothing else. It does NOT catch a bare issue or pull-request number belonging to the closed repository: the learning-loop skill arrived citing one three times, and no property of the text separates it from the public `#1455` and `#1473` two other skills cite usefully — a guess would either block those or catch nothing. That half was closed by rewriting the passages, not by this guard. Scope is the skill directories only, by design: docs/CORE_PREMIUM_SPLIT.md documents the split on purpose."
+      }
+    },
+    {
       "script": "scripts/check-doc-contract.sh",
       "purpose": "Every runtime route of the server is documented in the root README.",
       "workflow": ".github/workflows/doc-contract.yml",

--- a/scripts/sync-skills.py
+++ b/scripts/sync-skills.py
@@ -37,10 +37,30 @@ never installed these must not have their work refused over a machine-local
 state. The post-merge hook passes `--strict`, where absence is precisely what
 the reader needs told.
 
+## The one file the repository does not own
+
+A machine may keep a personal layer beside an installed skill, in `LOCAL.md`:
+never committed, never a copy of the shipped skill, complementing it. That
+file only survives if this tool knows about it — the install swaps whole
+directories, so anything the source lacks is gone, and the check lists
+everything it did not put there. Left alone, the first silently destroyed the
+only copy of a file the design invites you to write, and the second went red
+over it, which is how a reader learns to stop reading a guard.
+
+## The npm copies are generated, not maintained
+
+`crates/velesdb-node/skills/` ships inside the npm package (`package.json`
+"files"), so those copies leave the machine. They used to be hand-copied, with
+a comment asking the next person to remember — which is how a source moves and
+its artefact stays behind. `--bundle` regenerates them from the same source
+list this tool already owns, and the two byte-identity guards stay red until it
+has been run.
+
 Usage:
     python3 scripts/sync-skills.py --check            # drift fails; absent is reported
     python3 scripts/sync-skills.py --check --strict   # absent fails too
     python3 scripts/sync-skills.py --install          # repo -> ~/.claude/skills
+    python3 scripts/sync-skills.py --bundle           # repo -> the npm-bundled copies
 """
 
 from __future__ import annotations
@@ -62,8 +82,20 @@ REPO = Path(__file__).resolve().parents[1]
 #: in its lane.
 SKILLS: tuple[tuple[str, str], ...] = (
     ("skills/velesdb-context-optimizer", "velesdb-context-optimizer"),
+    ("skills/velesdb-learning-loop", "velesdb-learning-loop"),
     ("crates/velesdb-memory/skill/velesdb-memory", "velesdb-memory"),
 )
+
+#: Files an installed skill may hold that no source ships: the machine-local
+#: layer. Preserved across an install and never reported as drift.
+#:
+#: One name, not a rule of thumb. Widening this to "anything the source does
+#: not have" would retire the `unexpected` state, which is what catches a
+#: half-deleted install and a stale file from an older version of a skill.
+#: `scripts/tests/test_sync_skills.py` pins that no versioned skill ships a
+#: file by these names — otherwise the exemption would blind the check to a
+#: real one.
+LOCAL_FILES: tuple[str, ...] = ("LOCAL.md",)
 
 
 def installed_root() -> Path:
@@ -71,6 +103,14 @@ def installed_root() -> Path:
     is what lets this tool be tested without writing into a real install."""
     override = os.environ.get("CLAUDE_SKILLS_DIR")
     return Path(override) if override else Path.home() / ".claude" / "skills"
+
+
+def bundle_root() -> Path:
+    """Where the npm package's bundled copies live. `VELESDB_BUNDLE_DIR`
+    overrides it, so the regeneration can be exercised without rewriting the
+    committed artefact the guards are reading."""
+    override = os.environ.get("VELESDB_BUNDLE_DIR")
+    return Path(override) if override else REPO / "crates" / "velesdb-node" / "skills"
 
 
 def digest(root: Path) -> dict[str, str]:
@@ -87,17 +127,35 @@ def digest(root: Path) -> dict[str, str]:
 
 
 def drift(source: Path, installed: Path) -> list[str]:
-    """What differs between the two trees, in reader-facing terms."""
+    """What differs between the two trees, in reader-facing terms.
+
+    `LOCAL_FILES` present only on the installed side are the machine-local
+    layer, not drift: the design invites them, so reporting them would make
+    this guard red on a correct install.
+    """
     want, have = digest(source), digest(installed)
     problems = []
     for name in sorted(set(want) - set(have)):
         problems.append(f"missing: {name}")
-    for name in sorted(set(have) - set(want)):
+    for name in sorted(set(have) - set(want) - set(LOCAL_FILES)):
         problems.append(f"unexpected: {name}")
     for name in sorted(set(want) & set(have)):
         if want[name] != have[name]:
             problems.append(f"differs: {name}")
     return problems
+
+
+def carry_local_layer(installed: Path, staging: Path) -> None:
+    """Move the machine-local layer of `installed` into the tree replacing it.
+
+    Copied rather than left in place because the replacement is a rename of a
+    whole directory: whatever is not inside `staging` when the rename happens
+    does not exist afterwards.
+    """
+    for name in LOCAL_FILES:
+        current = installed / name
+        if current.is_file():
+            shutil.copy2(current, staging / name)
 
 
 def install_one(source: Path, target: Path) -> None:
@@ -108,6 +166,10 @@ def install_one(source: Path, target: Path) -> None:
     plain recursive copy over a live directory is what leaves a skill whose
     first half is new and second half is old — and a SKILL.md is read by an
     agent at arbitrary moments, including during an install.
+
+    The machine-local layer is carried across before the swap. Without that,
+    the atomicity that protects the shipped files is exactly what destroys the
+    one file nothing else holds a copy of.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
     staging = target.parent / f".{target.name}.staging-{os.getpid()}"
@@ -116,6 +178,7 @@ def install_one(source: Path, target: Path) -> None:
     shutil.rmtree(previous, ignore_errors=True)
     try:
         shutil.copytree(source, staging)
+        carry_local_layer(target, staging)
         if target.exists():
             os.replace(target, previous)
         os.replace(staging, target)
@@ -175,15 +238,29 @@ def run_check(root: Path, strict: bool) -> int:
     return 0
 
 
-def run_install(root: Path) -> int:
+def deploy(root: Path, verb: str) -> int:
+    """Write every managed skill into `root`, one atomic swap each.
+
+    Shared by `--install` and `--bundle` so the two destinations can never be
+    fed different source lists — the whole point of the second one is that the
+    artefact is derived from the same declaration as the install.
+    """
     for source_rel, name in SKILLS:
         source = REPO / source_rel
         if not source.is_dir():
             print(f"{source_rel} is missing from the repository", file=sys.stderr)
             return 1
         install_one(source, root / name)
-        print(f"  {name} <- {source_rel}")
+        print(f"  {verb} {name} <- {source_rel}")
     return 0
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    if args.check:
+        return run_check(installed_root(), args.strict)
+    if args.bundle:
+        return deploy(bundle_root(), "bundled")
+    return deploy(installed_root(), "installed")
 
 
 def main() -> int:
@@ -191,14 +268,17 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true", help="report drift, exit 1 if any")
     mode.add_argument("--install", action="store_true", help="copy repo skills into place")
+    mode.add_argument(
+        "--bundle",
+        action="store_true",
+        help="regenerate the npm-bundled copies under crates/velesdb-node/skills",
+    )
     parser.add_argument(
         "--strict",
         action="store_true",
         help="with --check: a managed skill that is absent also exits non-zero",
     )
-    args = parser.parse_args()
-    root = installed_root()
-    return run_check(root, args.strict) if args.check else run_install(root)
+    return dispatch(parser.parse_args())
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_check_skill_private_references.py
+++ b/scripts/tests/test_check_skill_private_references.py
@@ -1,0 +1,165 @@
+"""Behaviour of `scripts/check-skill-private-references.py`.
+
+A versioned skill is public twice over: it sits in the open-core repository,
+and `crates/velesdb-node/package.json` ships `skills/` to npm. Whoever loads it
+has the open core and nothing else.
+
+`AGENTS.md` already states the boundary — *core must never reference any
+premium crate, type, or symbol* — and CI enforces it on Rust. Skills were
+outside that reach, and it showed: the learning-loop skill this change versions
+arrived carrying four `premium` mentions and three citations of a pull request
+that only exists in the private repository. An agent reading it was told to
+cross-check a test standard it cannot open.
+
+Every rule below is pinned RED first on a synthetic tree, then GREEN on the
+same tree repaired, before the guard is pointed at the real repository.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "check-skill-private-references.py"
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class SyntheticTree(unittest.TestCase):
+    """One skill under a throwaway root, rewritten per test."""
+
+    def setUp(self) -> None:
+        self.root = Path(tempfile.mkdtemp(prefix="skill-private-refs-"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+        self.skill = self.root / "skills" / "demo"
+        self.skill.mkdir(parents=True)
+        self.write("# Demo\n\nUse `recall` before proposing an approach.\n")
+
+    def write(self, body: str, name: str = "SKILL.md") -> Path:
+        path = self.skill / name
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def check(self) -> subprocess.CompletedProcess[str]:
+        return run("--root", str(self.root))
+
+    def test_a_clean_skill_is_accepted(self) -> None:
+        result = self.check()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_a_premium_mention_is_refused(self) -> None:
+        """The actual leak. Four of these shipped in the learning-loop skill,
+        pointing an agent at a test standard held in the private repository."""
+        self.write("# Demo\n\nBefore declaring premium coverage done, cross-check.\n")
+
+        result = self.check()
+
+        self.assertEqual(result.returncode, 1, "a premium reference must be refused")
+        self.assertIn("skills/demo/SKILL.md", result.stdout + result.stderr)
+        self.assertIn("3", result.stdout + result.stderr, "the line number is missing")
+
+    def test_the_private_repository_name_is_refused(self) -> None:
+        self.write("# Demo\n\nSee velesdb-private for the enforcing policy.\n")
+        self.assertEqual(self.check().returncode, 1)
+
+    def test_a_refusal_becomes_an_acceptance_once_repaired(self) -> None:
+        """RED then GREEN on one tree — the pair is the proof, not either half."""
+        self.write("# Demo\n\nThe premium audit trail is out of scope here.\n")
+        self.assertEqual(self.check().returncode, 1)
+
+        self.write("# Demo\n\nThe audit trail is out of scope here.\n")
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_the_match_ignores_case(self) -> None:
+        """A capitalised sentence opener would otherwise walk straight through."""
+        self.write("# Demo\n\nPremium features live elsewhere.\n")
+        self.assertEqual(self.check().returncode, 1)
+
+    def test_every_offending_line_is_named_not_only_the_first(self) -> None:
+        """A guard that stops at the first hit turns one fix into N runs, and
+        the reader believes the last one when it finally goes quiet."""
+        self.write("# Demo\n\npremium one\nclean\npremium two\n")
+
+        report = self.check().stdout + self.check().stderr
+
+        self.assertIn("premium one", report)
+        self.assertIn("premium two", report)
+
+    def test_a_non_skill_file_under_the_same_root_is_ignored(self) -> None:
+        """`docs/CORE_PREMIUM_SPLIT.md` documents the split on purpose. The
+        rule is about what SHIPS as a skill, not about the word existing."""
+        docs = self.root / "docs"
+        docs.mkdir()
+        (docs / "CORE_PREMIUM_SPLIT.md").write_text("premium plan\n", encoding="utf-8")
+
+        self.assertEqual(self.check().returncode, 0)
+
+    def test_a_bundled_npm_copy_is_in_scope(self) -> None:
+        """That copy is the one that leaves the machine — package.json ships
+        `skills/`. Guarding the source and not the artefact guards nothing."""
+        bundled = self.root / "crates" / "velesdb-node" / "skills" / "demo"
+        bundled.mkdir(parents=True)
+        (bundled / "SKILL.md").write_text("premium\n", encoding="utf-8")
+
+        self.assertEqual(self.check().returncode, 1)
+
+    def test_a_crate_owned_skill_is_in_scope(self) -> None:
+        """`crates/velesdb-memory/skill/velesdb-memory` is a source too."""
+        owned = self.root / "crates" / "velesdb-memory" / "skill" / "demo"
+        owned.mkdir(parents=True)
+        (owned / "SKILL.md").write_text("velesdb-private\n", encoding="utf-8")
+
+        self.assertEqual(self.check().returncode, 1)
+
+    def test_a_root_holding_no_skill_at_all_is_refused(self) -> None:
+        """Same anti-disarm rule as the other guards here: a sweep that read
+        nothing must never answer success. Deleting the skills directory is
+        the cheapest way to retire a guard while leaving it in the workflow."""
+        shutil.rmtree(self.root / "skills")
+
+        result = run("--root", str(self.root))
+
+        self.assertEqual(result.returncode, 1, "an empty sweep must refuse")
+        self.assertIn("no versioned skill", (result.stdout + result.stderr).lower())
+
+
+class RealRepository(unittest.TestCase):
+    def test_the_repository_as_committed_is_clean(self) -> None:
+        result = run()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_the_guard_is_executable(self) -> None:
+        self.assertTrue(os.access(SCRIPT, os.X_OK), f"{SCRIPT.name} is not executable")
+
+    def test_the_sweep_reaches_every_versioned_skill(self) -> None:
+        """The count is read from the filesystem, never hard-coded: pinning a
+        number would fail on the next skill and teach the reader to bump it."""
+        expected = sorted(
+            str(path.relative_to(REPO))
+            for path in list((REPO / "skills").rglob("*"))
+            + list((REPO / "crates").glob("*/skill/*/*"))
+            + list((REPO / "crates").glob("*/skills/*/*"))
+            if path.is_file()
+        )
+        self.assertTrue(expected, "no versioned skill found — the pin reads nothing")
+
+        report = run("--verbose").stdout
+        for name in expected:
+            self.assertIn(name, report, f"{name} was never scanned")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_skill_copies_are_identical.py
+++ b/scripts/tests/test_skill_copies_are_identical.py
@@ -1,11 +1,14 @@
 """The bundled copies of a skill must stay byte-identical to their source.
 
 ``skills/velesdb-context-optimizer/SKILL.md`` and
-``crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md`` are
-hand-copied duplicates — no build step, no symlink. Both are surfaces the
-MCP return-contract guard polices (``scripts/check-mcp-doc-contract.py``), so
-letting them drift means fixing a contract in one and leaving the npm
-package shipping the other.
+``crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md`` are committed
+duplicates — no symlink, and nothing regenerates them on build. They are
+*produced* by ``python3 scripts/sync-skills.py --bundle``, which is what makes
+the fix one command instead of a remembered ``cp -r``; running it is still a
+deliberate act, so the copies can be stale between the edit and the run. Both
+are surfaces the MCP return-contract guard polices
+(``scripts/check-mcp-doc-contract.py``), so letting them drift means fixing a
+contract in one and leaving the npm package shipping the other.
 
 **A guard for this already exists, and it does block.** An earlier version of
 this header claimed a napi build failure would "take the skill comparison
@@ -58,6 +61,10 @@ SKILL_PAIRS: "tuple[tuple[str, str], ...]" = (
     (
         "skills/velesdb-context-optimizer",
         "crates/velesdb-node/skills/velesdb-context-optimizer",
+    ),
+    (
+        "skills/velesdb-learning-loop",
+        "crates/velesdb-node/skills/velesdb-learning-loop",
     ),
     (
         "crates/velesdb-memory/skill/velesdb-memory",
@@ -161,7 +168,7 @@ class RealSkillCopyTests(unittest.TestCase):
                     problems,
                     [],
                     f"{copy_rel} has drifted from {source_rel}: {'; '.join(problems)}. "
-                    f"Resync with: cp -r {source_rel}/. {copy_rel}/",
+                    "Resync with: python3 scripts/sync-skills.py --bundle",
                 )
 
     def test_the_registry_is_not_empty(self) -> None:

--- a/scripts/tests/test_sync_skills.py
+++ b/scripts/tests/test_sync_skills.py
@@ -13,7 +13,9 @@ own, which would make the result depend on whose machine ran it.
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -23,14 +25,32 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / "scripts" / "sync-skills.py"
+BUNDLE = REPO / "crates" / "velesdb-node" / "skills"
 
-#: Kept in step with `SKILLS` in the script, and asserted below rather than
-#: trusted — a divergence here would silently narrow what the tests cover.
-EXPECTED = ("velesdb-context-optimizer", "velesdb-memory")
+#: `(source in the repo, installed name)`, held against the script's own
+#: `SKILLS` below rather than trusted — a divergence here would silently narrow
+#: what every test in this file covers.
+EXPECTED_PAIRS = (
+    ("skills/velesdb-context-optimizer", "velesdb-context-optimizer"),
+    ("skills/velesdb-learning-loop", "velesdb-learning-loop"),
+    ("crates/velesdb-memory/skill/velesdb-memory", "velesdb-memory"),
+)
+EXPECTED = tuple(name for _source, name in EXPECTED_PAIRS)
+SOURCE_OF = dict((name, source) for source, name in EXPECTED_PAIRS)
 
 
-def run(*args: str, root: Path) -> subprocess.CompletedProcess[str]:
+def load_script():
+    """The script as a module, so its registry can be compared and not grepped."""
+    spec = importlib.util.spec_from_file_location("sync_skills", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(*args: str, root: Path, bundle: Path | None = None) -> subprocess.CompletedProcess[str]:
     env = dict(os.environ, CLAUDE_SKILLS_DIR=str(root))
+    if bundle is not None:
+        env["VELESDB_BUNDLE_DIR"] = str(bundle)
     return subprocess.run(
         [sys.executable, str(SCRIPT), *args],
         capture_output=True,
@@ -46,14 +66,15 @@ class SyncSkills(unittest.TestCase):
         self.root = Path(self._tmp.name)
         self.addCleanup(self._tmp.cleanup)
 
-    def test_the_script_covers_exactly_the_two_repo_skills(self) -> None:
+    def test_the_script_covers_exactly_the_repo_skills(self) -> None:
         """Guard the guard: a narrowed list would make every test below pass
-        while checking less, which is the failure mode a coverage guard has."""
-        source = SCRIPT.read_text(encoding="utf-8")
-        for name in EXPECTED:
-            self.assertIn(
-                f'"{name}"', source, f"{name} is no longer covered by sync-skills.py"
-            )
+        while checking less, which is the failure mode a coverage guard has.
+
+        Compared as a tuple, not searched for as substrings. A name search
+        answers "is it mentioned somewhere", which stays true for a skill that
+        was moved into a comment on its way out of the registry.
+        """
+        self.assertEqual(tuple(load_script().SKILLS), EXPECTED_PAIRS)
 
     def test_absent_is_reported_but_forgiven_by_default(self) -> None:
         """A skill that was never installed is NOT drift. A contributor who has
@@ -177,9 +198,201 @@ class SyncSkills(unittest.TestCase):
         target.write_text("half written", encoding="utf-8")
         run("--install", root=self.root)
 
-        source = (REPO / "crates/velesdb-memory/skill/velesdb-memory/SKILL.md").read_bytes()
+        source = (REPO / SOURCE_OF[EXPECTED[1]] / "SKILL.md").read_bytes()
         self.assertEqual(target.read_bytes(), source)
 
+class LocalLayer(unittest.TestCase):
+    """`LOCAL.md` — the one file an installed skill may hold that the repo does not.
+
+    The versioned SKILL.md carries the generic, shippable discipline. A machine
+    may add a personal layer beside it, uncommitted and never duplicated into
+    the repo. That file only survives if the installer knows about it: an
+    installer that swaps the whole directory DELETES it, and a checker that
+    lists everything it did not put there REPORTS it — the first silently
+    destroys work, the second trains the reader to ignore a red guard.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def local_file(self, name: str) -> Path:
+        return self.root / name / "LOCAL.md"
+
+    def test_install_preserves_an_existing_local_layer(self) -> None:
+        """The destructive one. `install_one` builds the new tree from the
+        source alone and renames it over the target, so anything the target
+        held and the source does not is gone — including the only copy."""
+        run("--install", root=self.root)
+        local = self.local_file(EXPECTED[0])
+        local.write_text("# personal layer\nnever versioned\n", encoding="utf-8")
+
+        self.assertEqual(run("--install", root=self.root).returncode, 0)
+
+        self.assertTrue(local.is_file(), "--install deleted the machine-local LOCAL.md")
+        self.assertEqual(
+            local.read_text(encoding="utf-8"), "# personal layer\nnever versioned\n"
+        )
+
+    def test_install_preserves_the_local_layer_of_each_skill_independently(self) -> None:
+        """Preserving one skill's layer while eating another's is the same
+        defect with a smaller blast radius."""
+        run("--install", root=self.root)
+        for index, name in enumerate(EXPECTED):
+            self.local_file(name).write_text(f"layer {index}\n", encoding="utf-8")
+
+        run("--install", root=self.root)
+
+        for index, name in enumerate(EXPECTED):
+            self.assertEqual(
+                self.local_file(name).read_text(encoding="utf-8"),
+                f"layer {index}\n",
+                f"{name} lost its local layer",
+            )
+
+    def test_check_never_reports_the_local_layer(self) -> None:
+        """`drift()` calls every file it did not install `unexpected`. A guard
+        that goes red on a file the design invites you to create is a guard
+        people learn to run with their eyes closed."""
+        run("--install", root=self.root)
+        self.local_file(EXPECTED[0]).write_text("# personal layer\n", encoding="utf-8")
+
+        result = run("--check", "--strict", root=self.root)
+
+        self.assertEqual(
+            result.returncode, 0, f"LOCAL.md was treated as drift:\n{result.stderr}"
+        )
+        self.assertNotIn("LOCAL.md", result.stdout + result.stderr)
+        self.assertIn(f"{EXPECTED[0]}: in step", result.stdout)
+
+    def test_a_stowaway_beside_the_local_layer_is_still_reported(self) -> None:
+        """The exemption is one named file, not "anything extra". Widening it
+        to a rule of thumb would retire the `unexpected` state entirely."""
+        run("--install", root=self.root)
+        self.local_file(EXPECTED[0]).write_text("# personal layer\n", encoding="utf-8")
+        (self.root / EXPECTED[0] / "STOWAWAY.md").write_text("x", encoding="utf-8")
+
+        result = run("--check", root=self.root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unexpected: STOWAWAY.md", result.stderr)
+        self.assertNotIn("LOCAL.md", result.stderr)
+
+    def test_no_versioned_skill_ships_a_local_md(self) -> None:
+        """The exemption assumes the name is free on the repo side. If a source
+        ever shipped a LOCAL.md, `--check` would stop noticing it was deleted
+        or altered on the installed copy — the exemption would have quietly
+        blinded the guard to a real file."""
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("LOCAL.md", source, "the local-layer exemption is gone")
+        for path in (REPO / "skills").rglob("LOCAL.md"):
+            self.fail(f"a versioned skill ships {path.relative_to(REPO)}")
+        for path in (REPO / "crates").rglob("LOCAL.md"):
+            self.fail(f"a versioned skill ships {path.relative_to(REPO)}")
+
+
+class BundledCopies(unittest.TestCase):
+    """`--bundle` — the npm artefact, derived rather than remembered.
+
+    `crates/velesdb-node/skills/` ships inside the package (`package.json`
+    "files"), so those copies leave the machine. They were kept in step by a
+    comment asking the next person to `cp -r`. Two byte-identity guards already
+    catch the omission; what did not exist is the command that repairs it from
+    the same declaration the install uses.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.bundle = Path(self._tmp.name) / "skills"
+        self.addCleanup(self._tmp.cleanup)
+        self._installed = tempfile.TemporaryDirectory()
+        self.root = Path(self._installed.name)
+        self.addCleanup(self._installed.cleanup)
+
+    def bundled(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return run(*args, root=self.root, bundle=self.bundle)
+
+    def test_bundle_reproduces_every_source_byte_for_byte(self) -> None:
+        self.assertEqual(self.bundled("--bundle").returncode, 0)
+
+        for source_rel, name in EXPECTED_PAIRS:
+            source = REPO / source_rel
+            for path in sorted(p for p in source.rglob("*") if p.is_file()):
+                mirrored = self.bundle / name / path.relative_to(source)
+                self.assertTrue(mirrored.is_file(), f"{name}: {path.name} was not bundled")
+                self.assertEqual(mirrored.read_bytes(), path.read_bytes(), str(mirrored))
+
+    def test_bundle_covers_exactly_the_installed_skills(self) -> None:
+        """One declaration feeds both destinations. Two lists would drift, and
+        the artefact is the one nobody looks at."""
+        self.bundled("--bundle")
+        self.assertEqual(sorted(p.name for p in self.bundle.iterdir()), sorted(EXPECTED))
+
+    def test_bundle_removes_a_file_an_older_version_left_behind(self) -> None:
+        """A regeneration that only adds is how a renamed file ships forever
+        beside its replacement."""
+        self.bundled("--bundle")
+        stale = self.bundle / EXPECTED[0] / "REMOVED-IN-2-0.md"
+        stale.write_text("from an older version\n", encoding="utf-8")
+
+        self.bundled("--bundle")
+
+        self.assertFalse(stale.exists(), "a stale bundled file survived the regeneration")
+
+    def test_the_committed_bundle_is_exactly_what_bundle_produces(self) -> None:
+        """The claim "generated, not hand-maintained" is only true if the
+        committed artefact matches a fresh run. Regenerating into a temporary
+        directory proves it without touching the tree under test."""
+        self.assertEqual(self.bundled("--bundle").returncode, 0)
+
+        produced = sorted(
+            str(p.relative_to(self.bundle)) for p in self.bundle.rglob("*") if p.is_file()
+        )
+        committed = sorted(str(p.relative_to(BUNDLE)) for p in BUNDLE.rglob("*") if p.is_file())
+        self.assertEqual(produced, committed, "the committed npm bundle is not the generated one")
+        for name in produced:
+            self.assertEqual(
+                (self.bundle / name).read_bytes(),
+                (BUNDLE / name).read_bytes(),
+                f"crates/velesdb-node/skills/{name} differs from a fresh --bundle",
+            )
+
+    def test_bundle_does_not_write_into_the_install_root(self) -> None:
+        """The two destinations are distinct. A `--bundle` that also touched
+        `~/.claude/skills` would make an artefact refresh a machine change."""
+        self.bundled("--bundle")
+        self.assertEqual(sorted(self.root.iterdir()), [])
+
+
+class ReleaseArchive(unittest.TestCase):
+    """`velesdb-skills.tar.gz` — the fifth list of the same skills.
+
+    The release workflow stages the skills by hand and names them again in the
+    `tar` line. Four other registries are pinned against one another; this one
+    was pinned against nothing, so a skill could be versioned, installed,
+    bundled into npm, guarded twice — and still be absent from the archive the
+    README tells people to install from, with every check green.
+    """
+
+    RELEASE = REPO / ".github" / "workflows" / "release.yml"
+
+    def setUp(self) -> None:
+        self.body = self.RELEASE.read_text(encoding="utf-8")
+
+    def test_the_archive_stages_every_managed_skill(self) -> None:
+        staged = set(re.findall(r'cp -r (\S+) "\$stage/"', self.body))
+        self.assertEqual(staged, set(source for source, _name in EXPECTED_PAIRS))
+
+    def test_the_archive_ships_every_staged_skill(self) -> None:
+        """Staging without naming it in `tar` copies a skill into a temporary
+        directory and throws it away."""
+        line = re.search(r'tar -czf velesdb-skills\.tar\.gz -C "\$stage" (.+)', self.body)
+        self.assertIsNotNone(line, "the skills archive is no longer built here")
+        self.assertEqual(set(line.group(1).split()), set(EXPECTED))
+
+
+class VersionedHooks(unittest.TestCase):
     def test_every_versioned_hook_is_described_by_the_activation_scripts(self) -> None:
         """A versioned hook is not a protection until git is pointed at it, and
         `setup-hooks.sh` is what does that. Both activation scripts name their

--- a/skills/velesdb-learning-loop/SKILL.md
+++ b/skills/velesdb-learning-loop/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: velesdb-learning-loop
+description: >
+  Turn every velesdb design / implement / verify cycle into durable, connected
+  memory so the SAME mistake is never repeated and later decisions build on
+  what was already learned, instead of re-deriving it or silently colliding
+  with it. Trigger BEFORE starting a design or implementation on
+  velesdb / velesdb-core / velesdb-memory (recall prior decisions and known
+  anti-patterns for this area first — don't propose an approach blind).
+  Trigger AFTER a bug is found and fixed, a review finding is confirmed, or a
+  non-trivial decision is made (check whether this failure mode was already
+  recorded before storing it — a match means RECURRENCE, not a fresh fact).
+  Trigger BEFORE declaring a change verified (cross-check the four adversarial
+  axes — OOM, performance, data loss, vulnerabilities — instead of closing on a
+  green suite or a coverage number). Trigger when a stored memory turns out to
+  be WRONG (correct it with forget plus a replacement; a stale fact outranks no
+  fact and keeps being recalled). Complements the velesdb-memory skill's
+  generic recall / recall_fused / remember / relate / entity / why / feedback
+  loop with a stricter, project-specific discipline: no design starts blind, no
+  fix ships without a recurrence check, no verification closes on coverage
+  alone, and writing to memory is never automatic.
+---
+
+# velesdb-learning-loop — don't repeat a mistake twice
+
+This skill is not a new set of tools — it's a **discipline on top of**
+`velesdb-memory`'s `remember`/`recall`/`recall_fused`/`relate`/`entity`/`why`/
+`feedback`, aimed specifically at making design → implementation →
+verification on velesdb *compound*: each cycle should make the next one faster
+and safer, not just add another isolated fact.
+
+## Writing is never systematic — sort first
+
+Most of what happens in a session must NOT be written. A memory store that
+accumulates everything stops being a memory and becomes a log: recall returns
+the noise ahead of the fact, and the discipline below quietly stops working
+because nothing useful surfaces.
+
+Before storing anything, sort it into one of five:
+
+| It is | What to do |
+|---|---|
+| **Durable** — a decision, an incident, a measured fact, an anti-pattern that will still be true next month | `remember`, with the metadata convention below, and `relate` it to what it touches |
+| **Temporary working state** — where you are in a task, what is next | not `remember`. It belongs to the working-context tools, which are the resumption mechanism, not durable memory |
+| **Ephemeral** — a command output, a path you just read, a number you are about to use once | nothing. Re-derive it if you need it again |
+| **A secret** — token, credential, private URL, personal data | never, under any framing. Not in a fact, not in metadata, not "temporarily" |
+| **An existing memory that is now wrong** | correct it (below). Adding the new version beside the old one leaves both in recall, and the reader cannot tell which is current |
+
+When in doubt, ask whether a *later* session reaching this fact would act on
+it. If not, it is noise.
+
+## The three checkpoints
+
+### 1. Before design/implementation — recall, don't assume
+
+Before proposing an approach or writing code for a feature/module/area, run:
+
+```
+recall_fused("<area> design decisions and known pitfalls", filter={"project":"velesdb"})
+```
+
+Read what comes back for:
+
+- **decisions already taken** in this area (don't re-litigate or silently
+  contradict one — if you must deviate, say so explicitly and `relate` the
+  new decision to the old one with `supersedes`).
+- **anti-patterns / incidents** tied to this area (a past bug, a rejected
+  design, a race condition class). Treat these as constraints, not trivia.
+
+When the area is a **named thing** rather than a topic — a crate, a module, a
+tool, a workflow — ask about the thing itself instead of about the sentences
+that mention it:
+
+```
+entity("velesdb-core")        # what is known ABOUT it, and what it connects to
+```
+
+`recall` ranks passages; `entity` returns the node and its edges. Asking
+`recall("velesdb-core")` for "what do we know about this crate" gets you the
+paragraphs where the name appears, which is a different and usually worse
+answer.
+
+If recall returns nothing, say so and proceed — never invent a memory to
+fill the gap.
+
+### 2. After a bug is found and fixed — check recurrence BEFORE remembering
+
+This is the step most likely to be skipped, and the one that matters most.
+When you fix a bug, a race, a silent data-loss path, or a review finding:
+
+1. **Recall first**, using the *failure signature* (symptom + mechanism, not
+   just the file name) — e.g. `recall("write path deadlocks under concurrent
+   compaction")`, not `recall("bug in wal.rs")`.
+2. **Score the match.** A close semantic match (same mechanism, same class of
+   trigger — concurrency, boundary, resource exhaustion) is a candidate
+   recurrence even if the surface symptom or the file differs.
+3. **If it's a likely recurrence:**
+   - Say so explicitly to the user — *"this looks like the same root cause as
+     <prior incident>, not a new bug"* — don't bury it in a routine commit
+     message.
+   - `relate(new_incident_id, prior_incident_id, "same_root_cause_as")`
+     instead of leaving two disconnected facts that `why` can't join.
+   - `remember` a **generalized** anti-pattern fact (the class of mistake,
+     not just this instance) if one doesn't already exist, and link both
+     incidents to it (`caused_by` → the anti-pattern).
+4. **If it's genuinely new:**
+   - `remember("<what broke, what the fix was, why>", metadata={"type":
+     "incident", "project": "velesdb", "area": "<area>", "date": <YYYYMMDD
+     numeric>})`.
+   - `relate` it to the fix (PR/commit description as a fact if durable
+     enough), the module it concerns, and any design decision it invalidates.
+
+Skipping step 1 is how the same class of bug gets fixed twice under two
+different names, two years apart, with nothing connecting them.
+
+### 3. Before closing verification — cross-check the adversarial standard
+
+Before marking a change "tested" or a PR "ready", recall the project's own
+test standard rather than trusting a green suite or a coverage number:
+
+```
+recall_fused("test standard adversarial axes", filter={"project":"velesdb","topic":"test-standard"})
+```
+
+Confirm, for the change at hand, that the four axes were exercised — not
+merely that lines were covered:
+
+- **OOM** — unbounded allocations, giant payloads, index and cache growth,
+  leaks under a long-running process.
+- **Performance** — regressions, lock contention, cost under concurrency.
+- **Data loss** — WAL, snapshots, compaction, retention and purge, restore
+  that is not atomic, anything that rewrites a file in place.
+- **Vulnerabilities** — input reaching a query or a path without validation,
+  an unauthenticated route, isolation between callers.
+
+A green suite is evidence about the cases someone thought to write. It is not
+evidence about these four, and it never becomes evidence about them by being
+greener. If a change ships without one of the axes exercised, say which one
+and why, before declaring it done — the point of saying it out loud is that a
+reader six months later can tell an axis was *considered and skipped* from an
+axis that was never looked at.
+
+## Correcting a memory that turned out to be wrong
+
+A stale fact is worse than a missing one: it outranks nothing, it keeps
+surfacing, and the reader has no way to know it has been superseded. When a
+stored memory is contradicted by something you have just proven:
+
+1. `why(<id>)` first — read what it was based on. Sometimes the fact is right
+   and the *conclusion* drawn from it was wrong, which is a different repair.
+2. If it is genuinely wrong, `forget(<id>)`, then `remember` the corrected
+   version. Two calls, in that order. Leaving the old one and adding the new
+   one beside it is the failure this step exists to prevent.
+3. If it is not wrong but no longer *current* — a decision that has since been
+   superseded — keep both and `relate(new_id, old_id, "supersedes")`. The
+   history is worth having; the ambiguity is not.
+4. Say which you did. "I corrected a memory" and "I recorded that a decision
+   changed" mean different things to whoever reads the trail.
+
+Use `feedback(id, false)` on a memory that surfaced and misled you, and
+`feedback(id, true)` on one that actually helped. Ranking only improves if the
+outcome comes back; skipping it leaves confidence flat forever.
+
+## Metadata convention (so recall/recurrence-check actually work)
+
+Use these consistently or the recurrence check in step 2 has nothing to match
+against:
+
+- `type`: `"decision" | "fact" | "incident" | "anti-pattern" | "milestone" |
+  "measurement"`
+- `project`: `"velesdb"`
+- `area`: the subsystem (`"raft"`, `"wal"`, `"hnsw"`, `"context-compiler"`,
+  `"velesql"`, …) — this is what makes an area-scoped `recall_fused` filter
+  useful before a design.
+- `date`: numeric `YYYYMMDD` (`recall_where`'s comparisons are type-strict —
+  see the velesdb-memory skill's date-format note).
+
+## Worked example
+
+A crash-recovery test finds that a compaction mid-write can leave a torn WAL
+tail (already fixed once, PR #1011).
+
+- Before writing a NEW compaction-adjacent fix, `recall_fused("compaction
+  torn WAL tail write path")` — this should surface PR #1011's fix and its
+  reasoning *before* re-deriving the same analysis or, worse, reintroducing
+  the same gap in a different code path.
+- If a second, distinct torn-tail bug shows up in a different subsystem later,
+  the recurrence check surfaces #1011 as `same_root_cause_as`, and a
+  generalized anti-pattern ("compaction-adjacent writes need X invariant")
+  gets remembered once instead of two unlinked incident facts nobody connects
+  six months later.
+
+## Anti-patterns
+
+- **Remembering the fix without checking for its predecessor first.** This is
+  the single most valuable step and the easiest to skip under time pressure.
+- **Storing the incident but not the generalized anti-pattern.** A recall hit
+  on the exact same bug is useful; a recall hit on the *same class* of bug in
+  a new file is what actually prevents repeats — that only works if the
+  anti-pattern fact exists and is linked.
+- **Writing every turn to memory.** The store fills with session chatter, and
+  the facts that matter stop being the ones that come back.
+- **Adding a corrected fact without removing the wrong one.** Now recall
+  returns both and the reader has to guess which is current.
+- **Treating coverage % as the verification checkpoint.** It's a floor, not a
+  substitute for the 4-axis check.
+- **Skipping this loop under time pressure "just this once."** The failure
+  mode this skill exists to prevent happens under exactly that pressure —
+  a suite that was green while three deterministic blockers sat behind it.
+
+## Where the tool contract lives
+
+This file holds the discipline. The tools' own contract — argument shapes,
+return envelopes, embedder and extractor setup, the date-format rule, and the
+working-context calls that resume a session — belongs to the **velesdb-memory
+skill**, which is the single source of truth for them. Read it there rather
+than trusting a paraphrase here: a duplicated contract is a contract that
+drifts.
+
+At the start of a session, load the previous working context before
+re-deriving anything; at the end, save it. If you do not know the session
+name, list the project's sessions before concluding that no earlier work
+exists — an empty result for a mistyped name looks exactly like a fresh start.
+
+## A machine-local layer, if one exists
+
+Everything above is generic and ships with the repository. A machine may add
+a personal layer beside this file, in `LOCAL.md`, in the same directory as
+this `SKILL.md`. It is never versioned and never a copy of what is above.
+
+If that file exists, **read it after** these rules and treat it as a
+complement, never a replacement — the generic rules resolve first, the local
+layer refines them. The harness does not load it for you.
+
+It must never contain a token, a credential, or personal data.


### PR DESCRIPTION
The `velesdb-learning-loop` skill lived only under `~/.claude/skills`, unversioned — the exact third copy #1712 exists to police, except this one had no source at all. It also pointed an agent at a test standard held in the closed repository: four `premium` mentions and three citations of a pull request a reader of the open core cannot open.

## What changed

**`skills/velesdb-learning-loop/SKILL.md` is the single source.** Removed: the private references and the section dated to `velesdb-memory` 0.11.1. Kept: the three checkpoints, the metadata convention, the worked example, the anti-patterns. Added: `entity` (asking about a *thing* rather than the sentences mentioning it), correcting a wrong memory with `forget` + replacement instead of adding one beside it, the five-way sort before storing anything (durable / working state / ephemeral / secret / already-stored-and-now-wrong), the rule that **writing is never systematic**, a pointer to the memory skill for the tool contract, and the `LOCAL.md` layer — after the generic rules, never instead of them.

**`sync-skills.py --bundle`** generates `crates/velesdb-node/skills/` from the same registry `--install` uses. Those copies ship on npm and were kept in step by a comment asking the next person to `cp -r`.

**`LOCAL.md` is preserved.** A machine may keep a personal layer beside an installed skill. The atomic swap deleted it — the one file nothing else holds a copy of — and `--check` reported it as `unexpected`, which is how a reader learns to ignore a red guard. One named file, not a rule of thumb: a stowaway beside it is still reported.

**`scripts/check-skill-private-references.py`** refuses a private reference in any versioned skill, bundled copy included. Strict, required, wired into `mcp-doc-contract`.

**The release archive was the fifth copy of the skill list** — `release.yml` stages and names the skills by hand, pinned against nothing. A skill could be versioned, installed, bundled into npm and guarded twice while silently missing from `velesdb-skills.tar.gz`. It is now held against the registry by a test.

## Proof

Three reds first, each executed and failing for its own reason:

| red | why it failed |
|---|---|
| `--install` preserves `LOCAL.md` | `install_one` renames a tree built from the source alone — the file was gone |
| `--check` never reports `LOCAL.md` | `drift()` reported `unexpected: LOCAL.md`, exit 1 |
| the private-reference guard | the script did not exist — exit **2**, a crash, not a refusal |

Then, measured:

- **231 → 256** python tests (`unittest discover -s scripts/tests`, baseline run on `develop@76b02c33`).
- The npm byte-identity guard went **red on the committed artefact** until `--bundle` was run — the "generated, not hand-maintained" claim held against an actual regeneration, and `test_the_committed_bundle_is_exactly_what_bundle_produces` keeps it that way.
- `npm pack --dry-run`: `skills/velesdb-learning-loop/SKILL.md`, 12.2 kB, inside the package.
- Source and bundled copy are byte-identical **in the committed tree** (`git show`, same sha256), and `LOCAL.md` appears in `git ls-files` zero times.
- The three refusal vectors were proven to run by **disarming the guard**: `if problems:` → `if False:` makes the vector suite name both content vectors; neutralising the empty-sweep path makes it name the third. Restored, all green.
- Against a copy of a real install carrying a real `LOCAL.md`: `drifted` → `--install` → `in step`, `LOCAL.md` never named in either report and byte-identical by sha256 afterwards.

## Known limit, stated rather than discovered

The guard does not catch a bare issue or PR number belonging to the closed repository. Nothing in the text separates `#147` from the public `#1455` and `#1473` two other skills cite usefully, and a guess would either block those or catch nothing. That half of the leak was closed by rewriting the passages. Recorded in the guard's `blind_spot`.

The measured `save_working_context` timeout/reconnect finding was dropped with the dated section rather than moved here: its home is the memory skill, which does not yet own the working-context tools. Deliberate, not lost.

Closes nothing on its own — first of three batches on the versioned-memory foundation.


Part of #1773 (lot 1 sur 3 du socle mémoire versionné).
