### PR TITLE
fix(memory): an unadvertised model alias is not a proven absence

### DIFF
--- a/crates/velesdb-memory/src/reachability.rs
+++ b/crates/velesdb-memory/src/reachability.rs
@@ -54,8 +54,14 @@ pub enum Reachability {
     },
     /// The server answered and refused the credential.
     Unauthorized,
-    /// The server answered, and the configured model is not in its listing.
-    ModelAbsent {
+    /// The server answered, and the configured name is not among the ids it
+    /// advertises. **Not** a proven absence: a server may route an alias it
+    /// does not list. Measured on 2026-08-02 against a local oMLX server —
+    /// `/v1/models` answered 200 with seven ids, none containing `ornith`,
+    /// while `/v1/chat/completions` accepted `ornith-35b` and echoed it back
+    /// (#1782). The old name for this variant asserted that absence, and the
+    /// line it produced sent an operator to repair a healthy configuration.
+    ModelNotAdvertised {
         /// How many models it did list — `0` reads very differently from `12`.
         listed: usize,
     },
@@ -118,7 +124,7 @@ fn classify_listing(body: &str, model: &str) -> Reachability {
     if ids.iter().any(|id| names_the_same_model(id, model)) {
         Reachability::Reachable
     } else {
-        Reachability::ModelAbsent { listed: ids.len() }
+        Reachability::ModelNotAdvertised { listed: ids.len() }
     }
 }
 
@@ -145,32 +151,63 @@ fn names_the_same_model(listed: &str, configured: &str) -> bool {
 /// works is a warning people filter out. Nothing here interpolates the
 /// credential — not the value, not the header name — because this line's
 /// destination is a log file.
-#[must_use]
-pub fn warning_line(role: &str, url: &str, model: &str, outcome: &Reachability) -> Option<String> {
-    let (what, action) = match outcome {
-        Reachability::Reachable => return None,
-        Reachability::Unreachable { detail } => (
+/// What the probe found, and what an operator can do about it.
+fn finding(outcome: &Reachability) -> Option<(String, &'static str)> {
+    match outcome {
+        Reachability::Reachable => None,
+        Reachability::Unreachable { detail } => Some((
             format!("unreachable ({detail})"),
             "start the server, or correct the URL",
-        ),
-        Reachability::Unauthorized => (
+        )),
+        Reachability::Unauthorized => Some((
             "refused the credential".to_owned(),
             "set the role's _API_TOKEN in the environment (never in the TOML)",
-        ),
-        Reachability::ModelAbsent { listed } => (
-            format!("answered, but does not list this model (it lists {listed})"),
-            "pull the model on that server, or name one it has",
-        ),
-        Reachability::ListingUnsupported => (
+        )),
+        Reachability::ModelNotAdvertised { listed } => Some((
+            format!(
+                "answered, but does not advertise this model alias among the \
+                 {listed} it lists — the alias may still be routable by the server"
+            ),
+            "no action if the server routes this alias; otherwise name one it lists",
+        )),
+        Reachability::ListingUnsupported => Some((
             "answered, but serves no model listing — reachability unconfirmed".to_owned(),
             "no action if this is a gateway; otherwise check the URL's base path",
-        ),
+        )),
+    }
+}
+
+/// Whether the verdict ESTABLISHES that the backend cannot serve writes, or
+/// merely fails to confirm that it can.
+///
+/// The distinction is the whole of #1782. `/v1/models` is a light signal, and
+/// a light signal has limits: it proves a server is up, and it proves nothing
+/// about an alias it does not mention. Stating degradation as a fact on that
+/// basis is what turned a healthy oMLX configuration into a bug report. The
+/// probe stays light either way — confirming an alias would mean asking
+/// `/v1/chat/completions`, which pulls a 35-billion-parameter model at startup.
+fn proves_backend_unusable(outcome: &Reachability) -> bool {
+    match outcome {
+        Reachability::Unreachable { .. } | Reachability::Unauthorized => true,
+        Reachability::Reachable
+        | Reachability::ModelNotAdvertised { .. }
+        | Reachability::ListingUnsupported => false,
+    }
+}
+
+#[must_use]
+pub fn warning_line(role: &str, url: &str, model: &str, outcome: &Reachability) -> Option<String> {
+    let (what, action) = finding(outcome)?;
+    let consequence = if proves_backend_unusable(outcome) {
+        "Graph enrichment will degrade silently for every write until it is fixed"
+    } else {
+        "Whether graph enrichment works is therefore unconfirmed — this is not \
+         proof that it is broken"
     };
     Some(format!(
         "velesdb-memory: the {role} backend at {url} (model {model}) {what}. \
-         Graph enrichment will degrade silently for every write until it is fixed — \
-         {action}, then restart. To run without it, unset VELESDB_MEMORY_EXTRACTOR \
-         or turn autograph off."
+         {consequence} — {action}, then restart. To run without it, unset \
+         VELESDB_MEMORY_EXTRACTOR or turn autograph off."
     ))
 }
 

--- a/crates/velesdb-memory/src/reachability_tests.rs
+++ b/crates/velesdb-memory/src/reachability_tests.rs
@@ -113,8 +113,8 @@ fn a_listing_without_the_model_is_a_different_diagnosis() {
     let (url, _seen, handle) = listening_server("200 OK", MODELS_JSON);
     let outcome = probe_at(&url, "a-model-nobody-pulled");
     assert!(
-        matches!(outcome, Reachability::ModelAbsent { .. }),
-        "a served listing without the model must be ModelAbsent, got {outcome:?}"
+        matches!(outcome, Reachability::ModelNotAdvertised { .. }),
+        "a served listing without the model must be ModelNotAdvertised, got {outcome:?}"
     );
     let line =
         warning_line("extraction", &url, "a-model-nobody-pulled", &outcome).expect("warning");
@@ -126,7 +126,7 @@ fn a_listing_without_the_model_is_a_different_diagnosis() {
 fn ollamas_latest_suffix_is_not_a_missing_model() {
     // Measured against the real Ollama on 2026-08-02: `/v1/models` answers
     // `bge-m3:latest` while the configuration says `bge-m3`. A strict equality
-    // would report ModelAbsent for a model that is loaded and serving — a
+    // would report ModelNotAdvertised for a model that is loaded and serving — a
     // false alarm is worse than no alarm, because it teaches people to ignore
     // the line this whole change exists to make them read.
     let (url, _seen, handle) = listening_server(
@@ -148,7 +148,7 @@ fn a_tag_that_differs_is_still_a_missing_model() {
     assert!(
         matches!(
             probe_at(&url, "bge-m3:v3"),
-            Reachability::ModelAbsent { .. }
+            Reachability::ModelNotAdvertised { .. }
         ),
         "a different explicit tag must stay a miss"
     );
@@ -181,7 +181,7 @@ fn no_warning_ever_echoes_the_credential() {
             detail: "connection refused".to_owned(),
         },
         Reachability::Unauthorized,
-        Reachability::ModelAbsent { listed: 3 },
+        Reachability::ModelNotAdvertised { listed: 3 },
         Reachability::ListingUnsupported,
     ];
     for outcome in &outcomes {
@@ -299,4 +299,63 @@ fn a_server_that_does_not_serve_a_listing_is_not_called_unreachable() {
         "a 404 on the listing must be its own verdict, got {outcome:?}"
     );
     drop(handle);
+}
+
+// --- #1782: an unadvertised alias is not a proven absence ---------------------
+//
+// Measured on 2026-08-02 against a local oMLX server: `GET /v1/models` answers
+// 200 with seven ids, none containing `ornith`; `POST /v1/chat/completions`
+// with `model: "ornith-35b"` answers 200 in 3.55 s and echoes that alias back.
+// The alias is routable WITHOUT being advertised, so a listing that omits it
+// proves nothing about whether writes work. The old line said enrichment
+// "will degrade silently for every write until it is fixed" and told the
+// operator to pull the model — an inference stated as a fact, about a
+// configuration that was healthy.
+
+/// The one word the line must not use about a verdict it has not established.
+fn asserts_degradation(line: &str) -> bool {
+    line.contains("will degrade silently")
+}
+
+#[test]
+fn an_unadvertised_alias_is_not_reported_as_a_proven_absence() {
+    let outcome = Reachability::ModelNotAdvertised { listed: 7 };
+    let line = warning_line(
+        "extraction",
+        "http://127.0.0.1:8080",
+        "ornith-35b",
+        &outcome,
+    )
+    .expect("an unadvertised alias is still worth one line");
+
+    assert!(
+        !asserts_degradation(&line),
+        "the line must not assert that enrichment degrades — a listing that \
+         omits an alias proves nothing about routability:\n{line}"
+    );
+    assert!(
+        line.contains("may still be routable"),
+        "the line must say the alias may still be routable, or the operator \
+         reads an omission as a breakage:\n{line}"
+    );
+}
+
+#[test]
+fn a_verdict_that_does_prove_breakage_still_says_so() {
+    // The positive control. Without it, a "fix" that simply stopped warning
+    // would pass the assertions above while making the guard useless.
+    for outcome in [
+        Reachability::Unreachable {
+            detail: "connection refused".to_owned(),
+        },
+        Reachability::Unauthorized,
+    ] {
+        let line = warning_line("extraction", "http://127.0.0.1:8080", "m", &outcome)
+            .expect("a proven breakage must produce a line");
+        assert!(
+            asserts_degradation(&line),
+            "a verdict that DOES establish the backend is unusable must keep \
+             saying enrichment degrades, got:\n{line}"
+        );
+    }
 }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✔️

## Description

The startup probe declared a model **missing** whenever its exact name was not in `GET /v1/models`, then told the operator enrichment *"will degrade silently for every write until it is fixed — pull the model on that server"*. **Both halves were inferences stated as facts.**

### The measurement that establishes it

Local oMLX server, configured model `ornith-35b`:

| check | result |
|---|---|
| `GET /v1/models` | **HTTP 200**, 7 ids, **none** containing `ornith` |
| `POST /v1/chat/completions` with `model: "ornith-35b"` | **HTTP 200 in 3.55 s**, response `model` field is **`ornith-35b`** |

The alias was **routable without being advertised**, enrichment was not degrading, and the line sent someone to repair a configuration that worked.

### The cause

A conflation of two different things: the id a server **advertises**, and the alias it **routes**. The second is not contained in the first.

### What changed

- **`ModelAbsent` → `ModelNotAdvertised`.** The variant name asserted an absence it cannot establish.
- **The line no longer demands a repair**: it says the alias may still be routable, and offers *"no action if the server routes this alias; otherwise name one it lists"*.
- **The consequence clause was shared by every verdict** — that is the deeper defect. `proves_backend_unusable` now splits them: nothing answering, or a refused credential, *does* establish that writes cannot work and keeps the original sentence. An unadvertised alias and an absent listing do not, and now read *"whether graph enrichment works is therefore unconfirmed — this is not proof that it is broken"*. `ListingUnsupported` already phrased itself that way; it was the only verdict that did.

### The probe stays light

Still one `GET /v1/models`, no generation. Confirming an alias would mean asking `/v1/chat/completions`, which pulls a 35-billion-parameter model into memory at startup — the cold-load cost tracked in #1727, and exactly what this module exists to avoid. `/v1/models` is kept as the light signal it is, with a diagnosis that no longer claims more than it proves.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

**Red first.** `an_unadvertised_alias_is_not_reported_as_a_proven_absence` fails to compile before the change (the variant it names does not exist) and asserts the line neither claims degradation nor omits *"may still be routable"*.

**Positive control.** `a_verdict_that_does_prove_breakage_still_says_so` requires `Unreachable` and `Unauthorized` to keep asserting degradation. Without it, a "fix" that simply stopped warning would pass every other assertion here and leave the guard useless.

The existing `the_probe_reads_a_listing_and_never_asks_for_a_generation` still passes, which is what keeps the probe light.

Gates rerun after the last edit, exit codes read without a pipe: `cargo fmt --all -- --check`, `cargo clippy -p velesdb-memory --all-targets --features extract,ollama,persistence -- -D warnings -D clippy::pedantic`, `cargo test -p velesdb-memory` (default), `--features extract,ollama,persistence`, `--features http`, `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown`, `cargo check -p velesdb-memory --no-default-features`, `python3 scripts/check-mcp-doc-contract.py`, `python3 -m unittest discover -s scripts/tests` — **all 0**. `python3 -m lizard -L 50 -C 8 -a 8`: 0 warnings.

**Test Configuration:**
- OS: macOS (darwin 25.5.0)
- Rust version: per `rust-toolchain.toml` (MSRV 1.90)

Closes #1782
