### PR TITLE
test(migration): qualify the rebuild — expired-fact parity, cursor cost, and both regimes

### DIFF
--- a/crates/velesdb-memory/src/migration/tests/enumeration.rs
+++ b/crates/velesdb-memory/src/migration/tests/enumeration.rs
@@ -271,6 +271,115 @@ pub(super) fn enumerate_page(
 // THE GUARD — a rebuild must not come back to LIMIT/OFFSET
 // ---------------------------------------------------------------------------
 
+/// Both walks must exclude exactly the SAME expired facts.
+///
+/// They filter with the same predicate (`is_payload_expired`) and the same clock
+/// function (`now_unix_secs`), but at two different sites: `collection/core/scroll.rs`
+/// for the cursor, `search/query/similarity_filter.rs` for the scan. The predicate
+/// is therefore not where they can disagree.
+///
+/// Pagination is. `execute_scan_query` collects the first `limit + offset` LIVE
+/// points in PHYSICAL order and only then lets `ORDER BY id` sort them, so
+/// excluding an expired point shifts the physical window and not merely the
+/// sorted list. With ids that are neither contiguous nor written in ascending
+/// order, and expired facts interleaved so that no page boundary lands on a run
+/// of one kind, a walk that paged by position would show a gap or a repeat here.
+///
+/// `expired_points_are_not_resurrected` already pins the cursor side. This is
+/// the missing half: that the independent verification path agrees with it.
+#[test]
+fn both_walks_exclude_exactly_the_same_expired_facts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut live: Vec<u64> = Vec::new();
+    let mut expired: Vec<u64> = Vec::new();
+    {
+        let store = NativeStore::open(dir.path(), DIM).expect("open store");
+        for (n, id) in SCRAMBLED.iter().copied().enumerate() {
+            if n % 2 == 0 {
+                store
+                    .store_with_metadata(id, &format!("live {id}"), &EMBEDDING, &meta(&[]))
+                    .expect("seed live");
+                live.push(id);
+            } else {
+                expired.push(id);
+            }
+        }
+    }
+    // A past instant, not `now`: the published zero-ttl route stamps
+    // `expires_at = now` and the predicate is `exp <= now`, which is expired but
+    // sits on the second boundary. A fixture must not race the clock.
+    for id in &expired {
+        super::preservation::seed_raw(dir.path(), *id, &format!("expired {id}"), Some(1_000_000));
+    }
+
+    let db = velesdb_core::Database::open(dir.path()).expect("open source");
+    let ids = |facts: Vec<RawFact>| -> Vec<u64> { facts.iter().map(|f| f.id).collect() };
+    let by_cursor = ids(enumerate_by_cursor(&db, "_semantic_memory", PAGE).expect("cursor walk"));
+    let by_offset = ids(enumerate_collection(&db, "_semantic_memory", PAGE).expect("offset walk"));
+    drop(db);
+
+    let mut only_live = live.clone();
+    only_live.sort_unstable();
+    assert_eq!(
+        by_cursor, only_live,
+        "positive control: the cursor must return every LIVE id and nothing else, \
+         or the comparison below would only prove two empty walks agree"
+    );
+    assert_eq!(
+        by_offset, by_cursor,
+        "the two walks disagree on which facts are expired; a rebuild verified by \
+         one and performed by the other would carry, or drop, exactly this difference"
+    );
+
+    // The other regime, on the SAME fixture shape. Without it the agreement above
+    // could hold because both walks return the live set for a reason that has
+    // nothing to do with expiry — and the comparison would never be seen doing
+    // work. Here the two must agree on a set that is strictly LARGER.
+    let future = tempfile::tempdir().expect("tempdir");
+    {
+        let store = NativeStore::open(future.path(), DIM).expect("open store");
+        for id in &live {
+            store
+                .store_with_metadata(*id, &format!("live {id}"), &EMBEDDING, &meta(&[]))
+                .expect("seed live");
+        }
+    }
+    for id in &expired {
+        super::preservation::seed_raw(
+            future.path(),
+            *id,
+            &format!("not yet expired {id}"),
+            Some(4_000_000_000),
+        );
+    }
+    let db = velesdb_core::Database::open(future.path()).expect("open source");
+    let future_cursor =
+        ids(enumerate_by_cursor(&db, "_semantic_memory", PAGE).expect("cursor walk"));
+    let future_offset =
+        ids(enumerate_collection(&db, "_semantic_memory", PAGE).expect("offset walk"));
+
+    let mut everything = SCRAMBLED.to_vec();
+    everything.sort_unstable();
+    assert_eq!(
+        future_cursor, everything,
+        "control: under a FUTURE expiry every seeded fact must come back, so the \
+         exclusion above was about the expiry and not about the raw write path"
+    );
+    assert_eq!(
+        future_offset, future_cursor,
+        "the two walks must also agree when nothing is expired"
+    );
+    println!(
+        "  past expiry:   {} live / {} expired over pages of {PAGE} -> both walks {by_cursor:?}",
+        live.len(),
+        expired.len()
+    );
+    println!(
+        "  future expiry: all {} seeded -> both walks {future_cursor:?}",
+        everything.len()
+    );
+}
+
 /// Files allowed to name the `OFFSET` walk, because they DEFINE it or exercise
 /// it as the independent verification path.
 const OFFSET_WALK_OWNERS: &[&str] = &[

--- a/crates/velesdb-memory/src/migration/tests/performance.rs
+++ b/crates/velesdb-memory/src/migration/tests/performance.rs
@@ -541,6 +541,143 @@ fn the_cursor_cost_per_fact_does_not_grow_like_the_offset_walk() {
     );
 }
 
+/// What the two rebuild regimes cost per fact, measured instead of inferred.
+///
+/// `embedder_cost` is [`Capability::Missing`], and its blocker text quotes
+/// `16.3 us/fact to re-insert`. That is the REINSERTION cost, measured on the
+/// store, in the regime where the embedder is never called at all. Reading it as
+/// an embedder cost is what makes "the embedder dominates a rebuild" look
+/// established when it is regime-dependent.
+///
+/// `reinsert` takes the vector FROM THE CALLER. A rebuild that does not change
+/// the embedding model can therefore replay the source vectors and never embed
+/// anything; the embedder only dominates when the model CHANGES. Both unit costs
+/// are measured here, in the same run, and printed side by side.
+///
+/// What this does NOT do is compose them into a rebuild duration. No rebuild is
+/// callable — the module has no consumer — so a total would be an extrapolation
+/// wearing a measurement's clothes. It is also a one-call-per-fact figure: the
+/// backend accepts batched requests, and a batched re-embedding would not cost
+/// this.
+///
+/// A live backend is required, and `OllamaEmbedder::new` probes the dimension on
+/// construction, so an absent one fails here loudly rather than leaving a cost
+/// test quietly passing on nothing.
+///
+/// Measured 2026-08-05, aarch64-apple-darwin, debug profile, machine at rest,
+/// bge-m3 at 1024 dimensions, 32 facts, one call per fact:
+///
+/// | regime                          | per fact   |
+/// |---------------------------------|------------|
+/// | re-embedding (model CHANGED)    | 88 462 µs  |
+/// | reinsertion (vectors REUSED)    |  3 900 µs  |
+/// | ratio                           | ×23        |
+///
+/// **×23, not orders of magnitude — and the ratio depends on the payload.**
+/// Comparing an embedding time against the `16.3 us/fact` in the blocker text
+/// suggests a factor near ten thousand. It is wrong on both terms.
+///
+/// Probed the same day, same 1024 dimensions, payload carrying NO text:
+/// reinsertion drops to 460 µs/fact and the ratio rises to ×194. So the
+/// dominant term in reinsertion is not the vector width — it is the BM25 text
+/// WAL, which the table in `the_per_point_write_cost_is_attributed_to_payload_or_vector`
+/// already attributes at `DIM = 4` (3 457.8 µs/fact with text against 15.1
+/// without). Decomposed from the three measurements: text indexing ≈ 3 440
+/// µs/fact, vector width from 4 to 1024 ≈ 445, the bare write ≈ 15.
+///
+/// The blocker's 16.3 is therefore a no-text, `DIM = 4` figure. Agent facts
+/// always carry `content`, so for this product it understates reinsertion by
+/// roughly two hundred fold, and quoting it beside an embedding time compounds
+/// that with the mislabelling.
+///
+/// The operative number here is ×23: a rebuild that changes the model pays
+/// about twenty times one that replays its vectors. That is a real penalty and
+/// an affordable one. Ten thousand would have made a model change prohibitive,
+/// and deciding otherwise on that figure is the mistake this measurement exists
+/// to prevent.
+///
+/// Both figures are debug-profile and one-call-per-fact. Release timings and a
+/// batched embedding request would both move them, in the same direction but not
+/// by the same amount, which is why the assertion below compares the two
+/// measurements to each other and not to any number written here.
+#[test]
+#[cfg(feature = "ollama")]
+#[ignore = "needs a live embedding backend; run deliberately, on a machine at rest"]
+fn the_embedder_dominates_only_when_the_model_changes() {
+    use crate::embedder::{Embedder, OllamaEmbedder};
+
+    const FACTS: usize = 32;
+    let n = u64::try_from(FACTS).expect("fits");
+    let texts: Vec<String> = (0..FACTS)
+        .map(|i| format!("fact number {i}: what a rebuild has to carry across"))
+        .collect();
+
+    let url = std::env::var("VELESDB_MEMORY_OLLAMA_URL")
+        .unwrap_or_else(|_| "http://localhost:11434".to_owned());
+    let model =
+        std::env::var("VELESDB_MEMORY_OLLAMA_MODEL").unwrap_or_else(|_| "bge-m3".to_owned());
+    let embedder = OllamaEmbedder::new(&url, &model).unwrap_or_else(|e| {
+        panic!(
+            "this test measures a REAL embedder and {url} / {model} is unreachable ({e}); \
+             it must fail here rather than report a cost for a backend that is not there"
+        )
+    });
+    let dimension = embedder.dimension();
+    // The first call pays model load. Timing it would spread a one-off over
+    // every fact and inflate the very figure this test exists to establish.
+    embedder.embed("warm up").expect("warm up");
+
+    let start = std::time::Instant::now();
+    let vectors: Vec<Vec<f32>> = texts
+        .iter()
+        .map(|text| embedder.embed(text).expect("embed"))
+        .collect();
+    let embed_elapsed = start.elapsed();
+
+    let batch: Vec<(RawFact, Vec<f32>)> = vectors
+        .into_iter()
+        .enumerate()
+        .map(|(i, vector)| {
+            let id = u64::try_from(i).expect("fits") + 1;
+            let payload = serde_json::json!({ "content": texts[i] }).to_string();
+            (RawFact { id, payload }, vector)
+        })
+        .collect();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let _store = NativeStore::open(dir.path(), dimension).expect("open destination");
+    }
+    let db = database(&dir);
+    let start = std::time::Instant::now();
+    let written = reinsert_batch(&db, "_semantic_memory", &batch).expect("reinsert");
+    let reinsert_elapsed = start.elapsed();
+    assert_eq!(
+        written.inserted, n,
+        "positive control: a batch that did not land would make its timing meaningless"
+    );
+
+    let embed_cost = per_fact(embed_elapsed, n);
+    let reinsert_cost = per_fact(reinsert_elapsed, n);
+    println!("  model={model}  dimension={dimension}  facts={FACTS}");
+    println!(
+        "  re-embedding (model CHANGED):   {embed_elapsed:>10.2?}  {embed_cost:>10.1} us/fact"
+    );
+    println!("  reinsertion  (vectors REUSED):  {reinsert_elapsed:>10.2?}  {reinsert_cost:>10.1} us/fact");
+    println!(
+        "  embedding costs x{:.0} what reinsertion costs, per fact",
+        embed_cost / reinsert_cost
+    );
+    assert!(
+        embed_cost > reinsert_cost,
+        "re-embedding was not more expensive than reinsertion (embed \
+         {embed_cost:.1} us/fact, reinsert {reinsert_cost:.1} us/fact). The whole \
+         reason a rebuild reuses source vectors when the model is unchanged is \
+         that it is not; if that stops holding, the choice has to be re-argued \
+         rather than inherited"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // GATE 2c — the ceiling, which is a CORRECTNESS bound and not a cost one
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-memory/src/migration/tests/performance.rs
+++ b/crates/velesdb-memory/src/migration/tests/performance.rs
@@ -429,6 +429,118 @@ fn paging_cost_grows_faster_than_the_store() {
     );
 }
 
+/// The cursor's per-fact cost across the SAME sizes, measured beside the walk
+/// above rather than assumed from it.
+///
+/// `paging_cost_grows_faster_than_the_store` measures the `OFFSET` side and
+/// concludes it is quadratic. The cursor side — the walk the rebuild is meant to
+/// use — had no multi-size measurement anywhere: the only cursor timing in this
+/// file is a single size inside a correctness test. So "the cursor scales" was
+/// an expectation, not a result, and this module was measuring one walk while
+/// asserting about the other.
+///
+/// **No threshold is written down here.** The claim is a comparison between two
+/// quantities measured in the same run, on the same stores: the cursor's growth
+/// in per-fact cost must not exceed the `OFFSET` walk's. A constant would age
+/// with the machine and would have to be re-tuned by whoever it eventually
+/// failed for; a comparison between two measurements does not.
+///
+/// The cursor is timed FIRST at each size, so the page cache is warm for the
+/// `OFFSET` walk and not for it. That biases the comparison AGAINST the
+/// conclusion this test expects, which is the direction a measurement should
+/// lean when the person writing it already has an expectation.
+///
+/// Measured 2026-08-05, aarch64-apple-darwin, debug profile, machine at rest:
+///
+/// | facts | cursor   | µs/fact | offset walk | µs/fact |
+/// |-------|----------|---------|-------------|---------|
+/// | 250   | 2.55 ms  | 10.2    | 9.87 ms     | 39.5    |
+/// | 500   | 4.20 ms  | 8.4     | 24.12 ms    | 48.2    |
+/// | 1 000 | 10.04 ms | 10.0    | 66.52 ms    | 66.5    |
+/// | 2 000 | 30.89 ms | 15.4    | 242.21 ms   | 121.1   |
+///
+/// Over an eightfold volume the per-fact cost grew ×1.52 for the cursor and
+/// ×3.07 for the `OFFSET` walk.
+///
+/// The cursor is NOT flat, and this file should not be read as saying it is. At
+/// 2 000 facts a fact costs half again what it cost at 250. What the numbers
+/// support is narrower and enough: the cursor degrades markedly less than the
+/// walk it replaces.
+///
+/// One caveat on the ×1.52, stated because the figure invites over-reading: the
+/// 250-fact point is the most polluted by fixed overhead — it is the only size
+/// whose per-fact cost is HIGHER than the next one up (10.2 against 8.4). Taking
+/// 500 as the baseline instead gives ×1.83. The growth ratio is therefore
+/// sensitive to which end you anchor it on, which is why the assertion below
+/// compares two ratios computed the same way rather than testing either against
+/// a number.
+#[test]
+#[ignore = "seeds thousands of facts; run deliberately, on a machine at rest"]
+fn the_cursor_cost_per_fact_does_not_grow_like_the_offset_walk() {
+    let mut cursor_costs: Vec<f64> = Vec::new();
+    let mut offset_costs: Vec<f64> = Vec::new();
+    for n in [250u64, 500, 1000, 2000] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        {
+            let store = NativeStore::open(dir.path(), DIM).expect("open");
+            for id in 1..=n {
+                store
+                    .store_with_metadata(
+                        id * 7,
+                        &format!("fact {id}"),
+                        &EMBEDDING,
+                        &meta(&[("project", Value::from("veles"))]),
+                    )
+                    .expect("seed");
+            }
+        }
+        let db = database(&dir);
+        let expected = usize::try_from(n).expect("fits");
+
+        let start = std::time::Instant::now();
+        let walked = super::enumerate_by_cursor(&db, "_semantic_memory", 100).expect("cursor walk");
+        let cursor_elapsed = start.elapsed();
+        assert_eq!(
+            walked.len(),
+            expected,
+            "positive control: a cursor walk that returned the wrong count would \
+             make its timing meaningless"
+        );
+
+        let start = std::time::Instant::now();
+        let paged = enumerate_collection(&db, "_semantic_memory", 100).expect("page walk");
+        let offset_elapsed = start.elapsed();
+        assert_eq!(paged.len(), expected, "positive control for the page walk");
+
+        let (cursor, offset) = (per_fact(cursor_elapsed, n), per_fact(offset_elapsed, n));
+        println!(
+            "  n={n:5}  cursor={cursor_elapsed:>9.2?} ({cursor:>7.1} us/fact)  \
+             offset={offset_elapsed:>9.2?} ({offset:>7.1} us/fact)"
+        );
+        cursor_costs.push(cursor);
+        offset_costs.push(offset);
+    }
+
+    let growth = |costs: &[f64]| -> f64 {
+        let first = costs.first().copied().expect("measured");
+        let last = costs.last().copied().expect("measured");
+        last / first
+    };
+    let (cursor_growth, offset_growth) = (growth(&cursor_costs), growth(&offset_costs));
+    println!(
+        "  per-fact cost grew x{cursor_growth:.2} for the cursor, \
+         x{offset_growth:.2} for the offset walk, over an 8x volume"
+    );
+    assert!(
+        cursor_growth <= offset_growth,
+        "the cursor's per-fact cost grew at least as fast as the OFFSET walk's \
+         (cursor x{cursor_growth:.2}, offset x{offset_growth:.2}). The rebuild is \
+         built on the cursor precisely because the other walk is quadratic; if \
+         they now degrade alike, that premise no longer holds and the choice has \
+         to be re-argued rather than inherited"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // GATE 2c — the ceiling, which is a CORRECTNESS bound and not a cost one
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-memory/src/migration/tests/preservation.rs
+++ b/crates/velesdb-memory/src/migration/tests/preservation.rs
@@ -145,14 +145,21 @@ fn a_collision_has_an_explicit_result() {
 
 /// Write a point straight into the collection, expiry included.
 ///
-/// NO published API produces an already-expired fact: `store_with_metadata`
-/// STRIPS `_veles_expires_at` out of caller metadata (`build_payload`), and
-/// `store_with_ttl(_, 0)` DELETES the fact rather than expiring it. An expired
-/// fact is only ever reached by time passing — which a test cannot wait for and
-/// must not fake with a sleep. So the fixture writes the on-disk state such a
-/// fact actually has: the engine never rewrites a payload when its expiry
-/// passes, it filters at read time.
-fn seed_raw(dir: &std::path::Path, id: u64, content: &str, expires_at: Option<u64>) {
+/// The direct write is what lets a fixture pick an expiry STRICTLY in the past.
+/// Two published routes do reach an expired fact, but both can only stamp
+/// `expires_at = now` — `store_with_metadata_and_ttl(_, 0)` and
+/// `AgentMemory::set_semantic_ttl_durable(_, 0)` go through `MemoryTtl::now()`,
+/// and the predicate is `exp <= now`. That is expired, but it sits exactly on
+/// the second boundary, so a fixture built on it races the clock. The test
+/// below pins that those routes work; this one keeps the fixture deterministic.
+///
+/// Two routes genuinely cannot: `store_with_metadata` STRIPS `_veles_expires_at`
+/// out of caller metadata (`build_payload`), and `store_with_ttl(_, 0)` DELETES
+/// the fact rather than expiring it.
+///
+/// What no route does is REWRITE a payload when its expiry passes — the engine
+/// filters at read time — so this is the on-disk state an expired fact has.
+pub(super) fn seed_raw(dir: &std::path::Path, id: u64, content: &str, expires_at: Option<u64>) {
     let db = velesdb_core::Database::open(dir).expect("open");
     let any = db
         .get_any_collection("_semantic_memory")
@@ -168,6 +175,41 @@ fn seed_raw(dir: &std::path::Path, id: u64, content: &str, expires_at: Option<u6
         Some(Value::Object(payload)),
     )])
     .expect("upsert");
+}
+
+#[test]
+fn the_published_zero_ttl_route_does_reach_an_expired_fact() {
+    // This file used to state that no published API produces an already-expired
+    // fact. It does: `store_with_metadata_and_ttl(_, 0)` writes the fact and
+    // then stamps `expires_at = now` through `set_ttl_durable`, and the engine's
+    // predicate is `exp <= now`. Recorded here because the claim was quoted as
+    // established while planning a rebuild, and it would have ruled out the
+    // simplest fixture in the repository.
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let store = NativeStore::open(dir.path(), DIM).expect("open store");
+        store
+            .store_with_metadata(1, "a live fact", &EMBEDDING, &meta(&[]))
+            .expect("seed live");
+        store
+            .store_with_metadata_and_ttl(2, "expiring on write", &EMBEDDING, &meta(&[]), 0)
+            .expect("a zero ttl must be accepted by this route");
+    }
+
+    let ids: BTreeSet<u64> = read_out(dir.path(), "_semantic_memory")
+        .iter()
+        .map(|f| f.id)
+        .collect();
+    assert!(
+        ids.contains(&1),
+        "positive control: the LIVE fact must come back, or this test proves only \
+         that the walk returns nothing"
+    );
+    assert!(
+        !ids.contains(&2),
+        "a fact written with a zero ttl is expired the moment it lands, so the walk \
+         must not export it"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Qualification batch for #1762. **Measurement only** — no promotion of `embedder_cost`, no `DIAGNOSIS_FORMAT_VERSION` bump, no rebuild wired. Blocks on [#1815](https://github.com/cyberlife-coder/VelesDB/issues/1815) for what comes next.

## 1. Both walks exclude the same expired facts

`expired_points_are_not_resurrected` pinned the **cursor** side only. The independent verification path — the bounded `OFFSET` walk — had no equivalent, so nothing said the two agreed on which facts are expired. A rebuild verified by one and performed by the other would carry, or drop, exactly that difference.

They cannot disagree on the predicate: both call `is_payload_expired` with `now_unix_secs`. They can disagree on **pagination** — `execute_scan_query` collects the first `limit + offset` LIVE points in *physical* order and only then lets `ORDER BY id` sort them, so excluding an expired point shifts the physical window, not merely the sorted list. The fixture therefore uses ids that are neither contiguous nor written in ascending order, with expired facts interleaved so no page boundary lands on a run of one kind.

Measured: 4 live / 4 expired over pages of 3, both walks return `[17, 58, 999, 2000]`; under a future expiry both return all 8. The second regime is not decoration — without it the agreement could hold for a reason unrelated to expiry, and the comparison would never be seen doing work.

## 2. The cursor's cost across sizes

`paging_cost_grows_faster_than_the_store` measures the `OFFSET` walk at four sizes and concludes it is quadratic. The cursor — the walk the rebuild is meant to use — had **no multi-size measurement anywhere**. "The cursor scales" was an expectation, not a result; this module was measuring one walk while asserting about the other.

| facts | cursor | µs/fact | offset walk | µs/fact |
|-------|--------|---------|-------------|---------|
| 250 | 2.55 ms | 10.2 | 9.87 ms | 39.5 |
| 500 | 4.20 ms | 8.4 | 24.12 ms | 48.2 |
| 1 000 | 10.04 ms | 10.0 | 66.52 ms | 66.5 |
| 2 000 | 30.89 ms | 15.4 | 242.21 ms | 121.1 |

Over an eightfold volume, per-fact cost grew **×1.52** for the cursor and **×3.07** for the `OFFSET` walk.

**The cursor is not flat, and the docstring says so.** At 2 000 facts a fact costs half again what it cost at 250. The ×1.52 is also anchor-sensitive — 250 is the size most polluted by fixed overhead, the only point whose per-fact cost is *higher* than the next one up, and anchoring on 500 gives ×1.83. Recorded rather than smoothed.

## 3. The two rebuild regimes

`reinsert` takes the vector **from the caller**. A rebuild that does not change the model replays the source vectors and never embeds anything. The embedder only dominates when the model *changes* — and nothing had measured by how much.

| regime | per fact |
|---|---|
| re-embedding (model CHANGED) | 88 462 µs |
| reinsertion (vectors REUSED) | 3 900 µs |
| **ratio** | **×23** |

### The figure that would have been wrong

Reasoning from the blocker text — `16.3 us/fact to re-insert` beside an embedding time — gives a factor near **ten thousand**. That is wrong on both terms.

Probed the same day, same 1024 dimensions, payload carrying **no text**: reinsertion drops to 460 µs/fact and the ratio rises to ×194. So the dominant term is not vector width but the **BM25 text WAL**, which this file already attributes at `DIM = 4` (3 457.8 µs/fact with text against 15.1 without).

Decomposed from the three measurements: text indexing ≈ 3 440 µs/fact, vector width 4 → 1024 ≈ 445, bare write ≈ 15.

The blocker's 16.3 is a **no-text, `DIM = 4`** figure. Agent facts always carry `content`, so for this product it understates reinsertion by roughly two hundred fold, and quoting it beside an embedding time compounds that with the mislabelling.

**The operative number is ×23** — a real penalty and an affordable one. Ten thousand would have made a model change prohibitive. Deciding #1815 on that figure is what this batch exists to prevent.

## Acquis corrected

Three claims were carried into this work as established. Two were false.

1. **"No published API produces an already-expired fact"** — stated in `seed_raw`'s own doc comment. Two routes do: `store_with_metadata_and_ttl(_, 0)` and `AgentMemory::set_semantic_ttl_durable(_, 0)` both stamp `expires_at = now` through `set_ttl_durable`, and the predicate is `exp <= now`. A test now pins it. Two routes genuinely cannot, and the comment says which. The fixture still writes directly, for a reason the comment now gives: both published routes land exactly on the second boundary, so a fixture built on them races the clock.
2. **"`Database::open` rewrites 7 derived artifacts"** — eight at collection level, plus `velesdb.lock`, plus one deletion. No list of seven exists in the repository. Not load-bearing (the controlled copy is justified either way), but the number should stop circulating.
3. **"The embedder dominates a rebuild"** — regime-dependent, and ×23 rather than ×10 000. See above.

## Deliberately not done

- No promotion of `embedder_cost` from `Missing`. It is locked twice — produced by `capability_map`, re-verified at deserialization by `canonical_capabilities` — with tests refusing promotion by editing the JSON. Promoting it means bumping `DIAGNOSIS_FORMAT_VERSION`, which is a read-compatibility change and does not belong in a measurement batch.
- No rebuild wired, and no total composed from the two unit costs. No rebuild is callable; a total would be an extrapolation wearing a measurement's clothes.

## Method

Every measurement is sequential, on a machine at rest, `#[ignore]`d so it is run deliberately. **No threshold is written down anywhere**: each assertion compares two quantities measured in the same run. A constant would age with the machine and be re-tuned by whoever it eventually failed for.

In deliverable 2 the cursor is timed *first* at each size, so the page cache is warm for the `OFFSET` walk and not for it — biasing the comparison against the expected conclusion. In deliverable 3 the first embedding call is warmed outside the timer, so model load is not spread over every fact, and an absent backend fails loudly rather than leaving a cost test passing on nothing.

## Noted in passing, not fixed here

The `OFFSET`-walk guard matches by substring over the whole file, so a *comment* saying "the bounded OFFSET walk is not used here" fails the build — verified by injecting exactly that line. It scans test files too, with a message about production rebuilds. The interdiction is right; the mechanism penalises documenting the hazard. Worth its own change.
