### PR TITLE
feat(hooks): refuse to ship a compilation that dropped critical content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,16 @@ jobs:
           cargo build -p velesdb-memory
           python3 crates/velesdb-memory/examples/context_savings/real_measures/mcp_e2e.py
 
+      # The fast hook harness also runs in mcp-doc-contract without a Rust
+      # toolchain. This second invocation owns the real wire check: it points
+      # at the binary built from this checkout immediately above, never at an
+      # arbitrary installation on PATH. Missing or renamed `risk` is a hard
+      # failure inside the harness, not a skip that reads like a pass.
+      - name: Agent hook contract against current checkout binary
+        run: bash integrations/agent-hooks/test/hooks.test.sh
+        env:
+          VELESDB_MEMORY_BIN_REAL: ${{ github.workspace }}/target/debug/velesdb-memory
+
   # ===========================================================================
   # Security Audit (parallèle - outils pré-compilés)
   # ===========================================================================

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -746,7 +746,9 @@ Tuning knobs:
 > byte-identical. This matters more here than on the MCP path: `compile-stdin`
 > runs with no store and no bridge, so the `ctx://source/…` handles it mints
 > resolve to nothing, and the archived temp file is the only way back to what
-> was dropped.
+> was dropped. Only explicit `risk: low` and `risk: medium` results may replace
+> a tool result; a missing, unknown, or non-string verdict fails closed to the
+> untouched original.
 
 > **`updatedToolOutput` is Claude-Code-specific.** No other agent harness is
 > known to expose an equivalent field — Windsurf's post-hooks cannot alter a

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -736,7 +736,17 @@ Tuning knobs:
 | `VELESDB_HOOK_COMPRESS_TOOLS` | `Bash,Grep,WebFetch` | Comma-separated tool allowlist. |
 | `VELESDB_HOOK_MIN_BYTES` | `12000` | Below this, pass through — compiling would cost more than it saves. |
 | `VELESDB_HOOK_TOKEN_BUDGET` | `2000` | Token budget handed to `compile-stdin`. |
+| `VELESDB_HOOK_TOKEN_BUDGET_MAX` | twice `VELESDB_HOOK_TOKEN_BUDGET` | Ceiling a `risk: high` compilation may retry at. Equal to the budget forbids the retry. |
+| `VELESDB_HOOK_ARCHIVE_DAYS` | `7` | Age, in days, past which session start deletes archived originals. |
 | `VELESDB_HOOK_PROBE_TIMEOUT` | `10` | Seconds the capability probe may take. |
+
+> **The hook refuses a `risk: high` compilation.** It retries once at the
+> ceiling — a 268 KB cargo log is `high` at 2 000 tokens and `medium` at
+> 4 000 — and if the ceiling does not rescue it, leaves the tool result
+> byte-identical. This matters more here than on the MCP path: `compile-stdin`
+> runs with no store and no bridge, so the `ctx://source/…` handles it mints
+> resolve to nothing, and the archived temp file is the only way back to what
+> was dropped.
 
 > **`updatedToolOutput` is Claude-Code-specific.** No other agent harness is
 > known to expose an equivalent field — Windsurf's post-hooks cannot alter a

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -737,7 +737,6 @@ Tuning knobs:
 | `VELESDB_HOOK_MIN_BYTES` | `12000` | Below this, pass through — compiling would cost more than it saves. |
 | `VELESDB_HOOK_TOKEN_BUDGET` | `2000` | Token budget handed to `compile-stdin`. |
 | `VELESDB_HOOK_TOKEN_BUDGET_MAX` | twice `VELESDB_HOOK_TOKEN_BUDGET` | Ceiling a `risk: high` compilation may retry at. Equal to the budget forbids the retry. |
-| `VELESDB_HOOK_ARCHIVE_DAYS` | `7` | Age, in days, past which session start deletes archived originals. |
 | `VELESDB_HOOK_PROBE_TIMEOUT` | `10` | Seconds the capability probe may take. |
 
 > **The hook refuses a `risk: high` compilation.** It retries once at the

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -331,8 +331,30 @@ rules are strict, and each is covered by `test/hooks.test.sh`:
 | `VELESDB_HOOK_COMPRESS_TOOLS` | `Bash,Grep,WebFetch` | Comma-separated tool allowlist. |
 | `VELESDB_HOOK_MIN_BYTES` | `12000` | Below this, pass through — compiling would cost more than it saves. |
 | `VELESDB_HOOK_TOKEN_BUDGET` | `2000` | Token budget handed to `compile-stdin`. |
+| `VELESDB_HOOK_TOKEN_BUDGET_MAX` | twice `VELESDB_HOOK_TOKEN_BUDGET` | Ceiling a `risk: high` compilation may retry at. Set it equal to the budget to forbid the retry. |
+| `VELESDB_HOOK_ARCHIVE_DAYS` | `7` | Age, in days, past which session start deletes archived originals. |
 | `VELESDB_MEMORY_BIN` | `velesdb-memory` on `PATH` | Binary to invoke. |
 | `VELESDB_HOOK_PROBE_TIMEOUT` | `10` | Seconds the capability probe may take. |
+
+**Fidelity.** A compilation the compiler reports as `risk: high` is **refused**,
+not shipped: `high` means at least one fragment it classifies as critical — a
+code fence, a negative constraint, an exact value, a URL — did not survive
+verbatim. The hook retries once at the ceiling first, because the budget is
+usually what is too tight rather than the content being incompressible; a
+268 KB cargo log measures `high` at 2 000 tokens and `medium` at 4 000. When
+the ceiling does not rescue it — a 584 KB thread-stack sample stays `high` at
+2 000, 4 000, 8 000 and 16 000 — the tool result is left byte-identical and the
+reason goes to stderr.
+
+Archiving the original is not a substitute for this. On the `compile-stdin`
+path the compiler runs with no store and no bridge, so the `ctx://source/…`
+handles it mints resolve to **nothing**; the temp file is the only way back,
+and a model that was never told to look will not look.
+
+This gate lives where the compression does, so it is Claude Code only. Codex
+cannot host the compression hook at all (see the parity table above), and there
+the same discipline exists only as guidance in the `velesdb-context-optimizer`
+skill.
 
 **Design note — why `PreCompact` blocks instead of using
 `additionalContext`:** the original plan for this feature assumed

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -346,6 +346,10 @@ the ceiling does not rescue it — a 584 KB thread-stack sample stays `high` at
 2 000, 4 000, 8 000 and 16 000 — the tool result is left byte-identical and the
 reason goes to stderr.
 
+The wire check is fail-closed too: only explicit `risk: low` and
+`risk: medium` results may replace a tool result. A missing field, an unknown
+enum value, or a value of the wrong JSON type leaves the original untouched.
+
 Archiving the original is not a substitute for this. On the `compile-stdin`
 path the compiler runs with no store and no bridge, so the `ctx://source/…`
 handles it mints resolve to **nothing**; the temp file is the only way back,

--- a/integrations/agent-hooks/README.md
+++ b/integrations/agent-hooks/README.md
@@ -332,7 +332,6 @@ rules are strict, and each is covered by `test/hooks.test.sh`:
 | `VELESDB_HOOK_MIN_BYTES` | `12000` | Below this, pass through — compiling would cost more than it saves. |
 | `VELESDB_HOOK_TOKEN_BUDGET` | `2000` | Token budget handed to `compile-stdin`. |
 | `VELESDB_HOOK_TOKEN_BUDGET_MAX` | twice `VELESDB_HOOK_TOKEN_BUDGET` | Ceiling a `risk: high` compilation may retry at. Set it equal to the budget to forbid the retry. |
-| `VELESDB_HOOK_ARCHIVE_DAYS` | `7` | Age, in days, past which session start deletes archived originals. |
 | `VELESDB_MEMORY_BIN` | `velesdb-memory` on `PATH` | Binary to invoke. |
 | `VELESDB_HOOK_PROBE_TIMEOUT` | `10` | Seconds the capability probe may take. |
 

--- a/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
+++ b/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
@@ -33,6 +33,13 @@
 #   4. Tool allowlist. Only tools whose output is prose/logs are compressed.
 #      `Read` and `Edit` are deliberately NEVER in it: the model needs file
 #      contents verbatim, byte for byte.
+#   5. Fidelity. A compilation the compiler reports as `risk: high` is REFUSED,
+#      not shipped: `high` means at least one fragment it classifies as
+#      critical — a code fence, a negative constraint, an exact value, a URL —
+#      did not survive verbatim. Rule 1 is not a substitute here. On this path
+#      the compiler runs with no store and no bridge, so the `ctx://source/…`
+#      handles it mints resolve to NOTHING; the temp file is the only way back,
+#      and a model that was never told to look will not look.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -126,25 +133,67 @@ archive="${archive_dir}/${session_id}-${tool_use_id}.txt"
 printf '%s' "$text" > "$archive"
 
 budget="${VELESDB_HOOK_TOKEN_BUDGET:-2000}"
+budget_max="${VELESDB_HOOK_TOKEN_BUDGET_MAX:-$((budget * 2))}"
 compiled_file="$(sentinel_path "compile-stdin-result" "${session_id}-${tool_use_id}")"
-if ! printf '%s' "$text" \
-  | run_with_watchdog 20 "$compiled_file" "$bin" compile-stdin --budget "$budget" --query "$tool_name output"; then
+
+# One compilation attempt at $1 tokens, into $compiled_file.
+compile_at() {
+  printf '%s' "$text" \
+    | run_with_watchdog 20 "$compiled_file" "$bin" compile-stdin --budget "$1" \
+      --query "$tool_name output"
+}
+
+field() {
+  jq -r "$1 // empty" "$compiled_file" 2>/dev/null || true
+}
+
+if ! compile_at "$budget"; then
   rm -f "$compiled_file"
   passthrough
 fi
+risk="$(field '.risk')"
 
-content="$(jq -r '.content // empty' "$compiled_file" 2>/dev/null || true)"
+# Rule 5: FIDELITY. `risk: high` is not a hint that the summary reads badly —
+# it is the compiler reporting that at least one fragment it classifies as
+# CRITICAL (a code fence, a negative constraint, an exact value, a URL) did not
+# survive into the output verbatim. Shipping that in place of the real result
+# is how a hook that exists to save tokens ends up costing a diagnosis.
+#
+# One escalation first, because the budget is usually what is too tight rather
+# than the content being incompressible: a 268 KB cargo log is `high` at 2 000
+# tokens and `medium` at 4 000. When the ceiling does not rescue it — a 584 KB
+# thread-stack sample stays `high` at 2 000, 4 000, 8 000 and 16 000 — the
+# answer is to compress nothing.
+if [ "$risk" = "high" ] && [ "$budget_max" -gt "$budget" ]; then
+  if ! compile_at "$budget_max"; then
+    rm -f "$compiled_file"
+    passthrough
+  fi
+  risk="$(field '.risk')"
+fi
+
+content="$(field '.content')"
 tokens_in="$(jq -r '.tokens_in // 0' "$compiled_file" 2>/dev/null || echo 0)"
 tokens_out="$(jq -r '.tokens_out // 0' "$compiled_file" 2>/dev/null || echo 0)"
 tokens_saved="$(jq -r '.tokens_saved // 0' "$compiled_file" 2>/dev/null || echo 0)"
 rm -f "$compiled_file"
 
+if [ "$risk" = "high" ]; then
+  # The tool result is left BYTE-IDENTICAL rather than annotated. Appending a
+  # sentence would mean re-encoding the whole original through `jq --arg` for
+  # no gain: the model already has the real thing, and the reason belongs to
+  # whoever is debugging the hook, not to the transcript.
+  printf 'velesdb: declined to compile a %s-byte %s result — risk=high even at budget %s; the original is untouched\n' \
+    "$original_bytes" "$tool_name" "$budget_max" >&2
+  passthrough
+fi
+
 # An empty compilation would replace a real result with nothing. compile-stdin
 # already refuses to emit one, but the hook does not take that on trust.
 [ -n "$content" ] || passthrough
 
-footer="$(printf '\n\n--- velesdb: compiled %s tokens down to %s (saved %s). Nothing was deleted — the untouched %s-byte original is at %s; Read it if this view is not enough. ---' \
-  "$tokens_in" "$tokens_out" "$tokens_saved" "$original_bytes" "$archive")"
+footer="$(printf '\n\n--- velesdb: compiled %s tokens down to %s (saved %s, fidelity risk %s). Nothing was deleted — the untouched %s-byte original is at %s; Read it if this view is not enough. ---' \
+  "$tokens_in" "$tokens_out" "$tokens_saved" "${risk:-unknown}" "$original_bytes" "$archive")"
 
 jq -n --arg out "${content}${footer}" \
   '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $out}}'

--- a/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
+++ b/integrations/agent-hooks/claude-code/hooks/post-tool-use.sh
@@ -117,7 +117,10 @@ if [ ! -f "$probe_marker" ]; then
   probe_out="$(sentinel_path "compile-stdin-probe-out-${probe_key}" "$session_id")"
   if printf 'probe corpus for the capability check\n' \
     | run_with_watchdog "${VELESDB_HOOK_PROBE_TIMEOUT:-10}" "$probe_out" "$bin" compile-stdin --budget 4096 \
-    && jq -e 'has("content")' "$probe_out" >/dev/null 2>&1; then
+    && jq -e '
+      has("content")
+      and (.risk == "low" or .risk == "medium" or .risk == "high")
+    ' "$probe_out" >/dev/null 2>&1; then
     echo "yes" > "$probe_marker"
   else
     echo "no" > "$probe_marker"
@@ -134,6 +137,7 @@ printf '%s' "$text" > "$archive"
 
 budget="${VELESDB_HOOK_TOKEN_BUDGET:-2000}"
 budget_max="${VELESDB_HOOK_TOKEN_BUDGET_MAX:-$((budget * 2))}"
+final_budget="$budget"
 compiled_file="$(sentinel_path "compile-stdin-result" "${session_id}-${tool_use_id}")"
 
 # One compilation attempt at $1 tokens, into $compiled_file.
@@ -169,8 +173,28 @@ if [ "$risk" = "high" ] && [ "$budget_max" -gt "$budget" ]; then
     rm -f "$compiled_file"
     passthrough
   fi
+  final_budget="$budget_max"
   risk="$(field '.risk')"
 fi
+
+# Fail closed on the wire contract. Only the two explicitly shippable verdicts
+# may replace a tool result. A missing field, a renamed enum value, or a value
+# of the wrong JSON type is not evidence that fidelity is acceptable.
+case "$risk" in
+  low|medium) ;;
+  high)
+    rm -f "$compiled_file"
+    printf 'velesdb: declined to compile a %s-byte %s result — risk=high even at budget %s; the original is untouched\n' \
+      "$original_bytes" "$tool_name" "$final_budget" >&2
+    passthrough
+    ;;
+  *)
+    rm -f "$compiled_file"
+    printf 'velesdb: declined to compile a %s-byte %s result — missing or unsupported fidelity risk; the original is untouched\n' \
+      "$original_bytes" "$tool_name" >&2
+    passthrough
+    ;;
+esac
 
 content="$(field '.content')"
 tokens_in="$(jq -r '.tokens_in // 0' "$compiled_file" 2>/dev/null || echo 0)"
@@ -178,22 +202,12 @@ tokens_out="$(jq -r '.tokens_out // 0' "$compiled_file" 2>/dev/null || echo 0)"
 tokens_saved="$(jq -r '.tokens_saved // 0' "$compiled_file" 2>/dev/null || echo 0)"
 rm -f "$compiled_file"
 
-if [ "$risk" = "high" ]; then
-  # The tool result is left BYTE-IDENTICAL rather than annotated. Appending a
-  # sentence would mean re-encoding the whole original through `jq --arg` for
-  # no gain: the model already has the real thing, and the reason belongs to
-  # whoever is debugging the hook, not to the transcript.
-  printf 'velesdb: declined to compile a %s-byte %s result — risk=high even at budget %s; the original is untouched\n' \
-    "$original_bytes" "$tool_name" "$budget_max" >&2
-  passthrough
-fi
-
 # An empty compilation would replace a real result with nothing. compile-stdin
 # already refuses to emit one, but the hook does not take that on trust.
 [ -n "$content" ] || passthrough
 
 footer="$(printf '\n\n--- velesdb: compiled %s tokens down to %s (saved %s, fidelity risk %s). Nothing was deleted — the untouched %s-byte original is at %s; Read it if this view is not enough. ---' \
-  "$tokens_in" "$tokens_out" "$tokens_saved" "${risk:-unknown}" "$original_bytes" "$archive")"
+  "$tokens_in" "$tokens_out" "$tokens_saved" "$risk" "$original_bytes" "$archive")"
 
 jq -n --arg out "${content}${footer}" \
   '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $out}}'

--- a/integrations/agent-hooks/claude-code/hooks/session-start.sh
+++ b/integrations/agent-hooks/claude-code/hooks/session-start.sh
@@ -26,18 +26,6 @@ fi
 
 resolve_config "$cwd"
 
-# The PostToolUse hook archives every original it compiles, and never deletes
-# one — deleting the only copy of a tool result is the one thing it must not
-# do. Nothing else swept them either, so the directory grew without bound.
-# Session start is the right moment: no compilation is in flight, and anything
-# a week old belongs to a session whose transcript is long gone. Best-effort
-# by construction: a failed purge must never cost the user a session start.
-archive_dir="${TMPDIR:-/tmp}/velesdb-agent-hooks/tool-output"
-if [ -d "$archive_dir" ]; then
-  find "$archive_dir" -type f -name '*.txt' \
-    -mtime "+${VELESDB_HOOK_ARCHIVE_DAYS:-7}" -delete 2>/dev/null || true
-fi
-
 context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. load_working_context returns {found, working, other_sessions}: read 'working' for the state. If 'found' is false, nothing was saved under that EXACT project+session — but check 'other_sessions' before starting fresh: a similarly-named session listed there means the session id was a typo, not a new task. 'other_sessions' is filled in on a hit too, so if one of them looks more like the session you meant, you may have just resumed the wrong work. Reinforcement loop: whenever a memory surfaced by recall/recall_fused (or pulled into compile_context — its decision carries the memory_id) actually helps you, call feedback(id, true) with the id_str string; if it misled you, feedback(id, false). This is what makes ranking improve with use — skipping it keeps confidence flat."
 
 # A daemon behind the published release is worth one line, and only when it

--- a/integrations/agent-hooks/claude-code/hooks/session-start.sh
+++ b/integrations/agent-hooks/claude-code/hooks/session-start.sh
@@ -26,6 +26,18 @@ fi
 
 resolve_config "$cwd"
 
+# The PostToolUse hook archives every original it compiles, and never deletes
+# one — deleting the only copy of a tool result is the one thing it must not
+# do. Nothing else swept them either, so the directory grew without bound.
+# Session start is the right moment: no compilation is in flight, and anything
+# a week old belongs to a session whose transcript is long gone. Best-effort
+# by construction: a failed purge must never cost the user a session start.
+archive_dir="${TMPDIR:-/tmp}/velesdb-agent-hooks/tool-output"
+if [ -d "$archive_dir" ]; then
+  find "$archive_dir" -type f -name '*.txt' \
+    -mtime "+${VELESDB_HOOK_ARCHIVE_DAYS:-7}" -delete 2>/dev/null || true
+fi
+
 context="Session memory (velesdb-memory): call load_working_context(project=\"$PROJECT\", session=\"$SESSION\") as your first action, unless you already loaded it earlier this session. It restores the prior distilled state (goal, constraints, verified facts, decisions, pending actions) left by save_working_context, so work continues instead of re-deriving context from scratch. load_working_context returns {found, working, other_sessions}: read 'working' for the state. If 'found' is false, nothing was saved under that EXACT project+session — but check 'other_sessions' before starting fresh: a similarly-named session listed there means the session id was a typo, not a new task. 'other_sessions' is filled in on a hit too, so if one of them looks more like the session you meant, you may have just resumed the wrong work. Reinforcement loop: whenever a memory surfaced by recall/recall_fused (or pulled into compile_context — its decision carries the memory_id) actually helps you, call feedback(id, true) with the id_str string; if it misled you, feedback(id, false). This is what makes ranking improve with use — skipping it keeps confidence flat."
 
 # A daemon behind the published release is worth one line, and only when it

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -397,8 +397,42 @@ else
 fi
 FAKE
 
+# Proves both halves of the fail-closed wire contract. The capability probe
+# gets a valid low-risk response, so these binaries cannot pass merely because
+# the hook disabled them before the real compilation. The queried invocation
+# then returns content whose risk is absent, unknown, or the wrong JSON type.
+cat > "$FAKE_BIN_DIR/fake-risk-contract" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+case " $* " in
+  *" --query "*)
+    case "${FAKE_FINAL_RISK_MODE:-missing}" in
+      missing)
+        printf '{"content":"UNVERIFIED SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700}\n'
+        ;;
+      unknown)
+        printf '{"content":"UNVERIFIED SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"critical"}\n'
+        ;;
+      malformed)
+        printf '{"content":"UNVERIFIED SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":{"level":"medium"}}\n'
+        ;;
+    esac
+    ;;
+  *)
+    printf '{"content":"PROBE","tokens_in":4,"tokens_out":1,"tokens_saved":3,"risk":"low"}\n'
+    ;;
+esac
+FAKE
+
+cat > "$FAKE_BIN_DIR/fake-low" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"content":"LOSSLESS SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"low"}\n'
+FAKE
+
 chmod +x "$FAKE_BIN_DIR/fake-ok" "$FAKE_BIN_DIR/fake-fail" "$FAKE_BIN_DIR/fake-old" \
-  "$FAKE_BIN_DIR/fake-high" "$FAKE_BIN_DIR/fake-escalate"
+  "$FAKE_BIN_DIR/fake-high" "$FAKE_BIN_DIR/fake-escalate" \
+  "$FAKE_BIN_DIR/fake-risk-contract" "$FAKE_BIN_DIR/fake-low"
 
 big_output="$(head -c 40000 < /dev/zero | tr '\0' 'x')"
 
@@ -443,6 +477,26 @@ if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.updatedToolOutput | conta
 else
   fail "PostToolUse: updatedToolOutput carries the compiled content"
 fi
+
+low_out="$(post_tool_payload "Bash" "low" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-low" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+if printf '%s' "$low_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("LOSSLESS SUMMARY")' >/dev/null; then
+  pass "PostToolUse: a risk=low compilation IS shipped (second positive control)"
+else
+  fail "PostToolUse: a risk=low compilation IS shipped (second positive control)"
+fi
+
+for bad_risk in missing unknown malformed; do
+  bad_risk_out="$(post_tool_payload "Bash" "risk-$bad_risk" "$big_output" \
+    | FAKE_FINAL_RISK_MODE="$bad_risk" \
+      VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-risk-contract" \
+      bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+  if [ "$(printf '%s' "$bad_risk_out" | jq -c .)" = "{}" ]; then
+    pass "PostToolUse: risk=$bad_risk is refused instead of shipping unverifiable content"
+  else
+    fail "PostToolUse: risk=$bad_risk is refused instead of shipping unverifiable content"
+  fi
+done
 
 # --- Rule 5: fidelity ------------------------------------------------------
 # `risk: high` is not "the summary reads badly". It is the compiler reporting
@@ -514,40 +568,43 @@ fi
 # expects. A rename on either side would leave every test above green.
 #
 # Two corpora, both generated here so the harness stays hermetic, both measured
-# against the installed binary:
+# against the current-checkout binary supplied explicitly by CI:
 #   * URLs and hex checksums — content the classifier calls CRITICAL. Dropping
 #     any of it is `high`, and stays `high` well past the ceiling.
 #   * identical heartbeat lines — the repetitive case abstraction handles
 #     cleanly, and reports `medium`.
-real_bin="${VELESDB_MEMORY_BIN_REAL:-velesdb-memory}"
-if command -v "$real_bin" >/dev/null 2>&1 \
-  && printf 'probe\n' | "$real_bin" compile-stdin --budget 4096 2>/dev/null | jq -e 'has("risk")' >/dev/null 2>&1; then
-
-  critical_corpus="$(awk 'BEGIN { for (i = 0; i < 200; i++)
-    printf "2026-08-04T00:%02d:00Z ERROR shard=%d url=https://example.invalid/api/v1/resource/%d checksum=0x%08x elapsed=%dms\n", i % 60, i, i, i, i * 7 }')"
-  repetitive_corpus="$(awk 'BEGIN { for (i = 0; i < 400; i++)
-    print "INFO  worker heartbeat ok, queue depth nominal, nothing to report" }')"
-
-  real_high="$(post_tool_payload "Bash" "realhigh" "$critical_corpus" \
-    | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
-  if [ "$(printf '%s' "$real_high" | jq -c .)" = "{}" ]; then
-    pass "PostToolUse/real: the real compiler's risk=high verdict is honoured"
+real_bin="${VELESDB_MEMORY_BIN_REAL:-}"
+if [ -n "$real_bin" ]; then
+  if [ ! -x "$real_bin" ]; then
+    fail "PostToolUse/real: VELESDB_MEMORY_BIN_REAL names an executable checkout binary"
+  elif ! printf 'probe\n' | "$real_bin" compile-stdin --budget 4096 2>/dev/null \
+    | jq -e '.risk == "low" or .risk == "medium" or .risk == "high"' >/dev/null 2>&1; then
+    fail "PostToolUse/real: the checkout binary exposes an explicit fidelity risk"
   else
-    fail "PostToolUse/real: the real compiler's risk=high verdict is honoured"
-  fi
 
-  real_ok="$(post_tool_payload "Bash" "realok" "$repetitive_corpus" \
-    | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
-  if printf '%s' "$real_ok" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("fidelity risk")' >/dev/null; then
-    pass "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
-  else
-    fail "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
+    critical_corpus="$(awk 'BEGIN { for (i = 0; i < 200; i++)
+      printf "2026-08-04T00:%02d:00Z ERROR shard=%d url=https://example.invalid/api/v1/resource/%d checksum=0x%08x elapsed=%dms\n", i % 60, i, i, i, i * 7 }')"
+    repetitive_corpus="$(awk 'BEGIN { for (i = 0; i < 400; i++)
+      print "INFO  worker heartbeat ok, queue depth nominal, nothing to report" }')"
+
+    real_high="$(post_tool_payload "Bash" "realhigh" "$critical_corpus" \
+      | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+    if [ "$(printf '%s' "$real_high" | jq -c .)" = "{}" ]; then
+      pass "PostToolUse/real: the real compiler's risk=high verdict is honoured"
+    else
+      fail "PostToolUse/real: the real compiler's risk=high verdict is honoured"
+    fi
+
+    real_ok="$(post_tool_payload "Bash" "realok" "$repetitive_corpus" \
+      | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+    if printf '%s' "$real_ok" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("fidelity risk")' >/dev/null; then
+      pass "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
+    else
+      fail "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
+    fi
   fi
 else
-  # Loud on purpose. A silent skip reads exactly like a pass, and the whole
-  # point of this section is that the fakes cannot catch a contract change.
-  printf '# SKIP - real-binary checks: no compile-stdin-capable velesdb-memory on PATH\n'
-  printf '#        (set VELESDB_MEMORY_BIN_REAL to point at one)\n'
+  printf '# INFO - real-binary contract runs in CI against target/debug/velesdb-memory\n'
 fi
 
 # Rule 1 — nothing is deleted: the replacement must point at the untouched
@@ -638,7 +695,7 @@ fi
 cat > "$FAKE_BIN_DIR/fake-record" <<FAKE
 #!/usr/bin/env bash
 cat > "$TMP_TEST_DIR/received.txt"
-printf '{"content":"COMPILED","tokens_in":4000,"tokens_out":300,"tokens_saved":3700}\n'
+printf '{"content":"COMPILED","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"medium"}\n'
 FAKE
 chmod +x "$FAKE_BIN_DIR/fake-record"
 

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -62,6 +62,16 @@ trap cleanup EXIT
 export TMPDIR="$TMP_TEST_DIR/tmp"
 mkdir -p "$TMPDIR"
 
+# An archived original is the only recovery path for a memoryless
+# `compile-stdin` result. Session startup must therefore never age it out behind
+# the transcript's back: retention is a separate product policy, not a hook
+# side effect. Make this file old enough that the former seven-day purge would
+# delete it, then require both its path and bytes to survive SessionStart.
+archive_control="$TMPDIR/velesdb-agent-hooks/tool-output/still-referenced.txt"
+mkdir -p "$(dirname "$archive_control")"
+printf 'original bytes still referenced by a transcript' > "$archive_control"
+touch -t 202001010000 "$archive_control"
+
 PROJECT_DIR="$TMP_TEST_DIR/project"
 mkdir -p "$PROJECT_DIR"
 cat > "$PROJECT_DIR/.velesdb-hooks.json" <<'EOF'
@@ -77,6 +87,13 @@ session_start_payload="$(jq -n --arg cwd "$PROJECT_DIR" --arg sid "$SESSION_ID" 
   '{session_id: $sid, cwd: $cwd, hook_event_name: "SessionStart", source: "startup"}')"
 
 session_start_out="$(printf '%s' "$session_start_payload" | bash "$HOOKS_DIR/session-start.sh")"
+
+if [ -f "$archive_control" ] \
+  && [ "$(cat "$archive_control")" = "original bytes still referenced by a transcript" ]; then
+  pass "SessionStart: never purges the only archived original"
+else
+  fail "SessionStart: never purges the only archived original"
+fi
 
 if printf '%s' "$session_start_out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null; then
   pass "SessionStart: hookSpecificOutput.hookEventName is SessionStart"

--- a/integrations/agent-hooks/test/hooks.test.sh
+++ b/integrations/agent-hooks/test/hooks.test.sh
@@ -371,7 +371,34 @@ cat > "$FAKE_BIN_DIR/fake-old" <<'FAKE'
 sleep 30
 FAKE
 
-chmod +x "$FAKE_BIN_DIR/fake-ok" "$FAKE_BIN_DIR/fake-fail" "$FAKE_BIN_DIR/fake-old"
+# Behaves like a corpus the compiler cannot fit without dropping something it
+# classifies as CRITICAL — a code fence, an exact value, a URL. No budget
+# rescues it; the real 584 KB thread-stack sample under
+# .investigation/http-deadlock-2026-07-22/ measures `high` at 2 000, 4 000,
+# 8 000 and 16 000.
+cat > "$FAKE_BIN_DIR/fake-high" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+printf '{"content":"LOSSY SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"high"}\n'
+FAKE
+
+# Behaves like a corpus that is merely CRAMPED rather than incompressible: the
+# first budget loses something critical, twice the budget does not. That is the
+# common case — the real 268 KB cargo log measures `high` at 2 000 and `medium`
+# at 4 000 — and it is why the hook escalates before it refuses.
+cat > "$FAKE_BIN_DIR/fake-escalate" <<'FAKE'
+#!/usr/bin/env bash
+cat >/dev/null
+# argv: compile-stdin --budget N --query ...
+if [ "${3:-0}" -ge 4000 ]; then
+  printf '{"content":"ROOMIER SUMMARY","tokens_in":4000,"tokens_out":600,"tokens_saved":3400,"risk":"medium"}\n'
+else
+  printf '{"content":"CRAMPED SUMMARY","tokens_in":4000,"tokens_out":300,"tokens_saved":3700,"risk":"high"}\n'
+fi
+FAKE
+
+chmod +x "$FAKE_BIN_DIR/fake-ok" "$FAKE_BIN_DIR/fake-fail" "$FAKE_BIN_DIR/fake-old" \
+  "$FAKE_BIN_DIR/fake-high" "$FAKE_BIN_DIR/fake-escalate"
 
 big_output="$(head -c 40000 < /dev/zero | tr '\0' 'x')"
 
@@ -415,6 +442,112 @@ if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.updatedToolOutput | conta
   pass "PostToolUse: updatedToolOutput carries the compiled content"
 else
   fail "PostToolUse: updatedToolOutput carries the compiled content"
+fi
+
+# --- Rule 5: fidelity ------------------------------------------------------
+# `risk: high` is not "the summary reads badly". It is the compiler reporting
+# that a fragment it classifies as critical did not survive verbatim — and on
+# this path there is no store behind the `ctx://source/…` handles it mints, so
+# the temp file is the ONLY way back. Shipping that in place of the real result
+# is how a hook meant to save tokens costs a diagnosis.
+high_out="$(post_tool_payload "Bash" "high" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-high" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+if [ "$(printf '%s' "$high_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: a risk=high compilation is refused, leaving the result untouched"
+else
+  fail "PostToolUse: a risk=high compilation is refused, leaving the result untouched"
+fi
+
+# The positive control for the refusal above. Without it, a hook that refused
+# EVERYTHING would satisfy it while never compressing anything — the same
+# assertion passing for the opposite reason. `fake-ok` reports `medium`, and
+# `$big_out` above shows it IS shipped.
+if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("COMPILED SUMMARY")' >/dev/null; then
+  pass "PostToolUse: a risk=medium compilation IS shipped (control for the refusal)"
+else
+  fail "PostToolUse: a risk=medium compilation IS shipped (control for the refusal)"
+fi
+
+# Escalate before refusing: the budget is usually what is too tight, not the
+# content that is incompressible.
+esc_out="$(post_tool_payload "Bash" "escalate" "$big_output" \
+  | VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-escalate" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+if printf '%s' "$esc_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("ROOMIER SUMMARY")' >/dev/null; then
+  pass "PostToolUse: risk=high at the first budget retries at the ceiling and ships that"
+else
+  fail "PostToolUse: risk=high at the first budget retries at the ceiling and ships that"
+fi
+
+# ...and the cramped first attempt must NOT be what reaches the model, or the
+# escalation would be decorative.
+if printf '%s' "$esc_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("CRAMPED SUMMARY") | not' >/dev/null; then
+  pass "PostToolUse: the refused first attempt never reaches the model"
+else
+  fail "PostToolUse: the refused first attempt never reaches the model"
+fi
+
+# A ceiling equal to the starting budget means there is no second attempt to
+# make, so the first `high` is final. This is what makes the ceiling a real
+# bound rather than a suggestion.
+noesc_out="$(post_tool_payload "Bash" "noesc" "$big_output" \
+  | VELESDB_HOOK_TOKEN_BUDGET=2000 VELESDB_HOOK_TOKEN_BUDGET_MAX=2000 \
+    VELESDB_MEMORY_BIN="$FAKE_BIN_DIR/fake-escalate" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+if [ "$(printf '%s' "$noesc_out" | jq -c .)" = "{}" ]; then
+  pass "PostToolUse: a ceiling equal to the budget forbids the retry and refuses"
+else
+  fail "PostToolUse: a ceiling equal to the budget forbids the retry and refuses"
+fi
+
+# The model must be told which fidelity it is reading. A compiled view that
+# looks identical whether it lost something or not is one the model cannot
+# reason about.
+if printf '%s' "$big_out" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("fidelity risk medium")' >/dev/null; then
+  pass "PostToolUse: the footer names the fidelity risk of what it shipped"
+else
+  fail "PostToolUse: the footer names the fidelity risk of what it shipped"
+fi
+
+# --- Against the REAL binary -----------------------------------------------
+# Everything above drives fake binaries, which is right for the decision logic
+# but proves nothing about the contract the two sides actually share: that the
+# compiler emits a `risk` field the hook can read, spelled the way the hook
+# expects. A rename on either side would leave every test above green.
+#
+# Two corpora, both generated here so the harness stays hermetic, both measured
+# against the installed binary:
+#   * URLs and hex checksums — content the classifier calls CRITICAL. Dropping
+#     any of it is `high`, and stays `high` well past the ceiling.
+#   * identical heartbeat lines — the repetitive case abstraction handles
+#     cleanly, and reports `medium`.
+real_bin="${VELESDB_MEMORY_BIN_REAL:-velesdb-memory}"
+if command -v "$real_bin" >/dev/null 2>&1 \
+  && printf 'probe\n' | "$real_bin" compile-stdin --budget 4096 2>/dev/null | jq -e 'has("risk")' >/dev/null 2>&1; then
+
+  critical_corpus="$(awk 'BEGIN { for (i = 0; i < 200; i++)
+    printf "2026-08-04T00:%02d:00Z ERROR shard=%d url=https://example.invalid/api/v1/resource/%d checksum=0x%08x elapsed=%dms\n", i % 60, i, i, i, i * 7 }')"
+  repetitive_corpus="$(awk 'BEGIN { for (i = 0; i < 400; i++)
+    print "INFO  worker heartbeat ok, queue depth nominal, nothing to report" }')"
+
+  real_high="$(post_tool_payload "Bash" "realhigh" "$critical_corpus" \
+    | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+  if [ "$(printf '%s' "$real_high" | jq -c .)" = "{}" ]; then
+    pass "PostToolUse/real: the real compiler's risk=high verdict is honoured"
+  else
+    fail "PostToolUse/real: the real compiler's risk=high verdict is honoured"
+  fi
+
+  real_ok="$(post_tool_payload "Bash" "realok" "$repetitive_corpus" \
+    | VELESDB_MEMORY_BIN="$real_bin" bash "$HOOKS_DIR/post-tool-use.sh" 2>/dev/null)"
+  if printf '%s' "$real_ok" | jq -e '.hookSpecificOutput.updatedToolOutput | contains("fidelity risk")' >/dev/null; then
+    pass "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
+  else
+    fail "PostToolUse/real: a compressible corpus is still compressed by the real compiler"
+  fi
+else
+  # Loud on purpose. A silent skip reads exactly like a pass, and the whole
+  # point of this section is that the fakes cannot catch a contract change.
+  printf '# SKIP - real-binary checks: no compile-stdin-capable velesdb-memory on PATH\n'
+  printf '#        (set VELESDB_MEMORY_BIN_REAL to point at one)\n'
 fi
 
 # Rule 1 — nothing is deleted: the replacement must point at the untouched

--- a/scripts/tests/test_sync_agent_hooks.py
+++ b/scripts/tests/test_sync_agent_hooks.py
@@ -472,6 +472,18 @@ class HarnessIsWired(unittest.TestCase):
         for disarm in ("continue-on-error:", "|| true"):
             self.assertNotIn(disarm, directives, f"the job is disarmed by {disarm}")
 
+    def test_real_binary_contract_uses_the_current_checkout_in_ci(self) -> None:
+        body = CI.read_text(encoding="utf-8")
+        job_start = body.index("\n  test:")
+        following = body.find("\n  security:", job_start)
+        job_body = body[job_start : following if following > 0 else len(body)]
+        self.assertIn("cargo build -p velesdb-memory", job_body)
+        self.assertIn(
+            "VELESDB_MEMORY_BIN_REAL: ${{ github.workspace }}/target/debug/velesdb-memory",
+            job_body,
+        )
+        self.assertIn("integrations/agent-hooks/test/hooks.test.sh", job_body)
+
     def test_the_harness_is_executable_and_can_fail(self) -> None:
         self.assertTrue(HARNESS.is_file())
         body = HARNESS.read_text(encoding="utf-8")
@@ -500,6 +512,32 @@ class HarnessIsWired(unittest.TestCase):
             ["bash", str(HARNESS)], capture_output=True, text=True, check=False
         )
         self.assertEqual(result.returncode, 0, result.stdout[-3000:] + result.stderr[-2000:])
+
+    def test_real_binary_contract_cannot_skip_a_missing_risk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "velesdb-memory-without-risk"
+            fake.write_text(
+                "#!/usr/bin/env bash\n"
+                "cat >/dev/null\n"
+                "printf '{\"content\":\"summary\",\"tokens_in\":4,"
+                "\"tokens_out\":1,\"tokens_saved\":3}\\n'\n",
+                encoding="utf-8",
+            )
+            fake.chmod(0o755)
+            env = os.environ.copy()
+            env["VELESDB_MEMORY_BIN_REAL"] = str(fake)
+            result = subprocess.run(
+                ["bash", str(HARNESS)],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=env,
+            )
+            self.assertEqual(result.returncode, 1, result.stdout[-3000:] + result.stderr[-2000:])
+            self.assertIn(
+                "not ok - PostToolUse/real: the checkout binary exposes an explicit fidelity risk",
+                result.stdout,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The gap

The Claude Code `PostToolUse` hook replaces oversized tool results with a
deterministic compiled view, but it did not enforce the compiler's fidelity
verdict. `risk: high` means at least one critical fragment (code, a negative
constraint, an exact value or a URL) did not survive verbatim. Such results
were still shipped as if they were safe.

## Measured with the installed 0.12.0 binary

| corpus | budget | tokens | risk |
|---|---:|---:|---|
| 268 KB cargo build log | 2,000 | 94,723 → 1,946 | **high** |
| same | 4,000 | 94,723 → 3,958 | medium |
| 584 KB thread-stack sample | 2,000 | 198,546 → 1,980 | **high** |
| same | 4,000 / 8,000 / 16,000 | → 3,994 / 7,974 / 15,984 | **high every time** |

The cargo log is rescued by a larger budget. The thread-stack sample is not,
so replacing its original would hide the exact frames needed for diagnosis.

## Fail-closed wire contract

- only the explicit `low` and `medium` verdicts may replace a tool result;
- `high` retries once at the configured ceiling, then preserves the original
  byte-for-byte if the verdict remains high;
- a missing, renamed, unknown or non-string `risk` also preserves the original;
- the footer names the verified verdict that was shipped;
- the untouched original remains archived at the path carried by the footer;
- `SessionStart` never deletes that only recovery copy. Retention needs a
  separate product policy that can prove an archive is no longer referenced.

The capability probe validates both `content` and the complete `risk` enum, so
an older or wire-incompatible binary cannot be mistaken for a compatible one.

## The real binary is a merge gate

Fakes exercise every decision branch and its positive controls. A second
invocation in the required Rust test job points
`VELESDB_MEMORY_BIN_REAL` at `target/debug/velesdb-memory` built from the
current checkout. Missing `risk` is a hard failure, never a skip that reads like
a pass and never an arbitrary binary found on `PATH`.

## Scope

Output replacement is Claude Code only. Codex has no equivalent
`PostToolUse.updatedToolOutput` contract; there, the context-optimizer skill
provides the discipline but cannot transparently replace tool results.

## Verification

- hook harness green against the binary built from this exact checkout;
- missing, unknown, malformed and high-risk verdicts all proven to preserve
  the original; low/medium positive controls still compile;
- 84 hook-wiring and CI-reachability Python tests green;
- shell syntax, ShellCheck, MCP documentation contracts and private-reference
  guards green;
- `git diff --check` clean.

No automatic archive deletion is included. The residual unbounded archive
growth is explicit follow-up work, not hidden data loss.
