### PR TITLE
fix(graph): TRUNCATE stops reporting Ok when an edge refuses to be removed

### DIFF
--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -5,7 +5,9 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::collection::graph::{GraphEdge, GraphSchema, TraversalConfig, TraversalResult};
+use crate::collection::graph::{
+    EdgeRemoval, GraphEdge, GraphSchema, TraversalConfig, TraversalResult,
+};
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::index::VectorIndex;
@@ -517,20 +519,38 @@ impl Collection {
     ///
     /// # Returns
     ///
-    /// `true` if the edge existed and was removed, `false` if it didn't exist.
+    /// `true` if the edge existed and was removed, `false` otherwise.
+    ///
+    /// A `false` does NOT mean "the edge didn't exist": it also covers a failed
+    /// WAL append and an index desynchronisation, which are real failures. Use
+    /// [`Self::remove_edge_detailed`] when the caller must not silently ignore
+    /// those.
     #[must_use]
     pub fn remove_edge(&self, edge_id: u64) -> bool {
+        self.remove_edge_detailed(edge_id).removed()
+    }
+
+    /// Removes an edge from the graph by ID, reporting WHY when it does not
+    /// happen.
+    ///
+    /// Separates the one benign outcome (the edge was not there) from the two
+    /// genuine failures this path can hit: the WAL refusing the remove — which
+    /// leaves the store unmutated and durability broken — and an index
+    /// desynchronisation inside the store.
+    pub(crate) fn remove_edge_detailed(&self, edge_id: u64) -> EdgeRemoval {
         // Cheap pre-check: a remove of a non-existent id must not create or
         // grow the WAL with junk tombstones (a racing remove between this
         // check and the append still replays as a harmless no-op).
         if !self.graph.edge_store.contains_edge(edge_id) {
-            return false;
+            return EdgeRemoval::Absent;
         }
         // WAL-before-apply (crash durability): log the remove intent before
         // mutating the store. Fail-closed: if the WAL append fails we do NOT
-        // mutate the store and report `false` (no panic — matches the
-        // no-unwrap policy and the bool return contract). Unconditional for
-        // the same reason as add_edge; the WAL lock spans append + apply.
+        // mutate the store (no panic — matches the no-unwrap policy). The
+        // failure is REPORTED rather than merely logged: the edge is still
+        // there, and a caller that treats this as "already gone" would be
+        // silently wrong. Unconditional for the same reason as add_edge; the
+        // WAL lock spans append + apply.
         let _wal_guard = self.graph.edge_wal_lock.lock();
         #[cfg(feature = "persistence")]
         if let Err(e) = crate::collection::graph::edge_wal::wal_append_remove(
@@ -538,17 +558,37 @@ impl Collection {
             edge_id,
         ) {
             tracing::error!("Edge WAL append remove failed for edge {edge_id}: {e}");
-            return false;
+            return EdgeRemoval::Failed(format!(
+                "write-ahead log refused the removal of edge {edge_id}: {e}; the edge was left in \
+                 place"
+            ));
         }
 
         // Atomic check-and-remove — no TOCTOU race.
-        let removed = self.graph.edge_store.remove_edge(edge_id);
-        if removed {
+        let outcome = self.graph.edge_store.remove_edge_detailed(edge_id);
+        if outcome.removed() {
             self.generations
                 .write_generation
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-        removed
+        outcome
+    }
+
+    /// Test-only fault injection: makes the edge write-ahead log impossible to
+    /// append to, by replacing its path with a directory (opening a directory
+    /// for writing fails with `EISDIR` on every Unix, including as root — a
+    /// read-only `chmod` would not).
+    ///
+    /// This is the failure mode a full disk or a revoked permission produces:
+    /// the edge is perfectly healthy and listed, but the removal cannot be
+    /// made durable, so the store is deliberately left unmutated.
+    #[cfg(all(test, feature = "persistence"))]
+    pub(crate) fn break_edge_wal_for_test(&self) -> std::io::Result<()> {
+        let path = crate::collection::graph::edge_wal::wal_path_for_edges(&self.storage.path);
+        if path.is_file() {
+            std::fs::remove_file(&path)?;
+        }
+        std::fs::create_dir_all(&path)
     }
 
     /// Returns the total number of edges in the graph.

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -18,6 +18,7 @@ mod snapshot;
 use super::clustered_index::ClusteredIndex;
 use super::csr_snapshot::{CsrSnapshot, SnapshotBuilder};
 use super::edge::{EdgeStore, GraphEdge};
+use super::edge_outcome::EdgeRemoval;
 use super::label_table::LabelTable;
 use super::metrics::GraphMetrics;
 use crate::error::{Error, Result};
@@ -348,16 +349,36 @@ impl ConcurrentEdgeStore {
 
     /// Removes an edge by ID using optimized 2-shard lookup.
     ///
+    /// Returns `true` only if the edge was actually removed. A `false` here
+    /// conflates "absent" with "index desynchronised" — use
+    /// [`Self::remove_edge_detailed`] when the difference matters.
+    ///
     /// # Concurrency Safety
     ///
     /// Lock ordering: edge_ids FIRST, then shards in ascending order.
     pub fn remove_edge(&self, edge_id: u64) -> bool {
+        self.remove_edge_detailed(edge_id).removed()
+    }
+
+    /// Removes an edge by ID, reporting WHY when it does not happen.
+    ///
+    /// The `bool` returned by [`Self::remove_edge`] cannot distinguish "the
+    /// edge was not there" (benign) from "the index and the shard disagree" (a
+    /// real failure that can strand a dangling incoming half-edge). Both leave
+    /// the edge absent from the index and from the source shard, so they are
+    /// indistinguishable to the caller *after* the call — only this function,
+    /// holding the locks, can tell them apart.
+    ///
+    /// # Concurrency Safety
+    ///
+    /// Lock ordering: edge_ids FIRST, then shards in ascending order.
+    pub(crate) fn remove_edge_detailed(&self, edge_id: u64) -> EdgeRemoval {
         let start = Instant::now();
         {
             let mut ids = self.edge_ids.write();
 
             let Some(&source_id) = ids.get(&edge_id) else {
-                return false;
+                return EdgeRemoval::Absent;
             };
 
             let source_shard_idx = self.shard_index(source_id);
@@ -366,8 +387,17 @@ impl ConcurrentEdgeStore {
                 if let Some(edge) = guard.get_edge(edge_id) {
                     edge.target()
                 } else {
+                    // The id was live in `edge_ids` but its source shard holds
+                    // no such edge: the two indices disagree. Repair what we
+                    // can, then report a FAILURE — `target_id` is unreachable
+                    // on this path, so an incoming half-edge on the target
+                    // shard cannot be cleaned up and may survive as an orphan.
                     ids.remove(&edge_id);
-                    return false;
+                    return EdgeRemoval::Failed(format!(
+                        "edge {edge_id} was indexed under source node {source_id} but is missing \
+                         from its source shard; the edge index has been repaired, but a dangling \
+                         incoming half-edge may remain"
+                    ));
                 }
             };
 
@@ -397,8 +427,35 @@ impl ConcurrentEdgeStore {
         } // All locks dropped here.
         self.invalidate_snapshot();
         self.rebuild_snapshot_best_effort();
-        // Record after all shard locks drop (true path only).
+        // Record after all shard locks drop (removed path only).
         self.metrics.record_edge_delete(start.elapsed());
+        EdgeRemoval::Removed
+    }
+
+    /// Test-only fault injection: desynchronises the edge id index from the
+    /// shards, exactly as a lost update would.
+    ///
+    /// Repoints `edge_id` to a source node that hashes to a DIFFERENT shard,
+    /// leaving the edge itself untouched in storage — so the edge is still
+    /// listed by `get_edges`, but `remove_edge_detailed` looks for it in the
+    /// wrong shard and cannot find it. That is the state described by #1749;
+    /// without this hook it is unreachable from any public API, which is why
+    /// the failure previously had no end-to-end test.
+    ///
+    /// Returns `false` if the store has a single shard (no "different shard"
+    /// exists) or if `edge_id` is not indexed.
+    #[cfg(test)]
+    pub(crate) fn desync_edge_index_for_test(&self, edge_id: u64) -> bool {
+        if self.num_shards < 2 {
+            return false;
+        }
+        let mut ids = self.edge_ids.write();
+        let Some(&source_id) = ids.get(&edge_id) else {
+            return false;
+        };
+        // shard = id % num_shards, so with num_shards >= 2 the successor of any
+        // node id always lands on a different shard.
+        ids.insert(edge_id, source_id.wrapping_add(1));
         true
     }
 

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
@@ -1534,3 +1534,58 @@ fn test_metrics_empty_batch_records_nothing() {
     assert_eq!(store.metrics().edge_inserts_total(), 0);
     assert_eq!(store.metrics().edge_insert_latency.count(), 0);
 }
+
+// =============================================================================
+// Removal outcome (#1749): a `false` must not hide a real failure
+// =============================================================================
+
+#[test]
+fn test_remove_edge_detailed_reports_absent_for_an_unknown_edge() {
+    let store = ConcurrentEdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 10, 20, "A").expect("edge"))
+        .expect("add");
+
+    assert_eq!(
+        store.remove_edge_detailed(999),
+        super::edge_outcome::EdgeRemoval::Absent,
+        "removing an edge that was never there is benign, not a failure"
+    );
+    assert_eq!(
+        store.remove_edge_detailed(1),
+        super::edge_outcome::EdgeRemoval::Removed
+    );
+    assert_eq!(
+        store.remove_edge_detailed(1),
+        super::edge_outcome::EdgeRemoval::Absent,
+        "removing the same edge twice stays benign"
+    );
+}
+
+#[test]
+fn test_remove_edge_detailed_reports_failure_on_index_desync() {
+    // The id index and the shards can disagree. Before #1749 this was reported
+    // as a plain `false`, indistinguishable from "the edge was not there" —
+    // even though the edge is still in storage and a dangling incoming
+    // half-edge may survive on the target shard.
+    let store = ConcurrentEdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 10, 20, "A").expect("edge"))
+        .expect("add");
+    assert!(
+        store.desync_edge_index_for_test(1),
+        "fault injection must apply, otherwise this test proves nothing"
+    );
+
+    let outcome = store.remove_edge_detailed(1);
+    let super::edge_outcome::EdgeRemoval::Failed(reason) = outcome else {
+        panic!("an index desynchronisation must be reported as a failure, got {outcome:?}");
+    };
+    assert!(
+        reason.contains("missing from its source shard"),
+        "the reason must say what actually went wrong, got: {reason}"
+    );
+
+    // The historical `bool` API still folds this to `false` — unchanged.
+    assert!(!store.remove_edge(1));
+}

--- a/crates/velesdb-core/src/collection/graph/edge_outcome.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_outcome.rs
@@ -1,0 +1,42 @@
+//! The outcome of a single edge removal.
+//!
+//! `remove_edge` returns `bool` across every layer of the graph stack, and that
+//! one bit conflates four genuinely different outcomes:
+//!
+//! 1. the edge was removed;
+//! 2. the edge was not there to begin with — benign, and callers rely on it;
+//! 3. the write-ahead log refused the remove, so the store was left untouched
+//!    and durability is broken;
+//! 4. the edge id was live in the index but missing from its source shard — an
+//!    index desynchronisation that can leave a dangling incoming half-edge.
+//!
+//! Cases 2 and 3/4 are indistinguishable from the outside *after* the call: in
+//! both the edge is absent from the index and from the source shard. Only the
+//! layer performing the removal can tell them apart, which is why the internal
+//! path reports this enum instead of re-deriving the answer afterwards.
+//!
+//! The public `remove_edge -> bool` API is unchanged and keeps folding this
+//! down to `matches!(.., Removed)`; this type stays `pub(crate)` so the folding
+//! happens at the crate boundary.
+
+/// What a single `remove_edge` attempt actually did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EdgeRemoval {
+    /// The edge existed and was removed.
+    Removed,
+    /// The edge was not present. Benign: removing an absent edge is a
+    /// documented no-op and must never be reported as a failure.
+    Absent,
+    /// The removal was attempted and failed. The edge may still be present, in
+    /// whole or in part. Carries a human-readable reason for the caller to
+    /// surface — no error is swallowed on this path.
+    Failed(String),
+}
+
+impl EdgeRemoval {
+    /// Folds the outcome back to the historical `bool` contract: `true` only
+    /// when the edge was actually removed.
+    pub(crate) fn removed(&self) -> bool {
+        matches!(self, Self::Removed)
+    }
+}

--- a/crates/velesdb-core/src/collection/graph/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/mod.rs
@@ -45,6 +45,7 @@ mod clustered_index;
 mod csr_snapshot;
 mod edge;
 mod edge_concurrent;
+mod edge_outcome;
 mod edge_persistence;
 mod edge_removal;
 #[cfg(feature = "persistence")]
@@ -96,6 +97,7 @@ pub(crate) use node::Element;
 #[allow(unused_imports)]
 pub(crate) use csr_snapshot::SnapshotBuilder;
 pub use edge_concurrent::ConcurrentEdgeStore;
+pub(crate) use edge_outcome::EdgeRemoval;
 pub use label_index::LabelIndex;
 pub use label_table::{LabelId, LabelTable};
 pub use metrics::{GraphMetrics, LatencyHistogram};

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -10,7 +10,9 @@
 
 use std::path::PathBuf;
 
-use crate::collection::graph::{GraphEdge, GraphSchema, TraversalConfig, TraversalResult};
+use crate::collection::graph::{
+    EdgeRemoval, GraphEdge, GraphSchema, TraversalConfig, TraversalResult,
+};
 use crate::collection::types::Collection;
 use crate::distance::DistanceMetric;
 use crate::error::Result;
@@ -283,10 +285,26 @@ impl GraphCollection {
 
     /// Removes an edge from the graph by ID.
     ///
-    /// Returns `true` if the edge existed and was removed, `false` otherwise.
+    /// Returns `true` if the edge existed and was removed, `false` otherwise —
+    /// including on the genuine failure paths. Use
+    /// [`Self::remove_edge_detailed`] when a failure must not pass for
+    /// "already gone".
     #[must_use]
     pub fn remove_edge(&self, edge_id: u64) -> bool {
         self.inner.remove_edge(edge_id)
+    }
+
+    /// Removes an edge from the graph by ID, reporting WHY when it does not
+    /// happen.
+    pub(crate) fn remove_edge_detailed(&self, edge_id: u64) -> EdgeRemoval {
+        self.inner.remove_edge_detailed(edge_id)
+    }
+
+    /// Test-only fault injection — makes the edge write-ahead log unwritable so
+    /// edge removals fail while the edges themselves stay healthy.
+    #[cfg(all(test, feature = "persistence"))]
+    pub(crate) fn break_edge_wal_for_test(&self) -> std::io::Result<()> {
+        self.inner.break_edge_wal_for_test()
     }
 
     /// Returns `true` if an edge with `edge_id` exists in the graph.

--- a/crates/velesdb-core/src/database/ddl_executor.rs
+++ b/crates/velesdb-core/src/database/ddl_executor.rs
@@ -7,7 +7,7 @@
 //! INSERT NODE) live in the sibling [`dml_executor`](super::dml_executor)
 //! module.
 
-use crate::collection::graph::{EdgeType, GraphSchema, NodeType, ValueType};
+use crate::collection::graph::{EdgeRemoval, EdgeType, GraphSchema, NodeType, ValueType};
 use crate::collection::Collection;
 use crate::velesql::{
     AlterCollectionStatement, AnalyzeStatement, CreateCollectionKind, CreateIndexStatement,
@@ -203,12 +203,33 @@ impl Database {
     }
 
     /// Truncates a graph collection: removes all edges then all nodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any edge or node removal fails. Edges and nodes are
+    /// held to the SAME policy — before #1749 the edge half swallowed its
+    /// failures while the node half propagated them, so a partial TRUNCATE
+    /// could report `Ok`.
+    ///
+    /// TRUNCATE is not atomic and makes no rollback promise: removals that
+    /// succeeded before the failure stay applied, and the error says how many
+    /// those were. Nodes are deliberately left in place when an edge removal
+    /// fails — deleting them anyway is what turns a surviving edge into a
+    /// dangling one pointing at ids that no longer exist.
     fn truncate_graph(gc: &crate::collection::GraphCollection) -> Result<Vec<SearchResult>> {
         // Remove all edges first (edges reference nodes).
         let edges = gc.get_edges(None);
-        let edge_count = count_successful_removals(edges.iter().map(crate::GraphEdge::id), |id| {
-            gc.remove_edge(id)
-        });
+        let (edge_count, failure) =
+            remove_edges_reporting_failure(edges.iter().map(crate::GraphEdge::id), |id| {
+                gc.remove_edge_detailed(id)
+            });
+        if let Some((edge_id, reason)) = failure {
+            return Err(Error::Storage(format!(
+                "TRUNCATE removed {edge_count} of {} edges, then failed on edge {edge_id}: \
+                 {reason}. The nodes were left in place; the collection is NOT empty.",
+                edges.len()
+            )));
+        }
         // Remove all node payloads.
         let node_ids = gc.all_node_ids();
         let node_count = node_ids.len();
@@ -378,15 +399,32 @@ fn build_typed_schema(definitions: &[SchemaDefinition]) -> GraphSchema {
     schema
 }
 
-/// Counts how many `ids` the injected `remove` closure reports as actually
-/// removed. Every id is attempted — `filter` + `count` never short-circuits —
-/// so a failure partway through still lets the remaining ids be tried and
-/// counted correctly.
-pub(super) fn count_successful_removals(
+/// Removes every id via the injected `remove` closure, returning how many were
+/// actually removed together with the FIRST genuine failure, if any.
+///
+/// Every id is attempted even after a failure — the loop never short-circuits —
+/// so a failure partway through still lets the remaining ids be removed rather
+/// than stranding them. [`EdgeRemoval::Absent`] is deliberately NOT a failure:
+/// removing an edge that is already gone is a documented no-op that callers
+/// rely on.
+pub(super) fn remove_edges_reporting_failure(
     ids: impl Iterator<Item = u64>,
-    mut remove: impl FnMut(u64) -> bool,
-) -> usize {
-    ids.filter(|&id| remove(id)).count()
+    mut remove: impl FnMut(u64) -> EdgeRemoval,
+) -> (usize, Option<(u64, String)>) {
+    let mut removed = 0usize;
+    let mut first_failure: Option<(u64, String)> = None;
+    for id in ids {
+        match remove(id) {
+            EdgeRemoval::Removed => removed += 1,
+            EdgeRemoval::Absent => {}
+            EdgeRemoval::Failed(reason) => {
+                if first_failure.is_none() {
+                    first_failure = Some((id, reason));
+                }
+            }
+        }
+    }
+    (removed, first_failure)
 }
 
 /// Parses and validates a single `ALTER COLLECTION SET` option into a typed

--- a/crates/velesdb-core/src/database/ddl_executor_tests.rs
+++ b/crates/velesdb-core/src/database/ddl_executor_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for DDL and extended DML executor (Phase 5).
 
 use super::*;
+use crate::collection::graph::EdgeRemoval;
 use crate::velesql::{
     AlterCollectionStatement, CompareOp, Comparison, Condition, CreateCollectionKind,
     CreateCollectionStatement, DdlStatement, DeleteEdgeStatement, DeleteStatement, DmlStatement,
@@ -560,24 +561,132 @@ fn test_truncate_graph_reports_actual_removed_edge_count() {
     assert_eq!(gc.get_edges(None).len(), 0);
 }
 
+#[cfg(feature = "persistence")]
 #[test]
-fn test_count_successful_removals_counts_only_successes_without_short_circuiting() {
+fn test_truncate_graph_fails_loudly_when_an_edge_removal_fails() {
+    // #1749: TRUNCATE used to return Ok even when an edge could not be
+    // removed — the edge half swallowed its failures while the node half, in
+    // the same function, propagated its own. This drives the real executor
+    // against a real failure: the edges are healthy and listed, but their
+    // removal cannot be made durable, so the store is left unmutated.
+    let dir = tempdir().expect("tempdir");
+    let db = Database::open(dir.path()).expect("open");
+
+    let create = DdlStatement::CreateCollection(CreateCollectionStatement {
+        name: "truncate_fail".to_string(),
+        kind: CreateCollectionKind::Graph(GraphCollectionParams {
+            dimension: None,
+            metric: None,
+            schema_mode: GraphSchemaMode::Schemaless,
+        }),
+    });
+    execute_ddl(&db, create).expect("create graph");
+
+    let gc = db.get_graph_collection("truncate_fail").expect("get");
+    for id in [10, 20, 30] {
+        gc.upsert_node_payload(id, &serde_json::json!({}))
+            .expect("store node");
+    }
+    gc.add_edge(crate::GraphEdge::new(1, 10, 20, "A").expect("edge"))
+        .expect("add 1");
+    gc.add_edge(crate::GraphEdge::new(2, 20, 30, "B").expect("edge"))
+        .expect("add 2");
+    assert_eq!(gc.edge_count(), 2);
+
+    gc.break_edge_wal_for_test().expect("break the edge WAL");
+
+    let ddl = DdlStatement::Truncate(TruncateStatement {
+        collection: "truncate_fail".to_string(),
+    });
+    let err = execute_ddl(&db, ddl).expect_err("TRUNCATE must NOT report success");
+
+    let message = err.to_string();
+    // `get_edges` iterates a hash map, so either edge may be attempted first —
+    // asserting a specific id here would make this test order-dependent.
+    assert!(
+        message.contains("failed on edge 1") || message.contains("failed on edge 2"),
+        "the error must name the edge that failed, got: {message}"
+    );
+    assert!(
+        message.contains("removed 0 of 2 edges"),
+        "the error must say what WAS removed before the failure, got: {message}"
+    );
+    assert!(
+        message.contains("write-ahead log refused"),
+        "the error must say WHY the removal failed, got: {message}"
+    );
+
+    // Fail-closed: a removal that could not be logged must not be applied.
+    assert_eq!(
+        gc.edge_count(),
+        2,
+        "edges must survive a removal that could not be made durable"
+    );
+    // The nodes must survive too: deleting them anyway is exactly what turns a
+    // surviving edge into a dangling one pointing at ids that no longer exist.
+    assert_eq!(
+        gc.all_node_ids().len(),
+        3,
+        "nodes must be left in place when an edge removal fails"
+    );
+}
+
+#[test]
+fn test_remove_edges_counts_only_successes_without_short_circuiting() {
     // Regression test for the TRUNCATE edge-count bug: the previous
     // implementation used `edges.len()` regardless of whether each
     // `remove_edge` call actually succeeded. This drives the extracted
-    // counting logic directly with an injected, deterministic failure —
+    // removal logic directly with an injected, deterministic outcome —
     // no fault injection into the graph storage layer required.
+    //
+    // An edge that was already gone is NOT a failure: the contract tolerates
+    // removing an absent edge, and this test pins that down.
     let attempted = std::cell::RefCell::new(Vec::new());
-    let count = super::ddl_executor::count_successful_removals([1, 2, 3, 4].into_iter(), |id| {
-        attempted.borrow_mut().push(id);
-        id % 2 == 0 // fails on odd ids, as if `remove_edge` reported them missing
-    });
+    let (count, failure) =
+        super::ddl_executor::remove_edges_reporting_failure([1, 2, 3, 4].into_iter(), |id| {
+            attempted.borrow_mut().push(id);
+            if id % 2 == 0 {
+                EdgeRemoval::Removed
+            } else {
+                EdgeRemoval::Absent // as if `remove_edge` reported it missing
+            }
+        });
 
     assert_eq!(count, 2, "only ids the removal succeeded on should count");
+    assert_eq!(failure, None, "an absent edge is not a failure");
     assert_eq!(
         *attempted.borrow(),
         vec![1, 2, 3, 4],
         "every id must be attempted — a failure must not skip the rest"
+    );
+}
+
+#[test]
+fn test_remove_edges_reports_first_failure_after_attempting_every_id() {
+    // #1749: a genuine `remove_edge` failure must NOT be swallowed. The
+    // helper reports the first real failure while still attempting every
+    // remaining id, so a mid-list failure never strands the rest.
+    let attempted = std::cell::RefCell::new(Vec::new());
+    let (count, failure) =
+        super::ddl_executor::remove_edges_reporting_failure([1, 2, 3, 4].into_iter(), |id| {
+            attempted.borrow_mut().push(id);
+            match id {
+                2 => EdgeRemoval::Failed("index desync".to_string()),
+                3 => EdgeRemoval::Failed("second failure, must not mask the first".to_string()),
+                _ => EdgeRemoval::Removed,
+            }
+        });
+
+    assert_eq!(count, 2, "ids 1 and 4 were removed");
+    assert_eq!(
+        failure,
+        Some((2, "index desync".to_string())),
+        "the FIRST genuine failure must be reported, never dropped"
+    );
+    assert_eq!(
+        *attempted.borrow(),
+        vec![1, 2, 3, 4],
+        "a failure must not short-circuit the remaining removals"
     );
 }
 


### PR DESCRIPTION
## The problem

`TRUNCATE` on a graph collection held its two halves to opposite error
policies, inside the same function: the nodes propagated their failure with a
`?`, the edges dropped theirs on the floor. A user truncating a collection to
start clean could get `Ok` back and keep a surviving edge — pointing, once the
nodes were deleted, at ids that no longer existed.

#1733 made the *count* honest. That was a real step, but an honest count inside
an `Ok` is still a silent failure for anyone who does not do the arithmetic
against a total they may not know.

## Why the edge half was mute

`remove_edge` answers with a `bool`, and that one bit conflates four outcomes:

| outcome | benign? | state left behind |
|---|---|---|
| edge removed | — | clean |
| edge was not there | yes, and callers rely on it | clean |
| WAL refused the removal | **no** | store unmutated, durability broken |
| id index vs shard disagree | **no** | dangling incoming half-edge possible |

The absent case and the failure cases are indistinguishable from the outside
*after* the call — in both, the edge is gone from the index and the source
shard. No post-check recovers the difference; only the layer holding the locks
knows. Hence a detailed internal return rather than a re-derivation.

## The change

`EdgeRemoval` (`Removed` / `Absent` / `Failed(reason)`) is reported at each of
the three layers, and `TRUNCATE` counts the removals, tolerates the absent, and
propagates the first genuine failure.

**The public API is untouched.** Every `remove_edge` still returns `bool`,
folded from the enum via `matches!(…, Removed)`; `EdgeRemoval` is `pub(crate)`
so it never reaches the crate boundary. That was a hard constraint — around
twelve non-test callers across server, python, cli, wasm, mobile and agent
depend on the current signature.

Two deliberate scope decisions:

- **No atomicity or rollback is promised, and none is added.** Removals that
  succeeded before the failure stay applied; the error says how many those were.
- **The nodes are now left in place when an edge fails.** Deleting them anyway
  is precisely what turns a surviving edge into a dangling one — the harm the
  report describes. This goes slightly beyond "do not return Ok", and it is the
  point of the fix rather than a side effect.

Arbitrating the issue's own question: option 1 (a partial `TRUNCATE` is an
error), because it aligns the edges with the node half that already behaves
that way, rather than making the nodes quieter.

## Two findings from measurement, not from reading

**The index desynchronisation cannot be reached from `TRUNCATE` at all.**
`get_edges` and `remove_edge` share the same source-shard lookup, so a desync
that breaks the removal also hides the edge from the enumeration — a probe
showed `get_edges` dropping from 2 edges to 1 — and `TRUNCATE` never attempts
it. The failure that *is* reachable from `TRUNCATE` is the WAL one, so that is
what the end-to-end test drives. The desync is proven where it does occur, at
the store. It remains reachable via the DML `DELETE EDGE` path, so the enum
earns its keep there.

**Neither failure had a test because neither was reachable from a public API.**
Both now have scoped fault injection: `break_edge_wal_for_test` replaces the WAL
path with a directory, so the append fails with `EISDIR` on every Unix
*including as root* — a read-only `chmod` would simply be ignored by root.

## Proofs

Red first, and a real one: the helper was written to reproduce today's
behaviour before being fixed, and the assertion failed with
`left: None, right: Some((2, "index desync"))`. Not a compilation error.

Six tests, all confirmed by name in the run output:

- nominal truncate still succeeds and reports the right counts
- end-to-end failure: `TRUNCATE` returns `Err`, the error names the edge and
  says `removed 0 of 2 edges`, and **both** the edges and the nodes survive
- the helper reports the first failure while still attempting every remaining id
- an absent edge is not a failure
- store level: `Absent` for an unknown edge, `Failed` on a desync, and the
  historical `bool` still folds to `false`

Gates, derived from `ci.yml` rather than improvised: `cargo fmt --check` clean;
all three clippy steps green (workspace with the CI excludes, plus the two
cdylib `--lib` steps); `cargo test --workspace` with the CI excludes and
`--test-threads=1` → **140 suites, 9168 passed, 0 failed**.

Lizard reports two CCN-10 warnings (`add_edge`, `traverse_dfs_config_inner`) —
both proven pre-existing on `develop` via `git show`, untouched here.

## Out of scope, noted not fixed

`crates/velesdb-core/src/agent/memory_helpers.rs:476` still has
`let _ = collection.remove_edge(edge_id)`. It is a best-effort cleanup inside a
function that already returns `Err(NotFound)`, in a different subsystem, and
pre-existing on `develop`. #1749 is scoped to `TRUNCATE`, so it stays out.

Closes #1749
