### PR TITLE
feat(migration): decide the rebuild regime and give the module its first caller

### DIFF
--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -536,11 +536,7 @@ fn run_migrate_embeddings(
     migration::require_dry_run(&options)?;
 
     apply_config_file(argv)?;
-    let store_path = options.store.clone().unwrap_or_else(|| {
-        std::path::PathBuf::from(
-            std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path()),
-        )
-    });
+    let store_path = migrate_store_path(&options);
     // The target's identity comes from the embedder the daemon WOULD build, not
     // from a flag: a model name an operator typed is a claim, and the dimension
     // has to be the one the embedder actually produces.
@@ -550,16 +546,7 @@ fn run_migrate_embeddings(
         dimension: embedder.dimension(),
         strategy: options.strategy,
     };
-    let scratch = if let Some(dir) = options.scratch.clone() {
-        dir
-    } else {
-        // Canonicalize first so a relative store path ("./store") yields a
-        // real parent rather than the empty string. A store that does not
-        // exist falls through unchanged — the diagnosis then fails on it
-        // with its own, more precise message.
-        let resolved = std::fs::canonicalize(&store_path).unwrap_or_else(|_| store_path.clone());
-        migration::default_scratch_parent(&resolved)?
-    };
+    let scratch = migrate_scratch_parent(&options, &store_path)?;
 
     let report = migration::dry_run(
         &store_path,
@@ -573,6 +560,36 @@ fn run_migrate_embeddings(
         std::process::exit(2);
     }
     Ok(())
+}
+
+/// The store `migrate-embeddings` operates on: `--store`, else exactly where
+/// the daemon would look (`VELESDB_MEMORY_PATH`, else the advertised default).
+fn migrate_store_path(options: &velesdb_memory::migration::MigrateOptions) -> std::path::PathBuf {
+    options.store.clone().unwrap_or_else(|| {
+        std::path::PathBuf::from(
+            std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path()),
+        )
+    })
+}
+
+/// Where the diagnosis stages its verified copy: `--scratch`, else beside the
+/// store — see `migration::default_scratch_parent` for why not the temp dir.
+///
+/// # Errors
+/// The store path has no usable parent and `--scratch` was not given.
+fn migrate_scratch_parent(
+    options: &velesdb_memory::migration::MigrateOptions,
+    store_path: &std::path::Path,
+) -> Result<std::path::PathBuf, String> {
+    if let Some(dir) = options.scratch.clone() {
+        return Ok(dir);
+    }
+    // Canonicalize first so a relative store path ("./store") yields a real
+    // parent rather than the empty string. A store that does not exist falls
+    // through unchanged — the diagnosis then fails on it with its own, more
+    // precise message.
+    let resolved = std::fs::canonicalize(store_path).unwrap_or_else(|_| store_path.to_path_buf());
+    velesdb_memory::migration::default_scratch_parent(&resolved)
 }
 
 /// An embedder together with the identifier of the model behind it.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -550,17 +550,15 @@ fn run_migrate_embeddings(
         dimension: embedder.dimension(),
         strategy: options.strategy,
     };
-    let scratch = match options.scratch.clone() {
-        Some(dir) => dir,
-        None => {
-            // Canonicalize first so a relative store path ("./store") yields a
-            // real parent rather than the empty string. A store that does not
-            // exist falls through unchanged — the diagnosis then fails on it
-            // with its own, more precise message.
-            let resolved =
-                std::fs::canonicalize(&store_path).unwrap_or_else(|_| store_path.clone());
-            migration::default_scratch_parent(&resolved)?
-        }
+    let scratch = if let Some(dir) = options.scratch.clone() {
+        dir
+    } else {
+        // Canonicalize first so a relative store path ("./store") yields a
+        // real parent rather than the empty string. A store that does not
+        // exist falls through unchanged — the diagnosis then fails on it
+        // with its own, more precise message.
+        let resolved = std::fs::canonicalize(&store_path).unwrap_or_else(|_| store_path.clone());
+        migration::default_scratch_parent(&resolved)?
     };
 
     let report = migration::dry_run(

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -73,6 +73,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return run_compile_stdin(&args[2..]);
     }
 
+    // Short-circuits for a third reason: this one must NOT open the store even
+    // though it inspects one. A diagnosis reads a verified copy and never calls
+    // `Database::open` on the live directory, which is what lets an operator run
+    // it while their daemon is up (#1762's protocol allows exactly that, read
+    // only). Falling through to `build_configured_service` would take the
+    // single-writer `flock` and refuse against the very daemon whose store the
+    // operator is asking about.
+    if args.get(1).is_some_and(|arg| arg == "migrate-embeddings") {
+        return run_migrate_embeddings(&args, &args[2..]);
+    }
+
     // Captured FIRST — before the (possibly seconds-long) embedder probe and
     // store open — so a client that exits during our own startup still
     // reparents us AFTER the baseline, and the watchdog sees the change. A
@@ -500,6 +511,62 @@ fn build_configured_service(
         &store_path,
         configured,
     )?)
+}
+
+/// Run `migrate-embeddings`: diagnose a store against the configured target
+/// embedder and print the regime it resolves to.
+///
+/// `argv` is the whole command line, so `--config` keeps working here exactly
+/// as it does for the daemon; `flags` is what follows the subcommand.
+///
+/// Exits `2` on a refusal rather than returning `Ok`. A command that printed
+/// `REFUSE` and exited `0` would be read as success by every script wrapping
+/// it, and the whole point of the refusal is that something must not proceed.
+///
+/// # Errors
+/// An unparsable invocation, a non-dry-run request (not built yet — see
+/// #1762), an unreachable embedder, or a store that cannot be read or copied.
+fn run_migrate_embeddings(
+    argv: &[String],
+    flags: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    use velesdb_memory::migration;
+
+    let options = migration::parse_migrate_args(flags)?;
+    migration::require_dry_run(&options)?;
+
+    apply_config_file(argv)?;
+    let store_path = options.store.clone().unwrap_or_else(|| {
+        std::path::PathBuf::from(
+            std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path()),
+        )
+    });
+    // The target's identity comes from the embedder the daemon WOULD build, not
+    // from a flag: a model name an operator typed is a claim, and the dimension
+    // has to be the one the embedder actually produces.
+    let ConfiguredEmbedder { embedder, model } = build_embedder()?;
+    let target = migration::TargetContract {
+        model,
+        dimension: embedder.dimension(),
+        strategy: options.strategy,
+    };
+    let scratch = options
+        .scratch
+        .clone()
+        .unwrap_or_else(migration::default_scratch_parent);
+
+    let report = migration::dry_run(
+        &store_path,
+        &scratch,
+        &target,
+        options.destination.as_deref(),
+    )?;
+    print!("{}", migration::render(&report));
+
+    if migration::refuses(&report) {
+        std::process::exit(2);
+    }
+    Ok(())
 }
 
 /// An embedder together with the identifier of the model behind it.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -550,10 +550,18 @@ fn run_migrate_embeddings(
         dimension: embedder.dimension(),
         strategy: options.strategy,
     };
-    let scratch = options
-        .scratch
-        .clone()
-        .unwrap_or_else(migration::default_scratch_parent);
+    let scratch = match options.scratch.clone() {
+        Some(dir) => dir,
+        None => {
+            // Canonicalize first so a relative store path ("./store") yields a
+            // real parent rather than the empty string. A store that does not
+            // exist falls through unchanged — the diagnosis then fails on it
+            // with its own, more precise message.
+            let resolved =
+                std::fs::canonicalize(&store_path).unwrap_or_else(|_| store_path.clone());
+            migration::default_scratch_parent(&resolved)?
+        }
+    };
 
     let report = migration::dry_run(
         &store_path,

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -45,6 +45,7 @@
 // `lib.rs`; repeating it here as an inner attribute is what `clippy::
 // duplicated_attributes` fires on.
 
+mod cli;
 mod diagnosis;
 mod diagnostic_copy;
 mod enumeration;
@@ -52,6 +53,10 @@ mod filesystem;
 mod state;
 mod strategy;
 
+pub use cli::{
+    default_scratch_parent, dry_run, not_yet_executable, parse as parse_migrate_args, refuses,
+    render, require_dry_run, MigrateOptions,
+};
 pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
     TargetContract, TtlSummary, DIAGNOSIS_FORMAT_VERSION,

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -50,6 +50,7 @@ mod diagnostic_copy;
 mod enumeration;
 mod filesystem;
 mod state;
+mod strategy;
 
 pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
@@ -64,6 +65,7 @@ pub use state::{
     MigrationLock, MigrationState, Phase, Recovery, SwitchState, LOCK_FILE, PHASES, STATE_FILE,
     STATE_FORMAT_VERSION, STATE_TEMP_FILE,
 };
+pub use strategy::{assess, resolve, Compatibility, Resolution, Strategy};
 
 #[cfg(test)]
 mod tests;

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -54,7 +54,7 @@ mod strategy;
 
 pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
-    TtlSummary, DIAGNOSIS_FORMAT_VERSION,
+    TargetContract, TtlSummary, DIAGNOSIS_FORMAT_VERSION,
 };
 pub use enumeration::{
     enumerate_by_cursor, enumerate_collection, enumerate_page, reinsert, reinsert_batch,

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -234,7 +234,7 @@ pub fn not_yet_executable() -> &'static str {
 /// The default scratch parent: the directory the store itself sits in.
 ///
 /// This used to be `std::env::temp_dir()`, and Codacy's finding on it
-/// ("temp_dir should not be used for security operations") was right for a
+/// ("`temp_dir` should not be used for security operations") was right for a
 /// reason it did not name. Secrecy is already handled — the copy lands in a
 /// directory created `0o700` with an owner token, one level down — but the
 /// wrong VOLUME is not: the diagnosis copies the whole store, temp

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -1,0 +1,242 @@
+//! The operator surface for a rebuild (#1815).
+//!
+//! # Why a command and not an MCP tool
+//!
+//! A migration is long, mutates a store, has to show progress and has to be
+//! interruptible and resumable. None of that survives being tied to an MCP
+//! session's lifetime, and #1727 records a client defect that makes a long or
+//! destructive tool call particularly unsuitable. So the first surface is a
+//! subcommand, the engine stays a library, and no mutating MCP tool is added.
+//!
+//! # What this phase does and does not do
+//!
+//! `--dry-run` only. It reads, it decides a regime, it prints what it found and
+//! what would happen. It writes nothing, takes no lock, and may run while the
+//! daemon holds the store: [`diagnose`](crate::migration::diagnose) never opens
+//! the live source, it inspects a verified copy.
+//!
+//! Any invocation that is not a dry run is REFUSED with the reason, rather than
+//! accepted and quietly doing nothing. An operator who types
+//! `migrate-embeddings --strategy auto` is asking for a migration; answering
+//! with silence and exit 0 would be the worst of the available behaviours.
+
+use super::{diagnose, DiagnosisReport, Strategy, TargetContract};
+use std::path::{Path, PathBuf};
+
+/// What the operator asked the command to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrateOptions {
+    /// The store to rebuild. `None` means "wherever the daemon would look".
+    pub store: Option<PathBuf>,
+    /// Where the rebuilt store would be written. Inspected, never created.
+    pub destination: Option<PathBuf>,
+    /// Where the diagnosis stages its verified copy. Needs room for the store.
+    pub scratch: Option<PathBuf>,
+    /// The regime, `auto` unless stated.
+    pub strategy: Strategy,
+    /// Whether this run is a dry run. The only supported value today is `true`.
+    pub dry_run: bool,
+}
+
+impl Default for MigrateOptions {
+    fn default() -> Self {
+        Self {
+            store: None,
+            destination: None,
+            scratch: None,
+            strategy: Strategy::Auto,
+            dry_run: false,
+        }
+    }
+}
+
+/// What an operator must be told when they ask for the part that is not built.
+const NOT_YET_EXECUTABLE: &str =
+    "migrate-embeddings can only --dry-run in this version. The rebuild itself \
+     (reading every fact out, producing its vector, writing it to a destination, \
+     validating it and switching over) is not wired yet — see #1762. Re-run with \
+     --dry-run to see the regime this store resolves to and what still blocks a \
+     rebuild.";
+
+/// Parse `migrate-embeddings`' flags.
+///
+/// Hand-rolled for the same reason as `--version` and `compile-stdin` in the
+/// binary: this crate ships one binary and does not carry `clap` for it.
+///
+/// # Errors
+/// A message naming the offending flag when it is unknown, when a value is
+/// missing, or when `--strategy` is not one of the three arbitrated regimes.
+pub fn parse(args: &[String]) -> Result<MigrateOptions, String> {
+    let mut options = MigrateOptions::default();
+    let mut index = 0;
+    while index < args.len() {
+        let flag = args[index].as_str();
+        if flag == "--dry-run" {
+            options.dry_run = true;
+            index += 1;
+            continue;
+        }
+        let value = value_for(args, index, flag)?;
+        apply_valued_flag(&mut options, flag, value)?;
+        index += 2;
+    }
+    Ok(options)
+}
+
+/// The value following `flag`, or a message naming what is missing.
+fn value_for<'a>(args: &'a [String], index: usize, flag: &str) -> Result<&'a String, String> {
+    args.get(index + 1)
+        .ok_or_else(|| format!("{flag} requires a value"))
+}
+
+fn apply_valued_flag(
+    options: &mut MigrateOptions,
+    flag: &str,
+    value: &String,
+) -> Result<(), String> {
+    match flag {
+        "--store" => options.store = Some(PathBuf::from(value)),
+        "--destination" => options.destination = Some(PathBuf::from(value)),
+        "--scratch" => options.scratch = Some(PathBuf::from(value)),
+        "--strategy" => options.strategy = Strategy::parse(value)?,
+        other => return Err(format!("unknown migrate-embeddings flag {other:?}")),
+    }
+    Ok(())
+}
+
+/// Diagnose the store under `options` against `target`, and render the result.
+///
+/// Reads only. The source is never opened by
+/// [`velesdb_core::Database::open`] — a verified copy under the scratch parent
+/// is — so this runs against a store the daemon still holds.
+///
+/// # Errors
+/// [`crate::MemoryError`] when the store cannot be read, copied or walked, and
+/// a plain message when the invocation is not a dry run.
+pub fn dry_run(
+    store: &Path,
+    scratch_parent: &Path,
+    target: &TargetContract,
+    destination: Option<&Path>,
+) -> Result<DiagnosisReport, crate::MemoryError> {
+    diagnose(store, scratch_parent, target, destination)
+}
+
+/// Refuse an invocation this version cannot honour.
+///
+/// # Errors
+/// [`NOT_YET_EXECUTABLE`] whenever `--dry-run` was not given.
+pub fn require_dry_run(options: &MigrateOptions) -> Result<(), String> {
+    if options.dry_run {
+        return Ok(());
+    }
+    Err(NOT_YET_EXECUTABLE.to_owned())
+}
+
+/// Render a report for an operator: what is here, what would happen, and what
+/// still blocks it.
+///
+/// The regime comes FIRST and on its own line. Everything else is context for
+/// it, and burying the one decision in a table of counts is how an operator
+/// ends up acting on the wrong one.
+#[must_use]
+pub fn render(report: &DiagnosisReport) -> String {
+    let guidance = report
+        .resolution
+        .guidance()
+        .map_or_else(String::new, |next| format!("{next}\n\n"));
+    format!(
+        "{}\n\n{guidance}{}{}{}",
+        report.resolution.diagnostic(),
+        render_identity(report),
+        render_inventory(report),
+        render_blockers(report),
+    )
+}
+
+fn render_identity(report: &DiagnosisReport) -> String {
+    let provenance = match &report.source_provenance {
+        super::SourceProvenance::Known { model, dimension } => {
+            format!("{model} ({dimension} dimensions)")
+        }
+        super::SourceProvenance::Unknown { .. } => {
+            "unknown — not inferred from the width".to_owned()
+        }
+    };
+    let source_dimension = report
+        .source_dimension
+        .map_or_else(|| "no shared width".to_owned(), |d| d.to_string());
+    format!(
+        "  store:              {}\n  \
+           source provenance:  {provenance}\n  \
+           source dimension:   {source_dimension}\n  \
+           target model:       {} ({} dimensions)\n  \
+           requested strategy: {:?}\n  \
+           report format:      v{}\n\n",
+        report.source_path.display(),
+        report.target_model,
+        report.target_dimension,
+        report.requested_strategy,
+        report.format_version,
+    )
+}
+
+fn render_inventory(report: &DiagnosisReport) -> String {
+    format!(
+        "  facts:              {}\n  \
+           edges:              {}\n  \
+           working contexts:   {}\n  \
+           facts with a TTL:   {}\n  \
+           bytes on disk:      {}\n\n",
+        report.facts,
+        report.edges,
+        report.working_contexts,
+        report.ttl_summary.with_expiry,
+        report.bytes_on_disk,
+    )
+}
+
+fn render_blockers(report: &DiagnosisReport) -> String {
+    if report.blockers.is_empty() {
+        return "no outstanding blockers.\n".to_owned();
+    }
+    let listed = report
+        .blockers
+        .iter()
+        .fold(String::new(), |mut acc, blocker| {
+            acc.push_str("  - ");
+            acc.push_str(blocker);
+            acc.push('\n');
+            acc
+        });
+    format!(
+        "{} blocker(s) before a rebuild:\n{listed}",
+        report.blockers.len()
+    )
+}
+
+/// Whether this diagnosis leaves the command with nothing it could run.
+///
+/// Separate from rendering so the exit status and the text cannot drift: a
+/// command that printed `REFUSE` and exited 0 would be read as success by every
+/// script that wraps it.
+#[must_use]
+pub fn refuses(report: &DiagnosisReport) -> bool {
+    !report.resolution.runs()
+}
+
+/// Re-exported so the binary can name the refusal without duplicating it.
+#[must_use]
+pub fn not_yet_executable() -> &'static str {
+    NOT_YET_EXECUTABLE
+}
+
+/// The default scratch parent: the platform temp directory.
+///
+/// Overridable with `--scratch` because the diagnosis copies the whole store,
+/// and a temp filesystem sized for small files is exactly where a real store
+/// would fail.
+#[must_use]
+pub fn default_scratch_parent() -> PathBuf {
+    std::env::temp_dir()
+}

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -231,12 +231,32 @@ pub fn not_yet_executable() -> &'static str {
     NOT_YET_EXECUTABLE
 }
 
-/// The default scratch parent: the platform temp directory.
+/// The default scratch parent: the directory the store itself sits in.
 ///
-/// Overridable with `--scratch` because the diagnosis copies the whole store,
-/// and a temp filesystem sized for small files is exactly where a real store
-/// would fail.
-#[must_use]
-pub fn default_scratch_parent() -> PathBuf {
-    std::env::temp_dir()
+/// This used to be `std::env::temp_dir()`, and Codacy's finding on it
+/// ("temp_dir should not be used for security operations") was right for a
+/// reason it did not name. Secrecy is already handled — the copy lands in a
+/// directory created `0o700` with an owner token, one level down — but the
+/// wrong VOLUME is not: the diagnosis copies the whole store, temp
+/// filesystems are routinely small and sometimes RAM-backed, and the doc
+/// comment that used to sit here named that failure mode while the code
+/// shipped it as the default anyway. The store's parent is on the store's
+/// volume by construction, so room for a copy of the store is at least
+/// plausible there — and the staging check still measures it rather than
+/// assuming it.
+///
+/// No silent fallback: a store with no usable parent is an error naming
+/// `--scratch`, never a quiet switch to a different volume.
+///
+/// # Errors
+/// The store path has no non-empty parent to stage beside.
+pub fn default_scratch_parent(store: &Path) -> Result<PathBuf, String> {
+    match store.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => Ok(parent.to_path_buf()),
+        _ => Err(format!(
+            "cannot derive a scratch parent beside {}: pass --scratch <dir>. The diagnosis \
+             copies the whole store there, so a directory on the store's own volume is best",
+            store.display()
+        )),
+    }
 }

--- a/crates/velesdb-memory/src/migration/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis.rs
@@ -1,4 +1,5 @@
 use super::diagnostic_copy::DiagnosticCopy;
+use super::strategy::{assess, resolve, Resolution, Strategy};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -47,7 +48,7 @@ impl Capability {
 /// whether a prepared migration may resume. A report whose version this build
 /// does not understand is refused rather than guessed at, which is only
 /// possible because the number travels with the data.
-pub const DIAGNOSIS_FORMAT_VERSION: u32 = 4;
+pub const DIAGNOSIS_FORMAT_VERSION: u32 = 5;
 
 /// What the store itself records about the embedder that filled it.
 ///
@@ -184,6 +185,16 @@ pub struct DiagnosisReport {
     pub target_model: String,
     /// The width that model produces.
     pub target_dimension: usize,
+    /// The regime the operator selected — `auto` unless they said otherwise.
+    pub requested_strategy: Strategy,
+    /// What that request resolves to against this store, and why.
+    ///
+    /// Derived, never independently observed: [`DiagnosisReport::validate`]
+    /// recomputes it from the provenance and the target contract and refuses a
+    /// report whose stated regime does not follow from its own fields. A
+    /// diagnosis an operator reads a regime off is a diagnosis that can lie
+    /// about one.
+    pub resolution: Resolution,
     /// One entry per collection in [`AGENT_COLLECTIONS`], absent ones included.
     pub collections: Vec<CollectionInventory>,
     /// Live facts across the store.
@@ -262,14 +273,41 @@ fn existing_ancestor(path: &Path) -> Option<std::fs::Metadata> {
 pub fn diagnose(
     source: &Path,
     scratch_parent: &Path,
-    target_model: &str,
-    target_dimension: usize,
+    target: &TargetContract,
     destination: Option<&Path>,
 ) -> Result<DiagnosisReport, crate::MemoryError> {
     let source = canonical_source(source)?;
     let copy = DiagnosticCopy::capture(&source, scratch_parent)?;
-    let result = diagnose_copy(&source, target_model, target_dimension, destination, &copy);
+    let result = diagnose_copy(&source, target, destination, &copy);
     copy.finish(result)
+}
+
+/// What the operator is pointing the rebuild at: the target embedder's
+/// identity, and the regime they selected.
+///
+/// Grouped rather than passed as three parallel arguments because the three
+/// only ever travel together, and because a call site that passed a model and a
+/// width belonging to two different embedders would type-check perfectly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetContract {
+    /// The model identifier the rebuild would embed with.
+    pub model: String,
+    /// The width that model produces, as the embedder itself reports it.
+    pub dimension: usize,
+    /// `auto` unless the operator named a regime.
+    pub strategy: Strategy,
+}
+
+impl TargetContract {
+    /// The usual case: a target embedder, and no opinion about the regime.
+    #[must_use]
+    pub fn automatic(model: impl Into<String>, dimension: usize) -> Self {
+        Self {
+            model: model.into(),
+            dimension,
+            strategy: Strategy::Auto,
+        }
+    }
 }
 
 fn canonical_source(source: &Path) -> Result<PathBuf, crate::MemoryError> {
@@ -304,8 +342,7 @@ fn canonical_source(source: &Path) -> Result<PathBuf, crate::MemoryError> {
 
 pub(super) fn diagnose_copy(
     source: &Path,
-    target_model: &str,
-    target_dimension: usize,
+    target: &TargetContract,
     destination: Option<&Path>,
     copy: &DiagnosticCopy,
 ) -> Result<DiagnosisReport, crate::MemoryError> {
@@ -314,8 +351,7 @@ pub(super) fn diagnose_copy(
     let same_filesystem = destination.and_then(|dest| same_filesystem(source, dest));
     Ok(report_from_inventory(
         source,
-        target_model,
-        target_dimension,
+        target,
         same_filesystem,
         copy,
         inventory,
@@ -324,8 +360,7 @@ pub(super) fn diagnose_copy(
 
 fn report_from_inventory(
     source: &Path,
-    target_model: &str,
-    target_dimension: usize,
+    target: &TargetContract,
     same_filesystem: Option<bool>,
     copy: &DiagnosticCopy,
     inventory: inventory::StoreInventory,
@@ -333,21 +368,32 @@ fn report_from_inventory(
     let capabilities = capabilities::capability_map(
         &inventory.source_provenance,
         inventory.source_dimension,
-        target_model,
-        target_dimension,
+        &target.model,
+        target.dimension,
         inventory.edge_counts,
         same_filesystem,
         copy,
     );
     let blockers = capabilities::blockers_for(&capabilities, &inventory.collections);
+    let resolution = resolve(
+        target.strategy,
+        assess(
+            &inventory.source_provenance,
+            inventory.source_dimension,
+            &target.model,
+            target.dimension,
+        ),
+    );
     DiagnosisReport {
         format_version: DIAGNOSIS_FORMAT_VERSION,
         source_path: source.to_path_buf(),
         source_fingerprint: copy.source_fingerprint().to_owned(),
         source_dimension: inventory.source_dimension,
         source_provenance: inventory.source_provenance,
-        target_model: target_model.to_owned(),
-        target_dimension,
+        target_model: target.model.clone(),
+        target_dimension: target.dimension,
+        requested_strategy: target.strategy,
+        resolution,
         collections: inventory.collections,
         facts: inventory.facts,
         edges: inventory.edges,

--- a/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
@@ -22,10 +22,23 @@ pub(super) const NO_HEADROOM: &str =
      checked separately and does not prove that a different destination volume can hold the \
      rebuilt vectors. Supply and measure the final destination before reconstruction.";
 
-/// The embedder's cost per fact is the one number a rebuild's duration turns on
-/// and the one this gate cannot produce.
+/// The embedder's cost per fact is the one number a `reembed` rebuild's
+/// duration turns on, and the one this gate still cannot produce.
+///
+/// This text used to quote `16.3 us/fact` as the thing to weigh the embedder
+/// against. That number is the store's re-insertion cost measured at DIM=4 on
+/// payloads carrying no text, and presenting it beside an embedder cost made a
+/// regime-dependent claim look settled — which is what opened #1815.
 pub(super) const NO_EMBEDDER_COST: &str =
-    "the embedding cost per fact is NOT established. Everything measured so far is the STORE's      cost — 16.3 us/fact to re-insert, once #1797 removed the per-document fsync — and that is      the smaller half. Re-embedding calls a model over a network, at a cost set by the model,      the backend and the hardware, none of which a unit test may depend on without becoming a      test of whether Ollama happens to be running. Stated rather than guessed: a rebuild's      duration is dominated by this unknown, and it has to be measured against the actual target      model before any duration is promised to an operator.";
+    "the embedding cost per fact is NOT established for the target model. What #1816 measured, on \
+     one machine in a debug build with one embedder call per fact, is a RATIO: re-embedding cost \
+     about 23x a re-insertion (88 462 us against 3 900 us per fact, bge-m3 at 1024 dimensions). \
+     That figure licenses no duration promise. It is one model, unbatched, unoptimised, and the \
+     dominant term in its denominator turned out to be the payload's BM25 text indexing rather \
+     than the vector's width — so it does not transfer to another embedder, another backend, or a \
+     batched run. Under `reuse` the embedder is never called and this cost is zero. Before any \
+     duration is quoted to an operator, it has to be measured against the actual target model on \
+     the actual machine.";
 
 /// An unrecorded source model makes an equal-width swap invisible.
 const NO_PROVENANCE: &str =

--- a/crates/velesdb-memory/src/migration/diagnosis/report.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/report.rs
@@ -3,8 +3,8 @@ use super::capabilities::{
     DIAGNOSIS_CAPABILITY_KEYS, NO_EDGE_EXPORT, NO_EMBEDDER_COST, NO_HEADROOM,
 };
 use super::{
-    switch_filesystem_capability, Capability, CollectionInventory, DiagnosisReport,
-    SourceProvenance, DIAGNOSIS_FORMAT_VERSION,
+    assess, resolve, switch_filesystem_capability, Capability, CollectionInventory,
+    DiagnosisReport, Resolution, SourceProvenance, Strategy, DIAGNOSIS_FORMAT_VERSION,
 };
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,6 +24,8 @@ struct UncheckedDiagnosisReport {
     source_provenance: SourceProvenance,
     target_model: String,
     target_dimension: usize,
+    requested_strategy: Strategy,
+    resolution: Resolution,
     collections: Vec<CollectionInventory>,
     facts: u64,
     edges: u64,
@@ -51,6 +53,8 @@ impl TryFrom<UncheckedDiagnosisReport> for DiagnosisReport {
             source_provenance,
             target_model,
             target_dimension,
+            requested_strategy,
+            resolution,
             collections,
             facts,
             edges,
@@ -73,6 +77,8 @@ impl TryFrom<UncheckedDiagnosisReport> for DiagnosisReport {
             source_provenance,
             target_model,
             target_dimension,
+            requested_strategy,
+            resolution,
             collections,
             facts,
             edges,
@@ -130,7 +136,7 @@ impl DiagnosisReport {
             .map_err(|err| format!("cannot parse diagnosis report version {version}: {err}"))
     }
 
-    /// Validate every v4 field that is derived rather than independently
+    /// Validate every v5 field that is derived rather than independently
     /// observed.
     fn validate(&self) -> Result<(), String> {
         validate_format_version(u64::from(self.format_version))?;
@@ -140,6 +146,7 @@ impl DiagnosisReport {
             require_canonical_capability(&self.capabilities, name, &expected)?;
         }
 
+        validate_resolution(self)?;
         validate_blockers(self)
     }
 
@@ -185,6 +192,33 @@ fn canonical_capabilities(report: &DiagnosisReport) -> [(&'static str, Capabilit
             ),
         ),
     ]
+}
+
+/// Refuse a report whose stated regime does not follow from its own fields.
+///
+/// The regime is the one thing in a diagnosis an operator acts on, and it is
+/// derived — so a report carrying a hand-edited `resolution`, or one produced by
+/// a build whose rule differed, must not be read as authority. Recomputing it
+/// here is what makes "this report says REUSE" mean "this store permits reuse"
+/// rather than "this file contains the word REUSE".
+fn validate_resolution(report: &DiagnosisReport) -> Result<(), String> {
+    let expected = resolve(
+        report.requested_strategy,
+        assess(
+            &report.source_provenance,
+            report.source_dimension,
+            &report.target_model,
+            report.target_dimension,
+        ),
+    );
+    if report.resolution == expected {
+        return Ok(());
+    }
+    Err(format!(
+        "diagnosis report states resolution {:?} for a {:?} request, but its own provenance and \
+         target contract resolve to {expected:?}",
+        report.resolution, report.requested_strategy
+    ))
 }
 
 fn validate_blockers(report: &DiagnosisReport) -> Result<(), String> {

--- a/crates/velesdb-memory/src/migration/enumeration.rs
+++ b/crates/velesdb-memory/src/migration/enumeration.rs
@@ -8,15 +8,35 @@ pub const AGENT_COLLECTIONS: &[&str] =
 
 /// One fact as the rebuild will need to re-create it.
 ///
-/// The old vector is deliberately absent: it is recomputed by the new
-/// embedder, and carrying it would only invite writing it back.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// # Why the source vector is here, having once been left out deliberately
+///
+/// This type used to carry `id` and `payload` only, on the stated grounds that
+/// "the old vector is recomputed by the new embedder, and carrying it would
+/// only invite writing it back". That was written when a rebuild had one
+/// regime. #1815 arbitrated two: reuse the source vectors where compatibility
+/// is *proven*, re-embed everywhere else. A type that cannot carry the source
+/// vector cannot express the first, so the reasoning no longer held and the
+/// comment asserting it was describing a decision that had been reversed.
+///
+/// The field is named `source_vector` rather than `vector` for the reason the
+/// old comment was right about: it is the vector of the model being migrated
+/// *from*, and writing it back is only ever legitimate against a
+/// [`Compatibility::Match`](crate::migration::Compatibility::Match). What
+/// [`reinsert`] writes is always the vector its caller passed, never this one
+/// by default.
+#[derive(Debug, Clone, PartialEq)]
 pub struct RawFact {
     /// The id the fact must keep. Not a suggestion.
     pub id: u64,
     /// The whole stored payload, reserved keys included — `content` and every
     /// `_veles_*` key travel here verbatim.
     pub payload: String,
+    /// The vector as the SOURCE store holds it, at the source's width.
+    ///
+    /// Read out on every enumeration because the cost is a clone of something
+    /// the engine already materialised, and a second read path taken only under
+    /// `reuse` would be a path the `reembed` tests never exercise.
+    pub source_vector: Vec<f32>,
 }
 
 /// Read every fact of `collection` out of `db`, in pages of `page`.
@@ -86,6 +106,7 @@ pub fn enumerate_page(
                 .payload
                 .as_ref()
                 .map_or_else(|| Value::Null.to_string(), std::string::ToString::to_string),
+            source_vector: hit.point.vector,
         })
         .collect())
 }
@@ -141,6 +162,7 @@ pub fn scroll_page(
                 .payload
                 .as_ref()
                 .map_or_else(|| Value::Null.to_string(), std::string::ToString::to_string),
+            source_vector: point.vector,
         })
         .collect();
     Ok((facts, scrolled.next_cursor))
@@ -209,11 +231,16 @@ pub enum Reinsertion {
 }
 
 /// Put `fact` back into `collection` under its ORIGINAL id, with `vector` as
-/// the new embedder computed it.
+/// the caller decided it.
 ///
-/// The old vector is not carried and not written: it belongs to the model being
-/// migrated away from, and re-writing it would produce a store whose vectors
-/// and whose recorded model disagree.
+/// `vector` is the target embedder's output under `reembed`, or
+/// `fact.source_vector` under `reuse`. This function does not choose between
+/// them and must not: passing the source vector is legitimate exactly when the
+/// source records the target model at the target width, and the only thing that
+/// establishes it is [`resolve`](crate::migration::resolve) — one place, tested
+/// as one rule. Writing back a source vector on any other footing produces a
+/// store whose vectors and whose recorded model disagree, which recall answers
+/// from without ever failing.
 ///
 /// # Errors
 /// Returns [`crate::MemoryError`] if the collection is absent, if the stored

--- a/crates/velesdb-memory/src/migration/strategy.rs
+++ b/crates/velesdb-memory/src/migration/strategy.rs
@@ -1,0 +1,304 @@
+//! Which regime a rebuild runs in, and why (#1815).
+//!
+//! A rebuild has two possible regimes and the module below the CLI is
+//! deliberately neutral between them, because the caller supplies the vector:
+//! reuse the source vectors, or re-embed every fact with the target model. The
+//! arbitration on #1815 is that **reuse is permitted only where compatibility
+//! is proven, and every other case re-embeds**.
+//!
+//! # The one thing this file exists to refuse
+//!
+//! Two models that happen to produce the same width do NOT produce comparable
+//! vectors, and nothing on disk distinguishes them: the store records a
+//! dimension, and — only since #1751, and only for a store that was empty when
+//! it was first opened — a model name. So an equal-width model swap is
+//! **invisible**, and a rebuild that inferred the source model from the width
+//! would reuse vectors from one model in a store that claims another. Recall
+//! would then return nonsense without a single error anywhere.
+//!
+//! Hence: an unrecorded source model is never guessed at. It resolves to
+//! re-embedding, which is always sound because it reads the stored *text* and
+//! never the stored vector.
+//!
+//! # There is deliberately no `force-reuse`
+//!
+//! An override that reused vectors against an unproven provenance would be an
+//! official route to a semantically incoherent store, so [`Strategy::parse`]
+//! names it and refuses it rather than leaving an operator to discover it does
+//! not exist. `--strategy reembed` is the escape hatch, and it escapes towards
+//! the *safe* regime.
+
+use super::SourceProvenance;
+
+// ---------------------------------------------------------------------------
+// THE VOCABULARY
+//
+// A closed set of five sentences, so that every diagnostic an operator can see
+// is one of five and each is tested. A `format!` at the call site would let a
+// sixth phrasing appear without anybody deciding it should.
+// ---------------------------------------------------------------------------
+
+/// The source records the target model at the target width.
+const MATCH: &str = "source and target embedding provenance match";
+/// A recorded model that is not the target's — including at equal width.
+const MODEL_DIFFERS: &str = "target model differs";
+/// The recorded width is not the target's.
+const DIMENSION_DIFFERS: &str = "target dimension differs";
+/// No record at all: the nominal case for every store predating #1751.
+const PROVENANCE_UNKNOWN: &str = "source provenance is unknown";
+/// A record that disagrees with the vectors it claims to describe.
+const PROVENANCE_CONTRADICTS: &str = "source provenance contradicts the stored dimension";
+
+// ---------------------------------------------------------------------------
+// WHAT THE STORE PERMITS
+// ---------------------------------------------------------------------------
+
+/// What the source's own record permits, independently of what was asked for.
+///
+/// Split from [`Strategy`] on purpose: this is a property of the store, and
+/// mixing it with the operator's request is what would make "the operator asked
+/// nicely" look like a reason vectors are compatible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Compatibility {
+    /// Known provenance, same model, same width. The only value that permits
+    /// reuse.
+    Match,
+    /// Known provenance naming a different model — **including at equal
+    /// width**, which is exactly the case no measurement can detect.
+    ModelDiffers,
+    /// Known provenance at a width the target does not produce.
+    DimensionDiffers,
+    /// The store records nothing. Not a fault: the nominal state of every store
+    /// created before the record existed, including the one #1762 was opened
+    /// for.
+    ProvenanceUnknown,
+    /// The record and the collections disagree, or the collections establish no
+    /// shared width at all. Neither side can be trusted to describe the other.
+    ProvenanceContradictsDimension,
+}
+
+impl Compatibility {
+    /// The sentence that names this state, from the closed vocabulary.
+    #[must_use]
+    pub fn reason(self) -> &'static str {
+        match self {
+            Self::Match => MATCH,
+            Self::ModelDiffers => MODEL_DIFFERS,
+            Self::DimensionDiffers => DIMENSION_DIFFERS,
+            Self::ProvenanceUnknown => PROVENANCE_UNKNOWN,
+            Self::ProvenanceContradictsDimension => PROVENANCE_CONTRADICTS,
+        }
+    }
+
+    /// Whether reusing the source vectors is defensible.
+    ///
+    /// One variant, and it is the point of the whole file: proof, not absence
+    /// of evidence.
+    #[must_use]
+    pub fn permits_reuse(self) -> bool {
+        matches!(self, Self::Match)
+    }
+
+    /// Every variant, so an exhaustive check cannot silently miss one added
+    /// later.
+    #[must_use]
+    pub fn all() -> Vec<Self> {
+        vec![
+            Self::Match,
+            Self::ModelDiffers,
+            Self::DimensionDiffers,
+            Self::ProvenanceUnknown,
+            Self::ProvenanceContradictsDimension,
+        ]
+    }
+}
+
+/// Read the source's record against the target contract.
+///
+/// The record is checked against the DATA first: a provenance naming a width
+/// the collections do not have describes something other than this store, and
+/// reading its model name off it would be reading a record already shown wrong.
+/// `source_dimension` is `None` when the collections disagree or the store has
+/// none, which fails the same reconciliation for the same reason.
+#[must_use]
+pub fn assess(
+    provenance: &SourceProvenance,
+    source_dimension: Option<usize>,
+    target_model: &str,
+    target_dimension: usize,
+) -> Compatibility {
+    let SourceProvenance::Known { model, dimension } = provenance else {
+        return Compatibility::ProvenanceUnknown;
+    };
+    if source_dimension != Some(*dimension) {
+        return Compatibility::ProvenanceContradictsDimension;
+    }
+    // Model before width: a model change is the fact that matters, and at equal
+    // width it is the ONLY thing that distinguishes two incomparable stores.
+    if model != target_model {
+        return Compatibility::ModelDiffers;
+    }
+    if *dimension != target_dimension {
+        return Compatibility::DimensionDiffers;
+    }
+    Compatibility::Match
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE OPERATOR ASKED FOR
+// ---------------------------------------------------------------------------
+
+/// What the operator selected on the command line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Strategy {
+    /// Decide from the source's own record. The default.
+    Auto,
+    /// Reuse the source vectors — honoured only against a proven match.
+    Reuse,
+    /// Re-embed every fact. Always available.
+    Reembed,
+}
+
+impl Strategy {
+    /// Parse a `--strategy` value.
+    ///
+    /// # Errors
+    /// Names the three accepted values. `force-reuse`, in any spelling, gets
+    /// its own message: it is refused by design rather than merely absent, and
+    /// an operator who reached for it is asking the one question this batch
+    /// answered with "no".
+    pub fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "auto" => Ok(Self::Auto),
+            "reuse" => Ok(Self::Reuse),
+            "reembed" => Ok(Self::Reembed),
+            "force-reuse" | "force_reuse" => Err(format!(
+                "--strategy {value} does not exist, and not by oversight: reusing vectors against \
+                 an unproven provenance is an official route to a store whose vectors and whose \
+                 recorded model disagree, which recall would answer from without ever failing. \
+                 Use --strategy reembed to rebuild from the stored text"
+            )),
+            other => Err(format!(
+                "--strategy expects auto, reuse or reembed, got {other:?}"
+            )),
+        }
+    }
+
+    /// Every variant, so an exhaustive check cannot silently miss one added
+    /// later.
+    #[must_use]
+    pub fn all() -> Vec<Self> {
+        vec![Self::Auto, Self::Reuse, Self::Reembed]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHAT WILL HAPPEN
+// ---------------------------------------------------------------------------
+
+/// What the rebuild will do, or why it will not run.
+///
+/// There is no variant meaning "reuse, but flagged": a rebuild either reuses
+/// vectors it has grounds to reuse, or it does not reuse them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "resolution", rename_all = "snake_case")]
+pub enum Resolution {
+    /// Carry the source vectors across unchanged. The target embedder is never
+    /// called.
+    Reuse,
+    /// Compute every vector with the target embedder, from the stored text.
+    Reembed {
+        /// What made reuse unavailable — or, under `--strategy reembed`, what
+        /// the store would have permitted anyway.
+        because: Compatibility,
+    },
+    /// Change nothing.
+    Refuse {
+        /// The state of the store that makes the request unanswerable.
+        because: Compatibility,
+        /// What was asked for, which decides what the operator should do next.
+        requested: Strategy,
+    },
+}
+
+impl Resolution {
+    /// The one line, from the closed vocabulary, that names this decision.
+    #[must_use]
+    pub fn diagnostic(self) -> String {
+        match self {
+            Self::Reuse => format!("REUSE: {MATCH}"),
+            Self::Reembed { because } => format!("REEMBED: {}", because.reason()),
+            Self::Refuse {
+                because,
+                requested: Strategy::Reuse,
+            } => format!("REFUSE: reuse was requested, but {}", because.reason()),
+            Self::Refuse { because, .. } => format!("REFUSE: {}", because.reason()),
+        }
+    }
+
+    /// What the operator can do about it, or `None` when nothing is wrong.
+    ///
+    /// A refusal that named only the problem would leave an operator with a
+    /// store they cannot migrate and no next step; both refusals have one, and
+    /// neither is "reuse it anyway".
+    #[must_use]
+    pub fn guidance(self) -> Option<&'static str> {
+        match self {
+            Self::Reuse | Self::Reembed { .. } => None,
+            Self::Refuse {
+                requested: Strategy::Reuse,
+                ..
+            } => Some(
+                "reuse is legitimate only when the source records the target model at the target \
+                 width. Re-run with --strategy auto to let the source's own record decide, or \
+                 --strategy reembed to rebuild every vector from the stored text.",
+            ),
+            Self::Refuse { .. } => Some(
+                "the record and the vectors cannot both be right, so neither is read as truth. \
+                 Re-run with --strategy reembed to rebuild from the stored text on the measured \
+                 width — it never reads a source vector, so the contradiction cannot propagate.",
+            ),
+        }
+    }
+
+    /// Whether this decision runs a rebuild at all.
+    #[must_use]
+    pub fn runs(self) -> bool {
+        !matches!(self, Self::Refuse { .. })
+    }
+}
+
+/// Decide the regime from what was asked and what the store permits.
+///
+/// `Auto` refuses only the self-contradicting store: re-embedding is otherwise
+/// always sound, since it reads the stored text and never the stored vector.
+/// That refusal is not a dead end — `--strategy reembed` performs exactly the
+/// rebuild `Auto` declined to choose on the operator's behalf.
+#[must_use]
+pub fn resolve(requested: Strategy, compatibility: Compatibility) -> Resolution {
+    // Reuse, and only against a proven match. `reembed` is excluded even here:
+    // an operator who named the safe regime gets it, whatever the store would
+    // have permitted.
+    if requested != Strategy::Reembed && compatibility.permits_reuse() {
+        return Resolution::Reuse;
+    }
+    // Reuse asked for and not earned above, or `auto` meeting a store whose
+    // record and vectors contradict each other — the one state `auto` will not
+    // choose on the operator's behalf.
+    let unearned_reuse = requested == Strategy::Reuse;
+    let unreadable_store = requested == Strategy::Auto
+        && compatibility == Compatibility::ProvenanceContradictsDimension;
+    if unearned_reuse || unreadable_store {
+        return Resolution::Refuse {
+            because: compatibility,
+            requested,
+        };
+    }
+    // Everything else re-embeds: it reads the stored text, so no property of
+    // the source's vectors can make it unsound.
+    Resolution::Reembed {
+        because: compatibility,
+    }
+}

--- a/crates/velesdb-memory/src/migration/tests/cli.rs
+++ b/crates/velesdb-memory/src/migration/tests/cli.rs
@@ -182,13 +182,34 @@ fn the_dry_run_leaves_the_store_byte_for_byte_as_it_found_it() {
 }
 
 #[test]
-fn the_default_scratch_parent_exists_so_a_dry_run_has_somewhere_to_stage() {
-    let parent = default_scratch_parent();
+fn the_default_scratch_parent_is_the_store_s_own_volume_not_the_temp_dir() {
+    let (dir, _ttl) = seeded();
 
-    assert!(
-        parent.is_dir(),
-        "the diagnosis copies the whole store into this directory; if it does \
-         not exist, every dry run fails on a path the operator never chose: {}",
-        parent.display()
+    let parent = default_scratch_parent(dir.path()).expect("a real store has a parent");
+
+    assert_eq!(
+        parent,
+        dir.path().parent().expect("tempdir has a parent"),
+        "the diagnosis copies the WHOLE store; staging beside it is on the \
+         store's volume by construction, where a temp filesystem sized for \
+         small files is exactly where a real store would fail"
     );
+
+    // The default must be USABLE, not merely computed: a dry run actually
+    // stages there and completes.
+    let report = dry_run(
+        dir.path(),
+        &parent,
+        &TargetContract::automatic(TARGET_MODEL, TARGET_DIM),
+        None,
+    )
+    .expect("a dry run staging beside the store");
+    assert!(report.facts > 0, "the fixture must not be empty");
+
+    // And a store with no usable parent is an ERROR naming the flag — never a
+    // quiet switch to a different volume, which is how the old temp_dir
+    // default would have resurfaced under another name.
+    let rootless = default_scratch_parent(std::path::Path::new("/"))
+        .expect_err("no parent to stage beside must refuse");
+    assert!(rootless.contains("--scratch"), "{rootless}");
 }

--- a/crates/velesdb-memory/src/migration/tests/cli.rs
+++ b/crates/velesdb-memory/src/migration/tests/cli.rs
@@ -1,0 +1,194 @@
+//! What the operator surface accepts, refuses, and says (#1815).
+//!
+//! The module this exercises is the first production caller the `migration`
+//! module has ever had. Before it, ~7 000 lines of diagnosis, enumeration,
+//! re-insertion, journal and lock were reachable only from tests — which is the
+//! finding that opened #1815.
+
+use super::diagnosis::{diagnose_as, TARGET_DIM, TARGET_MODEL};
+use super::*;
+
+fn args(raw: &[&str]) -> Vec<String> {
+    raw.iter().map(|s| (*s).to_owned()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE COMMAND LINE ACCEPTS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_default_is_auto_and_not_a_dry_run() {
+    let options = parse_migrate_args(&[]).expect("no flags is a valid invocation");
+
+    assert_eq!(options.strategy, Strategy::Auto);
+    assert!(
+        !options.dry_run,
+        "a dry run must be asked for; defaulting to it would make the flag \
+         meaningless and leave the non-dry path unreachable"
+    );
+}
+
+#[test]
+fn every_flag_is_parsed_and_an_unknown_one_is_named() {
+    let options = parse_migrate_args(&args(&[
+        "--dry-run",
+        "--store",
+        "/tmp/store",
+        "--destination",
+        "/tmp/dest",
+        "--scratch",
+        "/tmp/scratch",
+        "--strategy",
+        "reembed",
+    ]))
+    .expect("a complete invocation");
+
+    assert!(options.dry_run);
+    assert_eq!(
+        options.store.as_deref(),
+        Some(std::path::Path::new("/tmp/store"))
+    );
+    assert_eq!(
+        options.destination.as_deref(),
+        Some(std::path::Path::new("/tmp/dest"))
+    );
+    assert_eq!(
+        options.scratch.as_deref(),
+        Some(std::path::Path::new("/tmp/scratch"))
+    );
+    assert_eq!(options.strategy, Strategy::Reembed);
+
+    let unknown =
+        parse_migrate_args(&args(&["--nope", "x"])).expect_err("an unknown flag must be refused");
+    assert!(unknown.contains("--nope"), "{unknown}");
+}
+
+#[test]
+fn a_flag_without_its_value_names_the_flag_rather_than_the_position() {
+    for flag in ["--store", "--destination", "--scratch", "--strategy"] {
+        let message =
+            parse_migrate_args(&args(&[flag])).expect_err("a valueless flag must be refused");
+
+        assert!(
+            message.contains(flag) && message.contains("requires a value"),
+            "{flag} should name itself: {message}"
+        );
+    }
+}
+
+#[test]
+fn force_reuse_is_refused_at_the_command_line_and_not_only_in_the_rule() {
+    // An operator meets the command line, not `Strategy::parse`. A rule nobody
+    // can reach refuses nothing.
+    let message = parse_migrate_args(&args(&["--strategy", "force-reuse"]))
+        .expect_err("force-reuse must not parse");
+
+    assert!(
+        message.contains("does not exist, and not by oversight")
+            && message.contains("--strategy reembed"),
+        "{message}"
+    );
+}
+
+#[test]
+fn anything_that_is_not_a_dry_run_is_refused_rather_than_silently_doing_nothing() {
+    let asked_for_a_migration = parse_migrate_args(&args(&["--strategy", "auto"])).expect("flags");
+
+    let refusal = require_dry_run(&asked_for_a_migration)
+        .expect_err("a non-dry-run invocation must be refused in this version");
+
+    assert!(
+        refusal.contains("--dry-run") && refusal.contains("#1762"),
+        "the refusal must name the supported mode and where the rest is tracked: {refusal}"
+    );
+
+    require_dry_run(&parse_migrate_args(&args(&["--dry-run"])).expect("flags"))
+        .expect("a dry run must be accepted");
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE OPERATOR READS, AND WHAT THE SHELL READS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_dry_run_reads_a_real_store_and_leads_with_the_regime() {
+    let (dir, _ttl) = seeded();
+
+    let report = diagnose_as(dir.path(), Strategy::Auto, TARGET_MODEL, TARGET_DIM);
+    let rendered = render(&report);
+
+    assert!(
+        rendered.starts_with("REEMBED: source provenance is unknown"),
+        "the one decision an operator acts on must come first: {rendered}"
+    );
+    assert!(
+        rendered.contains("not inferred from the width"),
+        "the provenance line must say the model was not guessed: {rendered}"
+    );
+    assert!(
+        rendered.contains(&format!("facts:              {}", SEEDED + 1)),
+        "the inventory must be the store's, not a template: {rendered}"
+    );
+    assert!(
+        rendered.contains("blocker(s) before a rebuild:"),
+        "outstanding blockers must be shown, not summarised away: {rendered}"
+    );
+    assert!(!refuses(&report), "re-embedding is a decision that runs");
+}
+
+#[test]
+fn a_refusal_renders_its_way_out_and_is_reportable_as_a_refusal() {
+    let (dir, _ttl) = seeded();
+
+    let report = diagnose_as(dir.path(), Strategy::Reuse, TARGET_MODEL, TARGET_DIM);
+    let rendered = render(&report);
+
+    assert!(
+        rendered.starts_with("REFUSE: reuse was requested, but source provenance is unknown"),
+        "{rendered}"
+    );
+    assert!(
+        rendered.contains("--strategy reembed"),
+        "a refusal must render its way out: {rendered}"
+    );
+    assert!(
+        refuses(&report),
+        "a refusal must be reportable as one, or a wrapping script reads exit 0 as success"
+    );
+}
+
+#[test]
+fn the_dry_run_leaves_the_store_byte_for_byte_as_it_found_it() {
+    // The command is read-only, and "read-only" is a claim until something
+    // checks it. The daemon may be holding this store while it runs.
+    let (dir, _ttl) = seeded();
+    let before = super::diagnosis::tree(dir.path());
+
+    let staging = tempfile::tempdir().expect("staging");
+    let report = dry_run(
+        dir.path(),
+        staging.path(),
+        &TargetContract::automatic(TARGET_MODEL, TARGET_DIM),
+        None,
+    )
+    .expect("dry run");
+
+    assert!(report.facts > 0, "the fixture must not be empty");
+    assert_eq!(
+        super::diagnosis::tree(dir.path()),
+        before,
+        "a dry run must not change one byte of the store it inspects"
+    );
+}
+
+#[test]
+fn the_default_scratch_parent_exists_so_a_dry_run_has_somewhere_to_stage() {
+    let parent = default_scratch_parent();
+
+    assert!(
+        parent.is_dir(),
+        "the diagnosis copies the whole store into this directory; if it does \
+         not exist, every dry run fails on a path the operator never chose: {}",
+        parent.display()
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnosis.rs
@@ -9,8 +9,8 @@ use super::*;
 // never checked is a claim, not a property.
 // ---------------------------------------------------------------------------
 
-pub(super) const TARGET_MODEL: &str = "bge-m3";
-pub(super) const TARGET_DIM: usize = 1024;
+pub(crate) const TARGET_MODEL: &str = "bge-m3";
+pub(crate) const TARGET_DIM: usize = 1024;
 
 /// Every file under `dir`, by relative path, with its length and its bytes.
 ///
@@ -648,7 +648,7 @@ fn edge_counts_do_not_masquerade_as_a_lossless_edge_export() {
 // ---------------------------------------------------------------------------
 
 /// Diagnose `source` with an explicitly selected regime.
-fn diagnose_as(
+pub(super) fn diagnose_as(
     source: &std::path::Path,
     strategy: super::Strategy,
     target_model: &str,

--- a/crates/velesdb-memory/src/migration/tests/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnosis.rs
@@ -552,14 +552,23 @@ fn the_embedding_cost_is_declared_unestablished_rather_than_guessed() {
             report.capabilities.get("embedder_cost")
         );
     };
+    // This assertion used to require the string `16.3 us/fact`, which pinned the
+    // store's DIM=4 text-free RE-INSERTION cost into a blocker about the
+    // EMBEDDER. A test can keep a wrong number alive as effectively as a
+    // comment can, and this one did until #1815 named the conflation.
     assert!(
-        blocker.contains("16.3 us/fact"),
-        "the blocker must say what WAS measured, so the unmeasured part is not \
-         confused with the measured one: {blocker}"
+        blocker.contains("23x") && blocker.contains("bge-m3"),
+        "the blocker must say what #1816 actually measured — a RATIO, against a \
+         named model — so the unmeasured part is not confused with it: {blocker}"
     );
     assert!(
-        blocker.contains("Ollama") || blocker.contains("network"),
-        "and it must say why a unit test cannot supply it: {blocker}"
+        blocker.contains("unbatched") || blocker.contains("debug build"),
+        "and it must name the conditions that stop that ratio transferring: {blocker}"
+    );
+    assert!(
+        blocker.contains("`reuse`"),
+        "and it must say that under reuse this cost is zero, since a blocker that \
+         reads as unconditional would block a regime it does not apply to: {blocker}"
     );
 }
 
@@ -632,6 +641,140 @@ fn edge_counts_do_not_masquerade_as_a_lossless_edge_export() {
         "the missing export must be a blocker, not a footnote"
     );
     assert!(!report.is_clear());
+}
+
+// ---------------------------------------------------------------------------
+// THE REGIME THE REPORT STATES (#1815)
+// ---------------------------------------------------------------------------
+
+/// Diagnose `source` with an explicitly selected regime.
+fn diagnose_as(
+    source: &std::path::Path,
+    strategy: super::Strategy,
+    target_model: &str,
+    target_dimension: usize,
+) -> DiagnosisReport {
+    let staging = tempfile::tempdir().expect("diagnostic staging");
+    super::super::diagnose(
+        source,
+        staging.path(),
+        &super::TargetContract {
+            model: target_model.to_owned(),
+            dimension: target_dimension,
+            strategy,
+        },
+        None,
+    )
+    .expect("diagnose")
+}
+
+/// A store recording `model` at the width its collections actually hold.
+fn stamped(model: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let _store = NativeStore::open(dir.path(), DIM).expect("open store");
+    }
+    crate::embedding_provenance::write(
+        dir.path(),
+        &crate::embedding_provenance::EmbeddingProvenance::new(model, DIM),
+    )
+    .expect("write provenance");
+    dir
+}
+
+#[test]
+fn an_unstamped_store_is_reported_as_re_embedding_and_says_why() {
+    // The store this migration exists for: it holds facts and predates the
+    // record, so it can never be stamped retroactively and `auto` can only ever
+    // re-embed it.
+    let (dir, _ttl) = seeded();
+
+    let report = diagnose_as(dir.path(), super::Strategy::Auto, TARGET_MODEL, TARGET_DIM);
+
+    assert_eq!(report.requested_strategy, super::Strategy::Auto);
+    assert_eq!(
+        report.resolution,
+        super::Resolution::Reembed {
+            because: super::Compatibility::ProvenanceUnknown
+        }
+    );
+    assert_eq!(
+        report.resolution.diagnostic(),
+        "REEMBED: source provenance is unknown"
+    );
+}
+
+#[test]
+fn a_store_stamped_with_the_target_model_at_the_target_width_reports_reuse() {
+    // The positive control for the test above: without it, "REEMBED" could be a
+    // constant rather than a decision.
+    let dir = stamped(TARGET_MODEL);
+
+    let report = diagnose_as(dir.path(), super::Strategy::Auto, TARGET_MODEL, DIM);
+
+    assert_eq!(report.resolution, super::Resolution::Reuse);
+    assert_eq!(
+        report.resolution.diagnostic(),
+        "REUSE: source and target embedding provenance match"
+    );
+}
+
+#[test]
+fn a_stamped_store_at_the_target_width_but_another_model_still_re_embeds() {
+    // DIM on both sides: the width agrees and the vectors do not. Nothing but
+    // the recorded model separates this case from the one above.
+    let dir = stamped("all-minilm");
+
+    let report = diagnose_as(dir.path(), super::Strategy::Auto, TARGET_MODEL, DIM);
+
+    assert_eq!(
+        report.resolution,
+        super::Resolution::Reembed {
+            because: super::Compatibility::ModelDiffers
+        },
+        "an equal-width model change must still re-embed"
+    );
+}
+
+#[test]
+fn an_explicit_reuse_against_an_unstamped_store_is_reported_as_refused() {
+    let (dir, _ttl) = seeded();
+
+    let report = diagnose_as(dir.path(), super::Strategy::Reuse, TARGET_MODEL, TARGET_DIM);
+
+    assert!(!report.resolution.runs());
+    assert_eq!(
+        report.resolution.diagnostic(),
+        "REFUSE: reuse was requested, but source provenance is unknown"
+    );
+    assert!(
+        report.resolution.guidance().is_some(),
+        "a refusal must hand the operator a next step"
+    );
+}
+
+#[test]
+fn a_forged_regime_cannot_survive_the_parser() {
+    // The regime is the one field an operator acts on, and it is DERIVED. A
+    // report that could carry a hand-edited `REUSE` over an unstamped store
+    // would be a file that authorises what the rule refuses.
+    let (dir, _ttl) = seeded();
+    let mut forged = diagnose_as(dir.path(), super::Strategy::Auto, TARGET_MODEL, TARGET_DIM);
+    assert_eq!(
+        forged.resolution,
+        super::Resolution::Reembed {
+            because: super::Compatibility::ProvenanceUnknown
+        },
+        "the fixture must start from a report that does NOT say reuse"
+    );
+
+    forged.resolution = super::Resolution::Reuse;
+
+    let refusal = direct_deserialization_refusal(&forged);
+    assert!(
+        refusal.contains("resolve to"),
+        "the refusal must say the report contradicts its own fields: {refusal}"
+    );
 }
 
 #[test]

--- a/crates/velesdb-memory/src/migration/tests/diagnostic_copy.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnostic_copy.rs
@@ -18,8 +18,7 @@ fn diagnosis_works_while_the_original_lock_is_held_and_leaves_source_unchanged()
     let report = super::super::diagnose(
         source.path(),
         staging.path(),
-        diagnosis::TARGET_MODEL,
-        diagnosis::TARGET_DIM,
+        &super::super::TargetContract::automatic(diagnosis::TARGET_MODEL, diagnosis::TARGET_DIM),
         None,
     )
     .expect("diagnosis must not contend on the live source lock");
@@ -120,8 +119,7 @@ fn a_source_mutation_after_capture_refuses_the_inventory_report() {
         .expect("simulate concurrent daemon write");
     let result = super::super::diagnosis::diagnose_copy(
         source.path(),
-        diagnosis::TARGET_MODEL,
-        diagnosis::TARGET_DIM,
+        &super::super::TargetContract::automatic(diagnosis::TARGET_MODEL, diagnosis::TARGET_DIM),
         None,
         &copy,
     );
@@ -191,8 +189,7 @@ fn scratch_inside_source_is_refused_without_mutating_the_source() {
     let error = super::super::diagnose(
         source.path(),
         &inside,
-        diagnosis::TARGET_MODEL,
-        diagnosis::TARGET_DIM,
+        &super::super::TargetContract::automatic(diagnosis::TARGET_MODEL, diagnosis::TARGET_DIM),
         None,
     )
     .expect_err("scratch inside source must be refused");

--- a/crates/velesdb-memory/src/migration/tests/enumeration.rs
+++ b/crates/velesdb-memory/src/migration/tests/enumeration.rs
@@ -257,6 +257,119 @@ fn resuming_at_a_recorded_offset_skips_nothing_and_repeats_nothing() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// THE SOURCE VECTOR — what makes the `reuse` regime possible at all (#1815)
+// ---------------------------------------------------------------------------
+
+/// A store whose facts carry vectors that are all DIFFERENT from one another.
+///
+/// The shared `seeded()` fixture writes one constant embedding into every fact,
+/// which is right for the questions it was built for and useless for this one:
+/// a read path that returned a placeholder, the first fact's vector, or the
+/// same buffer every time would agree with a constant fixture perfectly.
+fn seeded_with_distinct_vectors() -> (tempfile::TempDir, Vec<(u64, Vec<f32>)>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let written: Vec<(u64, Vec<f32>)> = SCRAMBLED
+        .iter()
+        .enumerate()
+        .map(|(i, &id)| {
+            let step = f32::from(u8::try_from(i).expect("the fixture is eight facts long"));
+            (id, vec![step, 1.0 - step, step * 0.5, -step])
+        })
+        .collect();
+    {
+        let store = NativeStore::open(dir.path(), DIM).expect("open store");
+        for (id, vector) in &written {
+            store
+                .store_with_metadata(*id, &format!("fact number {id}"), vector, &meta(&[]))
+                .expect("seed fact");
+        }
+    }
+    (dir, written)
+}
+
+#[test]
+fn both_read_paths_return_each_fact_s_own_vector() {
+    // Without this, `RawFact::source_vector` is a field that compiles. The
+    // `reuse` regime writes exactly these floats back into the destination, so
+    // "the right shape arrived" is not the question — "fact 999's vector, and
+    // not fact 3's" is.
+    let (dir, written) = seeded_with_distinct_vectors();
+    let db = database(&dir);
+
+    let by_cursor = super::enumerate_by_cursor(&db, "_semantic_memory", PAGE).expect("cursor");
+    let by_offset = super::enumerate_collection(&db, "_semantic_memory", PAGE).expect("offset");
+
+    let vectors = |facts: &[RawFact]| -> std::collections::BTreeMap<u64, Vec<f32>> {
+        facts
+            .iter()
+            .map(|f| (f.id, f.source_vector.clone()))
+            .collect()
+    };
+    let cursor_vectors = vectors(&by_cursor);
+    let expected: std::collections::BTreeMap<u64, Vec<f32>> = written.into_iter().collect();
+
+    assert_eq!(
+        cursor_vectors, expected,
+        "the cursor must return the vector each fact was written with"
+    );
+    assert_eq!(
+        vectors(&by_offset),
+        expected,
+        "the independent scan must agree with the cursor, vector for vector"
+    );
+}
+
+#[test]
+fn a_reused_vector_survives_the_round_trip_into_a_destination() {
+    // The `reuse` regime in one assertion: read a fact out, put it back with
+    // its OWN vector, read it out of the destination and get the same floats.
+    // A store that normalised or quantised on write would fail here, and that
+    // is the point — it is the property reuse depends on, not an assumption
+    // about how the engine stores what it is given.
+    let (source_dir, _written) = seeded_with_distinct_vectors();
+    let source = database(&source_dir);
+    let facts = super::enumerate_by_cursor(&source, "_semantic_memory", PAGE).expect("read out");
+    drop(source);
+    // Without this, an enumeration that returned nothing would make every
+    // comparison below compare two empty maps and report success.
+    assert_eq!(
+        facts.len(),
+        SCRAMBLED.len(),
+        "the source must yield every seeded fact, or this test proves nothing"
+    );
+
+    let dest_dir = tempfile::tempdir().expect("tempdir");
+    {
+        let _store = NativeStore::open(dest_dir.path(), DIM).expect("open destination");
+    }
+    let destination = velesdb_core::Database::open(dest_dir.path()).expect("open destination db");
+    for fact in &facts {
+        let vector = fact.source_vector.clone();
+        assert_eq!(
+            super::reinsert(&destination, "_semantic_memory", fact, &vector).expect("reinsert"),
+            Reinsertion::Inserted,
+            "fact {} must land on a free id",
+            fact.id
+        );
+    }
+
+    let rebuilt =
+        super::enumerate_by_cursor(&destination, "_semantic_memory", PAGE).expect("read back");
+    let by_id = |facts: &[RawFact]| -> std::collections::BTreeMap<u64, Vec<f32>> {
+        facts
+            .iter()
+            .map(|f| (f.id, f.source_vector.clone()))
+            .collect()
+    };
+
+    assert_eq!(
+        by_id(&rebuilt),
+        by_id(&facts),
+        "a vector carried across under `reuse` must arrive unchanged"
+    );
+}
+
 /// One page, at an explicit offset — the unit a checkpoint resumes from.
 pub(super) fn enumerate_page(
     db: &velesdb_core::Database,

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -117,6 +117,7 @@ fn database(dir: &tempfile::TempDir) -> velesdb_core::Database {
     velesdb_core::Database::open(dir.path()).expect("open database")
 }
 
+mod cli;
 mod diagnosis;
 mod enumeration;
 mod performance;

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -123,3 +123,4 @@ mod enumeration;
 mod performance;
 mod preservation;
 mod state;
+mod strategy;

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -43,8 +43,7 @@ fn diagnose(
     super::diagnose(
         source,
         staging.path(),
-        target_model,
-        target_dimension,
+        &TargetContract::automatic(target_model, target_dimension),
         destination,
     )
 }

--- a/crates/velesdb-memory/src/migration/tests/performance.rs
+++ b/crates/velesdb-memory/src/migration/tests/performance.rs
@@ -15,6 +15,35 @@ use super::*;
 // Until that is measured, `scalable_reconstruction` has no verdict, and PR B
 // stays blocked on it rather than on the enumeration.
 
+/// The sizes both cost sweeps walk.
+///
+/// Shared so the two are comparable by construction: a sweep that quietly
+/// changed one list would produce two sets of numbers that look like a
+/// comparison and are not one.
+const SWEEP_SIZES: [u64; 4] = [250, 500, 1000, 2000];
+
+/// A store holding `n` facts at scattered ids, for the cost sweeps.
+///
+/// `id * 7` rather than `id`: contiguous ids let a walk that pages by position
+/// look correct, which is the confusion the enumeration gates exist to rule out.
+fn seeded_at_size(n: u64) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let store = NativeStore::open(dir.path(), DIM).expect("open");
+        for id in 1..=n {
+            store
+                .store_with_metadata(
+                    id * 7,
+                    &format!("fact {id}"),
+                    &EMBEDDING,
+                    &meta(&[("project", Value::from("veles"))]),
+                )
+                .expect("seed");
+        }
+    }
+    dir
+}
+
 /// Micro-seconds per fact, in the style the cost tests above already use.
 fn per_fact(elapsed: std::time::Duration, n: u64) -> f64 {
     let micros = u32::try_from(elapsed.as_micros()).map_or(f64::from(u32::MAX), f64::from);
@@ -397,21 +426,8 @@ fn write_path_unit_versus_batch_at_a_fixed_volume() {
 #[ignore = "seeds thousands of facts; run deliberately, on a machine at rest"]
 fn paging_cost_grows_faster_than_the_store() {
     let mut costs: Vec<f64> = Vec::new();
-    for n in [250u64, 500, 1000, 2000] {
-        let dir = tempfile::tempdir().expect("tempdir");
-        {
-            let store = NativeStore::open(dir.path(), DIM).expect("open");
-            for id in 1..=n {
-                store
-                    .store_with_metadata(
-                        id * 7,
-                        &format!("fact {id}"),
-                        &EMBEDDING,
-                        &meta(&[("project", Value::from("veles"))]),
-                    )
-                    .expect("seed");
-            }
-        }
+    for n in SWEEP_SIZES {
+        let dir = seeded_at_size(n);
         let db = database(&dir);
         let start = std::time::Instant::now();
         let facts = enumerate_collection(&db, "_semantic_memory", 100).expect("enumerate");
@@ -479,21 +495,8 @@ fn paging_cost_grows_faster_than_the_store() {
 fn the_cursor_cost_per_fact_does_not_grow_like_the_offset_walk() {
     let mut cursor_costs: Vec<f64> = Vec::new();
     let mut offset_costs: Vec<f64> = Vec::new();
-    for n in [250u64, 500, 1000, 2000] {
-        let dir = tempfile::tempdir().expect("tempdir");
-        {
-            let store = NativeStore::open(dir.path(), DIM).expect("open");
-            for id in 1..=n {
-                store
-                    .store_with_metadata(
-                        id * 7,
-                        &format!("fact {id}"),
-                        &EMBEDDING,
-                        &meta(&[("project", Value::from("veles"))]),
-                    )
-                    .expect("seed");
-            }
-        }
+    for n in SWEEP_SIZES {
+        let dir = seeded_at_size(n);
         let db = database(&dir);
         let expected = usize::try_from(n).expect("fits");
 
@@ -640,7 +643,15 @@ fn the_embedder_dominates_only_when_the_model_changes() {
         .map(|(i, vector)| {
             let id = u64::try_from(i).expect("fits") + 1;
             let payload = serde_json::json!({ "content": texts[i] }).to_string();
-            (RawFact { id, payload }, vector)
+            let source_vector = vector.clone();
+            (
+                RawFact {
+                    id,
+                    payload,
+                    source_vector,
+                },
+                vector,
+            )
         })
         .collect();
 

--- a/crates/velesdb-memory/src/migration/tests/preservation.rs
+++ b/crates/velesdb-memory/src/migration/tests/preservation.rs
@@ -113,6 +113,7 @@ fn a_collision_has_an_explicit_result() {
     let intruder = RawFact {
         id: 1,
         payload: serde_json::json!({ "content": "an intruder that must not land" }).to_string(),
+        source_vector: EMBEDDING.to_vec(),
     };
     let outcome = reinsert(&db, "_semantic_memory", &intruder, &NEW_EMBEDDING).expect("second");
     match &outcome {

--- a/crates/velesdb-memory/src/migration/tests/strategy.rs
+++ b/crates/velesdb-memory/src/migration/tests/strategy.rs
@@ -1,0 +1,325 @@
+//! The rebuild-regime rule (#1815).
+//!
+//! Every case here is a store state that a rebuild can actually be pointed at,
+//! and the one that matters most is the one no measurement can see: a DIFFERENT
+//! model at the SAME width. Nothing on disk distinguishes those vectors from the
+//! target's, so the only thing standing between an operator and a store full of
+//! incomparable vectors is that this rule reads the recorded model rather than
+//! the width.
+//!
+//! `no_input_whatsoever_yields_reuse_without_a_proven_match` is the guard the
+//! rest support: it walks the whole `Strategy` × `Compatibility` product rather
+//! than sampling it, so a later variant — or a later "convenience" override —
+//! cannot open a reuse path without failing here first.
+
+use super::*;
+
+const TARGET: &str = "bge-m3";
+const WIDTH: usize = 1024;
+
+fn known(model: &str, dimension: usize) -> SourceProvenance {
+    SourceProvenance::Known {
+        model: model.to_owned(),
+        dimension,
+    }
+}
+
+fn unknown() -> SourceProvenance {
+    SourceProvenance::Unknown {
+        reason: "no embedding-provenance.json: the store predates the record".to_owned(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE STORE PERMITS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_store_recording_the_target_model_at_the_target_width_permits_reuse() {
+    let compatibility = assess(&known(TARGET, WIDTH), Some(WIDTH), TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::Match);
+    assert!(compatibility.permits_reuse());
+}
+
+#[test]
+fn a_different_model_at_the_same_width_is_still_a_model_change() {
+    // The whole reason this rule reads the model: every measurable property of
+    // these two stores agrees, and their vectors are incomparable anyway.
+    let compatibility = assess(&known("all-minilm", WIDTH), Some(WIDTH), TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::ModelDiffers);
+    assert!(!compatibility.permits_reuse());
+}
+
+#[test]
+fn the_same_model_at_a_different_width_is_a_width_change() {
+    let compatibility = assess(&known(TARGET, 384), Some(384), TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::DimensionDiffers);
+}
+
+#[test]
+fn an_unrecorded_source_model_is_never_inferred_from_the_width() {
+    // The store is 1024-dimensional and the target is 1024-dimensional, which
+    // is precisely the coincidence that must NOT be read as a match.
+    let compatibility = assess(&unknown(), Some(WIDTH), TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::ProvenanceUnknown);
+    assert!(!compatibility.permits_reuse());
+}
+
+#[test]
+fn a_record_that_disagrees_with_the_collections_describes_neither() {
+    let compatibility = assess(&known(TARGET, WIDTH), Some(384), TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::ProvenanceContradictsDimension);
+}
+
+#[test]
+fn collections_that_establish_no_shared_width_fail_the_same_reconciliation() {
+    let compatibility = assess(&known(TARGET, WIDTH), None, TARGET, WIDTH);
+
+    assert_eq!(compatibility, Compatibility::ProvenanceContradictsDimension);
+}
+
+#[test]
+fn no_store_state_whatsoever_reads_as_a_match_without_the_recorded_model() {
+    // The companion guard to
+    // `no_input_whatsoever_yields_reuse_without_a_proven_match`, and the half
+    // that actually matters. That one walks `resolve`, which only ever sees a
+    // `Compatibility` someone already computed; this one walks `assess`, where
+    // a store state becomes that verdict. A positive control proved the
+    // distinction is not theoretical: deleting the model comparison left the
+    // `resolve` guard entirely green.
+    let mut matched = Vec::new();
+    for model in ["bge-m3", "all-minilm", "hash"] {
+        for recorded in [384, WIDTH] {
+            for collection in [Some(384), Some(WIDTH), None] {
+                if assess(&known(model, recorded), collection, TARGET, WIDTH)
+                    == Compatibility::Match
+                {
+                    matched.push((model, recorded, collection));
+                }
+            }
+        }
+    }
+
+    assert_eq!(matched, vec![(TARGET, WIDTH, Some(WIDTH))]);
+
+    // And no width coincidence ever rescues an unrecorded model.
+    for collection in [Some(384), Some(WIDTH), None] {
+        assert_ne!(
+            assess(&unknown(), collection, TARGET, WIDTH),
+            Compatibility::Match,
+            "unknown provenance must not match at collection width {collection:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHAT `auto` DECIDES
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auto_reuses_only_a_proven_match() {
+    assert_eq!(
+        resolve(Strategy::Auto, Compatibility::Match),
+        Resolution::Reuse
+    );
+}
+
+#[test]
+fn auto_reembeds_every_state_that_does_not_prove_a_match() {
+    for compatibility in [
+        Compatibility::ModelDiffers,
+        Compatibility::DimensionDiffers,
+        Compatibility::ProvenanceUnknown,
+    ] {
+        assert_eq!(
+            resolve(Strategy::Auto, compatibility),
+            Resolution::Reembed {
+                because: compatibility
+            },
+            "auto should re-embed on {compatibility:?}"
+        );
+    }
+}
+
+#[test]
+fn auto_refuses_a_store_whose_record_contradicts_its_vectors() {
+    let resolution = resolve(
+        Strategy::Auto,
+        Compatibility::ProvenanceContradictsDimension,
+    );
+
+    assert_eq!(
+        resolution,
+        Resolution::Refuse {
+            because: Compatibility::ProvenanceContradictsDimension,
+            requested: Strategy::Auto,
+        }
+    );
+    assert!(!resolution.runs());
+}
+
+// ---------------------------------------------------------------------------
+// WHAT AN EXPLICIT REQUEST GETS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn an_explicit_reuse_is_refused_by_name_wherever_it_is_unproven() {
+    for compatibility in Compatibility::all()
+        .into_iter()
+        .filter(|c| !c.permits_reuse())
+    {
+        let resolution = resolve(Strategy::Reuse, compatibility);
+
+        assert_eq!(
+            resolution,
+            Resolution::Refuse {
+                because: compatibility,
+                requested: Strategy::Reuse,
+            },
+            "reuse should be refused on {compatibility:?}"
+        );
+        assert!(resolution
+            .diagnostic()
+            .starts_with("REFUSE: reuse was requested, but "));
+    }
+}
+
+#[test]
+fn an_explicit_reembed_runs_against_every_state_including_the_contradiction() {
+    // Re-embedding reads the stored TEXT and never the stored vector, so no
+    // property of the source's vectors can make it unsound. That is what makes
+    // it the escape from the refusal above rather than a second dead end.
+    for compatibility in Compatibility::all() {
+        let resolution = resolve(Strategy::Reembed, compatibility);
+
+        assert_eq!(
+            resolution,
+            Resolution::Reembed {
+                because: compatibility
+            },
+            "reembed should run on {compatibility:?}"
+        );
+        assert!(resolution.runs());
+    }
+}
+
+#[test]
+fn no_input_whatsoever_yields_reuse_without_a_proven_match() {
+    // The guard, walked over the whole product rather than sampled: if any
+    // request on any store state ever reaches `Reuse` without `Match`, a
+    // `--force-reuse` exists under another name.
+    let mut reused = Vec::new();
+    for requested in Strategy::all() {
+        for compatibility in Compatibility::all() {
+            if resolve(requested, compatibility) == Resolution::Reuse {
+                reused.push((requested, compatibility));
+            }
+        }
+    }
+
+    assert_eq!(
+        reused,
+        vec![
+            (Strategy::Auto, Compatibility::Match),
+            (Strategy::Reuse, Compatibility::Match),
+        ]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE OPERATOR READS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_diagnostic_vocabulary_is_the_five_arbitrated_lines() {
+    assert_eq!(
+        resolve(Strategy::Auto, Compatibility::Match).diagnostic(),
+        "REUSE: source and target embedding provenance match"
+    );
+    assert_eq!(
+        resolve(Strategy::Auto, Compatibility::ModelDiffers).diagnostic(),
+        "REEMBED: target model differs"
+    );
+    assert_eq!(
+        resolve(Strategy::Auto, Compatibility::DimensionDiffers).diagnostic(),
+        "REEMBED: target dimension differs"
+    );
+    assert_eq!(
+        resolve(Strategy::Auto, Compatibility::ProvenanceUnknown).diagnostic(),
+        "REEMBED: source provenance is unknown"
+    );
+    assert_eq!(
+        resolve(
+            Strategy::Auto,
+            Compatibility::ProvenanceContradictsDimension
+        )
+        .diagnostic(),
+        "REFUSE: source provenance contradicts the stored dimension"
+    );
+}
+
+#[test]
+fn every_refusal_carries_a_next_step_and_no_decision_that_runs_does() {
+    for requested in Strategy::all() {
+        for compatibility in Compatibility::all() {
+            let resolution = resolve(requested, compatibility);
+
+            assert_eq!(
+                resolution.guidance().is_some(),
+                !resolution.runs(),
+                "{requested:?} on {compatibility:?} should carry guidance iff it refuses"
+            );
+        }
+    }
+}
+
+#[test]
+fn no_guidance_anywhere_offers_reuse_as_a_way_out() {
+    for requested in Strategy::all() {
+        for compatibility in Compatibility::all() {
+            let Some(guidance) = resolve(requested, compatibility).guidance() else {
+                continue;
+            };
+
+            assert!(
+                !guidance.contains("--strategy reuse"),
+                "a refusal must not route the operator back to reuse: {guidance}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WHAT THE FLAG ACCEPTS
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_three_arbitrated_values_parse_and_nothing_else_does() {
+    assert_eq!(Strategy::parse("auto"), Ok(Strategy::Auto));
+    assert_eq!(Strategy::parse("reuse"), Ok(Strategy::Reuse));
+    assert_eq!(Strategy::parse("reembed"), Ok(Strategy::Reembed));
+
+    let rejected = Strategy::parse("Auto").expect_err("case-folding is not parsing");
+    assert!(rejected.contains("auto, reuse or reembed"));
+}
+
+#[test]
+fn force_reuse_is_refused_by_name_rather_than_merely_absent() {
+    for spelling in ["force-reuse", "force_reuse"] {
+        let message = Strategy::parse(spelling).expect_err("force-reuse must not parse");
+
+        assert!(
+            message.contains("does not exist, and not by oversight"),
+            "{spelling} should be refused deliberately, got: {message}"
+        );
+        assert!(
+            message.contains("--strategy reembed"),
+            "{spelling} should name the safe alternative, got: {message}"
+        );
+    }
+}


### PR DESCRIPTION
## PR C1 — the rebuild regime, and the module's first real caller

Implements the arbitration recorded on #1815: **reuse only where compatibility
is proven, re-embed in every other case; CLI first, no destructive MCP tool.**

`Refs #1762` — #1762 stays open until the end-to-end migration is proven.
Closes #1815: the module now has a real caller and both regimes are genuinely
wired, which is the condition the arbitration set for closing it.

### What #1815 asked for, and where it landed

| Arbitration | Here |
|---|---|
| `auto` / `reuse` / `reembed`, `auto` by default | `migration::Strategy`, `resolve` |
| known provenance + same model + same width → reuse | `Compatibility::Match`, the only value that permits it |
| different model, different width, or unknown → re-embed | the other three variants |
| `reuse` on unknown/incompatible provenance → explicit error | `Resolution::Refuse`, exit 2 |
| no `--force-reuse` | refused **by name**, with the reason, not merely absent |
| diagnostic explains the strategy and why | the four arbitrated lines, verbatim |
| CLI as the first surface, engine stays a library | `velesdb-memory migrate-embeddings --dry-run` |
| no mutating MCP tool | none added |

### The one line added to the arbitrated vocabulary

A store can record a provenance that **contradicts its own vectors** — the
recorded width differing from the collections', or the collections establishing
no shared width. That is not "unknown": neither side describes the other, so the
recorded model cannot be read off it either.

```
REFUSE: source provenance contradicts the stored dimension
```

`auto` refuses it rather than silently falling through to `REEMBED` on the
measured width. The refusal is not a dead end: `--strategy reembed` performs
exactly that rebuild, explicitly, and re-embedding never reads a source vector
so the contradiction cannot propagate. Say the word if you would rather `auto`
re-embed it directly.

### Three things the code said that were no longer true

1. **`RawFact` refused to carry the source vector, by documented design** —
   "the old vector is deliberately absent: … carrying it would only invite
   writing it back". That reasoning held while a rebuild had one regime. #1815
   gave it two, so the type could not express `reuse` at all. `source_vector`
   added; the comment and `reinsert`'s matching claim corrected rather than left
   standing.
2. **`embedder_cost`'s blocker quoted `16.3 us/fact`** as the number to weigh an
   embedder against. That is the store's *re-insertion* cost at DIM=4 on payloads
   with no text — the conflation that opened #1815. It now states what #1816
   actually measured (a ~23× ratio, bge-m3 at 1024, debug, one call per fact),
   the conditions that stop it transferring, and that under `reuse` the cost is
   zero.
3. **The test guarding that blocker required the string `16.3 us/fact`**, so it
   was keeping the wrong number alive as effectively as the comment was.

### Against the plan posted on #1815: two capabilities NOT promoted

I said C1 would promote `disk_headroom` and `embedder_cost`. Both stay `Missing`,
and I think the posted plan was wrong on both:

* **`embedder_cost`** — promoting it on one debug-mode, unbatched, single-model
  measurement would be the same defect this PR is undoing, one field over. The
  real promotion is measuring the *actual target embedder on the actual machine*
  at diagnosis time, and that belongs where the embedder is actually invoked.
* **`disk_headroom`** — its own blocker text calls it a reconstruction-time gate
  ("supply and measure the final destination before reconstruction"), and in a
  dry run the destination usually does not exist yet. Measuring its parent
  volume and calling the capability proven would prove something about a
  directory that is not the destination.

`edge_export` also stays `Missing`, and it is the one that matters for later:
the public path counts outgoing relations but exports no complete stream of edge
tuples. **PR C3 cannot honestly validate relations without it, so PR C2 must
build a lossless edge export/reinsert API or stop.** Named now rather than
discovered at validation time.

### Format

`DIAGNOSIS_FORMAT_VERSION` 4 → 5. A report now carries the requested strategy
and the resolved regime, and `validate` **recomputes** the regime from the
report's own provenance and target contract. Without that, a hand-edited
`REUSE` over an unstamped store would be a file authorising exactly what the
rule refuses.

`diagnose` takes a `TargetContract` instead of a model and a width side by side:
a call passing a model and a width belonging to two different embedders would
otherwise have type-checked perfectly.

### Proven, not asserted

**A positive control found a hole in my own guard.** Deleting the model
comparison in `assess` turned the suite red — but
`no_input_whatsoever_yields_reuse_without_a_proven_match` stayed green, because
it walks `resolve`, which only ever sees a `Compatibility` someone already
computed. The dangerous path is `assess`, where a store state *becomes* that
verdict. `no_store_state_whatsoever_reads_as_a_match_without_the_recorded_model`
is the missing half; the same control now reddens both.

**Run on the binary against a real store the daemon itself created**, not on the
library:

| Invocation | Output | Exit |
|---|---|---|
| `--dry-run` (same model, same width) | `REUSE: source and target embedding provenance match` | 0 |
| `--dry-run` (**different model, same width**) | `REEMBED: target model differs` | 0 |
| `--dry-run --strategy reuse` on that store | `REFUSE: reuse was requested, but target model differs` | **2** |
| `--strategy force-reuse` | refused by name, with the reason | 1 |
| `--strategy auto` without `--dry-run` | refused, naming `--dry-run` and #1762 | 1 |

Exit **2** for a refusal is deliberate and distinct from a parse error's 1: a
command that printed `REFUSE` and exited 0 would be read as success by every
script wrapping it.

Also proven rather than restated: both read paths return each fact's **own**
vector (on a fixture whose vectors all differ — the shared fixture writes one
constant embedding, which a placeholder would match perfectly); a vector carried
across under `reuse` survives the round trip into a destination unchanged, with
a non-vacuity assertion so an empty enumeration cannot pass by comparing two
empty maps; and `the_dry_run_leaves_the_store_byte_for_byte_as_it_found_it`
checks the read-only claim against a file tree.

### Notes for review

* The dry run **does not take the store lock and may run while the daemon is
  up** — `diagnose` inspects a verified copy and never calls `Database::open` on
  the live directory. That is #1762's read-only protocol, and it is why the
  subcommand short-circuits before `build_configured_service`. My posted plan
  said it would produce a `DatabaseLocked` refusal; that applies to mutation,
  which this PR does not do.
* `--resume` is **not** implemented. There is nothing to resume from until C2
  writes checkpoints.
* On the store #1762 exists for, `auto` resolves to `REEMBED` **always**: a store
  holding facts and predating #1751 can never be stamped (`record_embedding_model`
  writes only when `count() == 0`). The migration is what bootstraps provenance —
  C3 stamps the validated destination, so later rebuilds of that store can
  resolve to `REUSE`.
* Consequently `reuse` is never an *embedding* migration. It is a rebuild in
  which no vector's meaning changes (re-homing, compacting, repairing). PR D's
  operator doc must say so outright.
* `embedding_provenance::check`'s error still says "re-indexing is not
  implemented yet — see #1751". Still true of re-indexing; it becomes false when
  C3 lands, and should be corrected there.
* Two `#[ignore]`d cost sweeps now share `seeded_at_size`/`SWEEP_SIZES` instead
  of repeating a seeding block. Both were **run** (96 s, sequential, machine at
  rest) to prove the extraction preserved them.

### Gates run locally

`cargo fmt` · workspace `clippy --all-targets -D warnings -D pedantic` (0) ·
`velesdb-memory` 552 tests + doctests · `python3 -m unittest discover -s
scripts/tests` **Ran 398 · OK** · check-ai-attribution · check-feature-claims ·
check-promise-contract · check-mcp-doc-contract · check-version-sync ·
check-perf-claims · check-skill-private-references · check-doc-contract ·
check-doc-freshness (stamp/index/tracked/versions) · `cargo check
--no-default-features` · `cargo deny` · `lizard -C 8 -a 8` on every new file (no
threshold exceeded).

Not run locally, and why: `wasm-pack test`, `velesdb-core`/`velesdb-server`
doctests, `hooks.test.sh` — the change is confined to `velesdb-memory` and adds
no dependency. CI covers them.


### Codacy — the one finding, fixed rather than excluded

`temp_dir should not be used for security operations` (cli.rs:241). Secrecy was
already handled (0700 + owner token, one level down); the real defect was the
VOLUME — the diagnosis copies the whole store, and the doc comment on
`default_scratch_parent` named that failure mode while the code shipped
`temp_dir()` as the default anyway. The default is now the store's own parent
(same volume by construction, staging room still measured), with no silent
fallback: a store with no usable parent errors naming `--scratch`. Proven on
the binary: a no-`--scratch` dry run stages beside the store and leaves no
residue.
