### PR TITLE
feat(migration): rebuild with per-collection resume, executed inside Prepared

### DIFF
--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -533,7 +533,6 @@ fn run_migrate_embeddings(
     use velesdb_memory::migration;
 
     let options = migration::parse_migrate_args(flags)?;
-    migration::require_dry_run(&options)?;
 
     apply_config_file(argv)?;
     let store_path = migrate_store_path(&options);
@@ -548,19 +547,56 @@ fn run_migrate_embeddings(
     };
     let scratch = migrate_scratch_parent(&options, &store_path)?;
 
-    let report = migration::dry_run(
-        &store_path,
-        &scratch,
-        &target,
-        options.destination.as_deref(),
-    )?;
-    print!("{}", migration::render(&report));
-
-    if migration::refuses(&report) {
-        std::process::exit(2);
+    if options.dry_run {
+        let report = migration::dry_run(
+            &store_path,
+            &scratch,
+            &target,
+            options.destination.as_deref(),
+        )?;
+        print!("{}", migration::render(&report));
+        if migration::refuses(&report) {
+            std::process::exit(2);
+        }
+        return Ok(());
     }
+    run_migrate_rebuild(&options, &store_path, &scratch, &target, embedder.as_ref())
+}
+
+/// The non-dry-run tail of `migrate-embeddings`: rebuild, then say plainly
+/// where the wired part ends.
+fn run_migrate_rebuild(
+    options: &velesdb_memory::migration::MigrateOptions,
+    store_path: &std::path::Path,
+    scratch: &std::path::Path,
+    target: &velesdb_memory::migration::TargetContract,
+    embedder: &dyn velesdb_memory::Embedder,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use velesdb_memory::migration;
+
+    let destination = migration::require_destination(options)?;
+    let outcome = migration::execute(
+        store_path,
+        scratch,
+        target,
+        &destination,
+        embedder,
+        MIGRATE_BATCH,
+    )?;
+    print!("{}", migration::render(&outcome.report));
+    println!(
+        "rebuild: {} facts written, {} already present, {} edges, journal at {}",
+        outcome.rebuild.facts,
+        outcome.rebuild.collisions,
+        outcome.rebuild.edges,
+        outcome.workspace.display(),
+    );
+    println!("{}", migration::not_yet_switchable());
     Ok(())
 }
+
+/// The rebuild's batch size: the fact export's own proven default.
+const MIGRATE_BATCH: usize = 1024;
 
 /// The store `migrate-embeddings` operates on: `--store`, else exactly where
 /// the daemon would look (`VELESDB_MEMORY_PATH`, else the advertised default).

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -50,13 +50,15 @@ mod diagnosis;
 mod diagnostic_copy;
 mod edges;
 mod enumeration;
+mod execute;
 mod filesystem;
+mod rebuild;
 mod state;
 mod strategy;
 
 pub use cli::{
-    default_scratch_parent, dry_run, not_yet_executable, parse as parse_migrate_args, refuses,
-    render, require_dry_run, MigrateOptions,
+    default_scratch_parent, dry_run, not_yet_switchable, parse as parse_migrate_args, refuses,
+    render, require_destination, MigrateOptions,
 };
 pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
@@ -69,10 +71,16 @@ pub use enumeration::{
     enumerate_by_cursor, enumerate_collection, enumerate_page, reinsert, reinsert_batch,
     scroll_page, BatchReinsertion, RawFact, Reinsertion, AGENT_COLLECTIONS,
 };
+pub use execute::{execute, ExecuteOutcome};
 pub use filesystem::{bytes_on_disk, fingerprint};
+#[cfg(test)]
+pub(crate) use rebuild::rebuild_with_stop;
+pub use rebuild::{
+    rebuild, RebuildDestination, RebuildJournal, RebuildOutcome, RebuildSource, VectorPolicy,
+};
 pub use state::{
-    MigrationLock, MigrationState, Phase, Recovery, SwitchState, LOCK_FILE, PHASES, STATE_FILE,
-    STATE_FORMAT_VERSION, STATE_TEMP_FILE,
+    CollectionProgress, MigrationLock, MigrationState, Phase, Recovery, SwitchState, LOCK_FILE,
+    PHASES, STATE_FILE, STATE_FORMAT_VERSION, STATE_TEMP_FILE,
 };
 pub use strategy::{assess, resolve, Compatibility, Resolution, Strategy};
 

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -50,13 +50,19 @@ impl Default for MigrateOptions {
     }
 }
 
-/// What an operator must be told when they ask for the part that is not built.
-const NOT_YET_EXECUTABLE: &str =
-    "migrate-embeddings can only --dry-run in this version. The rebuild itself \
-     (reading every fact out, producing its vector, writing it to a destination, \
-     validating it and switching over) is not wired yet — see #1762. Re-run with \
-     --dry-run to see the regime this store resolves to and what still blocks a \
-     rebuild.";
+/// What an operator must be told after a successful non-dry-run: how far it
+/// went, and exactly where the wired part ends.
+///
+/// This text replaced `NOT_YET_EXECUTABLE` when the rebuild itself was wired
+/// (#1762, PR C2b). What remains unwired moved, it did not shrink to nothing:
+/// the rebuilt destination is NOT validated and NOT switched into place, and a
+/// message that failed to say so would read as "the migration is done" to
+/// every operator who ran it.
+const NOT_YET_SWITCHABLE: &str =
+    "the rebuild is complete and journalled, but the destination has NOT been \
+     validated and has NOT been switched into place — that part is not wired \
+     yet, see #1762. The source store is still the live one. Keep the \
+     destination and its .migration-journal sibling until the switch ships.";
 
 /// Parse `migrate-embeddings`' flags.
 ///
@@ -122,15 +128,21 @@ pub fn dry_run(
     diagnose(store, scratch_parent, target, destination)
 }
 
-/// Refuse an invocation this version cannot honour.
+/// Require the flag a non-dry-run cannot proceed without.
+///
+/// The rebuild writes somewhere, and "wherever seems sensible" is not an
+/// answer when the somewhere will later be renamed over the live store: the
+/// operator names the destination, or the run does not start.
 ///
 /// # Errors
-/// [`NOT_YET_EXECUTABLE`] whenever `--dry-run` was not given.
-pub fn require_dry_run(options: &MigrateOptions) -> Result<(), String> {
-    if options.dry_run {
-        return Ok(());
-    }
-    Err(NOT_YET_EXECUTABLE.to_owned())
+/// A message naming the missing flag when `--destination` was not given.
+pub fn require_destination(options: &MigrateOptions) -> Result<PathBuf, String> {
+    options.destination.clone().ok_or_else(|| {
+        "a non-dry-run migrate-embeddings rebuilds into a destination you name: \
+         pass --destination <dir> (an empty or not-yet-existing directory on \
+         the store's filesystem), or --dry-run to only diagnose"
+            .to_owned()
+    })
 }
 
 /// Render a report for an operator: what is here, what would happen, and what
@@ -225,10 +237,10 @@ pub fn refuses(report: &DiagnosisReport) -> bool {
     !report.resolution.runs()
 }
 
-/// Re-exported so the binary can name the refusal without duplicating it.
+/// Re-exported so the binary can print the boundary without duplicating it.
 #[must_use]
-pub fn not_yet_executable() -> &'static str {
-    NOT_YET_EXECUTABLE
+pub fn not_yet_switchable() -> &'static str {
+    NOT_YET_SWITCHABLE
 }
 
 /// The default scratch parent: the directory the store itself sits in.

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -239,6 +239,28 @@ pub fn export_edges_verified(
     Ok(exported)
 }
 
+/// Whether two collections of edges hold the same SET OF TUPLES, every field
+/// included.
+///
+/// The failure names the sizes and the symmetric difference count rather than
+/// the tuples themselves: an operator debugging a mismatch wants to know HOW
+/// diverged before wading into WHAT, and the full tuples are one export away.
+///
+/// # Errors
+/// A message describing the divergence when the sets differ.
+pub(super) fn same_edge_tuples(left: &[GraphEdge], right: &[GraphEdge]) -> Result<(), String> {
+    let (left, right) = (comparable(left), comparable(right));
+    if left == right {
+        return Ok(());
+    }
+    Err(format!(
+        "{} tuples on one side, {} on the other, {} present in only one of them",
+        left.len(),
+        right.len(),
+        left.symmetric_difference(&right).count(),
+    ))
+}
+
 /// An edge reduced to something orderable, so two collections of edges compare
 /// as SETS OF TUPLES. Comparing counts would let two walks that had each lost
 /// one edge agree.

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -90,10 +90,29 @@ pub fn execute(
     // Release on BOTH paths. The fail-closed evidence a dropped lock leaves is
     // for crashes — a run that reached a clean `Err` has nothing for the
     // operator to acknowledge, and making them `rm` a lock file after every
-    // refusal would train them to do it after real crashes too.
-    let released = lock.release().map_err(query_error);
-    let rebuild = result?;
-    released?;
+    // refusal would train them to do it after real crashes too. And when BOTH
+    // fail, both are reported: an operator who fixes the rebuild error and
+    // reruns deserves to know beforehand that the lock evidence remains, not
+    // to discover it as a second surprise.
+    let released = lock.release();
+    let rebuild = match (result, released) {
+        (Ok(rebuild), Ok(())) => rebuild,
+        (Ok(_), Err(release_error)) => {
+            return Err(query_error(format!(
+                "the rebuild completed, but releasing the migration lock \
+                 failed: {release_error}. The canonical lock record remains \
+                 and must be removed by hand before the next run"
+            )));
+        }
+        (Err(error), Ok(())) => return Err(error),
+        (Err(error), Err(release_error)) => {
+            return Err(query_error(format!(
+                "{error}; additionally, releasing the migration lock failed: \
+                 {release_error} — the canonical lock record remains and must \
+                 be removed by hand before the next run"
+            )));
+        }
+    };
     Ok(ExecuteOutcome {
         report,
         rebuild,
@@ -162,14 +181,7 @@ fn execute_locked(
     lock: &MigrationLock,
     pass: &ExecutePass<'_>,
 ) -> Result<RebuildOutcome, crate::MemoryError> {
-    let mut state = journal_entry(
-        report,
-        target,
-        workspace,
-        lock,
-        pass.resuming,
-        pass.settled_fingerprint,
-    )?;
+    let mut state = journal_entry(report, target, workspace, lock, pass)?;
     let policy = match report.resolution {
         Resolution::Reuse => VectorPolicy::Reuse,
         Resolution::Reembed { .. } => VectorPolicy::Reembed(pass.embedder),
@@ -208,42 +220,67 @@ fn execute_locked(
     )
 }
 
+/// The sentence every `reembed` migration embeds once at prepare and once at
+/// every resume. Its content is arbitrary; its STABILITY is the contract —
+/// change it and every in-flight migration's witness stops matching.
+const WITNESS_SENTENCE: &str =
+    "velesdb embedder witness v1: one fixed sentence, embedded at prepare and at every resume";
+
+/// What the target embedder actually produces, as a digest — `Some` under
+/// `reembed`, `None` under `reuse` (where the embedder is never called).
+fn embedder_witness(
+    resolution: Resolution,
+    embedder: &dyn Embedder,
+) -> Result<Option<String>, crate::MemoryError> {
+    match resolution {
+        Resolution::Reuse => Ok(None),
+        Resolution::Reembed { .. } => {
+            use sha2::Digest;
+            let vector = embedder.embed(WITNESS_SENTENCE).map_err(|err| {
+                query_error(format!(
+                    "the target embedder cannot embed the witness: {err}"
+                ))
+            })?;
+            let mut hash = sha2::Sha256::new();
+            for value in &vector {
+                hash.update(value.to_le_bytes());
+            }
+            Ok(Some(format!(
+                "sha256:{}",
+                super::filesystem::encode_hex(&hash.finalize())
+            )))
+        }
+        Resolution::Refuse { .. } => {
+            unreachable!("execute gated Refuse before the witness was computed")
+        }
+    }
+}
+
 /// Read-and-verify the existing journal, or write the first entry.
 ///
 /// Both directions use the SETTLED fingerprint, never the diagnosis's: the
-/// diagnosis fingerprinted the tree before the settle compacted it.
+/// diagnosis fingerprinted the tree before the settle compacted it. And both
+/// carry the embedder WITNESS, not just the model name: `may_resume` checks
+/// what the embedder is CALLED, the witness what it PRODUCES, and only the
+/// second survives a model updated in place under a stable name — the replayed
+/// batches would keep run-one vectors while the remaining batches got
+/// run-two's, one store with two incompatible vector spaces.
 fn journal_entry(
     report: &DiagnosisReport,
     target: &TargetContract,
     workspace: &Path,
     lock: &MigrationLock,
-    resuming: bool,
-    settled_fingerprint: &str,
+    pass: &ExecutePass<'_>,
 ) -> Result<MigrationState, crate::MemoryError> {
-    if resuming {
-        let state = MigrationState::read(workspace)
-            .map_err(query_error)?
-            .ok_or_else(|| {
-                query_error(format!(
-                    "the journal at {} disappeared between inspection and locking",
-                    workspace.display()
-                ))
-            })?;
-        state
-            .may_resume(
-                &report.source_path,
-                settled_fingerprint,
-                &target.model,
-                target.dimension,
-            )
-            .map_err(query_error)?;
-        return Ok(state);
+    let witness = embedder_witness(report.resolution, pass.embedder)?;
+    if pass.resuming {
+        return resume_journal(report, target, workspace, pass, witness.as_deref());
     }
     let state = MigrationState {
         format_version: super::state::STATE_FORMAT_VERSION,
         phase: Phase::Prepared,
         source_path: report.source_path.clone(),
-        source_fingerprint: settled_fingerprint.to_owned(),
+        source_fingerprint: pass.settled_fingerprint.to_owned(),
         target_model: target.model.clone(),
         target_dimension: target.dimension,
         progress: super::enumeration::AGENT_COLLECTIONS
@@ -255,8 +292,46 @@ fn journal_entry(
                 )
             })
             .collect(),
+        embedder_witness: witness,
     };
     state.write(workspace, lock).map_err(query_error)?;
+    Ok(state)
+}
+
+/// Verify an existing journal against the run in front of us.
+fn resume_journal(
+    report: &DiagnosisReport,
+    target: &TargetContract,
+    workspace: &Path,
+    pass: &ExecutePass<'_>,
+    witness: Option<&str>,
+) -> Result<MigrationState, crate::MemoryError> {
+    let state = MigrationState::read(workspace)
+        .map_err(query_error)?
+        .ok_or_else(|| {
+            query_error(format!(
+                "the journal at {} disappeared between inspection and locking",
+                workspace.display()
+            ))
+        })?;
+    state
+        .may_resume(
+            &report.source_path,
+            pass.settled_fingerprint,
+            &target.model,
+            target.dimension,
+        )
+        .map_err(query_error)?;
+    if state.embedder_witness.as_deref() != witness {
+        return Err(query_error(format!(
+            "this migration was prepared with an embedder whose witness was \
+             {:?}, and the embedder answering to '{}' now produces {:?}. Same \
+             name, different vectors — the model was updated in place, or the \
+             regime changed between runs. Resuming would mix two vector spaces \
+             in one store; start a fresh migration",
+            state.embedder_witness, target.model, witness,
+        )));
+    }
     Ok(state)
 }
 

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -1,0 +1,329 @@
+//! The operator's path into the rebuild (#1762, PR C2b).
+//!
+//! [`super::rebuild`] takes staged handles and a journal and drives the pass;
+//! this module is everything an operator's `migrate-embeddings` invocation
+//! needs BEFORE that call can be made honestly: the diagnosis, the regime
+//! resolution, a destination that provably is not somebody else's data, a
+//! journal workspace outside both stores, and the lock. Each refusal here is
+//! distinct on purpose — an operator has to know whether they were refused by
+//! the regime, by the destination, or by another migration's lock, because the
+//! recovery for each is different.
+//!
+//! # Where the pieces live
+//!
+//! The journal workspace is a SIBLING of the destination, named after it
+//! (`<destination>.migration-journal`). Inside the source it would violate the
+//! read-only contract; inside the destination it would be swept along by the
+//! eventual switch rename (C3), which must move the rebuilt store and nothing
+//! else. A sibling survives the switch, which matters because the phases
+//! after the switch are journalled too.
+//!
+//! # What execute stops short of
+//!
+//! The pass ends with the journal at [`Phase::Prepared`] and every collection
+//! `Complete`. Validation of the destination and the switch itself are the
+//! next PR's work; see [`NOT_YET_SWITCHABLE`](super::not_yet_switchable).
+
+use std::path::{Path, PathBuf};
+
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::Database;
+
+use super::diagnosis::{diagnose, DiagnosisReport, TargetContract};
+use super::rebuild::{
+    rebuild, RebuildDestination, RebuildJournal, RebuildOutcome, RebuildSource, VectorPolicy,
+};
+use super::state::{CollectionProgress, MigrationLock, MigrationState, Phase};
+use super::strategy::Resolution;
+use crate::embedder::Embedder;
+
+/// What one `execute` run did, and where its artefacts live.
+#[derive(Debug)]
+pub struct ExecuteOutcome {
+    /// The diagnosis that gated the run.
+    pub report: DiagnosisReport,
+    /// What the pass wrote.
+    pub rebuild: RebuildOutcome,
+    /// The rebuilt store, still unswitched.
+    pub destination: PathBuf,
+    /// Where the journal (and the lock evidence) lives.
+    pub workspace: PathBuf,
+}
+
+/// Diagnose, stage, lock, rebuild, release — the whole non-dry-run path.
+///
+/// A pre-existing journal at the derived workspace is resumed, provided it
+/// describes this exact source, fingerprint and target; anything else about it
+/// is a refusal, never an overwrite.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] when the regime resolution refuses, the
+/// destination holds data no journal accounts for, the journal describes a
+/// different migration, the lock is held or left from a crash, or the pass
+/// itself fails.
+pub fn execute(
+    store: &Path,
+    scratch_parent: &Path,
+    target: &TargetContract,
+    destination: &Path,
+    embedder: &dyn Embedder,
+    batch: usize,
+) -> Result<ExecuteOutcome, crate::MemoryError> {
+    let report = diagnose(store, scratch_parent, target, Some(destination))?;
+    let staging = stage(&report, destination)?;
+
+    let lock =
+        MigrationLock::acquire(&staging.workspace, "migrate-embeddings").map_err(query_error)?;
+    let result = execute_locked(
+        &report,
+        target,
+        destination,
+        &staging.workspace,
+        &lock,
+        &ExecutePass {
+            embedder,
+            batch,
+            resuming: staging.resuming,
+            settled_fingerprint: &staging.settled_fingerprint,
+        },
+    );
+    // Release on BOTH paths. The fail-closed evidence a dropped lock leaves is
+    // for crashes — a run that reached a clean `Err` has nothing for the
+    // operator to acknowledge, and making them `rm` a lock file after every
+    // refusal would train them to do it after real crashes too.
+    let released = lock.release().map_err(query_error);
+    let rebuild = result?;
+    released?;
+    Ok(ExecuteOutcome {
+        report,
+        rebuild,
+        destination: destination.to_path_buf(),
+        workspace: staging.workspace,
+    })
+}
+
+/// What the pre-lock staging established.
+struct Staging {
+    workspace: PathBuf,
+    resuming: bool,
+    settled_fingerprint: String,
+}
+
+/// Everything between the diagnosis and the lock: the regime gate, the settle,
+/// the journal workspace and the destination checks.
+fn stage(report: &DiagnosisReport, destination: &Path) -> Result<Staging, crate::MemoryError> {
+    if let Resolution::Refuse { because, requested } = &report.resolution {
+        return Err(query_error(format!(
+            "the requested regime '{}' cannot run: {because:?}. Nothing was \
+             created; re-run --dry-run for the full report",
+            regime_word(*requested),
+        )));
+    }
+    // Settle the source BEFORE fingerprinting it: the first open of a store
+    // compacts its WAL into materialised index files, so the tree after an
+    // open is not the tree before it — and the rebuild below opens it. A
+    // fingerprint taken pre-settle would therefore never match on resume,
+    // refusing every legitimately interrupted migration as "source changed".
+    // A second open is proven to change nothing (see
+    // `settling_a_store_is_idempotent_which_the_resume_fingerprint_rests_on`),
+    // which is what makes the settled fingerprint stable. The settle itself is
+    // what any daemon start performs; it runs only after the regime gate, so a
+    // refusal leaves the source byte-identical.
+    {
+        let _settle = Database::open(&report.source_path)?;
+    }
+    let settled_fingerprint = super::filesystem::fingerprint(&report.source_path)?;
+    let workspace = journal_workspace(destination)?;
+    let resuming = workspace.join(super::state::STATE_FILE).exists();
+    ensure_destination(destination, resuming)?;
+    Ok(Staging {
+        workspace,
+        resuming,
+        settled_fingerprint,
+    })
+}
+
+/// The run's inputs beyond the diagnosis: how to embed, how much per batch,
+/// whether a journal already existed, and the post-settle fingerprint the
+/// journal carries (the diagnosis's own fingerprint predates the settle and
+/// would never match on resume).
+struct ExecutePass<'a> {
+    embedder: &'a dyn Embedder,
+    batch: usize,
+    resuming: bool,
+    settled_fingerprint: &'a str,
+}
+
+fn execute_locked(
+    report: &DiagnosisReport,
+    target: &TargetContract,
+    destination: &Path,
+    workspace: &Path,
+    lock: &MigrationLock,
+    pass: &ExecutePass<'_>,
+) -> Result<RebuildOutcome, crate::MemoryError> {
+    let mut state = journal_entry(
+        report,
+        target,
+        workspace,
+        lock,
+        pass.resuming,
+        pass.settled_fingerprint,
+    )?;
+    let policy = match report.resolution {
+        Resolution::Reuse => VectorPolicy::Reuse,
+        Resolution::Reembed { .. } => VectorPolicy::Reembed(pass.embedder),
+        Resolution::Refuse { .. } => {
+            unreachable!("execute gated Refuse before the lock was taken")
+        }
+    };
+    let Some(source_dimension) = report.source_dimension else {
+        return Err(query_error(
+            "the source collections do not establish one shared dimension, so \
+             no AgentMemory view can open them; the diagnosis carries the \
+             details",
+        ));
+    };
+
+    let source_db = std::sync::Arc::new(Database::open(&report.source_path)?);
+    let source_memory =
+        AgentMemory::with_dimension(std::sync::Arc::clone(&source_db), source_dimension)?;
+    let destination_db = std::sync::Arc::new(Database::open(destination)?);
+    let destination_memory =
+        AgentMemory::with_dimension(std::sync::Arc::clone(&destination_db), target.dimension)?;
+
+    rebuild(
+        &RebuildSource {
+            db: &source_db,
+            memory: &source_memory,
+        },
+        &RebuildDestination {
+            db: &destination_db,
+            memory: &destination_memory,
+        },
+        &mut state,
+        &RebuildJournal { workspace, lock },
+        &policy,
+        pass.batch,
+    )
+}
+
+/// Read-and-verify the existing journal, or write the first entry.
+///
+/// Both directions use the SETTLED fingerprint, never the diagnosis's: the
+/// diagnosis fingerprinted the tree before the settle compacted it.
+fn journal_entry(
+    report: &DiagnosisReport,
+    target: &TargetContract,
+    workspace: &Path,
+    lock: &MigrationLock,
+    resuming: bool,
+    settled_fingerprint: &str,
+) -> Result<MigrationState, crate::MemoryError> {
+    if resuming {
+        let state = MigrationState::read(workspace)
+            .map_err(query_error)?
+            .ok_or_else(|| {
+                query_error(format!(
+                    "the journal at {} disappeared between inspection and locking",
+                    workspace.display()
+                ))
+            })?;
+        state
+            .may_resume(
+                &report.source_path,
+                settled_fingerprint,
+                &target.model,
+                target.dimension,
+            )
+            .map_err(query_error)?;
+        return Ok(state);
+    }
+    let state = MigrationState {
+        format_version: super::state::STATE_FORMAT_VERSION,
+        phase: Phase::Prepared,
+        source_path: report.source_path.clone(),
+        source_fingerprint: settled_fingerprint.to_owned(),
+        target_model: target.model.clone(),
+        target_dimension: target.dimension,
+        progress: super::enumeration::AGENT_COLLECTIONS
+            .iter()
+            .map(|name| {
+                (
+                    (*name).to_owned(),
+                    CollectionProgress::Facts { cursor: None },
+                )
+            })
+            .collect(),
+    };
+    state.write(workspace, lock).map_err(query_error)?;
+    Ok(state)
+}
+
+/// The operator's word for a regime, as they typed it on the CLI.
+fn regime_word(strategy: super::strategy::Strategy) -> &'static str {
+    match strategy {
+        super::strategy::Strategy::Auto => "auto",
+        super::strategy::Strategy::Reuse => "reuse",
+        super::strategy::Strategy::Reembed => "reembed",
+    }
+}
+
+/// The journal's home: a sibling of the destination, named after it.
+fn journal_workspace(destination: &Path) -> Result<PathBuf, crate::MemoryError> {
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            query_error(format!(
+                "the destination {} has no usable directory name to derive the \
+                 journal workspace from",
+                destination.display()
+            ))
+        })?;
+    let workspace = destination.with_file_name(format!("{name}.migration-journal"));
+    std::fs::create_dir_all(&workspace).map_err(|err| {
+        query_error(format!(
+            "cannot create the journal workspace {}: {err}",
+            workspace.display()
+        ))
+    })?;
+    Ok(workspace)
+}
+
+/// Create the destination, or verify that what is there is ours to continue.
+fn ensure_destination(destination: &Path, resuming: bool) -> Result<(), crate::MemoryError> {
+    if !destination.exists() {
+        std::fs::create_dir_all(destination).map_err(|err| {
+            query_error(format!(
+                "cannot create the destination {}: {err}",
+                destination.display()
+            ))
+        })?;
+        return Ok(());
+    }
+    if resuming {
+        // The journal accounts for whatever the interrupted run left here, and
+        // `reinsert_batch`'s collision refusal is what protects each id.
+        return Ok(());
+    }
+    let mut entries = std::fs::read_dir(destination).map_err(|err| {
+        query_error(format!(
+            "cannot inspect the destination {}: {err}",
+            destination.display()
+        ))
+    })?;
+    if entries.next().is_some() {
+        return Err(query_error(format!(
+            "the destination {} already holds data and no migration journal \
+             accounts for it; rebuilding into it could mix two stores, so \
+             choose an empty destination or remove it deliberately",
+            destination.display()
+        )));
+    }
+    Ok(())
+}
+
+fn query_error(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -90,35 +90,39 @@ pub fn execute(
     // Release on BOTH paths. The fail-closed evidence a dropped lock leaves is
     // for crashes — a run that reached a clean `Err` has nothing for the
     // operator to acknowledge, and making them `rm` a lock file after every
-    // refusal would train them to do it after real crashes too. And when BOTH
-    // fail, both are reported: an operator who fixes the rebuild error and
-    // reruns deserves to know beforehand that the lock evidence remains, not
-    // to discover it as a second surprise.
-    let released = lock.release();
-    let rebuild = match (result, released) {
-        (Ok(rebuild), Ok(())) => rebuild,
-        (Ok(_), Err(release_error)) => {
-            return Err(query_error(format!(
-                "the rebuild completed, but releasing the migration lock \
-                 failed: {release_error}. The canonical lock record remains \
-                 and must be removed by hand before the next run"
-            )));
-        }
-        (Err(error), Ok(())) => return Err(error),
-        (Err(error), Err(release_error)) => {
-            return Err(query_error(format!(
-                "{error}; additionally, releasing the migration lock failed: \
-                 {release_error} — the canonical lock record remains and must \
-                 be removed by hand before the next run"
-            )));
-        }
-    };
+    // refusal would train them to do it after real crashes too.
+    let rebuild = reconcile(result, lock.release())?;
     Ok(ExecuteOutcome {
         report,
         rebuild,
         destination: destination.to_path_buf(),
         workspace: staging.workspace,
     })
+}
+
+/// Fold the pass's result and the lock release into one verdict.
+///
+/// When BOTH fail, both are reported: an operator who fixes the rebuild error
+/// and reruns deserves to know beforehand that the lock evidence remains, not
+/// to discover it as a second surprise.
+fn reconcile(
+    result: Result<RebuildOutcome, crate::MemoryError>,
+    released: Result<(), String>,
+) -> Result<RebuildOutcome, crate::MemoryError> {
+    match (result, released) {
+        (Ok(rebuild), Ok(())) => Ok(rebuild),
+        (Ok(_), Err(release_error)) => Err(query_error(format!(
+            "the rebuild completed, but releasing the migration lock failed: \
+             {release_error}. The canonical lock record remains and must be \
+             removed by hand before the next run"
+        ))),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(release_error)) => Err(query_error(format!(
+            "{error}; additionally, releasing the migration lock failed: \
+             {release_error} — the canonical lock record remains and must be \
+             removed by hand before the next run"
+        ))),
+    }
 }
 
 /// What the pre-lock staging established.

--- a/crates/velesdb-memory/src/migration/filesystem.rs
+++ b/crates/velesdb-memory/src/migration/filesystem.rs
@@ -248,7 +248,7 @@ fn query_error(message: String) -> crate::MemoryError {
     velesdb_core::Error::Query(message).into()
 }
 
-fn encode_hex(bytes: &[u8]) -> String {
+pub(super) fn encode_hex(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut encoded = String::with_capacity(bytes.len() * 2);
     for byte in bytes {

--- a/crates/velesdb-memory/src/migration/rebuild.rs
+++ b/crates/velesdb-memory/src/migration/rebuild.rs
@@ -1,0 +1,337 @@
+//! The rebuild pass (#1762, PR C2b): drive the proven parts over a real store.
+//!
+//! Everything this module calls was proven separately — facts round-trip
+//! ([`super::enumeration`]), edges round-trip ([`super::edges`]), the journal
+//! can only advance ([`super::state`]). What it adds is the loop, and the loop
+//! is where a migration actually dies: between a batch landing and its
+//! checkpoint, between the last fact and the first edge, between one
+//! collection and the next. Every one of those gaps is covered by the journal
+//! contract — a crash replays at most one batch, and the replay is tolerated
+//! by construction because [`super::reinsert_batch`] refuses to overwrite and
+//! reports collisions instead.
+//!
+//! # Checkpoint order: destination first, journal second
+//!
+//! Every batch is written to the destination BEFORE its cursor reaches the
+//! journal. The other order would be quietly catastrophic: a journal that runs
+//! ahead of the destination makes a resume SKIP facts that never landed, and
+//! nothing downstream can tell a skipped fact from a fact the source never
+//! had. With this order the crash window replays work instead of losing it,
+//! and replays are visible (counted as collisions) rather than silent.
+//!
+//! # What this module deliberately does not do
+//!
+//! It does not choose the vector policy — [`super::resolve`] does, one place,
+//! tested as one rule. It does not create the destination, acquire the lock,
+//! or write the first journal entry — the caller stages those, because each is
+//! refused differently and a monolithic "prepare everything" would blur whose
+//! refusal the operator is reading. And it does not touch the phase: the pass
+//! runs strictly inside [`Phase::Prepared`], and leaving that phase is the
+//! validation-and-switch work of a later PR.
+
+use std::path::Path;
+
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::Database;
+
+use super::edges::{export_edges_verified, reinsert_edges, same_edge_tuples};
+use super::enumeration::{reinsert_batch, scroll_page, RawFact, AGENT_COLLECTIONS};
+use super::state::{CollectionProgress, MigrationLock, MigrationState, Phase};
+use crate::embedder::Embedder;
+
+/// The source store, opened read-only in spirit: nothing here writes to it.
+pub struct RebuildSource<'a> {
+    /// The database the fact walk scrolls.
+    pub db: &'a Database,
+    /// The agent view the edge export reads through.
+    pub memory: &'a AgentMemory,
+}
+
+/// The destination store, created and sized by the caller.
+pub struct RebuildDestination<'a> {
+    /// The database facts are reinserted into.
+    pub db: &'a Database,
+    /// The agent view edges are reinserted through.
+    pub memory: &'a AgentMemory,
+}
+
+/// Where the journal lives and the proof we may write it.
+pub struct RebuildJournal<'a> {
+    /// The workspace holding `migration-state.json` — never the source store.
+    pub workspace: &'a Path,
+    /// The exclusive lock the caller acquired on that workspace.
+    pub lock: &'a MigrationLock,
+}
+
+/// Which vector each reinserted fact carries.
+///
+/// `Reuse` copies the source vector verbatim and never reads the fact's text;
+/// `Reembed` reads the fact's `content` and asks the target embedder. This is
+/// an enum rather than a closure so the pass cannot be handed a policy the
+/// regime resolution did not produce.
+pub enum VectorPolicy<'a> {
+    /// The compatibility-proven regime: the source vectors ARE the target's.
+    Reuse,
+    /// Every other regime: the target embedder produces every vector.
+    Reembed(&'a dyn Embedder),
+}
+
+/// What a completed pass did — counts, not verdicts. The verdict is the
+/// destination re-reads performed along the way.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct RebuildOutcome {
+    /// Facts written to the destination by this run.
+    pub facts: u64,
+    /// Ids that were already occupied — nonzero exactly when this run replayed
+    /// a batch an interrupted predecessor had landed but not journalled.
+    pub collisions: u64,
+    /// Edges reinserted (idempotent replays included).
+    pub edges: u64,
+}
+
+/// Run the rebuild to completion, resuming from whatever `state` records.
+///
+/// Collections already `Complete` are skipped; a collection at `Edges` re-runs
+/// its (idempotent) edge pass; a collection at `Facts` resumes strictly after
+/// its journalled cursor.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] if `state` is not in [`Phase::Prepared`], if
+/// any read, embed, write, or journal step fails, or if a destination re-read
+/// disagrees with the source export.
+pub fn rebuild(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    policy: &VectorPolicy<'_>,
+    batch: usize,
+) -> Result<RebuildOutcome, crate::MemoryError> {
+    rebuild_inner(source, destination, state, journal, policy, batch, None)
+}
+
+/// [`rebuild`], with an injected stop after `stop_after_batches` batches.
+///
+/// The stop fires after a batch is reinserted and BEFORE its checkpoint is
+/// journalled — the widest window a real crash can hit. This is the seam the
+/// interruption tests drive; production callers go through [`rebuild`], which
+/// never stops early — hence the `cfg(test)`: no production build carries it.
+#[cfg(test)]
+pub(crate) fn rebuild_with_stop(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    policy: &VectorPolicy<'_>,
+    batch: usize,
+    stop_after_batches: Option<u64>,
+) -> Result<RebuildOutcome, crate::MemoryError> {
+    rebuild_inner(
+        source,
+        destination,
+        state,
+        journal,
+        policy,
+        batch,
+        stop_after_batches,
+    )
+}
+
+/// Counters shared across collections, plus the run-wide stop seam.
+#[derive(Default)]
+struct Run {
+    facts: u64,
+    collisions: u64,
+    edges: u64,
+    batches: u64,
+    stop_after_batches: Option<u64>,
+}
+
+fn rebuild_inner(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    policy: &VectorPolicy<'_>,
+    batch: usize,
+    stop_after_batches: Option<u64>,
+) -> Result<RebuildOutcome, crate::MemoryError> {
+    if state.phase != Phase::Prepared {
+        return Err(query_error(format!(
+            "the rebuild runs strictly inside {:?}, and this journal stands at \
+             {:?}; a pass that ran after validation would invalidate what was \
+             validated",
+            Phase::Prepared,
+            state.phase
+        )));
+    }
+    let mut run = Run {
+        stop_after_batches,
+        ..Run::default()
+    };
+    for name in AGENT_COLLECTIONS {
+        let step = Step {
+            collection: name,
+            policy,
+            batch,
+        };
+        rebuild_collection(source, destination, state, journal, &step, &mut run)?;
+    }
+    Ok(RebuildOutcome {
+        facts: run.facts,
+        collisions: run.collisions,
+        edges: run.edges,
+    })
+}
+
+/// The immutable context of one collection's pass.
+struct Step<'a> {
+    collection: &'a str,
+    policy: &'a VectorPolicy<'a>,
+    batch: usize,
+}
+
+fn rebuild_collection(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    step: &Step<'_>,
+    run: &mut Run,
+) -> Result<(), crate::MemoryError> {
+    let current = *state.progress.get(step.collection).ok_or_else(|| {
+        query_error(format!(
+            "the journal carries no progress entry for '{}'; refusing to \
+             invent one mid-pass",
+            step.collection
+        ))
+    })?;
+    match current {
+        CollectionProgress::Complete => return Ok(()),
+        CollectionProgress::Edges => {}
+        CollectionProgress::Facts { cursor } => {
+            walk_facts(source, destination, state, journal, step, run, cursor)?;
+            journal_progress(state, journal, step.collection, CollectionProgress::Edges)?;
+        }
+    }
+    run.edges += edge_pass(source, destination, step)?;
+    journal_progress(
+        state,
+        journal,
+        step.collection,
+        CollectionProgress::Complete,
+    )
+}
+
+fn walk_facts(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    step: &Step<'_>,
+    run: &mut Run,
+    mut cursor: Option<u64>,
+) -> Result<(), crate::MemoryError> {
+    loop {
+        let (facts, next) = scroll_page(source.db, step.collection, cursor, step.batch)?;
+        if facts.is_empty() {
+            return Ok(());
+        }
+        let mut pairs: Vec<(RawFact, Vec<f32>)> = Vec::with_capacity(facts.len());
+        for fact in facts {
+            let vector = vector_for(step.policy, &fact)?;
+            pairs.push((fact, vector));
+        }
+        let outcome = reinsert_batch(destination.db, step.collection, &pairs)?;
+        run.facts += outcome.inserted;
+        run.collisions += outcome.collisions.len() as u64;
+        run.batches += 1;
+        if run.stop_after_batches == Some(run.batches) {
+            return Err(query_error(format!(
+                "rebuild interrupted by the injected stop after {} batches; the \
+                 destination holds this batch and the journal does not — the \
+                 exact window a crash leaves, and what a resume replays",
+                run.batches
+            )));
+        }
+        let Some(next) = next else {
+            return Ok(());
+        };
+        cursor = Some(next);
+        journal_progress(
+            state,
+            journal,
+            step.collection,
+            CollectionProgress::Facts { cursor: Some(next) },
+        )?;
+    }
+}
+
+/// The vector a fact carries at the destination, per the resolved regime.
+fn vector_for(policy: &VectorPolicy<'_>, fact: &RawFact) -> Result<Vec<f32>, crate::MemoryError> {
+    match policy {
+        VectorPolicy::Reuse => Ok(fact.source_vector.clone()),
+        VectorPolicy::Reembed(embedder) => {
+            let payload: serde_json::Value =
+                serde_json::from_str(&fact.payload).map_err(|err| {
+                    query_error(format!(
+                        "fact {} carries unreadable payload: {err}",
+                        fact.id
+                    ))
+                })?;
+            let Some(content) = payload.get("content").and_then(serde_json::Value::as_str) else {
+                return Err(query_error(format!(
+                    "fact {} carries no `content` text, so `reembed` cannot \
+                     produce its vector; skipping it would silently drop the \
+                     fact and re-using its old vector would mix models, so the \
+                     pass stops here",
+                    fact.id
+                )));
+            };
+            embedder
+                .embed(content)
+                .map_err(|err| query_error(format!("embedding fact {} failed: {err}", fact.id)))
+        }
+    }
+}
+
+/// Export the source's edges, put them back, and re-read the destination.
+fn edge_pass(
+    source: &RebuildSource<'_>,
+    destination: &RebuildDestination<'_>,
+    step: &Step<'_>,
+) -> Result<u64, crate::MemoryError> {
+    let exported = export_edges_verified(source.memory, source.db, step.collection, step.batch)?;
+    let outcome = reinsert_edges(destination.memory, step.collection, &exported)?;
+    let back = export_edges_verified(
+        destination.memory,
+        destination.db,
+        step.collection,
+        step.batch,
+    )?;
+    same_edge_tuples(&exported, &back).map_err(|difference| {
+        query_error(format!(
+            "after reinsertion the destination's edges do not match the export \
+             for '{}': {difference}. The return codes said success; the re-read \
+             is the verdict, and it says loss",
+            step.collection
+        ))
+    })?;
+    Ok(outcome.inserted)
+}
+
+fn journal_progress(
+    state: &mut MigrationState,
+    journal: &RebuildJournal<'_>,
+    collection: &str,
+    progress: CollectionProgress,
+) -> Result<(), crate::MemoryError> {
+    state.progress.insert(collection.to_owned(), progress);
+    state
+        .write(journal.workspace, journal.lock)
+        .map_err(query_error)
+}
+
+fn query_error(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}

--- a/crates/velesdb-memory/src/migration/rebuild.rs
+++ b/crates/velesdb-memory/src/migration/rebuild.rs
@@ -310,10 +310,20 @@ fn edge_pass(
         step.batch,
     )?;
     same_edge_tuples(&exported, &back).map_err(|difference| {
+        // Honesty about what this mismatch can mean: the export, the
+        // reinsertion and the re-read are three separate clock reads, and a
+        // fact whose ABSOLUTE expiry falls between them shrinks one side
+        // without anything being lost — the C2a lesson (two walks must share
+        // one snapshot) cannot apply here because a write sits between the
+        // walks. Distinguishing that transient from real loss mechanically is
+        // the validation pass's job (C3); until then the pass stops, says
+        // both readings, and stays resumable.
         query_error(format!(
             "after reinsertion the destination's edges do not match the export \
-             for '{}': {difference}. The return codes said success; the re-read \
-             is the verdict, and it says loss",
+             for '{}': {difference}. Either an edge was lost, or an endpoint's \
+             absolute expiry passed between the export and the re-read. The \
+             pass is resumable: re-run it, and a mismatch that PERSISTS across \
+             runs is real loss",
             step.collection
         ))
     })?;

--- a/crates/velesdb-memory/src/migration/state.rs
+++ b/crates/velesdb-memory/src/migration/state.rs
@@ -68,18 +68,16 @@ pub enum CollectionProgress {
 }
 
 impl CollectionProgress {
-    /// Stage order for the never-regress rule. Skipping forward is legal — a
-    /// collection with no edges goes straight from `Facts` to `Complete` — but
-    /// any step backwards would be a journal inventing undone work.
-    fn stage_rank(self) -> u8 {
-        match self {
-            Self::Facts { .. } => 0,
-            Self::Edges => 1,
-            Self::Complete => 2,
-        }
-    }
-
     /// Whether `self` may be recorded after `previous` for one collection.
+    ///
+    /// Exactly the transitions the pass emits, and no others. An earlier
+    /// version tolerated skipping `Edges` ("a collection with no edges goes
+    /// straight to Complete") — which was FALSE: the pass journals `Edges`
+    /// unconditionally, edges or none. A tolerance the writer never uses only
+    /// widens what a BUGGY writer can make the journal swallow — a refactor
+    /// that lost the edge pass would have journalled `Complete` without a
+    /// sound. Requiring the passage through `Edges` costs the real writer
+    /// nothing and makes that bug un-journallable.
     fn may_follow(self, previous: Self) -> bool {
         match (previous, self) {
             (Self::Facts { cursor: before }, Self::Facts { cursor: after }) => {
@@ -89,7 +87,9 @@ impl CollectionProgress {
                     (None, _) => true,
                 }
             }
-            _ => self.stage_rank() >= previous.stage_rank(),
+            (Self::Facts { .. } | Self::Edges, Self::Edges)
+            | (Self::Edges | Self::Complete, Self::Complete) => true,
+            _ => false,
         }
     }
 }
@@ -120,6 +120,20 @@ pub struct MigrationState {
     /// rebuild; an extra one would journal work nobody will do. Both are
     /// refused by validation rather than tolerated.
     pub progress: std::collections::BTreeMap<String, CollectionProgress>,
+    /// A digest of what the target embedder actually PRODUCES, not what it is
+    /// called — `sha256:` over the vector it answers for a fixed sentinel
+    /// sentence. `Some` exactly when the resolved regime is `reembed`, `None`
+    /// under `reuse`, so the field also records the regime without a second
+    /// field to drift from it.
+    ///
+    /// This exists because [`MigrationState::may_resume`]'s model check
+    /// compares NAMES, and a name is a claim: `ollama pull` updates a model's
+    /// weights in place under the same identifier. A run resumed across such
+    /// an update would collide its replayed batch into run-one vectors and
+    /// write run-two vectors after it — one store, one recorded model, two
+    /// incompatible vector spaces, which is exactly what the model check says
+    /// it prevents. Vectors do not lie about the embedder that made them.
+    pub embedder_witness: Option<String>,
 }
 
 impl MigrationState {
@@ -312,7 +326,32 @@ fn validate_state_semantics(state: &MigrationState) -> Result<(), String> {
         state.target_dimension,
     )?;
     validate_progress_keys(state)?;
-    validate_phase_against_progress(state)
+    validate_phase_against_progress(state)?;
+    validate_embedder_witness(state)
+}
+
+/// A present witness must be a well-formed digest, not free text an editor
+/// could plausibly have typed.
+fn validate_embedder_witness(state: &MigrationState) -> Result<(), String> {
+    let Some(witness) = &state.embedder_witness else {
+        return Ok(());
+    };
+    let digest = witness
+        .strip_prefix("sha256:")
+        .filter(|digest| digest.len() == 64)
+        .filter(|digest| {
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    if digest.is_none() {
+        return Err(
+            "embedder_witness must be exactly 'sha256:' followed by 64 lowercase hexadecimal \
+             characters"
+                .to_owned(),
+        );
+    }
+    Ok(())
 }
 
 /// The progress map must cover exactly the agent collections.
@@ -430,6 +469,14 @@ fn validate_state_update(
         Some(format!(
             "target_dimension changed from {} to {}",
             existing.target_dimension, candidate.target_dimension
+        ))
+    } else if existing.embedder_witness != candidate.embedder_witness {
+        Some(format!(
+            "embedder_witness changed from {:?} to {:?} — either the embedder's \
+             output drifted under a stable model name, or the resolved regime \
+             flipped between runs; both make the replayed and the remaining \
+             batches incompatible",
+            existing.embedder_witness, candidate.embedder_witness
         ))
     } else {
         None

--- a/crates/velesdb-memory/src/migration/state.rs
+++ b/crates/velesdb-memory/src/migration/state.rs
@@ -34,7 +34,65 @@ pub const STATE_TEMP_FILE: &str = "migration-state.json.tmp";
 /// Bumped when the state's meaning changes. Only the current version may
 /// resume: a newer state may contain unknown decisions, while an older one may
 /// rely on guarantees this build deliberately strengthened.
-pub const STATE_FORMAT_VERSION: u32 = 2;
+///
+/// # v3 — per-collection rebuild progress (#1762, PR C2b)
+///
+/// v2 recorded the phase and nothing else, so a resumed rebuild had to start
+/// every collection from zero. v3 adds [`MigrationState::progress`], and with
+/// it two rules a v2 build never enforced: progress can only advance, and the
+/// phase cannot leave [`Phase::Prepared`] while any collection is unfinished.
+pub const STATE_FORMAT_VERSION: u32 = 3;
+
+/// How far one collection's rebuild got inside [`Phase::Prepared`].
+///
+/// Three stages, because a resume needs to answer three different questions.
+/// `Facts` says where the cursor walk stands — `cursor` is the last fact id
+/// reinserted, and `None` means the walk has not started. `Edges` says every
+/// fact landed and the edge pass is running; it carries no cursor because the
+/// pass is idempotent end to end (reinserting an existing edge answers with
+/// the same id, and the destination is verified by re-reading, so replaying it
+/// after a crash is safe where replaying half a fact walk would not be).
+/// `Complete` says both are done and a resume must not touch the collection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+pub enum CollectionProgress {
+    /// The fact walk is under way, resumable strictly after `cursor`.
+    Facts {
+        /// The last fact id reinserted at the destination; `None` = not started.
+        cursor: Option<u64>,
+    },
+    /// Every fact landed; the (idempotent) edge pass runs until `Complete`.
+    Edges,
+    /// Facts and edges are both at the destination.
+    Complete,
+}
+
+impl CollectionProgress {
+    /// Stage order for the never-regress rule. Skipping forward is legal — a
+    /// collection with no edges goes straight from `Facts` to `Complete` — but
+    /// any step backwards would be a journal inventing undone work.
+    fn stage_rank(self) -> u8 {
+        match self {
+            Self::Facts { .. } => 0,
+            Self::Edges => 1,
+            Self::Complete => 2,
+        }
+    }
+
+    /// Whether `self` may be recorded after `previous` for one collection.
+    fn may_follow(self, previous: Self) -> bool {
+        match (previous, self) {
+            (Self::Facts { cursor: before }, Self::Facts { cursor: after }) => {
+                match (before, after) {
+                    (Some(before), Some(after)) => after >= before,
+                    (Some(_), None) => false,
+                    (None, _) => true,
+                }
+            }
+            _ => self.stage_rank() >= previous.stage_rank(),
+        }
+    }
+}
 
 /// What a prepared migration recorded, so a later run can decide whether to
 /// resume it.
@@ -57,6 +115,11 @@ pub struct MigrationState {
     pub target_model: String,
     /// The width that model produces.
     pub target_dimension: usize,
+    /// How far each collection's rebuild got — exactly one entry per agent
+    /// collection, always. A missing key would silently skip a collection's
+    /// rebuild; an extra one would journal work nobody will do. Both are
+    /// refused by validation rather than tolerated.
+    pub progress: std::collections::BTreeMap<String, CollectionProgress>,
 }
 
 impl MigrationState {
@@ -216,7 +279,7 @@ fn validate_serialized_state_version(version: u64) -> Result<(), String> {
         return Ok(());
     }
     let action = if version < u64::from(STATE_FORMAT_VERSION) {
-        "This older state predates content-based source fingerprints; start a fresh diagnosis."
+        "This older state predates per-collection rebuild progress; start a fresh diagnosis."
     } else {
         "Use the version that wrote it."
     };
@@ -230,7 +293,7 @@ fn validate_current_state_version(state: &MigrationState) -> Result<(), String> 
         return Ok(());
     }
     let action = if state.format_version < STATE_FORMAT_VERSION {
-        "This older state predates content-based source fingerprints. Start a fresh diagnosis."
+        "This older state predates per-collection rebuild progress. Start a fresh diagnosis."
     } else {
         "Use the version that wrote it."
     };
@@ -247,7 +310,51 @@ fn validate_state_semantics(state: &MigrationState) -> Result<(), String> {
         &state.source_fingerprint,
         &state.target_model,
         state.target_dimension,
-    )
+    )?;
+    validate_progress_keys(state)?;
+    validate_phase_against_progress(state)
+}
+
+/// The progress map must cover exactly the agent collections.
+fn validate_progress_keys(state: &MigrationState) -> Result<(), String> {
+    for name in super::enumeration::AGENT_COLLECTIONS {
+        if !state.progress.contains_key(*name) {
+            return Err(format!(
+                "progress carries no entry for collection '{name}'; a resume would \
+                 silently skip its rebuild"
+            ));
+        }
+    }
+    for name in state.progress.keys() {
+        if !super::enumeration::AGENT_COLLECTIONS.contains(&name.as_str()) {
+            return Err(format!(
+                "progress tracks '{name}', which is not an agent collection; this \
+                 journal describes work nobody will do"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// A phase past [`Phase::Prepared`] asserts the rebuild is finished, so every
+/// collection must say so too — otherwise the journal contradicts itself and
+/// a later phase would validate, archive, or activate a half-built store.
+fn validate_phase_against_progress(state: &MigrationState) -> Result<(), String> {
+    if state.phase == Phase::Prepared {
+        return Ok(());
+    }
+    for (name, progress) in &state.progress {
+        if *progress != CollectionProgress::Complete {
+            return Err(format!(
+                "phase {:?} asserts the rebuild is finished, but collection \
+                 '{name}' stands at {progress:?}; the phase cannot leave \
+                 {:?} while any collection is unfinished",
+                state.phase,
+                Phase::Prepared,
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validate_migration_identity(
@@ -337,6 +444,29 @@ fn validate_state_update(
             "refusing migration phase transition from {:?} to {:?}: journal updates may be idempotent or advance exactly one phase, never regress or skip work",
             existing.phase, candidate.phase
         ));
+    }
+    validate_progress_advance(existing, candidate)
+}
+
+/// Progress may repeat or advance per collection, never regress.
+///
+/// Key equality between the two maps is already established: both states
+/// passed [`validate_progress_keys`] before reaching this comparison.
+fn validate_progress_advance(
+    existing: &MigrationState,
+    candidate: &MigrationState,
+) -> Result<(), String> {
+    for (name, after) in &candidate.progress {
+        let Some(before) = existing.progress.get(name) else {
+            continue;
+        };
+        if !after.may_follow(*before) {
+            return Err(format!(
+                "refusing progress regression on collection '{name}': the journal \
+                 records {before:?} and the update asserts {after:?}; a rebuild \
+                 journal may repeat or advance, never regress"
+            ));
+        }
     }
     Ok(())
 }

--- a/crates/velesdb-memory/src/migration/tests/cli.rs
+++ b/crates/velesdb-memory/src/migration/tests/cli.rs
@@ -91,19 +91,49 @@ fn force_reuse_is_refused_at_the_command_line_and_not_only_in_the_rule() {
 }
 
 #[test]
-fn anything_that_is_not_a_dry_run_is_refused_rather_than_silently_doing_nothing() {
+fn a_rebuild_without_a_named_destination_is_refused_rather_than_guessing_one() {
+    // This test used to pin `require_dry_run` — "anything that is not a dry
+    // run is refused", because nothing else was wired. PR C2b wired the
+    // rebuild, so the premise moved: a non-dry-run now RUNS, and what must
+    // still be refused is running it without the operator naming where the
+    // rebuilt store goes. A guessed destination is a directory a later switch
+    // would rename over the live store.
     let asked_for_a_migration = parse_migrate_args(&args(&["--strategy", "auto"])).expect("flags");
 
-    let refusal = require_dry_run(&asked_for_a_migration)
-        .expect_err("a non-dry-run invocation must be refused in this version");
-
+    let refusal = require_destination(&asked_for_a_migration)
+        .expect_err("a rebuild must not invent its own destination");
     assert!(
-        refusal.contains("--dry-run") && refusal.contains("#1762"),
-        "the refusal must name the supported mode and where the rest is tracked: {refusal}"
+        refusal.contains("--destination") && refusal.contains("--dry-run"),
+        "the refusal must name the missing flag and the diagnose-only alternative: {refusal}"
     );
 
-    require_dry_run(&parse_migrate_args(&args(&["--dry-run"])).expect("flags"))
-        .expect("a dry run must be accepted");
+    let named = parse_migrate_args(&args(&["--destination", "/rebuilt"])).expect("flags");
+    assert_eq!(
+        require_destination(&named).expect("a named destination must be accepted"),
+        std::path::PathBuf::from("/rebuilt"),
+        "the destination handed back must be the one the operator named"
+    );
+}
+
+#[test]
+fn the_switch_boundary_message_says_what_did_not_happen() {
+    // The success message of a non-dry-run is load-bearing: `execute` stops at
+    // a rebuilt-but-unswitched destination, and an operator who reads its
+    // output as "migration done" will point their daemon at the OLD store and
+    // wonder where the new vectors went. The message must therefore say, in so
+    // many words, that nothing was validated and nothing was switched.
+    let boundary = not_yet_switchable();
+    for needle in [
+        "NOT been validated",
+        "NOT been switched",
+        "#1762",
+        "source store is still",
+    ] {
+        assert!(
+            boundary.contains(needle),
+            "the boundary message must contain '{needle}': {boundary}"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-memory/src/migration/tests/execute.rs
+++ b/crates/velesdb-memory/src/migration/tests/execute.rs
@@ -47,16 +47,38 @@ fn contents(dir: &std::path::Path) -> BTreeMap<u64, serde_json::Value> {
         .collect()
 }
 
-fn run(root: &std::path::Path) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
-    let embedder = HashEmbedder::new(NEW_DIM);
+fn run_with(
+    root: &std::path::Path,
+    embedder: &dyn crate::Embedder,
+) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
     super::super::execute(
         &root.join("store"),
         root,
         &TargetContract::automatic("hash", NEW_DIM),
         &root.join("rebuilt"),
-        &embedder,
+        embedder,
         1024,
     )
+}
+
+fn run(root: &std::path::Path) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
+    run_with(root, &HashEmbedder::new(NEW_DIM))
+}
+
+/// The same dimension, the same claimed identity, DIFFERENT vectors — what an
+/// in-place model update looks like from the outside.
+struct DriftedEmbedder(HashEmbedder);
+
+impl crate::Embedder for DriftedEmbedder {
+    fn dimension(&self) -> usize {
+        self.0.dimension()
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, crate::EmbedError> {
+        let mut vector = self.0.embed(text)?;
+        vector[0] += 1.0;
+        Ok(vector)
+    }
 }
 
 #[test]
@@ -119,6 +141,31 @@ fn a_second_execute_resumes_the_journal_and_replays_nothing() {
         contents(&first.destination),
         "the destination must be untouched by the no-op resume"
     );
+}
+
+#[test]
+fn a_resume_across_an_embedder_updated_in_place_is_refused_by_its_witness() {
+    // `may_resume` compares the model's NAME, and a name is a claim: `ollama
+    // pull` replaces a model's weights under the same identifier. A resume
+    // across such an update would leave the replayed batches with run-one
+    // vectors and write run-two vectors after them — one store, one recorded
+    // model, two incompatible vector spaces. The journal therefore carries a
+    // WITNESS of what the embedder produces, and this is the test that the
+    // witness actually refuses.
+    let root = root_with_source();
+    run(root.path()).expect("first execute");
+
+    let refusal = run_with(root.path(), &DriftedEmbedder(HashEmbedder::new(NEW_DIM)))
+        .expect_err("same name, same dimension, different vectors must refuse the resume");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("witness") && message.contains("fresh migration"),
+        "the refusal must name the witness and the recovery: {message}"
+    );
+
+    // Positive control: the UNCHANGED embedder still resumes — so the refusal
+    // above was about the vectors, not about resuming per se.
+    run(root.path()).expect("the same embedder must still resume");
 }
 
 #[test]

--- a/crates/velesdb-memory/src/migration/tests/execute.rs
+++ b/crates/velesdb-memory/src/migration/tests/execute.rs
@@ -1,0 +1,203 @@
+//! GATE 8 — the operator's path (#1762, PR C2b).
+//!
+//! [`rebuild`](super::super::rebuild) is proven on handles a test staged by
+//! hand. An operator has none of that: they have a store path, a destination
+//! path and an embedder. `execute` is the distance between the two — diagnose,
+//! resolve the regime, stage the destination and the journal, take the lock,
+//! run the pass, release the lock — and each of these tests pins one refusal
+//! or one guarantee of that staging, because staging is exactly where a
+//! "proven" pass gets driven with the wrong inputs.
+
+use super::*;
+use crate::embedder::HashEmbedder;
+use crate::storage::NativeStore;
+use crate::MemoryStore;
+use std::collections::BTreeMap;
+
+const NEW_DIM: usize = 8;
+const SEEDED: u64 = 5;
+
+/// A root holding the source store at `store/`, leaving room for a sibling
+/// destination on the same filesystem — the layout the switch (C3) requires.
+fn root_with_source() -> tempfile::TempDir {
+    let root = tempfile::tempdir().expect("root");
+    let store = root.path().join("store");
+    std::fs::create_dir(&store).expect("mkdir store");
+    {
+        let native = NativeStore::open(&store, DIM).expect("open source");
+        for id in 1..=SEEDED {
+            native
+                .store_with_metadata(id, &format!("fact number {id}"), &EMBEDDING, &meta(&[]))
+                .expect("seed");
+        }
+        native.relate(1, 2, "mentions").expect("edge");
+    }
+    root
+}
+
+fn contents(dir: &std::path::Path) -> BTreeMap<u64, serde_json::Value> {
+    super::preservation::read_out(dir, "_semantic_memory")
+        .iter()
+        .map(|fact| {
+            (
+                fact.id,
+                serde_json::from_str(&fact.payload).expect("payload json"),
+            )
+        })
+        .collect()
+}
+
+fn run(root: &std::path::Path) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
+    let embedder = HashEmbedder::new(NEW_DIM);
+    super::super::execute(
+        &root.join("store"),
+        root,
+        &TargetContract::automatic("hash", NEW_DIM),
+        &root.join("rebuilt"),
+        &embedder,
+        1024,
+    )
+}
+
+#[test]
+fn execute_rebuilds_into_the_destination_and_releases_the_lock() {
+    let root = root_with_source();
+    let outcome = run(root.path()).expect("execute");
+
+    assert_eq!(outcome.rebuild.facts, SEEDED, "every fact must land");
+    assert_eq!(outcome.rebuild.edges, 1, "the edge must land");
+    assert_eq!(
+        contents(&outcome.destination),
+        contents(&root.path().join("store")),
+        "the destination must hold the same facts as the source"
+    );
+
+    let journalled = MigrationState::read(&outcome.workspace)
+        .expect("read journal")
+        .expect("journal exists");
+    assert_eq!(
+        journalled.phase,
+        Phase::Prepared,
+        "execute stops at Prepared"
+    );
+    assert!(
+        journalled
+            .progress
+            .values()
+            .all(|p| *p == CollectionProgress::Complete),
+        "the journal must record completion, got {:?}",
+        journalled.progress
+    );
+
+    // The lock must be RELEASED, not dropped: a dropped lock leaves canonical
+    // evidence that blocks every later run until an operator removes it by
+    // hand, and there is nothing to acknowledge after a clean success.
+    MigrationLock::acquire(&outcome.workspace, "the-next-run")
+        .expect("a clean success must leave the workspace reacquirable")
+        .release()
+        .expect("release probe lock");
+}
+
+#[test]
+fn a_second_execute_resumes_the_journal_and_replays_nothing() {
+    let root = root_with_source();
+    let first = run(root.path()).expect("first execute");
+    let second = run(root.path()).expect("second execute must resume, not refuse");
+
+    assert_eq!(
+        (
+            second.rebuild.facts,
+            second.rebuild.collisions,
+            second.rebuild.edges
+        ),
+        (0, 0, 0),
+        "a journal at Complete has nothing to replay; any nonzero count means \
+         the resume re-did work the journal already recorded"
+    );
+    assert_eq!(
+        contents(&second.destination),
+        contents(&first.destination),
+        "the destination must be untouched by the no-op resume"
+    );
+}
+
+#[test]
+fn a_nonempty_destination_without_a_journal_is_refused() {
+    let root = root_with_source();
+    let destination = root.path().join("rebuilt");
+    std::fs::create_dir(&destination).expect("mkdir destination");
+    std::fs::write(destination.join("stray.txt"), b"not a rebuild").expect("stray file");
+
+    let refusal =
+        run(root.path()).expect_err("rebuilding into a directory that already holds something");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("rebuilt"),
+        "the refusal must name the destination: {message}"
+    );
+    assert!(
+        std::fs::read(destination.join("stray.txt")).is_ok(),
+        "a refusal must not have touched the directory it refused"
+    );
+}
+
+#[test]
+fn settling_a_store_is_idempotent_which_the_resume_fingerprint_rests_on() {
+    // Measured 2026-08-05: the FIRST open of a store compacts its WAL —
+    // `vectors.wal` drains into materialised index files — so the on-disk tree
+    // after an open is not the tree before it. `execute` therefore settles the
+    // source with one open BEFORE fingerprinting, and journals the settled
+    // fingerprint. That design is sound only while a SECOND open changes
+    // nothing, which is exactly what this test pins. (That the first open
+    // changes the tree is incidental engine behaviour and deliberately NOT
+    // asserted: if the engine ever stops compacting on open, the settle
+    // becomes a harmless no-op and this test must keep passing.)
+    let root = root_with_source();
+    let store = root.path().join("store");
+    {
+        let _db = velesdb_core::Database::open(&store).expect("first open settles");
+    }
+    let settled = super::super::fingerprint(&store).expect("settled fingerprint");
+    {
+        let db = velesdb_core::Database::open(&store).expect("second open");
+        let _ = super::super::enumerate_by_cursor(&db, "_semantic_memory", 16).expect("walk");
+    }
+    assert_eq!(
+        super::super::fingerprint(&store).expect("fingerprint after reopen"),
+        settled,
+        "a second open (with a full cursor walk) must leave the settled tree \
+         byte-identical; if this ever fails, the journalled fingerprint can no \
+         longer prove the source unchanged across a resume, and `execute`'s \
+         settle-then-fingerprint design is void"
+    );
+}
+
+#[test]
+fn a_refusing_regime_stops_execute_before_anything_is_created() {
+    let root = root_with_source();
+    let embedder = HashEmbedder::new(NEW_DIM);
+    // `reuse` against a store with no recorded provenance: the resolution is
+    // Refuse, and execute must relay it rather than "helpfully" re-embedding.
+    let refusal = super::super::execute(
+        &root.path().join("store"),
+        root.path(),
+        &TargetContract {
+            model: "hash".to_owned(),
+            dimension: NEW_DIM,
+            strategy: Strategy::Reuse,
+        },
+        &root.path().join("rebuilt"),
+        &embedder,
+        1024,
+    )
+    .expect_err("a refused regime must refuse the execution");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("reuse"),
+        "the refusal must name the requested regime: {message}"
+    );
+    assert!(
+        !root.path().join("rebuilt").exists(),
+        "a regime refusal must not leave a half-created destination behind"
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -27,6 +27,9 @@ use serde_json::Value;
 use std::collections::BTreeSet;
 
 mod diagnostic_copy;
+mod execute;
+mod rebuild;
+mod rebuild_state;
 mod state_persistence;
 
 const DIM: usize = 4;

--- a/crates/velesdb-memory/src/migration/tests/rebuild.rs
+++ b/crates/velesdb-memory/src/migration/tests/rebuild.rs
@@ -90,6 +90,7 @@ fn fresh_state() -> MigrationState {
         source_fingerprint: super::state_persistence::VALID_FINGERPRINT.to_owned(),
         target_model: "hash".to_owned(),
         target_dimension: NEW_DIM,
+        embedder_witness: None,
         progress: AGENT_COLLECTIONS
             .iter()
             .map(|name| {
@@ -293,6 +294,77 @@ fn an_interrupted_rebuild_resumes_replaying_only_the_unjournalled_batch() {
         edge_tuples(dest.path(), NEW_DIM),
         edge_tuples(source.path(), DIM),
         "and every edge"
+    );
+}
+
+#[test]
+fn an_interruption_past_the_first_checkpoint_resumes_from_the_journalled_cursor() {
+    // The test above stops after batch ONE, whose checkpoint is `cursor: None`
+    // — so its "resume" is byte-identical to starting over, and a `walk_facts`
+    // that IGNORED its cursor argument would pass it. This one stops after
+    // batch TWO: the journal holds batch one's real cursor, and the exact
+    // counts below are what pin the cursor as actually used. SEEDED = 7 and
+    // BATCH = 3 give batches of 3+3+1; a stop after the second leaves 6 facts
+    // at the destination and one journalled checkpoint.
+    let source = seeded_source();
+    let state = fresh_state();
+    let (dest, workspace, lock) = prepared_destination(&state);
+    let embedder = HashEmbedder::new(NEW_DIM);
+    let policy = super::super::VectorPolicy::Reembed(&embedder);
+
+    drive(
+        source.path(),
+        dest.path(),
+        NEW_DIM,
+        (workspace.path(), &lock),
+        &mut state.clone(),
+        &policy,
+        Some(2),
+    )
+    .expect_err("the injected stop must interrupt after the second batch");
+
+    let journalled = MigrationState::read(workspace.path())
+        .expect("read journal")
+        .expect("journal exists");
+    let Some(CollectionProgress::Facts { cursor: Some(_) }) =
+        journalled.progress.get("_semantic_memory").copied()
+    else {
+        panic!(
+            "positive control: batch one's checkpoint must be journalled as a \
+             REAL cursor, or this test degenerates into the one above; got {:?}",
+            journalled.progress.get("_semantic_memory")
+        );
+    };
+
+    let mut resumed = journalled;
+    let outcome = drive(
+        source.path(),
+        dest.path(),
+        NEW_DIM,
+        (workspace.path(), &lock),
+        &mut resumed,
+        &policy,
+        None,
+    )
+    .expect("resume");
+
+    let batch = u64::try_from(BATCH).expect("batch fits");
+    assert_eq!(
+        outcome.collisions, batch,
+        "exactly the ONE unjournalled batch is replayed: more collisions means \
+         the cursor was ignored and the walk started over; fewer means part of \
+         the replayed batch went missing"
+    );
+    assert_eq!(
+        outcome.facts,
+        SEEDED - 2 * batch,
+        "only the facts past the interrupted batch are new; anything else \
+         means the cursor did not resume where the journal said"
+    );
+    assert_eq!(
+        contents(dest.path()),
+        contents(source.path()),
+        "after the resume the destination must hold every fact exactly once"
     );
 }
 

--- a/crates/velesdb-memory/src/migration/tests/rebuild.rs
+++ b/crates/velesdb-memory/src/migration/tests/rebuild.rs
@@ -1,0 +1,405 @@
+//! GATE 7 — the rebuild itself (#1762, PR C2b).
+//!
+//! Everything before this file proves the PARTS: facts read out whole and go
+//! back whole, edges likewise, the journal can only advance. This file proves
+//! the PASS — the loop that drives those parts over a real store, checkpoints
+//! after every batch, survives being killed at the worst moment, and lands a
+//! destination that re-reads identical to the source.
+//!
+//! The interruption tests use an injected stop rather than a real kill because
+//! the property under test is WHERE the pass can stop, not whether the OS can
+//! stop it. The stop fires after a batch is reinserted and BEFORE its
+//! checkpoint is journalled — the widest window a crash can hit — so the
+//! resume must replay that batch and tolerate its collisions.
+
+use super::*;
+use crate::embedder::HashEmbedder;
+use crate::storage::NativeStore;
+use crate::MemoryStore;
+use std::collections::BTreeMap;
+use velesdb_core::agent::AgentMemory;
+
+/// Source facts, deliberately more than one batch at [`BATCH`].
+const SEEDED: u64 = 7;
+/// Small enough that the walk takes several batches, so a checkpoint exists
+/// between two of them for the interruption test to land in.
+const BATCH: usize = 3;
+const NEW_DIM: usize = 8;
+
+fn open_pair(
+    dir: &std::path::Path,
+    dimension: usize,
+) -> (std::sync::Arc<velesdb_core::Database>, AgentMemory) {
+    let db = std::sync::Arc::new(velesdb_core::Database::open(dir).expect("open db"));
+    let memory =
+        AgentMemory::with_dimension(std::sync::Arc::clone(&db), dimension).expect("agent memory");
+    (db, memory)
+}
+
+/// A seeded source: SEEDED facts with metadata, one TTL'd fact, and two edges,
+/// one of which carries properties.
+fn seeded_source() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let store = NativeStore::open(dir.path(), DIM).expect("open source");
+        for id in 1..=SEEDED {
+            store
+                .store_with_metadata(
+                    id,
+                    &format!("fact number {id}"),
+                    &EMBEDDING,
+                    &meta(&[("topic", serde_json::Value::from("rebuild"))]),
+                )
+                .expect("seed");
+        }
+        store.relate(1, 2, "mentions").expect("edge");
+    }
+    // One edge with properties, through the core API the reduced trait hides.
+    let (_db, memory) = open_pair(dir.path(), DIM);
+    let mut props = serde_json::Map::new();
+    props.insert("weight".to_owned(), serde_json::Value::from(0.5));
+    memory
+        .semantic()
+        .relate(2, 3, "supports", Some(&props))
+        .expect("edge with properties");
+    dir
+}
+
+/// An empty destination sized for the target embedder, plus a journal
+/// workspace, plus the initial `Prepared` journal entry.
+fn prepared_destination(
+    state_template: &MigrationState,
+) -> (tempfile::TempDir, tempfile::TempDir, MigrationLock) {
+    let dest = tempfile::tempdir().expect("destination");
+    {
+        let _store = NativeStore::open(dest.path(), NEW_DIM).expect("create destination");
+    }
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = MigrationLock::acquire(workspace.path(), "rebuild-test").expect("lock");
+    state_template
+        .write(workspace.path(), &lock)
+        .expect("initial journal entry");
+    (dest, workspace, lock)
+}
+
+fn fresh_state() -> MigrationState {
+    MigrationState {
+        format_version: STATE_FORMAT_VERSION,
+        phase: Phase::Prepared,
+        source_path: std::path::PathBuf::from("/store"),
+        source_fingerprint: super::state_persistence::VALID_FINGERPRINT.to_owned(),
+        target_model: "hash".to_owned(),
+        target_dimension: NEW_DIM,
+        progress: AGENT_COLLECTIONS
+            .iter()
+            .map(|name| {
+                (
+                    (*name).to_owned(),
+                    CollectionProgress::Facts { cursor: None },
+                )
+            })
+            .collect(),
+    }
+}
+
+/// Ids and payloads of every live fact, keyed for comparison.
+fn contents(dir: &std::path::Path) -> BTreeMap<u64, serde_json::Value> {
+    super::preservation::read_out(dir, "_semantic_memory")
+        .iter()
+        .map(|fact| {
+            (
+                fact.id,
+                serde_json::from_str(&fact.payload).expect("payload json"),
+            )
+        })
+        .collect()
+}
+
+fn edge_tuples(dir: &std::path::Path, dimension: usize) -> std::collections::BTreeSet<String> {
+    let (db, memory) = open_pair(dir, dimension);
+    super::super::export_edges_verified(&memory, &db, "_semantic_memory", 1024)
+        .expect("edge export")
+        .iter()
+        .map(|edge| {
+            format!(
+                "{}:{}:{}:{}:{:?}",
+                edge.id(),
+                edge.source(),
+                edge.target(),
+                edge.label(),
+                edge.properties().iter().collect::<BTreeMap<_, _>>()
+            )
+        })
+        .collect()
+}
+
+/// Open both stores, run one pass, and drop every handle before returning —
+/// the store's single-writer flock means any verification must reopen, so no
+/// handle may outlive the run it served.
+fn drive(
+    source: &std::path::Path,
+    dest: &std::path::Path,
+    dest_dim: usize,
+    journal: (&std::path::Path, &MigrationLock),
+    state: &mut MigrationState,
+    policy: &super::super::VectorPolicy<'_>,
+    stop: Option<u64>,
+) -> Result<super::super::RebuildOutcome, crate::MemoryError> {
+    let (source_db, source_memory) = open_pair(source, DIM);
+    let (dest_db, dest_memory) = open_pair(dest, dest_dim);
+    super::super::rebuild_with_stop(
+        &super::super::RebuildSource {
+            db: &source_db,
+            memory: &source_memory,
+        },
+        &super::super::RebuildDestination {
+            db: &dest_db,
+            memory: &dest_memory,
+        },
+        state,
+        &super::super::RebuildJournal {
+            workspace: journal.0,
+            lock: journal.1,
+        },
+        policy,
+        BATCH,
+        stop,
+    )
+}
+
+#[test]
+fn a_full_rebuild_lands_every_fact_and_edge_and_journals_completion() {
+    let source = seeded_source();
+    let mut state = fresh_state();
+    let (dest, workspace, lock) = prepared_destination(&state);
+
+    let embedder = HashEmbedder::new(NEW_DIM);
+    let outcome = drive(
+        source.path(),
+        dest.path(),
+        NEW_DIM,
+        (workspace.path(), &lock),
+        &mut state,
+        &super::super::VectorPolicy::Reembed(&embedder),
+        None,
+    )
+    .expect("rebuild");
+
+    assert_eq!(
+        outcome.facts, SEEDED,
+        "every live fact must land exactly once on a clean run"
+    );
+    assert_eq!(
+        outcome.collisions, 0,
+        "a clean run replays nothing, so a collision here means the walk \
+         re-read a fact it had already written"
+    );
+    assert_eq!(outcome.edges, 2, "both edges must land");
+
+    assert_eq!(
+        contents(dest.path()),
+        contents(source.path()),
+        "the destination must hold the same facts, ids and payloads included"
+    );
+    assert_eq!(
+        edge_tuples(dest.path(), NEW_DIM),
+        edge_tuples(source.path(), DIM),
+        "the destination must hold the same edge tuples, properties included"
+    );
+
+    // The journal on disk — not the in-memory copy — must say Complete for
+    // every collection: a resume reads the disk.
+    let journalled = MigrationState::read(workspace.path())
+        .expect("read journal")
+        .expect("journal exists");
+    assert!(
+        journalled
+            .progress
+            .values()
+            .all(|p| *p == CollectionProgress::Complete),
+        "the journal must record completion, got {:?}",
+        journalled.progress
+    );
+}
+
+#[test]
+fn an_interrupted_rebuild_resumes_replaying_only_the_unjournalled_batch() {
+    let source = seeded_source();
+    let state = fresh_state();
+    let (dest, workspace, lock) = prepared_destination(&state);
+    let embedder = HashEmbedder::new(NEW_DIM);
+    let policy = super::super::VectorPolicy::Reembed(&embedder);
+
+    // First run: killed after the FIRST batch is written to the destination
+    // but before its checkpoint reaches the journal — the widest crash window.
+    let interrupted = drive(
+        source.path(),
+        dest.path(),
+        NEW_DIM,
+        (workspace.path(), &lock),
+        &mut state.clone(),
+        &policy,
+        Some(1),
+    )
+    .expect_err("the injected stop must surface as an interruption");
+    assert!(
+        interrupted.to_string().contains("interrupted"),
+        "the stop must be reported as an interruption, got: {interrupted}"
+    );
+
+    // What the journal knows is LESS than what the destination holds: that is
+    // the crash window, and the positive control for the replay below.
+    let journalled = MigrationState::read(workspace.path())
+        .expect("read journal")
+        .expect("journal exists");
+    let semantic = journalled.progress.get("_semantic_memory").copied();
+    assert_eq!(
+        semantic,
+        Some(CollectionProgress::Facts { cursor: None }),
+        "the interrupted batch must NOT be journalled — if it were, the resume \
+         below would replay nothing and this test would prove nothing"
+    );
+    assert!(
+        !contents(dest.path()).is_empty(),
+        "positive control: the destination must already hold the batch the \
+         journal does not know about"
+    );
+
+    // Resume from the journal on disk, exactly as a fresh process would.
+    let mut resumed = journalled;
+    let outcome = drive(
+        source.path(),
+        dest.path(),
+        NEW_DIM,
+        (workspace.path(), &lock),
+        &mut resumed,
+        &policy,
+        None,
+    )
+    .expect("resume");
+
+    assert!(
+        outcome.collisions > 0,
+        "positive control: the resume must have replayed the unjournalled \
+         batch and met its ids; zero collisions would mean the crash window \
+         was never exercised"
+    );
+    assert_eq!(
+        contents(dest.path()),
+        contents(source.path()),
+        "after the resume the destination must hold every fact exactly once"
+    );
+    assert_eq!(
+        edge_tuples(dest.path(), NEW_DIM),
+        edge_tuples(source.path(), DIM),
+        "and every edge"
+    );
+}
+
+#[test]
+fn reuse_writes_the_source_vectors_verbatim() {
+    let source = seeded_source();
+    let mut state = fresh_state();
+    state.target_dimension = DIM;
+    let dest = tempfile::tempdir().expect("destination");
+    {
+        let _store = NativeStore::open(dest.path(), DIM).expect("create destination");
+    }
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = MigrationLock::acquire(workspace.path(), "reuse-test").expect("lock");
+    state.write(workspace.path(), &lock).expect("initial entry");
+
+    drive(
+        source.path(),
+        dest.path(),
+        DIM,
+        (workspace.path(), &lock),
+        &mut state,
+        &super::super::VectorPolicy::Reuse,
+        None,
+    )
+    .expect("rebuild under reuse");
+
+    let source_vectors: BTreeMap<u64, Vec<f32>> =
+        super::preservation::read_out(source.path(), "_semantic_memory")
+            .into_iter()
+            .map(|fact| (fact.id, fact.source_vector))
+            .collect();
+    let dest_vectors: BTreeMap<u64, Vec<f32>> =
+        super::preservation::read_out(dest.path(), "_semantic_memory")
+            .into_iter()
+            .map(|fact| (fact.id, fact.source_vector))
+            .collect();
+    assert_eq!(
+        dest_vectors, source_vectors,
+        "under reuse the destination must carry the source's vectors verbatim; \
+         anything else is a re-embedding the regime did not license"
+    );
+}
+
+#[test]
+fn a_fact_without_content_text_fails_reembed_by_name_and_passes_reuse() {
+    let source = tempfile::tempdir().expect("tempdir");
+    {
+        let store = NativeStore::open(source.path(), DIM).expect("open source");
+        store
+            .store_with_metadata(1, "an ordinary fact", &EMBEDDING, &meta(&[]))
+            .expect("seed");
+    }
+    {
+        // A payload with no `content` key, written straight to the collection —
+        // the shape an external writer can produce and `reembed` cannot serve.
+        let db = velesdb_core::Database::open(source.path()).expect("open");
+        let any = db
+            .get_any_collection("_semantic_memory")
+            .expect("collection");
+        any.upsert(vec![velesdb_core::Point::new(
+            2,
+            EMBEDDING.to_vec(),
+            Some(serde_json::json!({ "note": "no content key here" })),
+        )])
+        .expect("raw upsert");
+    }
+
+    let embedder = HashEmbedder::new(NEW_DIM);
+    let run = |policy: &super::super::VectorPolicy<'_>, dimension: usize| {
+        let mut state = fresh_state();
+        state.target_dimension = dimension;
+        let dest = tempfile::tempdir().expect("destination");
+        {
+            let _store = NativeStore::open(dest.path(), dimension).expect("create destination");
+        }
+        let workspace = tempfile::tempdir().expect("workspace");
+        let lock = MigrationLock::acquire(workspace.path(), "content-test").expect("lock");
+        state.write(workspace.path(), &lock).expect("initial entry");
+        let (source_db, source_memory) = open_pair(source.path(), DIM);
+        let (dest_db, dest_memory) = open_pair(dest.path(), dimension);
+        super::super::rebuild(
+            &super::super::RebuildSource {
+                db: &source_db,
+                memory: &source_memory,
+            },
+            &super::super::RebuildDestination {
+                db: &dest_db,
+                memory: &dest_memory,
+            },
+            &mut state,
+            &super::super::RebuildJournal {
+                workspace: workspace.path(),
+                lock: &lock,
+            },
+            policy,
+            BATCH,
+        )
+    };
+
+    let refusal = run(&super::super::VectorPolicy::Reembed(&embedder), NEW_DIM)
+        .expect_err("a fact `reembed` cannot serve must stop the pass, not be skipped");
+    assert!(
+        refusal.to_string().contains('2'),
+        "the refusal must name the fact: {refusal}"
+    );
+
+    run(&super::super::VectorPolicy::Reuse, DIM)
+        .expect("under reuse the same store rebuilds — content is never needed");
+}

--- a/crates/velesdb-memory/src/migration/tests/rebuild_state.rs
+++ b/crates/velesdb-memory/src/migration/tests/rebuild_state.rs
@@ -3,10 +3,11 @@
 //! v2 recorded WHERE a migration stood (its phase) but nothing about how far
 //! the work inside `Prepared` had progressed: a resumed rebuild would have had
 //! to start every collection from zero and re-answer every collision. v3 adds
-//! per-collection progress, and these tests pin the three properties that make
-//! it a journal rather than a scratchpad: it round-trips exactly, it can only
-//! advance, and the phase cannot leave `Prepared` while any collection is
-//! unfinished.
+//! per-collection progress, and these tests pin the properties that make it a
+//! journal rather than a scratchpad: it round-trips exactly, it can only
+//! advance ALONG THE TRANSITIONS THE PASS ACTUALLY EMITS (`Facts → Edges →
+//! Complete`, never skipping `Edges`), and the phase cannot leave `Prepared`
+//! while any collection is unfinished.
 
 use super::state_persistence::VALID_FINGERPRINT;
 use super::*;
@@ -26,6 +27,7 @@ fn state_with_progress(progress: BTreeMap<String, CollectionProgress>) -> Migrat
         target_model: diagnosis::TARGET_MODEL.to_owned(),
         target_dimension: diagnosis::TARGET_DIM,
         progress,
+        embedder_witness: None,
     }
 }
 
@@ -47,24 +49,29 @@ fn mixed_progress_round_trips_byte_exactly_through_write_and_read() {
     let lock = lock(workspace.path());
 
     // Every stage is represented at once, because the bug this guards against
-    // is a serde attribute that flattens one variant into another.
-    let mut progress = fresh_progress();
-    progress.insert(
+    // is a serde attribute that flattens one variant into another. The mixed
+    // shape is reached through the pass's own transitions — a journal must
+    // begin at the beginning and may not skip Edges.
+    let mut step = fresh_progress();
+    step.insert(
         "_semantic_memory".to_owned(),
         CollectionProgress::Facts { cursor: Some(42) },
     );
-    progress.insert("_episodic_memory".to_owned(), CollectionProgress::Edges);
-    progress.insert(
+    step.insert("_episodic_memory".to_owned(), CollectionProgress::Edges);
+    step.insert("_procedural_memory".to_owned(), CollectionProgress::Edges);
+    let mut mixed = step.clone();
+    mixed.insert(
         "_procedural_memory".to_owned(),
         CollectionProgress::Complete,
     );
-    let written = state_with_progress(progress);
+    let written = state_with_progress(mixed);
 
-    // A journal must begin at the beginning: seed the initial entry first,
-    // then advance to the mixed shape.
     state_with_progress(fresh_progress())
         .write(workspace.path(), &lock)
         .expect("initial write");
+    state_with_progress(step)
+        .write(workspace.path(), &lock)
+        .expect("advance through edges");
     written.write(workspace.path(), &lock).expect("advance");
 
     let read = MigrationState::read(workspace.path())
@@ -157,12 +164,30 @@ fn progress_may_advance_or_repeat_but_never_regress() {
         );
     }
 
+    // Skipping the Edges stage is REFUSED, not tolerated as "forward". The
+    // pass journals Edges unconditionally, so no honest writer ever produces
+    // Facts→Complete — only a writer that lost its edge pass would, and that
+    // is precisely the bug this refusal makes un-journallable.
+    let mut skipped = current.clone();
+    skipped.insert("_semantic_memory".to_owned(), CollectionProgress::Complete);
+    let refusal = state_with_progress(skipped)
+        .write(workspace.path(), &lock)
+        .expect_err("Complete without passing through Edges means the edge pass never ran");
+    assert!(
+        refusal.contains("_semantic_memory"),
+        "the refusal must name the collection: {refusal}"
+    );
+
     // ...and a finished stage cannot be reopened.
     let mut done = current.clone();
+    done.insert("_semantic_memory".to_owned(), CollectionProgress::Edges);
+    state_with_progress(done.clone())
+        .write(workspace.path(), &lock)
+        .expect("facts to edges is the pass's own transition");
     done.insert("_semantic_memory".to_owned(), CollectionProgress::Complete);
     state_with_progress(done.clone())
         .write(workspace.path(), &lock)
-        .expect("skip to complete is forward");
+        .expect("edges to complete is the pass's own transition");
     let mut reopened = done;
     reopened.insert("_semantic_memory".to_owned(), CollectionProgress::Edges);
     let refusal = state_with_progress(reopened)
@@ -178,7 +203,13 @@ fn progress_may_advance_or_repeat_but_never_regress() {
 fn the_phase_cannot_leave_prepared_while_any_collection_is_unfinished() {
     let workspace = tempfile::tempdir().expect("workspace");
     let lock = lock(workspace.path());
-    let mut almost = fresh_progress();
+    // Reached through the pass's own transitions: everything to Edges, then
+    // everything but episodic to Complete.
+    let mut edging = BTreeMap::new();
+    for name in AGENT_COLLECTIONS {
+        edging.insert((*name).to_owned(), CollectionProgress::Edges);
+    }
+    let mut almost = edging.clone();
     for name in AGENT_COLLECTIONS {
         almost.insert((*name).to_owned(), CollectionProgress::Complete);
     }
@@ -187,6 +218,9 @@ fn the_phase_cannot_leave_prepared_while_any_collection_is_unfinished() {
     state_with_progress(fresh_progress())
         .write(workspace.path(), &lock)
         .expect("initial write");
+    state_with_progress(edging)
+        .write(workspace.path(), &lock)
+        .expect("advance to edges");
     state_with_progress(almost.clone())
         .write(workspace.path(), &lock)
         .expect("advance");

--- a/crates/velesdb-memory/src/migration/tests/rebuild_state.rs
+++ b/crates/velesdb-memory/src/migration/tests/rebuild_state.rs
@@ -1,0 +1,244 @@
+//! GATE 6 — the journal knows how far the rebuild got (#1762, PR C2b).
+//!
+//! v2 recorded WHERE a migration stood (its phase) but nothing about how far
+//! the work inside `Prepared` had progressed: a resumed rebuild would have had
+//! to start every collection from zero and re-answer every collision. v3 adds
+//! per-collection progress, and these tests pin the three properties that make
+//! it a journal rather than a scratchpad: it round-trips exactly, it can only
+//! advance, and the phase cannot leave `Prepared` while any collection is
+//! unfinished.
+
+use super::state_persistence::VALID_FINGERPRINT;
+use super::*;
+use std::collections::BTreeMap;
+
+fn lock(workspace: &std::path::Path) -> MigrationLock {
+    MigrationLock::acquire(workspace, "rebuild-state-test").expect("lock")
+}
+
+/// A v3 state with explicit per-collection progress.
+fn state_with_progress(progress: BTreeMap<String, CollectionProgress>) -> MigrationState {
+    MigrationState {
+        format_version: STATE_FORMAT_VERSION,
+        phase: Phase::Prepared,
+        source_path: std::path::PathBuf::from("/store"),
+        source_fingerprint: VALID_FINGERPRINT.to_owned(),
+        target_model: diagnosis::TARGET_MODEL.to_owned(),
+        target_dimension: diagnosis::TARGET_DIM,
+        progress,
+    }
+}
+
+fn fresh_progress() -> BTreeMap<String, CollectionProgress> {
+    AGENT_COLLECTIONS
+        .iter()
+        .map(|name| {
+            (
+                (*name).to_owned(),
+                CollectionProgress::Facts { cursor: None },
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn mixed_progress_round_trips_byte_exactly_through_write_and_read() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = lock(workspace.path());
+
+    // Every stage is represented at once, because the bug this guards against
+    // is a serde attribute that flattens one variant into another.
+    let mut progress = fresh_progress();
+    progress.insert(
+        "_semantic_memory".to_owned(),
+        CollectionProgress::Facts { cursor: Some(42) },
+    );
+    progress.insert("_episodic_memory".to_owned(), CollectionProgress::Edges);
+    progress.insert(
+        "_procedural_memory".to_owned(),
+        CollectionProgress::Complete,
+    );
+    let written = state_with_progress(progress);
+
+    // A journal must begin at the beginning: seed the initial entry first,
+    // then advance to the mixed shape.
+    state_with_progress(fresh_progress())
+        .write(workspace.path(), &lock)
+        .expect("initial write");
+    written.write(workspace.path(), &lock).expect("advance");
+
+    let read = MigrationState::read(workspace.path())
+        .expect("read back")
+        .expect("state exists");
+    assert_eq!(
+        read, written,
+        "per-collection progress must survive the write/read round trip \
+         exactly; a variant that collapsed into another would resume the wrong \
+         amount of work"
+    );
+}
+
+#[test]
+fn a_v2_state_is_refused_for_predating_rebuild_progress() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    // Written by hand because no current API can produce one: this is the file
+    // a real v2 build left behind.
+    let v2 = serde_json::json!({
+        "format_version": 2,
+        "phase": "prepared",
+        "source_path": "/store",
+        "source_fingerprint": VALID_FINGERPRINT,
+        "target_model": diagnosis::TARGET_MODEL,
+        "target_dimension": diagnosis::TARGET_DIM,
+    });
+    std::fs::write(
+        workspace.path().join(STATE_FILE),
+        serde_json::to_string_pretty(&v2).expect("serialize v2"),
+    )
+    .expect("write v2 state");
+
+    let refusal = MigrationState::read(workspace.path())
+        .expect_err("a v2 state must be refused, not silently upgraded");
+    assert!(
+        refusal.contains("version 2") && refusal.contains(&STATE_FORMAT_VERSION.to_string()),
+        "the refusal must name both versions: {refusal}"
+    );
+    assert!(
+        refusal.contains("fresh diagnosis"),
+        "the refusal must tell the operator what to do: {refusal}"
+    );
+    assert!(
+        !refusal.contains("does not parse"),
+        "an old version must be refused AS a version, not surface as a parse \
+         error about the missing progress field: {refusal}"
+    );
+}
+
+#[test]
+fn progress_may_advance_or_repeat_but_never_regress() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = lock(workspace.path());
+    let mut current = fresh_progress();
+    current.insert(
+        "_semantic_memory".to_owned(),
+        CollectionProgress::Facts { cursor: Some(10) },
+    );
+    state_with_progress(fresh_progress())
+        .write(workspace.path(), &lock)
+        .expect("initial write");
+    state_with_progress(current.clone())
+        .write(workspace.path(), &lock)
+        .expect("advance to cursor 10");
+
+    // Idempotent replay of the same entry is a resume, not a regression.
+    state_with_progress(current.clone())
+        .write(workspace.path(), &lock)
+        .expect("the same progress may be written again");
+
+    let regressions: Vec<(&str, CollectionProgress)> = vec![
+        (
+            "a smaller cursor",
+            CollectionProgress::Facts { cursor: Some(5) },
+        ),
+        (
+            "no cursor at all",
+            CollectionProgress::Facts { cursor: None },
+        ),
+    ];
+    for (label, regressed) in regressions {
+        let mut candidate = current.clone();
+        candidate.insert("_semantic_memory".to_owned(), regressed);
+        let refusal = state_with_progress(candidate)
+            .write(workspace.path(), &lock)
+            .expect_err("a journal that can regress is a scratchpad");
+        assert!(
+            refusal.contains("_semantic_memory"),
+            "refusing {label} must name the collection: {refusal}"
+        );
+    }
+
+    // ...and a finished stage cannot be reopened.
+    let mut done = current.clone();
+    done.insert("_semantic_memory".to_owned(), CollectionProgress::Complete);
+    state_with_progress(done.clone())
+        .write(workspace.path(), &lock)
+        .expect("skip to complete is forward");
+    let mut reopened = done;
+    reopened.insert("_semantic_memory".to_owned(), CollectionProgress::Edges);
+    let refusal = state_with_progress(reopened)
+        .write(workspace.path(), &lock)
+        .expect_err("a completed collection cannot be reopened");
+    assert!(
+        refusal.contains("_semantic_memory"),
+        "the refusal must name the collection: {refusal}"
+    );
+}
+
+#[test]
+fn the_phase_cannot_leave_prepared_while_any_collection_is_unfinished() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = lock(workspace.path());
+    let mut almost = fresh_progress();
+    for name in AGENT_COLLECTIONS {
+        almost.insert((*name).to_owned(), CollectionProgress::Complete);
+    }
+    almost.insert("_episodic_memory".to_owned(), CollectionProgress::Edges);
+
+    state_with_progress(fresh_progress())
+        .write(workspace.path(), &lock)
+        .expect("initial write");
+    state_with_progress(almost.clone())
+        .write(workspace.path(), &lock)
+        .expect("advance");
+
+    let mut premature = state_with_progress(almost);
+    premature.phase = Phase::DestinationValidated;
+    let refusal = premature
+        .write(workspace.path(), &lock)
+        .expect_err("validating a destination whose rebuild is unfinished");
+    assert!(
+        refusal.contains("_episodic_memory"),
+        "the refusal must name the unfinished collection: {refusal}"
+    );
+
+    // Positive control: with every collection Complete the same transition is
+    // accepted, so the refusal above was about the progress and nothing else.
+    let mut complete = BTreeMap::new();
+    for name in AGENT_COLLECTIONS {
+        complete.insert((*name).to_owned(), CollectionProgress::Complete);
+    }
+    let mut ready = state_with_progress(complete);
+    ready.phase = Phase::DestinationValidated;
+    ready
+        .write(workspace.path(), &lock)
+        .expect("a finished rebuild may advance the phase");
+}
+
+#[test]
+fn progress_keys_must_be_exactly_the_agent_collections() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let lock = lock(workspace.path());
+
+    let mut missing = fresh_progress();
+    missing.remove("_procedural_memory");
+    let refusal = state_with_progress(missing)
+        .write(workspace.path(), &lock)
+        .expect_err("a journal silently dropping a collection would skip its rebuild");
+    assert!(
+        refusal.contains("_procedural_memory"),
+        "the refusal must name the absent collection: {refusal}"
+    );
+
+    let mut extra = fresh_progress();
+    extra.insert(
+        "_not_a_collection".to_owned(),
+        CollectionProgress::Facts { cursor: None },
+    );
+    let refusal = state_with_progress(extra)
+        .write(workspace.path(), &lock)
+        .expect_err("a journal tracking an unknown collection describes work nobody will do");
+    assert!(
+        refusal.contains("_not_a_collection"),
+        "the refusal must name the unknown collection: {refusal}"
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/state.rs
+++ b/crates/velesdb-memory/src/migration/tests/state.rs
@@ -22,6 +22,15 @@ fn resumable_state() -> MigrationState {
         source_fingerprint: VALID_FINGERPRINT.to_owned(),
         target_model: TARGET_MODEL.to_owned(),
         target_dimension: TARGET_DIM,
+        progress: AGENT_COLLECTIONS
+            .iter()
+            .map(|name| {
+                (
+                    (*name).to_owned(),
+                    CollectionProgress::Facts { cursor: None },
+                )
+            })
+            .collect(),
     }
 }
 
@@ -221,8 +230,13 @@ fn a_newer_state_version_is_refused() {
 #[test]
 fn an_older_weak_fingerprint_state_requires_a_fresh_diagnosis() {
     let workspace = tempfile::tempdir().expect("tempdir");
+    // Pinned to the LITERAL version 1, not `STATE_FORMAT_VERSION - 1`: this
+    // fixture is a real v1 file with the weak length-only fingerprint v1
+    // actually carried. Version-relative arithmetic made the fixture drift —
+    // at v3 it described a "v2" file with a fingerprint no v2 build ever
+    // wrote. (The v2 boundary has its own test in `rebuild_state`.)
     let old = serde_json::json!({
-        "format_version": super::STATE_FORMAT_VERSION - 1,
+        "format_version": 1,
         "phase": "prepared",
         "source_path": "/store",
         "source_fingerprint": "fnv1a64:0123456789abcdef",
@@ -238,10 +252,12 @@ fn an_older_weak_fingerprint_state_requires_a_fresh_diagnosis() {
     let refusal = MigrationState::read(workspace.path())
         .expect_err("a weak length-only fingerprint must never resume");
     assert!(
-        refusal.contains("older")
-            && refusal.contains("content-based")
-            && refusal.contains("fresh diagnosis"),
-        "the refusal must explain why the old state is unsafe and how to recover: {refusal}"
+        refusal.contains("older") && refusal.contains("fresh diagnosis"),
+        "the refusal must name the state as older and say how to recover: {refusal}"
+    );
+    assert!(
+        refusal.contains("version 1") && refusal.contains(&super::STATE_FORMAT_VERSION.to_string()),
+        "the refusal must name both versions: {refusal}"
     );
 
     let mut in_memory = resumable_state();

--- a/crates/velesdb-memory/src/migration/tests/state.rs
+++ b/crates/velesdb-memory/src/migration/tests/state.rs
@@ -22,6 +22,7 @@ fn resumable_state() -> MigrationState {
         source_fingerprint: VALID_FINGERPRINT.to_owned(),
         target_model: TARGET_MODEL.to_owned(),
         target_dimension: TARGET_DIM,
+        embedder_witness: None,
         progress: AGENT_COLLECTIONS
             .iter()
             .map(|name| {

--- a/crates/velesdb-memory/src/migration/tests/state_persistence.rs
+++ b/crates/velesdb-memory/src/migration/tests/state_persistence.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-const VALID_FINGERPRINT: &str =
+pub(super) const VALID_FINGERPRINT: &str =
     "sha256-tree-v2:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 fn state(phase: Phase) -> MigrationState {
@@ -11,6 +11,14 @@ fn state(phase: Phase) -> MigrationState {
         source_fingerprint: VALID_FINGERPRINT.to_owned(),
         target_model: diagnosis::TARGET_MODEL.to_owned(),
         target_dimension: diagnosis::TARGET_DIM,
+        // Complete rather than fresh, because this file's tests advance the
+        // PHASE — and a phase past Prepared with an unfinished rebuild is now
+        // itself a semantics refusal, which would shadow what each test is
+        // actually about.
+        progress: AGENT_COLLECTIONS
+            .iter()
+            .map(|name| ((*name).to_owned(), CollectionProgress::Complete))
+            .collect(),
     }
 }
 

--- a/crates/velesdb-memory/src/migration/tests/state_persistence.rs
+++ b/crates/velesdb-memory/src/migration/tests/state_persistence.rs
@@ -11,6 +11,7 @@ fn state(phase: Phase) -> MigrationState {
         source_fingerprint: VALID_FINGERPRINT.to_owned(),
         target_model: diagnosis::TARGET_MODEL.to_owned(),
         target_dimension: diagnosis::TARGET_DIM,
+        embedder_witness: None,
         // Complete rather than fresh, because this file's tests advance the
         // PHASE — and a phase past Prepared with an unfinished rebuild is now
         // itself a semantics refusal, which would shadow what each test is


### PR DESCRIPTION
Refs #1762 — PR C2b of the embedding-migration campaign, on top of C1 (#1818) and C2a (#1822).

## What was missing

Every part was proven separately — facts round-trip, edges round-trip, the
journal can only advance — and **nothing called any of it**: `Phase::Prepared`
was produced nowhere in production, `require_dry_run` cut off every non-dry-run
invocation, and a resumed migration would have restarted every collection from
zero.

## What this adds

**State format v3.** `MigrationState` gains per-collection progress
(`Facts { cursor } → Edges → Complete`), validated to advance only along the
transitions the pass actually emits — skipping `Edges` is refused, so a
refactor that lost the edge pass becomes un-journallable. The phase cannot
leave `Prepared` while any collection is unfinished. A v2 state is refused for
its age with a recovery action.

**The rebuild pass** (`migration/rebuild.rs`). Checkpoints destination-first:
every batch lands before its cursor reaches the journal, so the crash window
*replays* work — visibly, as counted collisions — instead of losing it. Two
interruption tests inject the stop after a batch is reinserted and before its
checkpoint is journalled, the widest window a real crash can hit: one covers
the degenerate first-batch case, the other stops past a real checkpoint and
pins the exact counts (collisions == exactly the one unjournalled batch, new
facts == exactly what lies beyond it).

**The operator's path** (`migration/execute.rs`). Diagnose → gate on the regime
resolution (the permanently-Missing capabilities stay informational) → settle →
fingerprint → stage → lock → journal → rebuild → release.

Two designs here came from measurements, not theory:

- **Settle-then-fingerprint.** The first open of a store compacts its WAL into
  materialised index files, so a fingerprint taken before that open never
  matches on resume — every legitimately interrupted migration would be refused
  as "source changed". A second open is proven idempotent, pinned by a test
  that deliberately asserts only the idempotence.
- **The embedder witness.** `may_resume` compares the model's *name*, and a
  name is a claim: `ollama pull` replaces weights in place under the same
  identifier. The journal now carries a digest of the vector the embedder
  produces for a fixed sentinel — `Some` under `reembed`, `None` under `reuse`,
  so it records the resolved regime too — and a resume whose recomputed witness
  differs is refused naming both readings.

**CLI.** `require_dry_run` is gone; a non-dry-run runs the rebuild and requires
`--destination`. The success message states that the destination has **not**
been validated and **not** been switched — an operator reading "rebuild
complete" as "migration done" would point their daemon at the old store.

## Adversarial review

A review of the first commit found five real gaps; the second commit closes all
five (the witness, the precise-cursor resume test, the dead `Facts→Complete`
tolerance with its false comment, the edge-pass mismatch message that accused
loss for what can be a transient expiry, and a swallowed lock-release error on
the failure path).

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check` with `-D warnings -D clippy::pedantic` — 0
- `lizard -l rust -C 8 -a 8` over the 14 files of the diff, with a positive control asserting all 14 were read — the only two violations (`main` CCN 13, `open_store_with_actionable_lock_error` CCN 9) are byte-identical on develop and untouched here
- `cargo test -p velesdb-memory --features persistence` — 136 migration tests, 35 binaries, 0 failures

## Not in scope

Validation of the destination and the switch (C3); the operator doc and
benchmarks (PR D, which closes #1762). Distinguishing transient-expiry edge
divergence from real loss mechanically is explicitly deferred to C3's
validation pass.