### PR TITLE
docs(decisions): record decisions with their cause, and guard the index

### DIFF
--- a/.github/workflows/doc-contract.yml
+++ b/.github/workflows/doc-contract.yml
@@ -86,3 +86,12 @@ jobs:
       # a broken copy-paste for whoever follows it.
       - name: Hardcoded doc versions vs Cargo manifests
         run: python3 scripts/check-doc-freshness.py --guard versions --mode strict
+
+      # BLOCKING from the day docs/decisions/ was created, because the two
+      # shapes it refuses were reachable by nobody else: `index` sweeps only the
+      # root of docs/, and it asks doc-to-index without ever asking
+      # index-to-doc, so a row pointing at a missing file was legal everywhere.
+      # Deleting the directory answers 2, not 0 — a guard that could not run is
+      # not a guard that found nothing.
+      - name: Every decision is indexed and every index row resolves
+        run: python3 scripts/check-doc-freshness.py --guard decisions --mode strict

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,6 +157,7 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 | [ANN state-of-the-art audit](./ANN_SOTA_AUDIT.md) | How the index compares to published ANN work. |
 | [Core wiring debt](./CORE_WIRING_DEBT.md) | Known gaps between what core exposes and what the surfaces use. |
 | [Core / Premium split](./CORE_PREMIUM_SPLIT.md) | Where the open-core boundary sits, and the contract both repos read identically. |
+| [Decisions](./decisions/README.md) | One decision per file: what was decided, why, and the code, PR or CI job that proves it. |
 
 ---
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,20 @@
+# Decisions
+
+One decision per file: what was decided, why, and the code, PR or CI job that
+proves it. See also the [docs index](../README.md) for the full documentation
+map.
+
+Entries are not edited into agreement with later thinking. A decision that no
+longer holds gets a new file that supersedes it, so the reason the old one
+looked right at the time survives.
+
+| Decision | Summary |
+|----------|---------|
+| [Core must never reference a premium crate](./core-premium-boundary.md) | The open-core split is a licence boundary, enforced by a `cargo tree` assertion |
+| [Locks are parking_lot, never std::sync](./parking-lot-only.md) | `std` locks poison on panic, turning one fault into permanent failure |
+| [Tests run single-threaded](./tests-single-threaded.md) | The suites share filesystem state |
+| [Repository scripts are tested with stdlib unittest](./unittest-not-pytest.md) | The gate jobs use a bare `setup-python`; a skipped guard reads like a passing one |
+| [The context optimizer refuses high-risk restitution](./optimizer-refuses-high-risk.md) | An unrestorable compiled view is worse than a large one |
+| [The shared daemon is reached over native HTTP](./native-http-over-bridge.md) | The bridge does not recover from an idle-expired session |
+| [A repository edit requires a successful causal recall first](./recall-before-edit.md) | Bound to the exact session and checkout, written only after success |
+| [Tool results are replaced on one host only](./no-auto-replacement-on-a-second-host.md) | Replacement needs an output contract; parity without one is a claim |

--- a/docs/decisions/core-premium-boundary.md
+++ b/docs/decisions/core-premium-boundary.md
@@ -1,0 +1,18 @@
+# Core must never reference a premium crate
+
+Status: accepted
+
+`velesdb-core` ships only the policy-free port — `DatabaseObserver`,
+`on_query_request` returning an `AccessDecision`, and `open_with_observer` —
+with an allow-all, no-op default. The enforcing policy (RBAC, tenancy, audit)
+lives in `velesdb-private` as an observer implementation.
+
+**Why.** The open-core split is a licence boundary, not a matter of taste. One
+premium symbol reachable from core would make the published crate carry code it
+cannot ship under its own licence, and the leak would be invisible until
+someone read the dependency tree.
+
+**Evidence.** The port is `crates/velesdb-core/src/observer/`. CI refuses the
+crossing rather than trusting review: the `node-binding-tests` job in
+`.github/workflows/ci.yml` fails if `cargo tree -p velesdb-node` resolves
+`velesdb-core`.

--- a/docs/decisions/native-http-over-bridge.md
+++ b/docs/decisions/native-http-over-bridge.md
@@ -1,0 +1,17 @@
+# The shared daemon is reached over native HTTP, not a stdio bridge
+
+Status: accepted
+
+Hosts that support Streamable HTTP talk to the shared `velesdb-memory` daemon
+directly. The pinned `mcp-remote` stdio bridge remains only for hosts whose
+config accepts stdio alone, and those must be restarted after a long idle
+period.
+
+**Why.** The server expires an MCP session after 60 minutes of inactivity, and
+SSE pings do not renew it. A request carrying an expired id is refused
+immediately — measured at 0.048 s — but `mcp-remote@0.1.38` neither completes
+the call nor re-initialises, so the host waits for its own timeout instead. A
+fresh native session runs initialize, list and recall in 0.1–0.2 s.
+
+**Evidence.** [PR #1807](https://github.com/cyberlife-coder/VelesDB/pull/1807),
+which shipped the native wiring and the session guards.

--- a/docs/decisions/no-auto-replacement-on-a-second-host.md
+++ b/docs/decisions/no-auto-replacement-on-a-second-host.md
@@ -1,0 +1,16 @@
+# Tool results are replaced on one host only
+
+Status: accepted
+
+The optimizer replaces an oversized tool result on the host whose hook protocol
+defines an output-replacement channel. On the other supported host it observes
+and records, but never substitutes a result.
+
+**Why.** Replacement is only safe when the protocol says what a replacement
+must look like and what happens when the shape is wrong. Without that contract,
+a substituted payload either is silently dropped or reaches the model in a shape
+the host never promised — and neither failure is visible from inside the hook.
+Parity here would be a claim, not a capability.
+
+**Evidence.** [PR #1810](https://github.com/cyberlife-coder/VelesDB/pull/1810);
+the host-by-host wiring is in `integrations/agent-hooks/`.

--- a/docs/decisions/optimizer-refuses-high-risk.md
+++ b/docs/decisions/optimizer-refuses-high-risk.md
@@ -1,0 +1,17 @@
+# The context optimizer refuses high-risk restitution
+
+Status: accepted
+
+The `PostToolUse` compression hook reads the compiler's `risk` field. It
+escalates the budget once, and if the result is still `high` it leaves the tool
+output byte for byte untouched and states the reason on stderr.
+
+**Why.** A compiled view that cannot be restored faithfully is worse than a
+large one: the agent keeps reasoning, but on text that no longer says what the
+original said. Measured before the guard existed, a 584 KB stack dump stayed
+`high` at budgets of 2000, 4000, 8000 and 16000 — every one of those
+replacements would have shipped.
+
+**Evidence.** [PR #1803](https://github.com/cyberlife-coder/VelesDB/pull/1803).
+Two of its assertions are refusal assertions: disarming the guard turns exactly
+those two red.

--- a/docs/decisions/parking-lot-only.md
+++ b/docs/decisions/parking-lot-only.md
@@ -1,0 +1,15 @@
+# Locks are parking_lot, never std::sync
+
+Status: accepted
+
+Every lock in the workspace comes from `parking_lot`. `std::sync::Mutex` and
+`std::sync::RwLock` are not used.
+
+**Why.** `std` locks poison on panic. A poisoned lock turns a fault in one
+operation into a permanent failure of every later one that touches the same
+data, which is a worse outcome than the original panic for an embedded database
+the caller cannot restart independently.
+
+**Evidence.** Stated as non-negotiable in [`AGENTS.md`](../../AGENTS.md); the
+lock ordering that goes with it is in
+[`CONCURRENCY_MODEL.md`](../CONCURRENCY_MODEL.md).

--- a/docs/decisions/recall-before-edit.md
+++ b/docs/decisions/recall-before-edit.md
@@ -1,0 +1,18 @@
+# A repository edit requires a successful causal recall first
+
+Status: accepted
+
+In an opted-in repository, the edit guard refuses a modification until a recall
+has succeeded, bound to the exact host session and the exact physical checkout.
+The sentinel is written only after a successful MCP result — never at the start
+of the call, never after a timeout or an error.
+
+**Why.** The recurring failure is not forgetting to recall; it is believing a
+recall happened. Binding to the session and the checkout is what stops a
+sentinel from one worktree authorising an edit in another, and stops a timeout
+from reading as a success.
+
+**Evidence.** [PR #1810](https://github.com/cyberlife-coder/VelesDB/pull/1810).
+The identity pinning it relies on is itself guarded, and that guard was
+corrected in [PR #1811](https://github.com/cyberlife-coder/VelesDB/pull/1811)
+after it was found to pass only by an accident of directory capitalisation.

--- a/docs/decisions/tests-single-threaded.md
+++ b/docs/decisions/tests-single-threaded.md
@@ -1,0 +1,13 @@
+# Tests run single-threaded
+
+Status: accepted
+
+The suites run with `--test-threads=1`.
+
+**Why.** The tests share filesystem state — they open, write and reopen stores
+under temporary directories that the same fixtures reuse. Run in parallel they
+interleave on that state and fail for reasons unrelated to the code under test,
+which is the most expensive kind of red: one that teaches nothing.
+
+**Evidence.** The workspace test job in `.github/workflows/ci.yml` passes
+`-- --test-threads=1` and sets `RUST_TEST_THREADS=1`.

--- a/docs/decisions/unittest-not-pytest.md
+++ b/docs/decisions/unittest-not-pytest.md
@@ -1,0 +1,15 @@
+# Repository scripts are tested with stdlib unittest
+
+Status: accepted
+
+Tests under `scripts/tests/` use `unittest` from the standard library, run with
+`python -m unittest discover`. `pytest` is not used there.
+
+**Why.** The gate jobs use a bare `setup-python` with nothing installed. A test
+suite that needs a dependency would either add an install step to every gate
+job or, worse, be skipped when that step is missing — and a skipped guard reads
+exactly like a passing one.
+
+**Evidence.** The reason is recorded in `scripts/guards.json` under the
+`_json_not_yaml` key; the discovery command runs in
+`.github/workflows/gate-contracts.yml`.

--- a/scripts/check-doc-freshness.py
+++ b/scripts/check-doc-freshness.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Documentation freshness guards.
 
-Three independent guards, all runnable separately so a guard that is still
+Five independent guards, all runnable separately so a guard that is still
 red on the current tree can be wired as a warning while the others block:
 
 ``stamp``
@@ -26,6 +26,20 @@ red on the current tree can be wired as a warning while the others block:
     inside doc snippets, and ``velesdb-memory-vX.Y.Z`` git-tag references.
     Dependency pins are allowed to be shorter than the full triple
     (``velesdb-core = "4.0"`` is fine for 4.0.0) but never to disagree.
+
+``tracked``
+    Every document an entry document designates is itself tracked by git. A
+    path that exists and a path a clone receives are not the same path: the
+    guard reads the index, not the filesystem.
+
+``decisions``
+    Every markdown file directly under ``docs/decisions/`` is listed in
+    ``docs/decisions/README.md``, AND every relative row of that index
+    resolves to a file that exists. ``index`` covers neither: it stops at the
+    root of ``docs/``, and it only ever asks doc-to-index, so a row pointing
+    at nothing has always been legal. A missing ``docs/decisions/`` is a
+    precondition (exit 2), never a silent pass — otherwise deleting the
+    directory would disarm the guard while CI stayed green.
 
 This script deliberately does NOT replace ``scripts/check-version-sync.py``:
 that one pins a curated list of files to exact readers for the release bump.
@@ -53,6 +67,12 @@ DOCS_INDEX = "README.md"
 # Keep this list empty unless there is a structural reason: the index itself
 # obviously cannot link to itself.
 ROOT_DOC_EXEMPTIONS: "frozenset[str]" = frozenset({DOCS_INDEX})
+
+# One decision per file, under docs/decisions/, presented by its own index.
+DECISIONS_SUBDIR = "decisions"
+
+# Same structural reason as above: an index cannot be a row of itself.
+DECISION_DOC_EXEMPTIONS: "frozenset[str]" = frozenset({DOCS_INDEX})
 
 # Directories whose docs legitimately pin OLD versions (historical migration
 # notes, archived releases). Paths are relative to the repository root.
@@ -199,6 +219,28 @@ def root_docs(root: Path) -> "list[Path]":
     ]
 
 
+def decision_docs(root: Path) -> "list[Path]":
+    """TRACKED markdown files directly under docs/decisions/, minus the index.
+
+    Non-recursive on purpose. A decision is atomic, so it is one file; a
+    subdirectory is another index's business, and sweeping into it would make
+    this index answer for documents it does not present. Tracked rather than
+    on-disk, for the reason spelled out in `root_docs`.
+    """
+    decisions_dir = root / DOCS_DIRNAME / DECISIONS_SUBDIR
+    on_disk = sorted(
+        path for path in decisions_dir.glob("*.md")
+        if path.name not in DECISION_DOC_EXEMPTIONS
+    )
+    tracked = tracked_files(root)
+    if tracked is None:
+        return on_disk
+    return [
+        path for path in on_disk
+        if path.relative_to(root).as_posix() in tracked
+    ]
+
+
 def scanned_doc_files(root: Path) -> "list[Path]":
     """Every markdown file the version guard sweeps."""
     excluded_dirs = tuple((root / d).resolve() for d in VERSION_SCAN_EXCLUDED_DIRS)
@@ -223,23 +265,34 @@ def scanned_doc_files(root: Path) -> "list[Path]":
     return out
 
 
-def index_link_targets(root: Path) -> "set[Path]":
-    """Resolved filesystem targets of every relative link in docs/README.md."""
-    index = root / DOCS_DIRNAME / DOCS_INDEX
+def index_links(index: Path) -> "list[tuple[str, Path, int]]":
+    """Every relative link of an index, as (raw target, resolved path, line).
+
+    `index_link_targets` only ever needed the resolved set, so that is all it
+    returned. Asking whether a row points at NOTHING needs the raw text to
+    quote back and the line to point at, and a set of paths carries neither.
+    """
     text = index.read_text(encoding="utf-8")
-    targets: "set[Path]" = set()
+    out: "list[tuple[str, Path, int]]" = []
     for match in list(MD_INLINE_LINK_RE.finditer(text)) + list(MD_REF_LINK_RE.finditer(text)):
         raw = match.group(1).strip()
         if not raw or raw.startswith(("#", "mailto:")) or "://" in raw:
             continue
-        raw = raw.split("#", 1)[0].split("?", 1)[0]
-        if not raw:
+        target = raw.split("#", 1)[0].split("?", 1)[0]
+        if not target:
             continue
         try:
-            targets.add((index.parent / raw).resolve())
+            resolved = (index.parent / target).resolve()
         except (OSError, ValueError):  # pragma: no cover - defensive
             continue
-    return targets
+        out.append((target, resolved, line_of(text, match.start())))
+    return out
+
+
+def index_link_targets(root: Path) -> "set[Path]":
+    """Resolved filesystem targets of every relative link in docs/README.md."""
+    index = root / DOCS_DIRNAME / DOCS_INDEX
+    return {resolved for _raw, resolved, _line in index_links(index)}
 
 
 def pin_agrees(pin: str, actual: str) -> bool:
@@ -317,6 +370,57 @@ def guard_index(root: Path) -> "tuple[list[str], list[str]]":
         f"against {len(targets)} relative link target(s) in {DOCS_DIRNAME}/{DOCS_INDEX}.",
     )
     return failures, info
+
+
+def guard_decisions(root: Path) -> "tuple[list[str], list[str]]":
+    """Both directions, because `index` only ever checked one.
+
+    `index` asks doc-to-index: is every document presented? It never asks
+    index-to-doc, so a row pointing at a file that does not exist has always
+    been legal there. Under docs/decisions/ neither question was asked at all,
+    since that guard stops at the root of docs/.
+    """
+    failures: "list[str]" = []
+    info: "list[str]" = []
+    index = root / DOCS_DIRNAME / DECISIONS_SUBDIR / DOCS_INDEX
+    index_name = rel(root, index)
+    links = index_links(index)
+    listed = {resolved for _raw, resolved, _line in links}
+    docs = decision_docs(root)
+
+    for path in docs:
+        name = rel(root, path)
+        if path.resolve() in listed:
+            info.append(f"  ok  {name}")
+            continue
+        failures.append(
+            f"{name}: not listed in {index_name}. Add a row such as "
+            f"`| [Title](./{path.name}) | one-line summary |` to the table."
+        )
+
+    for raw, resolved, line in links:
+        if not _inside(root, resolved) or resolved.exists():
+            continue
+        failures.append(
+            f"{index_name}:{line}: lists `{raw}`, which does not exist. "
+            "Either add the decision file or remove the row."
+        )
+
+    info.insert(
+        0,
+        f"Scanned {len(docs)} decision file(s) in {DOCS_DIRNAME}/{DECISIONS_SUBDIR}/ "
+        f"against {len(links)} relative link(s) in {index_name}.",
+    )
+    return failures, info
+
+
+def _inside(root: Path, path: Path) -> bool:
+    """A link climbing out of the repository is nobody's business here."""
+    try:
+        path.relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
 
 
 def guard_versions(root: Path) -> "tuple[list[str], list[str]]":
@@ -471,6 +575,10 @@ GUARDS = {
     "index": (guard_index, "every doc at the root of docs/ is linked from docs/README.md"),
     "versions": (guard_versions, "no hardcoded doc version contradicts the Cargo manifests"),
     "tracked": (guard_tracked, "every document an entry document designates is itself tracked"),
+    "decisions": (
+        guard_decisions,
+        "every docs/decisions/ file is listed in its index, and every row of that index resolves",
+    ),
 }
 
 
@@ -535,6 +643,15 @@ def main(argv: "list[str] | None" = None) -> int:
     # exercise one guard without staging the preconditions of the others.
     if {"index", "stamp"} & set(names) and not (root / DOCS_DIRNAME / DOCS_INDEX).is_file():
         print(f"ERROR: {root}/{DOCS_DIRNAME}/{DOCS_INDEX} not found", file=sys.stderr)
+        return 2
+    # Deleting docs/decisions/ must not read as "nothing to report". A silent 0
+    # there would leave CI green, the registry still announcing the subguard and
+    # the workflow step still running while measuring nothing — a disarm one
+    # notch below the one `subguards` was written to catch. `warn` does not
+    # soften it either: a precondition is not a finding.
+    decisions_index = root / DOCS_DIRNAME / DECISIONS_SUBDIR / DOCS_INDEX
+    if "decisions" in names and not decisions_index.is_file():
+        print(f"ERROR: {decisions_index} not found", file=sys.stderr)
         return 2
     try:
         return run(root, names, args.mode, args.verbose)

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -350,7 +350,7 @@
     },
     {
       "script": "scripts/check-doc-freshness.py",
-      "purpose": "Doc stamps, index, version references and the tracked-contract rule stay honest (four guards).",
+      "purpose": "Doc stamps, index, version references, the tracked-contract rule and the decisions index stay honest (five guards).",
       "workflow": ".github/workflows/doc-contract.yml",
       "job": "freshness",
       "required": true,
@@ -359,7 +359,7 @@
       "self_test_required": true,
       "blind_spot": {
         "issue": null,
-        "summary": "None known. The `index` guard ran in warn mode over eleven root docs a comment called unreachable; measured, all eleven are linked and strict exits 0, so the comment had kept a working guard disarmed. All four guards are strict from here. `tracked` reads git, not the filesystem: a path that exists and a path a clone receives are not the same path."
+        "summary": "None known. The `index` guard ran in warn mode over eleven root docs a comment called unreachable; measured, all eleven are linked and strict exits 0, so the comment had kept a working guard disarmed. All four guards are strict from here. `tracked` reads git, not the filesystem: a path that exists and a path a clone receives are not the same path. `decisions` sweeps docs/decisions/ only, non-recursively: a subdirectory is another index's business. Three limits it does not reach: docs/decisions/README.md is itself required by nothing, since `index` only sweeps the root of docs/; an index listing nothing, in a directory holding only that index, passes vacuously; and a listed file that exists but is untracked is `tracked`'s jurisdiction, not this one's."
       },
       "required_via": "doc-contract",
       "must_refuse": [
@@ -390,13 +390,59 @@
             "--root",
             "{root}"
           ]
+        },
+        {
+          "vector": "a decision file present in docs/decisions/ that the index does not list — the orphan `index` cannot see, because it only sweeps the root of docs/",
+          "files": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "accepts": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "argv": [
+            "--guard",
+            "decisions",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
+        },
+        {
+          "vector": "the decisions index listing a file that does not exist — the dead link `index` structurally cannot catch, since it only checks doc-to-index and never index-to-doc",
+          "files": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n"
+          },
+          "accepts": {
+            "docs/README.md": "# Docs\n\n- [Decisions](./decisions/README.md)\n",
+            "docs/decisions/README.md": "# Decisions\n\nOne decision per file. Back to the [docs index](../README.md).\n\n| Decision | Summary |\n|----------|---------|\n| [Storage engine](./storage-engine.md) | why the LSM tree |\n| [WAL fsync policy](./wal-fsync-policy.md) | why fsync on commit |\n",
+            "docs/decisions/storage-engine.md": "# Storage engine\n\nStatus: accepted\n",
+            "docs/decisions/wal-fsync-policy.md": "# WAL fsync policy\n\nStatus: accepted\n"
+          },
+          "argv": [
+            "--guard",
+            "decisions",
+            "--mode",
+            "strict",
+            "--root",
+            "{root}"
+          ]
         }
       ],
       "subguards": [
         "stamp",
         "index",
         "versions",
-        "tracked"
+        "tracked",
+        "decisions"
       ]
     },
     {

--- a/scripts/tests/test_check_doc_freshness.py
+++ b/scripts/tests/test_check_doc_freshness.py
@@ -175,6 +175,96 @@ class IndexGuardTests(FreshnessGuardTestCase):
         self.assertGuardPasses("index")
 
 
+DECISIONS_INDEX = """# Decisions
+
+One decision per file. Back to the [docs index](../README.md).
+
+| Decision | Summary |
+|----------|---------|
+{extra}"""
+
+
+class DecisionsGuardTests(FreshnessGuardTestCase):
+    """docs/decisions/ is swept by nothing else.
+
+    `index` only reaches the root of docs/, and it only asks doc-to-index —
+    never index-to-doc, so a row pointing at nothing has always been legal.
+    """
+
+    STORAGE = "| [Storage engine](./storage-engine.md) | why the LSM tree |\n"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.write("docs/decisions/README.md", DECISIONS_INDEX.format(extra=self.STORAGE))
+        self.write("docs/decisions/storage-engine.md", "# Storage engine\n\nStatus: accepted\n")
+
+    def index_with(self, extra: str) -> None:
+        self.write("docs/decisions/README.md", DECISIONS_INDEX.format(extra=self.STORAGE + extra))
+
+    def test_baseline_repository_passes(self) -> None:
+        self.assertGuardPasses("decisions")
+
+    def test_unlisted_decision_fails_then_passes_once_listed(self) -> None:
+        self.write("docs/decisions/wal-fsync.md", "# WAL fsync\n\nStatus: accepted\n")
+        self.assertGuardFails(
+            "decisions", "docs/decisions/wal-fsync.md", "not listed in docs/decisions/README.md"
+        )
+
+        self.index_with("| [WAL fsync](./wal-fsync.md) | why fsync on commit |\n")
+        self.assertGuardPasses("decisions")
+
+    def test_dead_link_fails_then_passes_once_the_file_exists(self) -> None:
+        self.index_with("| [Tiered cache](./tiered-cache.md) | why the second tier |\n")
+        self.assertGuardFails("decisions", "docs/decisions/README.md:", "does not exist")
+
+        self.write("docs/decisions/tiered-cache.md", "# Tiered cache\n\nStatus: accepted\n")
+        self.assertGuardPasses("decisions")
+
+    def test_the_index_is_not_required_to_list_itself(self) -> None:
+        self.assertNotIn(
+            self.tmp / "docs" / "decisions" / "README.md", cdf.decision_docs(self.tmp)
+        )
+
+    def test_a_decision_in_a_subdirectory_does_not_satisfy_the_guard(self) -> None:
+        # The row points at an archived namesake. A substring match would call
+        # docs/decisions/wal-fsync.md "listed". It is not.
+        self.write("docs/decisions/wal-fsync.md", "# WAL fsync\n\nStatus: accepted\n")
+        self.write("docs/decisions/archive/wal-fsync.md", "# WAL fsync (superseded)\n")
+        self.index_with("| [WAL fsync](./archive/wal-fsync.md) | superseded |\n")
+        self.assertGuardFails("decisions", "docs/decisions/wal-fsync.md")
+
+    def test_the_back_link_is_checked_but_a_link_leaving_the_tree_is_not(self) -> None:
+        # `../README.md` resolves inside the tree and must be verified; a link
+        # climbing out of the repository is nobody's business here.
+        self.write(
+            "docs/decisions/README.md",
+            DECISIONS_INDEX.format(extra=self.STORAGE)
+            + "\nSee [elsewhere](../../../outside.md).\n",
+        )
+        self.assertGuardPasses("decisions")
+
+    def test_reference_style_link_definition_counts(self) -> None:
+        self.write("docs/decisions/wal-fsync.md", "# WAL fsync\n\nStatus: accepted\n")
+        self.write(
+            "docs/decisions/README.md",
+            DECISIONS_INDEX.format(extra=self.STORAGE) + "\nSee [wal].\n\n[wal]: ./wal-fsync.md\n",
+        )
+        self.assertGuardPasses("decisions")
+
+    def test_a_missing_decisions_directory_is_a_precondition_not_a_pass(self) -> None:
+        # Otherwise `rm -rf docs/decisions/` disarms the guard in silence: CI
+        # green, the registry still announcing the subguard, the workflow step
+        # still running and measuring nothing. `warn` must not soften it either
+        # — a precondition is not a finding.
+        shutil.rmtree(self.tmp / "docs" / "decisions")
+        for mode in ("strict", "warn"):
+            with self.subTest(mode=mode):
+                self.assertEqual(
+                    cdf.main(["--root", str(self.tmp), "--guard", "decisions", "--mode", mode]),
+                    2,
+                )
+
+
 class VersionGuardTests(FreshnessGuardTestCase):
     def test_baseline_repository_passes(self) -> None:
         self.assertGuardPasses("versions")


### PR DESCRIPTION
## Why

The repository had nowhere a decision and its reason were written down. `docs/audit/` records findings, `docs/planning/` records remediations — nothing said **why** a constraint exists.

The cost is already on record in this repository. `doc-contract.yml:66-72` documents a stale comment that kept a *working* guard in warn mode for months, because the reason for that mode lived only in the comment. A reason nobody can verify decays into a reason nobody questions.

## The decisions

Eight files, one decision each, every one carrying the code, PR or CI job that proves it. **None of them is new** — each was already true and already enforced somewhere. They were simply unwritten.

| File | Proof |
|---|---|
| `core-premium-boundary.md` | `crates/velesdb-core/src/observer/`, the `cargo tree` assertion in `node-binding-tests` |
| `parking-lot-only.md` | `AGENTS.md`, `docs/CONCURRENCY_MODEL.md` |
| `tests-single-threaded.md` | the workspace test job's `--test-threads=1` |
| `unittest-not-pytest.md` | `scripts/guards.json`, key `_json_not_yaml` |
| `optimizer-refuses-high-risk.md` | #1803 |
| `native-http-over-bridge.md` | #1807 |
| `recall-before-edit.md` | #1810, corrected by #1811 |
| `no-auto-replacement-on-a-second-host.md` | #1810, `integrations/agent-hooks/` |

The index is linked from `docs/README.md` under *Design, Internals & Reference* — the section that already says "read these when you need the *why* behind a behaviour".

## The guard: a fifth subguard, not a new script

`subguards` exists for exactly this case, and it carries the anti-disarm property for free: `test_every_declared_subguard_is_actually_selected` demands the literal `--guard decisions` in the job, so the sub-guard cannot be dropped from CI while the registry keeps announcing it. A new `scripts/check-*.py` would instead have required a full `guards.json` entry, its own self-test module, two workflow steps, and a copy of `MD_INLINE_LINK_RE`, `rel()`, `line_of()` and the whole `--mode` mechanism.

It refuses two shapes, **neither reachable by anything that already existed**:

- **an orphan** — a file under `docs/decisions/` the index does not list. `index` cannot see it: it sweeps only the root of `docs/`.
- **a dead row** — an index line pointing at a file that is not there. `index` *structurally* cannot catch it: it asks doc-to-index and never index-to-doc, so a row pointing at nothing has always been legal.

**A missing `docs/decisions/` answers 2** — in `warn` as well as `strict`. A silent 0 would leave `rm -rf docs/decisions/` as a way to disarm the guard with CI green, the registry still announcing the subguard, and the workflow step still running while measuring nothing. That is a disarm one notch below the one `subguards` was written to catch.

`index_link_targets` is redefined over a new `index_links`, which also returns the raw target and the line — a set of resolved paths can express *is this document presented* but not *does this row point at anything*. `guard_index` is untouched, and `IndexGuardTests` is the regression net for the refactor.

## Verification — the registry first

| Step | Result |
|---|---|
| declare the subguard in `guards.json` **before writing it** | `test_every_declared_subguard_is_actually_selected` **RED**; both refusal vectors answer 2, which the harness rejects: *"1 is a refusal; 2 is a guard that could not run, which is not the same thing"* |
| add `DecisionsGuardTests` | **RED**, `KeyError: 'decisions'` |
| write the guard | `IndexGuardTests` + `DecisionsGuardTests` green |
| refusal vectors | 5/5, exit 1 on both shapes |
| wire the workflow step | wiring test green, 48/48 |
| full suite | 390 → **398**, `OK` |
| five guards on the real tree | exit 0 |

**Both disarm paths shown failing.** Removing the `--guard decisions` line from the workflow reddens the wiring test. Deleting the directory answers 2 under `strict` *and* `warn`.

## Pre-existing, not introduced

`lizard` warns on `guard_tracked` (CCN 12) and `run` (CCN 10) in this file. Both are identical on `develop` — verified with `git show develop:scripts/check-doc-freshness.py`. The four new functions are within thresholds: CCN 2–7, NLOC 6–30.

The module docstring said "Three independent guards" while four existed and only three were documented. It now says five, and documents `tracked` and `decisions`.
