### PR TITLE
fix(hooks): prove identity pinning on a checkout, not on the clone name

### DIFF
--- a/scripts/tests/test_learning_loop_policy.py
+++ b/scripts/tests/test_learning_loop_policy.py
@@ -285,6 +285,52 @@ class LearningLoopPolicy(unittest.TestCase):
             {"project": "velesdb", "session": "rolling", "enforce_learning_loop": True},
         )
 
+        # Exercise the leak on a checkout whose basename differs from the pinned
+        # project — the shape every worktree has. `REPO.name` could not stand in
+        # for it: on a canonical lowercase clone it IS "velesdb", so asserting it
+        # absent contradicted the assertIn above, and the test passed only where
+        # the directory happened to be cased differently from the project
+        # (GitHub checks out VelesDB/, so CI was green while a local velesdb/
+        # was red). `self.project` is named velesdb-wt-contract and carries its
+        # own pinning file, so the property holds in either casing.
+        # Both cwds matter. From the checkout root the fallback would emit the
+        # basename itself, so `assertNotIn` is the assertion that fires; from a
+        # nested path it would emit that path's basename instead, which only
+        # `assertIn` catches. Testing one of the two leaves the other unproven.
+        for host in HOSTS:
+            for cwd in (self.project, self.nested):
+                with self.subTest(host=host, cwd=cwd.name):
+                    result = self.run_hook(
+                        host,
+                        "session-start.sh",
+                        hook_payload(
+                            "SessionStart",
+                            cwd=cwd,
+                            session_id=f"identity-{host}",
+                        ),
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    context = json.loads(result.stdout)["hookSpecificOutput"][
+                        "additionalContext"
+                    ]
+                    self.assertIn('project="velesdb"', context)
+                    self.assertIn('session="rolling"', context)
+                    self.assertNotIn(
+                        self.project.name,
+                        context,
+                        "a worktree basename leaked into memory identity",
+                    )
+
+    def test_an_unpinned_checkout_does_leak_its_basename(self) -> None:
+        """Positive control: the guard above must be able to refuse.
+
+        `common.sh` falls back to `project=basename(cwd)` when no
+        `.velesdb-hooks.json` is found. That fallback is the whole reason the
+        guard exists; if it ever stops leaking, the assertion above becomes
+        vacuous and has to be re-derived rather than trusted.
+        """
+        unpinned = self.private / "velesdb-wt-unpinned"
+        unpinned.mkdir(parents=True)
         for host in HOSTS:
             with self.subTest(host=host):
                 result = self.run_hook(
@@ -292,19 +338,13 @@ class LearningLoopPolicy(unittest.TestCase):
                     "session-start.sh",
                     hook_payload(
                         "SessionStart",
-                        cwd=REPO / "crates",
-                        session_id=f"identity-{host}",
+                        cwd=unpinned,
+                        session_id=f"unpinned-{host}",
                     ),
                 )
                 self.assertEqual(result.returncode, 0, result.stderr)
                 context = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
-                self.assertIn('project="velesdb"', context)
-                self.assertIn('session="rolling"', context)
-                self.assertNotIn(
-                    REPO.name,
-                    context,
-                    "a worktree basename leaked into memory identity",
-                )
+                self.assertIn(f'project="{unpinned.name}"', context)
 
     def test_disabled_or_unconfigured_projects_do_not_gate_edits(self) -> None:
         unconfigured = self.private / "ordinary-project"


### PR DESCRIPTION
## The defect

`test_repository_policy_is_explicit_and_pins_worktree_identity` (shipped by #1810) asserted two things that cannot both hold:

```python
self.assertIn('project="velesdb"', context)          # line 300
self.assertNotIn(REPO.name, context, ...)            # line 303
```

On a canonical lowercase clone `REPO.name` **is** `velesdb`, so the second assertion contradicts the first. The test passed only where the checkout directory happened to be cased differently from the pinned project.

GitHub checks out into `.../VelesDB/VelesDB`, so `REPO.name` is `VelesDB` in CI and the assertion is vacuously satisfied. **The job was green while the same commit failed locally.**

Measured on `e199f5f3`, same commit, only the directory name changed:

| checkout directory | result |
|---|---|
| `VelesDB/` | OK |
| `velesdb/` | FAILED (failures=2) |

## Why `REPO.name` was never the right subject

`integrations/agent-hooks/*/hooks/lib/common.sh` walks up from the payload `cwd` looking for `.velesdb-hooks.json`, and **falls back to `project=basename(cwd)`** when none is found. That fallback is the leak the guard exists to catch.

The test ran the hook with `cwd=REPO / "crates"`. Had the pinning broken there, the fallback would have emitted `project="crates"` — a string the assertion never looked at. So the guard did not cover the defect it was named for, in either casing.

## The fix

The guard now runs against the synthetic checkout `setUp` already builds — `velesdb-wt-contract`, carrying its own pinning file — from **both** the checkout root and a nested path:

- from the root, the fallback would emit the basename itself, which is what `assertNotIn` catches;
- from a nested path it would emit that path's basename instead, which only `assertIn` catches.

Testing one of the two leaves the other unproven.

A positive control, `test_an_unpinned_checkout_does_leak_its_basename`, pins that the unpinned fallback really does leak the basename. Without it the absence assertion could go vacuous the day the fallback changes.

No assertion was weakened and no threshold moved: the property is now exercised on a checkout whose name genuinely differs from the pinned project, which is the situation the guard was written for.

## Verification

| step | before | after |
|---|---|---|
| `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` | `Ran 389 tests` / `FAILED (failures=2)` | `Ran 390 tests` / `OK` |
| same pair in a `VelesDB/` checkout | OK (vacuously) | OK |
| same pair in a `velesdb/` checkout | FAILED (2) | OK |

Disarm proof: with `write_policy` overridden to a no-op, all four subtests go red. `assertIn` is the assertion that fires, since it is evaluated first; the basename-leak property is independently pinned by the positive control.

## Out of scope

The reason this matters beyond one test: `.velesdb-hooks.json` is what keeps a worktree from resolving `project=velesdb-wt-XXXX` and loading a different memory context. It is tracked, so the property holds — but the guard proving it was disarmed by a coincidence of capitalisation.
