### PR TITLE
docs(claude): state what is still duplicated instead of denying it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ Read and follow [`AGENTS.md`](AGENTS.md) before making any change; it is the
 canonical repository contract — working principles, the CI-enforced constraints
 a PR cannot merge without, the pre-push validation sequence, and the
 architecture. This file used to duplicate it verbatim, and the two drifted: the
-declared MSRV was wrong in both for weeks. One source now.
+declared MSRV was wrong in both for weeks. What is left here is deliberate and
+bounded — the product line, three rules worth knowing before the first command,
+and the pointer list. Everywhere the two overlap, `AGENTS.md` wins.
 
 The three things worth knowing before you read it:
 


### PR DESCRIPTION
## The false claim

`CLAUDE.md:9-10` states:

> This file used to duplicate it verbatim, and the two drifted: the declared MSRV was wrong in both for weeks. **One source now.**

The last three words are not true. Two blocks are still duplicated from `AGENTS.md`, one of them word for word.

That matters more here than in an ordinary document. A file whose whole subject is "do not duplicate the contract" is read as authoritative about its own state. Someone who trusts the sentence will not check, and the drift it warns about is exactly the drift it is now hiding.

## Full duplication report

Verified line by line against `AGENTS.md` at `develop`. **Nothing below is removed by this PR** — the report is the deliverable, the arbitration is yours.

| `CLAUDE.md` | Line | Verdict | `AGENTS.md` |
|---|---|---|---|
| Product pitch | 3-4 | **duplicated word for word** (only the line wrapping differs) | 3 |
| "Read and follow AGENTS.md" | 6-10 | legitimate pointer | — |
| "One source now" | 10 | **provably false** — the only line this PR changes | — |
| Git Flow, target `develop` | 14-15 | substantive overlap | 36 |
| Enforced branch prefixes | 15-16 | **unique to CLAUDE.md** | absent |
| No AI attribution | 17-20 | substantive overlap, shorter here | 20 |
| `commit-msg` hook enforcement | 18-20 | **unique to CLAUDE.md** | absent |
| Core must not reference premium | 21-23 | substantive duplicate | 126 |
| Authoritative docs list | 25-28 | **link list identical**, lead-in sentence differs | 4 |

Two nuances worth stating precisely, because "duplicated verbatim" would be inaccurate for most rows:

- Only the pitch is literally identical. The other overlaps say the same thing in different words.
- Several overlaps are **asymmetric**: `AGENTS.md:36` adds that release and hotfix branches target `main`, which `CLAUDE.md` omits; `CLAUDE.md:15-16` lists the CI-enforced branch prefixes, which `AGENTS.md` omits. Deleting either side would lose something.

## Three items exist only here

Candidates for promotion into `AGENTS.md` — **not done in this PR**, since that is a change to the canonical contract and yours to arbitrate:

1. the CI-enforced branch prefixes, and that a `claude/*` branch is rejected;
2. that the `commit-msg` hook enforces the attribution rule against the *message text*, so even quoting a trailer in order to describe it fails the commit;
3. the meta-note itself.

## What changes

One sentence. `CLAUDE.md:9-10` now says what is actually true: the remaining repetition is deliberate and bounded, and `AGENTS.md` wins wherever the two overlap. No rule is deleted, no section moved.

## Verification

`check-doc-freshness.py --guard tracked --mode strict` — `CLAUDE.md` is an entry document that guard reads — plus the full `unittest discover` suite.
