### PR TITLE
feat(hooks): an installer for the agent hooks, and the harness finally runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,17 @@ jobs:
       - name: Resumption is owned by the memory skill
         run: python3 -m unittest scripts.tests.test_skill_resumption_ownership
 
+      # The agent-hook installer, and — finally — the hook harness itself.
+      # `hooks.test.sh` was referenced by six documents and executed by ZERO
+      # workflows: the exact shape of #1698, a gate nobody invokes. The suite
+      # above it holds the wiring, so deleting this step turns that suite red
+      # rather than turning the harness silent.
+      - name: Self-test the agent-hook installer
+        run: python3 -m unittest scripts.tests.test_sync_agent_hooks
+
+      - name: Agent hook harness
+        run: bash integrations/agent-hooks/test/hooks.test.sh
+
       # BLOCKING. Verified green on the whole tree (16 pinned surfaces, 20
       # declarations of load_working_context's envelope — including the three
       # agent session hooks and the napi `ts_return_type` shipped as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/sync-agent-hooks.py` — an installer and a drift check for the
+  Claude Code agent hooks.** The hooks a session actually runs live in
+  `~/.claude/hooks/velesdb-memory/`, outside any repository, and they had
+  diverged in *both* directions at once: the repository was ahead on the
+  model-facing text (`session-start.sh` carried the corrected
+  `{found, working, other_sessions}` guidance while the installed copy still
+  said *"if it returns null, nothing was saved yet"* — an instruction that
+  makes a model start fresh on top of work a mistyped session id hid from it),
+  and the install was ahead on function (`lib/freshness.sh`,
+  `update-daemon.sh`, and `jq` hardening that existed nowhere in the repo). The
+  source absorbed the local layer first, so the installer is not destructive;
+  both are now versioned, with no path from any one contributor's machine.
+  Modes: `--check`, `--check --strict`, `--install`, `--install --dry-run`,
+  `--uninstall`. It reports three states per artefact, merges at *hook*
+  granularity because a foreign hook can share a group with ours, backs
+  `settings.json` up before writing, replaces it atomically, and never prints
+  its contents.
+- **`integrations/agent-hooks/test/hooks.test.sh` runs in CI.** It was
+  referenced by six documents and executed by zero workflows. It now runs in
+  the required `mcp-doc-contract` job, with a reachability guard that fails if
+  the step is removed *or* disarmed.
+
 ### Changed
 
 - **Cross-session resumption belongs to the `velesdb-memory` skill.**

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -104,7 +104,31 @@ Both variants need `bash` and `jq` on `PATH` — the hooks refuse to run
 without `jq` rather than silently emitting malformed JSON.
 
 **Global (recommended for continuous CLI usage — every project, one-time
-setup):**
+setup).** One command does both halves — the scripts and the four
+`settings.json` entries:
+
+```bash
+python3 scripts/sync-agent-hooks.py --install
+```
+
+It touches only entries whose command contains `.claude/hooks/velesdb-memory/`,
+merges at hook granularity (a foreign hook may share a group with ours), backs
+`settings.json` up before writing, replaces it atomically, and never prints its
+contents. Three more modes are worth knowing:
+
+```bash
+python3 scripts/sync-agent-hooks.py --check --strict   # in step / drifted / absent, per artefact
+python3 scripts/sync-agent-hooks.py --install --dry-run # say what would change, write nothing
+python3 scripts/sync-agent-hooks.py --uninstall         # remove ours, and only ours
+```
+
+An installed copy that drifts from this repository is the failure mode this
+exists for: the hooks a session runs live outside any repository, and measured
+on 2026-08-02 they had diverged in *both* directions at once — the repository
+ahead on the model-facing text, the install ahead on function.
+
+<details>
+<summary>Doing it by hand</summary>
 
 ```bash
 mkdir -p ~/.claude/hooks/velesdb-memory
@@ -121,20 +145,22 @@ be relative to for a global install):
 {
   "hooks": {
     "SessionStart": [
-      { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/session-start.sh" }] }
+      { "hooks": [{ "type": "command", "command": "bash \"/Users/you/.claude/hooks/velesdb-memory/session-start.sh\"" }] }
     ],
     "Stop": [
-      { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/stop.sh" }] }
+      { "hooks": [{ "type": "command", "command": "bash \"/Users/you/.claude/hooks/velesdb-memory/stop.sh\"" }] }
     ],
     "PreCompact": [
-      { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/pre-compact.sh" }] }
+      { "hooks": [{ "type": "command", "command": "bash \"/Users/you/.claude/hooks/velesdb-memory/pre-compact.sh\"" }] }
     ],
     "PostToolUse": [
-      { "hooks": [{ "type": "command", "command": "bash /Users/you/.claude/hooks/velesdb-memory/post-tool-use.sh" }] }
+      { "hooks": [{ "type": "command", "command": "bash \"/Users/you/.claude/hooks/velesdb-memory/post-tool-use.sh\"" }] }
     ]
   }
 }
 ```
+
+</details>
 
 `PostToolUse` additionally needs a `velesdb-memory` binary on `PATH` that
 knows the `compile-stdin` subcommand. Until you have one, the hook is

--- a/integrations/agent-hooks/claude-code/hooks/lib/freshness.sh
+++ b/integrations/agent-hooks/claude-code/hooks/lib/freshness.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Is the running velesdb-memory daemon the latest published release?
+#
+# Sourced by session-start.sh. Prints ONE line of guidance when the daemon is
+# behind, and nothing at all otherwise — silence is the normal case, so a
+# session that is already current pays no attention cost.
+#
+# Three rules this file exists to respect:
+#
+#  1. **It must never fail the session.** Every step is best-effort: an
+#     unreachable daemon, an offline registry, a missing tool — each returns
+#     empty and the hook stays silent. `set -e` is deliberately NOT relied on
+#     here; the caller's `set -euo pipefail` is neutralised per-command.
+#  2. **It must not add a network round-trip to every session start.** The
+#     crates.io answer is cached for a day; only the local daemon is queried
+#     each time, over loopback, in well under a second.
+#  3. **It must not update anything by itself.** A `cargo install` is ~90
+#     seconds and needs the source tree; doing that while a session boots
+#     would block the user for a minute with no warning. The hook reports;
+#     the agent decides and acts.
+
+# Where this file sits, so the notice below can name the updater beside it
+# instead of a path guessed at authoring time. `BASH_SOURCE[0]` is this file
+# even though it is *sourced*, which is exactly what makes it usable here.
+VELESDB_FRESHNESS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+VELESDB_FRESHNESS_CACHE="${HOME}/.velesdb-memory/.latest-version"
+VELESDB_FRESHNESS_TTL_SECONDS=86400
+# The daemon's shared HTTP transport, same default port as
+# `scripts/install-memory-daemon.sh` writes into the service definition.
+VELESDB_MCP_URL="${VELESDB_MCP_URL:-https://127.0.0.1:18090/mcp}"
+
+# Version string the daemon answers with, or empty if it cannot be reached.
+veles_running_version() {
+  local body
+  body=$(curl -sk --max-time 3 "$VELESDB_MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"freshness","version":"1"}}}' \
+    2>/dev/null) || return 0
+  # Anchored on the server NAME so a version string belonging to anything
+  # else in the envelope (protocol, client echo) can never be mistaken for
+  # the daemon's. The trailing quote is stripped with a second `grep -o`
+  # over digits-and-dots, NOT with a `$` anchor: the match ends in `"`, so
+  # anchoring at end-of-line silently yields nothing — which is how a
+  # freshness check turns into a check that never fires.
+  printf '%s' "$body" \
+    | grep -o '"name":"velesdb-memory","version":"[0-9][0-9.]*"' \
+    | grep -o '"[0-9][0-9.]*"$' \
+    | tr -d '"' \
+    | head -1
+}
+
+# Latest version on crates.io, cached for a day. Empty when offline — an
+# offline session must behave exactly like an up-to-date one.
+veles_latest_version() {
+  local now cached_at
+  now=$(date +%s)
+  if [ -f "$VELESDB_FRESHNESS_CACHE" ]; then
+    cached_at=$(sed -n '1p' "$VELESDB_FRESHNESS_CACHE" 2>/dev/null)
+    if [ -n "${cached_at:-}" ] && [ $((now - cached_at)) -lt "$VELESDB_FRESHNESS_TTL_SECONDS" ]; then
+      sed -n '2p' "$VELESDB_FRESHNESS_CACHE" 2>/dev/null
+      return 0
+    fi
+  fi
+  local latest
+  latest=$(curl -s --max-time 4 -H 'User-Agent: velesdb-memory-freshness' \
+    https://crates.io/api/v1/crates/velesdb-memory 2>/dev/null \
+    | grep -o '"max_version":"[0-9][0-9.]*"' \
+    | grep -o '[0-9][0-9.]*' \
+    | head -1) || return 0
+  [ -z "${latest:-}" ] && return 0
+  mkdir -p "$(dirname "$VELESDB_FRESHNESS_CACHE")" 2>/dev/null || true
+  printf '%s\n%s\n' "$now" "$latest" > "$VELESDB_FRESHNESS_CACHE" 2>/dev/null || true
+  printf '%s' "$latest"
+}
+
+# `0` when $1 is strictly older than $2, comparing numerically field by field.
+# A lexical compare would call 0.9.2 newer than 0.11.3 — a mistake already made
+# once by hand on this very crate.
+veles_version_lt() {
+  [ "$1" = "$2" ] && return 1
+  local smallest
+  smallest=$(printf '%s\n%s\n' "$1" "$2" | sort -t. -k1,1n -k2,2n -k3,3n | head -1)
+  [ "$smallest" = "$1" ]
+}
+
+# The guidance line, or nothing.
+veles_freshness_notice() {
+  local running latest
+  running=$(veles_running_version) || return 0
+  [ -z "${running:-}" ] && return 0
+  latest=$(veles_latest_version) || return 0
+  [ -z "${latest:-}" ] && return 0
+  veles_version_lt "$running" "$latest" || return 0
+  # SC2016: the backticks below are markdown for the model reading this line,
+  # and the string is a printf FORMAT — it must stay single-quoted so `%s` is
+  # substituted by printf rather than by the shell.
+  # shellcheck disable=SC2016
+  printf 'velesdb-memory freshness: the running daemon is %s, but %s is published. Bring it up to date EARLY in this session (before writing memories, so the session benefits from the fixes) by running `%s/update-daemon.sh` with VELESDB_REPO pointing at the source tree, then confirm the version it reports. The script installs from that tree, restarts the daemon, and verifies over the wire.' \
+    "$running" "$latest" "$VELESDB_FRESHNESS_SCRIPT_DIR"
+}

--- a/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
+++ b/integrations/agent-hooks/claude-code/hooks/pre-compact.sh
@@ -27,8 +27,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 require_jq
 
 payload="$(read_stdin_payload)"
-session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
-cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null || true)"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 
 if [ -z "$cwd" ]; then
   cwd="$PWD"

--- a/integrations/agent-hooks/claude-code/hooks/session-start.sh
+++ b/integrations/agent-hooks/claude-code/hooks/session-start.sh
@@ -12,11 +12,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=./lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=./lib/freshness.sh
+source "$SCRIPT_DIR/lib/freshness.sh"
 
 require_jq
 
 payload="$(read_stdin_payload)"
-cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 if [ -z "$cwd" ]; then
   cwd="$PWD"
 fi
@@ -24,6 +27,16 @@ fi
 resolve_config "$cwd"
 
 context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. load_working_context returns {found, working, other_sessions}: read 'working' for the state. If 'found' is false, nothing was saved under that EXACT project+session — but check 'other_sessions' before starting fresh: a similarly-named session listed there means the session id was a typo, not a new task. 'other_sessions' is filled in on a hit too, so if one of them looks more like the session you meant, you may have just resumed the wrong work. Reinforcement loop: whenever a memory surfaced by recall/recall_fused (or pulled into compile_context — its decision carries the memory_id) actually helps you, call feedback(id, true) with the id_str string; if it misled you, feedback(id, false). This is what makes ranking improve with use — skipping it keeps confidence flat."
+
+# A daemon behind the published release is worth one line, and only when it
+# is true: an up-to-date session sees nothing. Best-effort by construction —
+# `|| true` because no version check may ever cost the user a session start.
+freshness="$(veles_freshness_notice 2>/dev/null || true)"
+if [ -n "${freshness:-}" ]; then
+  context="$context
+
+$freshness"
+fi
 
 jq -n --arg ctx "$context" \
   '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'

--- a/integrations/agent-hooks/claude-code/hooks/stop.sh
+++ b/integrations/agent-hooks/claude-code/hooks/stop.sh
@@ -15,8 +15,8 @@ source "$SCRIPT_DIR/lib/common.sh"
 require_jq
 
 payload="$(read_stdin_payload)"
-session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty')"
-cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty')"
+session_id="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null || true)"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 
 if [ -z "$cwd" ]; then
   cwd="$PWD"

--- a/integrations/agent-hooks/claude-code/hooks/update-daemon.sh
+++ b/integrations/agent-hooks/claude-code/hooks/update-daemon.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Bring the running velesdb-memory daemon up to a source tree's version.
+#
+# Build, install, restart, and VERIFY over the wire — the last step is the
+# point: `cargo install` replacing a file proves nothing about what is
+# actually serving, because the service manager keeps the old process alive on
+# its own inode until it is restarted.
+#
+# Safe to run mid-session since 0.11.4: the daemon drains in-flight MCP
+# sessions on SIGTERM instead of dropping them. Before that it killed live
+# connections, which is exactly how a "quick update" used to break the very
+# session that ran it.
+#
+# The source tree is NEVER guessed from a directory layout — `VELESDB_REPO`,
+# or the current directory when it is itself the tree. A default pointing at
+# one contributor's folders is how a shipped script works on exactly one
+# machine.
+set -euo pipefail
+
+REPO="${VELESDB_REPO:-$PWD}"
+URL="${VELESDB_MCP_URL:-https://127.0.0.1:18090/mcp}"
+# Same label `scripts/install-memory-daemon.sh` registers the service under.
+LABEL="${VELESDB_SERVICE_LABEL:-com.velesdb.memory}"
+
+running_version() {
+  curl -sk --max-time 5 "$URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"update","version":"1"}}}' \
+    2>/dev/null | grep -o '"version":"[0-9][0-9.]*"' | grep -o '[0-9][0-9.]*' | head -1
+}
+
+manifest="$REPO/crates/velesdb-memory/Cargo.toml"
+if [ ! -f "$manifest" ]; then
+  echo "not a velesdb source tree: $REPO" >&2
+  echo "run this from the source tree, or set VELESDB_REPO to its path" >&2
+  exit 1
+fi
+
+before=$(running_version || true)
+target=$(grep -m1 '^version' "$manifest" | cut -d'"' -f2)
+echo "daemon: ${before:-unreachable} → building ${target} from ${REPO}"
+
+# The daemon's own features, not the crate defaults: http for the shared
+# transport every client joins, ollama for the semantic embedder, extract for
+# autograph. Installing without them yields a daemon that starts and quietly
+# does less.
+cargo install --path "$REPO/crates/velesdb-memory" \
+  --bin velesdb-memory \
+  --features http,ollama,extract \
+  --force
+
+if command -v launchctl >/dev/null 2>&1; then
+  launchctl kickstart -k "gui/$(id -u)/${LABEL}"
+elif command -v systemctl >/dev/null 2>&1; then
+  systemctl --user restart "${LABEL}"
+else
+  echo "no launchctl or systemctl found — restart the daemon yourself, then re-run" >&2
+  exit 1
+fi
+
+for _ in $(seq 1 20); do
+  after=$(running_version || true)
+  [ -n "${after:-}" ] && break
+  sleep 1
+done
+
+if [ -z "${after:-}" ]; then
+  echo "daemon did not answer after the restart — inspect the ${LABEL} service" >&2
+  exit 1
+fi
+if [ "$after" != "$target" ]; then
+  echo "daemon answers ${after}, expected ${target} — the restart did not pick up the new binary" >&2
+  exit 1
+fi
+
+# The freshness cache is keyed on time, not on version: drop it so the next
+# session re-reads the registry instead of repeating a now-stale verdict.
+rm -f "$HOME/.velesdb-memory/.latest-version" 2>/dev/null || true
+echo "daemon now serving ${after}, verified over the wire"

--- a/scripts/sync-agent-hooks.py
+++ b/scripts/sync-agent-hooks.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Keep the Claude Code agent hooks installed under `~/.claude` in step with this repo.
+
+## The defect this closes
+
+The hooks a session actually runs live in `~/.claude/hooks/velesdb-memory/`,
+outside any repository — the same blind spot as the installed skills of #1712,
+and it drifted the same way. Measured on 2026-08-02, in BOTH directions at once:
+
+* the repository was ahead on the text — `session-start.sh` carried the
+  corrected `{found, working, other_sessions}` guidance while the installed
+  copy still told the model *"if it returns null, nothing was saved yet"*. The
+  tool never returns null, so a model reading that never checks
+  `other_sessions` and starts fresh on top of work a typo hid from it;
+* the install was ahead on function — `lib/freshness.sh` and
+  `update-daemon.sh` existed only there.
+
+A mirror-the-repo installer would have deleted working code. So the source
+absorbed the local layer first, and this tool exists only because the two
+sides now describe the same thing.
+
+## Two artefacts, not one
+
+A hook is *scripts on disk* AND *an entry in `~/.claude/settings.json`*. Either
+alone does nothing: a script nobody registers never runs, an entry pointing at
+a missing script fails every session. Both are reported, per hook.
+
+## The settings file belongs to its owner
+
+It holds other people's hooks, a theme, permissions, a status line. This tool
+touches exactly the entries whose command contains
+`.claude/hooks/velesdb-memory/` and nothing else — measured on a real machine,
+that marker matched 4 entries and none of the 4 foreign ones, and no foreign
+entry mentions velesdb at all.
+
+The merge works at HOOK granularity, never at group granularity: on that same
+machine `SessionStart` holds a foreign hook and ours in the SAME group, so
+replacing a group would silently delete the neighbour.
+
+The document is never printed. A hook command carries paths and project names,
+and a report that echoed it is how one ends up in a log.
+
+Usage:
+    python3 scripts/sync-agent-hooks.py --check              # drift fails; absent reported
+    python3 scripts/sync-agent-hooks.py --check --strict     # absent fails too
+    python3 scripts/sync-agent-hooks.py --install            # repo -> ~/.claude
+    python3 scripts/sync-agent-hooks.py --install --dry-run  # say it, write nothing
+    python3 scripts/sync-agent-hooks.py --uninstall          # remove ours, only ours
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+SOURCE = REPO / "integrations" / "agent-hooks" / "claude-code" / "hooks"
+
+#: `(settings.json event, script file)`. An explicit list, not a scan of the
+#: source directory: `lib/` and `update-daemon.sh` ship with the hooks but are
+#: not themselves events, and inventing an entry for them would register a
+#: library as a hook.
+HOOKS: "tuple[tuple[str, str], ...]" = (
+    ("SessionStart", "session-start.sh"),
+    ("Stop", "stop.sh"),
+    ("PreCompact", "pre-compact.sh"),
+    ("PostToolUse", "post-tool-use.sh"),
+)
+
+#: The substring that says an entry is ours. Also the installed directory name,
+#: which is what makes the two impossible to disagree.
+INSTALL_DIR = "velesdb-memory"
+MARKER = f".claude/hooks/{INSTALL_DIR}/"
+
+#: Files an installed tree may hold that the repo does not ship. Same rule as
+#: the skill installer's: one named file, never "anything extra", so a stale
+#: script from an older version is still reported.
+LOCAL_FILES: "tuple[str, ...]" = ("LOCAL.md",)
+
+
+def claude_root() -> Path:
+    """`~/.claude`, resolved through the running HOME so the whole tool can be
+    exercised against a fake one."""
+    return Path.home() / ".claude"
+
+
+def hooks_target() -> Path:
+    return claude_root() / "hooks" / INSTALL_DIR
+
+
+def settings_path() -> Path:
+    return claude_root() / "settings.json"
+
+
+def command_for(script: str) -> str:
+    """The exact command an entry must carry, built from the running HOME."""
+    return f'bash "{hooks_target() / script}"'
+
+
+def source_files() -> "list[str]":
+    return sorted(str(p.relative_to(SOURCE)) for p in SOURCE.rglob("*") if p.is_file())
+
+
+def read_settings() -> dict:
+    path = settings_path()
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def is_ours(hook: dict) -> bool:
+    return MARKER in hook.get("command", "")
+
+
+def script_state(script: str) -> str:
+    """`in step` / `drifted` / `absent` for one script on disk."""
+    installed = hooks_target() / script
+    if not installed.is_file():
+        return "absent"
+    if installed.read_bytes() != (SOURCE / script).read_bytes():
+        return "drifted"
+    return "in step"
+
+
+def entry_state(document: dict, event: str, script: str) -> str:
+    """Same three states for the `settings.json` entry."""
+    ours = [
+        hook
+        for group in document.get("hooks", {}).get(event, [])
+        for hook in group.get("hooks", [])
+        if is_ours(hook)
+    ]
+    if not ours:
+        return "absent"
+    if any(hook.get("command") != command_for(script) for hook in ours):
+        return "drifted"
+    return "in step"
+
+
+def extra_installed_files() -> "list[str]":
+    """Installed files the repo does not ship, minus the permitted local layer."""
+    target = hooks_target()
+    if not target.is_dir():
+        return []
+    present = {str(p.relative_to(target)) for p in target.rglob("*") if p.is_file()}
+    return sorted(present - set(source_files()) - set(LOCAL_FILES))
+
+
+def merge_entries(document: dict) -> dict:
+    """Put our four entries in, leaving every other hook exactly as it was.
+
+    Replaces the command of an entry already carrying the marker; otherwise
+    appends one hook to the first existing group, or creates a group when the
+    event has none. Never rewrites a group wholesale — a foreign hook may be
+    sitting in it.
+    """
+    hooks = document.setdefault("hooks", {})
+    for event, script in HOOKS:
+        groups = hooks.setdefault(event, [])
+        replaced = False
+        for group in groups:
+            for hook in group.get("hooks", []):
+                if is_ours(hook):
+                    hook["command"] = command_for(script)
+                    hook.setdefault("type", "command")
+                    replaced = True
+        if not replaced:
+            if not groups:
+                groups.append({"hooks": []})
+            groups[0].setdefault("hooks", []).append(
+                {"type": "command", "command": command_for(script)}
+            )
+    return document
+
+
+def strip_entries(document: dict) -> dict:
+    """Remove ours, and only ours. An event left with no hook at all loses its
+    key, so an uninstall does not leave empty scaffolding behind."""
+    hooks = document.get("hooks", {})
+    for event in list(hooks):
+        groups = []
+        for group in hooks[event]:
+            survivors = [hook for hook in group.get("hooks", []) if not is_ours(hook)]
+            if survivors:
+                kept = dict(group)
+                kept["hooks"] = survivors
+                groups.append(kept)
+        if groups:
+            hooks[event] = groups
+        else:
+            del hooks[event]
+    if not hooks:
+        document.pop("hooks", None)
+    return document
+
+
+def write_settings(document: dict) -> None:
+    """Back up, then replace atomically.
+
+    `indent=2` with a trailing newline is what the file already uses, so
+    everything this tool does not touch is rewritten byte for byte.
+    """
+    path = settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_file():
+        shutil.copy2(path, path.with_name(path.name + ".velesdb-backup"))
+    staging = path.with_name(f".{path.name}.staging-{os.getpid()}")
+    staging.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(staging, path)
+
+
+def install_scripts() -> None:
+    """Replace the hook tree by rename, carrying the local layer across."""
+    target = hooks_target()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    staging = target.parent / f".{target.name}.staging-{os.getpid()}"
+    previous = target.parent / f".{target.name}.previous-{os.getpid()}"
+    shutil.rmtree(staging, ignore_errors=True)
+    shutil.rmtree(previous, ignore_errors=True)
+    try:
+        shutil.copytree(SOURCE, staging)
+        for name in LOCAL_FILES:
+            if (target / name).is_file():
+                shutil.copy2(target / name, staging / name)
+        if target.exists():
+            os.replace(target, previous)
+        os.replace(staging, target)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(previous, ignore_errors=True)
+
+
+def collect_states() -> "tuple[list[str], list[str], list[str]]":
+    """`(in step, drifted, absent)` lines, one per artefact."""
+    document = read_settings()
+    fine, drifted, absent = [], [], []
+    for event, script in HOOKS:
+        for what, state in (
+            (f"{script}", script_state(script)),
+            (f"{event} entry", entry_state(document, event, script)),
+        ):
+            {"in step": fine, "drifted": drifted, "absent": absent}[state].append(what)
+    return fine, drifted, absent
+
+
+def run_check(strict: bool) -> int:
+    fine, drifted, absent = collect_states()
+    extras = extra_installed_files()
+    for label, names in (("in step", fine), ("drifted", drifted), ("absent", absent)):
+        for name in names:
+            print(f"  {name}: {label}")
+    for name in extras:
+        print(f"  {name}: unexpected (installed, not shipped by this repository)")
+
+    problems = list(drifted) + extras + (list(absent) if strict else [])
+    if problems:
+        print(
+            "\nAgent hook(s) are not in step with the repository:\n\n    "
+            + "\n    ".join(problems)
+            + "\n\nThe repository is the source of truth. Re-sync with:\n"
+            "    python3 scripts/sync-agent-hooks.py --install\n",
+            file=sys.stderr,
+        )
+        return 1
+    if absent:
+        print("\n  (absent hooks are not treated as drift here; --strict makes them fail)")
+    return 0
+
+
+def run_install(dry_run: bool) -> int:
+    if not SOURCE.is_dir():
+        print(f"{SOURCE} is missing from the repository", file=sys.stderr)
+        return 1
+    _, drifted, absent = collect_states()
+    if dry_run:
+        pending = drifted + absent
+        print(f"  would install {len(source_files())} file(s) into {hooks_target()}")
+        print(f"  would reconcile {len(HOOKS)} entr(y/ies) in {settings_path()}")
+        for name in pending:
+            print(f"  would repair: {name}")
+        if not pending:
+            print("  would change nothing — already in step")
+        return 0
+    install_scripts()
+    write_settings(merge_entries(read_settings()))
+    for _event, script in HOOKS:
+        print(f"  installed {script}")
+    print(f"  reconciled {len(HOOKS)} entr(y/ies) in settings.json")
+    return 0
+
+
+def run_uninstall(dry_run: bool) -> int:
+    target = hooks_target()
+    if dry_run:
+        print(f"  would remove {target}")
+        print(f"  would remove {len(HOOKS)} entr(y/ies) from {settings_path()}")
+        return 0
+    if settings_path().is_file():
+        write_settings(strip_entries(read_settings()))
+    shutil.rmtree(target, ignore_errors=True)
+    print(f"  removed {target}")
+    print(f"  removed {len(HOOKS)} entr(y/ies) from settings.json")
+    return 0
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="report drift, exit 1 if any")
+    mode.add_argument("--install", action="store_true", help="copy hooks and merge entries")
+    mode.add_argument("--uninstall", action="store_true", help="remove ours, and only ours")
+    parser.add_argument("--strict", action="store_true", help="with --check: absent fails too")
+    parser.add_argument("--dry-run", action="store_true", help="report, write nothing")
+    args = parser.parse_args(argv)
+    if args.check:
+        return run_check(args.strict)
+    if args.uninstall:
+        return run_uninstall(args.dry_run)
+    return run_install(args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_sync_agent_hooks.py
+++ b/scripts/tests/test_sync_agent_hooks.py
@@ -1,0 +1,506 @@
+"""Behaviour of `scripts/sync-agent-hooks.py` — the agent-hook installer.
+
+## The two defects this closes
+
+**One.** The hooks a Claude Code session actually runs live in
+`~/.claude/hooks/velesdb-memory/`, outside any repository, exactly like the
+installed skills of #1712 — and they drifted the same way, in both directions
+at once. Measured on 2026-08-02 against `develop@e36a99f9`:
+
+* the *repository* was ahead on the text: `session-start.sh` carries the
+  corrected `{found, working, other_sessions}` guidance, while the installed
+  copy still told the model *"if it returns null, nothing was saved yet"* — the
+  stale instruction `integrations/agent-hooks/test/hooks.test.sh`'s own header
+  names as the defect that matters, because the tool never returns null and a
+  model told to look for null never reads `other_sessions`;
+* the *install* was ahead on function: `lib/freshness.sh` and
+  `update-daemon.sh` existed only there, plus `2>/dev/null || true` hardening
+  on three `jq` calls.
+
+So an installer that simply mirrored the repository would have silently deleted
+working code, and one that did nothing left a hook misinforming every session.
+The source absorbs the local layer first; these tests pin that it did.
+
+**Two.** `hooks.test.sh` is referenced by six documents and executed by **zero**
+workflows. A gate nobody invokes protects nothing, so this file also pins the
+wiring — and that the harness can still fail.
+
+Every test runs against a **fake HOME**, so the suite never reads or writes the
+developer's own hooks or settings.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "sync-agent-hooks.py"
+SOURCE = REPO / "integrations" / "agent-hooks" / "claude-code" / "hooks"
+HARNESS = REPO / "integrations" / "agent-hooks" / "test" / "hooks.test.sh"
+CI = REPO / ".github" / "workflows" / "ci.yml"
+
+#: `(settings.json event, script file)` for the four VelesDB hooks. Held
+#: against the script's own registry below rather than trusted.
+EXPECTED_HOOKS = (
+    ("SessionStart", "session-start.sh"),
+    ("Stop", "stop.sh"),
+    ("PreCompact", "pre-compact.sh"),
+    ("PostToolUse", "post-tool-use.sh"),
+)
+
+#: What the install must contain after the local layer is absorbed. The two
+#: last entries are the capability that existed ONLY on the machine.
+EXPECTED_FILES = (
+    "session-start.sh",
+    "stop.sh",
+    "pre-compact.sh",
+    "post-tool-use.sh",
+    "lib/common.sh",
+    "lib/freshness.sh",
+    "update-daemon.sh",
+)
+
+#: A settings.json with foreign hooks arranged the way a real one is — note
+#: SessionStart holds a foreign hook and a VelesDB hook in the SAME group, so
+#: anything operating at group granularity destroys the neighbour.
+FOREIGN_SETTINGS = {
+    "theme": "dark",
+    "model": "opus",
+    "permissions": {"allow": ["Bash(git status)"]},
+    "hooks": {
+        "PreToolUse": [
+            {
+                "hooks": [
+                    {"type": "command", "command": "bash ~/.claude/other/cpu_loop_guard.sh"},
+                    {"type": "command", "command": "bash ~/.claude/other/dup_check.sh"},
+                    {"type": "command", "command": "bash ~/.claude/other/dup_check.sh --deep"},
+                ]
+            }
+        ],
+        "SessionStart": [
+            {"hooks": [{"type": "command", "command": "bash ~/.claude/other/orphan_reaper.sh"}]}
+        ],
+    },
+}
+
+
+def run(*args: str, home: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ, HOME=str(home))
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def foreign_view(settings: Path) -> str:
+    """Everything in `settings` that is NOT VelesDB's, canonically ordered.
+
+    Compared as a string so a test failure shows what moved. Built from the
+    parsed document, so it is immune to whitespace and answers the question
+    that matters: did anything of someone else's change?
+    """
+    document = json.loads(settings.read_text(encoding="utf-8"))
+    hooks = document.pop("hooks", {})
+    kept = {}
+    for event, groups in hooks.items():
+        survivors = [
+            [h for h in group.get("hooks", []) if "velesdb-memory/" not in h.get("command", "")]
+            for group in groups
+        ]
+        survivors = [group for group in survivors if group]
+        if survivors:
+            kept[event] = survivors
+    return json.dumps({"rest": document, "foreign_hooks": kept}, sort_keys=True, indent=1)
+
+
+def tree_state(root: Path) -> "dict[str, str]":
+    """`{relative path: content}` for every file under `root`."""
+    if not root.is_dir():
+        return {}
+    return {
+        str(p.relative_to(root)): p.read_text(encoding="utf-8", errors="replace")
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+class SourceAbsorbedTheLocalLayer(unittest.TestCase):
+    """The RED that motivated widening this batch: the machine had working
+    code the repository had never seen, so no honest installer could exist
+    until the source covered it."""
+
+    def test_the_source_ships_every_file_the_install_needs(self) -> None:
+        for name in EXPECTED_FILES:
+            self.assertTrue(
+                (SOURCE / name).is_file(),
+                f"{name} is missing from the versioned hooks — an --install would "
+                "delete it from a machine that has it",
+            )
+
+    def test_the_freshness_check_is_wired_into_session_start(self) -> None:
+        """Shipping the file without sourcing it is the orphan case: the
+        capability is present on disk and never runs."""
+        body = (SOURCE / "session-start.sh").read_text(encoding="utf-8")
+        self.assertIn("lib/freshness.sh", body)
+        self.assertIn("veles_freshness_notice", body)
+
+    def test_the_jq_calls_are_hardened(self) -> None:
+        """`set -euo pipefail` plus a bare `jq` on a malformed payload kills
+        the hook. The install had the guard; the source did not."""
+        for name in ("session-start.sh", "stop.sh", "pre-compact.sh"):
+            body = (SOURCE / name).read_text(encoding="utf-8")
+            for line in body.splitlines():
+                if "jq -r" in line and "//" in line:
+                    self.assertIn(
+                        "2>/dev/null",
+                        line,
+                        f"{name}: an unhardened jq call can fail the whole hook:\n{line}",
+                    )
+
+    def test_the_corrected_load_contract_survived_the_merge(self) -> None:
+        """The repository's half of the divergence. Absorbing the machine's
+        version wholesale would have re-imported the stale sentence."""
+        body = (SOURCE / "session-start.sh").read_text(encoding="utf-8")
+        self.assertIn("other_sessions", body)
+        self.assertIn("{found, working, other_sessions}", body)
+        self.assertNotIn(
+            "returns null",
+            body,
+            "the stale 'if it returns null' instruction is back — the tool "
+            "returns an object whose only required key is `found`",
+        )
+
+    def test_the_updater_carries_no_path_from_one_developer_machine(self) -> None:
+        """It defaulted to `$HOME/Developer/personal/velesdb`. Anything of that
+        shape is one person's layout shipped as a product default."""
+        body = (SOURCE / "update-daemon.sh").read_text(encoding="utf-8")
+        for personal in ("Developer/personal", "/Users/", "/home/"):
+            self.assertNotIn(personal, body, f"{personal} is a machine-specific path")
+
+    def test_the_freshness_notice_points_at_a_computed_path(self) -> None:
+        body = (SOURCE / "lib" / "freshness.sh").read_text(encoding="utf-8")
+        self.assertNotIn("/Users/", body)
+        self.assertIn("SCRIPT_DIR", body, "the notice must name a path it computed")
+
+    def test_no_secret_travelled_with_the_local_layer(self) -> None:
+        # Written without the trailing `=` on purpose. The repository's own
+        # pre-commit scanner matches `token = "…"`-shaped text, and a literal
+        # list of the patterns this test searches FOR is exactly that shape —
+        # it refused this file once. The name alone is enough: `API_TOKEN`
+        # appearing anywhere in a shipped hook is already the finding.
+        for name in EXPECTED_FILES:
+            body = (SOURCE / name).read_text(encoding="utf-8")
+            for marker in ("api_key", "API_TOKEN", "Bearer ", "sk-"):
+                self.assertNotIn(marker, body, f"{name} carries something secret-shaped")
+
+
+class InstallerBehaviour(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.claude = self.home / ".claude"
+        self.claude.mkdir()
+        self.settings = self.claude / "settings.json"
+        self.hooks = self.claude / "hooks" / "velesdb-memory"
+        self.write_settings(FOREIGN_SETTINGS)
+
+    def write_settings(self, document: dict) -> None:
+        self.settings.write_text(
+            json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+
+    def test_the_registry_matches_the_scripts_own(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        for event, script in EXPECTED_HOOKS:
+            self.assertIn(f'"{event}"', source)
+            self.assertIn(script, source)
+
+    def test_absent_is_reported_and_forgiven_then_refused_under_strict(self) -> None:
+        """Three states, never two — the same rule the skill installer keeps."""
+        forgiving = run("--check", home=self.home)
+        self.assertEqual(forgiving.returncode, 0, forgiving.stderr)
+        self.assertIn("absent", forgiving.stdout)
+
+        strict = run("--check", "--strict", home=self.home)
+        self.assertEqual(strict.returncode, 1, "strict must refuse an absent hook")
+
+    def test_a_diverged_hook_is_reported_as_drifted_not_absent(self) -> None:
+        run("--install", home=self.home)
+        (self.hooks / "stop.sh").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+
+        result = run("--check", home=self.home)
+
+        self.assertEqual(result.returncode, 1, "drift must fail without --strict too")
+        self.assertIn("drifted", result.stdout + result.stderr)
+        self.assertNotIn("absent", result.stdout + result.stderr)
+
+    def test_an_absent_hook_is_reported_as_absent_not_drifted(self) -> None:
+        run("--install", home=self.home)
+        (self.hooks / "stop.sh").unlink()
+
+        result = run("--check", "--strict", home=self.home)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("absent", result.stdout + result.stderr)
+
+    def test_install_then_check_is_green(self) -> None:
+        self.assertEqual(run("--install", home=self.home).returncode, 0)
+        result = run("--check", "--strict", home=self.home)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_install_lays_down_every_expected_file(self) -> None:
+        run("--install", home=self.home)
+        for name in EXPECTED_FILES:
+            self.assertTrue((self.hooks / name).is_file(), f"{name} was not installed")
+
+    def test_install_preserves_every_foreign_hook_and_setting(self) -> None:
+        """The one thing this tool must never do."""
+        before = foreign_view(self.settings)
+        run("--install", home=self.home)
+        self.assertEqual(foreign_view(self.settings), before)
+
+    def test_install_keeps_a_foreign_hook_sharing_a_group_with_ours(self) -> None:
+        """SessionStart holds `orphan_reaper` and the VelesDB hook in the SAME
+        group on the real machine. Anything working at group granularity eats
+        the neighbour, and the check would still pass."""
+        run("--install", home=self.home)
+        document = json.loads(self.settings.read_text(encoding="utf-8"))
+        commands = [
+            h["command"]
+            for group in document["hooks"]["SessionStart"]
+            for h in group["hooks"]
+        ]
+        self.assertTrue(any("orphan_reaper" in c for c in commands), commands)
+        self.assertTrue(any("velesdb-memory/session-start.sh" in c for c in commands), commands)
+
+    def test_two_installs_are_byte_identical(self) -> None:
+        run("--install", home=self.home)
+        first_settings = self.settings.read_bytes()
+        first_tree = tree_state(self.hooks)
+
+        run("--install", home=self.home)
+
+        self.assertEqual(self.settings.read_bytes(), first_settings, "install is not idempotent")
+        self.assertEqual(tree_state(self.hooks), first_tree)
+
+    def test_install_writes_a_backup_before_touching_settings(self) -> None:
+        original = self.settings.read_bytes()
+        run("--install", home=self.home)
+        backups = [p for p in self.claude.iterdir() if "backup" in p.name]
+        self.assertTrue(backups, "no backup of settings.json was written")
+        self.assertEqual(backups[0].read_bytes(), original)
+
+    def test_dry_run_changes_nothing_on_disk(self) -> None:
+        before_settings = self.settings.read_bytes()
+        before_listing = sorted(str(p) for p in self.claude.rglob("*"))
+
+        result = run("--install", "--dry-run", home=self.home)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.settings.read_bytes(), before_settings)
+        self.assertEqual(sorted(str(p) for p in self.claude.rglob("*")), before_listing)
+        self.assertFalse(self.hooks.exists(), "--dry-run created the hooks directory")
+
+    def test_dry_run_still_says_what_it_would_do(self) -> None:
+        result = run("--install", "--dry-run", home=self.home)
+        self.assertIn("would", result.stdout.lower())
+
+    def test_uninstall_removes_only_velesdb(self) -> None:
+        before = foreign_view(self.settings)
+        run("--install", home=self.home)
+
+        result = run("--uninstall", home=self.home)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(foreign_view(self.settings), before, "uninstall touched someone else's")
+        self.assertFalse(self.hooks.exists(), "the VelesDB hook scripts survived --uninstall")
+        document = json.loads(self.settings.read_text(encoding="utf-8"))
+        remaining = [
+            h["command"]
+            for groups in document.get("hooks", {}).values()
+            for group in groups
+            for h in group.get("hooks", [])
+        ]
+        self.assertFalse([c for c in remaining if "velesdb-memory/" in c], remaining)
+
+    def test_uninstall_removes_the_absorbed_files_too(self) -> None:
+        run("--install", home=self.home)
+        run("--uninstall", home=self.home)
+        for name in ("update-daemon.sh", "lib/freshness.sh"):
+            self.assertFalse((self.hooks / name).exists(), name)
+
+    def test_uninstall_then_install_returns_to_the_same_state(self) -> None:
+        run("--install", home=self.home)
+        reference = self.settings.read_bytes()
+        run("--uninstall", home=self.home)
+        run("--install", home=self.home)
+        self.assertEqual(self.settings.read_bytes(), reference)
+
+    def test_settings_content_is_never_printed(self) -> None:
+        """A hook command can carry a path, a project name, a token. Printing
+        the document to make a report readable is how one ends up in a log."""
+        run("--install", home=self.home)
+        for args in (("--check",), ("--check", "--strict"), ("--install",), ("--uninstall",)):
+            result = run(*args, home=self.home)
+            output = result.stdout + result.stderr
+            for secret in ("cpu_loop_guard", "orphan_reaper", "Bash(git status)", "opus"):
+                self.assertNotIn(secret, output, f"{args}: settings content leaked into output")
+
+    def test_install_creates_settings_when_the_file_is_absent(self) -> None:
+        self.settings.unlink()
+        self.assertEqual(run("--install", home=self.home).returncode, 0)
+        document = json.loads(self.settings.read_text(encoding="utf-8"))
+        self.assertEqual(len(document["hooks"]), len(EXPECTED_HOOKS))
+
+    def test_the_installed_commands_carry_no_hard_coded_home(self) -> None:
+        """The command must be built from the running HOME, not from a string
+        baked at authoring time."""
+        run("--install", home=self.home)
+        document = json.loads(self.settings.read_text(encoding="utf-8"))
+        ours = [
+            h["command"]
+            for groups in document["hooks"].values()
+            for group in groups
+            for h in group.get("hooks", [])
+            if "velesdb-memory/" in h["command"]
+        ]
+        self.assertEqual(len(ours), len(EXPECTED_HOOKS))
+        for command in ours:
+            self.assertIn(str(self.home), command, "the command ignores the running HOME")
+
+    def test_the_updater_runs_from_the_install_without_a_repo_guess(self) -> None:
+        """`update-daemon.sh` must refuse clearly when it cannot find a source
+        tree — never fall back to somebody's directory layout."""
+        run("--install", home=self.home)
+        script = self.hooks / "update-daemon.sh"
+        self.assertTrue(os.access(script, os.X_OK), "update-daemon.sh is not executable")
+
+        result = subprocess.run(
+            ["bash", str(script)],
+            capture_output=True,
+            text=True,
+            cwd=str(self.home),
+            env=dict(os.environ, HOME=str(self.home), VELESDB_REPO=str(self.home / "nope")),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1, "a missing source tree must be a clean refusal")
+        self.assertIn("VELESDB_REPO", result.stdout + result.stderr)
+
+
+class ManualInstructionsAgree(unittest.TestCase):
+    """The README's hand-install JSON and what the tool writes must match.
+
+    They already disagreed once, invisibly: the documented entries were
+    unquoted (`bash /Users/you/…`), the tool quotes the path so a home
+    directory containing a space does not split the command. Both "worked" on
+    a machine without spaces, and `--check` reported drift on an install that
+    had followed the documentation to the letter.
+    """
+
+    README = REPO / "integrations" / "agent-hooks" / "README.md"
+
+    def test_every_documented_command_has_the_shape_the_tool_writes(self) -> None:
+        body = self.README.read_text(encoding="utf-8")
+        documented = [
+            line
+            for line in body.splitlines()
+            if ".claude/hooks/velesdb-memory/" in line and '"command"' in line
+        ]
+        self.assertTrue(documented, "the README no longer documents the entries at all")
+        for line in documented:
+            self.assertIn(
+                'bash \\"',
+                line,
+                "a documented command leaves the path unquoted, so a HOME with a "
+                f"space splits it — and --check calls the result drift:\n{line}",
+            )
+
+    def test_every_hook_script_is_named_in_the_readme(self) -> None:
+        body = self.README.read_text(encoding="utf-8")
+        for _event, script in EXPECTED_HOOKS:
+            self.assertIn(script, body, f"{script} is installed but never documented")
+
+    def test_the_absorbed_files_are_documented_too(self) -> None:
+        """A capability that ships and is written down nowhere is a capability
+        nobody turns on."""
+        body = self.README.read_text(encoding="utf-8")
+        self.assertIn("sync-agent-hooks.py", body)
+
+
+class HarnessIsWired(unittest.TestCase):
+    """`hooks.test.sh` was documented six times and run by nothing."""
+
+    def test_a_workflow_actually_invokes_the_harness(self) -> None:
+        self.assertIn(
+            "integrations/agent-hooks/test/hooks.test.sh",
+            CI.read_text(encoding="utf-8"),
+            "the hook harness is still executed by no workflow",
+        )
+
+    def test_the_harness_runs_inside_a_job_that_blocks_the_merge(self) -> None:
+        """Being invoked is not the same as blocking. `mcp-doc-contract` is in
+        `CI Success`'s `needs` AND read by its `[[ … ]]` chain — proved by
+        `test_ci_gate_reachability`, which this leans on rather than
+        re-implements. A step parked in an unrequired workflow would satisfy
+        the assertion above and gate nothing, which is #1698 one level down.
+        """
+        body = CI.read_text(encoding="utf-8")
+        job_start = body.index("\n  mcp-doc-contract:")
+        following = body.find("\n  bench-sift1m", job_start)
+        job_body = body[job_start : following if following > 0 else len(body)]
+        self.assertIn("integrations/agent-hooks/test/hooks.test.sh", job_body)
+        self.assertIn("scripts.tests.test_sync_agent_hooks", job_body)
+
+        # Directives only. The job's own comments *discuss* `continue-on-error`
+        # to explain why it has none, and a substring search over the raw text
+        # reports that prose as a disarm — a guard that fires on the sentence
+        # describing the thing it forbids.
+        directives = "\n".join(
+            line for line in job_body.splitlines() if not line.lstrip().startswith("#")
+        )
+        for disarm in ("continue-on-error:", "|| true"):
+            self.assertNotIn(disarm, directives, f"the job is disarmed by {disarm}")
+
+    def test_the_harness_is_executable_and_can_fail(self) -> None:
+        self.assertTrue(HARNESS.is_file())
+        body = HARNESS.read_text(encoding="utf-8")
+        self.assertIn("exit 1", body, "a harness with no failing exit cannot gate anything")
+
+    def test_the_harness_refuses_a_broken_hook(self) -> None:
+        """The positive control. A harness that passes on a sabotaged tree is
+        decorative, and nothing else here would notice."""
+        with tempfile.TemporaryDirectory() as tmp:
+            copy = Path(tmp) / "agent-hooks"
+            shutil.copytree(REPO / "integrations" / "agent-hooks", copy)
+            broken = copy / "claude-code" / "hooks" / "session-start.sh"
+            broken.write_text("#!/usr/bin/env bash\necho '{}'\n", encoding="utf-8")
+
+            result = subprocess.run(
+                ["bash", str(copy / "test" / "hooks.test.sh")],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, "the harness passed a sabotaged hook")
+
+    def test_the_harness_passes_on_the_tree_as_committed(self) -> None:
+        result = subprocess.run(
+            ["bash", str(HARNESS)], capture_output=True, text=True, check=False
+        )
+        self.assertEqual(result.returncode, 0, result.stdout[-3000:] + result.stderr[-2000:])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The hooks a Claude Code session actually runs live in `~/.claude/hooks/velesdb-memory/` — outside any repository, the blind spot #1712 closed for skills, one surface over. Measured against `develop@e36a99f9`, they had diverged in **both directions at once**:

- **the repository was ahead on the text.** `session-start.sh` carries the corrected `{found, working, other_sessions}` guidance; the installed copy still said *"if it returns null, nothing was saved yet"*. The tool never returns null — its only required key is `found` — so a model reading that never checks `other_sessions` and starts fresh on top of work a mistyped session id hid from it. This is the defect `hooks.test.sh`'s own header names, and it was live: the SessionStart context injected while this batch was being written carried that stale sentence.
- **the install was ahead on function.** `lib/freshness.sh` (one line of guidance when the running daemon is behind the published release) and `update-daemon.sh` (build, install, restart, verify over the wire) existed **nowhere** in this repository, plus `2>/dev/null || true` hardening on five `jq` calls.

So an installer that mirrored the repo would have deleted working code on its first run, and doing nothing left a hook misinforming every session. **The source absorbs the local layer first** — that is why this batch touches the hooks themselves and not only the tooling.

## What changed

**Absorbed and generalised.** `lib/freshness.sh` and `update-daemon.sh` are versioned. No path from one contributor's machine survived: the updater took `$HOME/Developer/personal/velesdb` as its default and now takes `VELESDB_REPO` or the current tree, refusing clearly when neither is one. The freshness notice names the updater beside it, computed from `BASH_SOURCE`, instead of a path written at authoring time. The daemon restart falls back to `systemctl` where there is no `launchctl`. The repository's corrected wording is what survived the merge — the stale sentence is asserted absent.

**`scripts/sync-agent-hooks.py`.** A hook is *scripts on disk* **and** *an entry in `settings.json`*; either alone does nothing, so both are reported, per hook, as `in step` / `drifted` / `absent`. The merge works at **hook granularity, never group granularity** — measured on a real machine, `SessionStart` holds a foreign hook and ours in the *same* group, so replacing a group would silently delete the neighbour. It touches only entries whose command contains `.claude/hooks/velesdb-memory/` (that marker matched 4 entries and none of the 4 foreign ones; no foreign entry mentions velesdb at all), backs the file up, writes atomically, and never prints its contents. `--check` `--strict` `--install` `--dry-run` `--uninstall`.

**`hooks.test.sh` runs in CI.** Referenced by six documents, executed by zero workflows. It now runs in the required `mcp-doc-contract` job.

## Proof

Red first — **21 failures out of 30**, and the three that already passed are the ones that mattered up front: the harness genuinely refuses a sabotaged hook, so it was never decorative, only unwired.

Measured after:

- **268 → 302** python tests (baseline re-run on `develop@e36a99f9`, not assumed).
- Every installer test runs against a **fake HOME**; the developer's own hooks and settings are never read or written by the suite.
- **Reachability, positive control twice.** Deleting the `hooks.test.sh` step turns two tests red; adding `continue-on-error: true` turns the blocking test red on its own. The first version of that guard had a false positive — it matched `continue-on-error` inside the comment explaining the job has none — so it now reads directives, not prose.
- **Foreign preservation** is asserted on a settings fixture shaped like the real one: three foreign `PreToolUse` hooks, a foreign `SessionStart` hook sharing a group with ours, plus `theme`, `model` and `permissions`. `--install` and `--uninstall` both leave every one of them equal.
- Two successive installs are **byte-identical**, settings and tree.
- `--dry-run` leaves the directory listing and the settings bytes untouched, and does not create the hooks directory.
- No output of any mode contains a fragment of the settings document.
- Against the **real** install, read-only: `stop.sh`, `pre-compact.sh` and `post-tool-use.sh` now report `in step` — the absorption is what made that true — and `session-start.sh` reports `drifted`, in the intended direction.

## Scope and findings recorded, not widened

Absorbing the local layer was classified as indispensable to this contract: no honest installer could exist while the source could not reproduce what it would overwrite.

Two independent findings go to the registry rather than into this PR: `post-tool-use.sh` is versioned `100644` while its three neighbours are `100755` (harmless — hooks are invoked as `bash <path>`), and the README's hand-install JSON left the path unquoted while the tool quotes it, so a `HOME` containing a space would have split the command. The second is fixed here, since it is this PR's own surface, and pinned by a test.

Part of #1773 (lot 3 sur 3 du socle mémoire versionné).