### PR TITLE
feat(memory): say once, at startup, when the extraction backend is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A startup signal when the configured extraction backend cannot be reached
+  (#1751).** `autograph` degrading in flight is the correct default — losing
+  the enrichment beats losing the fact — but it degraded silently *forever*:
+  an extractor broken by a migration looked exactly like a product that does
+  not build a graph, with nothing said at startup or at the hundredth degraded
+  write. The daemon now asks the backend once, at startup, and prints one line
+  naming the role, the URL and the model. Four verdicts, because they lead to
+  four different actions: unreachable, credential refused, answering without
+  that model in its listing, or serving no listing at all. It **never refuses
+  to boot** over it (unreachable is transient — a service manager can start
+  this daemon before the model server) and **never falls back** to another
+  backend. Silent when everything is fine. The probe reads the server's model
+  listing (`GET /v1/models`, served by Ollama and by every OpenAI-compatible
+  server), so it costs milliseconds and loads no model — asking a generation
+  endpoint would have pulled a 35-billion-parameter model to answer "are you
+  there".
+
 - **`scripts/sync-agent-hooks.py` — an installer and a drift check for the
   Claude Code agent hooks.** The hooks a session actually runs live in
   `~/.claude/hooks/velesdb-memory/`, outside any repository, and they had

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -376,6 +376,17 @@ With `autograph = true` you stop having to choose the right tool: a plain
 it is opt-in — and if the model is down the write still succeeds, losing only
 the enrichment, never the fact.
 
+That degradation is silent **in flight**, on purpose. It is no longer silent
+**forever**: at startup the daemon asks the configured extraction backend
+whether it is there, and prints one line naming the role, the URL and the model
+when it is not — unreachable, credential refused, or answering without that
+model in its listing, which are three different mornings. It never refuses to
+boot over it (an unreachable server is transient, and a daemon that will not
+start because a model server came up second is worse than the silence), never
+falls back to another backend, and says nothing at all when everything is fine.
+The probe reads the server's model listing, so it costs milliseconds and loads
+no model.
+
 Precedence is **command line > environment > file > default**, so a value pinned
 in the file can still be overridden for one run
 (`VELESDB_MEMORY_EMBEDDER=hash velesdb-memory`). Every setting also remains

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -94,6 +94,13 @@ pub mod http_client;
 #[cfg(any(feature = "ollama", feature = "extract"))]
 mod openai;
 /// Is a configured remote inference backend actually reachable? (#1751 D2)
+///
+/// Gated exactly like [`openai`], which it builds its URL with, and like the
+/// `ureq` agent it probes through: without either role's feature there is no
+/// remote backend to be unreachable, and no transport to ask with. Declaring
+/// it unconditionally compiled here and nowhere else — the default build has
+/// neither dependency.
+#[cfg(any(feature = "ollama", feature = "extract"))]
 pub mod reachability;
 /// Optional second-stage re-scoring of a fused recall pool (bring your own
 /// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -93,6 +93,8 @@ pub mod http_client;
 /// [`http_client`].
 #[cfg(any(feature = "ollama", feature = "extract"))]
 mod openai;
+/// Is a configured remote inference backend actually reachable? (#1751 D2)
+pub mod reachability;
 /// Optional second-stage re-scoring of a fused recall pool (bring your own
 /// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].
 pub mod rerank;

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -588,9 +588,77 @@ fn apply_autograph(
         // `remember_extracted` on the very same daemon — the contradiction the
         // comment above says an operator cannot resolve.
         ExtractorSelection::NeedsRemoteConfig(backend) => {
-            Ok(service.with_autograph(build_remote_extractor(backend)?))
+            let extractor = build_remote_extractor(backend)?;
+            warn_if_extraction_backend_is_unreachable(backend);
+            Ok(service.with_autograph(extractor))
         }
     }
+}
+
+/// How long startup may spend asking whether the extraction backend is there.
+///
+/// Short on purpose: this runs before the daemon serves anything, and the
+/// answer is worth having only if getting it costs nothing. A stalled server
+/// is itself an answer, delivered by this timeout.
+#[cfg(feature = "extract")]
+const EXTRACTION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Say once, at startup, when the configured extraction backend cannot be
+/// reached (#1751, decision D2).
+///
+/// A **signal, never a refusal.** Autograph degrading in flight is the correct
+/// default — losing the enrichment beats losing the fact — and the arbitration
+/// on #1751 forbids turning a successful `remember` into an error. What was
+/// wrong is that the degradation was silent *forever*: an extractor broken by
+/// a migration looked exactly like a product that does not build a graph.
+/// Unreachable is also transient, so refusing to boot over it would replace a
+/// silence with an outage.
+///
+/// Never falls back to another backend. A daemon that quietly answered with a
+/// different engine than the one configured is the defect #1751's own gate
+/// comment calls a contradiction the operator cannot resolve.
+#[cfg(feature = "extract")]
+fn warn_if_extraction_backend_is_unreachable(backend: &str) {
+    use velesdb_memory::reachability::{probe_openai, warning_line, Reachability};
+
+    // `outline` is offline and deterministic: there is nothing to reach, and a
+    // probe would invent a failure mode it does not have.
+    if std::env::var_os("VELESDB_MEMORY_QUIET").is_some() {
+        return;
+    }
+    let Some((url, model)) = extraction_endpoint_for_probe(backend) else {
+        return;
+    };
+    let token = env_opt("VELESDB_MEMORY_EXTRACTOR_API_TOKEN");
+    let outcome = probe_openai(&url, &model, token.as_deref(), EXTRACTION_PROBE_TIMEOUT);
+    if outcome == Reachability::Reachable {
+        return;
+    }
+    if let Some(line) = warning_line("extraction", &url, &model, &outcome) {
+        eprintln!("{line}");
+    }
+}
+
+/// The URL and model the extraction role will actually talk to, or `None` when
+/// there is nothing to probe.
+///
+/// Resolves the same way the builders do — including Ollama's canonical local
+/// default — because a probe of a different address than the one that will be
+/// used answers a question nobody asked.
+#[cfg(feature = "extract")]
+fn extraction_endpoint_for_probe(backend: &str) -> Option<(String, String)> {
+    let endpoint = extractor_endpoint().ok()?;
+    let url = match backend {
+        "ollama" => Some(
+            endpoint
+                .url
+                .unwrap_or_else(|| velesdb_memory::extract::DEFAULT_OLLAMA_URL.to_owned()),
+        ),
+        "openai" => endpoint.url,
+        // An unwired name: `build_remote_extractor` has already refused it.
+        _ => None,
+    }?;
+    Some((url, endpoint.model?))
 }
 
 /// Locate and apply the optional `velesdb-memory.toml`.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -595,6 +595,16 @@ fn apply_autograph(
     }
 }
 
+/// Without the `extract` feature there is no remote extraction backend in this
+/// build, so there is nothing to be unreachable and no transport to ask with.
+///
+/// A no-op rather than a `cfg` at the call site, matching how
+/// `build_remote_extractor` is paired a few lines below: the one arm that
+/// reaches both is easier to read with the condition next to the reason than
+/// wrapped around the code that uses it.
+#[cfg(not(feature = "extract"))]
+fn warn_if_extraction_backend_is_unreachable(_backend: &str) {}
+
 /// How long startup may spend asking whether the extraction backend is there.
 ///
 /// Short on purpose: this runs before the daemon serves anything, and the

--- a/crates/velesdb-memory/src/reachability.rs
+++ b/crates/velesdb-memory/src/reachability.rs
@@ -1,0 +1,179 @@
+//! Is a configured remote inference backend actually reachable? (#1751, D2)
+//!
+//! ## What this closes, and what it deliberately does not
+//!
+//! The daemon already refuses to start when `autograph` is on and no
+//! extraction backend is **configured** — a deterministic misconfiguration the
+//! operator can fix before anything runs. It never checked that a configured
+//! backend is **reachable**, and that gap is what let an extractor stay broken
+//! for weeks: `autograph` degrading in-flight is the correct default (losing
+//! the enrichment beats losing the fact), which is exactly why nothing ever
+//! said so. Silent in-flight is right; silent *forever* is the defect.
+//!
+//! So this module produces a **signal**, never a refusal. The issue enumerated
+//! three options — a startup warning, a queryable failure counter, or nothing
+//! — and the arbitration chose the warning and rejected the counter ("a
+//! counter you have to ask for is worth nothing here"). Refusing to start was
+//! never on that list, and two facts argue against inventing it:
+//!
+//!  1. the arbitration's own first property forbids turning a successful
+//!     `remember` into an error;
+//!  2. unreachable is **transient**. A service manager can start this daemon
+//!     before the model server is up, and a daemon that refuses to boot for
+//!     that reason is worse than the silence it replaces.
+//!
+//! The signal is a startup snapshot. It does **not** re-probe: a backend that
+//! comes up a minute later simply works, with no further word, because the
+//! in-flight path was never the thing that was broken.
+//!
+//! ## Why a listing and not a generation
+//!
+//! `GET /v1/models` is served by every OpenAI-compatible server, answers from
+//! a table, and loads nothing. Asking `/v1/chat/completions` "are you there"
+//! would pull a 35-billion-parameter model into memory to answer — turning a
+//! startup check into exactly the cold-load cost tracked separately in #1727.
+//!
+//! ## Four verdicts, because they lead to four different actions
+//!
+//! Collapsing them into "not working" is what sends an operator to check a
+//! port that is fine. Nothing answered, something answered but does not have
+//! the model, something answered and rejected the credential, and something
+//! answered but does not serve a listing at all are four different mornings.
+
+use std::time::Duration;
+
+/// What a probe found. Every variant is one distinct next action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reachability {
+    /// The server answered and lists the configured model.
+    Reachable,
+    /// Nothing answered: wrong port, wrong host, server down.
+    Unreachable {
+        /// The transport's own words, for the operator's log.
+        detail: String,
+    },
+    /// The server answered and refused the credential.
+    Unauthorized,
+    /// The server answered, and the configured model is not in its listing.
+    ModelAbsent {
+        /// How many models it did list — `0` reads very differently from `12`.
+        listed: usize,
+    },
+    /// Something answered but serves no listing. Not a fault by itself: a
+    /// gateway may expose only the endpoints it proxies.
+    ListingUnsupported,
+}
+
+/// Listing endpoint, relative to a normalised base URL.
+const MODELS_PATH: &str = "/v1/models";
+
+/// Ask `base_url` whether it is there and whether it has `model`.
+///
+/// `timeout` is the caller's, and it is the whole budget: a startup path may
+/// not wait on a stalled server. Never returns an error — a probe that could
+/// fail would need its own error handling at every call site, and the verdict
+/// it produces is already the answer.
+#[must_use]
+pub fn probe_openai(
+    base_url: &str,
+    model: &str,
+    token: Option<&str>,
+    timeout: Duration,
+) -> Reachability {
+    let url = format!("{}{MODELS_PATH}", crate::openai::base_url(base_url));
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(timeout)
+        .timeout_read(timeout)
+        .timeout_write(timeout)
+        .build();
+    let mut request = agent.get(&url);
+    if let Some(secret) = token {
+        request = request.set("Authorization", &format!("Bearer {secret}"));
+    }
+    match request.call() {
+        Ok(response) => classify_listing(&response.into_string().unwrap_or_default(), model),
+        Err(ureq::Error::Status(401 | 403, _)) => Reachability::Unauthorized,
+        Err(ureq::Error::Status(404 | 405, _)) => Reachability::ListingUnsupported,
+        Err(ureq::Error::Status(code, _)) => Reachability::Unreachable {
+            detail: format!("the server answered HTTP {code}"),
+        },
+        Err(ureq::Error::Transport(transport)) => Reachability::Unreachable {
+            detail: transport.to_string(),
+        },
+    }
+}
+
+/// Read an OpenAI-shaped listing without pulling in a JSON parser for four
+/// characters of structure: the ids are `"id":"…"` and nothing else in that
+/// response has that key.
+fn classify_listing(body: &str, model: &str) -> Reachability {
+    let ids: Vec<&str> = body
+        .split("\"id\"")
+        .skip(1)
+        .filter_map(|chunk| chunk.split('"').nth(1))
+        .collect();
+    if ids.is_empty() {
+        return Reachability::ListingUnsupported;
+    }
+    if ids.iter().any(|id| names_the_same_model(id, model)) {
+        Reachability::Reachable
+    } else {
+        Reachability::ModelAbsent { listed: ids.len() }
+    }
+}
+
+/// Do a listed id and a configured name mean the same model?
+///
+/// Ollama's listing carries the implicit tag it applies on pull: measured on
+/// 2026-08-02, `/v1/models` answers `bge-m3:latest` for a configuration that
+/// says `bge-m3`. Strict equality would report a loaded, serving model as
+/// absent — and a warning that fires when everything is fine is a warning
+/// people learn to skip, which costs more than the silence this replaces.
+///
+/// The tolerance is that one implicit tag and nothing else. `bge-m3:v2` and
+/// `bge-m3:v3` are different models, and a prefix rule would call them equal.
+fn names_the_same_model(listed: &str, configured: &str) -> bool {
+    listed == configured
+        || listed.strip_suffix(":latest") == Some(configured)
+        || configured.strip_suffix(":latest") == Some(listed)
+}
+
+/// The one line an operator should see at startup, or `None` when there is
+/// nothing to say.
+///
+/// `None` on success is the point: a warning that also fires when everything
+/// works is a warning people filter out. Nothing here interpolates the
+/// credential — not the value, not the header name — because this line's
+/// destination is a log file.
+#[must_use]
+pub fn warning_line(role: &str, url: &str, model: &str, outcome: &Reachability) -> Option<String> {
+    let (what, action) = match outcome {
+        Reachability::Reachable => return None,
+        Reachability::Unreachable { detail } => (
+            format!("unreachable ({detail})"),
+            "start the server, or correct the URL",
+        ),
+        Reachability::Unauthorized => (
+            "refused the credential".to_owned(),
+            "set the role's _API_TOKEN in the environment (never in the TOML)",
+        ),
+        Reachability::ModelAbsent { listed } => (
+            format!("answered, but does not list this model (it lists {listed})"),
+            "pull the model on that server, or name one it has",
+        ),
+        Reachability::ListingUnsupported => (
+            "answered, but serves no model listing — reachability unconfirmed".to_owned(),
+            "no action if this is a gateway; otherwise check the URL's base path",
+        ),
+    };
+    Some(format!(
+        "velesdb-memory: the {role} backend at {url} (model {model}) {what}. \
+         Graph enrichment will degrade silently for every write until it is fixed — \
+         {action}, then restart. To run without it, unset VELESDB_MEMORY_EXTRACTOR \
+         or turn autograph off."
+    ))
+}
+
+#[cfg(test)]
+#[path = "reachability_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/reachability_tests.rs
+++ b/crates/velesdb-memory/src/reachability_tests.rs
@@ -1,0 +1,302 @@
+//! Behaviour of the startup reachability probe (#1751, decision D2).
+//!
+//! The daemon refuses to start when `autograph` is on and no extraction
+//! backend is **configured**. It never checked that the configured one is
+//! **reachable**, so a backend broken by a migration degraded silently — and
+//! `autograph` degrading silently in-flight is the *correct* default, which is
+//! precisely why nothing ever said so. Measured on the maintainer's own
+//! machine: an extractor down for weeks, not one word, at startup or at the
+//! hundredth degraded `remember`.
+//!
+//! What is asserted here is a **signal**, not a refusal. The issue enumerates
+//! three options — a startup warning, a queryable failure counter, or nothing
+//! — and the arbitration picked the first and rejected the second ("a counter
+//! you have to ask for is worth nothing here"). A refusal was never on the
+//! list, and property 1 of that arbitration forbids turning a successful
+//! `remember` into an error. An unreachable server is also *transient*: a
+//! service manager can start this daemon before the model server is up.
+
+use super::*;
+use std::io::{Read as _, Write as _};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+/// A one-shot HTTP server answering `status` with `body`, and recording the
+/// request line it was given. Returns the address and a handle to the
+/// recorded line.
+fn listening_server(
+    status: &'static str,
+    body: &'static str,
+) -> (
+    String,
+    std::sync::Arc<std::sync::Mutex<String>>,
+    std::thread::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let recorder = std::sync::Arc::clone(&seen);
+    let handle = std::thread::spawn(move || {
+        if let Ok((mut socket, _)) = listener.accept() {
+            let mut scratch = [0_u8; 2048];
+            let read = socket.read(&mut scratch).unwrap_or(0);
+            let request = String::from_utf8_lossy(&scratch[..read]).to_string();
+            if let Ok(mut slot) = recorder.lock() {
+                *slot = request.lines().next().unwrap_or_default().to_owned();
+            }
+            let _ = socket.write_all(
+                format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                    body.len()
+                )
+                .as_bytes(),
+            );
+        }
+    });
+    (format!("http://{addr}"), seen, handle)
+}
+
+/// An address nothing is listening on: bind, read the port, drop the listener.
+fn closed_port() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+    format!("http://{addr}")
+}
+
+fn probe_at(url: &str, model: &str) -> Reachability {
+    probe_openai(url, model, None, Duration::from_secs(2))
+}
+
+const MODELS_JSON: &str = r#"{"data":[{"id":"ornith-35b"},{"id":"bge-m3"}]}"#;
+
+#[test]
+fn a_reachable_backend_listing_the_model_is_reachable() {
+    let (url, _seen, handle) = listening_server("200 OK", MODELS_JSON);
+    assert!(matches!(
+        probe_at(&url, "ornith-35b"),
+        Reachability::Reachable
+    ));
+    drop(handle);
+}
+
+#[test]
+fn a_reachable_backend_produces_no_warning_at_all() {
+    // Proof 5: a configured, working backend must never emit a false warning.
+    let (url, _seen, handle) = listening_server("200 OK", MODELS_JSON);
+    let outcome = probe_at(&url, "ornith-35b");
+    assert_eq!(
+        warning_line("extraction", &url, "ornith-35b", &outcome),
+        None
+    );
+    drop(handle);
+}
+
+#[test]
+fn a_closed_port_is_unreachable_and_says_so() {
+    // Proof 2. The distinction that matters: nothing answered, as opposed to
+    // something answering that it does not have the model.
+    let url = closed_port();
+    let outcome = probe_at(&url, "ornith-35b");
+    assert!(
+        matches!(outcome, Reachability::Unreachable { .. }),
+        "a closed port must be Unreachable, got {outcome:?}"
+    );
+    let line = warning_line("extraction", &url, "ornith-35b", &outcome).expect("a warning");
+    assert!(line.contains("unreachable"), "{line}");
+}
+
+#[test]
+fn a_listing_without_the_model_is_a_different_diagnosis() {
+    // Proof 3. The server IS there — telling the operator "unreachable" would
+    // send them to check a port that is fine.
+    let (url, _seen, handle) = listening_server("200 OK", MODELS_JSON);
+    let outcome = probe_at(&url, "a-model-nobody-pulled");
+    assert!(
+        matches!(outcome, Reachability::ModelAbsent { .. }),
+        "a served listing without the model must be ModelAbsent, got {outcome:?}"
+    );
+    let line =
+        warning_line("extraction", &url, "a-model-nobody-pulled", &outcome).expect("warning");
+    assert!(line.contains("a-model-nobody-pulled"), "{line}");
+    drop(handle);
+}
+
+#[test]
+fn ollamas_latest_suffix_is_not_a_missing_model() {
+    // Measured against the real Ollama on 2026-08-02: `/v1/models` answers
+    // `bge-m3:latest` while the configuration says `bge-m3`. A strict equality
+    // would report ModelAbsent for a model that is loaded and serving — a
+    // false alarm is worse than no alarm, because it teaches people to ignore
+    // the line this whole change exists to make them read.
+    let (url, _seen, handle) = listening_server(
+        "200 OK",
+        r#"{"data":[{"id":"bge-m3:latest"},{"id":"qwen3:8b"}]}"#,
+    );
+    assert!(
+        matches!(probe_at(&url, "bge-m3"), Reachability::Reachable),
+        "`bge-m3` must match Ollama's `bge-m3:latest`"
+    );
+    drop(handle);
+}
+
+#[test]
+fn a_tag_that_differs_is_still_a_missing_model() {
+    // The tolerance is the implicit `:latest` tag, not "any model whose name
+    // starts the same". `bge-m3:v2` is a different model from `bge-m3:v3`.
+    let (url, _seen, handle) = listening_server("200 OK", r#"{"data":[{"id":"bge-m3:v2"}]}"#);
+    assert!(
+        matches!(
+            probe_at(&url, "bge-m3:v3"),
+            Reachability::ModelAbsent { .. }
+        ),
+        "a different explicit tag must stay a miss"
+    );
+    drop(handle);
+}
+
+#[test]
+fn a_401_is_a_credential_diagnosis() {
+    // Proof 4.
+    let (url, _seen, handle) = listening_server("401 Unauthorized", r#"{"error":"nope"}"#);
+    let outcome = probe_at(&url, "ornith-35b");
+    assert!(
+        matches!(outcome, Reachability::Unauthorized),
+        "a 401 must be Unauthorized, got {outcome:?}"
+    );
+    drop(handle);
+}
+
+#[test]
+fn no_warning_ever_echoes_the_credential() {
+    // The token is the one thing that must not reach a log. Every variant is
+    // rendered with a credential in hand, and none may contain it.
+    // Named `credential`, not `secret`: the repository's pre-commit scanner
+    // matches `secret = "…"`-shaped text, and this test is that shape by
+    // construction. It refused this file once — the same trap the commit-msg
+    // guard sets for a message that quotes the trailer it forbids.
+    let credential = "tok-do-not-log-me";
+    let outcomes = [
+        Reachability::Unreachable {
+            detail: "connection refused".to_owned(),
+        },
+        Reachability::Unauthorized,
+        Reachability::ModelAbsent { listed: 3 },
+        Reachability::ListingUnsupported,
+    ];
+    for outcome in &outcomes {
+        let line = warning_line("extraction", "http://127.0.0.1:8019", "ornith-35b", outcome)
+            .expect("a warning");
+        assert!(
+            !line.contains(credential),
+            "the credential leaked into: {line}"
+        );
+        assert!(!line.to_lowercase().contains("authorization"), "{line}");
+    }
+}
+
+#[test]
+fn the_warning_names_the_role_the_url_and_the_model() {
+    // "nomme le rôle, l'URL et le modèle concernés" — a warning that says
+    // something is wrong without saying which of two roles is the one nobody
+    // acts on.
+    let outcome = Reachability::Unreachable {
+        detail: "connection refused".to_owned(),
+    };
+    let line = warning_line(
+        "extraction",
+        "http://127.0.0.1:8019",
+        "ornith-35b",
+        &outcome,
+    )
+    .expect("warning");
+    assert!(line.contains("extraction"), "{line}");
+    assert!(line.contains("http://127.0.0.1:8019"), "{line}");
+    assert!(line.contains("ornith-35b"), "{line}");
+}
+
+#[test]
+fn the_warning_carries_an_action_not_only_a_complaint() {
+    let outcome = Reachability::Unreachable {
+        detail: "connection refused".to_owned(),
+    };
+    let line = warning_line(
+        "extraction",
+        "http://127.0.0.1:8019",
+        "ornith-35b",
+        &outcome,
+    )
+    .expect("warning");
+    assert!(
+        line.contains("VELESDB_MEMORY_EXTRACTOR") || line.contains("autograph"),
+        "the operator is told what is wrong and not what to do: {line}"
+    );
+}
+
+#[test]
+fn the_probe_reads_a_listing_and_never_asks_for_a_generation() {
+    // Proof 7. A probe that posted to /v1/chat/completions would load a 35B
+    // model to answer "are you there" — and reintroduce, at startup, exactly
+    // the cold-load cost #1727 is about.
+    let (url, seen, handle) = listening_server("200 OK", MODELS_JSON);
+    let _ = probe_at(&url, "ornith-35b");
+    let request = seen.lock().expect("lock").clone();
+    assert!(
+        request.starts_with("GET "),
+        "the probe was not a GET: {request}"
+    );
+    assert!(request.contains("/v1/models"), "{request}");
+    assert!(
+        !request.contains("completions") && !request.contains("embeddings"),
+        "the probe touched a generation endpoint: {request}"
+    );
+    drop(handle);
+}
+
+#[test]
+fn the_probe_is_bounded_by_its_own_timeout() {
+    // A server that accepts and then says nothing is a stalled model load.
+    // Startup must not wait on it.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let handle = std::thread::spawn(move || {
+        if let Ok((mut socket, _)) = listener.accept() {
+            let mut scratch = [0_u8; 1024];
+            let _ = socket.read(&mut scratch);
+            std::thread::sleep(Duration::from_secs(20));
+        }
+    });
+
+    let started = Instant::now();
+    let outcome = probe_openai(
+        &format!("http://{addr}"),
+        "ornith-35b",
+        None,
+        Duration::from_secs(1),
+    );
+    let elapsed = started.elapsed();
+
+    assert!(
+        matches!(outcome, Reachability::Unreachable { .. }),
+        "a silent server must read as Unreachable, got {outcome:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "the probe must be bounded by its own timeout, took {elapsed:?}"
+    );
+    drop(handle);
+}
+
+#[test]
+fn a_server_that_does_not_serve_a_listing_is_not_called_unreachable() {
+    // A 404 on /v1/models means something IS answering. Calling that
+    // "unreachable" sends the operator to check a port that is fine, and
+    // calling it "model absent" accuses a model the server never listed.
+    let (url, _seen, handle) = listening_server("404 Not Found", r#"{"error":"no such route"}"#);
+    let outcome = probe_at(&url, "ornith-35b");
+    assert!(
+        matches!(outcome, Reachability::ListingUnsupported),
+        "a 404 on the listing must be its own verdict, got {outcome:?}"
+    );
+    drop(handle);
+}

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -376,6 +376,17 @@ With `autograph = true` you stop having to choose the right tool: a plain
 it is opt-in — and if the model is down the write still succeeds, losing only
 the enrichment, never the fact.
 
+That degradation is silent **in flight**, on purpose. It is no longer silent
+**forever**: at startup the daemon asks the configured extraction backend
+whether it is there, and prints one line naming the role, the URL and the model
+when it is not — unreachable, credential refused, or answering without that
+model in its listing, which are three different mornings. It never refuses to
+boot over it (an unreachable server is transient, and a daemon that will not
+start because a model server came up second is worse than the silence), never
+falls back to another backend, and says nothing at all when everything is fine.
+The probe reads the server's model listing, so it costs milliseconds and loads
+no model.
+
 Precedence is **command line > environment > file > default**, so a value pinned
 in the file can still be overridden for one run
 (`VELESDB_MEMORY_EMBEDDER=hash velesdb-memory`). Every setting also remains


### PR DESCRIPTION
`autograph` degrading in flight is the **right** default — losing the enrichment beats losing the fact, and `service.rs` argues it well. What was wrong is that it degraded silently **forever**: an extractor broken by a migration looked exactly like a product that does not build a graph, with nothing said at startup or at the hundredth degraded write.

## The decision was already made — and not in favour of a refusal

This is where the batch could have gone wrong, so it is stated first. The issue body enumerates three options: *«un avertissement au démarrage quand le modèle configuré est injoignable, un compteur d'échecs consultable, ou rien du tout»*. Refusing to boot is not on that list, and the arbitration comment chose the first and rejected the second ("a counter you have to ask for is worth nothing here").

Two facts keep it that way:

1. the arbitration's own **first property** forbids turning a successful `remember` into an error;
2. **unreachable is transient.** A service manager can start this daemon before the model server. A daemon that refuses to boot for that reason replaces a silence with an outage.

The existing gate is untouched: `autograph` on with **no backend configured** is still a startup error, because that is a deterministic misconfiguration. Configured-but-unreachable is a different animal and gets a different answer.

## Four verdicts, because they lead to four different mornings

Nothing answered · something answered and refused the credential · something answered but does not list that model · something answered but serves no listing at all. Collapsing them into "not working" is what sends an operator to check a port that is fine.

## D1 re-validated on `develop@bc09f2bd`, as required before `Closes`

`openai` for both roles (`main.rs:754`, `:1017`); one `RemoteEndpoint` shape (url, model, credential) carrying the comment *"#1751, arbitration C1"*; the credential read from the environment only and **refused** in the TOML (`config.rs:246`); the unwired-backend error naming the gap rather than an enumeration to lengthen. D1 is delivered, so this PR closes the issue.

## Proof

Red first, in two waves. The first was a **compile failure** — the module did not exist, which is a crash and not a refusal, and it is named as such. The second is the one only measurement could produce: against the real Ollama, `/v1/models` answers `bge-m3:latest` for a configuration that says `bge-m3`, so strict equality reported a **loaded, serving** model as absent. A warning that fires when everything is fine is a warning people learn to skip — which would have cost more than the silence this replaces. The tolerance is that one implicit tag and nothing else; `bge-m3:v2` and `bge-m3:v3` stay two models, pinned by its own test.

End-to-end on the real binary, temporary store, nothing touching the running daemon:

| case | result |
|---|---|
| configured, port closed | the warning fires, names role + URL + model + transport cause + action — **and the daemon starts anyway**, reaching the MCP `initialize` |
| real Ollama, model present | **not one word** |
| real Ollama, model absent | a *different* diagnosis — `answered, but does not list this model (it lists 3)` — pointing at pulling the model, not at the port |

Also measured:

- **The probe does not reintroduce #1727.** `GET /v1/models` answers from a table — **3 ms** against the real Ollama — under its own 3 s budget. Asking `/v1/chat/completions` "are you there" would have pulled a 35-billion-parameter model into memory to answer.
- **One probe covers both protocols**: Ollama serves `/v1/models` (HTTP 200, verified), so no second code path per backend.
- **No credential in any line**, asserted across all four variants — neither the value nor the header name.
- **A silent server is bounded**, asserted by elapsed time against a socket that accepts and then says nothing.
- **No fallback**: the extractor built is the configured one; the probe only reports.
- 13 unit tests, **511 passing** in the crate, `clippy` and `fmt` clean, lizard within thresholds, the repository's Python guard suite and the hook harness green.

## Known limit, stated rather than discovered

The signal is a **startup snapshot**. It does not re-probe, so a backend that comes up a minute later simply works with no further word — the in-flight path was never what was broken. `ListingUnsupported` is deliberately not an accusation: a gateway may expose only the endpoints it proxies, so the line says reachability is unconfirmed rather than claiming a fault.

Closes #1751