### PR TITLE
fix(memory): bound why/recall_fused's graph walk in width, not just depth

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -106,7 +106,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any one node, and `MAX_WHY_NODES` (500) caps the total nodes a walk collects
   across every hop. Both apply to `why` and `recall_fused` alike — they share
   the same internal traversal. `MAX_WHY_HOPS`'s comment now says what it
-  actually bounds.
+  actually bounds. Review hardening on the same fix: the node ceiling is now
+  exact — enforced at the push site, where checking only between expansions
+  let the crossing expansion overshoot to a measured 522 of the documented
+  500 — and `MAX_WHY_EDGES` (2000) caps the edges a walk records, the half of
+  #1743's ask ("nodes AND edges") the first cut left unbounded: 60
+  fully-connected nodes returned 3 540 edges against a node count of 60.
 
 - **`recall_fused`'s graph reach is no longer quadratic in a hub's fan-out
   (#1742).** `reach_weight` used to rescan every edge the traversal collected,

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -95,6 +95,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`why`/`recall_fused`'s graph walk had no width budget: a hub could dump its
+  entire neighborhood, full fact content included, into one response (#1743).**
+  The only existing guard, `MAX_WHY_HOPS`, bounds traversal *depth* — its own
+  comment claimed it "prevents exponential graph fan-out", which was false: an
+  entity hub is a super-node by construction (degree scales with the whole
+  store), so a single hop through one could still return thousands of
+  full-content nodes. Two width caps now bound the walk directly:
+  `MAX_WHY_NODE_DEGREE` (64) limits how many outgoing edges are followed from
+  any one node, and `MAX_WHY_NODES` (500) caps the total nodes a walk collects
+  across every hop. Both apply to `why` and `recall_fused` alike — they share
+  the same internal traversal. `MAX_WHY_HOPS`'s comment now says what it
+  actually bounds.
+
 - **`recall_fused`'s graph reach is no longer quadratic in a hub's fan-out
   (#1742).** `reach_weight` used to rescan every edge the traversal collected,
   once per reached node, to find the `mentions` edges pointing at it —

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -77,7 +77,25 @@ pub const MAX_WHY_NODE_DEGREE: usize = 64;
 /// contribution; this bounds the walk's total size across every node it
 /// expands, so many hubs each under the per-node cap still cannot together
 /// grow a response past a fixed ceiling.
+///
+/// An exact ceiling, enforced at the push site: the expansion that reaches it
+/// stops mid-node. Checking only between expansions read as the same
+/// guarantee but let the crossing expansion finish its whole degree first —
+/// a measured 522 nodes of a documented 500.
 pub const MAX_WHY_NODES: usize = 500;
+
+/// Maximum edges one `why`/`recall_fused` graph walk may record.
+///
+/// [`MAX_WHY_NODES`] alone does not bound a response: every edge FOLLOWED is
+/// recorded even when its target is already visited, so a dense subgraph far
+/// under the node budget can still return on the order of
+/// `nodes x MAX_WHY_NODE_DEGREE` edges — tens of thousands at the caps, a
+/// multi-megabyte response, which is the other half of what issue #1743
+/// asked to bound ("nombre maximal de noeuds et d'aretes retournes"). Four
+/// edges per node of budget covers a spanning forest (which needs fewer than
+/// one edge per node) plus three cross-links per node on top — a fixed
+/// ceiling on the response, not a tuning knob.
+pub const MAX_WHY_EDGES: usize = MAX_WHY_NODES * 4;
 
 /// Maximum accepted size of a single context-compiler fragment (1 MiB, the
 /// same ceiling as [`MAX_FACT_BYTES`]) — prevents a single fragment from

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -57,8 +57,27 @@ pub fn metadata_bytes(meta: &Metadata) -> usize {
 /// cap `k`, so the adapters do).
 pub const MAX_RECALL_LIMIT: usize = 1_000;
 
-/// Cap on `why` hop depth — prevents exponential graph fan-out.
+/// Cap on `why`/`recall_fused` hop depth. Bounds DEPTH only: an entity hub
+/// reached at any hop is, by construction, a super-node whose degree scales
+/// with the whole store, so this alone does not bound how much a walk
+/// returns — see [`MAX_WHY_NODE_DEGREE`] and [`MAX_WHY_NODES`] for the width
+/// budget (issue #1743: a hub dumped its entire neighborhood, full fact
+/// content included, into a single response).
 pub const MAX_WHY_HOPS: usize = 10;
+
+/// Maximum outgoing edges a `why`/`recall_fused` graph walk follows from any
+/// ONE node. Without this, expanding a single entity hub pushes one edge
+/// (and, for each unseen target, a full-content node) per fact that ever
+/// mentioned it — the walk's cost is then `O(store size)` at a single hop,
+/// no matter how shallow [`MAX_WHY_HOPS`] is set.
+pub const MAX_WHY_NODE_DEGREE: usize = 64;
+
+/// Maximum number of nodes one `why`/`recall_fused` graph walk may collect,
+/// seed included. [`MAX_WHY_NODE_DEGREE`] bounds any single node's
+/// contribution; this bounds the walk's total size across every node it
+/// expands, so many hubs each under the per-node cap still cannot together
+/// grow a response past a fixed ceiling.
+pub const MAX_WHY_NODES: usize = 500;
 
 /// Maximum accepted size of a single context-compiler fragment (1 MiB, the
 /// same ceiling as [`MAX_FACT_BYTES`]) — prevents a single fragment from

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1154,7 +1154,13 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         'hops: for hop in 1..=max_hops {
             next.clear();
             for node_id in frontier.drain(..) {
-                if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES {
+                // Both width budgets, checked here AND inside `expand`: this
+                // check alone would let the expansion that crosses the line
+                // finish its node — up to MAX_WHY_NODE_DEGREE nodes past the
+                // "ceiling", which a review measured at 522 of a promised 500.
+                if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES
+                    || explanation.edges.len() >= crate::limits::MAX_WHY_EDGES
+                {
                     break 'hops; // width budget spent — depth left in max_hops is moot
                 }
                 self.expand(node_id, hop, &mut explanation, &mut visited, &mut next)?;
@@ -1184,6 +1190,15 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     ) -> Result<(), MemoryError> {
         let edges = self.store.relations(node_id)?;
         for edge in edges.into_iter().take(crate::limits::MAX_WHY_NODE_DEGREE) {
+            // The budgets are ceilings, not suggestions: once either is spent,
+            // this node's expansion stops MID-NODE rather than finishing. The
+            // caller's check between nodes cannot provide that — an expansion
+            // that crosses the line would otherwise add its whole degree.
+            if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES
+                || explanation.edges.len() >= crate::limits::MAX_WHY_EDGES
+            {
+                break;
+            }
             let target = edge.to;
             if !visited.contains(&target) {
                 let Some((content, _embedding)) = self.store.get(target)? else {

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1151,9 +1151,12 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let mut visited: HashSet<u64> = HashSet::from([seed_id]);
         let mut frontier = vec![seed_id];
         let mut next: Vec<u64> = Vec::new();
-        for hop in 1..=max_hops {
+        'hops: for hop in 1..=max_hops {
             next.clear();
             for node_id in frontier.drain(..) {
+                if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES {
+                    break 'hops; // width budget spent — depth left in max_hops is moot
+                }
                 self.expand(node_id, hop, &mut explanation, &mut visited, &mut next)?;
             }
             if next.is_empty() {
@@ -1164,7 +1167,10 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         Ok(explanation)
     }
 
-    /// Expand a single node: enqueue unseen targets and record edges. An edge is
+    /// Expand a single node: enqueue unseen targets and record edges, following
+    /// at most [`crate::limits::MAX_WHY_NODE_DEGREE`] outgoing edges — an entity
+    /// hub's degree scales with the whole store, so an unbounded walk here would
+    /// dump its entire neighborhood into one response (issue #1743). An edge is
     /// only recorded once its target is a resolved node, so the subgraph never
     /// contains an edge pointing at a node absent from `nodes` (e.g. a forgotten
     /// target whose edge outlived it).
@@ -1176,7 +1182,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         visited: &mut HashSet<u64>,
         next: &mut Vec<u64>,
     ) -> Result<(), MemoryError> {
-        for edge in self.store.relations(node_id)? {
+        let edges = self.store.relations(node_id)?;
+        for edge in edges.into_iter().take(crate::limits::MAX_WHY_NODE_DEGREE) {
             let target = edge.to;
             if !visited.contains(&target) {
                 let Some((content, _embedding)) = self.store.get(target)? else {

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -9,7 +9,7 @@ mod common;
 
 use common::service;
 use tempfile::TempDir;
-use velesdb_memory::limits::{MAX_WHY_NODES, MAX_WHY_NODE_DEGREE};
+use velesdb_memory::limits::{MAX_WHY_EDGES, MAX_WHY_NODES, MAX_WHY_NODE_DEGREE};
 use velesdb_memory::{HashEmbedder, Link, MemoryService};
 
 const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
@@ -274,4 +274,78 @@ fn why_on_blank_decision_is_empty() {
     let explanation = svc.why("   ", 2, None).expect("why on blank decision");
 
     assert!(explanation.nodes.is_empty() && explanation.edges.is_empty());
+}
+
+#[test]
+fn why_cannot_overshoot_the_node_budget_mid_expansion() {
+    // Regression for the review of this fix itself. The chain test above can
+    // never see an overshoot: with out-degree 1, the budget check before each
+    // expansion is exact. With hubs near the boundary it is not — a check
+    // that only runs BEFORE an expansion lets the expansion that crosses the
+    // line add up to `MAX_WHY_NODE_DEGREE` nodes past it, so the documented
+    // ceiling of 500 was actually 563. Nine 64-target hubs cross the line
+    // mid-hop and expose exactly that.
+    let (_dir, svc) = service();
+    let seed = svc
+        .remember("hub overshoot seed", &[], None)
+        .expect("remember seed");
+    for hub_index in 0..9 {
+        let hub = svc
+            .remember(&format!("hub number {hub_index}"), &[], None)
+            .expect("remember hub");
+        svc.relate(seed, hub, "spokes").expect("relate seed->hub");
+        for target_index in 0..MAX_WHY_NODE_DEGREE {
+            let target = svc
+                .remember(&format!("target {hub_index}/{target_index}"), &[], None)
+                .expect("remember target");
+            svc.relate(hub, target, "mentions")
+                .expect("relate hub->target");
+        }
+    }
+
+    let explanation = svc.why("hub overshoot seed", 2, None).expect("why");
+
+    assert_eq!(
+        explanation.nodes.len(),
+        MAX_WHY_NODES,
+        "the node budget is a ceiling, not a suggestion: the expansion that \
+         reaches it must stop AT it, not finish its node first"
+    );
+}
+
+#[test]
+fn why_caps_the_total_edges_across_the_whole_walk() {
+    // The other half of #1743's own words: "nombre maximal de noeuds ET
+    // d'aretes retournes". Every edge followed is recorded even when its
+    // target is already visited, so a dense subgraph well under the node
+    // budget could still return edges without any bound — 60 fully-connected
+    // nodes produce 3 540 directed edges against a node count of 60.
+    let (_dir, svc) = service();
+    let mut ids = Vec::new();
+    for i in 0..60 {
+        ids.push(
+            svc.remember(&format!("dense clique member {i}"), &[], None)
+                .expect("remember member"),
+        );
+    }
+    for &from in &ids {
+        for &to in &ids {
+            if from != to {
+                svc.relate(from, to, "sees").expect("relate");
+            }
+        }
+    }
+
+    let explanation = svc.why("dense clique member 0", 3, None).expect("why");
+
+    assert!(
+        explanation.nodes.len() <= MAX_WHY_NODES,
+        "sanity: the clique sits well under the node budget"
+    );
+    assert_eq!(
+        explanation.edges.len(),
+        MAX_WHY_EDGES,
+        "a walk over a dense subgraph must stop recording edges at the edge \
+         budget; without one, 60 nodes can still return thousands of edges"
+    );
 }

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -9,6 +9,7 @@ mod common;
 
 use common::service;
 use tempfile::TempDir;
+use velesdb_memory::limits::{MAX_WHY_NODES, MAX_WHY_NODE_DEGREE};
 use velesdb_memory::{HashEmbedder, Link, MemoryService};
 
 const DECISION: &str = "we chose parking_lot to avoid lock poisoning";
@@ -127,6 +128,65 @@ fn why_stops_at_the_hop_budget() {
     assert!(
         !ids.contains(&ticket),
         "one hop must not reach the two-hop ticket"
+    );
+}
+
+#[test]
+fn why_caps_a_single_nodes_out_degree() {
+    // Regression for issue #1743: a super-node (an entity hub in production,
+    // but the cap applies to any node) must not dump its entire neighborhood
+    // into one response. Relate the seed directly to more facts than
+    // `MAX_WHY_NODE_DEGREE` allows and check the walk stops following that
+    // node's edges once the cap is spent.
+    let (_dir, svc) = service();
+    let seed = svc
+        .remember("a fact many others point at", &[], None)
+        .expect("remember seed");
+    for i in 0..MAX_WHY_NODE_DEGREE + 20 {
+        let target = svc
+            .remember(&format!("fact number {i} related to the seed"), &[], None)
+            .expect("remember target");
+        svc.relate(seed, target, "mentions").expect("relate");
+    }
+
+    let explanation = svc
+        .why("a fact many others point at", 1, None)
+        .expect("why");
+
+    assert_eq!(
+        explanation.nodes.len(),
+        1 + MAX_WHY_NODE_DEGREE,
+        "the seed plus at most MAX_WHY_NODE_DEGREE one-hop targets, not all of them"
+    );
+}
+
+#[test]
+fn why_caps_the_total_nodes_across_the_whole_walk() {
+    // Regression for issue #1743: even when no single node exceeds the
+    // per-node degree cap, a long enough chain must not grow the response
+    // past `MAX_WHY_NODES`. Each link here has out-degree 1, so
+    // `why_caps_a_single_nodes_out_degree` alone would never catch this.
+    let (_dir, svc) = service();
+    let mut previous = svc
+        .remember("chain link 0, the seed", &[], None)
+        .expect("remember seed");
+    let chain_len = MAX_WHY_NODES + 10;
+    for i in 1..chain_len {
+        let next = svc
+            .remember(&format!("chain link {i}"), &[], None)
+            .expect("remember link");
+        svc.relate(previous, next, "next").expect("relate");
+        previous = next;
+    }
+
+    let explanation = svc
+        .why("chain link 0, the seed", chain_len, None)
+        .expect("why");
+
+    assert_eq!(
+        explanation.nodes.len(),
+        MAX_WHY_NODES,
+        "the walk stops at the total node budget, well short of the full chain"
     );
 }
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -291,6 +291,13 @@ subgraph** reachable from it through typed links.
 Returns `{ nodes: [ { id, id_str, content, hop } ], edges: [ { from, from_str, to, to_str, relation } ] }`
 — the seed is `hop: 0`.
 
+The walk is width-bounded as well as depth-bounded: at most 64 outgoing edges
+are followed from any one node (`MAX_WHY_NODE_DEGREE`), at most 500 nodes
+(`MAX_WHY_NODES`) and 2000 edges (`MAX_WHY_EDGES`) are returned per walk. A
+walk that hits a budget is cut silently — a response whose counts sit at a cap
+is the signal that more of the graph exists than was returned. The same
+budgets bound the graph half of `recall_fused`.
+
 This is what a pure vector search cannot do: it surfaces the PR, the ticket,
 or the benchmark reachable through typed links **even when they share no
 words** with the question.


### PR DESCRIPTION
## Description

`why` and the graph walk `recall_fused` shares with it (`MemoryService::traverse`/`expand`) had no width budget — only `MAX_WHY_HOPS` bounded traversal *depth*. An entity hub is a super-node by construction (its degree scales with the whole store), so a single hop through one could still push every fact that ever mentioned it, full content included, into one response — several megabytes for a one-sentence question. `MAX_WHY_HOPS`'s own doc comment claimed it "prevents exponential graph fan-out," which is not what it does.

Root fix: two explicit width caps on the shared traversal, so both `why` and `recall_fused` are covered by one change:

- `MAX_WHY_NODE_DEGREE` (64) — the maximum outgoing edges followed from any ONE node while expanding it.
- `MAX_WHY_NODES` (500) — the maximum total nodes a single walk may collect across every hop, so many nodes each under the per-node cap still can't together blow past a bounded response size.

`MAX_WHY_HOPS`'s comment is corrected to say what it actually bounds (depth only), pointing at the two new constants for width.

Fixes #1743

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Two new regression tests in `crates/velesdb-memory/tests/why_bdd.rs`:
- `why_caps_a_single_nodes_out_degree` — a node related directly to `MAX_WHY_NODE_DEGREE + 20` facts; asserts the walk follows only the first `MAX_WHY_NODE_DEGREE` of them.
- `why_caps_the_total_nodes_across_the_whole_walk` — a chain of `MAX_WHY_NODES + 10` facts each with out-degree 1 (so the per-node cap alone would never trip); asserts the walk stops at exactly `MAX_WHY_NODES`.

Ran locally:
- `cargo test -p velesdb-memory --test why_bdd -- --test-threads=1` — 12 passed
- `cargo test -p velesdb-memory --test recall_fused_bdd -- --test-threads=1` — 21 passed (unaffected, confirms the shared traversal still behaves for existing hub/graph-reach scenarios)
- `cargo clippy -p velesdb-memory --all-targets -- -D warnings -D clippy::pedantic` — clean
- `cargo check -p velesdb-memory --no-default-features` — clean
- `cargo fmt --all -- --check` — clean
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` — passed
- `python3 scripts/check-doc-freshness.py --guard {stamp,index,tracked,versions} --mode strict` — all passed

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`crates/velesdb-memory/CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Scope is deliberately limited to the graph walk itself — `MAX_WHY_NODE_DEGREE`/`MAX_WHY_NODES` are plain `usize` constants in `crates/velesdb-memory/src/limits.rs`, alongside the existing `MAX_WHY_HOPS`/`MAX_RECALL_LIMIT`, with no new adapter surface or config knob.
