### PR TITLE
docs(agents): document the CI gates the pre-push block was missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,21 +49,67 @@ cargo fmt --all
 cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
   --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic
 cargo clippy -p velesdb-node --lib -- -D warnings   # node is excluded above (N-API link), linted separately
+PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib -- -D warnings   # excluded above too (PyO3 link)
+cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check \
+  -- -A warnings -D clippy::undocumented_unsafe_blocks
 cargo test -p velesdb-core --features persistence -- --test-threads=1
 # A single test by name:
 cargo test -p velesdb-core --features persistence <test_name> -- --test-threads=1
 # If search path modified:
 cargo test -p velesdb-core --features persistence test_recall -- --test-threads=1
+# Doctests are a separate CI job from the test suite above:
+cargo test --doc --package velesdb-core
+cargo test --doc --package velesdb-server
 # Feature-gate sanity:
 cargo check --no-default-features
 cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
+# Guards and contracts. Every one of these blocks a PR through `CI Success`, and
+# every one runs here. `unittest discover` prints "Performance claims audit
+# FAILED" on stdout while passing — that is a test exercising a guard's refusal
+# path, so read `Ran N tests` + `OK`, never grep for FAILED.
+python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .
+python3 scripts/check-version-sync.py
+python3 scripts/check-feature-claims.py
+python3 scripts/check-perf-claims.py --no-criterion
+python3 scripts/check-promise-contract.py
+python3 scripts/check-mcp-doc-contract.py --verbose
+python3 scripts/check-skill-private-references.py
+python3 scripts/check-ai-attribution.py "origin/develop..HEAD"
+bash scripts/check-doc-contract.sh
+for g in stamp index tracked versions; do
+  python3 scripts/check-doc-freshness.py --guard "$g" --mode strict
+done
+bash integrations/agent-hooks/test/hooks.test.sh
+cargo deny check advisories licenses bans sources
 # Shipping a new surface? grep the READMEs/CHANGELOG for now-stale availability caveats.
 ```
 
 Shortcut: `.\scripts\local-ci.ps1` (full) or `-Quick` (fmt + clippy). Git hooks: `git config core.hooksPath .githooks`.
 Benchmarks: `cargo bench -p velesdb-core --bench hnsw_benchmark` (also `simd_benchmark`, `sparse_benchmark`); end-to-end perf/recall via `python benchmarks/velesdb_benchmark.py --recall`.
+
+---
+
+## What the pre-push block does not catch
+
+The block above is not the whole of `CI Success`. These jobs block a PR too, but
+need a toolchain, a build, or a state a local run does not have. When one of them
+goes red, the cause is not in what you just ran — go read that job.
+
+| CI job | Why it is not in the block above |
+|---|---|
+| `python-integrations` | installs the wheel plus the four integration packages |
+| `python-sdk-tests` | maturin build of `velesdb-python` |
+| `node-binding-tests` | `napi build` plus npm install; the Windows job runs only when `crates/velesdb-node/` changed |
+| `velesql-conformance` | seven cargo suites plus an npm contract fixture |
+| `openapi-drift` | regenerates the spec and diffs the committed copy |
+| `perf-smoke` | criterion bench plus a 15% regression comparison |
+| `binary-size` | release build of three binaries |
+| `run-production-gates`, `propagation-guard` | cross-crate sweeps over every SDK, demo and example |
+| `compat-matrix` | Windows, wasm32 and a nightly loom pass |
+| node licence boundary | `cargo tree` assertion that `velesdb-node` never pulls `velesdb-core` |
+| `pr-governance` | branch prefix, and "not behind base" — properties of the PR, not of the tree |
 
 ---
 


### PR DESCRIPTION
## Why

`AGENTS.md` heads its pre-push section with a promise:

> CI runs on every PR — run this locally before every push to avoid red pipelines

`CI Success` aggregates **20 verified jobs**. The block listed the cargo gates and nothing else: no guard, no contract, no doc gate. A contributor could run every documented command and still arrive red, which is the failure the section exists to prevent.

## What was added

Only gates that `ci.yml` — or a workflow `ci.yml` calls — actually executes. Nothing invented, nothing reformulated. **Every command below was run on `develop` before being written down, and every one exits 0.**

| Added | Source |
|---|---|
| `PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib` | `ci.yml:258` |
| `cargo clippy -p velesdb-core … -D clippy::undocumented_unsafe_blocks` | `ci.yml:262-264` |
| `cargo test --doc` for core and server | `ci.yml:350-351` |
| `python3 -m unittest discover -s scripts/tests` | `gate-contracts.yml:34` |
| `check-version-sync.py` | `ci.yml:329` |
| `check-feature-claims.py` | `ci.yml:338` |
| `check-perf-claims.py --no-criterion` | `ci.yml:341` |
| `check-promise-contract.py` | `promise-contract.yml:29` |
| `check-mcp-doc-contract.py --verbose` | `ci.yml:669` |
| `check-skill-private-references.py` | `ci.yml:643` |
| `check-ai-attribution.py` | `pr-governance.yml:143` |
| `check-doc-contract.sh` | `doc-contract.yml:48` |
| the four `check-doc-freshness.py` guards | `doc-contract.yml:64-88` |
| `hooks.test.sh` | `ci.yml:662` |
| `cargo deny check advisories licenses bans sources` | `ci.yml:483` |

The two clippy lines that were missing are exactly the two crates the strict workspace line above them excludes — the exclusion was documented, the compensating lint was not.

A comment records that `unittest discover` prints `Performance claims audit FAILED` on stdout **while passing**, because a test exercises a guard's refusal path. Reading that line instead of `Ran N tests` + `OK` misreads a green suite as red.

## What the block still does not catch

A second section names every remaining blocking job with the reason it cannot be local: builds, toolchains, or properties of the PR rather than of the tree. The contract now states its own coverage instead of implying it.

## Findings reported, not fixed

Out of scope here; each needs its own arbitration.

1. **`AGENTS.md:20`** reads "Anthropic, Codex, Codex" — a duplicated word, residue of an automated replacement.
2. **The local hooks under-approximate CI.** `.githooks/pre-push:65` runs clippy **without** `-D clippy::pedantic` and without features; `:73` runs the tests **without** features and **without** `--test-threads=1`, which `AGENTS.md:33` calls non-negotiable because the tests share filesystem state; `:81` makes `cargo deny` **non-blocking** while the `security` job blocks. A green hook does not predict a green CI.
3. **`CONTRIBUTING.md:130-131`** is two gates behind `AGENTS.md`: no separate `velesdb-node` clippy line, no `wasm-pack test`.

Checked and **not** reported: `AGENTS.md:58` documents `cargo check --no-default-features` where `ci.yml:138` runs the `--workspace --exclude velesdb-python` form. The scopes differ, but all four variants exit 0 on `develop` today, so there is nothing to correct.

## Verification

All doc gates re-run after the edit: the four freshness guards, `doc-contract`, `feature-claims`, `perf-claims`, `mcp-doc-contract`, `promise-contract` — all exit 0. Full suite: `Ran 390 tests` / `OK`.
