### PR TITLE
fix(memory): closing one MCP session must free exactly one slot

### DIFF
--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -140,7 +140,37 @@ pub fn router_with_limits(
     max_body_bytes: usize,
     max_sessions: usize,
 ) -> Router {
-    let session_manager = BoundedSessionManager::new(LocalSessionManager::default(), max_sessions);
+    router_with_limits_and_keep_alive(
+        server,
+        cancellation_token,
+        max_body_bytes,
+        max_sessions,
+        None,
+    )
+}
+
+/// [`router_with_limits`], but with the session idle timeout passed explicitly.
+///
+/// `keep_alive` is how long a session may sit with no traffic before rmcp
+/// retires it; `None` keeps rmcp's own default. A session that is retired this
+/// way is gone: the next request carrying its id gets a `404`, which a client
+/// is expected to answer by re-initializing.
+///
+/// Exposed so tests can inject a very short timeout (~100–200 ms) and observe
+/// a full expire-and-reuse cycle without waiting minutes of wall-clock time.
+#[doc(hidden)]
+pub fn router_with_limits_and_keep_alive(
+    server: McpServer,
+    cancellation_token: CancellationToken,
+    max_body_bytes: usize,
+    max_sessions: usize,
+    keep_alive: Option<std::time::Duration>,
+) -> Router {
+    let mut inner = LocalSessionManager::default();
+    if let Some(keep_alive) = keep_alive {
+        inner.session_config.keep_alive = Some(keep_alive);
+    }
+    let session_manager = BoundedSessionManager::new(inner, max_sessions);
     let mcp_service: StreamableHttpService<McpServer, BoundedSessionManager<LocalSessionManager>> =
         StreamableHttpService::new(
             move || Ok(server.clone()),

--- a/crates/velesdb-memory/src/http/session_limit.rs
+++ b/crates/velesdb-memory/src/http/session_limit.rs
@@ -13,25 +13,36 @@
 //!
 //! [`BoundedSessionManager`] wraps any [`SessionManager`] and refuses
 //! `create_session`/`restore_session` once `max_sessions` sessions are
-//! outstanding. It tracks the count itself (an [`AtomicUsize`]) rather than
-//! reaching into a specific implementation's internals, so it works for
+//! outstanding. It tracks the live session ids itself rather than reaching
+//! into a specific implementation's internals, so it works for
 //! `LocalSessionManager` today and for any future custom `SessionManager`
 //! (e.g. a Redis-backed one) the same way.
 //!
-//! # Caveat inherited from `rmcp`
+//! # Session lifetime, and why the bound tracks IDS rather than a count
 //!
-//! A session that goes idle past its `SessionConfig::keep_alive` timeout has
-//! its worker task exit — but nothing calls [`SessionManager::close_session`]
-//! for it (confirmed against rmcp 2.2.0: `LocalSessionManager`'s `sessions`
-//! map is touched only by `create_session`, `close_session`, and
-//! `restore_session`; there is no reaper). So our counter, like the
-//! underlying map, only shrinks on an explicit close (an HTTP DELETE from a
-//! well-behaved client) — pure inactivity never frees a slot. In this
-//! daemon's actual deployment (a handful of local, cooperating MCP clients)
-//! that only matters over very long uptimes; a full fix belongs upstream in
-//! `rmcp`, not here.
+//! An earlier version of this comment claimed that a session going idle past
+//! `SessionConfig::keep_alive` never frees its slot, because nothing calls
+//! [`SessionManager::close_session`] for it. **That is wrong**, and it is
+//! worth stating plainly because it sent one investigation down the wrong
+//! path: rmcp's `StreamableHttpService` spawns a task per session that awaits
+//! the service and then calls `close_session` (rmcp 2.2.0,
+//! `streamable_http_server/tower.rs`), so an idle-expired session IS closed
+//! and its slot IS returned. `tests/http_transport.rs` pins that down.
+//!
+//! The real hazard is the opposite one. A session is routinely closed
+//! **twice**: once by the `DELETE` a well-behaved client sends, and once by
+//! that per-session task when the service finishes. `LocalSessionManager`'s
+//! `close_session` is idempotent and answers `Ok` either way, so a wrapper
+//! counting closes cannot tell the second from a first — and an anonymous
+//! counter decremented twice for one session drifts BELOW reality, letting
+//! more than `max_sessions` run at once and quietly weakening the bound this
+//! module exists to enforce.
+//!
+//! Hence the set of live session ids: a release is matched to the session it
+//! belongs to, removing an absent id is a no-op, and the count cannot
+//! underflow.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::collections::HashSet;
 
 use futures::Stream;
 use rmcp::model::{ClientJsonRpcMessage, ServerJsonRpcMessage};
@@ -39,13 +50,27 @@ use rmcp::transport::streamable_http_server::session::{
     RestoreOutcome, ServerSseMessage, SessionId, SessionManager,
 };
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 /// Wraps `inner: SM`, refusing new sessions once `max_sessions` are live.
+///
+/// The bound is enforced against the SET of session ids this wrapper has
+/// created and not yet seen closed, rather than against a bare count. That
+/// distinction is the whole point: a count is anonymous, so nothing ties a
+/// decrement to the session it belongs to, and one session closed twice
+/// decrements twice. Sessions ARE closed twice in normal operation — a
+/// well-behaved client sends `DELETE`, and rmcp's own session worker calls
+/// `close_session` again when the service finishes — so an anonymous count
+/// drifts below reality and lets more than `max_sessions` run at once.
+///
+/// With a set, releasing is idempotent by construction (removing an id that
+/// is not there does nothing), the count can never underflow, and
+/// `live.len()` is exactly the set of sessions believed to be alive.
 #[derive(Debug)]
 pub struct BoundedSessionManager<SM> {
     inner: SM,
     max_sessions: usize,
-    live: AtomicUsize,
+    live: Mutex<HashSet<SessionId>>,
 }
 
 impl<SM> BoundedSessionManager<SM> {
@@ -53,39 +78,14 @@ impl<SM> BoundedSessionManager<SM> {
         Self {
             inner,
             max_sessions,
-            live: AtomicUsize::new(0),
+            live: Mutex::new(HashSet::new()),
         }
     }
 
-    /// Reserve one slot, or refuse if `max_sessions` is already reached.
-    /// CAS loop (not load-then-store) so two concurrent callers can't both
-    /// observe room for the last slot and overshoot the bound.
-    fn try_reserve(&self) -> bool {
-        loop {
-            let current = self.live.load(Ordering::Acquire);
-            if current >= self.max_sessions {
-                return false;
-            }
-            if self
-                .live
-                .compare_exchange_weak(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-            {
-                return true;
-            }
-        }
-    }
-
-    /// Release a slot reserved by [`try_reserve`](Self::try_reserve) that
-    /// turned out not to correspond to a real live session (creation
-    /// failed, or `restore_session` didn't actually create one). Saturating:
-    /// never underflows even if called more than its matching reserve.
-    fn release(&self) {
-        let _ = self
-            .live
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
-                Some(n.saturating_sub(1))
-            });
+    /// Number of sessions currently believed to be alive.
+    #[cfg(test)]
+    pub(crate) async fn live_count(&self) -> usize {
+        self.live.lock().await.len()
     }
 }
 
@@ -109,18 +109,18 @@ where
     type Transport = SM::Transport;
 
     async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
-        if !self.try_reserve() {
+        // The lock spans the check AND the creation, so two concurrent
+        // callers cannot both see room for the last slot. A failed creation
+        // records nothing, so there is no reservation left to leak.
+        let mut live = self.live.lock().await;
+        if live.len() >= self.max_sessions {
             return Err(BoundedSessionManagerError::TooManySessions(
                 self.max_sessions,
             ));
         }
-        match self.inner.create_session().await {
-            Ok(created) => Ok(created),
-            Err(e) => {
-                self.release();
-                Err(e.into())
-            }
-        }
+        let (id, transport) = self.inner.create_session().await?;
+        live.insert(id.clone());
+        Ok((id, transport))
     }
 
     async fn initialize_session(
@@ -139,9 +139,14 @@ where
     }
 
     async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+        // Removing an id that is not in the set does nothing, so the second
+        // close of the same session — the routine case, `DELETE` from the
+        // client plus rmcp's own close when the session worker finishes —
+        // cannot free a slot that belongs to a still-live session.
+        let mut live = self.live.lock().await;
         let result = self.inner.close_session(id).await;
         if result.is_ok() {
-            self.release();
+            live.remove(id);
         }
         result.map_err(Into::into)
     }
@@ -193,23 +198,22 @@ where
         &self,
         id: SessionId,
     ) -> Result<RestoreOutcome<Self::Transport>, Self::Error> {
-        if !self.try_reserve() {
+        let mut live = self.live.lock().await;
+        if live.len() >= self.max_sessions {
             return Err(BoundedSessionManagerError::TooManySessions(
                 self.max_sessions,
             ));
         }
-        match self.inner.restore_session(id).await {
-            Ok(outcome @ RestoreOutcome::Restored(_)) => Ok(outcome),
-            // `AlreadyPresent`/`NotSupported` (and any future variant): no
-            // new session was actually created, release the reservation.
-            Ok(other) => {
-                self.release();
-                Ok(other)
+        match self.inner.restore_session(id.clone()).await {
+            // Only a genuine restore adds a live session. `AlreadyPresent` /
+            // `NotSupported` (and any future variant) created nothing, so
+            // nothing is recorded and no slot is consumed.
+            Ok(outcome @ RestoreOutcome::Restored(_)) => {
+                live.insert(id);
+                Ok(outcome)
             }
-            Err(e) => {
-                self.release();
-                Err(e.into())
-            }
+            Ok(other) => Ok(other),
+            Err(e) => Err(e.into()),
         }
     }
 }
@@ -292,12 +296,13 @@ mod tests {
         }
 
         async fn close_session(&self, id: &SessionId) -> Result<(), Self::Error> {
+            // Modelled on `LocalSessionManager::close_session`, which answers
+            // `Ok` whether or not the id was there. That idempotence is not
+            // incidental — it is exactly what makes a close-counting wrapper
+            // unable to tell a second close from a first, so a fake that
+            // errored here would hide the defect these tests exist to pin.
             let mut sessions = self.sessions.lock().expect("lock");
-            let before = sessions.len();
             sessions.retain(|existing| existing != id);
-            if sessions.len() == before {
-                return Err(FakeError(format!("no such session: {id}")));
-            }
             Ok(())
         }
 
@@ -337,7 +342,7 @@ mod tests {
     }
 
     fn uuid_like() -> u64 {
-        use std::sync::atomic::AtomicU64;
+        use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         COUNTER.fetch_add(1, Ordering::Relaxed)
     }
@@ -464,5 +469,66 @@ mod tests {
             !err.is_too_many_sessions(),
             "a failed create must not leak its reservation: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn closing_the_same_session_twice_frees_exactly_one_slot() {
+        // The routine double close: the client's DELETE, then rmcp's own
+        // close when the session worker finishes. An anonymous counter
+        // decremented twice here would drift below reality.
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 2);
+        let (a, _ta) = manager.create_session().await.expect("session A");
+        let (_b, _tb) = manager.create_session().await.expect("session B");
+        assert_eq!(manager.live_count().await, 2);
+
+        manager.close_session(&a).await.expect("first close");
+        manager.close_session(&a).await.expect("second close");
+
+        assert_eq!(
+            manager.live_count().await,
+            1,
+            "closing ONE session twice must still free exactly one slot"
+        );
+        manager
+            .create_session()
+            .await
+            .expect("the freed slot must be reusable");
+        manager
+            .create_session()
+            .await
+            .expect_err("but only ONE slot was freed, so the next must be refused");
+    }
+
+    #[tokio::test]
+    async fn closing_an_unknown_session_frees_nothing() {
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 1);
+        let (_a, _ta) = manager.create_session().await.expect("session A");
+
+        let stranger: SessionId = "never-created".to_string().into();
+        manager
+            .close_session(&stranger)
+            .await
+            .expect("closing an unknown id is a no-op, not an error");
+
+        assert_eq!(manager.live_count().await, 1);
+        manager
+            .create_session()
+            .await
+            .expect_err("an unknown id must not free the live session's slot");
+    }
+
+    #[tokio::test]
+    async fn many_create_then_close_cycles_never_exhaust_the_bound() {
+        // The guarantee that matters in production: a daemon cycling sessions
+        // far more times than `max_sessions` must never lock itself out.
+        let manager = BoundedSessionManager::new(FakeSessionManager::default(), 2);
+        for cycle in 0..64 {
+            let (id, _t) = manager
+                .create_session()
+                .await
+                .unwrap_or_else(|_| panic!("cycle {cycle} must still be able to open a session"));
+            manager.close_session(&id).await.expect("close");
+        }
+        assert_eq!(manager.live_count().await, 0);
     }
 }

--- a/crates/velesdb-memory/tests/http_transport.rs
+++ b/crates/velesdb-memory/tests/http_transport.rs
@@ -408,3 +408,167 @@ async fn audit_shared_session_concurrent_calls_are_bounded() {
         .await
         .expect("shared-session server shutdown exceeded five seconds");
 }
+
+// ===========================================================================
+// Session lifecycle: an idle-expired session must return its slot (#1778)
+// ===========================================================================
+
+/// [`spawn_http_server_with_limits`], but with the session idle timeout
+/// injected — so an expire-and-reuse cycle takes milliseconds instead of the
+/// five minutes rmcp defaults to.
+async fn spawn_http_server_with_keep_alive(
+    max_sessions: usize,
+    keep_alive: std::time::Duration,
+) -> TestServer {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let server = McpServer::new(service);
+
+    let ct = CancellationToken::new();
+    let app = velesdb_memory::http::router_with_limits_and_keep_alive(
+        server,
+        ct.child_token(),
+        velesdb_memory::http::DEFAULT_HTTP_MAX_BODY_BYTES,
+        max_sessions,
+        Some(keep_alive),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("read bound local addr");
+
+    let shutdown_ct = ct.clone();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled_owned().await })
+            .await;
+    });
+
+    TestServer {
+        addr,
+        handle,
+        ct,
+        _store_dir: store_dir,
+    }
+}
+
+const INITIALIZE_BODY: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"slot-probe","version":"0"}}}"#;
+
+/// `initialize` over raw HTTP, returning the new session id, or `None` when
+/// the server refused to create one.
+///
+/// Deliberately NOT rmcp's client: that one keeps a stream open and sends an
+/// explicit `DELETE` when dropped, which is precisely the well-behaved close
+/// this test must avoid — the defect under test is what happens when a
+/// session dies of pure inactivity instead.
+async fn try_raw_initialize(addr: SocketAddr) -> Option<String> {
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(INITIALIZE_BODY)
+        .send()
+        .await
+        .expect("initialize POST reaches the server");
+    if !response.status().is_success() {
+        return None;
+    }
+    response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(std::borrow::ToOwned::to_owned)
+}
+
+/// Status code the server answers for a `tools/list` carrying `session_id`.
+async fn status_for_session(addr: SocketAddr, session_id: &str) -> u16 {
+    reqwest::Client::new()
+        .post(format!("http://{addr}/mcp"))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Session-Id", session_id)
+        .body(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#)
+        .send()
+        .await
+        .expect("tools/list POST reaches the server")
+        .status()
+        .as_u16()
+}
+
+#[tokio::test]
+async fn an_idle_expired_session_returns_its_slot() {
+    // `max_sessions = 1` makes the accounting observable: whether the slot
+    // came back is exactly whether a second session can be created.
+    let server = spawn_http_server_with_keep_alive(1, std::time::Duration::from_millis(150)).await;
+
+    let first = try_raw_initialize(server.addr)
+        .await
+        .expect("the first session must be created");
+    assert!(
+        try_raw_initialize(server.addr).await.is_none(),
+        "the cap must hold while the only slot is genuinely occupied"
+    );
+
+    // Let it die of pure inactivity — no DELETE, no close, just silence.
+    tokio::time::sleep(std::time::Duration::from_millis(700)).await;
+
+    assert_eq!(
+        status_for_session(server.addr, &first).await,
+        404,
+        "an expired session must be gone, and say so"
+    );
+    let second = try_raw_initialize(server.addr).await;
+    assert!(
+        second.is_some(),
+        "a session that died of inactivity must return its slot — otherwise the \
+         daemon locks itself out after `max_sessions` idle expiries"
+    );
+    assert_ne!(second, Some(first), "the reused slot must be a NEW session");
+
+    shutdown(server).await;
+}
+
+/// Explicitly terminate `session_id` the way a well-behaved client does.
+async fn delete_session(addr: SocketAddr, session_id: &str) -> u16 {
+    reqwest::Client::new()
+        .delete(format!("http://{addr}/mcp"))
+        .header("Mcp-Session-Id", session_id)
+        .send()
+        .await
+        .expect("DELETE reaches the server")
+        .status()
+        .as_u16()
+}
+
+#[tokio::test]
+async fn closing_one_session_frees_exactly_one_slot() {
+    // Two slots, and a keep_alive long enough that nothing expires during the
+    // test — the only thing that may free a slot here is the explicit DELETE.
+    let server = spawn_http_server_with_keep_alive(2, std::time::Duration::from_secs(30)).await;
+
+    let a = try_raw_initialize(server.addr).await.expect("session A");
+    let _b = try_raw_initialize(server.addr).await.expect("session B");
+    assert!(
+        try_raw_initialize(server.addr).await.is_none(),
+        "with both slots occupied the third session must be refused"
+    );
+
+    // Close A explicitly. The session worker ALSO finishes and closes the
+    // session on its own — so the accounting sees two closes for one session.
+    delete_session(server.addr, &a).await;
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    assert!(
+        try_raw_initialize(server.addr).await.is_some(),
+        "closing A must free A's slot"
+    );
+    assert!(
+        try_raw_initialize(server.addr).await.is_none(),
+        "closing ONE session must free exactly ONE slot — B still holds the other, \
+         so this fourth session must be refused"
+    );
+
+    shutdown(server).await;
+}


### PR DESCRIPTION
## Le defaut

`BoundedSessionManager` plafonne les sessions MCP concurrentes, et il appliquait
ce plafond en **comptant** : reservation a la creation, liberation a la
fermeture. Un compteur est anonyme — rien ne rattache une liberation a la
session qu'elle concerne. Et `LocalSessionManager::close_session` rend `Ok` que
l'id ait ete present ou non, donc le wrapper ne pouvait pas distinguer une
seconde fermeture d'une premiere.

Or **une session est fermee deux fois en fonctionnement normal** : une fois par
le `DELETE` d'un client correct, une fois par la tache que rmcp lance par
session et qui appelle `close_session` quand le service se termine.

Une session, deux liberations : le compteur derive **sous** la realite, et
**plus de `max_sessions` sessions peuvent tourner simultanement**. Le garde
anti-DoS que ce module existe pour appliquer etait donc plus faible qu'annonce.

## La correction

Le plafond suit desormais l'**ensemble des ids de sessions vivantes** :

- une liberation est rattachee a sa session ;
- retirer un id absent ne fait rien — l'idempotence est structurelle, pas
  defensive ;
- le compte ne peut pas passer sous zero ;
- le verrou couvre la verification **et** la creation, donc deux appelants
  concurrents ne peuvent plus voir tous les deux la derniere place libre.

## Une erreur de ma part, corrigee en place

J'avais ouvert #1778 en affirmant l'inverse : qu'une session expiree ne rendait
**jamais** sa place, et que le demon se verrouillerait apres 64 expirations. Je
m'etais fie au commentaire de module, sans lire rmcp.

C'est faux. `StreamableHttpService::spawn_session_worker`
(`streamable_http_server/tower.rs:686-691`) lance une tache par session qui
attend la fin du service **puis** appelle `close_session` : l'expiration rend
bien la place.

Le commentaire fautif est corrige **dans le fichier** plutot que discretement
supprime, parce que c'est lui qui a envoye une investigation sur une fausse
piste. Il dit maintenant ce que fait rmcp, et pourquoi le suivi porte sur des
ids.

## Preuves

**Rouge d'abord, et un vrai rouge.**
`closing_one_session_frees_exactly_one_slot` pilote le vrai transport HTTP :
deux sessions avec `max_sessions = 2`, la troisieme refusee, puis la premiere
fermee explicitement — et **deux** nouvelles ont ete acceptees la ou une seule
etait due. Rouge avant ce changement, verte apres.

`an_idle_expired_session_returns_its_slot` epingle le comportement que
l'ancien commentaire niait, avec un `keep_alive` injecte a 150 ms pour qu'un
cycle expiration-puis-reutilisation prenne des millisecondes au lieu des cinq
minutes par defaut : la session expiree rend 404, et sa place est reutilisable.
Ce test passe deja sur le code d'origine — c'est ce qui refute ma formulation
initiale.

Tests unitaires : fermeture deux fois de la meme session, fermeture d'un id
inconnu, et 64 cycles creation/fermeture contre un plafond de 2. Le faux
gestionnaire a ete rendu idempotent a la fermeture pour coller a
`LocalSessionManager` — un faux qui echouait a la seconde fermeture n'aurait
jamais pu exhiber le defaut que ces tests existent pour epingler.

## Portes

Derivees de `ci.yml`, pas improvisees : `cargo fmt --check` propre ;
`clippy -p velesdb-memory --all-targets --features http,persistence -D warnings
-D clippy::pedantic` a 0 ; `cargo test -p velesdb-memory --features http` =
**801 passed / 0 failed** ; `--features extract,ollama,persistence` = **846
passed / 0 failed**.

## Portee

`router_with_limits_and_keep_alive` est ajoute comme point d'injection du delai
d'inactivite, necessaire ici pour tester un cycle d'expiration sans attendre
cinq minutes. Le comportement de production est **inchange** : `keep_alive`
vaut `None`, donc le defaut de rmcp s'applique exactement comme avant.

L'allongement de ce delai est une autre affaire — c'est la mitigation de #1727,
dont la cause racine est cote client et sera traitee separement.

Closes #1778
