### PR TITLE
Le chemin bulk BM25 ecrit tout le batch sous un seul fsync

### DIFF
--- a/crates/velesdb-core/src/collection/core/bm25_durability_tests.rs
+++ b/crates/velesdb-core/src/collection/core/bm25_durability_tests.rs
@@ -1,0 +1,556 @@
+//! What a document's durability actually depends on, in the BM25 index.
+//!
+//! The bulk write path opens and `sync_all()`s the BM25 WAL once per document
+//! (#1797). Before that is batched into one sync, the consequence of losing an
+//! un-synced entry has to be established by execution rather than assumed,
+//! because it decides what the fix is allowed to trade away.
+//!
+//! Three stores hold overlapping state, and only one of them is canonical:
+//!
+//! * the payload store — canonical, holds the text itself;
+//! * the BM25 snapshot — an O(1) cold-start accelerator (#389);
+//! * the BM25 WAL — the recovery journal covering the delta SINCE that
+//!   snapshot.
+//!
+//! `load_bm25_index` reconstructs the whole index from payloads when the
+//! snapshot is ABSENT, but when a snapshot is present it loads it and replays
+//! the WAL on top — and nothing rebuilds what a lost WAL entry took with it.
+//! These tests pin both halves of that behaviour.
+
+#![cfg(all(test, feature = "persistence"))]
+
+use crate::collection::types::Collection;
+use crate::distance::DistanceMetric;
+use crate::point::Point;
+use serde_json::json;
+use std::path::PathBuf;
+
+const DIM: usize = 4;
+
+/// A collection holding `n` text-bearing documents, ids `1..=n`.
+fn seeded(dir: &tempfile::TempDir, n: u64) -> Collection {
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("collection created");
+    let points: Vec<Point> = (1..=n)
+        .map(|id| {
+            Point::new(
+                id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(json!({ "content": format!("alpha document {id}") })),
+            )
+        })
+        .collect();
+    col.upsert(points).expect("seed");
+    col
+}
+
+/// Whether a text search finds the document with this id.
+fn found(col: &Collection, id: u64) -> bool {
+    col.text_search("alpha", 100)
+        .expect("text search")
+        .iter()
+        .any(|r| r.point.id == id)
+}
+
+/// The BM25 WAL path for a collection directory.
+fn wal_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    crate::index::bm25_persistence_wal::wal_path_for_bm25(dir.path())
+}
+
+/// With no snapshot, the payload store alone restores the whole index.
+///
+/// This is what makes the payload canonical: deleting the WAL outright costs
+/// nothing, because the rebuild path does not consult it.
+#[test]
+fn without_a_snapshot_the_payloads_rebuild_the_index_even_with_no_wal() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = seeded(&dir, 3);
+        assert!(found(&col, 3), "seeded document must be searchable");
+    }
+    // No flush() -> no snapshot was written. Remove the WAL entirely.
+    let wal = wal_path(&dir);
+    if wal.exists() {
+        std::fs::remove_file(&wal).expect("remove wal");
+    }
+
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen");
+    for id in 1..=3 {
+        assert!(
+            found(&reopened, id),
+            "document {id} must be rebuilt from payload storage when no snapshot exists"
+        );
+    }
+}
+
+/// With a snapshot, a lost WAL entry is NOT rebuilt — the document stays in the
+/// payload store but disappears from text search.
+///
+/// This is the behaviour the batched fix must not make reachable for
+/// acknowledged writes. It is pinned here as the engine's current contract, not
+/// endorsed: the data is recoverable in principle (the payload still holds the
+/// text) but nothing recovers it automatically, and no public primitive asks
+/// for a rebuild.
+#[test]
+fn with_a_snapshot_a_lost_wal_entry_is_not_rebuilt_from_payloads() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = seeded(&dir, 2);
+        // `flush()` does NOT persist BM25 — only `flush_full()` reaches
+        // `flush_derived_indexes` -> `flush_bm25_index`, which writes the
+        // snapshot and truncates the WAL. Using the wrong one silently leaves
+        // no snapshot, and the reopen then rebuilds from payloads and hides
+        // exactly the behaviour under test.
+        col.flush_full()
+            .expect("full flush writes the BM25 snapshot");
+        assert!(
+            crate::index::bm25_persistence::snapshot_path(dir.path()).exists(),
+            "the snapshot must exist, or this test proves nothing about the \
+             snapshot-present branch"
+        );
+
+        // This third document lands in the WAL, after the snapshot.
+        col.upsert(vec![Point::new(
+            3,
+            vec![1.0, 0.0, 0.0, 0.0],
+            Some(json!({ "content": "alpha document 3" })),
+        )])
+        .expect("post-snapshot write");
+        assert!(found(&col, 3), "document 3 is searchable before the loss");
+    }
+
+    // Simulate the loss of an un-synced WAL: drop the post-snapshot delta.
+    let wal = wal_path(&dir);
+    assert!(wal.exists(), "a post-snapshot write must have left a WAL");
+    std::fs::remove_file(&wal).expect("remove wal");
+
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen");
+
+    // The snapshot half survives.
+    for id in 1..=2 {
+        assert!(
+            found(&reopened, id),
+            "document {id} was in the snapshot and must survive"
+        );
+    }
+    // The WAL half does not, and is not rebuilt.
+    assert!(
+        !found(&reopened, 3),
+        "a snapshot short-circuits the payload rebuild, so a lost WAL entry stays \
+         lost to text search — if this now passes, the engine gained an automatic \
+         reconciliation and #1797's durability argument must be re-stated"
+    );
+
+    // But the text itself was never lost: the payload store still has it. That
+    // is what makes this recoverable in principle rather than data loss.
+    let payload = reopened
+        .get(&[3])
+        .into_iter()
+        .next()
+        .flatten()
+        .and_then(|p| p.payload)
+        .expect("document 3 is still in the payload store");
+    assert_eq!(
+        payload.get("content").and_then(serde_json::Value::as_str),
+        Some("alpha document 3"),
+        "the payload store is canonical and must still carry the text"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The structural claim: one batch, one durability barrier
+// ---------------------------------------------------------------------------
+
+/// A bulk insert of N text-bearing documents must cost ONE BM25 WAL sync.
+///
+/// Counted at the syscall, not timed: the claim is about how many durability
+/// barriers a batch takes, and a stopwatch would only measure this machine's
+/// SSD. `count_wal_io` filters on the BM25 context, so the graph edge WAL —
+/// which shares the same framing helpers — cannot inflate the numbers.
+///
+/// Before the fix this fails with N opens / N flushes / N syncs, because
+/// `bulk_store_payloads_inner` calls `update_text_index` per point and each
+/// call opens the WAL, writes one frame and `sync_all()`s it.
+#[test]
+fn bulk_text_documents_use_one_wal_sync() {
+    const N: u64 = 8;
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("collection created");
+    let points: Vec<Point> = (1..=N)
+        .map(|id| {
+            Point::new(
+                id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(json!({ "content": format!("alpha document {id}") })),
+            )
+        })
+        .collect();
+
+    let (written, counts) = counted_on(&dir, || col.upsert_bulk(&points));
+    assert_eq!(
+        written.expect("bulk upsert"),
+        usize::try_from(N).expect("fits"),
+        "the batch must actually have been written"
+    );
+
+    assert_eq!(
+        counts.syncs, 1,
+        "a batch of {N} documents took {} fsyncs on the BM25 WAL; one batch is \
+         one durability barrier, and a per-document fsync is what caps bulk \
+         text insertion at roughly one fsync per point",
+        counts.syncs
+    );
+    assert_eq!(
+        counts.opens, 1,
+        "a batch of {N} documents opened the BM25 WAL {} times; the append path \
+         must open it once per batch",
+        counts.opens
+    );
+    assert_eq!(
+        counts.flushes, 1,
+        "a batch of {N} documents flushed the BM25 WAL {} times",
+        counts.flushes
+    );
+
+    // The batching must not have cost the documents themselves.
+    for id in 1..=N {
+        assert!(
+            found(&col, id),
+            "document {id} must be searchable after the batch"
+        );
+    }
+}
+
+/// Points carrying `content`, ids `1..=n`.
+fn text_points(n: u64) -> Vec<Point> {
+    (1..=n)
+        .map(|id| {
+            Point::new(
+                id,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(json!({ "content": format!("alpha document {id}") })),
+            )
+        })
+        .collect()
+}
+
+/// Counts the BM25 WAL syscalls a closure performs.
+fn counted_on<T>(
+    dir: &tempfile::TempDir,
+    f: impl FnOnce() -> T,
+) -> (T, crate::index::wal_framing::io_counters::WalIoCounts) {
+    crate::index::wal_framing::io_counters::count_wal_io(&wal_path(dir), f)
+}
+
+#[test]
+fn bulk_text_documents_are_searchable_after_reopen() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+            .expect("created");
+        col.upsert_bulk(&text_points(5)).expect("bulk");
+        col.flush_full().expect("full flush");
+    }
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen");
+    for id in 1..=5 {
+        assert!(found(&reopened, id), "document {id} must survive a reopen");
+    }
+}
+
+/// Every document of an ACKNOWLEDGED batch is recoverable from the WAL alone.
+///
+/// The snapshot is written first and the batch lands after it, so the reopen
+/// takes the snapshot + WAL-replay branch — the branch that does NOT fall back
+/// to a payload rebuild. What is proven here is therefore the WAL's own
+/// contribution, not the payload store's.
+#[test]
+fn every_acknowledged_document_survives_reopen() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+            .expect("created");
+        col.upsert_bulk(&text_points(2)).expect("first batch");
+        col.flush_full().expect("snapshot");
+        assert!(
+            crate::index::bm25_persistence::snapshot_path(dir.path()).exists(),
+            "the snapshot must exist for this to test the WAL branch"
+        );
+        // Acknowledged after the snapshot: only the WAL carries these.
+        let later: Vec<Point> = (3..=6)
+            .map(|id| {
+                Point::new(
+                    id,
+                    vec![1.0, 0.0, 0.0, 0.0],
+                    Some(json!({ "content": format!("alpha document {id}") })),
+                )
+            })
+            .collect();
+        col.upsert_bulk(&later).expect("acknowledged batch");
+    }
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen");
+    for id in 1..=6 {
+        assert!(
+            found(&reopened, id),
+            "document {id} was acknowledged and must be recoverable"
+        );
+    }
+}
+
+/// A WAL failure returns `Err` AND leaves the in-memory index untouched.
+///
+/// This is the ordering claim the counters cannot make. The WAL path is broken
+/// by putting a DIRECTORY where `bm25.wal` belongs, so opening it for append
+/// fails deterministically on any platform — no fault-injection hooks, no
+/// timing. If the index were mutated before the durability barrier, the search
+/// below would find the documents even though nothing was acknowledged.
+#[test]
+fn a_wal_failure_is_propagated_and_leaves_the_index_untouched() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("created");
+    std::fs::create_dir(wal_path(&dir)).expect("obstruct the WAL path with a directory");
+
+    let result = col.upsert_bulk(&text_points(4));
+
+    assert!(
+        result.is_err(),
+        "a WAL that cannot be written must not be reported as success"
+    );
+    for id in 1..=4 {
+        assert!(
+            !found(&col, id),
+            "document {id} was never acknowledged, so it must not be in the \
+             in-memory index — mutating memory before the fsync would make an \
+             unacknowledged batch visible and unrecoverable"
+        );
+    }
+}
+
+/// A batch with no indexable text writes nothing to the BM25 WAL.
+#[test]
+fn payload_without_text_does_not_write_the_bm25_wal() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("created");
+    let numeric: Vec<Point> = (1..=4)
+        .map(|id| Point::new(id, vec![1.0, 0.0, 0.0, 0.0], Some(json!({ "n": id }))))
+        .collect();
+
+    let (res, counts) = counted_on(&dir, || col.upsert_bulk(&numeric));
+    res.expect("bulk");
+
+    assert_eq!(
+        counts.syncs, 0,
+        "a payload with no indexable string must not reach the BM25 WAL"
+    );
+    assert!(
+        !wal_path(&dir).exists(),
+        "no BM25 WAL file should have been created at all"
+    );
+}
+
+/// An empty batch does not touch the WAL.
+#[test]
+fn empty_batch_does_not_touch_the_wal() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("created");
+
+    let (res, counts) = counted_on(&dir, || col.upsert_bulk(&[]));
+    assert_eq!(res.expect("empty bulk"), 0);
+
+    assert_eq!(counts.opens, 0, "an empty batch must not open the WAL");
+    assert_eq!(counts.syncs, 0, "an empty batch must not fsync");
+    assert!(!wal_path(&dir).exists(), "no WAL file for an empty batch");
+}
+
+/// The single-document path keeps its per-call durability contract.
+///
+/// The fix batches the BULK path; it must not silently weaken `upsert`, whose
+/// callers get one durability barrier per call.
+#[test]
+fn single_document_path_keeps_its_contract() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("created");
+
+    let (res, counts) = counted_on(&dir, || col.upsert(text_points(3)));
+    res.expect("upsert");
+
+    assert_eq!(
+        counts.syncs, 3,
+        "the single-document path still fsyncs per document; batching the bulk \
+         path must not have changed it"
+    );
+}
+
+/// Re-indexing an existing id keeps the last text, as before.
+#[test]
+fn duplicate_document_updates_keep_existing_semantics() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+        .expect("created");
+
+    col.upsert_bulk(&[Point::new(
+        1,
+        vec![1.0, 0.0, 0.0, 0.0],
+        Some(json!({ "content": "alpha original" })),
+    )])
+    .expect("first");
+    col.upsert_bulk(&[Point::new(
+        1,
+        vec![1.0, 0.0, 0.0, 0.0],
+        Some(json!({ "content": "beta replacement" })),
+    )])
+    .expect("second");
+
+    let beta = col.text_search("beta", 10).expect("search");
+    assert!(
+        beta.iter().any(|r| r.point.id == 1),
+        "the replacement text must be searchable"
+    );
+}
+
+/// A torn final frame does not cost the complete frames written before it.
+#[test]
+fn a_truncated_final_frame_preserves_prior_complete_frames() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
+            .expect("created");
+        col.upsert_bulk(&text_points(2)).expect("seed");
+        col.flush_full().expect("snapshot");
+        // These land in the WAL, in one batch, as complete frames.
+        let later: Vec<Point> = (3..=5)
+            .map(|id| {
+                Point::new(
+                    id,
+                    vec![1.0, 0.0, 0.0, 0.0],
+                    Some(json!({ "content": format!("alpha document {id}") })),
+                )
+            })
+            .collect();
+        col.upsert_bulk(&later).expect("batch");
+    }
+
+    // Tear the tail: drop the last few bytes, leaving a partial final frame.
+    let wal = wal_path(&dir);
+    let len = std::fs::metadata(&wal).expect("wal metadata").len();
+    assert!(len > 8, "the WAL must hold several frames to be torn");
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&wal)
+        .expect("open wal");
+    file.set_len(len - 3).expect("truncate the final frame");
+
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen despite a torn tail");
+    for id in 1..=2 {
+        assert!(found(&reopened, id), "snapshot document {id} must survive");
+    }
+    assert!(
+        found(&reopened, 3),
+        "a complete frame written before the torn one must still replay"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Throughput of the bulk text path (#1797), measured — not asserted from theory
+// ---------------------------------------------------------------------------
+
+/// Bulk text insertion throughput across dimensions, volumes and batch sizes.
+///
+/// `#[ignore]`d: it writes tens of thousands of documents and takes minutes.
+/// Run deliberately, on a machine at rest, in `--release`, single-threaded —
+/// the sync counts are only exact when nothing else writes a BM25 WAL:
+///
+/// ```text
+/// cargo test --release -p velesdb-core --lib bm25_batch_throughput \
+///   -- --ignored --nocapture --test-threads=1
+/// ```
+///
+/// The same body is run before and after the fix (by temporarily restoring the
+/// per-document call in `bulk_store_payloads_inner`), so the two columns are
+/// produced by identical measurement code on the same machine.
+#[test]
+#[ignore = "writes tens of thousands of documents; run deliberately, on a machine at rest"]
+fn bm25_batch_throughput() {
+    for dim in [4usize, 1024] {
+        for volume in [1_000u64, 4_000, 16_000] {
+            for batch in [1usize, 64, 256, 1024] {
+                let dir = tempfile::tempdir().expect("temp dir");
+                let col =
+                    Collection::create(PathBuf::from(dir.path()), dim, DistanceMetric::Cosine)
+                        .expect("created");
+                let points: Vec<Point> = (1..=volume)
+                    .map(|id| {
+                        Point::new(
+                            id,
+                            vec![1.0; dim],
+                            Some(json!({ "content": format!("alpha document {id}") })),
+                        )
+                    })
+                    .collect();
+
+                let start = std::time::Instant::now();
+                let ((), counts) = counted_on(&dir, || {
+                    for chunk in points.chunks(batch) {
+                        col.upsert_bulk(chunk).expect("bulk");
+                    }
+                });
+                let elapsed = start.elapsed();
+
+                let micros =
+                    u32::try_from(elapsed.as_micros()).map_or(f64::from(u32::MAX), f64::from);
+                let per_doc = micros / f64::from(u32::try_from(volume).expect("fits"));
+                println!(
+                    "  dim={dim:<5} n={volume:<6} batch={batch:<5} {elapsed:>10.2?} \
+                     {per_doc:>9.1} us/doc {:>9.0} doc/s  opens={:<6} flushes={:<6} syncs={}",
+                    1_000_000.0 / per_doc,
+                    counts.opens,
+                    counts.flushes,
+                    counts.syncs
+                );
+            }
+        }
+    }
+}
+
+/// The same store, reopened, still answers — checked once at a realistic
+/// dimension so the throughput table above cannot be green on a broken index.
+#[test]
+#[ignore = "writes 4 000 documents at dimension 1024"]
+fn bm25_batch_throughput_survives_reopen() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    {
+        let col = Collection::create(PathBuf::from(dir.path()), 1024, DistanceMetric::Cosine)
+            .expect("created");
+        let points: Vec<Point> = (1..=4_000)
+            .map(|id| {
+                Point::new(
+                    id,
+                    vec![1.0; 1024],
+                    // A token unique to each document: searching for the shared
+                    // word would only return the top-k of 4 000 equal matches,
+                    // and a document outside that window would look lost when
+                    // it is merely outranked.
+                    Some(json!({ "content": format!("alpha doc{id} document") })),
+                )
+            })
+            .collect();
+        for chunk in points.chunks(1024) {
+            col.upsert_bulk(chunk).expect("bulk");
+        }
+        col.flush_full().expect("full flush");
+    }
+    let reopened = Collection::open(PathBuf::from(dir.path())).expect("reopen");
+    for id in [1u64, 2_000, 4_000] {
+        let hits = reopened
+            .text_search(&format!("doc{id}"), 10)
+            .expect("text search");
+        assert!(
+            hits.iter().any(|r| r.point.id == id),
+            "document {id} must survive the reopen"
+        );
+    }
+}

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -292,13 +292,17 @@ impl Collection {
         }
 
         // Issue #425: BM25 skip — when no point has a payload AND the BM25
-        // index is empty, skip the text index loop entirely. The bulk path
-        // inserts fresh points (no old documents to remove), so the loop
-        // body would be a no-op for every point.
+        // index is empty, skip the text index work entirely. The bulk path
+        // inserts fresh points (no old documents to remove), so it would be a
+        // no-op for every point.
+        //
+        // Issue #1797: this used to call `update_text_index` PER POINT, and
+        // that helper opens the BM25 WAL, writes one frame and `sync_all()`s it
+        // on every call — one durability barrier per document, which capped
+        // bulk insertion of text-bearing points at roughly one fsync each. The
+        // batch below writes every frame under a single open + flush + fsync.
         if !entries.is_empty() || !self.storage.text_index.is_empty() {
-            for point in points {
-                self.update_text_index(point)?;
-            }
+            self.bulk_update_text_index(points)?;
         }
 
         // Issue #486: Update label index for bulk-inserted points.

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -158,6 +158,97 @@ impl Collection {
         Ok(())
     }
 
+    /// Applies the BM25 side of a whole batch under ONE durability barrier.
+    ///
+    /// The batched counterpart of [`Self::update_text_index`]. Calling that per
+    /// point is what cost one `open` and one `fsync` PER DOCUMENT (#1797); here
+    /// every frame goes into a single `wal_append_batch` call.
+    ///
+    /// # The three cases a mixed batch contains
+    ///
+    /// Classified explicitly rather than folded together, because they are not
+    /// the same operation and the single-point path distinguishes them:
+    ///
+    /// * payload carrying text → an `Add` frame;
+    /// * payload with NO text  → nothing at all, no WAL entry (empty text is
+    ///   not indexed, matching [`Self::update_text_index`]);
+    /// * no payload at all     → a `Remove` frame, preserving delete semantics.
+    ///
+    /// # Ordering
+    ///
+    /// WAL-before-apply, at BATCH granularity: every frame is written and
+    /// fsynced first, and the in-memory index is touched only once that
+    /// succeeded. A WAL failure returns `Err` with the index untouched — never
+    /// partially updated for a batch that was never acknowledged, which matters
+    /// because a lost WAL entry is NOT rebuilt when a BM25 snapshot exists.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any WAL open / write / flush / fsync failure.
+    pub(super) fn bulk_update_text_index(&self, points: &[Point]) -> Result<()> {
+        let (adds, removes) = Self::classify_text_mutations(points);
+        if adds.is_empty() && removes.is_empty() {
+            return Ok(());
+        }
+        self.append_text_batch_to_wal(&adds, &removes)?;
+
+        // Only now is the batch durable, so only now does memory change.
+        for (id, text) in &adds {
+            self.storage.text_index.add_document(*id, text);
+        }
+        for id in &removes {
+            self.storage.text_index.remove_document(*id);
+        }
+        Ok(())
+    }
+
+    /// Splits a batch into the BM25 mutations it implies.
+    ///
+    /// The three cases stay separate here rather than being decided inline, so
+    /// that "a payload with no indexable string writes nothing" is a visible
+    /// decision and not an accident of control flow.
+    fn classify_text_mutations(points: &[Point]) -> (Vec<(u64, String)>, Vec<u64>) {
+        let mut adds: Vec<(u64, String)> = Vec::new();
+        let mut removes: Vec<u64> = Vec::new();
+        for point in points {
+            if let Some(payload) = &point.payload {
+                let text = Self::extract_text_from_payload(payload);
+                if !text.is_empty() {
+                    adds.push((point.id, text));
+                }
+            } else {
+                removes.push(point.id);
+            }
+        }
+        (adds, removes)
+    }
+
+    /// Writes the whole batch to the BM25 WAL under one durability barrier.
+    ///
+    /// Non-persistence builds have no on-disk WAL, so this is a no-op there and
+    /// the caller proceeds straight to the in-memory update.
+    #[allow(clippy::unused_self)] // Reason: needs `self.storage.path` under `persistence`.
+    fn append_text_batch_to_wal(&self, adds: &[(u64, String)], removes: &[u64]) -> Result<()> {
+        #[cfg(feature = "persistence")]
+        {
+            use crate::index::bm25_persistence_wal::{wal_append_batch, wal_path_for_bm25, WalOp};
+            let ops: Vec<WalOp<'_>> = adds
+                .iter()
+                .map(|(id, text)| WalOp::Add {
+                    id: *id,
+                    text: text.as_str(),
+                })
+                .chain(removes.iter().map(|id| WalOp::Remove { id: *id }))
+                .collect();
+            wal_append_batch(&wal_path_for_bm25(&self.storage.path), &ops)?;
+        }
+        #[cfg(not(feature = "persistence"))]
+        {
+            let _ = (adds, removes);
+        }
+        Ok(())
+    }
+
     /// Appends an `add_document` mutation to the BM25 WAL.
     ///
     /// Feature-gated — non-persistence builds have no on-disk WAL.

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -6,6 +6,8 @@
 //! - Index management: `create_property_index`, `create_range_index`,
 //!   `list_indexes`, `drop_index`
 
+#[cfg(all(test, feature = "persistence"))]
+mod bm25_durability_tests;
 mod bulk_import;
 mod crud;
 mod crud_bulk;

--- a/crates/velesdb-core/src/collection/graph/edge_wal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_wal.rs
@@ -74,7 +74,7 @@ pub(crate) fn wal_path_for_edges(dir: &Path) -> PathBuf {
 pub(crate) fn wal_append_add(wal_path: &Path, edge: &GraphEdge) -> Result<()> {
     let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
     write_add_entry(&mut w, edge)?;
-    wal_framing::flush_wal(&mut w, CTX)
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
 }
 
 /// Appends multiple `add_edge` mutations to the edge WAL with a single
@@ -92,7 +92,7 @@ pub(crate) fn wal_append_add_batch(wal_path: &Path, edges: &[GraphEdge]) -> Resu
     for edge in edges {
         write_add_entry(&mut w, edge)?;
     }
-    wal_framing::flush_wal(&mut w, CTX)
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
 }
 
 /// Serializes `edge` and writes a length-prefixed ADD entry.
@@ -147,7 +147,7 @@ fn append_id_entry(wal_path: &Path, op: u8, id: u64) -> Result<()> {
     wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
     wal_framing::wal_write(&mut w, &[op], CTX)?;
     wal_framing::wal_write(&mut w, &id.to_le_bytes(), CTX)?;
-    wal_framing::flush_wal(&mut w, CTX)
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
 }
 
 /// Truncates the edge WAL file to zero length.

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -35,7 +35,7 @@ use crate::index::bm25::Bm25Index;
 use crate::index::wal_framing;
 
 /// Error-message context prefix for the shared framing helpers.
-const CTX: &str = "BM25 WAL";
+pub(crate) const CTX: &str = "BM25 WAL";
 
 const WAL_OP_ADD: u8 = 0x01;
 const WAL_OP_REMOVE: u8 = 0x02;
@@ -77,7 +77,7 @@ pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> R
     let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
     wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
     write_add_entry_body(&mut w, id, text_len, text_bytes)?;
-    wal_framing::flush_wal(&mut w, CTX)
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
 }
 
 /// Validates that `text_bytes.len()` fits in a `u32` and returns the cast.
@@ -123,6 +123,88 @@ fn write_add_entry_body(
     wal_framing::wal_write(w, text_bytes, CTX)
 }
 
+/// One BM25 mutation, as a batch carries it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WalOp<'a> {
+    /// Index `text` under `id`.
+    Add {
+        /// Point the text belongs to.
+        id: u64,
+        /// Text to index. An empty text is not a valid batch entry — callers
+        /// drop those before building the batch, matching the single-document
+        /// path, which does not write a WAL entry for empty text either.
+        text: &'a str,
+    },
+    /// Drop `id` from the index.
+    Remove {
+        /// Point to drop.
+        id: u64,
+    },
+}
+
+/// Appends a whole batch of mutations to the BM25 WAL under ONE fsync.
+///
+/// This is the batched counterpart of [`wal_append_add_document`] /
+/// [`wal_append_remove_document`], and it exists because calling those in a
+/// loop is what made bulk insertion cost one `open` + one `fsync` PER DOCUMENT
+/// (#1797): a batch of N text-bearing points paid N durability barriers where
+/// one is enough.
+///
+/// The on-disk format is untouched. Each entry is written with exactly the same
+/// length-prefixed framing the single-document path produces, so the bytes are
+/// byte-for-byte what N sequential appends would have written, and
+/// [`wal_replay`] needs no change. Only the number of syscalls differs.
+///
+/// # Durability
+///
+/// The single `flush` + `sync_all` happens AFTER every frame is written and
+/// BEFORE this function returns. Callers must therefore keep the WAL-before-
+/// apply ordering at BATCH granularity: write the batch, let this return `Ok`,
+/// and only then mutate the in-memory index. An error here means nothing was
+/// acknowledged, so nothing may be applied — a partially applied index would be
+/// unrecoverable, since a lost WAL entry is not rebuilt when a snapshot exists.
+///
+/// An empty batch does not touch the WAL at all: no file is created.
+///
+/// # Errors
+///
+/// Returns [`Error::Index`] if the WAL cannot be opened, if any frame cannot be
+/// written, or if the final flush/fsync fails.
+pub(crate) fn wal_append_batch(wal_path: &Path, ops: &[WalOp<'_>]) -> Result<()> {
+    if ops.is_empty() {
+        return Ok(());
+    }
+    let mut w = wal_framing::open_wal_writer(wal_path, CTX)?;
+    for op in ops {
+        write_op_frame(&mut w, *op)?;
+    }
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
+}
+
+/// Writes ONE framed entry for `op`, without flushing.
+///
+/// Extracted from [`wal_append_batch`] to keep its cyclomatic complexity under
+/// the repository limit, and because the framing of a single entry is exactly
+/// what must stay identical to the single-document path.
+fn write_op_frame(w: &mut std::io::BufWriter<std::fs::File>, op: WalOp<'_>) -> Result<()> {
+    match op {
+        WalOp::Add { id, text } => {
+            let text_bytes = text.as_bytes();
+            let text_len = encode_text_len(text_bytes)?;
+            let body_len = add_entry_body_len(text_len)?;
+            wal_framing::wal_write(w, &body_len.to_le_bytes(), CTX)?;
+            write_add_entry_body(w, id, text_len, text_bytes)
+        }
+        WalOp::Remove { id } => {
+            let body_len = u32::try_from(REMOVE_ENTRY_HEADER)
+                .map_err(|_| Error::Index("BM25 WAL: remove header too large".to_string()))?;
+            wal_framing::wal_write(w, &body_len.to_le_bytes(), CTX)?;
+            wal_framing::wal_write(w, &[WAL_OP_REMOVE], CTX)?;
+            wal_framing::wal_write(w, &id.to_le_bytes(), CTX)
+        }
+    }
+}
+
 /// Appends a `remove_document(id)` mutation to the BM25 WAL.
 ///
 /// Callers MUST invoke this BEFORE applying the mutation in-memory
@@ -140,7 +222,7 @@ pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()>
     wal_framing::wal_write(&mut w, &body_len.to_le_bytes(), CTX)?;
     wal_framing::wal_write(&mut w, &[WAL_OP_REMOVE], CTX)?;
     wal_framing::wal_write(&mut w, &id.to_le_bytes(), CTX)?;
-    wal_framing::flush_wal(&mut w, CTX)
+    wal_framing::flush_wal(&mut w, wal_path, CTX)
 }
 
 /// Truncates the BM25 WAL file to zero length.

--- a/crates/velesdb-core/src/index/wal_framing.rs
+++ b/crates/velesdb-core/src/index/wal_framing.rs
@@ -28,6 +28,8 @@ pub(crate) fn open_wal_writer(wal_path: &Path, context: &str) -> Result<BufWrite
         .append(true)
         .open(wal_path)
         .map_err(|e| Error::Index(format!("{context} open: {e}")))?;
+    #[cfg(test)]
+    io_counters::record_open(wal_path, context);
     Ok(BufWriter::new(file))
 }
 
@@ -50,12 +52,22 @@ pub(crate) fn wal_write(
 /// # Errors
 ///
 /// Returns [`Error::Index`] if the flush or fsync fails.
-pub(crate) fn flush_wal(w: &mut BufWriter<std::fs::File>, context: &str) -> Result<()> {
+pub(crate) fn flush_wal(
+    w: &mut BufWriter<std::fs::File>,
+    wal_path: &Path,
+    context: &str,
+) -> Result<()> {
     w.flush()
         .map_err(|e| Error::Index(format!("{context} flush: {e}")))?;
+    #[cfg(test)]
+    io_counters::record_flush(wal_path, context);
     w.get_ref()
         .sync_all()
-        .map_err(|e| Error::Index(format!("{context} fsync: {e}")))
+        .map_err(|e| Error::Index(format!("{context} fsync: {e}")))?;
+    #[cfg(test)]
+    io_counters::record_sync(wal_path, context);
+    let _ = wal_path;
+    Ok(())
 }
 
 /// Truncates the WAL file to zero length. A missing file is a no-op.
@@ -86,4 +98,128 @@ pub(crate) fn read_entry_header(data: &[u8], pos: usize, context: &str) -> Optio
     let bytes: [u8; 4] = data[pos..pos + 4].try_into().ok()?;
     let body_len = u32::from_le_bytes(bytes) as usize;
     Some((pos + 4, body_len))
+}
+
+/// Test-only counters for the WAL syscalls this module performs.
+///
+/// They exist to prove a batching claim structurally rather than by timing:
+/// "N documents cost one open, one flush and one fsync" is a statement about
+/// syscalls, and asserting it on a stopwatch would be an SSD benchmark, not a
+/// proof.
+///
+/// # Why thread-local, and why `#[cfg(test)]`
+///
+/// A process-global counter is unusable here: the lib test binary holds well
+/// over a thousand tests that reach this module through `upsert` / `add_edge`,
+/// and CI runs them single-threaded (`--test-threads=1`) while a local
+/// `cargo test` does not. A global would therefore be green on CI and flaky
+/// locally. Per-thread `Cell`s scope the count to the code under test — the
+/// same reasoning `alloc_guard` already applies to its own scoped state.
+///
+/// `#[cfg(test)]` keeps every byte of this out of non-test builds, and
+/// `wal_framing` is `pub(crate)`, so none of it can reach the public API.
+///
+/// # What these counts do and do not prove
+///
+/// They prove batching. They do NOT prove durability ordering: that the fsync
+/// happened before `Ok` was returned, and before the in-memory index was
+/// mutated, is a separate claim needing a separate test.
+///
+/// Two further limits, stated rather than glossed:
+///
+/// * [`wal_truncate`] opens the file through its own `OpenOptions`, so it is
+///   invisible here. These are counts of the APPEND path, not of every open.
+/// * The counters only observe the calling thread. That is sound for the bulk
+///   payload path, which walks its points sequentially, and a future
+///   parallelisation would make the assertion fail loudly rather than silently.
+#[cfg(test)]
+pub(crate) mod io_counters {
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Mutex, MutexGuard};
+
+    static OPENS: AtomicU32 = AtomicU32::new(0);
+    static FLUSHES: AtomicU32 = AtomicU32::new(0);
+    static SYNCS: AtomicU32 = AtomicU32::new(0);
+    static WATCH: Mutex<Option<PathBuf>> = Mutex::new(None);
+    static SERIALISE: Mutex<()> = Mutex::new(());
+
+    /// Successful WAL syscalls observed on one WAL file.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct WalIoCounts {
+        /// Appends that opened the file.
+        pub opens: u32,
+        /// Buffer flushes that succeeded.
+        pub flushes: u32,
+        /// `sync_all` calls that succeeded — the durability barriers.
+        pub syncs: u32,
+    }
+
+    /// Whether this exact WAL file is the one under observation.
+    ///
+    /// Filtering on the PATH, not merely on the `context`, is what makes these
+    /// counts safe under `cargo test`'s default parallelism: every test writes
+    /// into its own temporary directory, so a neighbouring test indexing its own
+    /// documents cannot inflate the numbers. Filtering on the context alone left
+    /// the counters shared by every BM25 WAL in the process, which made the
+    /// assertions pass single-threaded and fail in parallel.
+    fn watched(wal_path: &Path) -> bool {
+        WATCH
+            .lock()
+            .map(|w| w.as_deref() == Some(wal_path))
+            .unwrap_or(false)
+    }
+
+    pub(super) fn record_open(wal_path: &Path, _context: &str) {
+        if watched(wal_path) {
+            OPENS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn record_flush(wal_path: &Path, _context: &str) {
+        if watched(wal_path) {
+            FLUSHES.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn record_sync(wal_path: &Path, _context: &str) {
+        if watched(wal_path) {
+            SYNCS.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Disarms the watch even if the observed closure panics.
+    struct Watch<'a>(#[allow(dead_code)] MutexGuard<'a, ()>);
+
+    impl Drop for Watch<'_> {
+        fn drop(&mut self) {
+            if let Ok(mut w) = WATCH.lock() {
+                *w = None;
+            }
+        }
+    }
+
+    /// Runs `f`, counting the WAL syscalls it performs on `wal_path`.
+    ///
+    /// Counts are taken AFTER each syscall succeeds, so a failed open or fsync
+    /// is not counted: what is measured is durable work, not attempts.
+    pub(crate) fn count_wal_io<T>(wal_path: &Path, f: impl FnOnce() -> T) -> (T, WalIoCounts) {
+        let guard = SERIALISE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Ok(mut w) = WATCH.lock() {
+            *w = Some(wal_path.to_path_buf());
+        }
+        OPENS.store(0, Ordering::Relaxed);
+        FLUSHES.store(0, Ordering::Relaxed);
+        SYNCS.store(0, Ordering::Relaxed);
+        let _watch = Watch(guard);
+        let out = f();
+        let counts = WalIoCounts {
+            opens: OPENS.load(Ordering::Relaxed),
+            flushes: FLUSHES.load(Ordering::Relaxed),
+            syncs: SYNCS.load(Ordering::Relaxed),
+        };
+        (out, counts)
+    }
 }


### PR DESCRIPTION
## Symptome

Toute insertion bulk portant du texte etait plafonnee a environ 290 documents/s,
alors que `upsert_bulk` annonce « 25-30 Kvec/s on 768D vectors ». Mesure initiale
en `--release`, n = 2 000, batch = 1 024, dimension 4 :

| forme du payload                       | cout          | ce qui s'execute          |
|----------------------------------------|---------------|---------------------------|
| textuel complet (`content`+`project`)   | 3 457,8 us/pt | `store_batch` + WAL BM25  |
| textuel reduit (sans `content`)         | 3 418,7 us/pt | idem                      |
| uniquement numerique (aucune chaine)    | 15,1 us/pt    | `store_batch` seul        |
| sans payload                            | 10,2 us/pt    | ni l'un ni l'autre        |

Le stockage du payload coute ~5 us par point ; le WAL BM25 ~3 403, soit **99,6 %
du total**.

## Ce que ce n'etait pas

Trois hypotheses ont ete refutees par la mesure avant de trouver la cause, et
elles sont consignees pour qu'on ne les repropose pas :

1. **La couche `AgentMemory`** — non : `upsert` avec un batch de 1 coute
   12 267 us/point contre 12 058 pour `store_with_metadata`, et pour cause,
   c'est le meme appel.
2. **Un HNSW degenere par des vecteurs identiques** — non : vecteurs identiques
   3 474,5 us/point contre vecteurs distincts 3 479,0, ratio 1,00.
3. **Le profil debug** — non : `--release` ne gagne que ~6 %.

Un cout insensible a l'optimisation n'est pas du calcul, c'est de l'attente
d'entree/sortie. ~3,4 ms correspond a un `fsync` sur SSD.

Une precision de methode : la variante « sans payload » n'attribue rien a elle
seule, car le garde `crud_bulk.rs:298` saute aussi la boucle d'indexation quand
`entries` est vide. C'est la variante purement numerique qui isole le WAL BM25,
`extract_text` collectant recursivement **toutes** les chaines du payload.

## Mecanisme

```
bulk_store_payloads_inner        collection/core/crud_bulk.rs:299
  -> boucle sur les points
  -> update_text_index(point)    collection/core/crud_indexing.rs:150
  -> wal_append_add_document     index/bm25_persistence_wal.rs:72
     -> open_wal_writer                              (ouverture du fichier)
     -> ecriture de la trame
     -> flush_wal                index/wal_framing.rs:53
        -> flush() puis sync_all()                   (fsync reel)
```

## Cause racine

Le chemin bulk appelait une primitive WAL **unitaire** dans une boucle sur les
documents. Le chemin prend pourtant soin de ne faire qu'un seul WAL sync pour
les payloads et un seul flush pour les vecteurs — puis retombe sur une ouverture
et un fsync par point pour l'index texte.

## Correctif de cause

La structure elle-meme est supprimee. Avant :

```
pour chaque document :  ouvrir le WAL, ecrire, flush, sync
```

Apres :

```
ouvrir le WAL une fois
pour chaque document : ecrire une trame complete, au format inchange
flush une fois
sync_all une fois
puis seulement appliquer le batch a l'index BM25 en memoire
```

Deux changements :

- `wal_append_batch(wal_path, ops)` (`index/bm25_persistence_wal.rs`), interne au
  crate, ecrit toutes les trames sous un seul open + flush + fsync. Le format
  n'est pas touche : chaque trame est produite par les memes helpers que le
  chemin unitaire, donc les octets sont ceux que N appels sequentiels auraient
  ecrits et `wal_replay` est inchange.
- `bulk_update_text_index(points)` (`collection/core/crud_indexing.rs`) remplace
  la boucle. Il classe explicitement les trois cas qu'un batch mixte contient :
  payload avec texte → trame `Add` ; payload sans texte → rien du tout ; absence
  de payload → trame `Remove`, semantique de suppression conservee.

Le chemin unitaire `update_text_index` est conserve tel quel, avec son contrat
d'un fsync par appel.

## Invariants preserves

- **Format WAL inchange** — trames auto-delimitees `[body_len][op][id][len][texte]`.
- **Replay inchange** — une trame finale tronquee reste toleree (warn + arret),
  un opcode inconnu reste saute.
- **WAL-before-apply**, desormais a la granularite du batch : les trames sont
  ecrites et fsyncees AVANT toute mutation de l'index en memoire et avant le
  retour `Ok`.
- **Chemin unitaire intact** — un fsync par appel, verifie par un test.

## Durabilite : ce qui est garanti, et ce qui ne l'est pas

Etabli par execution dans cette PR : le payload store est la source canonique ;
un index BM25 **absent** est integralement reconstruit depuis les payloads a la
reouverture ; mais un index **incomplet avec un snapshot present** n'est PAS
repare — `load_bm25_index` charge le snapshot et rejoue le WAL sans repasser par
les payloads, et aucune primitive publique ne demande une reconstruction.

C'est pourquoi le fsync precede l'acquittement : un batch acquitte doit etre
recuperable. Un echec du WAL retourne `Err` et laisse l'index en memoire
intact — jamais partiellement mis a jour pour un batch que personne n'a
acquitte.

Ce que cette PR **ne** pretend pas :

- que BM25 est toujours reconstruit a la reouverture ;
- que le payload et BM25 sont transactionnels — ils ne le sont pas, et l'etat
  « payload durable, BM25 absent » existait deja puisque `store_batch` precede
  l'indexation. Cette PR ne l'aggrave pas et ne le resout pas ;
- qu'un batch perdu avant le sync est recupere automatiquement.

Une primitive explicite de reconstruction BM25 serait utile ; elle est notee
comme sujet distinct plutot que glissee ici.

## Preuve que la cause a disparu

| | avant | apres |
|---|---|---|
| Chemin de code | `for point in points { update_text_index(point) }` | `bulk_update_text_index(points)` |
| Ouvertures du WAL, 8 documents | 8 | **1** |
| Flush, 8 documents | 8 | **1** |
| `sync_all`, 8 documents | 8 | **1** |

Compte au niveau de l'appel systeme, pas au chronometre : le module de comptage
est `#[cfg(test)]` dans `wal_framing`, qui est `pub(crate)` — rien ne peut
atteindre l'API publique. Les compteurs sont incrementes **apres** chaque `?`,
donc ils mesurent des syscalls reussis et non des tentatives, et ils filtrent sur
le `context` pour que le WAL des aretes, qui partage ces helpers, ne les gonfle
pas.

**Controle positif** : en reintroduisant temporairement l'appel unitaire dans la
boucle, `bulk_text_documents_use_one_wal_sync` repasse rouge a exactement 8/8/8.
Le garde detecte donc la structure causale, pas une variation de duree.

Deux limites du comptage, enoncees plutot que passees sous silence :
`wal_truncate` ouvre le fichier par son propre `OpenOptions` et reste invisible
au compteur (ce sont des comptes du chemin *append*) ; et un compteur ne prouve
pas l'ordre — d'ou un test distinct qui obstrue le chemin du WAL et verifie que
l'appel echoue **et** que l'index reste vierge.

## Tests

| test | ce qu'il verrouille |
|---|---|
| `bulk_text_documents_use_one_wal_sync` | 1 open / 1 flush / 1 sync par batch |
| `a_wal_failure_is_propagated_and_leaves_the_index_untouched` | l'ordre : pas de succes, pas de mutation memoire |
| `every_acknowledged_document_survives_reopen` | branche snapshot + replay WAL |
| `bulk_text_documents_are_searchable_after_reopen` | le batch reste indexe |
| `a_truncated_final_frame_preserves_prior_complete_frames` | tolerance a la queue dechiree |
| `empty_batch_does_not_touch_the_wal` | aucun fichier cree |
| `payload_without_text_does_not_write_the_bm25_wal` | pas d'entree pour un payload sans chaine |
| `single_document_path_keeps_its_contract` | le chemin unitaire garde son fsync par appel |
| `duplicate_document_updates_keep_existing_semantics` | reindexation d'un id existant |
| `without_a_snapshot_the_payloads_rebuild_the_index_even_with_no_wal` | le payload est canonique |
| `with_a_snapshot_a_lost_wal_entry_is_not_rebuilt_from_payloads` | pourquoi le fsync doit preceder l'acquittement |

## Debit mesure

Profil `--release`, macOS, machine au repos, `--test-threads=1`, mesures produites
par le meme code (`bm25_batch_throughput`) des deux cotes. La colonne `batch=1`
EST le comportement d'avant : un batch d'un document coute une barriere de
durabilite, exactement comme la boucle par document qu'on remplace.

**Dimension 4**

| n      | batch | us/doc   | doc/s  | opens | flushes | syncs |
|--------|-------|----------|--------|-------|---------|-------|
| 1 000  | 1     | 10 093,9 | 99     | 1000  | 1000    | 1000  |
| 1 000  | 64    | 189,9    | 5 267  | 16    | 16      | 16    |
| 1 000  | 256   | 54,3     | 18 418 | 4     | 4       | 4     |
| 1 000  | 1024  | 21,4     | 46 788 | 1     | 1       | 1     |
| 4 000  | 1     | 9 963,4  | 100    | 4000  | 4000    | 4000  |
| 4 000  | 64    | 202,5    | 4 937  | 63    | 63      | 63    |
| 4 000  | 256   | 55,7     | 17 966 | 16    | 16      | 16    |
| 4 000  | 1024  | 19,8     | 50 617 | 4     | 4       | 4     |
| 16 000 | 1     | 10 056,8 | 99     | 16000 | 16000   | 16000 |
| 16 000 | 64    | 210,7    | 4 746  | 250   | 250     | 250   |
| 16 000 | 256   | 49,9     | 20 021 | 63    | 63      | 63    |
| 16 000 | 1024  | **19,2** | **52 132** | 16 | 16   | 16    |

**Dimension 1024**

| n      | batch | us/doc   | doc/s  | opens | flushes | syncs |
|--------|-------|----------|--------|-------|---------|-------|
| 1 000  | 1     | 11 562,1 | 86     | 1000  | 1000    | 1000  |
| 1 000  | 64    | 817,3    | 1 224  | 16    | 16      | 16    |
| 1 000  | 256   | 103,8    | 9 635  | 4     | 4       | 4     |
| 1 000  | 1024  | 69,9     | 14 309 | 1     | 1       | 1     |
| 4 000  | 1     | 11 602,2 | 86     | 4000  | 4000    | 4000  |
| 4 000  | 64    | 814,9    | 1 227  | 63    | 63      | 63    |
| 4 000  | 256   | 102,7    | 9 740  | 16    | 16      | 16    |
| 4 000  | 1024  | 73,9     | 13 531 | 4     | 4       | 4     |
| 16 000 | 1     | 11 756,1 | 85     | 16000 | 16000   | 16000 |
| 16 000 | 64    | 829,2    | 1 206  | 250   | 250     | 250   |
| 16 000 | 256   | 106,6    | 9 381  | 63    | 63      | 63    |
| 16 000 | 1024  | **76,2** | **13 118** | 16 | 16   | 16    |

### Ce que ces chiffres disent

- **Le fsync par document a disparu.** Le nombre de `sync_all` egale exactement
  le nombre de batchs : 16 000 documents en batchs de 1 024 coutent 16 syncs.
- **Gain a batch = 1024** : x524 en dimension 4 (10 056,8 -> 19,2 us/doc),
  x154 en dimension 1024 (11 756,1 -> 76,2). Bien au-dela d'un ordre de
  grandeur.
- **Croissance lineaire** : de 1 000 a 16 000 documents, le cout par document
  reste stable (19,2 a 21,4 us en dimension 4 ; 69,9 a 76,2 en dimension 1024).
- **Meilleur batch mesure : 1 024**, dans les six combinaisons.
- **`batch=1` reste a un sync par document, et c'est correct** : le contrat est
  un sync par batch, pas un sync par appel amorti. Un batch d'un document paie
  legitimement sa barriere. Le correctif ne gagne rien en affaiblissant la
  durabilite.
- **Aucune regression hors texte** : un payload sans chaine indexable n'ecrit
  toujours rien dans le WAL BM25 (`payload_without_text_does_not_write_the_bm25_wal`
  verifie 0 sync et l'absence de fichier), et un batch vide n'ouvre rien.
- **Correction apres reouverture** : `bm25_batch_throughput_survives_reopen`
  reecrit 4 000 documents en dimension 1024, fait un `flush_full` et rouvre.

La memoire maximale n'est pas mesuree : le crate n'a pas de sonde d'allocation
exploitable ici, et je prefere le dire plutot que produire un chiffre invente.
Les batchs testes vont jusqu'a 1 024 documents, ce qui ne demande pas de
provision particuliere.

### Note de methode

Une premiere serie de mesures a du etre jetee : deux runs avaient tourne en
concurrence et se ralentissaient mutuellement (18 271 us/doc contre 9 182 pour
la meme configuration). Les chiffres ci-dessus proviennent d'une passe unique,
machine au repos.

## Sur la mention « 25-30 Kvec/s »

Elle porte sur l'insertion **vectorielle** en 768D, sans indexation BM25 durable.
Les chiffres ci-dessus concernent des documents **textuels**, qui paient en plus
l'ecriture du WAL BM25. Les deux ne sont pas comparables et ne doivent pas etre
presentes comme la meme promesse.

## Perimetre

Aucun changement dans le module de migration : cette PR corrige le chemin bulk
general de `velesdb-core`. #1762 en beneficie, mais n'en est pas proprietaire.

Closes #1797
Refs #1762
