### PR TITLE
feat(migration): validate the destination, switch it live, stamp its provenance

### DIFF
--- a/crates/velesdb-memory/src/embedding_provenance.rs
+++ b/crates/velesdb-memory/src/embedding_provenance.rs
@@ -131,10 +131,10 @@ pub fn check(
         "this store was filled with the embedding model '{}' ({} dimensions), and the daemon is \
          configured for '{}' ({} dimensions). Vectors from two different models are not \
          comparable, so recall would silently return nonsense. Either point \
-         VELESDB_MEMORY_EMBEDDER_MODEL back at '{}', or re-index the store against the new model \
-         (re-indexing is not implemented yet — see #1751). Which backend serves the model does \
-         not matter and is not recorded: the same model over Ollama, oMLX or an \
-         OpenAI-compatible API produces the same vectors.",
+         VELESDB_MEMORY_EMBEDDER_MODEL back at '{}', or migrate the store against the new model \
+         with `velesdb-memory migrate-embeddings` (start with --dry-run; see #1762). Which \
+         backend serves the model does not matter and is not recorded: the same model over \
+         Ollama, oMLX or an OpenAI-compatible API produces the same vectors.",
         stored.model, stored.dimension, model, dimension, stored.model
     ))
 }

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -563,8 +563,10 @@ fn run_migrate_embeddings(
     run_migrate_rebuild(&options, &store_path, &scratch, &target, embedder.as_ref())
 }
 
-/// The non-dry-run tail of `migrate-embeddings`: rebuild, then say plainly
-/// where the wired part ends.
+/// The non-dry-run tail of `migrate-embeddings`: rebuild, validate, switch.
+///
+/// Three stages, three refusal surfaces — a failure names its stage, and each
+/// stage is independently resumable by re-running the same command.
 fn run_migrate_rebuild(
     options: &velesdb_memory::migration::MigrateOptions,
     store_path: &std::path::Path,
@@ -591,7 +593,17 @@ fn run_migrate_rebuild(
         outcome.rebuild.edges,
         outcome.workspace.display(),
     );
-    println!("{}", migration::not_yet_switchable());
+
+    let validated =
+        migration::validate_destination(store_path, &destination, target, MIGRATE_BATCH)?;
+    println!(
+        "validated: {} facts and {} edges compared, {} divergence(s) explained by expiry",
+        validated.facts, validated.edges, validated.explained_by_expiry,
+    );
+
+    let switched = migration::switch_over(store_path, &destination)?;
+    println!("activated: {}", switched.activated.display());
+    println!("{}", migration::migration_complete_notice());
     Ok(())
 }
 

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -565,8 +565,10 @@ fn run_migrate_embeddings(
 
 /// The non-dry-run tail of `migrate-embeddings`: rebuild, validate, switch.
 ///
-/// Three stages, three refusal surfaces — a failure names its stage, and each
-/// stage is independently resumable by re-running the same command.
+/// The chain enters wherever the journal stands — a re-run after any crash
+/// resumes rather than failing on the stage the crash already completed —
+/// and each stage that ran reports itself; one that was journalled as done
+/// stays silent rather than misreporting work this run did not do.
 fn run_migrate_rebuild(
     options: &velesdb_memory::migration::MigrateOptions,
     store_path: &std::path::Path,
@@ -577,7 +579,7 @@ fn run_migrate_rebuild(
     use velesdb_memory::migration;
 
     let destination = migration::require_destination(options)?;
-    let outcome = migration::execute(
+    let outcome = migration::migrate(
         store_path,
         scratch,
         target,
@@ -585,24 +587,23 @@ fn run_migrate_rebuild(
         embedder,
         MIGRATE_BATCH,
     )?;
-    print!("{}", migration::render(&outcome.report));
-    println!(
-        "rebuild: {} facts written, {} already present, {} edges, journal at {}",
-        outcome.rebuild.facts,
-        outcome.rebuild.collisions,
-        outcome.rebuild.edges,
-        outcome.workspace.display(),
-    );
-
-    let validated =
-        migration::validate_destination(store_path, &destination, target, MIGRATE_BATCH)?;
-    println!(
-        "validated: {} facts and {} edges compared, {} divergence(s) explained by expiry",
-        validated.facts, validated.edges, validated.explained_by_expiry,
-    );
-
-    let switched = migration::switch_over(store_path, &destination)?;
-    println!("activated: {}", switched.activated.display());
+    if let Some(executed) = &outcome.executed {
+        print!("{}", migration::render(&executed.report));
+        println!(
+            "rebuild: {} facts written, {} already present, {} edges, journal at {}",
+            executed.rebuild.facts,
+            executed.rebuild.collisions,
+            executed.rebuild.edges,
+            executed.workspace.display(),
+        );
+    }
+    if let Some(validated) = &outcome.validated {
+        println!(
+            "validated: {} facts and {} edges compared, {} divergence(s) explained by expiry",
+            validated.facts, validated.edges, validated.explained_by_expiry,
+        );
+    }
+    println!("activated: {}", outcome.switched.activated.display());
     println!("{}", migration::migration_complete_notice());
     Ok(())
 }

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -52,6 +52,7 @@ mod edges;
 mod enumeration;
 mod execute;
 mod filesystem;
+mod orchestrate;
 mod rebuild;
 mod state;
 mod strategy;
@@ -75,6 +76,7 @@ pub use enumeration::{
 };
 pub use execute::{execute, ExecuteOutcome};
 pub use filesystem::{bytes_on_disk, fingerprint};
+pub use orchestrate::{migrate, MigrateOutcome};
 #[cfg(test)]
 pub(crate) use rebuild::rebuild_with_stop;
 pub use rebuild::{
@@ -89,6 +91,13 @@ pub use switchover::{switch_over, SwitchOutcome, ARCHIVE_SUFFIX};
 #[cfg(test)]
 pub(crate) use validate::divergence_explained_by_expiry;
 pub use validate::{validate_destination, ValidationOutcome};
+
+/// The one conversion every migration module needs: a message become the
+/// engine's query error, become this crate's. Defined once — six private
+/// copies of it had already drifted into two signatures.
+pub(crate) fn query_error(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -55,10 +55,12 @@ mod filesystem;
 mod rebuild;
 mod state;
 mod strategy;
+mod switchover;
+mod validate;
 
 pub use cli::{
-    default_scratch_parent, dry_run, not_yet_switchable, parse as parse_migrate_args, refuses,
-    render, require_destination, MigrateOptions,
+    default_scratch_parent, dry_run, migration_complete_notice, parse as parse_migrate_args,
+    refuses, render, require_destination, MigrateOptions,
 };
 pub use diagnosis::{
     diagnose, same_filesystem, Capability, CollectionInventory, DiagnosisReport, SourceProvenance,
@@ -83,6 +85,10 @@ pub use state::{
     PHASES, STATE_FILE, STATE_FORMAT_VERSION, STATE_TEMP_FILE,
 };
 pub use strategy::{assess, resolve, Compatibility, Resolution, Strategy};
+pub use switchover::{switch_over, SwitchOutcome, ARCHIVE_SUFFIX};
+#[cfg(test)]
+pub(crate) use validate::divergence_explained_by_expiry;
+pub use validate::{validate_destination, ValidationOutcome};
 
 #[cfg(test)]
 mod tests;

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -50,19 +50,24 @@ impl Default for MigrateOptions {
     }
 }
 
-/// What an operator must be told after a successful non-dry-run: how far it
-/// went, and exactly where the wired part ends.
+/// What an operator must be told after a COMPLETED migration.
 ///
-/// This text replaced `NOT_YET_EXECUTABLE` when the rebuild itself was wired
-/// (#1762, PR C2b). What remains unwired moved, it did not shrink to nothing:
-/// the rebuilt destination is NOT validated and NOT switched into place, and a
-/// message that failed to say so would read as "the migration is done" to
-/// every operator who ran it.
-const NOT_YET_SWITCHABLE: &str =
-    "the rebuild is complete and journalled, but the destination has NOT been \
-     validated and has NOT been switched into place — that part is not wired \
-     yet, see #1762. The source store is still the live one. Keep the \
-     destination and its .migration-journal sibling until the switch ships.";
+/// This text replaced `NOT_YET_SWITCHABLE` when C3 wired validation and the
+/// switch. Two things in it are load-bearing. The daemon holds its store as
+/// an in-memory handle taken at startup and never refreshed, so a daemon that
+/// was running against the old store keeps serving the old data until it is
+/// RESTARTED — a message that failed to say so would let an operator migrate
+/// perfectly and then wonder where the new vectors went. And the journal is
+/// left in place deliberately: it is the evidence of what happened, and its
+/// removal is the operator's call, not this command's.
+const MIGRATION_COMPLETE: &str =
+    "the migration is complete: the rebuilt store now sits at the source's \
+     path, its provenance stamp names the target embedder, and the archived \
+     old store has been freed. RESTART the daemon — it holds its store as a \
+     handle taken at startup, and until it restarts it keeps serving the old \
+     data from memory. The .migration-journal directory beside the (now \
+     empty) destination path is the journal of what happened; it may be \
+     removed once you no longer want the evidence.";
 
 /// Parse `migrate-embeddings`' flags.
 ///
@@ -237,10 +242,10 @@ pub fn refuses(report: &DiagnosisReport) -> bool {
     !report.resolution.runs()
 }
 
-/// Re-exported so the binary can print the boundary without duplicating it.
+/// Re-exported so the binary can print the completion without duplicating it.
 #[must_use]
-pub fn not_yet_switchable() -> &'static str {
-    NOT_YET_SWITCHABLE
+pub fn migration_complete_notice() -> &'static str {
+    MIGRATION_COMPLETE
 }
 
 /// The default scratch parent: the directory the store itself sits in.

--- a/crates/velesdb-memory/src/migration/diagnosis/report.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/report.rs
@@ -145,6 +145,7 @@ impl DiagnosisReport {
         for (name, expected) in canonical_capabilities(self) {
             require_canonical_capability(&self.capabilities, name, &expected)?;
         }
+        validate_uncalculated_capability_shapes(&self.capabilities)?;
 
         validate_resolution(self)?;
         validate_blockers(self)
@@ -171,6 +172,44 @@ fn validate_capability_keys(capabilities: &BTreeMap<String, Capability>) -> Resu
     Err(format!(
         "diagnosis report capabilities are incomplete or unknown: expected exactly {DIAGNOSIS_CAPABILITY_KEYS:?}, got {actual_keys:?}"
     ))
+}
+
+/// Hold the four capabilities the parser cannot recalculate to their SHAPE.
+///
+/// Their evidence embeds measurements only the live diagnosis could take —
+/// staging room, edge counts, the read-only fingerprint check — so a parsed
+/// report cannot re-derive the text. Two shape facts survive parsing anyway:
+/// three of them have no Missing-producing code path in `diagnose`, so a
+/// Missing one was not produced by a diagnosis; and evidence or blocker text
+/// that is empty says nothing, which no capability of any provenance does.
+fn validate_uncalculated_capability_shapes(
+    capabilities: &BTreeMap<String, Capability>,
+) -> Result<(), String> {
+    for name in [
+        "diagnostic_staging",
+        "inventory",
+        "source_access_is_read_only",
+    ] {
+        if let Some(Capability::Missing { .. }) = capabilities.get(name) {
+            return Err(format!(
+                "diagnosis capability `{name}` is inconsistent with its report \
+                 fields: no diagnosis produces it as Missing"
+            ));
+        }
+    }
+    for (name, capability) in capabilities {
+        let text = match capability {
+            Capability::Proven { evidence } => evidence,
+            Capability::Missing { blocker } => blocker,
+        };
+        if text.trim().is_empty() {
+            return Err(format!(
+                "diagnosis capability `{name}` carries an empty text; evidence \
+                 that says nothing is not evidence"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn canonical_capabilities(report: &DiagnosisReport) -> [(&'static str, Capability); 5] {

--- a/crates/velesdb-memory/src/migration/diagnostic_copy.rs
+++ b/crates/velesdb-memory/src/migration/diagnostic_copy.rs
@@ -1,4 +1,5 @@
 use super::filesystem::{bytes_on_disk, fingerprint};
+use super::query_error;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -444,8 +445,4 @@ fn combined_error(
     query_error(format!(
         "{primary}; additionally, scratch cleanup failed: {cleanup}"
     ))
-}
-
-fn query_error(message: String) -> crate::MemoryError {
-    velesdb_core::Error::Query(message).into()
 }

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -261,23 +261,30 @@ pub(super) fn same_edge_tuples(left: &[GraphEdge], right: &[GraphEdge]) -> Resul
     ))
 }
 
-/// An edge reduced to something orderable, so two collections of edges compare
-/// as SETS OF TUPLES. Comparing counts would let two walks that had each lost
-/// one edge agree.
-fn comparable(edges: &[GraphEdge]) -> std::collections::BTreeSet<(u64, u64, u64, String, String)> {
-    edges
-        .iter()
-        .map(|edge| {
-            let properties: std::collections::BTreeMap<_, _> = edge.properties().iter().collect();
-            (
-                edge.id(),
-                edge.source(),
-                edge.target(),
-                edge.label().to_owned(),
-                serde_json::to_string(&properties).unwrap_or_default(),
-            )
-        })
-        .collect()
+/// The canonical, orderable form of one edge: every field, with properties
+/// rendered through a `BTreeMap` for a stable key order. This is THE reduction
+/// every comparison in the migration uses — the cross-check here and the
+/// validation pass both — so two comparisons cannot quietly disagree about
+/// what "the same edge" means.
+pub(super) type CanonicalEdge = (u64, u64, u64, String, String);
+
+/// See [`CanonicalEdge`]. The render cannot fail: the properties came out of
+/// the store as JSON, and a `BTreeMap` of them serialises deterministically.
+pub(super) fn canonical_edge(edge: &GraphEdge) -> CanonicalEdge {
+    let properties: std::collections::BTreeMap<_, _> = edge.properties().iter().collect();
+    (
+        edge.id(),
+        edge.source(),
+        edge.target(),
+        edge.label().to_owned(),
+        serde_json::to_string(&properties).expect("stored JSON properties render"),
+    )
+}
+
+/// Edges as a SET of canonical tuples. Comparing counts would let two walks
+/// that had each lost one edge agree.
+fn comparable(edges: &[GraphEdge]) -> std::collections::BTreeSet<CanonicalEdge> {
+    edges.iter().map(canonical_edge).collect()
 }
 
 /// The same collection of edges, gathered through the INCOMING index instead.

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -268,8 +268,11 @@ pub(super) fn same_edge_tuples(left: &[GraphEdge], right: &[GraphEdge]) -> Resul
 /// what "the same edge" means.
 pub(super) type CanonicalEdge = (u64, u64, u64, String, String);
 
-/// See [`CanonicalEdge`]. The render cannot fail: the properties came out of
-/// the store as JSON, and a `BTreeMap` of them serialises deterministically.
+/// See [`CanonicalEdge`]. The render of a `BTreeMap` of stored JSON values
+/// cannot fail in practice; if it ever does, the error TEXT becomes the
+/// rendering — still deterministic, still distinct from every successful
+/// render, and (unlike a default empty string) incapable of making a failed
+/// comparison pass by making both sides say nothing.
 pub(super) fn canonical_edge(edge: &GraphEdge) -> CanonicalEdge {
     let properties: std::collections::BTreeMap<_, _> = edge.properties().iter().collect();
     (
@@ -277,7 +280,8 @@ pub(super) fn canonical_edge(edge: &GraphEdge) -> CanonicalEdge {
         edge.source(),
         edge.target(),
         edge.label().to_owned(),
-        serde_json::to_string(&properties).expect("stored JSON properties render"),
+        serde_json::to_string(&properties)
+            .unwrap_or_else(|err| format!("<properties failed to render: {err}>")),
     )
 }
 

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -349,7 +349,7 @@ fn regime_word(strategy: super::strategy::Strategy) -> &'static str {
 }
 
 /// The journal's home: a sibling of the destination, named after it.
-fn journal_workspace(destination: &Path) -> Result<PathBuf, crate::MemoryError> {
+pub(super) fn journal_workspace(destination: &Path) -> Result<PathBuf, crate::MemoryError> {
     let name = destination
         .file_name()
         .and_then(|name| name.to_str())

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -24,6 +24,7 @@
 //! `Complete`. Validation of the destination and the switch itself are the
 //! next PR's work; see [`NOT_YET_SWITCHABLE`](super::not_yet_switchable).
 
+use super::query_error;
 use std::path::{Path, PathBuf};
 
 use velesdb_core::agent::AgentMemory;
@@ -100,19 +101,22 @@ pub fn execute(
     })
 }
 
-/// Fold the pass's result and the lock release into one verdict.
+/// Fold a locked pass's result and the lock release into one verdict.
 ///
-/// When BOTH fail, both are reported: an operator who fixes the rebuild error
+/// When BOTH fail, both are reported: an operator who fixes the pass's error
 /// and reruns deserves to know beforehand that the lock evidence remains, not
-/// to discover it as a second surprise.
-fn reconcile(
-    result: Result<RebuildOutcome, crate::MemoryError>,
+/// to discover it as a second surprise. Shared by every locked entry point in
+/// this module tree — execute, validate, switch — because the first rewrite of
+/// this pattern silently dropped the release error, and the second and third
+/// would have too.
+pub(super) fn reconcile<T>(
+    result: Result<T, crate::MemoryError>,
     released: Result<(), String>,
-) -> Result<RebuildOutcome, crate::MemoryError> {
+) -> Result<T, crate::MemoryError> {
     match (result, released) {
-        (Ok(rebuild), Ok(())) => Ok(rebuild),
+        (Ok(value), Ok(())) => Ok(value),
         (Ok(_), Err(release_error)) => Err(query_error(format!(
-            "the rebuild completed, but releasing the migration lock failed: \
+            "the pass completed, but releasing the migration lock failed: \
              {release_error}. The canonical lock record remains and must be \
              removed by hand before the next run"
         ))),
@@ -401,8 +405,4 @@ fn ensure_destination(destination: &Path, resuming: bool) -> Result<(), crate::M
         )));
     }
     Ok(())
-}
-
-fn query_error(message: impl Into<String>) -> crate::MemoryError {
-    velesdb_core::Error::Query(message.into()).into()
 }

--- a/crates/velesdb-memory/src/migration/filesystem.rs
+++ b/crates/velesdb-memory/src/migration/filesystem.rs
@@ -1,3 +1,4 @@
+use super::query_error;
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
 use std::fs::File;
@@ -242,10 +243,6 @@ fn update_os_str(hash: &mut Sha256, value: &OsStr) {
     let bytes = value.to_string_lossy();
     hash.update(u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes());
     hash.update(bytes.as_bytes());
-}
-
-fn query_error(message: String) -> crate::MemoryError {
-    velesdb_core::Error::Query(message).into()
 }
 
 pub(super) fn encode_hex(bytes: &[u8]) -> String {

--- a/crates/velesdb-memory/src/migration/orchestrate.rs
+++ b/crates/velesdb-memory/src/migration/orchestrate.rs
@@ -1,0 +1,73 @@
+//! The operator's one command, end to end (#1762, PR C3).
+//!
+//! `execute`, `validate_destination` and `switch_over` each acquire the lock,
+//! do one phase's work, and release — independently provable, independently
+//! refusable. What they cannot do alone is RESUME as a chain: after the
+//! switch's first rename the source path is vacant, and a re-run that blindly
+//! started from the diagnosis would fail on the absent directory before
+//! reaching the one function that knows how to continue. This module reads
+//! the journal FIRST and enters the chain where the journal says — which is
+//! what makes "re-run the same command" a true recovery instruction.
+
+use std::path::Path;
+
+use super::diagnosis::TargetContract;
+use super::execute::{execute, journal_workspace, ExecuteOutcome};
+use super::query_error;
+use super::state::{MigrationState, Phase};
+use super::switchover::{switch_over, SwitchOutcome};
+use super::validate::{validate_destination, ValidationOutcome};
+use crate::embedder::Embedder;
+
+/// What one `migrate` run did. The early stages are `None` exactly when the
+/// journal routed past them — reporting a rebuild that did not run would be
+/// misreporting, and with the source already archived it could not have run.
+#[derive(Debug)]
+pub struct MigrateOutcome {
+    /// The rebuild, when this run performed it.
+    pub executed: Option<ExecuteOutcome>,
+    /// The validation, when this run performed it.
+    pub validated: Option<ValidationOutcome>,
+    /// The switch — every completed run ends here.
+    pub switched: SwitchOutcome,
+}
+
+/// Rebuild, validate and switch — entering wherever the journal stands.
+///
+/// A journal already at [`Phase::DestinationValidated`] or beyond routes
+/// straight to the switch: the earlier stages are journalled as done, and
+/// after the first rename the source path no longer exists for them to run
+/// against.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] from whichever stage refuses; each stage
+/// names itself, and re-running the same command resumes from the journal.
+pub fn migrate(
+    store: &Path,
+    scratch_parent: &Path,
+    target: &TargetContract,
+    destination: &Path,
+    embedder: &dyn Embedder,
+    batch: usize,
+) -> Result<MigrateOutcome, crate::MemoryError> {
+    let (executed, validated) = if past_validation(destination)? {
+        (None, None)
+    } else {
+        let executed = execute(store, scratch_parent, target, destination, embedder, batch)?;
+        let validated = validate_destination(store, destination, target, batch)?;
+        (Some(executed), Some(validated))
+    };
+    let switched = switch_over(store, destination)?;
+    Ok(MigrateOutcome {
+        executed,
+        validated,
+        switched,
+    })
+}
+
+/// Whether the journal says validation already happened.
+fn past_validation(destination: &Path) -> Result<bool, crate::MemoryError> {
+    let workspace = journal_workspace(destination)?;
+    let state = MigrationState::read(&workspace).map_err(query_error)?;
+    Ok(state.is_some_and(|state| state.phase >= Phase::DestinationValidated))
+}

--- a/crates/velesdb-memory/src/migration/rebuild.rs
+++ b/crates/velesdb-memory/src/migration/rebuild.rs
@@ -29,6 +29,7 @@
 //! runs strictly inside [`Phase::Prepared`], and leaving that phase is the
 //! validation-and-switch work of a later PR.
 
+use super::query_error;
 use std::path::Path;
 
 use velesdb_core::agent::AgentMemory;
@@ -340,8 +341,4 @@ fn journal_progress(
     state
         .write(journal.workspace, journal.lock)
         .map_err(query_error)
-}
-
-fn query_error(message: impl Into<String>) -> crate::MemoryError {
-    velesdb_core::Error::Query(message.into()).into()
 }

--- a/crates/velesdb-memory/src/migration/switchover.rs
+++ b/crates/velesdb-memory/src/migration/switchover.rs
@@ -1,0 +1,360 @@
+//! The switch (#1762, PR C3): put the validated destination where the source
+//! was, and free the archive.
+//!
+//! Two renames, each journalled AFTER it happens — a journal that ran ahead of
+//! the disk would let a resume skip a rename that never happened. Every crash
+//! window therefore leaves the disk one step ahead of the journal at most, and
+//! the re-run's job is to recognise that step and journal it late, never to
+//! undo it: going backwards would discard work the disk already holds, and
+//! [`Phase::may_follow`] refuses journal regressions anyway.
+//!
+//! # The one ambiguous landing spot, and its discriminator
+//!
+//! After the second rename and before its journal entry, the disk says: a
+//! store at the source's name, an archive beside it, no destination — the
+//! shape [`SwitchState`] calls two authorities and refuses, because from the
+//! filesystem alone nothing distinguishes "the destination was activated" from
+//! "something else sat down at the source's name". This module has one more
+//! fact available: validation stamped the destination with the TARGET's
+//! provenance, and the old source does not carry that stamp. An occupant WITH
+//! the stamp is the activated destination (continue); an occupant without it
+//! is an impostor (refuse, both stores intact).
+//!
+//! # What commit means
+//!
+//! [`Phase::recovery`] has said since C1 that advancing from
+//! `DestinationActivated` "frees the archive". Commit is that advance: verify
+//! the activated store opens and carries the stamp, delete the archive, then
+//! journal `Committed`. Deletion before journalling, so a crash between the
+//! two re-runs an idempotent commit instead of leaving a freed archive that
+//! the journal still believes in.
+
+use std::path::{Path, PathBuf};
+
+use super::execute::journal_workspace;
+use super::state::{MigrationLock, MigrationState, Phase, SwitchState};
+
+/// The archive slot: a sibling of the source, named after it.
+pub const ARCHIVE_SUFFIX: &str = ".archive";
+
+/// What a completed switch did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchOutcome {
+    /// Where the rebuilt store now lives — the source's own path.
+    pub activated: PathBuf,
+    /// The archive slot that held the old source until commit freed it.
+    pub archive: PathBuf,
+}
+
+/// Drive the switch from wherever the journal stands to `Committed`.
+///
+/// Requires a validated destination ([`Phase::DestinationValidated`] or
+/// later). Each step is act-then-journal; a re-run after a crash recognises
+/// completed-but-unjournalled steps and journals them late.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] when the journal is missing or earlier than
+/// validation, the archive slot is occupied, the disk is in a shape no step of
+/// this migration produces, or a rename, deletion, or journal write fails.
+pub fn switch_over(store: &Path, destination: &Path) -> Result<SwitchOutcome, crate::MemoryError> {
+    let workspace = journal_workspace(destination)?;
+    let lock = MigrationLock::acquire(&workspace, "migrate-switch").map_err(query_error)?;
+    let result = switch_locked(store, destination, &workspace, &lock);
+    let released = lock.release().map_err(query_error);
+    let outcome = result?;
+    released?;
+    Ok(outcome)
+}
+
+fn switch_locked(
+    store: &Path,
+    destination: &Path,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    let mut state = entry_state(workspace)?;
+    let slots = Slots::resolve(store, &state, destination)?;
+    loop {
+        match state.phase {
+            Phase::Prepared => {
+                return Err(query_error(
+                    "the destination has not been validated; validate it first \
+                     — the switch moves stores and must not be the step that \
+                     discovers a bad rebuild",
+                ));
+            }
+            Phase::DestinationValidated => step_archive(&slots, &mut state, workspace, lock)?,
+            Phase::SourceArchived => step_activate(&slots, &mut state, workspace, lock)?,
+            Phase::DestinationActivated => step_commit(&slots, &mut state, workspace, lock)?,
+            Phase::Committed => {
+                return Ok(SwitchOutcome {
+                    activated: slots.source.clone(),
+                    archive: slots.archive.clone(),
+                });
+            }
+        }
+    }
+}
+
+/// Read the journal, refusing an absent one and a migration already done.
+///
+/// The Committed check runs only at ENTRY: a run that just advanced to
+/// `Committed` reports its outcome, while a fresh invocation on a committed
+/// journal has nothing left to do — the recovery table has said since C1 that
+/// replaying a step would act on a store that is already the new one.
+fn entry_state(workspace: &Path) -> Result<MigrationState, crate::MemoryError> {
+    let state = MigrationState::read(workspace)
+        .map_err(query_error)?
+        .ok_or_else(|| {
+            query_error(format!(
+                "no migration journal at {}; there is nothing to switch",
+                workspace.display()
+            ))
+        })?;
+    if state.phase == Phase::Committed {
+        return Err(query_error(
+            "this migration is complete; there is nothing left to switch, and \
+             replaying a step would act on a store that is already the new one",
+        ));
+    }
+    Ok(state)
+}
+
+/// The three fixed paths of the switch, resolved once and checked against the
+/// journal's identity.
+struct Slots {
+    source: PathBuf,
+    archive: PathBuf,
+    destination: PathBuf,
+}
+
+impl Slots {
+    fn resolve(
+        store: &Path,
+        state: &MigrationState,
+        destination: &Path,
+    ) -> Result<Self, crate::MemoryError> {
+        let source = canonical_slot(store)?;
+        if source != state.source_path {
+            return Err(query_error(format!(
+                "this journal describes a migration of '{}', and the request \
+                 names '{}'; a switch cannot be transferred between stores",
+                state.source_path.display(),
+                source.display()
+            )));
+        }
+        let name = source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                query_error(format!(
+                    "the source {} has no usable directory name to derive the \
+                     archive slot from",
+                    source.display()
+                ))
+            })?;
+        Ok(Self {
+            archive: source.with_file_name(format!("{name}{ARCHIVE_SUFFIX}")),
+            destination: canonical_slot(destination)?,
+            source,
+        })
+    }
+
+    fn on_disk(&self) -> SwitchState {
+        SwitchState {
+            source: self.source.exists(),
+            archive: self.archive.exists(),
+            destination: self.destination.exists(),
+        }
+    }
+}
+
+/// First rename: the source steps aside into the archive slot.
+fn step_archive(
+    slots: &Slots,
+    state: &mut MigrationState,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    match slots.on_disk() {
+        // The step is pending: the slot must be free, or renaming would eat
+        // whatever sits there.
+        SwitchState {
+            source: true,
+            archive: false,
+            destination: true,
+        } => {
+            rename_durably(&slots.source, &slots.archive)?;
+        }
+        // The step already happened and its journal entry did not — the crash
+        // window. Journal it late; undoing a rename the disk holds would
+        // discard the step.
+        SwitchState {
+            source: false,
+            archive: true,
+            destination: true,
+        } => {}
+        SwitchState {
+            source: true,
+            archive: true,
+            ..
+        } => {
+            return Err(query_error(format!(
+                "the archive slot {} is already occupied; renaming the source \
+                 over it would destroy whatever it holds — move it aside \
+                 deliberately, or remove it if it is yours to remove",
+                slots.archive.display()
+            )));
+        }
+        other => return Err(unrecognised_disk(other, Phase::DestinationValidated)),
+    }
+    advance(state, Phase::SourceArchived, workspace, lock)
+}
+
+/// Second rename: the destination takes the source's name.
+fn step_activate(
+    slots: &Slots,
+    state: &mut MigrationState,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    match slots.on_disk() {
+        SwitchState {
+            source: false,
+            archive: true,
+            destination: true,
+        } => {
+            rename_durably(&slots.destination, &slots.source)?;
+        }
+        // Source-name occupied, archive present, destination gone: either the
+        // rename happened and its journal entry did not, or something else sat
+        // down at the source's name. The provenance stamp validation wrote on
+        // the destination is what tells them apart.
+        SwitchState {
+            source: true,
+            archive: true,
+            destination: false,
+        } => {
+            require_target_stamp(slots, state)?;
+        }
+        other => return Err(unrecognised_disk(other, Phase::SourceArchived)),
+    }
+    advance(state, Phase::DestinationActivated, workspace, lock)
+}
+
+/// Commit: verify the activated store, free the archive, journal the end.
+fn step_commit(
+    slots: &Slots,
+    state: &mut MigrationState,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    require_target_stamp(slots, state)?;
+    {
+        let _opens = velesdb_core::Database::open(&slots.source)?;
+    }
+    if slots.archive.exists() {
+        std::fs::remove_dir_all(&slots.archive).map_err(|err| {
+            query_error(format!(
+                "the activated store is verified but the archive {} could not \
+                 be freed: {err}; nothing is lost — re-run the switch",
+                slots.archive.display()
+            ))
+        })?;
+    }
+    advance(state, Phase::Committed, workspace, lock)
+}
+
+/// The occupant of the source's name must carry the TARGET's provenance stamp
+/// — the one validation wrote on the destination and the old source never had.
+fn require_target_stamp(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
+    let stamped = crate::embedding_provenance::read(&slots.source)
+        .map_err(query_error)?
+        .filter(|stamp| {
+            stamp.model == state.target_model && stamp.dimension == state.target_dimension
+        });
+    if stamped.is_some() {
+        return Ok(());
+    }
+    Err(query_error(format!(
+        "what occupies {} does not carry the target's provenance stamp \
+         ('{}', {} dimensions), so it cannot be assumed to be the activated \
+         destination; the archive and the destination are left untouched — \
+         inspect {} by hand",
+        slots.source.display(),
+        state.target_model,
+        state.target_dimension,
+        slots.source.display(),
+    )))
+}
+
+fn advance(
+    state: &mut MigrationState,
+    phase: Phase,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    state.phase = phase;
+    state.write(workspace, lock).map_err(query_error)
+}
+
+fn unrecognised_disk(observed: SwitchState, at: Phase) -> crate::MemoryError {
+    let recovery = observed.recovery();
+    query_error(format!(
+        "the journal stands at {at:?} but the disk does not match any step of \
+         this migration (source: {}, archive: {}, destination: {}). The \
+         recovery table says: {recovery:?}",
+        observed.source, observed.archive, observed.destination,
+    ))
+}
+
+/// A path's canonical form, computable even while its slot is empty: the
+/// parent canonicalises, the final component is carried verbatim.
+fn canonical_slot(path: &Path) -> Result<PathBuf, crate::MemoryError> {
+    let name = path
+        .file_name()
+        .ok_or_else(|| query_error(format!("{} has no final path component", path.display())))?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    let base = match parent {
+        Some(parent) => parent
+            .canonicalize()
+            .map_err(|err| query_error(format!("cannot resolve {}: {err}", parent.display())))?,
+        None => std::env::current_dir()
+            .map_err(|err| query_error(format!("cannot resolve the working directory: {err}")))?,
+    };
+    Ok(base.join(name))
+}
+
+/// A rename, made durable: the parent directory is synced so the entry's move
+/// survives a power cut, not just a process crash.
+fn rename_durably(from: &Path, to: &Path) -> Result<(), crate::MemoryError> {
+    std::fs::rename(from, to).map_err(|err| {
+        query_error(format!(
+            "cannot rename {} to {}: {err}",
+            from.display(),
+            to.display()
+        ))
+    })?;
+    if let Some(parent) = to.parent() {
+        let directory = std::fs::File::open(parent).map_err(|err| {
+            query_error(format!(
+                "cannot open {} to sync it: {err}",
+                parent.display()
+            ))
+        })?;
+        directory.sync_all().map_err(|err| {
+            query_error(format!(
+                "the rename of {} is visible but not yet durable: {err}; do \
+                 not power off before re-running",
+                to.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn query_error(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}

--- a/crates/velesdb-memory/src/migration/switchover.rs
+++ b/crates/velesdb-memory/src/migration/switchover.rs
@@ -29,6 +29,7 @@
 //! two re-runs an idempotent commit instead of leaving a freed archive that
 //! the journal still believes in.
 
+use super::query_error;
 use std::path::{Path, PathBuf};
 
 use super::execute::journal_workspace;
@@ -60,10 +61,7 @@ pub fn switch_over(store: &Path, destination: &Path) -> Result<SwitchOutcome, cr
     let workspace = journal_workspace(destination)?;
     let lock = MigrationLock::acquire(&workspace, "migrate-switch").map_err(query_error)?;
     let result = switch_locked(store, destination, &workspace, &lock);
-    let released = lock.release().map_err(query_error);
-    let outcome = result?;
-    released?;
-    Ok(outcome)
+    super::execute::reconcile(result, lock.release())
 }
 
 fn switch_locked(
@@ -178,22 +176,29 @@ fn step_archive(
 ) -> Result<(), crate::MemoryError> {
     match slots.on_disk() {
         // The step is pending: the slot must be free, or renaming would eat
-        // whatever sits there.
+        // whatever sits there — and the source must still BE the store the
+        // journal describes. A stale journal (a crashed migration, overtaken
+        // by later writes or by a whole second migration) would otherwise
+        // archive the LIVE store here and destroy it at commit.
         SwitchState {
             source: true,
             archive: false,
             destination: true,
         } => {
+            require_journalled_fingerprint(&slots.source, state, "source")?;
             rename_durably(&slots.source, &slots.archive)?;
         }
         // The step already happened and its journal entry did not — the crash
         // window. Journal it late; undoing a rename the disk holds would
-        // discard the step.
+        // discard the step. The archive must fingerprint as the journalled
+        // source, or what was archived is not what this journal describes.
         SwitchState {
             source: false,
             archive: true,
             destination: true,
-        } => {}
+        } => {
+            require_journalled_fingerprint(&slots.archive, state, "archive")?;
+        }
         SwitchState {
             source: true,
             archive: true,
@@ -224,22 +229,56 @@ fn step_activate(
             archive: true,
             destination: true,
         } => {
+            require_journalled_fingerprint(&slots.archive, state, "archive")?;
             rename_durably(&slots.destination, &slots.source)?;
         }
         // Source-name occupied, archive present, destination gone: either the
         // rename happened and its journal entry did not, or something else sat
-        // down at the source's name. The provenance stamp validation wrote on
-        // the destination is what tells them apart.
+        // down at the source's name. Two proofs discriminate: the occupant
+        // carries the TARGET's provenance stamp (validation wrote it on the
+        // destination and nothing else has it), and the archive fingerprints
+        // as the journalled source (so this archive belongs to THIS journal,
+        // not to a later migration toward the same target).
         SwitchState {
             source: true,
             archive: true,
             destination: false,
-        } => {
-            require_target_stamp(slots, state)?;
-        }
+        } => late_activation(slots, state)?,
+        // The recovery table's manual advice for this phase is "move the
+        // archive back to the source's name". An operator who followed it and
+        // re-ran presents the journal AHEAD of the disk: source restored,
+        // archive slot empty, destination intact. Redo the first rename —
+        // fingerprint-checked like any other — and continue, rather than
+        // stranding the migration in a shape everything refuses.
+        SwitchState {
+            source: true,
+            archive: false,
+            destination: true,
+        } => redo_after_manual_restore(slots, state)?,
         other => return Err(unrecognised_disk(other, Phase::SourceArchived)),
     }
     advance(state, Phase::DestinationActivated, workspace, lock)
+}
+
+/// The second rename already happened and only the journal is behind. Two
+/// proofs before the late journal entry: the occupant carries the TARGET's
+/// stamp, and the archive fingerprints as THIS journal's source.
+fn late_activation(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
+    require_target_stamp(slots, state)?;
+    require_journalled_fingerprint(&slots.archive, state, "archive")
+}
+
+/// The operator followed the recovery table's manual advice and moved the
+/// archive back; the journal is AHEAD of the disk. Redo both renames —
+/// fingerprint-checked — instead of stranding the migration in a shape
+/// everything refuses.
+fn redo_after_manual_restore(
+    slots: &Slots,
+    state: &MigrationState,
+) -> Result<(), crate::MemoryError> {
+    require_journalled_fingerprint(&slots.source, state, "restored source")?;
+    rename_durably(&slots.source, &slots.archive)?;
+    rename_durably(&slots.destination, &slots.source)
 }
 
 /// Commit: verify the activated store, free the archive, journal the end.
@@ -254,6 +293,14 @@ fn step_commit(
         let _opens = velesdb_core::Database::open(&slots.source)?;
     }
     if slots.archive.exists() {
+        // The archive is the ONLY copy of the old data, and no flock stops a
+        // rename or a recursive delete (measured in review: a daemon that
+        // opened the source in a lock-free window keeps writing into the
+        // archive after the first rename, and remove_dir_all succeeds under
+        // it, unlinking its inodes silently). Before destruction, the archive
+        // must still fingerprint as the settled source the journal knows —
+        // anything else means writes landed here that exist nowhere else.
+        require_journalled_fingerprint(&slots.archive, state, "archive")?;
         std::fs::remove_dir_all(&slots.archive).map_err(|err| {
             query_error(format!(
                 "the activated store is verified but the archive {} could not \
@@ -263,6 +310,29 @@ fn step_commit(
         })?;
     }
     advance(state, Phase::Committed, workspace, lock)
+}
+
+/// The tree at `path` must still fingerprint as the source this journal was
+/// written about. This is the switch's identity check — the stamp says WHAT
+/// KIND of store an occupant is, the fingerprint says WHICH store a tree is,
+/// and only the second can tell this migration's source from a later state of
+/// the same path.
+fn require_journalled_fingerprint(
+    path: &Path,
+    state: &MigrationState,
+    role: &str,
+) -> Result<(), crate::MemoryError> {
+    let observed = super::filesystem::fingerprint(path)?;
+    if observed == state.source_fingerprint {
+        return Ok(());
+    }
+    Err(query_error(format!(
+        "the {role} at {} no longer fingerprints as the store this journal \
+         describes — something wrote to it after the journal was written. \
+         Nothing was moved or deleted; a store that changed hands must be \
+         inspected, not migrated on a stale journal",
+        path.display(),
+    )))
 }
 
 /// The occupant of the source's name must carry the TARGET's provenance stamp
@@ -353,8 +423,4 @@ fn rename_durably(from: &Path, to: &Path) -> Result<(), crate::MemoryError> {
         })?;
     }
     Ok(())
-}
-
-fn query_error(message: impl Into<String>) -> crate::MemoryError {
-    velesdb_core::Error::Query(message.into()).into()
 }

--- a/crates/velesdb-memory/src/migration/tests/cli.rs
+++ b/crates/velesdb-memory/src/migration/tests/cli.rs
@@ -116,22 +116,23 @@ fn a_rebuild_without_a_named_destination_is_refused_rather_than_guessing_one() {
 }
 
 #[test]
-fn the_switch_boundary_message_says_what_did_not_happen() {
-    // The success message of a non-dry-run is load-bearing: `execute` stops at
-    // a rebuilt-but-unswitched destination, and an operator who reads its
-    // output as "migration done" will point their daemon at the OLD store and
-    // wonder where the new vectors went. The message must therefore say, in so
-    // many words, that nothing was validated and nothing was switched.
-    let boundary = not_yet_switchable();
+fn the_completion_message_names_the_restart_and_the_journal() {
+    // This test used to pin the BOUNDARY message — "nothing was validated,
+    // nothing was switched" — because C2b stopped there. C3 wired both, so
+    // the premise inverted, and what the success message must now carry is
+    // the two facts an operator cannot discover from the exit code: the
+    // daemon serves the OLD data from its startup handle until it restarts,
+    // and the journal is left behind on purpose, theirs to remove.
+    let notice = migration_complete_notice();
     for needle in [
-        "NOT been validated",
-        "NOT been switched",
-        "#1762",
-        "source store is still",
+        "RESTART",
+        "handle taken at startup",
+        "journal",
+        "may be removed",
     ] {
         assert!(
-            boundary.contains(needle),
-            "the boundary message must contain '{needle}': {boundary}"
+            notice.contains(needle),
+            "the completion message must contain '{needle}': {notice}"
         );
     }
 }

--- a/crates/velesdb-memory/src/migration/tests/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/tests/diagnosis.rs
@@ -1004,6 +1004,54 @@ fn permanent_v4_gates_cannot_be_promoted_by_editing_json() {
 }
 
 #[test]
+fn the_uncalculated_capabilities_are_still_held_to_their_shape() {
+    // Five capabilities are recalculated verbatim at deserialisation; the
+    // other four carry evidence only the live diagnosis could compute
+    // (staging room, edge counts, the read-only fingerprint check), so a
+    // parsed report cannot re-derive their text. What CAN be held is their
+    // shape: three of them are Proven by construction — `diagnose` has no
+    // code path that produces them Missing — so a report carrying one as
+    // Missing was not produced by `diagnose`. And every capability's text
+    // must be non-empty: evidence that says nothing is not evidence.
+    let (dir, _ttl) = seeded();
+    let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");
+
+    for name in [
+        "diagnostic_staging",
+        "inventory",
+        "source_access_is_read_only",
+    ] {
+        let mut forged = report.clone();
+        forged.capabilities.insert(
+            name.to_owned(),
+            Capability::Missing {
+                blocker: "forged into a blocker no diagnosis ever produced".to_owned(),
+            },
+        );
+        let refusal = direct_deserialization_refusal(&forged);
+        assert!(
+            refusal.contains(name),
+            "{name} has no Missing-producing code path, so a Missing one must \
+             be refused by name: {refusal}"
+        );
+    }
+
+    let mut hollow = report.clone();
+    hollow.capabilities.insert(
+        "edge_counts".to_owned(),
+        Capability::Proven {
+            evidence: String::new(),
+        },
+    );
+    let refusal = direct_deserialization_refusal(&hollow);
+    assert!(
+        refusal.contains("edge_counts") && refusal.contains("empty"),
+        "evidence that says nothing is not evidence, and the refusal must say \
+         which capability said nothing: {refusal}"
+    );
+}
+
+#[test]
 fn a_proven_capability_cannot_have_its_evidence_rewritten_either() {
     let (dir, _ttl) = seeded();
     let report = diagnose(dir.path(), TARGET_MODEL, TARGET_DIM, None).expect("diagnose");

--- a/crates/velesdb-memory/src/migration/tests/execute.rs
+++ b/crates/velesdb-memory/src/migration/tests/execute.rs
@@ -14,12 +14,12 @@ use crate::storage::NativeStore;
 use crate::MemoryStore;
 use std::collections::BTreeMap;
 
-const NEW_DIM: usize = 8;
-const SEEDED: u64 = 5;
+pub(super) const NEW_DIM: usize = 8;
+pub(super) const SEEDED: u64 = 5;
 
 /// A root holding the source store at `store/`, leaving room for a sibling
 /// destination on the same filesystem — the layout the switch (C3) requires.
-fn root_with_source() -> tempfile::TempDir {
+pub(super) fn root_with_source() -> tempfile::TempDir {
     let root = tempfile::tempdir().expect("root");
     let store = root.path().join("store");
     std::fs::create_dir(&store).expect("mkdir store");
@@ -35,7 +35,7 @@ fn root_with_source() -> tempfile::TempDir {
     root
 }
 
-fn contents(dir: &std::path::Path) -> BTreeMap<u64, serde_json::Value> {
+pub(super) fn contents(dir: &std::path::Path) -> BTreeMap<u64, serde_json::Value> {
     super::preservation::read_out(dir, "_semantic_memory")
         .iter()
         .map(|fact| {
@@ -61,7 +61,9 @@ fn run_with(
     )
 }
 
-fn run(root: &std::path::Path) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
+pub(super) fn run(
+    root: &std::path::Path,
+) -> Result<super::super::ExecuteOutcome, crate::MemoryError> {
     run_with(root, &HashEmbedder::new(NEW_DIM))
 }
 

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -28,6 +28,7 @@ use std::collections::BTreeSet;
 
 mod diagnostic_copy;
 mod execute;
+mod orchestrate;
 mod rebuild;
 mod rebuild_state;
 mod state_persistence;

--- a/crates/velesdb-memory/src/migration/tests/mod.rs
+++ b/crates/velesdb-memory/src/migration/tests/mod.rs
@@ -31,6 +31,8 @@ mod execute;
 mod rebuild;
 mod rebuild_state;
 mod state_persistence;
+mod switchover;
+mod validate;
 
 const DIM: usize = 4;
 const EMBEDDING: [f32; 4] = [1.0, 0.0, 0.0, 0.0];

--- a/crates/velesdb-memory/src/migration/tests/orchestrate.rs
+++ b/crates/velesdb-memory/src/migration/tests/orchestrate.rs
@@ -1,0 +1,90 @@
+//! GATE 11 — the operator's one command, end to end (#1762, PR C3).
+//!
+//! `execute`, `validate_destination` and `switch_over` are each proven; what
+//! an operator actually runs is one command that chains them — and the chain
+//! has a failure mode none of the parts has: after the first rename, the
+//! SOURCE PATH IS VACANT, so a re-run that blindly started from the diagnosis
+//! would fail on an absent directory and never reach the switch that knows
+//! how to continue. `migrate` reads the journal first and enters the chain
+//! where the journal says, which is what makes "re-run the same command" a
+//! true recovery instruction instead of a wall.
+
+use super::execute::{root_with_source, NEW_DIM, SEEDED};
+use super::switchover::journal_phase;
+use super::*;
+use crate::embedder::HashEmbedder;
+
+fn migrate(root: &std::path::Path) -> Result<super::super::MigrateOutcome, crate::MemoryError> {
+    let embedder = HashEmbedder::new(NEW_DIM);
+    super::super::migrate(
+        &root.join("store"),
+        root,
+        &TargetContract::automatic("hash", NEW_DIM),
+        &root.join("rebuilt"),
+        &embedder,
+        1024,
+    )
+}
+
+#[test]
+fn a_fresh_migrate_runs_the_whole_chain_to_committed() {
+    let root = root_with_source();
+    let outcome = migrate(root.path()).expect("migrate");
+
+    let executed = outcome.executed.expect("a fresh run rebuilds, and says so");
+    assert_eq!(executed.rebuild.facts, SEEDED);
+    let validated = outcome
+        .validated
+        .expect("a fresh run validates, and says so");
+    assert_eq!(validated.facts, SEEDED);
+
+    let store = root.path().join("store");
+    assert_eq!(
+        outcome.switched.activated,
+        store.canonicalize().expect("exists"),
+        "the chain must end with the rebuilt store live at the source's path"
+    );
+    let journalled = MigrationState::read(&executed.workspace)
+        .expect("read journal")
+        .expect("journal exists");
+    assert_eq!(journalled.phase, Phase::Committed);
+}
+
+#[test]
+fn migrate_resumes_past_a_crash_at_source_archived() {
+    // The crash the chain must survive: the switch archived the source and
+    // died. The source path is now VACANT — a re-run that started from the
+    // diagnosis would fail on the absent directory before ever reaching the
+    // code that knows how to continue. The journal is what routes around it.
+    let root = root_with_source();
+    let executed = super::execute::run(root.path()).expect("execute");
+    super::super::validate_destination(
+        &root.path().join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect("validate");
+    let store = root.path().join("store");
+    std::fs::rename(&store, root.path().join("store.archive")).expect("crashed first rename");
+    journal_phase(&executed.workspace, Phase::SourceArchived);
+
+    let outcome = migrate(root.path()).expect("the re-run must resume at the switch");
+    assert!(
+        outcome.executed.is_none() && outcome.validated.is_none(),
+        "a resume past validation must not re-run the earlier stages — with \
+         the source vacant it could not, and pretending it did would misreport"
+    );
+    assert_eq!(
+        outcome.switched.activated,
+        store.canonicalize().expect("exists"),
+        "the switch must have completed from where the journal stood"
+    );
+    assert_eq!(
+        MigrationState::read(&executed.workspace)
+            .expect("read journal")
+            .expect("journal exists")
+            .phase,
+        Phase::Committed
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/switchover.rs
+++ b/crates/velesdb-memory/src/migration/tests/switchover.rs
@@ -30,7 +30,7 @@ fn journal(workspace: &std::path::Path) -> MigrationState {
 }
 
 /// Advance the journal by hand, as the crashed run would have.
-fn journal_phase(workspace: &std::path::Path, phase: Phase) {
+pub(super) fn journal_phase(workspace: &std::path::Path, phase: Phase) {
     let lock = MigrationLock::acquire(workspace, "switch-test").expect("lock");
     let mut state = journal(workspace);
     state.phase = phase;
@@ -207,6 +207,97 @@ fn an_unstamped_occupant_of_the_source_slot_is_refused() {
         elsewhere.exists(),
         "the set-aside destination must be untouched"
     );
+}
+
+#[test]
+fn a_source_that_moved_on_cannot_be_archived_by_a_stale_journal() {
+    // The stamp alone cannot tell two migrations toward the same target
+    // apart, and a crashed migration's journal stays at DestinationValidated
+    // forever. If a LATER write lands in the source — a daemon, or a whole
+    // second migration — this journal describes a store that no longer
+    // exists, and archiving the live one on its say-so would end with commit
+    // DESTROYING post-journal writes. The fingerprint is what notices.
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    {
+        let native = crate::storage::NativeStore::open(&store, DIM).expect("open");
+        native
+            .store(77, "written after validation", &EMBEDDING)
+            .expect("late write");
+    }
+
+    let refusal = super::super::switch_over(&store, &executed.destination)
+        .expect_err("a stale journal must not move a store that moved on");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("fingerprint") || message.contains("changed"),
+        "the refusal must say the source no longer matches the journal: {message}"
+    );
+    assert!(store.exists(), "nothing may have moved");
+    assert!(executed.destination.exists(), "nothing may have moved");
+}
+
+#[test]
+fn commit_refuses_to_free_an_archive_that_received_writes() {
+    // The archive is the ONLY copy of the old data, and (measured in review)
+    // neither a rename nor remove_dir_all is stopped by a daemon's flock on a
+    // file inside it: a daemon that opened the source in the validate→switch
+    // window keeps writing into the ARCHIVE after the first rename, silently.
+    // Freeing that archive would destroy its writes. Before destruction, the
+    // archive must still fingerprint as the settled source the journal knows.
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    // Both renames done, journal caught up to DestinationActivated — and then
+    // a foreign write lands in the archive.
+    std::fs::rename(&store, &archive).expect("first rename");
+    journal_phase(&executed.workspace, Phase::SourceArchived);
+    std::fs::rename(&executed.destination, &store).expect("second rename");
+    journal_phase(&executed.workspace, Phase::DestinationActivated);
+    std::fs::write(archive.join("daemon-was-here.wal"), b"unsynced writes").expect("foreign write");
+
+    let refusal = super::super::switch_over(&store, &executed.destination)
+        .expect_err("an archive that changed since the journal must not be destroyed");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("archive"),
+        "the refusal must name the archive: {message}"
+    );
+    assert!(
+        std::fs::read(archive.join("daemon-was-here.wal")).is_ok(),
+        "the foreign write — possibly the only copy of someone's data — must survive"
+    );
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationActivated,
+        "a refused commit must leave the journal where it was"
+    );
+}
+
+#[test]
+fn a_manual_restore_is_re_archived_and_the_switch_completes() {
+    // The recovery table's advice for SourceArchived is "move the archive
+    // back to the source's name". An operator who follows it and then re-runs
+    // the switch presents: source at its name, no archive, destination
+    // intact, journal at SourceArchived — the journal AHEAD of the disk. The
+    // switch redoes the first rename (fingerprint-checked) and completes,
+    // instead of stranding the migration in a shape everything refuses.
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    std::fs::rename(&store, &archive).expect("first rename");
+    journal_phase(&executed.workspace, Phase::SourceArchived);
+    std::fs::rename(&archive, &store).expect("the operator's manual restore");
+
+    let outcome = super::super::switch_over(&store, &executed.destination)
+        .expect("a restored source under a SourceArchived journal must re-archive and continue");
+    assert_eq!(outcome.activated, store.canonicalize().expect("exists"));
+    assert_eq!(journal(&executed.workspace).phase, Phase::Committed);
 }
 
 #[test]

--- a/crates/velesdb-memory/src/migration/tests/switchover.rs
+++ b/crates/velesdb-memory/src/migration/tests/switchover.rs
@@ -1,0 +1,225 @@
+//! GATE 10 — the switch (#1762, PR C3).
+//!
+//! Two renames stand between a validated destination and a live store, and a
+//! crash can land between any two steps. What these tests pin is that every
+//! landing spot either CONTINUES forward — a rename that already happened is
+//! journalled late, never undone — or refuses with both stores intact. The
+//! discriminator for the ambiguous spot is the provenance stamp validation
+//! wrote: the activated store carries the TARGET's stamp, the old source does
+//! not, so "who is sitting at the source's name" is readable from disk.
+
+use super::execute::{root_with_source, run, NEW_DIM};
+use super::*;
+
+fn validated(root: &std::path::Path) -> super::super::ExecuteOutcome {
+    let executed = run(root).expect("execute");
+    super::super::validate_destination(
+        &root.join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect("validate");
+    executed
+}
+
+fn journal(workspace: &std::path::Path) -> MigrationState {
+    MigrationState::read(workspace)
+        .expect("read journal")
+        .expect("journal exists")
+}
+
+/// Advance the journal by hand, as the crashed run would have.
+fn journal_phase(workspace: &std::path::Path, phase: Phase) {
+    let lock = MigrationLock::acquire(workspace, "switch-test").expect("lock");
+    let mut state = journal(workspace);
+    state.phase = phase;
+    state.write(workspace, &lock).expect("journal write");
+    lock.release().expect("release");
+}
+
+#[test]
+fn a_full_switch_activates_the_destination_and_frees_the_archive() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    let outcome = super::super::switch_over(&store, &executed.destination).expect("switch");
+
+    assert_eq!(
+        outcome.activated,
+        store.canonicalize().expect("the activated store exists"),
+        "the new store must sit at the source's name"
+    );
+    assert!(
+        !archive.exists(),
+        "committing must free the archive — the recovery table says advancing \
+         frees it, and this is the advance"
+    );
+    assert!(
+        !executed.destination.exists(),
+        "the destination directory moved; a copy left behind would be a third \
+         authority"
+    );
+    assert_eq!(journal(&executed.workspace).phase, Phase::Committed);
+
+    // The store at the source's name IS the rebuilt one: it opens, carries the
+    // TARGET's provenance, and holds the rebuilt facts.
+    let stamped = crate::embedding_provenance::read(&store)
+        .expect("read provenance")
+        .expect("the activated store carries the stamp validation wrote");
+    assert_eq!(
+        (stamped.model.as_str(), stamped.dimension),
+        ("hash", NEW_DIM)
+    );
+    let db = velesdb_core::Database::open(&store).expect("the activated store opens");
+    let facts = super::super::enumerate_by_cursor(&db, "_semantic_memory", 1024).expect("walk");
+    assert_eq!(
+        facts.len() as u64,
+        super::execute::SEEDED,
+        "the facts are the rebuilt ones"
+    );
+}
+
+#[test]
+fn a_switch_before_validation_is_refused() {
+    let root = root_with_source();
+    let executed = run(root.path()).expect("execute");
+
+    let refusal = super::super::switch_over(&root.path().join("store"), &executed.destination)
+        .expect_err("switching an unvalidated destination");
+    assert!(
+        refusal.to_string().contains("validate"),
+        "the refusal must point at the missing validation: {refusal}"
+    );
+    assert!(root.path().join("store").exists(), "nothing may have moved");
+    assert!(executed.destination.exists(), "nothing may have moved");
+}
+
+#[test]
+fn an_occupied_archive_slot_is_refused_with_everything_intact() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let archive = root.path().join("store.archive");
+    std::fs::create_dir(&archive).expect("occupy the archive slot");
+    std::fs::write(archive.join("evidence.txt"), b"someone else's data").expect("mark it");
+
+    let refusal = super::super::switch_over(&root.path().join("store"), &executed.destination)
+        .expect_err("renaming the source over an existing archive would eat it");
+    assert!(
+        refusal.to_string().contains("store.archive"),
+        "the refusal must name the occupied slot: {refusal}"
+    );
+    assert!(
+        root.path().join("store").exists(),
+        "the source must not have moved"
+    );
+    assert!(
+        executed.destination.exists(),
+        "the destination must not have moved"
+    );
+    assert!(
+        std::fs::read(archive.join("evidence.txt")).is_ok(),
+        "whatever occupies the slot must be untouched"
+    );
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationValidated,
+        "a refused switch must leave the journal where it was"
+    );
+}
+
+#[test]
+fn a_crash_after_the_first_rename_is_continued_not_undone() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    // The crash window: rename one happened, its journal entry did not.
+    std::fs::rename(&store, &archive).expect("simulate the crashed rename");
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationValidated
+    );
+
+    let outcome = super::super::switch_over(&store, &executed.destination)
+        .expect("the re-run must journal the rename late and continue forward");
+    assert_eq!(outcome.activated, store.canonicalize().expect("exists"));
+    assert_eq!(journal(&executed.workspace).phase, Phase::Committed);
+    assert!(!archive.exists(), "the completed switch frees the archive");
+}
+
+#[test]
+fn a_crash_after_the_second_rename_is_recognised_by_the_stamp() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    // Both renames happened; the journal only knows about the first. What sits
+    // at the source's name is the ACTIVATED destination — and the proof is the
+    // provenance stamp validation wrote on it.
+    std::fs::rename(&store, &archive).expect("first rename");
+    journal_phase(&executed.workspace, Phase::SourceArchived);
+    std::fs::rename(&executed.destination, &store).expect("second rename");
+
+    let outcome = super::super::switch_over(&store, &executed.destination)
+        .expect("the stamp identifies the activated store; the run continues");
+    assert_eq!(outcome.activated, store.canonicalize().expect("exists"));
+    assert_eq!(journal(&executed.workspace).phase, Phase::Committed);
+    assert!(!archive.exists());
+}
+
+#[test]
+fn an_unstamped_occupant_of_the_source_slot_is_refused() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    // Same disk shape as the crash above — source-name occupied, archive
+    // present — but what occupies the slot does NOT carry the target's stamp:
+    // this is the two-authorities shape nothing in this migration produced.
+    std::fs::rename(&store, &archive).expect("first rename");
+    journal_phase(&executed.workspace, Phase::SourceArchived);
+    // The destination moves aside too: the shape under test is (source-name
+    // occupied, archive present, destination GONE) — with the destination
+    // still in place the disk is the three-authorities shape, which refuses
+    // earlier and for a different reason.
+    let elsewhere = root.path().join("elsewhere");
+    std::fs::rename(&executed.destination, &elsewhere).expect("destination aside");
+    std::fs::create_dir(&store).expect("an impostor at the source's name");
+
+    let refusal = super::super::switch_over(&store, &executed.destination)
+        .expect_err("an unstamped occupant cannot be assumed to be the destination");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("stamp") || message.contains("provenance"),
+        "the refusal must say WHY the occupant is not trusted: {message}"
+    );
+    assert!(
+        archive.exists(),
+        "the archive — the only authority — must be untouched"
+    );
+    assert!(
+        elsewhere.exists(),
+        "the set-aside destination must be untouched"
+    );
+}
+
+#[test]
+fn a_committed_migration_refuses_to_switch_again() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    super::super::switch_over(&store, &executed.destination).expect("switch");
+
+    let refusal = super::super::switch_over(&store, &executed.destination)
+        .expect_err("a committed migration has nothing left to switch");
+    assert!(
+        refusal.to_string().contains("complete"),
+        "the refusal must say the migration is done: {refusal}"
+    );
+}

--- a/crates/velesdb-memory/src/migration/tests/validate.rs
+++ b/crates/velesdb-memory/src/migration/tests/validate.rs
@@ -1,0 +1,220 @@
+//! GATE 9 — validation of the rebuilt destination (#1762, PR C3).
+//!
+//! The rebuild's own re-reads run WHILE it writes, collection by collection.
+//! This is the other kind of proof: one pass over the finished destination,
+//! against the source as it stands, before anything is allowed to move. It is
+//! also where the destination earns its provenance stamp — the daemon reads
+//! `embedding-provenance.json` before it opens a store, so an unstamped
+//! destination would degrade into the unrecorded-model warning the moment the
+//! switch put it live.
+//!
+//! Divergences have exactly one tolerated explanation: a fact whose ABSOLUTE
+//! expiry passed between the two walks — the clock window Fable's C2b review
+//! named, discriminated mechanically here as promised there. Everything else
+//! is loss, and it is named.
+
+use super::execute::{root_with_source, run, NEW_DIM, SEEDED};
+use super::*;
+
+#[test]
+fn a_validated_destination_advances_the_journal_and_carries_provenance() {
+    let root = root_with_source();
+    let executed = run(root.path()).expect("execute");
+
+    let outcome = super::super::validate_destination(
+        &root.path().join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect("validate");
+
+    assert_eq!(outcome.facts, SEEDED, "every fact must have been compared");
+    assert_eq!(outcome.edges, 1, "every edge must have been compared");
+    assert_eq!(
+        outcome.explained_by_expiry, 0,
+        "nothing expired mid-walk in this fixture; a nonzero count here means \
+         the discriminator explained something it should not have"
+    );
+
+    let journalled = MigrationState::read(&executed.workspace)
+        .expect("read journal")
+        .expect("journal exists");
+    assert_eq!(
+        journalled.phase,
+        Phase::DestinationValidated,
+        "the validation is worthless unless the journal records it"
+    );
+
+    let stamped = crate::embedding_provenance::read(&executed.destination)
+        .expect("read provenance")
+        .expect("the validated destination must carry a provenance stamp");
+    assert_eq!(
+        (stamped.model.as_str(), stamped.dimension),
+        ("hash", NEW_DIM),
+        "the stamp must name the TARGET embedder — the daemon reads it before \
+         opening, and a wrong stamp would be trusted forever"
+    );
+
+    // Idempotence: validating a validated destination succeeds and changes
+    // nothing — the re-run an operator performs after any doubt.
+    super::super::validate_destination(
+        &root.path().join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect("re-validation is idempotent");
+}
+
+#[test]
+fn a_fact_the_source_does_not_hold_is_refused_by_name() {
+    let root = root_with_source();
+    let executed = run(root.path()).expect("execute");
+
+    // A live intruder written straight into the destination — the shape of a
+    // corruption, an operator mistake, or a rebuild bug. It carries no expiry,
+    // so the discriminator must NOT explain it away.
+    {
+        let db = velesdb_core::Database::open(&executed.destination).expect("open destination");
+        let any = db
+            .get_any_collection("_semantic_memory")
+            .expect("collection");
+        any.upsert(vec![velesdb_core::Point::new(
+            999,
+            vec![0.0; NEW_DIM],
+            Some(serde_json::json!({ "content": "an intruder the source never held" })),
+        )])
+        .expect("plant intruder");
+    }
+
+    let refusal = super::super::validate_destination(
+        &root.path().join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect_err("a destination holding a fact the source does not is not valid");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("_semantic_memory") && message.contains("999"),
+        "the refusal must name the collection and the fact: {message}"
+    );
+
+    // ...and the journal must NOT have advanced past a failed validation.
+    let journalled = MigrationState::read(&executed.workspace)
+        .expect("read journal")
+        .expect("journal exists");
+    assert_eq!(
+        journalled.phase,
+        Phase::Prepared,
+        "a failed validation must leave the journal exactly where it was"
+    );
+}
+
+#[test]
+fn an_unfinished_rebuild_cannot_be_validated() {
+    let root = root_with_source();
+    // A destination and a journal staged by hand, with one collection still
+    // mid-facts — the state a killed rebuild leaves.
+    let destination = root.path().join("rebuilt");
+    {
+        let _store =
+            crate::storage::NativeStore::open(&destination, NEW_DIM).expect("create destination");
+    }
+    let workspace = root.path().join("rebuilt.migration-journal");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let lock = MigrationLock::acquire(&workspace, "unfinished-test").expect("lock");
+    let mut progress = std::collections::BTreeMap::new();
+    for name in AGENT_COLLECTIONS {
+        progress.insert((*name).to_owned(), CollectionProgress::Complete);
+    }
+    progress.insert(
+        "_episodic_memory".to_owned(),
+        CollectionProgress::Facts { cursor: Some(3) },
+    );
+    let state = MigrationState {
+        format_version: STATE_FORMAT_VERSION,
+        phase: Phase::Prepared,
+        source_path: root.path().join("store"),
+        source_fingerprint: super::super::fingerprint(&root.path().join("store"))
+            .expect("fingerprint"),
+        target_model: "hash".to_owned(),
+        target_dimension: NEW_DIM,
+        progress,
+        embedder_witness: None,
+    };
+    state.write(&workspace, &lock).expect("journal");
+    lock.release().expect("release");
+
+    let refusal = super::super::validate_destination(
+        &root.path().join("store"),
+        &destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect_err("validating a rebuild that is not finished");
+    assert!(
+        refusal.to_string().contains("_episodic_memory"),
+        "the refusal must name the unfinished collection: {refusal}"
+    );
+}
+
+#[test]
+fn a_source_that_changed_since_the_rebuild_is_refused() {
+    let root = root_with_source();
+    let executed = run(root.path()).expect("execute");
+
+    // The daemon (or anyone) writes one more fact to the SOURCE after the
+    // rebuild. Validating against it would compare the destination to a store
+    // it was never built from, and every difference would read as loss.
+    {
+        let store =
+            crate::storage::NativeStore::open(root.path().join("store"), DIM).expect("open");
+        store
+            .store(100, "written after the rebuild", &EMBEDDING)
+            .expect("late write");
+    }
+
+    let refusal = super::super::validate_destination(
+        &root.path().join("store"),
+        &executed.destination,
+        &TargetContract::automatic("hash", NEW_DIM),
+        1024,
+    )
+    .expect_err("a moved source invalidates the comparison, not the destination");
+    let message = refusal.to_string();
+    assert!(
+        message.contains("fingerprint") || message.contains("changed"),
+        "the refusal must say the SOURCE moved, not accuse the destination: {message}"
+    );
+}
+
+#[test]
+fn the_expiry_discriminator_tells_vanished_from_live() {
+    // The only tolerated divergence is a fact whose absolute expiry passed
+    // between the two walks. That race cannot be staged deterministically, and
+    // the expiry itself cannot be read back — an expired point is invisible on
+    // EVERY public read surface, `get` answering `None` for it exactly as for
+    // a deleted one. What the discriminator actually tests is that narrower,
+    // sufficient fact: under the validation's held lock, an id a walk returned
+    // that now reads back absent can only have expired. So: an expired point
+    // explains (it reads back absent), a live one does not. An id the store
+    // never held ALSO reads back absent — the function cannot tell, which is
+    // why its contract restricts callers to ids this session's walks returned;
+    // that restriction is upheld by construction in `compare_facts` and
+    // `compare_edges`, where every probed id comes out of a walk's diff.
+    let root = root_with_source();
+    let store = root.path().join("store");
+    super::preservation::seed_raw(&store, 50, "expired long ago", Some(1_000_000));
+
+    let db = velesdb_core::Database::open(&store).expect("open");
+    assert!(
+        super::super::divergence_explained_by_expiry(&db, "_semantic_memory", 50),
+        "a point whose absolute expiry passed must explain its own absence"
+    );
+    assert!(
+        !super::super::divergence_explained_by_expiry(&db, "_semantic_memory", 1),
+        "a live point explains nothing — its divergence is loss"
+    );
+}

--- a/crates/velesdb-memory/src/migration/validate.rs
+++ b/crates/velesdb-memory/src/migration/validate.rs
@@ -1,0 +1,465 @@
+//! Validation of the rebuilt destination (#1762, PR C3).
+//!
+//! The rebuild re-reads what it writes, but it does so collection by
+//! collection, WHILE writing. This is the other proof: one pass over the
+//! finished destination against the source as it stands, before anything is
+//! allowed to move. [`Phase::DestinationValidated`] — defined since C1 and
+//! never produced by any code until now — is exactly this pass's journal
+//! entry.
+//!
+//! # What is compared, and what deliberately is not
+//!
+//! Facts are compared as id → payload maps, both sides walked by the same
+//! cursor the rebuild used; edges as sets of complete tuples through
+//! [`super::edges::export_edges_verified`] on both stores. Vectors are NOT
+//! compared: under `reembed` they differ from the source's by design, and
+//! re-embedding every fact to check them would repeat the rebuild to validate
+//! the rebuild. What stands in for them is the embedder witness the journal
+//! already carries.
+//!
+//! # The one tolerated divergence
+//!
+//! A fact whose ABSOLUTE expiry passes between the source walk and the
+//! destination walk is visible in one and hidden in the other, with nothing
+//! lost — the clock window named in C2b's review, discriminated mechanically
+//! here as promised there: a diverging id explains itself if and only if the
+//! point's payload carries `_veles_expires_at <= now`. A durably expired fact
+//! is invisible to BOTH walks, so this discriminator can never excuse real
+//! loss: a live intruder or a missing live fact has no expiry to hide behind.
+//!
+//! # The provenance stamp
+//!
+//! The daemon reads `embedding-provenance.json` BEFORE it opens a store. A
+//! destination switched live without a stamp would degrade into the
+//! unrecorded-model warning on every start, and stamping it any earlier than
+//! validation would stamp a store nobody had proven. The stamp is written from
+//! the JOURNAL's identity — the same model and dimension every resume was
+//! checked against — after the comparison passes and before the phase
+//! advances.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use velesdb_core::Database;
+
+use super::diagnosis::TargetContract;
+use super::edges::export_edges_verified;
+use super::enumeration::{enumerate_by_cursor, AGENT_COLLECTIONS};
+use super::execute::journal_workspace;
+use super::state::{CollectionProgress, MigrationLock, MigrationState, Phase};
+use velesdb_core::agent::AgentMemory;
+use velesdb_core::collection::graph::GraphEdge;
+
+/// What one validation pass established.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct ValidationOutcome {
+    /// Facts compared across the two stores.
+    pub facts: u64,
+    /// Edges compared across the two stores.
+    pub edges: u64,
+    /// Divergences explained by an absolute expiry crossing the walk window —
+    /// tolerated, counted, and reported rather than silently absorbed.
+    pub explained_by_expiry: u64,
+}
+
+/// Validate `destination` against `store` and journal the result.
+///
+/// Requires the journal at [`Phase::Prepared`] with every collection
+/// `Complete` (or already at [`Phase::DestinationValidated`], making the call
+/// an idempotent re-validation). The source must still match the journalled
+/// fingerprint: a source that moved since the rebuild invalidates the
+/// comparison, not the destination, and the refusal says which.
+///
+/// # Errors
+/// Returns [`crate::MemoryError`] when there is no journal, the rebuild is
+/// unfinished, the source changed, the identity mismatches, the stores
+/// diverge beyond the expiry window, or the stamp or journal write fails.
+pub fn validate_destination(
+    store: &Path,
+    destination: &Path,
+    target: &TargetContract,
+    batch: usize,
+) -> Result<ValidationOutcome, crate::MemoryError> {
+    let workspace = journal_workspace(destination)?;
+    let lock = MigrationLock::acquire(&workspace, "migrate-validate").map_err(query_error)?;
+    let result = validate_locked(store, destination, target, batch, &workspace, &lock);
+    let released = lock.release().map_err(query_error);
+    let outcome = result?;
+    released?;
+    Ok(outcome)
+}
+
+fn validate_locked(
+    store: &Path,
+    destination: &Path,
+    target: &TargetContract,
+    batch: usize,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<ValidationOutcome, crate::MemoryError> {
+    let mut state = journalled_state(target, workspace)?;
+    let outcome = compare_stores(store, destination, &state, batch)?;
+
+    crate::embedding_provenance::write(
+        destination,
+        &crate::embedding_provenance::EmbeddingProvenance::new(
+            &state.target_model,
+            state.target_dimension,
+        ),
+    )
+    .map_err(query_error)?;
+
+    if state.phase == Phase::Prepared {
+        state.phase = Phase::DestinationValidated;
+        state.write(workspace, lock).map_err(query_error)?;
+    }
+    Ok(outcome)
+}
+
+/// Open both stores and compare every collection's facts and edges.
+fn compare_stores(
+    store: &Path,
+    destination: &Path,
+    state: &MigrationState,
+    batch: usize,
+) -> Result<ValidationOutcome, crate::MemoryError> {
+    let source = StoreView::open_source(store, state.target_dimension)?;
+    let destination = StoreView::open_destination(destination, state.target_dimension)?;
+    let mut outcome = ValidationOutcome::default();
+    for collection in AGENT_COLLECTIONS {
+        Comparison {
+            source: &source,
+            destination: &destination,
+            collection,
+            batch,
+            outcome: &mut outcome,
+        }
+        .run()?;
+    }
+    Ok(outcome)
+}
+
+/// Read the journal and refuse everything a validation cannot stand on.
+fn journalled_state(
+    target: &TargetContract,
+    workspace: &Path,
+) -> Result<MigrationState, crate::MemoryError> {
+    let state = MigrationState::read(workspace)
+        .map_err(query_error)?
+        .ok_or_else(|| {
+            query_error(format!(
+                "no migration journal at {}; there is nothing to validate — run \
+                 the rebuild first",
+                workspace.display()
+            ))
+        })?;
+    require_validatable(&state)?;
+    let fingerprint = super::filesystem::fingerprint(&state.source_path)?;
+    state
+        .may_resume(
+            &state.source_path,
+            &fingerprint,
+            &target.model,
+            target.dimension,
+        )
+        .map_err(|reason| {
+            query_error(format!(
+                "the comparison would be against a store the destination was \
+                 not built from: {reason}"
+            ))
+        })?;
+    Ok(state)
+}
+
+/// The journal must stand where a validation makes sense: rebuild finished,
+/// switch not yet begun.
+fn require_validatable(state: &MigrationState) -> Result<(), crate::MemoryError> {
+    if state.phase != Phase::Prepared && state.phase != Phase::DestinationValidated {
+        return Err(query_error(format!(
+            "the journal stands at {:?}; validation runs before the switch, \
+             not after it",
+            state.phase
+        )));
+    }
+    for (name, progress) in &state.progress {
+        if *progress != CollectionProgress::Complete {
+            return Err(query_error(format!(
+                "collection '{name}' stands at {progress:?}; an unfinished \
+                 rebuild cannot be validated — resume it first"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// One store as the validation reads it: the database handle and the agent
+/// view the edge export goes through, opened together because neither is
+/// meaningful for this pass without the other.
+struct StoreView {
+    db: std::sync::Arc<Database>,
+    memory: AgentMemory,
+}
+
+impl StoreView {
+    /// The source opens its `AgentMemory` at its OWN width, discovered from
+    /// the store — the fact walk does not care, but the edge export does, and
+    /// under `reembed` the source's width is not the target's.
+    fn open_source(dir: &Path, target_dimension: usize) -> Result<Self, crate::MemoryError> {
+        let db = std::sync::Arc::new(Database::open(dir)?);
+        let dimension = db
+            .get_any_collection(AGENT_COLLECTIONS[0])
+            .map_or(target_dimension, |collection| collection.config().dimension);
+        let memory = AgentMemory::with_dimension(std::sync::Arc::clone(&db), dimension)?;
+        Ok(Self { db, memory })
+    }
+
+    /// The destination was built at the target's width, and says so.
+    fn open_destination(dir: &Path, target_dimension: usize) -> Result<Self, crate::MemoryError> {
+        let db = std::sync::Arc::new(Database::open(dir)?);
+        let memory = AgentMemory::with_dimension(std::sync::Arc::clone(&db), target_dimension)?;
+        Ok(Self { db, memory })
+    }
+
+    fn facts(
+        &self,
+        collection: &str,
+        batch: usize,
+    ) -> Result<BTreeMap<u64, serde_json::Value>, crate::MemoryError> {
+        let mut facts = BTreeMap::new();
+        for fact in enumerate_by_cursor(&self.db, collection, batch)? {
+            let payload: serde_json::Value =
+                serde_json::from_str(&fact.payload).map_err(|err| {
+                    query_error(format!(
+                        "fact {} in '{collection}' carries unreadable payload: {err}",
+                        fact.id
+                    ))
+                })?;
+            facts.insert(fact.id, payload);
+        }
+        Ok(facts)
+    }
+
+    fn edges(&self, collection: &str, batch: usize) -> Result<Vec<GraphEdge>, crate::MemoryError> {
+        export_edges_verified(&self.memory, &self.db, collection, batch)
+    }
+
+    /// See [`divergence_explained_by_expiry`] for why absence means expiry.
+    fn vanished(&self, collection: &str, id: u64) -> bool {
+        divergence_explained_by_expiry(&self.db, collection, id)
+    }
+}
+
+/// Which of the two stores an observation belongs to — named, because a
+/// refusal that cannot say WHICH side held the stray fact is half a refusal.
+#[derive(Debug, Clone, Copy)]
+enum Side {
+    Source,
+    Destination,
+}
+
+impl Side {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Destination => "destination",
+        }
+    }
+}
+
+/// One collection compared across the two views, accumulating into the
+/// outcome. A struct rather than a parameter list, because every method needs
+/// the same five things and a signature repeating them five times is where
+/// the sixth one gets threaded through wrongly.
+struct Comparison<'a> {
+    source: &'a StoreView,
+    destination: &'a StoreView,
+    collection: &'a str,
+    batch: usize,
+    outcome: &'a mut ValidationOutcome,
+}
+
+impl Comparison<'_> {
+    fn run(&mut self) -> Result<(), crate::MemoryError> {
+        self.compare_facts()?;
+        self.compare_edges()
+    }
+
+    fn view(&self, side: Side) -> &StoreView {
+        match side {
+            Side::Source => self.source,
+            Side::Destination => self.destination,
+        }
+    }
+
+    fn compare_facts(&mut self) -> Result<(), crate::MemoryError> {
+        let source_facts = self.source.facts(self.collection, self.batch)?;
+        let destination_facts = self.destination.facts(self.collection, self.batch)?;
+        self.outcome.facts += source_facts.len() as u64;
+
+        for (id, payload) in &source_facts {
+            self.compare_one_fact(*id, payload, destination_facts.get(id))?;
+        }
+        for id in destination_facts.keys() {
+            if !source_facts.contains_key(id) {
+                self.fact_explained_or_loss(Side::Destination, *id)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// One source fact against what the destination holds under the same id.
+    fn compare_one_fact(
+        &mut self,
+        id: u64,
+        payload: &serde_json::Value,
+        found: Option<&serde_json::Value>,
+    ) -> Result<(), crate::MemoryError> {
+        match found {
+            Some(found) if found == payload => Ok(()),
+            Some(_) => Err(query_error(format!(
+                "fact {id} in '{}' differs between source and destination; a \
+                 payload that changed in transit is loss, and no expiry \
+                 explains a fact both stores still hold",
+                self.collection
+            ))),
+            None => self.fact_explained_or_loss(Side::Source, id),
+        }
+    }
+
+    /// A diverging id either explains itself by expiry or fails the pass.
+    fn fact_explained_or_loss(&mut self, side: Side, id: u64) -> Result<(), crate::MemoryError> {
+        if self.view(side).vanished(self.collection, id) {
+            self.outcome.explained_by_expiry += 1;
+            return Ok(());
+        }
+        Err(query_error(format!(
+            "fact {id} in '{}' exists only on the {} side and is still live \
+             there; this is loss, not a clock window",
+            self.collection,
+            side.name(),
+        )))
+    }
+
+    fn compare_edges(&mut self) -> Result<(), crate::MemoryError> {
+        let exported = self.source.edges(self.collection, self.batch)?;
+        let back = self.destination.edges(self.collection, self.batch)?;
+        self.outcome.edges += exported.len() as u64;
+
+        let source_tuples = edge_map(&exported);
+        let destination_tuples = edge_map(&back);
+        self.sweep_missing_or_changed(&source_tuples, &destination_tuples, &exported)?;
+        self.sweep_surplus(&source_tuples, &destination_tuples, &back)
+    }
+
+    /// Source edges the destination lacks or holds differently.
+    fn sweep_missing_or_changed(
+        &mut self,
+        source_tuples: &BTreeMap<u64, EdgeTuple>,
+        destination_tuples: &BTreeMap<u64, EdgeTuple>,
+        exported: &[GraphEdge],
+    ) -> Result<(), crate::MemoryError> {
+        for (id, tuple) in source_tuples {
+            if destination_tuples.get(id) != Some(tuple) {
+                self.edge_explained_or_loss(Side::Source, exported, *id)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Destination edges the source never exported.
+    fn sweep_surplus(
+        &mut self,
+        source_tuples: &BTreeMap<u64, EdgeTuple>,
+        destination_tuples: &BTreeMap<u64, EdgeTuple>,
+        back: &[GraphEdge],
+    ) -> Result<(), crate::MemoryError> {
+        for id in destination_tuples.keys() {
+            if !source_tuples.contains_key(id) {
+                self.edge_explained_or_loss(Side::Destination, back, *id)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// A diverging edge explains itself iff one of its endpoints expired.
+    fn edge_explained_or_loss(
+        &mut self,
+        side: Side,
+        edges: &[GraphEdge],
+        id: u64,
+    ) -> Result<(), crate::MemoryError> {
+        let Some(edge) = edges.iter().find(|edge| edge.id() == id) else {
+            return Err(query_error(format!(
+                "edge {id} in '{}' diverges and its tuple is not in the export \
+                 that reported it; the comparison itself is inconsistent",
+                self.collection
+            )));
+        };
+        let holder = self.view(side);
+        if holder.vanished(self.collection, edge.source())
+            || holder.vanished(self.collection, edge.target())
+        {
+            self.outcome.explained_by_expiry += 1;
+            return Ok(());
+        }
+        Err(query_error(format!(
+            "edge {id} ({} -{}-> {}) in '{}' diverges between source and \
+             destination and both endpoints are still live; this is loss, not \
+             a clock window",
+            edge.source(),
+            edge.label(),
+            edge.target(),
+            self.collection,
+        )))
+    }
+}
+
+type EdgeTuple = (u64, u64, String, String);
+
+/// Edges keyed by id, each reduced to an orderable tuple with its properties
+/// rendered through a `BTreeMap` for a stable order.
+fn edge_map(edges: &[GraphEdge]) -> BTreeMap<u64, EdgeTuple> {
+    edges
+        .iter()
+        .map(|edge| {
+            let properties: BTreeMap<_, _> = edge.properties().iter().collect();
+            (
+                edge.id(),
+                (
+                    edge.source(),
+                    edge.target(),
+                    edge.label().to_owned(),
+                    serde_json::to_string(&properties).unwrap_or_default(),
+                ),
+            )
+        })
+        .collect()
+}
+
+/// Whether an id one of THIS validation's walks returned now reads back as
+/// absent — which, under the lock this validation holds, can only mean its
+/// absolute expiry passed between the walk and this probe.
+///
+/// The reasoning is deliberately indirect, because it has to be: an expired
+/// point is invisible on EVERY public read surface — `get` answers `None` for
+/// it exactly as for a deleted one — so its expiry cannot be read back
+/// directly. What makes `None` conclusive here is the flock: this validation
+/// holds both stores open for its whole pass, nothing else can write or
+/// delete under it, and so the only mover left between a walk that saw the id
+/// and a probe that does not is the clock crossing the point's own
+/// `_veles_expires_at`.
+///
+/// The contract is therefore narrow: call this ONLY with ids a walk of this
+/// same session returned. An arbitrary id the store never held also reads
+/// back `None`, and this function cannot tell the two apart — the caller's
+/// provenance of the id is what gives the answer its meaning.
+pub(crate) fn divergence_explained_by_expiry(db: &Database, collection: &str, id: u64) -> bool {
+    let Some(any) = db.get_any_collection(collection) else {
+        return false;
+    };
+    !matches!(any.get(&[id]).into_iter().next(), Some(Some(_)))
+}
+
+fn query_error(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}

--- a/crates/velesdb-memory/src/migration/validate.rs
+++ b/crates/velesdb-memory/src/migration/validate.rs
@@ -37,6 +37,7 @@
 //! checked against — after the comparison passes and before the phase
 //! advances.
 
+use super::query_error;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -83,10 +84,7 @@ pub fn validate_destination(
     let workspace = journal_workspace(destination)?;
     let lock = MigrationLock::acquire(&workspace, "migrate-validate").map_err(query_error)?;
     let result = validate_locked(store, destination, target, batch, &workspace, &lock);
-    let released = lock.release().map_err(query_error);
-    let outcome = result?;
-    released?;
-    Ok(outcome)
+    super::execute::reconcile(result, lock.release())
 }
 
 fn validate_locked(
@@ -354,8 +352,8 @@ impl Comparison<'_> {
     /// Source edges the destination lacks or holds differently.
     fn sweep_missing_or_changed(
         &mut self,
-        source_tuples: &BTreeMap<u64, EdgeTuple>,
-        destination_tuples: &BTreeMap<u64, EdgeTuple>,
+        source_tuples: &BTreeMap<u64, super::edges::CanonicalEdge>,
+        destination_tuples: &BTreeMap<u64, super::edges::CanonicalEdge>,
         exported: &[GraphEdge],
     ) -> Result<(), crate::MemoryError> {
         for (id, tuple) in source_tuples {
@@ -369,8 +367,8 @@ impl Comparison<'_> {
     /// Destination edges the source never exported.
     fn sweep_surplus(
         &mut self,
-        source_tuples: &BTreeMap<u64, EdgeTuple>,
-        destination_tuples: &BTreeMap<u64, EdgeTuple>,
+        source_tuples: &BTreeMap<u64, super::edges::CanonicalEdge>,
+        destination_tuples: &BTreeMap<u64, super::edges::CanonicalEdge>,
         back: &[GraphEdge],
     ) -> Result<(), crate::MemoryError> {
         for id in destination_tuples.keys() {
@@ -414,25 +412,12 @@ impl Comparison<'_> {
     }
 }
 
-type EdgeTuple = (u64, u64, String, String);
-
-/// Edges keyed by id, each reduced to an orderable tuple with its properties
-/// rendered through a `BTreeMap` for a stable order.
-fn edge_map(edges: &[GraphEdge]) -> BTreeMap<u64, EdgeTuple> {
+/// Edges keyed by id, in the migration's one canonical form
+/// ([`super::edges::canonical_edge`]).
+fn edge_map(edges: &[GraphEdge]) -> BTreeMap<u64, super::edges::CanonicalEdge> {
     edges
         .iter()
-        .map(|edge| {
-            let properties: BTreeMap<_, _> = edge.properties().iter().collect();
-            (
-                edge.id(),
-                (
-                    edge.source(),
-                    edge.target(),
-                    edge.label().to_owned(),
-                    serde_json::to_string(&properties).unwrap_or_default(),
-                ),
-            )
-        })
+        .map(|edge| (edge.id(), super::edges::canonical_edge(edge)))
         .collect()
 }
 
@@ -458,8 +443,4 @@ pub(crate) fn divergence_explained_by_expiry(db: &Database, collection: &str, id
         return false;
     };
     !matches!(any.get(&[id]).into_iter().next(), Some(Some(_)))
-}
-
-fn query_error(message: impl Into<String>) -> crate::MemoryError {
-    velesdb_core::Error::Query(message.into()).into()
 }


### PR DESCRIPTION
Refs #1762 — PR C3 of the embedding-migration campaign, on top of C1 (#1818), C2a (#1822) and C2b (#1824). The last two phases of the state machine, defined since C1 and never produced by any code until now.

## Validation (`migration/validate.rs`)

One pass over the finished destination against the source as it stands, before anything moves. Facts compare as id → payload maps, edges as sets of canonical tuples, per collection. The one tolerated divergence is an id one of this session's walks returned that now reads back absent — under the held flocks, the only mover left is the clock crossing the point's own absolute expiry. That is the mechanical discriminator promised in C2b's review: counted, reported, and unable to excuse real loss, since a live intruder reads back present. The pass then stamps the destination with the journal's model and dimension — the daemon reads `embedding-provenance.json` before opening, and an unstamped destination would degrade into the unrecorded-model warning the moment it went live — and journals `DestinationValidated`.

The comparison lives in named types (`StoreView`, `Side`, `Comparison`), not parameter lists.

## The switch (`migration/switchover.rs`)

Two renames, act-then-journal, so every crash window leaves the disk at most one step ahead of the journal, and a re-run recognises the completed step and journals it late — never undoes it.

**Two discriminators, because each answers a different question.** The provenance stamp says what KIND of store an occupant is — validation wrote it on the destination and nothing else carries it. The journalled source fingerprint says WHICH store a tree is, and it is verified at every step that touches one: the source before it is archived, the archive before the second rename and **before its destruction at commit**, the restored source before it is re-archived. The review proved with an executed probe that no flock stops a rename or a recursive delete — a daemon that opened the source in a lock-free window keeps writing into the archive after the first rename, silently — so the archive is never freed on the activated side's say-so alone: it must still fingerprint as the settled source the journal knows, or the commit refuses and everything stays.

The recovery table's manual advice for `SourceArchived` ("move the archive back") no longer leads into a shape everything refuses: a restored source under that journal is recognised, fingerprint-checked, re-archived, and the switch completes.

## The one command (`migration/orchestrate.rs`)

`migrate` reads the journal first and enters the chain where the journal says. After the first rename the source path is vacant — a chain that blindly restarted from the diagnosis would fail on the absent directory before reaching the switch. Stages routed past are reported as skipped, never invented. The completion message carries the two facts an operator cannot read from the exit code: the daemon serves the OLD data from its startup handle until restarted, and the journal is left behind deliberately, theirs to remove.

## Also

- The stale note in `embedding_provenance::check` ("re-indexing is not implemented yet — see #1751") now points at `migrate-embeddings`.
- The four diagnosis capabilities the parser cannot recalculate are held to their **shape** at deserialisation: the three with no Missing-producing code path refuse a forged Missing, and empty evidence is refused everywhere.
- Structure: `reconcile` is generic and shared by every locked entry point; `query_error` exists once instead of six times in two signatures; the canonical edge tuple lives in `edges.rs` alone.

## Adversarial review

A review of the first commit produced five reserves — the archive-destruction probe (CONFIRMED by execution), the stale-journal switch, the resume wall, the manual-restore trap, and three structure findings. The second commit closes all five; the guards each carry a red-first test (`a_source_that_moved_on_cannot_be_archived_by_a_stale_journal`, `commit_refuses_to_free_an_archive_that_received_writes`, `a_manual_restore_is_re_archived_and_the_switch_completes`, `migrate_resumes_past_a_crash_at_source_archived`).

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check` with `-D warnings -D clippy::pedantic` — 0
- `lizard -l rust -C 8 -a 8` over the 20 files of the diff, positive control 20/20 read; the only violations (`main` CCN 13, `open_store_with_actionable_lock_error` CCN 9) are byte-identical on develop
- `cargo test -p velesdb-memory --features persistence` — 154 migration tests, 35 binaries, 0 failures

## Not in scope

The operator doc and the benchmarks (PR D, which closes #1762).