### PR TITLE
Resoudre brace-expansion en 5.0.9 pour lever GHSA-rgw5-rvv9-x895

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -2015,9 +2015,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Le gate `Gate Contracts / npm advisories (sdks/typescript)` est rouge sur toute
nouvelle PR, sans qu'aucun changement de lockfile en soit la cause.

## Advisory

- **GHSA-rgw5-rvv9-x895** — `brace-expansion`: DoS via unbounded intermediate
  arrays, bypassing the CVE-2026-14257 mitigation
- **Severite rapportee par `npm audit`** : high
- **Plage vulnerable** : `4.0.0 - 5.0.8`
- **Premiere version corrigee disponible** : `5.0.9`

## Chaine de dependances

```
sdks/typescript
  └─ eslint ^10.4.0                (devDependency directe)
       └─ minimatch ^10.2.5         (installe 10.2.5)
            └─ brace-expansion ^5.0.5   (installe 5.0.8  <-- vulnerable)
```

`minimatch` est egalement tire par `@eslint/config-array` (`^10.2.4`) et
`@typescript-eslint/typescript-estree` (`^10.2.2`). Une seule instance de
`brace-expansion` existe dans l'arbre : `node_modules/brace-expansion`, en
`5.0.8`, marquee `dev`.

## Pourquoi le gate est devenu rouge sans commit

`npm audit` interroge la base d'advisories **en direct**. Le meme
`package-lock.json` passait le matin et echoue l'apres-midi :

| PR | check `npm advisories (sdks/typescript)` | resultat |
|----|------------------------------------------|----------|
| #1787, #1788, #1789 | termine 07:00-07:13 UTC | pass |
| #1798 | termine 17:26 UTC | **fail** |

#1798 ne modifie aucun fichier npm ou TypeScript. L'advisory a simplement ete
publiee entre les deux. Toute PR ouverte a partir de maintenant est bloquee, y
compris le lot Dependabot.

## Portee reelle

`brace-expansion` arrive par `eslint`, une devDependency. Les `dependencies`
publiees du SDK se limitent a `@wiscale/velesdb-wasm`, donc l'artefact distribue
ne l'embarque pas. Cela reduit la portee a la chaine de build et de lint ; cela
ne rend pas le gate ignorable pour autant, et ce n'est pas la raison pour
laquelle le correctif est simple.

## Correction de cause

`minimatch` declare `brace-expansion: ^5.0.5`, et cette contrainte accepte deja
`5.0.9`. La version vulnerable n'est donc pas imposee par un parent : c'est le
lockfile qui est fige sur `5.0.8`. Rafraichir la seule resolution concernee
suffit, sans `override`, sans montee de `minimatch`, et sans toucher au reste de
l'arbre.

---

## Correctif applique

`npm update brace-expansion --package-lock-only` : la seule resolution de
`brace-expansion` passe de 5.0.8 a 5.0.9. **Diff : 3 lignes**, aucune autre
dependance touchee, aucun `overrides`, aucune montee de `minimatch`.

## Preuves

| verification | avant | apres |
|---|---|---|
| `npm audit --package-lock-only --audit-level=high` (commande exacte du gate) | exit 1, 1 high severity | **exit 0, "found 0 vulnerabilities"** |
| version resolue | 5.0.8 (plage vulnerable) | **5.0.9** |
| `npm ls brace-expansion --all` apres `npm ci` propre | — | `brace-expansion@5.0.9` |

Depuis un `npm ci` sur un `node_modules` supprime : `typecheck` = 0,
`build` = 0, `lint` = 0, `test` = **927 tests passes (37 fichiers)**.

## Perimetre

Un seul fichier : `sdks/typescript/package-lock.json`. Aucun fichier Rust,
aucun changement BM25. Cette PR ne debloque pas seulement #1798 : elle debloque
le gate securite pour toutes les PR ouvertes, dont le lot Dependabot.

Closes #1799