### PR TITLE
docs(skills): resumption belongs to the memory skill, not the compression one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,6 +632,14 @@ jobs:
       - name: Versioned skills carry no private reference
         run: python3 scripts/check-skill-private-references.py
 
+      # Which skill owns cross-session resumption. The working-context tools
+      # were documented in the COMPRESSION skill and not once in the memory
+      # one, so an agent loading the skill named after memory was never told
+      # a previous session could be read back — and nobody was told to
+      # discover sessions, so a mistyped id read as "no previous work".
+      - name: Resumption is owned by the memory skill
+        run: python3 -m unittest scripts.tests.test_skill_resumption_ownership
+
       # BLOCKING. Verified green on the whole tree (16 pinned surfaces, 20
       # declarations of load_working_context's envelope — including the three
       # agent session hooks and the napi `ts_return_type` shipped as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Cross-session resumption belongs to the `velesdb-memory` skill.**
+  `list_working_contexts`, `load_working_context` and `save_working_context`
+  were documented in `velesdb-context-optimizer` — the *compression* skill —
+  and not once in the memory one, so an agent loading the skill named after
+  memory was never told a previous session could be read back.
+  `list_working_contexts` was taught nowhere at all, which left a mistyped
+  session id returning `found: false` and reading as "no previous work". The
+  memory skill now walks `list → load → work → save`, ties an empty load to
+  discovery, and warns that `other_sessions` is filled in on a *hit* too — the
+  wrong session resumed is the failure that looks like success. The
+  compression skill keeps an explicit handoff to it and no longer restates the
+  `working` envelope. The `load_working_context` return-shape pins moved with
+  the declaration rather than being dropped, and
+  `crates/velesdb-memory/skill/**` joined the swept surfaces: the bundled npm
+  copy was policed while the source it is generated from was not.
+
 ### Added
 
 - **A third versioned agent skill, `velesdb-learning-loop`.** It ships in

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -12,6 +12,12 @@ description: >
   Use remember_extracted when a passage states relationships or properties of
   named people/places/things, and entity(name) to answer a question ABOUT such a
   thing rather than about the sentences that mention it.
+  Use it ACROSS sessions too: list_working_contexts to discover what a project
+  already has, load_working_context to pick up a previous session's hand-off,
+  and save_working_context to leave one. When a load returns found:false, or
+  when you do not know the exact session name, list the project's contexts
+  before concluding that no earlier work exists — a mistyped id looks exactly
+  like a fresh start.
   Especially relevant for: multi-session projects, architecture/config decisions,
   incident postmortems, "why is this value/setting like this", onboarding to an
   unfamiliar codebase, and any place a fact learned now must survive to a later
@@ -126,6 +132,77 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    confidence, so over time useful facts rise and noise sinks — the memory
    improves without any retraining. Give feedback on the memory you actually
    used, not on everything.
+
+## Resuming a session: list → load → work → save
+
+The loop above runs *inside* one session. A **working context** is what crosses
+between them: a distilled hand-off — goal, active constraints, verified facts,
+open hypotheses, decisions, evidence handles, pending actions — stored under a
+`project` and a `session` id and read back by whoever comes next, which is
+usually you, tomorrow, with none of today's context.
+
+This is memory, not compression. `save_working_context` embeds and stores; it
+returns a fact id. The compression skill (`velesdb-context-optimizer`) shrinks
+one prompt with a pure function and keeps nothing — a different mechanism for a
+different problem. It points here when a distilled context deserves to survive.
+
+**1. `list_working_contexts` — discover before you assume.**
+Run it when you do not know the exact session name, and whenever a load comes
+back empty. Session ids are chosen by hand (`"rolling"`, a task id, a
+conversation id), which means they are mistyped by hand too.
+
+**2. `load_working_context(project, session)` — read the hand-off.**
+It returns `{found, working, other_sessions}`.
+
+- `found: true` — adopt `working.goal`, re-assert `active_constraints`, trust
+  `verified_facts`, and continue from `pending_actions` instead of re-deriving
+  them. Fetch `exact_evidence` handles with `retrieve_context_source` when you
+  need the actual bytes.
+- `found: false` (with `working: null`) — **this is not proof that no earlier
+  work exists.** It says nothing was ever saved under *that exact pair*. Read
+  `other_sessions`, or call `list_working_contexts`, before you say "fresh
+  start": a similarly-named session in that list means the id was a typo and
+  the work is sitting one character away from where you looked.
+- `other_sessions` is filled in **on a hit too**. If one of them looks more
+  like the session you meant, you may have just resumed the *wrong* one — the
+  failure that reads as success.
+
+**3. Work**, running the loop above: recall, remember, relate, feedback.
+
+**4. `save_working_context(project, session, working)` — leave a hand-off.**
+Near the end of a session, or whenever the state changes meaningfully. Keep it
+distilled: this is the note, not the transcript. Saving again under the same
+project and session **replaces** the previous state, so a resumed session
+should re-save rather than accumulate. An entirely empty `working` is refused
+instead of being allowed to wipe what the last save stored.
+
+```json
+{"tool": "list_working_contexts", "arguments": {"project": "veles"}}
+```
+
+```json
+{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
+```
+
+```json
+{"tool": "save_working_context", "arguments": {
+  "project": "veles", "session": "task-1234",
+  "working": {
+    "goal": "fix the failing canary deploy",
+    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
+    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
+    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
+  }
+}}
+```
+
+**Field shapes are not uniform, and guessing costs a confusing error.**
+`active_constraints`, `verified_facts` and `open_hypotheses` are lists of
+`{text, source?}` objects; `decisions` and `exact_evidence` are typed structs
+where `fragment_id` is required; **`pending_actions` is a plain list of
+strings.** Sending `pending_actions: [{"text": "..."}]` fails with a `missing
+field fragment_id` that never names the field actually at fault. Follow the
+example above literally rather than inventing one shape for every field.
 
 ## Entities: let the graph build itself
 

--- a/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md
@@ -7,11 +7,11 @@ description: >
   repeated context, long logs, or accumulated conversation turns; when token
   costs need to drop measurably; or when the user says "compress my context",
   "optimize my prompt", "reduce token usage", "context is too big", or asks
-  why part of their context was dropped; or when a session should be
-  resumable later (save the working context at the end, load it back at the
-  start of the next one). Requires the velesdb-memory MCP server (tools:
-  compile_context, compile_transcript, context_savings, explain_compilation,
-  retrieve_context_source, save_working_context, load_working_context).
+  why part of their context was dropped. Requires the velesdb-memory MCP
+  server (tools: compile_context, compile_transcript, context_savings,
+  explain_compilation, retrieve_context_source). Making a session RESUMABLE is
+  a different job and belongs to the velesdb-memory skill, which owns the
+  working-context tools; this one hands a distilled context over to it.
 ---
 
 # VelesDB context optimizer
@@ -193,46 +193,23 @@ tokens — `content`, `insights`, `risk`, `warnings`, `sources`, and
 `retrieval_handles` are unaffected, and the full audit trail is one
 re-compile away (deterministic, so nothing is actually lost).
 
-## Inter-session resumption (save at the end, load at the start)
+## A distilled context can outlive the prompt — see the memory skill
 
-Compression keeps one prompt small; `save_working_context` /
-`load_working_context` keep the *session itself* resumable:
+Compression keeps one prompt small. It does not make the *session* resumable,
+and the two are different mechanisms: the compiler is a pure function that
+keeps nothing, while a working context is a fact that is embedded and stored.
 
-- **At the START of a session**, call `load_working_context` with the
-  project and a stable session id (e.g. the conversation/task id). It returns
-  `{found, working, other_sessions}`. When `found` is true, a prior session
-  left off here: adopt `working.goal`, re-assert `active_constraints`, trust
-  `verified_facts` (re-fetch `exact_evidence` handles with
-  `retrieve_context_source` when you need the bytes), and continue from
-  `pending_actions` instead of re-deriving everything. `found: false` (with
-  `working: null`) is not an error — but do not call it a fresh start until
-  you have read `other_sessions`: a similarly-named session listed there
-  means the id was a typo and the work is sitting right next to where you
-  looked. `other_sessions` is filled in on a HIT too, so if one of them
-  looks more like the session you meant, you may have just resumed the
-  WRONG one.
-- **At the END of a session** (or whenever the state changes meaningfully),
-  call `save_working_context` with the distilled state: `goal`,
-  `active_constraints`, `verified_facts` (with sources), `open_hypotheses`,
-  `decisions`, `exact_evidence`, `pending_actions`. Keep it small — this is
-  the hand-off note, not the transcript. Saving again under the same
-  project + session replaces the previous state (idempotent upsert).
+So when you have just distilled a context worth surviving the session — the
+goal, what is settled, what is next — hand it to the memory side rather than
+re-deriving it tomorrow. `save_working_context` is the handoff;
+`load_working_context` reads it back at the start of the next session, and
+neither is documented here: the **`velesdb-memory` skill** owns the
+working-context tools, the field shapes, and the discovery step that keeps an
+unknown session name from being mistaken for an absence of prior work.
 
-```json
-{"tool": "save_working_context", "arguments": {
-  "project": "veles", "session": "task-1234",
-  "working": {
-    "goal": "fix the failing canary deploy",
-    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
-    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
-    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
-  }
-}}
-```
-
-```json
-{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
-```
+One rule is worth repeating rather than looking up: **an empty load is not
+proof of a fresh start.** Ask the memory skill's discovery step before you
+conclude anything from it.
 
 ## Screenshots and images
 

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -12,6 +12,12 @@ description: >
   Use remember_extracted when a passage states relationships or properties of
   named people/places/things, and entity(name) to answer a question ABOUT such a
   thing rather than about the sentences that mention it.
+  Use it ACROSS sessions too: list_working_contexts to discover what a project
+  already has, load_working_context to pick up a previous session's hand-off,
+  and save_working_context to leave one. When a load returns found:false, or
+  when you do not know the exact session name, list the project's contexts
+  before concluding that no earlier work exists — a mistyped id looks exactly
+  like a fresh start.
   Especially relevant for: multi-session projects, architecture/config decisions,
   incident postmortems, "why is this value/setting like this", onboarding to an
   unfamiliar codebase, and any place a fact learned now must survive to a later
@@ -126,6 +132,77 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    confidence, so over time useful facts rise and noise sinks — the memory
    improves without any retraining. Give feedback on the memory you actually
    used, not on everything.
+
+## Resuming a session: list → load → work → save
+
+The loop above runs *inside* one session. A **working context** is what crosses
+between them: a distilled hand-off — goal, active constraints, verified facts,
+open hypotheses, decisions, evidence handles, pending actions — stored under a
+`project` and a `session` id and read back by whoever comes next, which is
+usually you, tomorrow, with none of today's context.
+
+This is memory, not compression. `save_working_context` embeds and stores; it
+returns a fact id. The compression skill (`velesdb-context-optimizer`) shrinks
+one prompt with a pure function and keeps nothing — a different mechanism for a
+different problem. It points here when a distilled context deserves to survive.
+
+**1. `list_working_contexts` — discover before you assume.**
+Run it when you do not know the exact session name, and whenever a load comes
+back empty. Session ids are chosen by hand (`"rolling"`, a task id, a
+conversation id), which means they are mistyped by hand too.
+
+**2. `load_working_context(project, session)` — read the hand-off.**
+It returns `{found, working, other_sessions}`.
+
+- `found: true` — adopt `working.goal`, re-assert `active_constraints`, trust
+  `verified_facts`, and continue from `pending_actions` instead of re-deriving
+  them. Fetch `exact_evidence` handles with `retrieve_context_source` when you
+  need the actual bytes.
+- `found: false` (with `working: null`) — **this is not proof that no earlier
+  work exists.** It says nothing was ever saved under *that exact pair*. Read
+  `other_sessions`, or call `list_working_contexts`, before you say "fresh
+  start": a similarly-named session in that list means the id was a typo and
+  the work is sitting one character away from where you looked.
+- `other_sessions` is filled in **on a hit too**. If one of them looks more
+  like the session you meant, you may have just resumed the *wrong* one — the
+  failure that reads as success.
+
+**3. Work**, running the loop above: recall, remember, relate, feedback.
+
+**4. `save_working_context(project, session, working)` — leave a hand-off.**
+Near the end of a session, or whenever the state changes meaningfully. Keep it
+distilled: this is the note, not the transcript. Saving again under the same
+project and session **replaces** the previous state, so a resumed session
+should re-save rather than accumulate. An entirely empty `working` is refused
+instead of being allowed to wipe what the last save stored.
+
+```json
+{"tool": "list_working_contexts", "arguments": {"project": "veles"}}
+```
+
+```json
+{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
+```
+
+```json
+{"tool": "save_working_context", "arguments": {
+  "project": "veles", "session": "task-1234",
+  "working": {
+    "goal": "fix the failing canary deploy",
+    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
+    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
+    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
+  }
+}}
+```
+
+**Field shapes are not uniform, and guessing costs a confusing error.**
+`active_constraints`, `verified_facts` and `open_hypotheses` are lists of
+`{text, source?}` objects; `decisions` and `exact_evidence` are typed structs
+where `fragment_id` is required; **`pending_actions` is a plain list of
+strings.** Sending `pending_actions: [{"text": "..."}]` fails with a `missing
+field fragment_id` that never names the field actually at fault. Follow the
+example above literally rather than inventing one shape for every field.
 
 ## Entities: let the graph build itself
 

--- a/scripts/check-mcp-doc-contract.py
+++ b/scripts/check-mcp-doc-contract.py
@@ -192,7 +192,16 @@ POLICED_TOOLS: "tuple[PolicedTool, ...]" = (
         ("loadWorkingContext", "LoadedWorkingContext"),
         (
             "crates/velesdb-node/README.md",
-            "crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md",
+            # The skill that OWNS the working-context tools, and its bundled
+            # npm copy. The pin moved here from the two
+            # `velesdb-context-optimizer` copies when resumption moved with
+            # it: the compression skill now points at this one instead of
+            # restating the envelope, so it no longer declares a shape and
+            # cannot be pinned for one. Coverage did not shrink — the
+            # declaration and its pin travelled together, which is the only
+            # way a moved contract stays policed.
+            "crates/velesdb-memory/skill/velesdb-memory/SKILL.md",
+            "crates/velesdb-node/skills/velesdb-memory/SKILL.md",
             # The `ts_return_type` string is the .d.ts every npm consumer
             # compiles against. binding_parity_bdd.rs reads this region but
             # treats that string as EVIDENCE of a relay, never checks its
@@ -213,7 +222,6 @@ POLICED_TOOLS: "tuple[PolicedTool, ...]" = (
             "integrations/langgraph/README.md",
             "integrations/langgraph/src/langgraph_velesdb/tools.py",
             "sdks/typescript/src/memory.ts",
-            "skills/velesdb-context-optimizer/SKILL.md",
         ),
     ),
     PolicedTool(
@@ -264,6 +272,12 @@ SURFACE_GLOBS: "tuple[str, ...]" = (
     "docs/**/*.md",
     "skills/**/*.md",
     "crates/velesdb-memory/README.md",
+    # The velesdb-memory skill's SOURCE. Its bundled npm copy under
+    # `crates/velesdb-node/skills/` was already swept, which had the polarity
+    # backwards: the copy is generated from this file by
+    # `sync-skills.py --bundle`, so policing only the artefact means the thing
+    # a contributor edits is the one nothing reads.
+    "crates/velesdb-memory/skill/**/*.md",
     "crates/velesdb-node/README.md",
     "crates/velesdb-node/skills/**/*.md",
     # The shipped TypeScript return type of the napi addon.
@@ -340,7 +354,7 @@ ERROR_PAYLOAD_KEYS = frozenset({"error"})
 # skill page shows one, and prose about what a tool `returns` routinely sits a
 # few dozen characters above the example of how to call it, which is enough for
 # the return anchor to claim it (measured at
-# skills/velesdb-context-optimizer/SKILL.md:340, both copies). Exactly two keys
+# skills/velesdb-context-optimizer/SKILL.md:317, both copies). Exactly two keys
 # wide, for the same reason the one above is exactly one: an exemption that can
 # grow can hide a rename.
 CALL_ENVELOPE_KEYS = frozenset({"tool", "arguments"})

--- a/scripts/tests/test_check_mcp_doc_contract.py
+++ b/scripts/tests/test_check_mcp_doc_contract.py
@@ -341,7 +341,7 @@ class ExtractionTests(unittest.TestCase):
     def test_the_mcp_call_envelope_is_not_a_return_shape(self) -> None:
         # A skill page shows how to CALL a tool a few dozen characters after
         # prose about what it `returns`, which is enough for the return anchor
-        # to claim the example (skills/velesdb-context-optimizer/SKILL.md:340).
+        # to claim the example (skills/velesdb-context-optimizer/SKILL.md:317).
         self.assertEqual(
             self._declarations(
                 "`demo_tool` returns the state.\n\n"
@@ -603,8 +603,13 @@ class RealRepositoryTests(unittest.TestCase):
                 "docs/reference/MCP_TOOLS.md",
             },
             "load_working_context": {
+                # The two `velesdb-context-optimizer` copies used to be here.
+                # Resumption moved to the memory skill, and the pin moved with
+                # the declaration rather than being dropped — same count, same
+                # coverage, different owner.
+                "crates/velesdb-memory/skill/velesdb-memory/SKILL.md",
                 "crates/velesdb-node/README.md",
-                "crates/velesdb-node/skills/velesdb-context-optimizer/SKILL.md",
+                "crates/velesdb-node/skills/velesdb-memory/SKILL.md",
                 "crates/velesdb-node/src/lib.rs",
                 "docs/guides/NODE_ADDON.md",
                 "docs/guides/PYTHON_CONTEXT_COMPILER.md",
@@ -618,7 +623,6 @@ class RealRepositoryTests(unittest.TestCase):
                 "integrations/langgraph/README.md",
                 "integrations/langgraph/src/langgraph_velesdb/tools.py",
                 "sdks/typescript/src/memory.ts",
-                "skills/velesdb-context-optimizer/SKILL.md",
             },
             "recall_fused": {
                 "crates/velesdb-node/src/lib.rs",

--- a/scripts/tests/test_skill_resumption_ownership.py
+++ b/scripts/tests/test_skill_resumption_ownership.py
@@ -1,0 +1,183 @@
+"""Which skill owns cross-session resumption, asserted rather than intended.
+
+`save_working_context`, `load_working_context` and `list_working_contexts` are
+memory tools: they embed, they store a fact, they are read back in a later
+session. They were documented in `velesdb-context-optimizer` — the compression
+skill — and **not once** in `velesdb-memory`, measured on 2026-08-02: four
+mentions each of save/load in the optimizer, zero of anything in the memory
+skill, and `list_working_contexts` taught nowhere at all.
+
+The consequence is not cosmetic. An agent that loads only the memory skill —
+the one whose name says "memory" — is never told that a previous session's
+state can be read back. And nobody was told to *discover* sessions, so a
+mistyped session id returns `found: false` and reads as "no previous work".
+
+This file pins the split so it cannot drift back:
+
+1. the resumption tools are taught in the memory skill, not mainly elsewhere;
+2. the memory skill teaches the whole path — list -> load -> work -> save;
+3. an unknown or wrong session name forces discovery before concluding;
+4. the compression skill keeps its pointer to the durable save, without
+   re-documenting resumption.
+
+Each rule's helper is pinned RED-then-GREEN on synthetic text before it is
+pointed at the real skills, so a rule that silently stopped matching anything
+fails here rather than passing over an empty search.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MEMORY = REPO / "crates/velesdb-memory/skill/velesdb-memory/SKILL.md"
+OPTIMIZER = REPO / "skills/velesdb-context-optimizer/SKILL.md"
+
+#: The three tools whose ownership this file decides.
+RESUMPTION_TOOLS = ("list_working_contexts", "load_working_context", "save_working_context")
+
+#: Fields of `save_working_context`'s `working` envelope. Their presence is
+#: what distinguishes DOCUMENTING the tool from POINTING AT it — the line the
+#: compression skill must stay on.
+ENVELOPE_FIELDS = ("active_constraints", "verified_facts", "open_hypotheses", "exact_evidence")
+
+
+def mentions(text: str, token: str) -> int:
+    """How many times `token` appears. Plain count: a skill teaches by
+    repetition — example, explanation, tool call — and one passing mention is
+    exactly what "taught elsewhere" looks like."""
+    return len(re.findall(re.escape(token), text))
+
+
+def appear_in_order(text: str, tokens: "tuple[str, ...]") -> bool:
+    """True when each token first appears after the previous one.
+
+    Order is the claim being made: `list -> load -> work -> save` is a path,
+    and a skill that mentions all three in any arrangement has not taught it.
+    """
+    position = -1
+    for token in tokens:
+        found = text.find(token, position + 1)
+        if found < 0:
+            return False
+        position = found
+    return True
+
+
+def ties_together(text: str, anchor: str, partner: str, window: int = 600) -> bool:
+    """True when `partner` appears within `window` characters of some
+    occurrence of `anchor` — the two are taught in the same breath, not merely
+    present in the same document."""
+    for match in re.finditer(re.escape(anchor), text):
+        start = max(0, match.start() - window)
+        if partner in text[start : match.end() + window]:
+            return True
+    return False
+
+
+class Helpers(unittest.TestCase):
+    """The three rules' machinery, pinned before it judges anything real."""
+
+    def test_mentions_counts_every_occurrence(self) -> None:
+        self.assertEqual(mentions("a b a", "a"), 2)
+        self.assertEqual(mentions("nothing here", "a b"), 0)
+
+    def test_order_holds_only_when_the_path_is_walked(self) -> None:
+        self.assertTrue(appear_in_order("first then second", ("first", "second")))
+        self.assertFalse(appear_in_order("second then first", ("first", "second")))
+        self.assertFalse(appear_in_order("only first", ("first", "second")))
+
+    def test_a_repeated_token_may_satisfy_order_at_its_later_occurrence(self) -> None:
+        # save ... load ... save is a legitimate path: the rule asks that each
+        # step BE reachable in order, not that a word never appears early.
+        self.assertTrue(appear_in_order("save load save", ("load", "save")))
+
+    def test_ties_together_needs_proximity_not_mere_presence(self) -> None:
+        near = "the flag is false, so call discover next"
+        self.assertTrue(ties_together(near, "false", "discover", window=40))
+
+        far = "the flag is false." + ("x" * 500) + "discover"
+        self.assertFalse(ties_together(far, "false", "discover", window=40))
+        self.assertTrue(ties_together(far, "false", "discover", window=600))
+
+
+class ResumptionOwnership(unittest.TestCase):
+    def setUp(self) -> None:
+        self.memory = MEMORY.read_text(encoding="utf-8")
+        self.optimizer = OPTIMIZER.read_text(encoding="utf-8")
+
+    def test_both_skills_are_readable_and_substantial(self) -> None:
+        """Anti-disarm: emptying either file would make every rule below pass
+        over nothing."""
+        for name, body in (("memory", self.memory), ("optimizer", self.optimizer)):
+            self.assertGreater(len(body), 2000, f"the {name} skill is suspiciously small")
+
+    def test_the_memory_skill_teaches_each_resumption_tool(self) -> None:
+        for tool in RESUMPTION_TOOLS:
+            self.assertGreater(
+                mentions(self.memory, tool),
+                0,
+                f"{tool} is not taught in the skill named after memory",
+            )
+
+    def test_the_memory_skill_teaches_them_more_than_the_compression_skill(self) -> None:
+        """Rule 1. "Owner" is not a claim in a header — it is where a reader
+        who wants to learn the tool actually finds it taught."""
+        for tool in RESUMPTION_TOOLS:
+            here, there = mentions(self.memory, tool), mentions(self.optimizer, tool)
+            self.assertGreater(
+                here,
+                there,
+                f"{tool}: taught {there}x in the compression skill and only {here}x "
+                "in the memory skill — the ownership is the wrong way round",
+            )
+
+    def test_the_memory_skill_walks_list_then_load_then_save(self) -> None:
+        """Rule 2. The path, in order — discovery, then read, then write."""
+        self.assertTrue(
+            appear_in_order(self.memory, RESUMPTION_TOOLS),
+            "the memory skill does not walk list -> load -> save in that order",
+        )
+
+    def test_an_unknown_session_forces_discovery_before_concluding(self) -> None:
+        """Rule 3. `found: false` must be tied to `list_working_contexts` in
+        the same passage. Stating both somewhere in a 300-line file does not
+        teach an agent to reach for one when it sees the other."""
+        self.assertTrue(
+            ties_together(self.memory, "found", "list_working_contexts"),
+            "nothing ties a `found: false` result to discovering the existing "
+            "sessions — a mistyped id still reads as 'no previous work'",
+        )
+
+    def test_the_memory_skill_warns_that_a_hit_can_be_the_wrong_session(self) -> None:
+        """`other_sessions` is filled in on a hit too. Resuming the wrong
+        session is the failure that looks like success."""
+        self.assertIn("other_sessions", self.memory)
+
+    def test_the_compression_skill_still_points_at_the_durable_save(self) -> None:
+        """Rule 4. Moving ownership must not sever the referral: an agent that
+        has just distilled a context is exactly the one that should save it."""
+        self.assertIn("save_working_context", self.optimizer)
+        self.assertTrue(
+            ties_together(self.optimizer, "save_working_context", "velesdb-memory"),
+            "the compression skill mentions the tool without pointing at the "
+            "skill that owns it",
+        )
+
+    def test_the_compression_skill_no_longer_documents_the_envelope(self) -> None:
+        """The line between pointing and re-documenting. Two copies of a
+        parameter contract is the drift this whole campaign exists to prevent —
+        and the optimizer's copy is the one nobody would think to update."""
+        duplicated = [f for f in ENVELOPE_FIELDS if f in self.optimizer]
+        self.assertEqual(
+            duplicated,
+            [],
+            f"the compression skill still documents the `working` envelope "
+            f"({', '.join(duplicated)}) — that contract belongs to the memory skill",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/velesdb-context-optimizer/SKILL.md
+++ b/skills/velesdb-context-optimizer/SKILL.md
@@ -7,11 +7,11 @@ description: >
   repeated context, long logs, or accumulated conversation turns; when token
   costs need to drop measurably; or when the user says "compress my context",
   "optimize my prompt", "reduce token usage", "context is too big", or asks
-  why part of their context was dropped; or when a session should be
-  resumable later (save the working context at the end, load it back at the
-  start of the next one). Requires the velesdb-memory MCP server (tools:
-  compile_context, compile_transcript, context_savings, explain_compilation,
-  retrieve_context_source, save_working_context, load_working_context).
+  why part of their context was dropped. Requires the velesdb-memory MCP
+  server (tools: compile_context, compile_transcript, context_savings,
+  explain_compilation, retrieve_context_source). Making a session RESUMABLE is
+  a different job and belongs to the velesdb-memory skill, which owns the
+  working-context tools; this one hands a distilled context over to it.
 ---
 
 # VelesDB context optimizer
@@ -193,46 +193,23 @@ tokens — `content`, `insights`, `risk`, `warnings`, `sources`, and
 `retrieval_handles` are unaffected, and the full audit trail is one
 re-compile away (deterministic, so nothing is actually lost).
 
-## Inter-session resumption (save at the end, load at the start)
+## A distilled context can outlive the prompt — see the memory skill
 
-Compression keeps one prompt small; `save_working_context` /
-`load_working_context` keep the *session itself* resumable:
+Compression keeps one prompt small. It does not make the *session* resumable,
+and the two are different mechanisms: the compiler is a pure function that
+keeps nothing, while a working context is a fact that is embedded and stored.
 
-- **At the START of a session**, call `load_working_context` with the
-  project and a stable session id (e.g. the conversation/task id). It returns
-  `{found, working, other_sessions}`. When `found` is true, a prior session
-  left off here: adopt `working.goal`, re-assert `active_constraints`, trust
-  `verified_facts` (re-fetch `exact_evidence` handles with
-  `retrieve_context_source` when you need the bytes), and continue from
-  `pending_actions` instead of re-deriving everything. `found: false` (with
-  `working: null`) is not an error — but do not call it a fresh start until
-  you have read `other_sessions`: a similarly-named session listed there
-  means the id was a typo and the work is sitting right next to where you
-  looked. `other_sessions` is filled in on a HIT too, so if one of them
-  looks more like the session you meant, you may have just resumed the
-  WRONG one.
-- **At the END of a session** (or whenever the state changes meaningfully),
-  call `save_working_context` with the distilled state: `goal`,
-  `active_constraints`, `verified_facts` (with sources), `open_hypotheses`,
-  `decisions`, `exact_evidence`, `pending_actions`. Keep it small — this is
-  the hand-off note, not the transcript. Saving again under the same
-  project + session replaces the previous state (idempotent upsert).
+So when you have just distilled a context worth surviving the session — the
+goal, what is settled, what is next — hand it to the memory side rather than
+re-deriving it tomorrow. `save_working_context` is the handoff;
+`load_working_context` reads it back at the start of the next session, and
+neither is documented here: the **`velesdb-memory` skill** owns the
+working-context tools, the field shapes, and the discovery step that keeps an
+unknown session name from being mistaken for an absence of prior work.
 
-```json
-{"tool": "save_working_context", "arguments": {
-  "project": "veles", "session": "task-1234",
-  "working": {
-    "goal": "fix the failing canary deploy",
-    "active_constraints": [{"text": "never restart the primary during a rebalance"}],
-    "verified_facts": [{"text": "the canary fails only on arm64 runners"}],
-    "pending_actions": ["bisect the arm64-only failure", "re-run the canary"]
-  }
-}}
-```
-
-```json
-{"tool": "load_working_context", "arguments": {"project": "veles", "session": "task-1234"}}
-```
+One rule is worth repeating rather than looking up: **an empty load is not
+proof of a fresh start.** Ask the memory skill's discovery step before you
+conclude anything from it.
 
 ## Screenshots and images
 


### PR DESCRIPTION
`list_working_contexts`, `load_working_context` and `save_working_context` are memory tools — they embed, they store a fact, they are read back in a later session. They were documented in `velesdb-context-optimizer`, the **compression** skill, and **not once** in `velesdb-memory`.

Two consequences, both measured on this tree before the change:

- an agent that loads the skill named after memory is never told that a previous session's state can be read back at all;
- `list_working_contexts` was taught **nowhere** — 0 mentions in either skill — so nobody was told to *discover* sessions. A mistyped session id returns `found: false`, and `found: false` reads as "no previous work".

## What changed

**`velesdb-memory` owns resumption.** A new section walks `list → load → work → save`: discovery first, then the `{found, working, other_sessions}` envelope with an explicit rule that an empty load is *not* proof of absence, then the work, then the handoff. It also states the thing that only bites once — `other_sessions` is filled in on a **hit** too, so resuming the wrong session is the failure that reads as success — and the non-uniform field shapes (`pending_actions` is a plain list of strings; sending objects fails with a `missing field fragment_id` that never names the field at fault).

**`velesdb-context-optimizer` keeps the handoff, drops the contract.** It still says a distilled context can outlive the prompt and points at the memory skill by name, and it no longer restates the `working` envelope — two copies of a parameter contract is exactly the drift this campaign exists to prevent, and the optimizer's copy is the one nobody would think to update.

**The pins moved with the declaration.** `check-mcp-doc-contract.py` pinned both `velesdb-context-optimizer` copies as surfaces declaring `load_working_context`'s return shape. Removing the declaration without moving the pin would have been a silent loss of coverage — the guard refused, by name, and said so. The two `velesdb-memory` copies took their place: still 16 surfaces declaring, still 16 pinned.

**One polarity bug fixed on the way.** `crates/velesdb-node/skills/**` was swept but `crates/velesdb-memory/skill/**` was not — the *generated* npm copy was policed while the source it is generated from was not. The source now joins the sweep.

## Proof

Red first, and it failed for six distinct reasons, not one:

| red | why it failed |
|---|---|
| the memory skill teaches each resumption tool | `list_working_contexts`: **0** mentions anywhere in the repo's skills |
| ownership is not inverted | `save`/`load`: 4 and 4 in the compression skill, **0** and **0** in the memory skill |
| the path is walked in order | no `list → load → save` sequence existed |
| an empty load forces discovery | nothing tied `found` to `list_working_contexts` within 600 characters |
| a hit can be the wrong session | `other_sessions` absent from the memory skill |
| the compression skill stops re-documenting | it still carried all four `working` envelope fields |

The rule helpers are pinned RED-then-GREEN on synthetic text before they judge either skill, so a rule that silently stopped matching fails here instead of passing over an empty search.

Measured after:

- **256 → 268** python tests (baseline re-run on `develop@b60f5d16`, not assumed).
- Counts now `list` 4/0, `load` 3/1, `save` 4/1 — memory skill over compression skill, every tool.
- `check-mcp-doc-contract.py --verbose` recognises the declaration at `crates/velesdb-memory/skill/velesdb-memory/SKILL.md:155` and at its npm copy, same line.
- Source and bundled copy byte-identical **in the committed tree** for both skills (`git show`, same sha256).
- Every other guard re-run individually after the last edit, exit code captured before any pipe: mcp-doc-contract, skill-private-references, doc-freshness, doc-contract, promise-contract, ai-attribution — all 0.

## Scope

No MCP tool implementation is touched. This is documentation ownership, the agent path, and the guards that hold them. `sync-skills.py --check` reports drift against an unmerged working tree by design; the installed copies are re-synced after merge.

Part of #1773 (lot 2 sur 3 du socle mémoire versionné).