### PR TITLE
fix(memory): `ne` requires a present, non-null field on both backends

### DIFF
--- a/crates/velesdb-memory/src/column_filter_conformance.rs
+++ b/crates/velesdb-memory/src/column_filter_conformance.rs
@@ -1,0 +1,268 @@
+//! The ONE table every [`MemoryStore`](crate::storage::MemoryStore) backend
+//! must satisfy for [`ColumnFilter`], and the fixture it runs against.
+//!
+//! Why it is shared rather than written twice: the native backend translates
+//! `ColumnFilter` into `VelesQL` while the WASM backend tests the payload
+//! directly, so the two evaluate the same public filter through completely
+//! different machinery. Two parallel test files would drift — and did: `ne`
+//! on an ABSENT field matched natively and never matched on WASM, for the
+//! whole life of the API, because nothing ever compared them (#1759).
+//!
+//! Both backends therefore import [`fixture`] and [`cases`] from here. A case
+//! added once is enforced on both, or neither.
+//!
+//! # The contract for [`ColumnOp::Ne`]
+//!
+//! `field != target` matches only when the field is **present**, its value is
+//! **not null**, and that value **differs** from the target.
+//!
+//! | field state | `field != target` |
+//! |---|---|
+//! | absent | does not match |
+//! | present, `null` | does not match |
+//! | present, equal to target | does not match |
+//! | present, different from target | matches |
+//!
+//! This mirrors SQL, where a comparison against `NULL` is never true.
+//! [`Condition::IsNull`](velesdb_core::filter::Condition) and its `IsNotNull`
+//! twin remain the operators dedicated to null-ness — `Ne` is not one of them.
+
+use crate::model::{column_value_matches, ColumnFilter, ColumnOp};
+use crate::service::Metadata;
+use serde_json::Value;
+
+/// Fixture id whose `status` field is absent entirely.
+pub const ABSENT: u64 = 1;
+/// Fixture id whose `status` is present and explicitly `null`.
+pub const NULL_VALUED: u64 = 2;
+/// Fixture id whose `status` equals the target every case compares against.
+pub const EQUAL: u64 = 3;
+/// Fixture id whose `status` differs from that target.
+pub const DIFFERENT: u64 = 4;
+/// Differing `status`, plus a `year` below the ordering cases' pivot.
+pub const DIFFERENT_EARLY: u64 = 5;
+/// Differing `status`, plus a `year` above that pivot.
+pub const DIFFERENT_LATE: u64 = 6;
+/// `year` exactly on the pivot, with NO `status` — pins that a second filter
+/// still excludes a fact the first one would have kept.
+pub const YEAR_ONLY: u64 = 7;
+/// Internal scaffolding, which no case may ever return.
+pub const SCAFFOLDING: u64 = 90;
+
+/// The value every `status` case compares against.
+pub const TARGET: &str = "archived";
+/// The value the ordering cases pivot on.
+pub const PIVOT: i64 = 2010;
+
+/// One fact the conformance fixture stores.
+pub struct FixtureFact {
+    /// Stable id, so a case names the facts it expects by constant.
+    pub id: u64,
+    /// Stored content — identical across facts, since no case reads it.
+    pub content: &'static str,
+    /// The payload whose fields the filters address.
+    pub metadata: Metadata,
+}
+
+/// One conformance case: filters applied to [`fixture`], and the ids that must
+/// come back, ascending.
+pub struct Case {
+    /// Name carried into the assertion message, so a failure says WHICH rule broke.
+    pub name: &'static str,
+    /// Filters to pass to `query_columnar`, AND-combined.
+    pub filters: Vec<ColumnFilter>,
+    /// Ids the backend must return, ascending.
+    pub expected: Vec<u64>,
+}
+
+fn meta(pairs: &[(&str, Value)]) -> Metadata {
+    pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), value.clone()))
+        .collect()
+}
+
+fn filter(field: &str, op: ColumnOp, value: Value) -> ColumnFilter {
+    ColumnFilter {
+        field: field.to_string(),
+        op,
+        value,
+    }
+}
+
+/// Every fact both backends store before running [`cases`].
+///
+/// [`SCAFFOLDING`] is deliberately in here: a backend that stopped excluding
+/// internal scaffolding would return it, and every case would fail — which is
+/// how the exclusion is kept alive by this suite rather than by a separate
+/// test that could be deleted without anyone noticing.
+#[must_use]
+pub fn fixture() -> Vec<FixtureFact> {
+    vec![
+        FixtureFact {
+            id: ABSENT,
+            content: "status absent",
+            metadata: Metadata::new(),
+        },
+        FixtureFact {
+            id: NULL_VALUED,
+            content: "status null",
+            metadata: meta(&[("status", Value::Null)]),
+        },
+        FixtureFact {
+            id: EQUAL,
+            content: "status equals the target",
+            metadata: meta(&[("status", Value::from(TARGET))]),
+        },
+        FixtureFact {
+            id: DIFFERENT,
+            content: "status differs",
+            metadata: meta(&[("status", Value::from("active"))]),
+        },
+        FixtureFact {
+            id: DIFFERENT_EARLY,
+            content: "status differs, early year",
+            metadata: meta(&[
+                ("status", Value::from("active")),
+                ("year", Value::from(2003)),
+            ]),
+        },
+        FixtureFact {
+            id: DIFFERENT_LATE,
+            content: "status differs, late year",
+            metadata: meta(&[
+                ("status", Value::from("active")),
+                ("year", Value::from(2020)),
+            ]),
+        },
+        FixtureFact {
+            id: YEAR_ONLY,
+            content: "year only, no status",
+            metadata: meta(&[("year", Value::from(PIVOT))]),
+        },
+        FixtureFact {
+            id: SCAFFOLDING,
+            content: "internal scaffolding",
+            metadata: meta(&[("_veles_hub", Value::Bool(true))]),
+        },
+    ]
+}
+
+/// Every rule both backends must satisfy, run against [`fixture`].
+#[must_use]
+pub fn cases() -> Vec<Case> {
+    vec![
+        Case {
+            name: "ne excludes absent, null and equal; keeps only present-and-different",
+            filters: vec![filter("status", ColumnOp::Ne, Value::from(TARGET))],
+            expected: vec![DIFFERENT, DIFFERENT_EARLY, DIFFERENT_LATE],
+        },
+        Case {
+            name: "eq keeps only the exact match",
+            filters: vec![filter("status", ColumnOp::Eq, Value::from(TARGET))],
+            expected: vec![EQUAL],
+        },
+        Case {
+            name: "eq on an absent field matches nothing",
+            filters: vec![filter("missing", ColumnOp::Eq, Value::from(TARGET))],
+            expected: vec![],
+        },
+        Case {
+            name: "lt requires the field and compares below the pivot",
+            filters: vec![filter("year", ColumnOp::Lt, Value::from(PIVOT))],
+            expected: vec![DIFFERENT_EARLY],
+        },
+        Case {
+            name: "le includes the pivot",
+            filters: vec![filter("year", ColumnOp::Le, Value::from(PIVOT))],
+            expected: vec![DIFFERENT_EARLY, YEAR_ONLY],
+        },
+        Case {
+            name: "gt excludes the pivot",
+            filters: vec![filter("year", ColumnOp::Gt, Value::from(PIVOT))],
+            expected: vec![DIFFERENT_LATE],
+        },
+        Case {
+            name: "ge includes the pivot",
+            filters: vec![filter("year", ColumnOp::Ge, Value::from(PIVOT))],
+            expected: vec![DIFFERENT_LATE, YEAR_ONLY],
+        },
+        Case {
+            name: "several filters are AND-combined",
+            filters: vec![
+                filter("status", ColumnOp::Ne, Value::from(TARGET)),
+                filter("year", ColumnOp::Ge, Value::from(PIVOT)),
+            ],
+            expected: vec![DIFFERENT_LATE],
+        },
+        Case {
+            name: "no filter returns every caller fact and no scaffolding",
+            filters: Vec::new(),
+            expected: vec![
+                ABSENT,
+                NULL_VALUED,
+                EQUAL,
+                DIFFERENT,
+                DIFFERENT_EARLY,
+                DIFFERENT_LATE,
+                YEAR_ONLY,
+            ],
+        },
+    ]
+}
+
+/// How a backend evaluates `Ne`, for the positive control below.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NeSemantics {
+    /// The contract this module documents.
+    Contract,
+    /// The native backend's behaviour before #1759: an ABSENT field matched.
+    AbsentMatched,
+    /// Both backends' behaviour before #1759: an explicit `null` matched.
+    NullMatched,
+}
+
+/// The contract's own decision, with `semantics` overriding only the two
+/// answers this change replaced.
+///
+/// The per-value rule is [`column_value_matches`] — the same function both
+/// backends run. Re-implementing it here would defeat the purpose: a control
+/// that drifted from the rule it guards would certify a backend against a
+/// contract nobody enforces.
+fn matches(metadata: &Metadata, one: &ColumnFilter, semantics: NeSemantics) -> bool {
+    let stored = metadata.get(&one.field);
+    match (one.op, semantics, stored) {
+        (ColumnOp::Ne, NeSemantics::AbsentMatched, None) => true,
+        (ColumnOp::Ne, NeSemantics::NullMatched, Some(value)) if value.is_null() => true,
+        (_, _, Some(value)) => column_value_matches(value, one.op, &one.value),
+        (_, _, None) => false,
+    }
+}
+
+/// Names of the cases a backend evaluating `Ne` with `semantics` would FAIL.
+///
+/// This is the suite's positive control. `Contract` must yield an empty list;
+/// every other variant must yield a non-empty one, which is what proves the
+/// table can still tell the contract apart from the behaviour it replaced. A
+/// table that accepted the old behaviour too would be green and worthless.
+#[must_use]
+pub fn cases_failed_under(semantics: NeSemantics) -> Vec<&'static str> {
+    let facts = fixture();
+    cases()
+        .into_iter()
+        .filter(|case| {
+            let got: Vec<u64> = facts
+                .iter()
+                .filter(|fact| fact.id != SCAFFOLDING)
+                .filter(|fact| {
+                    case.filters
+                        .iter()
+                        .all(|one| matches(&fact.metadata, one, semantics))
+                })
+                .map(|fact| fact.id)
+                .collect();
+            got != case.expected
+        })
+        .map(|case| case.name)
+        .collect()
+}

--- a/crates/velesdb-memory/src/column_filter_conformance.rs
+++ b/crates/velesdb-memory/src/column_filter_conformance.rs
@@ -148,9 +148,8 @@ pub fn fixture() -> Vec<FixtureFact> {
     ]
 }
 
-/// Every rule both backends must satisfy, run against [`fixture`].
-#[must_use]
-pub fn cases() -> Vec<Case> {
+/// The equality half of the contract — the rules #1759 changed.
+fn equality_cases() -> Vec<Case> {
     vec![
         Case {
             name: "ne excludes absent, null and equal; keeps only present-and-different",
@@ -167,6 +166,12 @@ pub fn cases() -> Vec<Case> {
             filters: vec![filter("missing", ColumnOp::Eq, Value::from(TARGET))],
             expected: vec![],
         },
+    ]
+}
+
+/// The ordering half — untouched by #1759, and pinned so it stays that way.
+fn ordering_cases() -> Vec<Case> {
+    vec![
         Case {
             name: "lt requires the field and compares below the pivot",
             filters: vec![filter("year", ColumnOp::Lt, Value::from(PIVOT))],
@@ -187,6 +192,13 @@ pub fn cases() -> Vec<Case> {
             filters: vec![filter("year", ColumnOp::Ge, Value::from(PIVOT))],
             expected: vec![DIFFERENT_LATE, YEAR_ONLY],
         },
+    ]
+}
+
+/// How filters compose, and what a caller sees with none — the case that also
+/// proves scaffolding never surfaces.
+fn composition_cases() -> Vec<Case> {
+    vec![
         Case {
             name: "several filters are AND-combined",
             filters: vec![
@@ -209,6 +221,15 @@ pub fn cases() -> Vec<Case> {
             ],
         },
     ]
+}
+
+/// Every rule both backends must satisfy, run against [`fixture`].
+#[must_use]
+pub fn cases() -> Vec<Case> {
+    let mut all = equality_cases();
+    all.extend(ordering_cases());
+    all.extend(composition_cases());
+    all
 }
 
 /// How a backend evaluates `Ne`, for the positive control below.

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -30,14 +30,15 @@
 /// context compiler, which stays clock-free and deterministic. Internal:
 /// nothing outside the crate needs to read the clock directly.
 mod clock;
+/// The ONE `ColumnFilter` conformance table both `MemoryStore` backends run,
+/// so the native (`VelesQL`-translating) and WASM (payload-testing) paths
+/// cannot drift apart again (#1759). Deliberately NOT target-gated: the WASM
+/// backend is one of the two that must run it.
+pub mod column_filter_conformance;
 /// The optional TOML configuration file: one place to set every knob, with
 /// `command line > environment > file > default` precedence. Native-only —
 /// it reads the filesystem.
 #[cfg(not(target_arch = "wasm32"))]
-/// The ONE `ColumnFilter` conformance table both `MemoryStore` backends run,
-/// so the native (`VelesQL`-translating) and WASM (payload-testing) paths
-/// cannot drift apart again (#1759).
-pub mod column_filter_conformance;
 pub mod config;
 /// The deterministic context compiler (EPIC-P-070): classify, dedup, and pack
 /// caller-supplied context fragments under a token budget — no LLM, no cloud,

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -34,6 +34,10 @@ mod clock;
 /// `command line > environment > file > default` precedence. Native-only —
 /// it reads the filesystem.
 #[cfg(not(target_arch = "wasm32"))]
+/// The ONE `ColumnFilter` conformance table both `MemoryStore` backends run,
+/// so the native (`VelesQL`-translating) and WASM (payload-testing) paths
+/// cannot drift apart again (#1759).
+pub mod column_filter_conformance;
 pub mod config;
 /// The deterministic context compiler (EPIC-P-070): classify, dedup, and pack
 /// caller-supplied context fragments under a token budget — no LLM, no cloud,
@@ -163,8 +167,9 @@ pub use http_client::{Auth, HttpJsonClient};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
 pub use model::{
-    ColumnFilter, ColumnOp, EntityProfile, EntityRelation, Explanation, FusionOptions, Link,
-    MemoryEdge, MemoryNode, Recollection, RememberedExtraction, UnrelateOutcome,
+    column_value_matches, ColumnFilter, ColumnOp, EntityProfile, EntityRelation, Explanation,
+    FusionOptions, Link, MemoryEdge, MemoryNode, Recollection, RememberedExtraction,
+    UnrelateOutcome,
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -119,6 +119,54 @@ impl ColumnOp {
     }
 }
 
+/// Whether a STORED value satisfies `op` against a filter's `target`.
+///
+/// The single definition of what a [`ColumnFilter`] means once its field has
+/// been found, so a backend that evaluates payloads directly and one that
+/// translates to `VelesQL` cannot answer differently. `ne` on an absent field
+/// diverged between the two for the API's whole life precisely because each
+/// carried its own copy of this rule (#1759).
+///
+/// **A `null` satisfies nothing**, whatever the operator — a comparison
+/// against null is not true, as in SQL, and `ne` is no exception. Querying for
+/// null-ness is what `IsNull`/`IsNotNull` are for at the `VelesQL` layer. The
+/// caller is responsible for the *absent* case: no value here means no match.
+///
+/// Comparison is numeric when both sides are numbers, lexicographic when both
+/// are strings, and equality-only otherwise — an ordering over two unrelated
+/// JSON shapes has no meaning, so it is false rather than arbitrary.
+#[must_use]
+pub fn column_value_matches(stored: &Value, op: ColumnOp, target: &Value) -> bool {
+    if stored.is_null() {
+        return false;
+    }
+    if let (Some(left), Some(right)) = (stored.as_f64(), target.as_f64()) {
+        return match op {
+            ColumnOp::Eq => (left - right).abs() < f64::EPSILON,
+            ColumnOp::Ne => (left - right).abs() >= f64::EPSILON,
+            ColumnOp::Lt => left < right,
+            ColumnOp::Le => left <= right,
+            ColumnOp::Gt => left > right,
+            ColumnOp::Ge => left >= right,
+        };
+    }
+    if let (Some(left), Some(right)) = (stored.as_str(), target.as_str()) {
+        return match op {
+            ColumnOp::Eq => left == right,
+            ColumnOp::Ne => left != right,
+            ColumnOp::Lt => left < right,
+            ColumnOp::Le => left <= right,
+            ColumnOp::Gt => left > right,
+            ColumnOp::Ge => left >= right,
+        };
+    }
+    match op {
+        ColumnOp::Eq => stored == target,
+        ColumnOp::Ne => stored != target,
+        ColumnOp::Lt | ColumnOp::Le | ColumnOp::Gt | ColumnOp::Ge => false,
+    }
+}
+
 /// A structured predicate over a memory's metadata column, for the fused
 /// vector+`ColumnStore` recall
 /// [`MemoryService::recall_where`](crate::service::MemoryService::recall_where).

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -152,6 +152,29 @@ pub trait MemoryStore {
     /// and comparisons, not just equality) — the engine behind
     /// [`crate::service::MemoryService::recall_where`].
     ///
+    /// # Absent and null fields
+    ///
+    /// **A filter is satisfied only by a fact that HAS the field with a
+    /// non-null value.** A fact missing the field, or storing `null` in it, is
+    /// never returned — and `ne` is no exception, exactly as a SQL comparison
+    /// against `NULL` is never true.
+    ///
+    /// | field state | `field != target` | `field == target` | `<` `<=` `>` `>=` |
+    /// |---|---|---|---|
+    /// | absent | no match | no match | no match |
+    /// | present, `null` | no match | no match | no match |
+    /// | present, equal | no match | match | per the comparison |
+    /// | present, different | **match** | no match | per the comparison |
+    ///
+    /// This is stated because it did not hold: `ne` on an absent field matched
+    /// on the native backend and never matched on WASM, for the API's whole
+    /// life, because nothing compared them (#1759). Every backend is now held
+    /// to one shared table —
+    /// [`crate::column_filter_conformance`] — run against both.
+    ///
+    /// Null-ness is not expressible through [`ColumnFilter`]; querying for it
+    /// is what `IsNull`/`IsNotNull` are for at the `VelesQL` layer.
+    ///
     /// # Errors
     /// Returns [`MemoryError::InvalidFilter`] if a filter field is not a
     /// plain identifier or a filter value is non-scalar, or [`MemoryError`]
@@ -419,6 +442,21 @@ impl NativeStore {
         for (index, filter) in filters.iter().enumerate() {
             validate_column_filter(filter)?;
             let key = format!("p{index}");
+            // `ne` is spelled out rather than left to `!=` alone. Core's
+            // `Condition::Neq` is `is_none_or`, so a bare `field != $p` also
+            // matches a fact that HAS no such field — which made `ne` mean two
+            // different things on the two backends (#1759). Requiring the
+            // field first pins the published contract here, at the adapter,
+            // instead of redefining `!=` for all of `VelesQL` — that is a
+            // product-wide semantic break, deliberately out of scope.
+            //
+            // `IS NOT NULL` is false for an absent field AND for an explicit
+            // `null`, which is exactly the contract: a comparison against null
+            // is never true, as in SQL. `IsNull`/`IsNotNull` stay the operators
+            // dedicated to null-ness.
+            if matches!(filter.op, crate::model::ColumnOp::Ne) {
+                let _ = write!(predicate, " AND {} IS NOT NULL", filter.field);
+            }
             let _ = write!(
                 predicate,
                 " AND {} {} ${key}",
@@ -439,6 +477,13 @@ impl NativeStore {
         // so they go straight into the text without passing through
         // `validate_column_filter` — whose job is to reject a CALLER filter
         // naming a reserved key.
+        //
+        // The asymmetry with the caller loop above is DELIBERATE and load-
+        // bearing: a caller's `ne` now carries an `IS NOT NULL`, this exclusion
+        // must NOT. It depends on the absent field matching — that is how it
+        // keeps every caller fact while dropping the marked ones. Giving these
+        // markers the same treatment would exclude every caller fact instead,
+        // since none of them carries a marker column at all.
         for (index, marker) in INTERNAL_MARKER_FIELDS.iter().enumerate() {
             let key = format!("m{index}");
             let _ = write!(predicate, " AND {marker} != ${key}");

--- a/crates/velesdb-memory/tests/column_filter_conformance_bdd.rs
+++ b/crates/velesdb-memory/tests/column_filter_conformance_bdd.rs
@@ -1,0 +1,82 @@
+//! The native half of the shared `ColumnFilter` conformance suite.
+//!
+//! The table itself lives in
+//! [`velesdb_memory::column_filter_conformance`] and is run verbatim by the
+//! WASM backend too (`crates/velesdb-wasm/src/memory_store_tests.rs`). Adding
+//! a case there enforces it on both backends at once — which is the whole
+//! point, since `ne` on an absent field diverged between them unnoticed for
+//! the API's entire life (#1759).
+//!
+//! This side goes through `NativeStore`, which translates `ColumnFilter` into
+//! `VelesQL` — a completely different evaluator from the WASM one. Identical
+//! results here and there is the parity the suite exists to prove.
+
+#![cfg(feature = "persistence")]
+
+use velesdb_memory::column_filter_conformance::{
+    cases, cases_failed_under, fixture, NeSemantics, SCAFFOLDING,
+};
+use velesdb_memory::storage::NativeStore;
+use velesdb_memory::MemoryStore;
+
+const EMBEDDING: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+
+/// A store preloaded with the shared fixture.
+fn seeded() -> (tempfile::TempDir, NativeStore) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = NativeStore::open(dir.path(), 4).expect("open store");
+    for fact in fixture() {
+        store
+            .store_with_metadata(fact.id, fact.content, &EMBEDDING, &fact.metadata)
+            .expect("seed fixture");
+    }
+    (dir, store)
+}
+
+#[test]
+fn the_native_backend_satisfies_every_conformance_case() {
+    let (_dir, store) = seeded();
+    for case in cases() {
+        let hits = store
+            .query_columnar(&EMBEDDING, 50, &case.filters)
+            .expect("query_columnar");
+        let mut ids: Vec<u64> = hits.iter().map(|hit| hit.id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, case.expected, "native: {}", case.name);
+    }
+}
+
+#[test]
+fn the_native_backend_never_returns_internal_scaffolding() {
+    let (_dir, store) = seeded();
+    for case in cases() {
+        let hits = store
+            .query_columnar(&EMBEDDING, 50, &case.filters)
+            .expect("query_columnar");
+        assert!(
+            hits.iter().all(|hit| hit.id != SCAFFOLDING),
+            "native: {} leaked internal scaffolding",
+            case.name
+        );
+    }
+}
+
+/// The positive control. Without it the table could be green and worthless:
+/// a suite that also accepts the behaviour it replaced has proven nothing.
+#[test]
+fn the_table_rejects_the_behaviour_it_replaced() {
+    assert!(
+        cases_failed_under(NeSemantics::Contract).is_empty(),
+        "the contract itself must satisfy every case"
+    );
+    assert!(
+        !cases_failed_under(NeSemantics::AbsentMatched).is_empty(),
+        "a backend where `ne` matched an ABSENT field must fail at least one case, \
+         or this suite cannot detect the native regression it was written for"
+    );
+    assert!(
+        !cases_failed_under(NeSemantics::NullMatched).is_empty(),
+        "a backend where `ne` matched an explicit NULL must fail at least one case, \
+         or this suite cannot detect a regression on either backend"
+    );
+}

--- a/crates/velesdb-memory/tests/recall_where_scaffolding_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_where_scaffolding_bdd.rs
@@ -12,6 +12,13 @@
 //! carries only reserved keys, so it has none of the caller's columns, so
 //! `status != "archived"` sweeps in every artefact the service ever wrote.
 //!
+//! Since #1759 the adapter also spells a caller's `ne` as
+//! `field IS NOT NULL AND field != $p`, so a fact lacking the column no longer
+//! matches at all — which closes this leak a second time, at its root. The
+//! marker exclusion below is kept regardless: it still relies on `is_none_or`
+//! (that is how it keeps caller facts while dropping marked ones), and it is
+//! what protects the paths where the caller passes no `ne` predicate.
+//!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
 #![cfg(all(feature = "context", feature = "persistence"))]
@@ -183,11 +190,24 @@ fn recall_where_ne_predicate_still_returns_caller_facts() {
         ids.contains(&seed.with_status),
         "a caller fact whose `status` is not \"archived\" must be returned"
     );
+    // This assertion was inverted by #1759, deliberately. It used to require a
+    // caller fact with NO `status` column to survive `status != "archived"`,
+    // because `Condition::Neq` is `is_none_or` and a missing field matched.
+    // That is the very shape that made `ne` mean two different things on the
+    // two backends, and the published contract now says a filter is satisfied
+    // only by a fact that HAS the field with a non-null value.
+    //
+    // The concern the old assertion protected — that excluding scaffolding must
+    // not black out caller facts — is NOT dropped: it is what
+    // `recall_where_without_predicates_returns_no_internal_scaffolding` proves,
+    // by getting both caller facts back when no predicate names `status`. Here,
+    // the fact is excluded by the CALLER'S OWN predicate, which is the contract
+    // working, not a blackout.
     assert!(
-        ids.contains(&seed.without_status),
-        "a caller fact with NO `status` column must still be returned: `!=` \
-         keeps a missing caller field, and excluding scaffolding must not \
-         quietly turn that into a blackout"
+        !ids.contains(&seed.without_status),
+        "a caller fact with NO `status` column must NOT satisfy \
+         `status != \"archived\"`: the published contract requires the field to \
+         be present and non-null (#1759)"
     );
 }
 

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -17,7 +17,8 @@ use std::collections::HashMap;
 
 use serde_json::{Map, Value};
 use velesdb_memory::{
-    ColumnFilter, ColumnOp, MemoryEdge, MemoryError, MemoryStore, Metadata, Recollection,
+    column_value_matches, ColumnFilter, MemoryEdge, MemoryError, MemoryStore, Metadata,
+    Recollection,
 };
 
 use crate::graph_store::WasmGraphStore;
@@ -439,44 +440,19 @@ impl WasmStore {
 }
 
 /// True when every filter in `filters` is satisfied by `payload` (AND-combined).
+///
+/// The per-value rule is [`velesdb_memory::column_value_matches`], not a copy
+/// of it: this backend and the `VelesQL`-translating one each carrying their
+/// own is exactly how `ne` came to mean two different things (#1759). A field
+/// this payload does not carry satisfies nothing, which — with the shared
+/// rule's refusal of a stored `null` — is the published contract: present,
+/// non-null, and comparing true.
 fn columnar_matches(payload: &Map<String, Value>, filters: &[ColumnFilter]) -> bool {
     filters.iter().all(|filter| {
         payload
             .get(&filter.field)
-            .is_some_and(|value| compare(value, filter.op, &filter.value))
+            .is_some_and(|value| column_value_matches(value, filter.op, &filter.value))
     })
-}
-
-/// Evaluate one [`ColumnOp`] between a stored payload value and the filter's
-/// value: numeric comparison when both are numbers, lexicographic when both
-/// are strings, equality-only otherwise (matches `VelesQL`'s scalar-comparison
-/// semantics for the types `MemoryService::recall_where` accepts).
-fn compare(stored: &Value, op: ColumnOp, target: &Value) -> bool {
-    if let (Some(a), Some(b)) = (stored.as_f64(), target.as_f64()) {
-        return match op {
-            ColumnOp::Eq => (a - b).abs() < f64::EPSILON,
-            ColumnOp::Ne => (a - b).abs() >= f64::EPSILON,
-            ColumnOp::Lt => a < b,
-            ColumnOp::Le => a <= b,
-            ColumnOp::Gt => a > b,
-            ColumnOp::Ge => a >= b,
-        };
-    }
-    if let (Some(a), Some(b)) = (stored.as_str(), target.as_str()) {
-        return match op {
-            ColumnOp::Eq => a == b,
-            ColumnOp::Ne => a != b,
-            ColumnOp::Lt => a < b,
-            ColumnOp::Le => a <= b,
-            ColumnOp::Gt => a > b,
-            ColumnOp::Ge => a >= b,
-        };
-    }
-    match op {
-        ColumnOp::Eq => stored == target,
-        ColumnOp::Ne => stored != target,
-        _ => false,
-    }
 }
 
 #[cfg(test)]

--- a/crates/velesdb-wasm/src/memory_store_tests.rs
+++ b/crates/velesdb-wasm/src/memory_store_tests.rs
@@ -362,3 +362,54 @@ fn test_expired_fact_is_excluded_from_vector_search() {
     assert!(hits.iter().all(|h| h.0 != 1));
     assert!(hits.iter().any(|h| h.0 == 2));
 }
+
+// ---------------------------------------------------------------------------
+// The WASM half of the shared `ColumnFilter` conformance suite.
+//
+// The table lives in `velesdb_memory::column_filter_conformance` and is run
+// verbatim by the native backend too
+// (`crates/velesdb-memory/tests/column_filter_conformance_bdd.rs`). One table,
+// two evaluators: this side tests the payload directly, the native side
+// translates to `VelesQL`. A case added once is enforced on both, which is
+// what stops the two from drifting apart again (#1759).
+// ---------------------------------------------------------------------------
+
+/// A store preloaded with the shared fixture.
+fn conformance_store() -> WasmStore {
+    let store = WasmStore::new(4);
+    for fact in velesdb_memory::column_filter_conformance::fixture() {
+        store
+            .store_with_metadata(fact.id, fact.content, &[1.0, 0.0, 0.0, 0.0], &fact.metadata)
+            .expect("seed fixture");
+    }
+    store
+}
+
+#[test]
+fn the_wasm_backend_satisfies_every_conformance_case() {
+    let store = conformance_store();
+    for case in velesdb_memory::column_filter_conformance::cases() {
+        let hits = store
+            .query_columnar(&[1.0, 0.0, 0.0, 0.0], 50, &case.filters)
+            .expect("query_columnar");
+        let mut ids: Vec<u64> = hits.iter().map(|hit| hit.id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, case.expected, "wasm: {}", case.name);
+    }
+}
+
+#[test]
+fn the_wasm_backend_never_returns_internal_scaffolding() {
+    let store = conformance_store();
+    for case in velesdb_memory::column_filter_conformance::cases() {
+        let hits = store
+            .query_columnar(&[1.0, 0.0, 0.0, 0.0], 50, &case.filters)
+            .expect("query_columnar");
+        assert!(
+            hits.iter()
+                .all(|hit| hit.id != velesdb_memory::column_filter_conformance::SCAFFOLDING),
+            "wasm: {} leaked internal scaffolding",
+            case.name
+        );
+    }
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✔️

## Description

`recall_where`'s `ne` meant two different things depending on which `MemoryStore` answered. On an **absent** field it matched natively and never matched on WASM — same public API, opposite results — for the API's whole life, because nothing ever compared the two.

### Why the fix is not in the core

The native backend does not evaluate `ColumnFilter` at all: it translates it into VelesQL, so the operator that decided was **core's** `Condition::Neq`, which is `is_none_or`. Changing that would redefine `!=` for every VelesQL query, the REST surface, the CLI and every binding — a product-wide semantic break needing its own contract and a major version. **Deliberately out of scope.**

The fix is a more explicit translation at the adapter: `build_fused_query` emits `field IS NOT NULL AND field != $p` for `ColumnOp::Ne`. **Core is untouched.**

### Measuring the null case changed the shape of the fix

Before this change **both** backends let an explicit `null` satisfy a `ne` — the divergence was only about the absent field. Core's `IsNotNull` is false for an explicit null too, so fixing only the native side would have **closed one divergence by opening another**. The contract therefore covers both:

> `field != target` matches only when the field is **present**, its value is **not null**, and that value **differs** from the target.

| field state | `field != target` |
|---|---|
| absent | does not match |
| present, `null` | does not match |
| present, equal | does not match |
| present, different | **matches** |

This mirrors SQL, where a comparison against `NULL` is never true. `IsNull`/`IsNotNull` stay the operators dedicated to null-ness. **The null change is intended and documented, not a side effect.**

### One rule, not two copies

`model::column_value_matches` is now the single definition of what a filter means once its field is found, and the WASM backend calls it instead of carrying its own copy. Two copies of that rule is how the backends drifted in the first place — the fix should not reintroduce the shape of the defect it repairs.

### Scaffolding

Internal scaffolding stays excluded, and the marker loop deliberately does **not** get the same `IS NOT NULL` treatment: it depends on the absent field matching, which is how it keeps caller facts while dropping marked ones. Unifying the two loops would black out every caller fact — the comment says so, in place.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

**One shared table, two backends, red first.** `column_filter_conformance` holds the fixture and the cases; the native suite runs them through VelesQL and the WASM suite through direct payload testing. Before the change it failed **1/9 on each backend, for different reasons**:

| backend | returned | expected |
|---|---|---|
| native | `[1, 2, 4, 5, 6, 7]` — absent **and** null | `[4, 5, 6]` |
| WASM | `[2, 4, 5, 6]` — null only | `[4, 5, 6]` |

Covered: absent, explicit null, equal, different, multiple filters AND-combined, `Eq`/`lt`/`le`/`gt`/`ge` unchanged, scaffolding never returned, and identical results on both backends from the same fixture.

**Positive control.** `cases_failed_under` replays the table against the two behaviours this change replaces and asserts each still fails a case — so a table that quietly stopped discriminating cannot sit green. It decides per value through `column_value_matches` too, so the control can never certify a backend against a rule nobody enforces.

**One existing assertion is inverted on purpose.** `recall_where_scaffolding_bdd` required a caller fact with no `status` to survive `status != "archived"`. The concern it protected — that excluding scaffolding must not black out caller facts — is unchanged and still proven by the no-predicate test beside it; here the fact is excluded by the caller's own predicate, which is the contract working.

Gates rerun after the last edit, exit codes read without a pipe: `cargo fmt --all -- --check`, `cargo clippy -p velesdb-memory --all-targets --features persistence -- -D warnings -D clippy::pedantic`, the same for `-p velesdb-wasm`, `cargo test -p velesdb-memory` (default), `--features extract,ollama,persistence`, `--features http`, `cargo test -p velesdb-wasm --lib`, `cargo test -p velesdb-node --lib`, `cargo check -p velesdb-memory --no-default-features`, `python3 scripts/check-mcp-doc-contract.py`, `python3 -m unittest discover -s scripts/tests` — **all 0**. `python3 -m lizard -C 8 -a 8` on the changed files: 0 warnings.

`cargo test -p velesdb-python --lib` fails to link locally (pyo3 cdylib on macOS) — **reproduced identically on `develop`**, so pre-existing and unrelated.

**Test Configuration:**
- OS: macOS (darwin 25.5.0)
- Rust version: per `rust-toolchain.toml` (MSRV 1.90)

Closes #1759
