### PR TITLE
fix(memory): orient kinship on the relation named, not on its spelling

### DIFF
--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -120,80 +120,98 @@ pub struct Extraction {
 /// Deliberately NOT here: `"partner"` / `"compagnon"`. "X has a partner, Y" is
 /// a business relation as often as a family one, and a wrong re-point is worse
 /// than none at all.
-const KINSHIP_NOUNS: &[&str] = &[
-    // Blood ties, fr.
-    "pere",
-    "mere",
-    "frere",
-    "soeur",
-    "fils",
-    "fille",
-    "oncle",
-    "tante",
-    "cousin",
-    "cousine",
-    "neveu",
-    "niece",
-    "grand-pere",
-    "grand-mere",
-    "grand-oncle",
-    "grand-tante",
-    "arriere-grand-pere",
-    "arriere-grand-mere",
-    "petit-fils",
-    "petite-fille",
-    // Alliances and step-family, fr.
-    "beau-pere",
-    "belle-mere",
-    "beau-frere",
-    "belle-soeur",
-    "beau-fils",
-    "belle-fille",
-    "gendre",
-    "bru",
-    "demi-frere",
-    "demi-soeur",
-    "parrain",
-    "marraine",
-    "filleul",
-    "filleule",
-    "epoux",
-    "epouse",
-    "mari",
-    "femme",
-    // Blood ties, en.
-    "father",
-    "mother",
-    "brother",
-    "sister",
-    "son",
-    "daughter",
-    "uncle",
-    "aunt",
-    "nephew",
-    "grandfather",
-    "grandmother",
-    "grandson",
-    "granddaughter",
-    // Alliances and step-family, en.
-    "husband",
-    "wife",
-    "father-in-law",
-    "mother-in-law",
-    "brother-in-law",
-    "sister-in-law",
-    "son-in-law",
-    "daughter-in-law",
-    "stepfather",
-    "stepmother",
-    "stepbrother",
-    "stepsister",
-    "half-brother",
-    "half-sister",
-    "godfather",
-    "godmother",
-    "godson",
-    "goddaughter",
+/// Every noun is paired with the CANONICAL noun of the relation it denotes.
+///
+/// The orientation pass decides direction by asking whether the predicate names
+/// the same kinship the passage named. Asking that of the SPELLING made two
+/// words for one relation read as each other's converse, and stored the edge
+/// backwards (#1754) — across languages (`"sister"` vs `"soeur"`), and just as
+/// much within one (`"mari"` vs `"epoux"`, `"gendre"` vs `"beau-fils"`, both
+/// listed here). Comparing canonical forms asks it of the MEANING instead, so a
+/// synonym orients like the word it stands for and only a real converse flips.
+///
+/// Where one French noun covers two English ones — `"beau-pere"` is both the
+/// father-in-law and the stepfather — every spelling folds onto that single
+/// canonical. Deliberate: the pass has no "unrelated" branch, so anything not
+/// judged identical is treated as the converse. Reading two step/in-law words
+/// as ONE relation leaves an edge unturned; reading them as converses points it
+/// the wrong way, and this pass already holds that a missing correction beats a
+/// wrong one.
+const KINSHIP_NOUNS: &[(&str, &str)] = &[
+    // Blood ties, fr. — each its own canonical.
+    ("pere", "pere"),
+    ("mere", "mere"),
+    ("frere", "frere"),
+    ("soeur", "soeur"),
+    ("fils", "fils"),
+    ("fille", "fille"),
+    ("oncle", "oncle"),
+    ("tante", "tante"),
+    ("cousin", "cousin"),
+    ("cousine", "cousine"),
+    ("neveu", "neveu"),
+    ("niece", "niece"),
+    ("grand-pere", "grand-pere"),
+    ("grand-mere", "grand-mere"),
+    ("grand-oncle", "grand-oncle"),
+    ("grand-tante", "grand-tante"),
+    ("arriere-grand-pere", "arriere-grand-pere"),
+    ("arriere-grand-mere", "arriere-grand-mere"),
+    ("petit-fils", "petit-fils"),
+    ("petite-fille", "petite-fille"),
+    // Alliances and step-family, fr. — `gendre`/`bru` and `mari`/`femme` are
+    // synonyms of the nouns they fold onto, not converses of them.
+    ("beau-pere", "beau-pere"),
+    ("belle-mere", "belle-mere"),
+    ("beau-frere", "beau-frere"),
+    ("belle-soeur", "belle-soeur"),
+    ("beau-fils", "beau-fils"),
+    ("belle-fille", "belle-fille"),
+    ("gendre", "beau-fils"),
+    ("bru", "belle-fille"),
+    ("demi-frere", "demi-frere"),
+    ("demi-soeur", "demi-soeur"),
+    ("parrain", "parrain"),
+    ("marraine", "marraine"),
+    ("filleul", "filleul"),
+    ("filleule", "filleule"),
+    ("epoux", "epoux"),
+    ("epouse", "epouse"),
+    ("mari", "epoux"),
+    ("femme", "epouse"),
+    // Blood ties, en. — folded onto their French twin.
+    ("father", "pere"),
+    ("mother", "mere"),
+    ("brother", "frere"),
+    ("sister", "soeur"),
+    ("son", "fils"),
+    ("daughter", "fille"),
+    ("uncle", "oncle"),
+    ("aunt", "tante"),
+    ("nephew", "neveu"),
+    ("grandfather", "grand-pere"),
+    ("grandmother", "grand-mere"),
+    ("grandson", "petit-fils"),
+    ("granddaughter", "petite-fille"),
+    // Alliances and step-family, en. — folded onto their French twin.
+    ("husband", "epoux"),
+    ("wife", "epouse"),
+    ("father-in-law", "beau-pere"),
+    ("mother-in-law", "belle-mere"),
+    ("brother-in-law", "beau-frere"),
+    ("sister-in-law", "belle-soeur"),
+    ("son-in-law", "beau-fils"),
+    ("daughter-in-law", "belle-fille"),
+    ("stepfather", "beau-pere"),
+    ("stepmother", "belle-mere"),
+    ("stepbrother", "beau-frere"),
+    ("stepsister", "belle-soeur"),
+    ("half-brother", "demi-frere"),
+    ("half-sister", "demi-soeur"),
+    ("godfather", "parrain"),
+    ("godmother", "marraine"),
+    ("godson", "filleul"),
+    ("goddaughter", "filleule"),
 ];
 
 /// What precedes the kinship noun when the sentence hangs the relation on the
@@ -324,18 +342,20 @@ fn ends_exactly(head: &str, word: &str) -> bool {
 
 /// The kinship noun written at the start of `text`, and how many bytes it
 /// occupies there.
+/// The length is that of the spelling actually written; the noun returned is
+/// its CANONICAL form, so a caller compares meanings and never spellings.
 fn noun_at(text: &str) -> Option<(&'static str, usize)> {
-    KINSHIP_NOUNS
-        .iter()
-        .find_map(|noun| word_prefix_len(text, noun).map(|len| (*noun, len)))
+    KINSHIP_NOUNS.iter().find_map(|(spelling, canonical)| {
+        word_prefix_len(text, spelling).map(|len| (*canonical, len))
+    })
 }
 
-/// The kinship noun `head` ends on.
+/// The kinship noun `head` ends on, in its canonical form.
 fn noun_before(head: &str) -> Option<&'static str> {
     KINSHIP_NOUNS
         .iter()
-        .copied()
-        .find(|noun| ends_with_word(head, noun))
+        .find(|(spelling, _)| ends_with_word(head, spelling))
+        .map(|(_, canonical)| *canonical)
 }
 
 /// The text left once the first of `prefixes` that `text` starts with is
@@ -578,8 +598,8 @@ fn predicate_noun(predicate: &str) -> Option<&'static str> {
     let stem = predicate_stem(predicate);
     KINSHIP_NOUNS
         .iter()
-        .copied()
-        .find(|noun| word_prefix_len(&stem, noun) == Some(stem.len()))
+        .find(|(spelling, _)| word_prefix_len(&stem, spelling) == Some(stem.len()))
+        .map(|(_, canonical)| *canonical)
 }
 
 /// Whether the triple runs between exactly these two entities, either way round.
@@ -590,12 +610,16 @@ fn joins(relation: &ExtractedRelation, one: &str, other: &str) -> bool {
 
 /// Point one triple the way the passage states it.
 ///
-/// The triple built on the noun the passage used belongs to the person that
-/// noun introduced; any *other* kinship label over the same pair is its
+/// The triple built on the RELATION the passage named belongs to the person
+/// that noun introduced; any *other* kinship relation over the same pair is its
 /// converse and therefore runs the other way. That single rule is also all an
 /// alliance ever needs: list `"beau-frere"` in the table and its converse is
 /// whatever else the extractor labelled the pair with. Anything else is
 /// untouched.
+///
+/// "Same relation" is decided on the CANONICAL noun, never on the spelling —
+/// otherwise `"sister"` and `"soeur"`, or `"mari"` and `"epoux"`, read as each
+/// other's converse and the edge is stored backwards (#1754).
 fn reorient(relation: &mut ExtractedRelation, noun: &str, holder: &str, bearer: &str) {
     let Some(stem) = predicate_noun(&relation.predicate) else {
         return;

--- a/crates/velesdb-memory/tests/kinship_synonym_bdd.rs
+++ b/crates/velesdb-memory/tests/kinship_synonym_bdd.rs
@@ -1,0 +1,203 @@
+//! Behaviour: a kinship triple points the way the passage states it, whatever
+//! WORDS the passage and the predicate use to say the same thing.
+//!
+//! `reorient` decides direction by asking whether the predicate names the same
+//! kinship the passage named. It asked that question with `stem == noun` — a
+//! comparison of SPELLING. Two labels that mean the same relation but are not
+//! spelled alike therefore read as each other's converse, and the edge is
+//! stored backwards.
+//!
+//! Two families of passage hit this, and both are ordinary:
+//!
+//! * **across languages** — `KINSHIP_NOUNS` is bilingual and `POSSESSIVE_MARKERS`
+//!   contains `" has a "`, so an English passage meets a French predicate as soon
+//!   as a model labels in one language what it read in the other;
+//! * **within one language** — the table itself lists `epoux`/`mari`,
+//!   `epouse`/`femme` and `gendre`/`beau-fils`, which are synonyms, not converses.
+//!
+//! Every case is paired with the CONVERSE over the same nouns, which must keep
+//! being re-pointed. Without that pair a "fix" that simply stopped re-orienting
+//! would pass every other assertion here.
+
+use tempfile::TempDir;
+use velesdb_memory::{
+    ExtractError, ExtractedFact, ExtractedRelation, Extraction, Extractor, HashEmbedder,
+    MemoryService, DEFAULT_DIMENSION,
+};
+
+/// One triple as an extractor backend spells it: subject, predicate, object.
+type Triple = (&'static str, &'static str, &'static str);
+
+/// A stub returning one canned triple for the sentence under test, so the
+/// behaviour is proven with no model, no network and no flake.
+struct Scripted {
+    triple: Triple,
+}
+
+impl Extractor for Scripted {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(self.extract_graph(text)?.facts)
+    }
+
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        let (subject, predicate, object) = self.triple;
+        Ok(Extraction {
+            facts: vec![ExtractedFact {
+                text: text.to_string(),
+                entities: vec![],
+            }],
+            relations: vec![ExtractedRelation {
+                subject: subject.to_string(),
+                predicate: predicate.to_string(),
+                object: object.to_string(),
+            }],
+            attributes: vec![],
+        })
+    }
+}
+
+/// A fresh service over a temp store. The [`TempDir`] must outlive the service.
+fn service() -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DEFAULT_DIMENSION))
+        .expect("open service");
+    (dir, svc)
+}
+
+/// The hub id of `name`, which must already exist.
+fn hub_id(svc: &MemoryService<HashEmbedder>, name: &str) -> u64 {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .unwrap_or_else(|| panic!("{name} has a hub"))
+        .id
+}
+
+/// The predicates leaving `name`'s hub, paired with the hub they point AT — so
+/// a direction is asserted as (who states it, about whom), never as "an edge
+/// exists somewhere".
+fn outgoing(svc: &MemoryService<HashEmbedder>, name: &str) -> Vec<(String, u64)> {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .map(|profile| {
+            profile
+                .relations
+                .into_iter()
+                .map(|r| (r.predicate, r.target_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Remember `sentence` with `triple` extracted from it, then assert `carrier`
+/// is the one `predicate` hangs on and `held` the one it points at.
+fn assert_carries(
+    sentence: &'static str,
+    triple: Triple,
+    carrier: &str,
+    predicate: &str,
+    held: &str,
+) {
+    let (_dir, svc) = service();
+    svc.remember_extracted(sentence, &Scripted { triple }, None)
+        .expect("extract and remember");
+    let target = hub_id(&svc, held);
+    assert!(
+        outgoing(&svc, carrier).contains(&(predicate.to_string(), target)),
+        "{sentence:?} + {triple:?}: expected {carrier} -[{predicate}]-> {held}, \
+         got outgoing({carrier}) = {:?}",
+        outgoing(&svc, carrier)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The defect: same relation, different words — the edge must NOT flip.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_english_passage_with_a_french_predicate_keeps_the_sister_on_the_sister() {
+    // The exact case of #1754. `"soeur"` and `"sister"` name ONE relation.
+    assert_carries(
+        "Theo has a sister called Camille",
+        ("Camille", "soeur de", "Theo"),
+        "Camille",
+        "soeur de",
+        "Theo",
+    );
+}
+
+#[test]
+fn a_french_passage_with_an_english_predicate_keeps_the_brother_on_the_brother() {
+    assert_carries(
+        "Theo a un frere, Marc",
+        ("Marc", "brother of", "Theo"),
+        "Marc",
+        "brother of",
+        "Theo",
+    );
+}
+
+#[test]
+fn two_french_synonyms_for_one_relation_do_not_flip_the_edge() {
+    // `epoux` and `mari` are listed as separate nouns but name ONE relation:
+    // the defect is not confined to a language boundary.
+    assert_carries(
+        "Theo a un epoux, Marc",
+        ("Marc", "mari de", "Theo"),
+        "Marc",
+        "mari de",
+        "Theo",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The guard: genuine converses must KEEP being re-pointed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_genuine_converse_across_languages_is_still_repointed() {
+    // Camille is the sister, so the triple labelled `frere de` belongs to Theo.
+    assert_carries(
+        "Theo has a sister called Camille",
+        ("Camille", "frere de", "Theo"),
+        "Theo",
+        "frere de",
+        "Camille",
+    );
+}
+
+#[test]
+fn a_genuine_converse_within_one_language_is_still_repointed() {
+    assert_carries(
+        "Theo a une soeur, Camille",
+        ("Camille", "frere de", "Theo"),
+        "Theo",
+        "frere de",
+        "Camille",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The controls already measured on develop: monolingual cases stay correct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_all_english_passage_is_unchanged() {
+    assert_carries(
+        "Theo has a sister called Camille",
+        ("Camille", "sister of", "Theo"),
+        "Camille",
+        "sister of",
+        "Theo",
+    );
+}
+
+#[test]
+fn an_all_french_passage_is_unchanged() {
+    assert_carries(
+        "Theo a une soeur, Camille",
+        ("Camille", "soeur de", "Theo"),
+        "Camille",
+        "soeur de",
+        "Theo",
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✔️

## Description

`reorient` decided a triple's direction by asking whether the predicate named the same kinship the passage named — and asked it of the **spelling**, with `stem == noun`. Two words for one relation therefore read as each other's **converse**, and the edge was stored backwards.

`KINSHIP_NOUNS` is bilingual and `POSSESSIVE_MARKERS` contains `" has a "`, so `"Theo has a sister called Camille"` with a triple labelled `"soeur de"` produced `Theo -[soeur de]-> Camille`: **the graph stated that Theo was Camille's sister.**

### The defect is not confined to a language boundary

The table already lists `mari`/`epoux`, `femme`/`epouse` and `gendre`/`beau-fils` — synonyms **within one language**, which flipped exactly the same way. A fix keyed on language pairs would have left those broken. The pass now compares **meaning**.

Every noun is paired with the canonical noun of the relation it denotes; `noun_at`, `noun_before` and `predicate_noun` all return that canonical form. The comparison in `reorient` is unchanged in shape and now correct in substance: a synonym orients like the word it stands for, and only a genuine converse still flips.

### Deliberate trade-off, stated

Where one French noun covers two English ones — `beau-pere` is both the father-in-law and the stepfather — every spelling folds onto that canonical. The pass has no "unrelated" branch, so anything not judged identical is treated as the converse. Reading two step/in-law words as **one relation** leaves an edge unturned; reading them as **converses** points it the wrong way, and this pass already holds that a missing correction beats a wrong one.

### Scope

- **Kinship only, unchanged.** `predicate_noun` returns `None` for any other label, so `reorient` returns before touching it and a non-kinship edge keeps the direction the extractor gave it.
- **No migration.** The change affects extraction only; edges already written keep whatever orientation they were given.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

**Red first, and non-vacuous.** `kinship_synonym_bdd.rs` fails **3/7** on `develop` before this change and passes 7/7 after:

| Test | Before |
|---|---|
| `an_english_passage_with_a_french_predicate_keeps_the_sister_on_the_sister` (the issue's exact case) | **FAILED** |
| `a_french_passage_with_an_english_predicate_keeps_the_brother_on_the_brother` | **FAILED** |
| `two_french_synonyms_for_one_relation_do_not_flip_the_edge` (`epoux`/`mari`) | **FAILED** |
| `a_genuine_converse_across_languages_is_still_repointed` | ok — guard |
| `a_genuine_converse_within_one_language_is_still_repointed` | ok — guard |
| `an_all_english_passage_is_unchanged` | ok — control |
| `an_all_french_passage_is_unchanged` | ok — control |

The four that already passed are what make the three failures meaningful: a "fix" that simply stopped re-orienting would break the two converse guards.

Regression: `kinship_forms_bdd` **14/14**, plus `extract_bdd` 18, `graph_autocomplete_bdd` 21, `recall_fused_bdd` 20, `why_bdd` 10, `unrelate_bdd` 6, `forget_orphan_hubs_bdd` 5 — all green.

Gates rerun after the last edit: `cargo fmt --all -- --check`, `cargo clippy -p velesdb-memory --all-targets --features persistence -- -D warnings -D clippy::pedantic`, `cargo test -p velesdb-memory` (default), `--features extract,ollama,persistence`, `--features http`, `python3 scripts/check-mcp-doc-contract.py`, `python3 -m unittest discover -s scripts/tests` — all exit 0. `python3 -m lizard -C 8 -a 8` on the changed file: 0 warnings.

**Test Configuration:**
- OS: macOS (darwin 25.5.0)
- Rust version: per `rust-toolchain.toml` (MSRV 1.90)

Closes #1754
