### PR TITLE
feat(migration): lossless graph edge export and reinsertion

### DIFF
--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -48,6 +48,7 @@
 mod cli;
 mod diagnosis;
 mod diagnostic_copy;
+mod edges;
 mod enumeration;
 mod filesystem;
 mod state;
@@ -61,6 +62,7 @@ pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
     TargetContract, TtlSummary, DIAGNOSIS_FORMAT_VERSION,
 };
+pub use edges::{cross_check_edges, export_edges, reinsert_edges, EdgeReinsertion};
 pub use enumeration::{
     enumerate_by_cursor, enumerate_collection, enumerate_page, reinsert, reinsert_batch,
     scroll_page, BatchReinsertion, RawFact, Reinsertion, AGENT_COLLECTIONS,

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -62,7 +62,9 @@ pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
     TargetContract, TtlSummary, DIAGNOSIS_FORMAT_VERSION,
 };
-pub use edges::{cross_check_edges, export_edges, reinsert_edges, EdgeReinsertion};
+pub use edges::{
+    cross_check_edges, export_edges, export_edges_verified, reinsert_edges, EdgeReinsertion,
+};
 pub use enumeration::{
     enumerate_by_cursor, enumerate_collection, enumerate_page, reinsert, reinsert_batch,
     scroll_page, BatchReinsertion, RawFact, Reinsertion, AGENT_COLLECTIONS,

--- a/crates/velesdb-memory/src/migration/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis.rs
@@ -48,7 +48,16 @@ impl Capability {
 /// whether a prepared migration may resume. A report whose version this build
 /// does not understand is refused rather than guessed at, which is only
 /// possible because the number travels with the data.
-pub const DIAGNOSIS_FORMAT_VERSION: u32 = 5;
+/// # v6 — `edge_export` became `Proven` (#1762, PR C2a)
+///
+/// The bump is not cosmetic and not optional. A capability's canonical verdict
+/// is part of the report's shape: [`DiagnosisReport::validate`] refuses a report
+/// whose `edge_export` disagrees with what this build derives. A v5 report on
+/// disk carries the `Missing` verdict that was canonical when it was written,
+/// so a v6 build reading it would reject it as *inconsistent* — an accusation
+/// about the report's contents, when the truth is that it predates the
+/// capability. The version number is what turns that into a clear refusal.
+pub const DIAGNOSIS_FORMAT_VERSION: u32 = 6;
 
 /// What the store itself records about the embedder that filled it.
 ///

--- a/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
@@ -46,13 +46,30 @@ const NO_PROVENANCE: &str =
      vectors would be silently incomparable. The operator has to state the source model; it \
      cannot be discovered.";
 
-/// Counting relations is not an export contract.
-pub(super) const NO_EDGE_EXPORT: &str =
-    "the public diagnosis/rebuild path can count outgoing relations, but it does not export a \
-     complete stream of edge tuples (stable edge id, source, target, label and properties). \
-     Reconstructing edges from an external list would only prove that list agrees with itself, \
-     not that every source edge was preserved. A lossless edge export and reinsertion API must \
-     exist and be tested before reconstruction.";
+/// What used to block `edge_export`, kept as the text this capability had to
+/// answer: "a lossless edge export and reinsertion API must exist and be tested
+/// before reconstruction". [`edge_export_capability`] is that answer, and the
+/// evidence it publishes names the tests rather than restating the intention.
+///
+/// The blocker itself is gone rather than softened. A capability that stayed
+/// `Missing` with a gentler wording would still stop the rebuild, and one that
+/// went `Proven` with the old text as evidence would be quoting the problem as
+/// if it were the solution.
+pub(super) fn edge_export_capability() -> Capability {
+    Capability::Proven {
+        evidence: "edges export as complete tuples — stable edge id, source, target, label and \
+                   properties — through `migration::export_edges`, which walks the live fact ids \
+                   with the fact export's own cursor and refuses any edge whose id its triple \
+                   does not derive. `migration::cross_check_edges` re-collects the same set \
+                   through the physically distinct incoming index, and the two are compared as \
+                   sets of tuples rather than as counts. `migration::reinsert_edges` puts them \
+                   back after the facts and the destination is verified by RE-READING it through \
+                   the same export, never by the return code. Both guards are mutation-tested: \
+                   dropping properties on reinsertion, and disabling the id check, each turn \
+                   exactly one test red."
+            .to_owned(),
+    }
+}
 
 /// A canonical missing verdict used both when generating and validating v4.
 pub(super) fn missing_capability(blocker: &str) -> Capability {
@@ -185,7 +202,7 @@ pub(super) fn capability_map(
         ("diagnostic_staging".to_owned(), staging_capability(copy)),
         ("disk_headroom".to_owned(), missing_capability(NO_HEADROOM)),
         ("edge_counts".to_owned(), edge_counts),
-        ("edge_export".to_owned(), missing_capability(NO_EDGE_EXPORT)),
+        ("edge_export".to_owned(), edge_export_capability()),
         (
             "embedder_cost".to_owned(),
             missing_capability(NO_EMBEDDER_COST),

--- a/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/capabilities.rs
@@ -57,16 +57,20 @@ const NO_PROVENANCE: &str =
 /// if it were the solution.
 pub(super) fn edge_export_capability() -> Capability {
     Capability::Proven {
-        evidence: "edges export as complete tuples — stable edge id, source, target, label and \
-                   properties — through `migration::export_edges`, which walks the live fact ids \
-                   with the fact export's own cursor and refuses any edge whose id its triple \
-                   does not derive. `migration::cross_check_edges` re-collects the same set \
-                   through the physically distinct incoming index, and the two are compared as \
-                   sets of tuples rather than as counts. `migration::reinsert_edges` puts them \
-                   back after the facts and the destination is verified by RE-READING it through \
-                   the same export, never by the return code. Both guards are mutation-tested: \
-                   dropping properties on reinsertion, and disabling the id check, each turn \
-                   exactly one test red."
+        evidence: "a lossless edge export and reinsertion API exists and is tested. Edges export \
+                   as complete tuples — stable edge id, source, target, label and properties — \
+                   through `migration::export_edges_verified`, which walks the live fact ids with \
+                   the fact export's own cursor, refuses any edge whose id its triple does not \
+                   derive, and collects the outgoing and incoming adjacency maps over ONE \
+                   snapshot before comparing them as sets of tuples rather than as counts. That \
+                   comparison attests MEMBERSHIP in two indexes; it is not a second copy of the \
+                   tuple, since both indexes resolve the edge through the same stored record. The \
+                   content is attested instead by `migration::reinsert_edges`, which puts the \
+                   edges back after the facts and is verified by RE-READING the destination \
+                   through the same export, never by the return code. Both guards are \
+                   mutation-tested: dropping properties on reinsertion, and disabling the id \
+                   check, each turn exactly one test red. The rebuild does not yet call this API \
+                   — that is the reconstruction pass this capability unblocks."
             .to_owned(),
     }
 }

--- a/crates/velesdb-memory/src/migration/diagnosis/report.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/report.rs
@@ -1,6 +1,6 @@
 use super::capabilities::{
-    blockers_for, missing_capability, provenance_capability, require_canonical_capability,
-    DIAGNOSIS_CAPABILITY_KEYS, NO_EDGE_EXPORT, NO_EMBEDDER_COST, NO_HEADROOM,
+    blockers_for, edge_export_capability, missing_capability, provenance_capability,
+    require_canonical_capability, DIAGNOSIS_CAPABILITY_KEYS, NO_EMBEDDER_COST, NO_HEADROOM,
 };
 use super::{
     assess, resolve, switch_filesystem_capability, Capability, CollectionInventory,
@@ -175,7 +175,7 @@ fn validate_capability_keys(capabilities: &BTreeMap<String, Capability>) -> Resu
 
 fn canonical_capabilities(report: &DiagnosisReport) -> [(&'static str, Capability); 5] {
     [
-        ("edge_export", missing_capability(NO_EDGE_EXPORT)),
+        ("edge_export", edge_export_capability()),
         ("disk_headroom", missing_capability(NO_HEADROOM)),
         ("embedder_cost", missing_capability(NO_EMBEDDER_COST)),
         (

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -71,9 +71,12 @@ fn subsystem_of(collection: &str) -> Result<Subsystem, crate::MemoryError> {
     }
 }
 
-/// Which index a walk reads. The two are physically distinct — `outgoing` and
-/// `incoming` are separate maps in the edge store — which is what makes one a
-/// check on the other rather than a restatement of it.
+/// Which adjacency map a walk reads.
+///
+/// `outgoing` and `incoming` are separate maps, so an edge missing from one of
+/// them is caught by the other. They are not separate copies: both resolve the
+/// id through the same stored record. See [`cross_check_edges`] for what that
+/// buys and what it does not.
 #[derive(Debug, Clone, Copy)]
 enum Direction {
     Outgoing,
@@ -119,30 +122,55 @@ fn require_derived_id(edge: GraphEdge) -> Result<GraphEdge, crate::MemoryError> 
     .into())
 }
 
-/// Walk `collection` and collect its edges through `direction`.
+/// Collect the edges reachable from `ids` through `direction`.
+///
+/// Takes the fact ids rather than finding them, so that a caller checking one
+/// direction against the other can hand both walks the SAME snapshot. That is
+/// not a convenience: expiry is evaluated against the wall clock on every read,
+/// so two walks that each enumerated the store afresh could straddle a fact's
+/// expiry instant and disagree — reporting a divergence that is a tick of the
+/// clock rather than a lost edge, and aborting a migration whose indexes were
+/// never anything but consistent.
 fn collect(
     memory: &AgentMemory,
-    db: &Database,
-    collection: &str,
-    batch: usize,
+    subsystem: Subsystem,
+    ids: &[u64],
     direction: Direction,
 ) -> Result<Vec<GraphEdge>, crate::MemoryError> {
-    let subsystem = subsystem_of(collection)?;
     let mut out: Vec<GraphEdge> = Vec::new();
     let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
-    for fact in enumerate_by_cursor(db, collection, batch)? {
-        for edge in edges_at(memory, subsystem, direction, fact.id)? {
+    for &id in ids {
+        for edge in edges_at(memory, subsystem, direction, id)? {
             let edge = require_derived_id(edge)?;
-            // A self-loop is reachable from its single endpoint through BOTH
-            // indexes, so the walk would otherwise report it twice and the two
-            // directions would disagree on cardinality for a reason that has
-            // nothing to do with loss.
-            if seen.insert(edge.id()) {
-                out.push(edge);
+            // Each walk reads ONE index, and an edge id is unique within a
+            // collection — the edge store refuses a duplicate id inside its
+            // write guard. A self-loop is pushed into both the outgoing and the
+            // incoming index, but a single walk still meets it once. So this
+            // branch is unreachable today, measured rather than assumed, and it
+            // is an ERROR rather than a silent skip: were it ever reached, the
+            // edge store would be handing out one id twice and quietly keeping
+            // the first is the worst available answer.
+            if !seen.insert(edge.id()) {
+                return Err(velesdb_core::Error::Query(format!(
+                    "edge {} was reported twice by a single {direction:?} walk of \
+                     one collection; edge ids are unique per collection, so the \
+                     edge index is inconsistent and no export from it can be \
+                     trusted",
+                    edge.id(),
+                ))
+                .into());
             }
+            out.push(edge);
         }
     }
     Ok(out)
+}
+
+fn live_ids(db: &Database, collection: &str, batch: usize) -> Result<Vec<u64>, crate::MemoryError> {
+    Ok(enumerate_by_cursor(db, collection, batch)?
+        .into_iter()
+        .map(|fact| fact.id)
+        .collect())
 }
 
 /// Every edge of `collection` that lies between two exported facts, as complete
@@ -161,14 +189,90 @@ pub fn export_edges(
     collection: &str,
     batch: usize,
 ) -> Result<Vec<GraphEdge>, crate::MemoryError> {
-    collect(memory, db, collection, batch, Direction::Outgoing)
+    let subsystem = subsystem_of(collection)?;
+    collect(
+        memory,
+        subsystem,
+        &live_ids(db, collection, batch)?,
+        Direction::Outgoing,
+    )
+}
+
+/// The export, checked against the incoming index over ONE snapshot of the live
+/// facts.
+///
+/// This is the entry point a rebuild should use. [`export_edges`] and
+/// [`cross_check_edges`] each enumerate the store for themselves, which is fine
+/// in isolation and wrong as a pair: expiry is evaluated against the wall clock
+/// on every read, so a fact whose expiry falls between the two calls leaves the
+/// two walks disagreeing about an edge neither of them lost. Enumerating once
+/// and walking both directions over that one list removes the window rather than
+/// narrowing it.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] under the conditions of [`export_edges`], and
+/// additionally when the two indexes do not yield the same set of tuples.
+pub fn export_edges_verified(
+    memory: &AgentMemory,
+    db: &Database,
+    collection: &str,
+    batch: usize,
+) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+    let subsystem = subsystem_of(collection)?;
+    let ids = live_ids(db, collection, batch)?;
+    let exported = collect(memory, subsystem, &ids, Direction::Outgoing)?;
+    let crossed = collect(memory, subsystem, &ids, Direction::Incoming)?;
+    let (left, right) = (comparable(&exported), comparable(&crossed));
+    if left != right {
+        return Err(velesdb_core::Error::Query(format!(
+            "the outgoing and incoming edge indexes disagree over the same {} live \
+             facts: {} tuples out, {} tuples in, {} present in only one of them. \
+             An export cannot be called lossless while the two indexes describe \
+             different graphs",
+            ids.len(),
+            left.len(),
+            right.len(),
+            left.symmetric_difference(&right).count(),
+        ))
+        .into());
+    }
+    Ok(exported)
+}
+
+/// An edge reduced to something orderable, so two collections of edges compare
+/// as SETS OF TUPLES. Comparing counts would let two walks that had each lost
+/// one edge agree.
+fn comparable(edges: &[GraphEdge]) -> std::collections::BTreeSet<(u64, u64, u64, String, String)> {
+    edges
+        .iter()
+        .map(|edge| {
+            let properties: std::collections::BTreeMap<_, _> = edge.properties().iter().collect();
+            (
+                edge.id(),
+                edge.source(),
+                edge.target(),
+                edge.label().to_owned(),
+                serde_json::to_string(&properties).unwrap_or_default(),
+            )
+        })
+        .collect()
 }
 
 /// The same collection of edges, gathered through the INCOMING index instead.
 ///
-/// The independent second path [`export_edges`] is checked against. The caller
-/// compares the two as SETS OF TUPLES, not as counts: two walks that had each
-/// lost one edge would agree on cardinality and disagree on nothing else.
+/// Prefer [`export_edges_verified`], which walks both directions over one
+/// snapshot; this is the single-direction primitive, and comparing its result
+/// against a separately-enumerated [`export_edges`] reintroduces the clock
+/// window that entry point exists to close.
+///
+/// # What the agreement of the two indexes does and does not prove
+///
+/// `outgoing` and `incoming` are separate adjacency maps, so an edge that fell
+/// out of one of them is caught. They are NOT separate copies of the edge: both
+/// resolve the id through the same `edges` map in the shard, so a tuple whose
+/// stored properties were corrupted would come back identically corrupted
+/// through both. This checks MEMBERSHIP in two indexes, not the content twice.
+/// The content is checked by re-reading the destination after reinsertion.
 ///
 /// # Errors
 /// Returns [`crate::MemoryError`] under the same conditions as [`export_edges`].
@@ -178,7 +282,13 @@ pub fn cross_check_edges(
     collection: &str,
     batch: usize,
 ) -> Result<Vec<GraphEdge>, crate::MemoryError> {
-    collect(memory, db, collection, batch, Direction::Incoming)
+    let subsystem = subsystem_of(collection)?;
+    collect(
+        memory,
+        subsystem,
+        &live_ids(db, collection, batch)?,
+        Direction::Incoming,
+    )
 }
 
 /// What putting the edges back produced.

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -1,0 +1,267 @@
+//! Lossless edge export and reinsertion (#1762, PR C2a).
+//!
+//! The fact export ([`super::enumeration`]) moves points. It cannot move
+//! relations, and a rebuild that shipped without them would hand back a store
+//! whose facts are all present and whose graph is empty — a loss that no
+//! per-fact comparison detects, because every fact is intact.
+//!
+//! # Why there is no transport type here
+//!
+//! Facts travel as [`RawFact`](super::RawFact), a type this module's sibling
+//! defines. Edges travel as [`GraphEdge`] itself, the engine's own type, and
+//! that is deliberate. `velesdb-memory` already owns a reduced edge — the
+//! public `MemoryEdge` (`crate::model`) — and it has no `properties` field at
+//! all: `storage::to_memory_edges` builds it from `id`, `source`, `target` and
+//! `label` and never calls `edge.properties()`. Reusing it here would have
+//! compiled, round-tripped, and lost every property in silence. Carrying the
+//! engine's own tuple means there is no field for a conversion to forget.
+//!
+//! # What makes the export sound
+//!
+//! An edge is exported when it lies between two facts the fact export also
+//! carries. That is not a filter this module implements: the edge walk and the
+//! fact walk already agree on which endpoints are live, because
+//! `MemoryTtl`'s map is refilled from the durable `_veles_expires_at` key by
+//! every subsystem constructor (`rebuild_ttl_from_payloads`). The agreement is
+//! MEASURED, three-armed, in `tests::edges::the_two_walks_agree_on_which_endpoints_are_live`
+//! — it was reasoned wrongly twice before it was measured once.
+//!
+//! # The one shape this refuses
+//!
+//! Every edge `relate` writes derives its id from its triple through
+//! [`velesdb_core::hash_edge_id`]. `VelesQL` DML does not: it accepts an
+//! explicit edge id. An edge whose id its triple does not derive cannot be
+//! reinserted honestly — `relate` at the destination would compute a
+//! *different* id, and one logical edge would end up with two identities across
+//! the migration. Rather than renumber it silently, the export stops and names
+//! it.
+
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::collection::graph::GraphEdge;
+use velesdb_core::Database;
+
+use super::enumeration::{enumerate_by_cursor, AGENT_COLLECTIONS};
+
+/// Which agent subsystem owns a collection.
+///
+/// The three expose byte-identical `relations`/`incoming_relations`/`relate`
+/// signatures but are distinct types, so the dispatch is explicit rather than
+/// generic. `tests::edges::every_agent_collection_is_dispatchable` is what
+/// proves this list has not drifted from [`AGENT_COLLECTIONS`].
+#[derive(Debug, Clone, Copy)]
+enum Subsystem {
+    Semantic,
+    Episodic,
+    Procedural,
+}
+
+fn subsystem_of(collection: &str) -> Result<Subsystem, crate::MemoryError> {
+    if collection == AGENT_COLLECTIONS[0] {
+        Ok(Subsystem::Semantic)
+    } else if collection == AGENT_COLLECTIONS[1] {
+        Ok(Subsystem::Episodic)
+    } else if collection == AGENT_COLLECTIONS[2] {
+        Ok(Subsystem::Procedural)
+    } else {
+        Err(velesdb_core::Error::Query(format!(
+            "`{collection}` is not an agent memory collection; edges are exported \
+             per subsystem, and the subsystems are {AGENT_COLLECTIONS:?}"
+        ))
+        .into())
+    }
+}
+
+/// Which index a walk reads. The two are physically distinct — `outgoing` and
+/// `incoming` are separate maps in the edge store — which is what makes one a
+/// check on the other rather than a restatement of it.
+#[derive(Debug, Clone, Copy)]
+enum Direction {
+    Outgoing,
+    Incoming,
+}
+
+fn edges_at(
+    memory: &AgentMemory,
+    subsystem: Subsystem,
+    direction: Direction,
+    id: u64,
+) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+    let result = match (subsystem, direction) {
+        (Subsystem::Semantic, Direction::Outgoing) => memory.semantic().relations(id),
+        (Subsystem::Semantic, Direction::Incoming) => memory.semantic().incoming_relations(id),
+        (Subsystem::Episodic, Direction::Outgoing) => memory.episodic().relations(id),
+        (Subsystem::Episodic, Direction::Incoming) => memory.episodic().incoming_relations(id),
+        (Subsystem::Procedural, Direction::Outgoing) => memory.procedural().relations(id),
+        (Subsystem::Procedural, Direction::Incoming) => memory.procedural().incoming_relations(id),
+    };
+    result.map_err(crate::MemoryError::from)
+}
+
+/// Refuse an edge whose id its own triple does not derive.
+///
+/// Returning the edge rather than `()` keeps the guard on the value path, so a
+/// caller cannot collect the edge and forget to call this.
+fn require_derived_id(edge: GraphEdge) -> Result<GraphEdge, crate::MemoryError> {
+    let derived = velesdb_core::hash_edge_id(edge.source(), edge.target(), edge.label());
+    if edge.id() == derived {
+        return Ok(edge);
+    }
+    Err(velesdb_core::Error::Query(format!(
+        "edge {} ({} -{}-> {}) carries an id its triple does not derive (expected \
+         {derived}); reinserting it would rederive the expected id and give one \
+         logical edge two identities, so the export stops here rather than \
+         renumbering it",
+        edge.id(),
+        edge.source(),
+        edge.label(),
+        edge.target(),
+    ))
+    .into())
+}
+
+/// Walk `collection` and collect its edges through `direction`.
+fn collect(
+    memory: &AgentMemory,
+    db: &Database,
+    collection: &str,
+    batch: usize,
+    direction: Direction,
+) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+    let subsystem = subsystem_of(collection)?;
+    let mut out: Vec<GraphEdge> = Vec::new();
+    let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    for fact in enumerate_by_cursor(db, collection, batch)? {
+        for edge in edges_at(memory, subsystem, direction, fact.id)? {
+            let edge = require_derived_id(edge)?;
+            // A self-loop is reachable from its single endpoint through BOTH
+            // indexes, so the walk would otherwise report it twice and the two
+            // directions would disagree on cardinality for a reason that has
+            // nothing to do with loss.
+            if seen.insert(edge.id()) {
+                out.push(edge);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Every edge of `collection` that lies between two exported facts, as complete
+/// tuples.
+///
+/// Walks the live fact ids with the same cursor the fact export uses, then
+/// takes each fact's outgoing edges. Each edge is checked against
+/// [`require_derived_id`] before it is collected.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] if `collection` is not an agent subsystem, if
+/// the fact walk fails, or if any edge carries an id its triple does not derive.
+pub fn export_edges(
+    memory: &AgentMemory,
+    db: &Database,
+    collection: &str,
+    batch: usize,
+) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+    collect(memory, db, collection, batch, Direction::Outgoing)
+}
+
+/// The same collection of edges, gathered through the INCOMING index instead.
+///
+/// The independent second path [`export_edges`] is checked against. The caller
+/// compares the two as SETS OF TUPLES, not as counts: two walks that had each
+/// lost one edge would agree on cardinality and disagree on nothing else.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] under the same conditions as [`export_edges`].
+pub fn cross_check_edges(
+    memory: &AgentMemory,
+    db: &Database,
+    collection: &str,
+    batch: usize,
+) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+    collect(memory, db, collection, batch, Direction::Incoming)
+}
+
+/// What putting the edges back produced.
+///
+/// Deliberately thin. It is NOT the verdict, and a caller that treats it as one
+/// has been misled: `relate` is idempotent on an id that already exists and
+/// IGNORES the properties it was handed in that case, so a destination that
+/// dropped every property would still report every edge inserted. The verdict
+/// is a re-read of the destination compared against the export — see
+/// `tests::edges::reinserted_edges_are_read_back_identical_at_the_destination`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct EdgeReinsertion {
+    /// Edges `relate` accepted, each having answered with the exported id.
+    pub inserted: u64,
+}
+
+/// Put `edges` back into `collection`, AFTER the facts.
+///
+/// `relate` requires both endpoints live, so this cannot run before the fact
+/// reinsertion — not as a matter of tidiness but because it would fail. The id
+/// `relate` answers with is compared against the exported id on every edge: they
+/// must agree, since both sides derive it from the same triple, and a
+/// disagreement means the destination is deriving ids differently from the
+/// source and the whole export is void.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] if `collection` is not an agent subsystem, if
+/// an endpoint is missing or expired at the destination, or if a reinserted edge
+/// answers with an id other than the one exported.
+pub fn reinsert_edges(
+    memory: &AgentMemory,
+    collection: &str,
+    edges: &[GraphEdge],
+) -> Result<EdgeReinsertion, crate::MemoryError> {
+    let subsystem = subsystem_of(collection)?;
+    let mut inserted = 0u64;
+    for edge in edges {
+        let properties: serde_json::Map<String, serde_json::Value> = edge
+            .properties()
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let properties = if properties.is_empty() {
+            None
+        } else {
+            Some(properties)
+        };
+        let returned = relate_on(
+            memory,
+            subsystem,
+            (edge.source(), edge.target()),
+            edge.label(),
+            properties.as_ref(),
+        )?;
+        if returned != edge.id() {
+            return Err(velesdb_core::Error::Query(format!(
+                "edge {} ({} -{}-> {}) was reinserted under id {returned}; the \
+                 destination derives edge ids differently from the source, so no \
+                 edge in this export can be trusted to keep its identity",
+                edge.id(),
+                edge.source(),
+                edge.label(),
+                edge.target(),
+            ))
+            .into());
+        }
+        inserted += 1;
+    }
+    Ok(EdgeReinsertion { inserted })
+}
+
+fn relate_on(
+    memory: &AgentMemory,
+    subsystem: Subsystem,
+    endpoints: (u64, u64),
+    label: &str,
+    properties: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> Result<u64, crate::MemoryError> {
+    let (from, to) = endpoints;
+    let result = match subsystem {
+        Subsystem::Semantic => memory.semantic().relate(from, to, label, properties),
+        Subsystem::Episodic => memory.episodic().relate(from, to, label, properties),
+        Subsystem::Procedural => memory.procedural().relate(from, to, label, properties),
+    };
+    result.map_err(crate::MemoryError::from)
+}

--- a/crates/velesdb-memory/src/migration/tests/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnosis.rs
@@ -623,24 +623,52 @@ fn edge_counts_do_not_masquerade_as_a_lossless_edge_export() {
         ),
         "counting should remain separately evidenced"
     );
-    let Some(Capability::Missing { blocker }) = report.capabilities.get("edge_export") else {
+    // #1762 PR C2a promoted `edge_export`. What this test guards did not change
+    // with it: counting relations is still not exporting them, so the two
+    // capabilities must remain SEPARATELY evidenced. A promotion that let
+    // `edge_export` inherit the counter's evidence would read as proven and
+    // prove nothing.
+    let (Some(Capability::Proven { evidence: counted }), Some(Capability::Proven { evidence })) = (
+        report.capabilities.get("edge_counts"),
+        report.capabilities.get("edge_export"),
+    ) else {
         panic!(
-            "a count-only report must not claim complete edge export, got {:?}",
+            "both must be proven and separately so, got counts={:?} export={:?}",
+            report.capabilities.get("edge_counts"),
             report.capabilities.get("edge_export")
         );
     };
-    assert!(
-        blocker.contains("edge id") && blocker.contains("properties"),
-        "the blocker must name the fields a lossless export needs: {blocker}"
+    assert_ne!(
+        counted, evidence,
+        "the export must not be evidenced by the COUNT; identical evidence is \
+         exactly the masquerade this test is named after"
     );
+    for field in ["edge id", "source", "target", "label", "properties"] {
+        assert!(
+            evidence.contains(field),
+            "the evidence must name `{field}`, one of the fields a lossless \
+             export has to carry: {evidence}"
+        );
+    }
+    assert!(
+        !report
+            .blockers
+            .iter()
+            .any(|entry| entry.starts_with("edge_export:")),
+        "a proven export must no longer block, got {:?}",
+        report.blockers
+    );
+    // ...and the report is still not clear, on the gates that remain. Asserted
+    // by NAME rather than as a bare `!is_clear()`, which would keep passing if
+    // `edge_export` had silently come back as the reason.
     assert!(
         report
             .blockers
             .iter()
-            .any(|entry| entry.starts_with("edge_export:")),
-        "the missing export must be a blocker, not a footnote"
+            .any(|entry| entry.starts_with("disk_headroom:")),
+        "the remaining blockers must be the permanent ones, got {:?}",
+        report.blockers
     );
-    assert!(!report.is_clear());
 }
 
 // ---------------------------------------------------------------------------
@@ -906,7 +934,13 @@ fn permanent_v4_gates_cannot_be_promoted_by_editing_json() {
     let (dir, _ttl) = seeded();
     let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");
 
-    for capability_name in ["edge_export", "disk_headroom", "embedder_cost"] {
+    // `edge_export` used to be on this list. #1762 PR C2a promoted it, so it is
+    // asserted below on its own footing instead of being carried along here —
+    // it would still have PASSED in this loop, refused for having the wrong
+    // evidence rather than for being wrongly promoted, and a test that passes
+    // for a reason that no longer exists is the kind of green this suite is
+    // written to avoid.
+    for capability_name in ["disk_headroom", "embedder_cost"] {
         let mut forged = report.clone();
         forged.capabilities.insert(
             capability_name.to_owned(),
@@ -920,4 +954,37 @@ fn permanent_v4_gates_cannot_be_promoted_by_editing_json() {
             "the canonical v4 Missing verdict for {capability_name} must be immutable: {refusal}"
         );
     }
+}
+
+#[test]
+fn a_proven_capability_cannot_have_its_evidence_rewritten_either() {
+    let (dir, _ttl) = seeded();
+    let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");
+
+    assert!(
+        matches!(
+            report.capabilities.get("edge_export"),
+            Some(Capability::Proven { .. })
+        ),
+        "positive control: this test is about a PROVEN capability, and it stops \
+         meaning anything the day `edge_export` goes back to Missing"
+    );
+
+    // Promotion moves a capability from "cannot be forged into Proven" to
+    // "cannot be forged into a DIFFERENT Proven". Evidence is what an operator
+    // reads to decide whether to run a migration; if it could be edited in the
+    // JSON, a rebuild could be authorised by a sentence nobody derived.
+    let mut forged = report.clone();
+    forged.capabilities.insert(
+        "edge_export".to_owned(),
+        Capability::Proven {
+            evidence: "an operator wrote this by hand".to_owned(),
+        },
+    );
+    let refusal = direct_deserialization_refusal(&forged);
+    assert!(
+        refusal.contains("edge_export") && refusal.contains("inconsistent"),
+        "the evidence for edge_export must be recalculated, never accepted from \
+         the file: {refusal}"
+    );
 }

--- a/crates/velesdb-memory/src/migration/tests/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnosis.rs
@@ -826,6 +826,53 @@ fn a_diagnosis_report_round_trips_through_its_versioned_parser() {
 }
 
 #[test]
+fn a_v5_report_is_refused_for_its_age_and_never_accused_of_inconsistency() {
+    // The only version test used to be the NEWER direction, on a fixture whose
+    // capabilities were canonical for the current build. That combination cannot
+    // see the failure this one is about. A REAL v5 report carries
+    // `edge_export: Missing`, which was canonical when it was written and is
+    // inconsistent now — so if `validate` ever checked capabilities before the
+    // version, an operator holding a legitimate older report would be told their
+    // file was tampered with. The version check must come first, and the message
+    // must say so.
+    let (dir, _ttl) = seeded();
+    let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");
+    assert_eq!(
+        DIAGNOSIS_FORMAT_VERSION, 6,
+        "positive control: this test is about the v5 -> v6 step and must be \
+         revisited, not silently kept, when the version moves again"
+    );
+
+    let mut older = serde_json::to_value(report).expect("serialize report");
+    older["format_version"] = serde_json::json!(DIAGNOSIS_FORMAT_VERSION - 1);
+    older["capabilities"]["edge_export"] = serde_json::to_value(Capability::Missing {
+        blocker: "the public diagnosis/rebuild path can count outgoing relations, but it does \
+                  not export a complete stream of edge tuples"
+            .to_owned(),
+    })
+    .expect("serialize the v5 verdict");
+    let json = serde_json::to_string(&older).expect("serialize older report");
+
+    for refusal in [
+        DiagnosisReport::parse(&json).expect_err("an older format must be refused"),
+        serde_json::from_str::<DiagnosisReport>(&json)
+            .expect_err("Deserialize itself must refuse an older report")
+            .to_string(),
+    ] {
+        assert!(
+            refusal.contains("older") && refusal.contains("fresh diagnosis"),
+            "the refusal must name the report's AGE and the recovery action: {refusal}"
+        );
+        assert!(
+            !refusal.contains("inconsistent"),
+            "a legitimate v5 report must never be accused of internal \
+             inconsistency — its `edge_export` verdict was canonical when it was \
+             written: {refusal}"
+        );
+    }
+}
+
+#[test]
 fn a_report_from_a_future_format_is_refused_before_its_shape_is_interpreted() {
     let (dir, _ttl) = seeded();
     let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");

--- a/crates/velesdb-memory/src/migration/tests/edges.rs
+++ b/crates/velesdb-memory/src/migration/tests/edges.rs
@@ -292,6 +292,46 @@ fn the_incoming_walk_yields_the_same_tuples_as_the_outgoing_one() {
 }
 
 #[test]
+fn the_verified_export_walks_both_directions_over_one_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let expected = source_with_rich_edges(dir.path());
+
+    let (db, memory) = opened(dir.path(), DIM);
+    let verified = super::super::export_edges_verified(&memory, &db, "_semantic_memory", 1024)
+        .expect("verified export");
+    assert_eq!(
+        tuples(&verified),
+        expected,
+        "the verified entry point must return what the outgoing walk returns, \
+         having agreed with the incoming one"
+    );
+    drop(memory);
+    drop(db);
+
+    // Why this entry point exists: `export_edges` and `cross_check_edges` each
+    // enumerate the store for themselves, and expiry is read against the wall
+    // clock on every read. A fact expiring between two such calls leaves them
+    // disagreeing about an edge neither of them lost. The verified walk takes
+    // ONE snapshot of the live ids, so it cannot see a fact live in one
+    // direction and dead in the other however long the two halves take.
+    super::preservation::seed_raw(dir.path(), LATER_EXPIRED, "fact 3", Some(PAST));
+    let (db, memory) = opened(dir.path(), DIM);
+    let after = super::super::export_edges_verified(&memory, &db, "_semantic_memory", 1024)
+        .expect("verified export after expiry");
+    assert!(
+        after.len() < verified.len(),
+        "positive control: expiring an endpoint must actually change the export, \
+         or this test compares a walk against itself"
+    );
+    assert!(
+        after
+            .iter()
+            .all(|edge| edge.source() != LATER_EXPIRED && edge.target() != LATER_EXPIRED),
+        "no edge touching the expired fact may survive, in either direction"
+    );
+}
+
+#[test]
 fn reinserted_edges_are_read_back_identical_at_the_destination() {
     let dir = tempfile::tempdir().expect("tempdir");
     let expected = source_with_rich_edges(dir.path());

--- a/crates/velesdb-memory/src/migration/tests/edges.rs
+++ b/crates/velesdb-memory/src/migration/tests/edges.rs
@@ -1,0 +1,341 @@
+//! GATE 5 — edges (#1762, PR C2a)
+//!
+//! The fact export is proven. Edges are the other half, and everything below
+//! rests on one claim the feasibility note made on #1762: the fact walk and the
+//! edge walk already agree on which endpoints are live, so an edge export can
+//! be defined as "the edges between exported facts" without inventing a filter.
+//!
+//! That claim was reasoned, not measured, and reasoning got it wrong once in
+//! each direction while this file was being written. It is now MEASURED, in
+//! [`the_two_walks_agree_on_which_endpoints_are_live`], because the mechanism is
+//! not where reading `AgentMemory::with_dimension` suggests. `MemoryTtl` is
+//! indeed built empty there (`velesdb-core/src/agent/memory.rs:82`) and
+//! `is_expired` does read that in-process map only
+//! (`velesdb-core/src/agent/ttl.rs:191`) — but every subsystem constructor
+//! immediately refills it from the durable payload key via
+//! `memory_helpers::rebuild_ttl_from_payloads`
+//! (`velesdb-core/src/agent/semantic_memory.rs:62`). The convergence is real,
+//! and it hangs entirely on that one call: drop it and the edge export starts
+//! carrying edges into facts the fact export refused, silently.
+
+use super::*;
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::collection::graph::GraphEdge;
+
+/// Facts the export keeps.
+const LIVE: u64 = 1;
+const ALSO_LIVE: u64 = 2;
+/// A fact that is live when its edge is written and expires afterwards — the
+/// ordinary lifecycle, and the only one that could strand an edge on an
+/// endpoint the fact export drops.
+const LATER_EXPIRED: u64 = 3;
+/// An epoch second in the past, so the engine's `expires_at <= now` holds.
+const PAST: u64 = 1_000_000;
+/// ...and one far enough ahead that it does not.
+const FUTURE: u64 = 4_000_000_000;
+
+/// An `AgentMemory` as a migration opens one: brand new, over a store that
+/// already holds everything.
+fn fresh_memory(dir: &std::path::Path) -> AgentMemory {
+    let db = std::sync::Arc::new(velesdb_core::Database::open(dir).expect("open db"));
+    AgentMemory::with_dimension(db, DIM).expect("agent memory")
+}
+
+fn outgoing_targets(dir: &std::path::Path, id: u64) -> BTreeSet<u64> {
+    fresh_memory(dir)
+        .semantic()
+        .relations(id)
+        .expect("relations")
+        .iter()
+        .map(GraphEdge::target)
+        .collect()
+}
+
+/// Three facts and two edges out of [`LIVE`], one of them into
+/// [`LATER_EXPIRED`]. Nothing is expired yet.
+fn seeded_with_edges(dir: &std::path::Path) {
+    let store = NativeStore::open(dir, DIM).expect("open source");
+    for id in [LIVE, ALSO_LIVE, LATER_EXPIRED] {
+        store
+            .store_with_metadata(id, &format!("fact {id}"), &EMBEDDING, &meta(&[]))
+            .expect("seed");
+    }
+    store
+        .relate(LIVE, ALSO_LIVE, "mentions")
+        .expect("live edge");
+    store
+        .relate(LIVE, LATER_EXPIRED, "mentions")
+        .expect("edge that may dangle");
+}
+
+#[test]
+fn the_two_walks_agree_on_which_endpoints_are_live() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seeded_with_edges(dir.path());
+
+    // ARM A — a plain reopen. Establishes that edges are durable at all, so a
+    // later disappearance is a filter and not a lost write.
+    assert_eq!(
+        outgoing_targets(dir.path(), LIVE),
+        BTreeSet::from([ALSO_LIVE, LATER_EXPIRED]),
+        "positive control: both edges must survive a reopen, or every arm below \
+         is measuring an edge index that simply forgot"
+    );
+
+    // ARM B — the endpoint is rewritten by a RAW upsert carrying a FUTURE
+    // expiry. This is the arm that rules out the rival explanation: if the raw
+    // rewrite cost the edge its place in the index, the edge would vanish here
+    // too, and arm C would prove nothing about expiry.
+    super::preservation::seed_raw(dir.path(), LATER_EXPIRED, "fact 3", Some(FUTURE));
+    assert_eq!(
+        outgoing_targets(dir.path(), LIVE),
+        BTreeSet::from([ALSO_LIVE, LATER_EXPIRED]),
+        "rewriting the endpoint must not cost the edge its place; if it did, the \
+         disappearance in arm C would be about the WRITE, not about the expiry"
+    );
+
+    // ARM C — the same rewrite, one field different: the expiry is now past.
+    super::preservation::seed_raw(dir.path(), LATER_EXPIRED, "fact 3", Some(PAST));
+    assert_eq!(
+        outgoing_targets(dir.path(), LIVE),
+        BTreeSet::from([ALSO_LIVE]),
+        "REGRESSION GUARD for `rebuild_ttl_from_payloads`: the edge walk must drop \
+         an edge into a DURABLY expired fact on a store it has only just opened. \
+         The filter is `MemoryTtl`, whose map is refilled from the payload key at \
+         construction — remove that refill and this assertion is the only thing \
+         standing between a rebuild and an edge pointing at nothing"
+    );
+
+    // ...and the fact walk, reading the durable key directly, drops exactly the
+    // same fact. Same store, same instant, two engines, one answer.
+    assert_eq!(
+        super::preservation::read_out(dir.path(), "_semantic_memory")
+            .iter()
+            .map(|fact| fact.id)
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([LIVE, ALSO_LIVE]),
+        "the fact walk must exclude the same endpoint the edge walk just did — \
+         this agreement is what lets `export_edges` be defined as the edges \
+         between exported facts, with no filter of its own to get wrong"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// THE EXPORT ITSELF
+//
+// Everything above establishes that "the edges between exported facts" is a
+// well-defined set. These prove the export carries it WHOLE — every field of
+// every tuple — and refuses, loudly, the one shape it cannot carry honestly.
+// ---------------------------------------------------------------------------
+
+/// An edge reduced to something orderable, so two collections of edges can be
+/// compared as SETS rather than as sequences. Properties are canonicalised
+/// through a `BTreeMap`, whose JSON rendering is key-ordered and therefore
+/// stable — a `HashMap` is neither `Ord` nor `Hash`, and comparing its debug
+/// rendering would compare an iteration order.
+type EdgeTuple = (u64, u64, u64, String, String);
+
+fn tuple(edge: &GraphEdge) -> EdgeTuple {
+    let props: std::collections::BTreeMap<_, _> = edge.properties().iter().collect();
+    (
+        edge.id(),
+        edge.source(),
+        edge.target(),
+        edge.label().to_owned(),
+        serde_json::to_string(&props).expect("properties render"),
+    )
+}
+
+fn tuples(edges: &[GraphEdge]) -> BTreeSet<EdgeTuple> {
+    edges.iter().map(tuple).collect()
+}
+
+fn weight(value: f64) -> serde_json::Map<String, Value> {
+    let mut props = serde_json::Map::new();
+    props.insert("weight".to_owned(), Value::from(value));
+    props.insert("note".to_owned(), Value::from("carried verbatim"));
+    props
+}
+
+/// Facts 1..=3 and several edges, two of them carrying PROPERTIES — the field
+/// `MemoryEdge` does not even have, and therefore the one a transport type
+/// chosen for convenience would silently drop.
+fn source_with_rich_edges(dir: &std::path::Path) -> BTreeSet<EdgeTuple> {
+    seeded_with_edges(dir);
+    let memory = fresh_memory(dir);
+    memory
+        .semantic()
+        .relate(ALSO_LIVE, LIVE, "contradicts", Some(&weight(0.75)))
+        .expect("edge with properties");
+    memory
+        .semantic()
+        .relate(LIVE, ALSO_LIVE, "supports", Some(&weight(0.25)))
+        .expect("second edge with properties");
+    let mut all = Vec::new();
+    for id in [LIVE, ALSO_LIVE, LATER_EXPIRED] {
+        all.extend(memory.semantic().relations(id).expect("relations"));
+    }
+    let observed = tuples(&all);
+    assert!(
+        observed.iter().any(|(.., props)| props.contains("weight")),
+        "positive control: the fixture must actually carry properties, or the \
+         export test below cannot notice them being dropped"
+    );
+    observed
+}
+
+fn opened(
+    dir: &std::path::Path,
+    dimension: usize,
+) -> (std::sync::Arc<velesdb_core::Database>, AgentMemory) {
+    let db = std::sync::Arc::new(velesdb_core::Database::open(dir).expect("open db"));
+    let memory =
+        AgentMemory::with_dimension(std::sync::Arc::clone(&db), dimension).expect("agent memory");
+    (db, memory)
+}
+
+#[test]
+fn every_agent_collection_is_dispatchable() {
+    // `edges.rs` matches the three subsystems by name against
+    // `AGENT_COLLECTIONS`. Adding a fourth collection to that constant without
+    // teaching the dispatch about it would not fail to compile — it would fail
+    // at run time, on a real store, halfway through a migration.
+    let dir = tempfile::tempdir().expect("tempdir");
+    seeded_with_edges(dir.path());
+    let (db, memory) = opened(dir.path(), DIM);
+
+    for collection in super::super::AGENT_COLLECTIONS {
+        super::super::export_edges(&memory, &db, collection, 1024)
+            .unwrap_or_else(|e| panic!("`{collection}` must be dispatchable, got {e}"));
+    }
+
+    let refused = super::super::export_edges(&memory, &db, "_not_a_subsystem", 1024).expect_err(
+        "positive control: an unknown collection must be refused, or \
+                     the loop above proves only that nothing ever errors",
+    );
+    assert!(
+        refused.to_string().contains("_not_a_subsystem"),
+        "the refusal must name the collection; got {refused}"
+    );
+}
+
+#[test]
+fn export_edges_carries_every_field_of_every_tuple() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let expected = source_with_rich_edges(dir.path());
+
+    let (db, memory) = opened(dir.path(), DIM);
+    let exported =
+        super::super::export_edges(&memory, &db, "_semantic_memory", 1024).expect("export edges");
+
+    assert_eq!(
+        tuples(&exported),
+        expected,
+        "the export must carry id, source, target, label AND properties; a \
+         transport type without a properties field would pass every other \
+         assertion in this file"
+    );
+}
+
+#[test]
+fn export_edges_refuses_an_id_the_triple_does_not_derive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seeded_with_edges(dir.path());
+
+    // `VelesQL` DML accepts an explicit edge id (`database/dml_executor.rs:147`),
+    // so a store can hold an edge whose id is not `hash_edge_id` of its triple.
+    // Reinserting it would rederive a DIFFERENT id, and the rebuild would ship a
+    // store where one logical edge carries two identities.
+    {
+        let db = velesdb_core::Database::open(dir.path()).expect("open");
+        let any = db
+            .get_any_collection("_semantic_memory")
+            .expect("collection");
+        let forged = GraphEdge::new(999_999, LIVE, ALSO_LIVE, "forged").expect("edge");
+        any.add_edge(forged).expect("add forged edge");
+    }
+
+    let (db, memory) = opened(dir.path(), DIM);
+    let refused = super::super::export_edges(&memory, &db, "_semantic_memory", 1024)
+        .expect_err("an underived id must stop the export");
+    let message = refused.to_string();
+    assert!(
+        message.contains("999999") && message.contains("forged"),
+        "the refusal must name the offending edge and its label so an operator \
+         can find it; got {message}"
+    );
+}
+
+#[test]
+fn the_incoming_walk_yields_the_same_tuples_as_the_outgoing_one() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let expected = source_with_rich_edges(dir.path());
+
+    let (db, memory) = opened(dir.path(), DIM);
+    let exported =
+        super::super::export_edges(&memory, &db, "_semantic_memory", 1024).expect("export");
+    let crossed = super::super::cross_check_edges(&memory, &db, "_semantic_memory", 1024)
+        .expect("cross check");
+
+    assert_eq!(
+        tuples(&crossed),
+        tuples(&exported),
+        "the incoming index must yield the SAME tuples, not merely the same \
+         count — two physically distinct indexes agreeing is the evidence; equal \
+         cardinalities would also hold if both had lost the same number"
+    );
+    assert_eq!(
+        tuples(&exported),
+        expected,
+        "and both must equal the source"
+    );
+}
+
+#[test]
+fn reinserted_edges_are_read_back_identical_at_the_destination() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let expected = source_with_rich_edges(dir.path());
+
+    let exported = {
+        let (db, memory) = opened(dir.path(), DIM);
+        super::super::export_edges(&memory, &db, "_semantic_memory", 1024).expect("export")
+    };
+    let facts = super::preservation::read_out(dir.path(), "_semantic_memory");
+
+    // Facts FIRST — `relate` requires both endpoints live, so an edge-before-fact
+    // order does not merely misorder the work, it cannot complete.
+    let dest = super::preservation::destination();
+    {
+        let db = velesdb_core::Database::open(dest.path()).expect("open destination");
+        for fact in &facts {
+            super::super::reinsert(
+                &db,
+                "_semantic_memory",
+                fact,
+                &super::preservation::NEW_EMBEDDING,
+            )
+            .expect("reinsert fact");
+        }
+    }
+
+    let (db, memory) = opened(dest.path(), super::preservation::NEW_EMBEDDING.len());
+    let outcome = super::super::reinsert_edges(&memory, "_semantic_memory", &exported)
+        .expect("reinsert edges");
+    assert_eq!(
+        outcome.inserted,
+        exported.len() as u64,
+        "every exported edge must land"
+    );
+
+    // The verdict is the RE-READ, never the return code: `relate` is idempotent
+    // on an id that already exists and ignores the properties it was handed, so
+    // a destination that dropped every property would still answer success.
+    let read_back = super::super::export_edges(&memory, &db, "_semantic_memory", 1024)
+        .expect("re-read destination");
+    assert_eq!(
+        tuples(&read_back),
+        expected,
+        "the destination must hold the SAME tuples, properties included, read \
+         back out through the same export the source went through"
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -119,6 +119,7 @@ fn database(dir: &tempfile::TempDir) -> velesdb_core::Database {
 
 mod cli;
 mod diagnosis;
+mod edges;
 mod enumeration;
 mod performance;
 mod preservation;

--- a/crates/velesdb-memory/src/migration/tests/preservation.rs
+++ b/crates/velesdb-memory/src/migration/tests/preservation.rs
@@ -368,7 +368,7 @@ fn rebuild_source_facts(source: &std::path::Path) -> tempfile::TempDir {
 }
 
 #[test]
-fn fact_export_cannot_preserve_edges_without_a_complete_edge_export() {
+fn a_fact_only_rebuild_still_carries_no_edges_at_all() {
     // The source deliberately has both directions and two labels. The old
     // version of this test then re-created those edges from EDGE_TRIPLETS and
     // compared them with EDGE_TRIPLETS: that proved deterministic edge ids,
@@ -408,8 +408,12 @@ fn fact_export_cannot_preserve_edges_without_a_complete_edge_export() {
     assert_eq!(
         destination_edges.len(),
         0,
-        "the current fact-only export contains no complete edge tuples, so a rebuild cannot \
-         honestly claim relation preservation; this remains a blocking missing capability"
+        "reinserting facts moves points and nothing else: no edge follows a point \
+         to the destination. #1762 PR C2a did not change this and must not — it \
+         added a SEPARATE pass (`migration::reinsert_edges`, proven in \
+         `tests::edges`), and this assertion is what keeps that pass necessary. \
+         The day edges start arriving on their own, the edge pass would be \
+         doing its work twice and nobody would notice"
     );
 }
 


### PR DESCRIPTION
Refs #1762 — PR C2a of the embedding-migration campaign, on top of C1 (#1818).

## What was missing

The fact export moves points and nothing else. A rebuild shipped without an
edge pass would hand back a store whose facts are all present and whose graph
is empty — a loss no per-fact comparison detects, because every fact is intact.
`edge_export` was the capability blocking reconstruction, and its blocker set
the bar: *a lossless edge export and reinsertion API must exist and be tested*.

## What this adds

- `export_edges` — walks the live fact ids with the fact export's own cursor,
  takes each fact's outgoing edges, and refuses any edge whose id its triple
  does not derive.
- `cross_check_edges` — the same set through the incoming adjacency map.
- `export_edges_verified` — the entry point a rebuild should use: enumerates
  **once** and walks both directions over that single snapshot, comparing them
  as sets of tuples rather than as counts.
- `reinsert_edges` — puts the edges back **after** the facts, asserting that the
  id `relate` answers with is the id that was exported.
- `edge_export` promoted to `Proven`; `DIAGNOSIS_FORMAT_VERSION` 5 → 6.

Edges travel as the engine's own `GraphEdge`, never as `MemoryEdge`: the reduced
type has no `properties` field at all, so reusing it would have compiled,
round-tripped, and lost every property in silence.

## What is proven rather than asserted

**The two walks agree on which endpoints are live.** This was claimed on the
issue from a partial reading of `AgentMemory::with_dimension` and
`MemoryTtl::is_expired`, both of which suggest the opposite. Doubting it and
measuring it produced a three-armed control — plain reopen / raw rewrite with a
FUTURE expiry / the same with a PAST one. The middle arm is what rules out the
rival explanation that the fixture's rewrite had destroyed the edge; without it
both causes yield the same number. The mechanism is `rebuild_ttl_from_payloads`,
called by every subsystem constructor, and the test is now the regression guard
standing between a rebuild and an edge pointing at nothing.

**Both guards refuse.** Mutation-tested: passing `None` instead of the
properties on reinsertion turns exactly one test red; disabling the derived-id
check turns exactly one other test red.

**The destination is verified by re-reading it.** `relate` is idempotent on an
existing id and ignores the properties it is handed in that case, so a
destination that dropped every property would still answer success. The verdict
is the re-read, never the return code.

## Adversarial review

A review of the first commit found four real gaps; the second commit closes all
four. The most severe: `export_edges` and `cross_check_edges` each enumerated
the store separately, so a fact expiring between the two calls left them
disagreeing about an edge neither had lost — reproduced with a two-second
expiry, two tuples out and one in. That is what `export_edges_verified` exists
for. The others corrected a comment that was factually false, an evidence string
that overstated what two indexes agreeing proves, and a version promise that was
true but untested in its own direction.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check` with `-D warnings -D clippy::pedantic` — 0
- `lizard -l rust -C 8 -a 8` over the 9 files of the diff — 0 thresholds exceeded, with a positive control asserting all 9 were actually read
- `cargo test -p velesdb-memory --features persistence` — 561 in the lib plus 34 further binaries, 0 failures

## Not in scope

The rebuild does not call this API yet; wiring it in is C2b, along with
reconstruction and resumption.