### PR TITLE
fix(memory): index mentions edges so reach_weight stops rescanning the walk

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -95,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`recall_fused`'s graph reach is no longer quadratic in a hub's fan-out
+  (#1742).** `reach_weight` used to rescan every edge the traversal collected,
+  once per reached node, to find the `mentions` edges pointing at it —
+  O(hub degree) work repeated for each of O(hub degree) nodes. A user
+  accumulating facts about the same entity (the product's nominal use case,
+  not an edge case) paid a cost growing with the square of their history on
+  that topic. `mentions` edges are now indexed by target once per call
+  (`fact_id -> [hub_id, ...]`), turning the whole pass into O(edges + nodes).
+  Weighting is unchanged — a fact reached through several hubs still ranks by
+  the rarest (highest-idf) one — locked in by a new test
+  (`recall_fused_weighs_a_dual_hub_fact_by_its_rarest_hub`) and tracked going
+  forward by `benches/fused_recall_benchmark.rs`.
+
 - **TypeScript SDK: `CompileContextFragment` gains `priority`.** The wire has
   accepted it since the context compiler shipped, and this SDK never declared
   it — so a TypeScript caller could reach `compileContext` and not express the

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -177,6 +177,13 @@ name = "context_compiler_benchmark"
 harness = false
 required-features = ["context"]
 
+# Latency of recall_fused's graph walk as a single entity hub's fan-out
+# grows (issue #1742) — needs the file-backed store.
+[[bench]]
+name = "fused_recall_benchmark"
+harness = false
+required-features = ["persistence"]
+
 # Reproducible before/after benchmark of the deterministic context compiler.
 # Offline and dependency-free — needs only the `context` feature.
 [[example]]

--- a/crates/velesdb-memory/benches/fused_recall_benchmark.rs
+++ b/crates/velesdb-memory/benches/fused_recall_benchmark.rs
@@ -1,0 +1,77 @@
+//! Latency of [`MemoryService::recall_fused`] as a single entity hub's
+//! fan-out grows — the shape issue #1742 diagnosed: `graph_reached`'s
+//! per-node `reach_weight` scan used to rescan every edge in the traversal
+//! for each reached node, making the whole walk O(hub degree²). Indexing
+//! `mentions` edges by target turned that into O(edges + nodes). This bench
+//! is the empirical check: latency should grow ~linearly with hub degree,
+//! not quadratically — a user accumulating facts about the same topic (the
+//! product's nominal use case) must not pay a cost that grows with the
+//! square of their history on it.
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo bench -p velesdb-memory --bench fused_recall_benchmark
+//! ```
+//!
+//! Results land in `target/criterion/`; store setup happens outside the
+//! timed section, so each measured iteration is `recall_fused` alone.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use tempfile::TempDir;
+use velesdb_memory::{FusionOptions, HashEmbedder, MemoryService};
+
+const DIM: usize = 384;
+const SEED: &str = "seed fact anchors the walk";
+
+/// A store wired like the autograph's bipartite hub: a seed fact linked to
+/// one entity hub, which in turn `mentions` `degree` facts — the exact shape
+/// `recall_fused`'s default 2-hop walk exercises (hop 1 reaches the hub, hop
+/// 2 reaches everything it mentions).
+fn hub_store(degree: usize) -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = TempDir::new().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DIM)).expect("open store");
+    let seed = svc.remember(SEED, &[], None).expect("remember seed");
+    let hub = svc
+        .remember("Entity: benchmark-topic", &[], None)
+        .expect("remember hub");
+    svc.relate(seed, hub, "about").expect("relate seed->hub");
+    for i in 0..degree {
+        let fact = svc
+            .remember(&format!("fact number {i} about the topic"), &[], None)
+            .expect("remember fact");
+        svc.relate(hub, fact, "mentions").expect("relate hub->fact");
+    }
+    (dir, svc)
+}
+
+fn bench_recall_fused_by_hub_degree(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recall_fused_hub_degree");
+    // Capped at 1000: past roughly 1195 total memories in a store, seed
+    // lookup by exact vector match stops finding anything at all (tracked
+    // separately, not a `recall_fused`/graph-walk issue) — so degrees above
+    // this would silently benchmark a no-op walk instead of the real one.
+    for degree in [50_usize, 200, 500, 1000] {
+        let (_dir, svc) = hub_store(degree);
+        // The walk must actually reach every fact under the hub (seed + hub
+        // + degree facts) — otherwise a regression elsewhere silently turns
+        // this into a no-op benchmark instead of failing loudly.
+        let reached = svc.why(SEED, 2, None).expect("why").nodes.len();
+        assert_eq!(
+            reached,
+            degree + 2,
+            "traversal did not reach the full hub fan-out"
+        );
+        group.throughput(Throughput::Elements(degree as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
+            b.iter(|| {
+                svc.recall_fused(SEED, 10, None, FusionOptions::default())
+                    .expect("recall_fused")
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_recall_fused_by_hub_degree);
+criterion_main!(benches);

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -225,12 +225,13 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let nodes: Vec<&MemoryNode> = explanation.nodes.iter().filter(|n| n.hop != 0).collect();
         let ids: Vec<u64> = nodes.iter().map(|n| n.id).collect();
         let raw_payloads = self.store.get_metadata_batch(&ids)?;
+        let mentions_by_target = index_mentions_edges(&explanation.edges);
 
         let mut idf_cache: HashMap<u64, f64> = HashMap::new();
         let mut reached = Vec::new();
         for (node, raw) in nodes.into_iter().zip(raw_payloads) {
             if let Some(candidate) =
-                self.reached_candidate(node, raw, &explanation.edges, filter, &mut idf_cache)?
+                self.reached_candidate(node, raw, &mentions_by_target, filter, &mut idf_cache)?
             {
                 reached.push(candidate);
             }
@@ -254,7 +255,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         &self,
         node: &MemoryNode,
         raw: Option<Metadata>,
-        edges: &[MemoryEdge],
+        mentions_by_target: &HashMap<u64, Vec<u64>>,
         filter: Option<&Metadata>,
         idf_cache: &mut HashMap<u64, f64>,
     ) -> Result<Option<Candidate>, MemoryError> {
@@ -268,7 +269,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if !matches_filter(metadata.as_ref(), filter) {
             return Ok(None);
         }
-        let weight = self.reach_weight(node.id, edges, idf_cache)?;
+        let weight = self.reach_weight(node.id, mentions_by_target, idf_cache)?;
         Ok(Some(Candidate {
             recollection: Recollection {
                 id: node.id,
@@ -282,22 +283,23 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     }
 
     /// The strength of the link(s) that reached `fact_id`: the maximum
-    /// entity-idf ([`Self::entity_idf`]) over every hub with a `mentions`
-    /// edge into it, or a flat `1.0` when it was reached through a direct
+    /// entity-idf ([`Self::entity_idf`]) over every hub `mentions_by_target`
+    /// lists for it, or a flat `1.0` when it was reached through a direct
     /// (non-hub) [`Self::relate`] edge instead — idf has nothing to weight
     /// there, so the original flat signal is kept.
     fn reach_weight(
         &self,
         fact_id: u64,
-        edges: &[MemoryEdge],
+        mentions_by_target: &HashMap<u64, Vec<u64>>,
         idf_cache: &mut HashMap<u64, f64>,
     ) -> Result<f64, MemoryError> {
+        let Some(hub_ids) = mentions_by_target.get(&fact_id) else {
+            return Ok(1.0);
+        };
         let mut weight: Option<f64> = None;
-        for edge in edges {
-            if edge.to == fact_id && edge.relation == MENTIONS_RELATION {
-                let idf = self.cached_entity_idf(edge.from, idf_cache)?;
-                weight = Some(weight.map_or(idf, |w: f64| w.max(idf)));
-            }
+        for &hub_id in hub_ids {
+            let idf = self.cached_entity_idf(hub_id, idf_cache)?;
+            weight = Some(weight.map_or(idf, |w: f64| w.max(idf)));
         }
         Ok(weight.unwrap_or(1.0))
     }
@@ -335,6 +337,23 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let (n, d) = (n as f64, degree as f64);
         Ok((n / d).ln() / n.ln())
     }
+}
+
+/// Index of `mentions` edges by target, built once per [`MemoryService::graph_reached`]
+/// call: `fact_id -> [hub_id, ...]`. [`MemoryService::reach_weight`] used to
+/// rescan every edge in the traversal for each reached node, making
+/// `graph_reached` quadratic in the number of facts a hub mentions (a single
+/// entity accumulating history is the product's nominal use case, not an edge
+/// case). This index turns that per-node scan into an O(1) lookup, so the
+/// whole pass over `edges` costs O(edges) once instead of O(edges) per node.
+fn index_mentions_edges(edges: &[MemoryEdge]) -> HashMap<u64, Vec<u64>> {
+    let mut index: HashMap<u64, Vec<u64>> = HashMap::new();
+    for edge in edges {
+        if edge.relation == MENTIONS_RELATION {
+            index.entry(edge.to).or_default().push(edge.from);
+        }
+    }
+    index
 }
 
 /// True when `filter` is absent, or every key in it matches `metadata`

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -13,8 +13,8 @@ mod common;
 use common::service;
 use serde_json::Value;
 use velesdb_memory::{
-    ExtractError, ExtractedFact, Extractor, FusionOptions, HashEmbedder, Link, MemoryError,
-    MemoryService, RerankError, Reranker,
+    EmbedError, Embedder, ExtractError, ExtractedFact, Extractor, FusionOptions, HashEmbedder,
+    Link, MemoryError, MemoryService, RerankError, Reranker,
 };
 
 const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
@@ -93,31 +93,24 @@ impl Extractor for WeightedExtractor {
     }
 }
 
-/// A seed tagged with a rare and a common topic, plus one sibling reached
-/// through BOTH hubs and two siblings reached through the common hub only —
-/// isolates `reach_weight`'s max-over-hubs rule from its single-hub case.
-struct DualHubExtractor;
+/// Exact query match for the seed; a small vector advantage for common-only
+/// siblings; no vector signal for any other fact. This makes the graph weight,
+/// rather than incidental token overlap, decide whether the dual-hub fact wins.
+struct DualHubEmbedder;
 
-impl Extractor for DualHubExtractor {
-    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
-        Ok(vec![
-            ExtractedFact {
-                text: SEED_TEXT.to_string(),
-                entities: vec!["raretopic".to_string(), "commontopic".to_string()],
-            },
-            ExtractedFact {
-                text: "dual sibling via the rare and common topics".to_string(),
-                entities: vec!["raretopic".to_string(), "commontopic".to_string()],
-            },
-            ExtractedFact {
-                text: "common-only sibling via the common topic".to_string(),
-                entities: vec!["commontopic".to_string()],
-            },
-            ExtractedFact {
-                text: "common sibling two via the common topic".to_string(),
-                entities: vec!["commontopic".to_string()],
-            },
-        ])
+impl Embedder for DualHubEmbedder {
+    fn dimension(&self) -> usize {
+        2
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        if text == SEED_TEXT {
+            return Ok(vec![1.0, 0.0]);
+        }
+        if text.starts_with("common-only") {
+            return Ok(vec![0.05, 0.998_749_2]);
+        }
+        Ok(vec![0.0, 1.0])
     }
 }
 
@@ -392,25 +385,64 @@ fn recall_fused_ranks_rare_hub_sibling_above_common_hub_sibling() {
 
 #[test]
 fn recall_fused_weighs_a_dual_hub_fact_by_its_rarest_hub() {
-    let (_dir, svc) = service();
-    svc.remember_extracted(SEED_TEXT, &DualHubExtractor, None)
-        .expect("extract and remember");
+    let dir = tempfile::TempDir::new().expect("create tempdir");
+    let svc = MemoryService::open(dir.path(), DualHubEmbedder).expect("open memory store");
+    let seed = svc.remember(SEED_TEXT, &[], None).expect("remember seed");
+    let common_hub = svc
+        .remember("common hub", &[], None)
+        .expect("remember common hub");
+    let rare_hub = svc
+        .remember("rare hub", &[], None)
+        .expect("remember rare hub");
+    let dual = svc
+        .remember("dual sibling", &[], None)
+        .expect("remember dual sibling");
+    let common_one = svc
+        .remember("common-only sibling one", &[], None)
+        .expect("remember common sibling one");
+    let common_two = svc
+        .remember("common-only sibling two", &[], None)
+        .expect("remember common sibling two");
 
-    // The dual sibling is reached through BOTH the rare and the common hub;
-    // reach_weight must take the MAX over every reaching hub, so it should
-    // rank strictly above a sibling reached through the common hub alone —
-    // proof the multi-hub weighting survives being computed from an index
-    // instead of a per-node scan over every edge.
+    svc.relate(seed, common_hub, "about")
+        .expect("relate seed to common hub first");
+    svc.relate(seed, rare_hub, "about")
+        .expect("relate seed to rare hub second");
+    for target in [dual, common_one, common_two] {
+        svc.relate(common_hub, target, "mentions")
+            .expect("relate common hub to sibling");
+    }
+    svc.relate(rare_hub, dual, "mentions")
+        .expect("relate rare hub to dual sibling second");
+
+    let explanation = svc.why(SEED_TEXT, 2, None).expect("why");
+    let reaching_hubs: Vec<u64> = explanation
+        .edges
+        .iter()
+        .filter(|edge| edge.to == dual && edge.relation == "mentions")
+        .map(|edge| edge.from)
+        .collect();
+    assert_eq!(reaching_hubs, [common_hub, rare_hub]);
+
+    let vector_only = svc.recall(SEED_TEXT, 10, None).expect("recall");
+    let vector_score = |id| {
+        vector_only
+            .iter()
+            .find(|hit| hit.id == id)
+            .map(|hit| hit.score)
+    };
+    assert!(vector_score(common_one) > vector_score(dual));
+
     let fused = svc
         .recall_fused(SEED_TEXT, 10, None, FusionOptions::default())
         .expect("recall_fused");
-    let rank_of = |needle: &str| fused.iter().position(|r| r.content.contains(needle));
-    let dual_rank = rank_of("dual sibling").expect("dual-hub sibling present");
-    for common in ["common-only sibling", "common sibling two"] {
+    let rank_of = |id| fused.iter().position(|hit| hit.id == id);
+    let dual_rank = rank_of(dual).expect("dual-hub sibling present");
+    for common in [common_one, common_two] {
         let common_rank = rank_of(common).expect("common-hub sibling present");
         assert!(
             dual_rank < common_rank,
-            "the dual-hub sibling must outrank {common:?} (max-over-hubs idf weighting)"
+            "the dual-hub sibling must use the second, rarer hub instead of the first"
         );
     }
 }

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -93,6 +93,34 @@ impl Extractor for WeightedExtractor {
     }
 }
 
+/// A seed tagged with a rare and a common topic, plus one sibling reached
+/// through BOTH hubs and two siblings reached through the common hub only —
+/// isolates `reach_weight`'s max-over-hubs rule from its single-hub case.
+struct DualHubExtractor;
+
+impl Extractor for DualHubExtractor {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![
+            ExtractedFact {
+                text: SEED_TEXT.to_string(),
+                entities: vec!["raretopic".to_string(), "commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "dual sibling via the rare and common topics".to_string(),
+                entities: vec!["raretopic".to_string(), "commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "common-only sibling via the common topic".to_string(),
+                entities: vec!["commontopic".to_string()],
+            },
+            ExtractedFact {
+                text: "common sibling two via the common topic".to_string(),
+                entities: vec!["commontopic".to_string()],
+            },
+        ])
+    }
+}
+
 /// A reranker that reverses the candidate order — proof the pool actually
 /// reaches the caller's hook and its output order is honored, not ignored.
 struct ReverseReranker;
@@ -358,6 +386,31 @@ fn recall_fused_ranks_rare_hub_sibling_above_common_hub_sibling() {
         assert!(
             rare_rank < common_rank,
             "the rare-hub sibling must outrank {common:?} (idf weighting)"
+        );
+    }
+}
+
+#[test]
+fn recall_fused_weighs_a_dual_hub_fact_by_its_rarest_hub() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(SEED_TEXT, &DualHubExtractor, None)
+        .expect("extract and remember");
+
+    // The dual sibling is reached through BOTH the rare and the common hub;
+    // reach_weight must take the MAX over every reaching hub, so it should
+    // rank strictly above a sibling reached through the common hub alone —
+    // proof the multi-hub weighting survives being computed from an index
+    // instead of a per-node scan over every edge.
+    let fused = svc
+        .recall_fused(SEED_TEXT, 10, None, FusionOptions::default())
+        .expect("recall_fused");
+    let rank_of = |needle: &str| fused.iter().position(|r| r.content.contains(needle));
+    let dual_rank = rank_of("dual sibling").expect("dual-hub sibling present");
+    for common in ["common-only sibling", "common sibling two"] {
+        let common_rank = rank_of(common).expect("common-hub sibling present");
+        assert!(
+            dual_rank < common_rank,
+            "the dual-hub sibling must outrank {common:?} (max-over-hubs idf weighting)"
         );
     }
 }


### PR DESCRIPTION
## Root cause

`recall_fused` computed a reach weight once per reached fact. Each computation
rescanned the complete flat edge list to find `mentions` edges targeting that
fact. A hub with growing fan-out therefore paid a nested node × edge scan.

The fix builds one `fact_id -> [hub_id, ...]` index in O(E), then looks up the
reaching hubs for each node. The existing IDF cache and max-over-hubs rule are
unchanged: a fact reached through several hubs still uses its rarest hub.

Fixes #1742.

## Regression proof

The original dual-hub test still passed after deliberately mutating
`reach_weight` to use only the first reaching hub. The strengthened fixture now:

1. creates the common hub first and the rare hub second;
2. proves the traversal order is `[common, rare]`;
3. gives common-only siblings a small vector advantage;
4. requires the dual-hub fact to outrank both through the second, rarer hub.

That test fails under the first-hub mutation and passes on this PR. Production
code is unchanged by the test-only follow-up commit.

## Sequential base → head benchmark

Same Criterion harness and parameters for `develop@02f508bd` then
`a806771e`: 3 s warm-up, 100 samples, hub degrees 50/200/500/1000. The harness
did not exist at the base, so the exact head harness was copied into the base
archive; its blobs were checked before the sequential runs.

| degree | base estimate (95% CI) | head estimate (95% CI) | comparable sample-mean reduction |
|---:|---:|---:|---:|
| 50 | 647.59 µs (642.12–652.41) | 615.03 µs (610.02–622.07) | 2.78% |
| 200 | 855.47 µs (846.50–865.33) | 782.55 µs (780.52–785.04) | 7.58% |
| 500 | 2.2079 ms (2.1834–2.2336) | 1.8677 ms (1.8543–1.8825) | 16.45% |
| 1000 | 4.0325 ms (3.9932–4.0755) | 3.4997 ms (3.4758–3.5281) | 13.21% |

The confidence intervals do not overlap. This is a real 2.8–16.5% local gain,
not an order-of-magnitude claim. From degree 200 to 1000, total recall latency
still grows 4.76× at the base and 4.47× at the head: other recall costs dominate
on this range, so the benchmark does not by itself expose the former quadratic
wall.

## Boundaries kept explicit

- The benchmark is in-process with `HashEmbedder` and `NativeStore`; setup is
  outside the measured section.
- It does not cover Ollama, MCP/HTTP, `mcp-remote`, cancellation,
  `memory_scope` or concurrent load. It therefore does **not** explain the
  observed MCP calls exceeding 50 seconds.
- The run order was base then head once, so machine-local thermal/order effects
  remain possible.
- The fan-out walk is still unbounded and allocates O(E); the OOM/DoS concern
  remains tracked by #1743.
- The benchmark stops at 1000 because #1805 reproduces a separate hard recall
  cliff: 1192 total memories returns the exact seed; 1193 returns no result.

## Verification

- `recall_fused_bdd`: 21/21 single-threaded;
- strengthened test RED under the first-hub mutation, GREEN after restoration;
- `cargo fmt --all --check`;
- targeted Clippy pedantic with warnings denied;
- full pre-commit workspace gate green;
- `git diff --check` clean.
