### PR TITLE
docs(migration): the operator's guide to migrate-embeddings

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -242,6 +242,7 @@ capabilities (`query`, `create_collection`, `upsert`, `traverse`).
 | [MCP tool reference](../../docs/reference/MCP_TOOLS.md) | one section per tool: parameters, returns, limits, error model |
 | [Context compiler](../../docs/guides/CONTEXT_COMPILER.md) | budgets, preservation rules, `risk`, retrieval handles, media, `path` ingestion, transcripts, the `compile-stdin` CLI and the `PostToolUse` hook |
 | [Agent Memory SDK](../../docs/guides/AGENT_MEMORY.md) | the *other* path: the embedded, language-native `AgentMemory` API |
+| [Migrating embedding models](../../docs/guides/MIGRATE_EMBEDDINGS.md) | `migrate-embeddings` end to end: regimes, the journal, crash recovery, the switch, and what it costs |
 | [`BENCHMARK.md`](BENCHMARK.md) | every published retrieval number, its method, and how to reproduce it |
 | [`POSITIONING.md`](POSITIONING.md) | honest comparison against Mem0 and Zep/Graphiti, and where local-first is a hard requirement |
 | [`CHANGELOG.md`](CHANGELOG.md) | what changed in each release |

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -524,8 +524,9 @@ fn build_configured_service(
 /// it, and the whole point of the refusal is that something must not proceed.
 ///
 /// # Errors
-/// An unparsable invocation, a non-dry-run request (not built yet — see
-/// #1762), an unreachable embedder, or a store that cannot be read or copied.
+/// An unparsable invocation, a non-dry-run request without `--destination`,
+/// an unreachable embedder, a store that cannot be read or copied, or any
+/// stage of the migration itself refusing.
 fn run_migrate_embeddings(
     argv: &[String],
     flags: &[String],

--- a/crates/velesdb-memory/src/migration/cli.rs
+++ b/crates/velesdb-memory/src/migration/cli.rs
@@ -8,17 +8,15 @@
 //! destructive tool call particularly unsuitable. So the first surface is a
 //! subcommand, the engine stays a library, and no mutating MCP tool is added.
 //!
-//! # What this phase does and does not do
+//! # What this module does and does not do
 //!
-//! `--dry-run` only. It reads, it decides a regime, it prints what it found and
-//! what would happen. It writes nothing, takes no lock, and may run while the
-//! daemon holds the store: [`diagnose`](crate::migration::diagnose) never opens
-//! the live source, it inspects a verified copy.
-//!
-//! Any invocation that is not a dry run is REFUSED with the reason, rather than
-//! accepted and quietly doing nothing. An operator who types
-//! `migrate-embeddings --strategy auto` is asking for a migration; answering
-//! with silence and exit 0 would be the worst of the available behaviours.
+//! Parsing, the dry-run entry point, rendering, and the operator-facing
+//! texts. `--dry-run` reads, decides a regime, and prints what it found and
+//! what would happen — it writes nothing, takes no lock, and may run while
+//! the daemon holds the store: [`diagnose`](crate::migration::diagnose) never
+//! opens the live source, it inspects a verified copy. A non-dry-run runs the
+//! whole migration ([`migrate`](crate::migration::migrate) — rebuild,
+//! validation, switch) and requires the operator to name the destination.
 
 use super::{diagnose, DiagnosisReport, Strategy, TargetContract};
 use std::path::{Path, PathBuf};

--- a/crates/velesdb-memory/src/migration/tests/orchestrate.rs
+++ b/crates/velesdb-memory/src/migration/tests/orchestrate.rs
@@ -88,3 +88,58 @@ fn migrate_resumes_past_a_crash_at_source_archived() {
         Phase::Committed
     );
 }
+
+/// An embedder that proves it was never consulted: any call is a test failure.
+struct PanickingEmbedder(usize);
+
+impl crate::Embedder for PanickingEmbedder {
+    fn dimension(&self) -> usize {
+        self.0
+    }
+
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, crate::EmbedError> {
+        panic!("reuse must never call the embedder — this call IS the regression");
+    }
+}
+
+#[test]
+fn reuse_migrates_end_to_end_without_ever_calling_the_embedder() {
+    // #1815's arbitration in one sentence: reuse is NOT an embedding
+    // migration. The doc says it, the strategy module enforces when it is
+    // allowed — and this pins that the whole chain (rebuild, witness,
+    // validation, switch) structurally cannot embed under reuse, by running
+    // it with an embedder whose every call panics.
+    let root = root_with_source();
+    let store = root.path().join("store");
+    crate::embedding_provenance::write(
+        &store,
+        &crate::embedding_provenance::EmbeddingProvenance::new("hash", DIM),
+    )
+    .expect("record provenance matching the target");
+
+    let embedder = PanickingEmbedder(DIM);
+    let outcome = super::super::migrate(
+        &store,
+        root.path(),
+        &TargetContract::automatic("hash", DIM),
+        &root.path().join("rebuilt"),
+        &embedder,
+        1024,
+    )
+    .expect("a provenance-matched store migrates under reuse");
+
+    let executed = outcome.executed.expect("a fresh run rebuilds");
+    assert!(
+        matches!(executed.report.resolution, Resolution::Reuse),
+        "positive control: the regime must actually have been reuse, or the \
+         panicking embedder proved nothing — got {:?}",
+        executed.report.resolution
+    );
+    let db = velesdb_core::Database::open(&store).expect("activated store opens");
+    let facts = super::super::enumerate_by_cursor(&db, "_semantic_memory", 1024).expect("walk");
+    assert_eq!(
+        facts.len() as u64,
+        SEEDED,
+        "every fact crossed, no embedder involved"
+    );
+}

--- a/docs/guides/MIGRATE_EMBEDDINGS.md
+++ b/docs/guides/MIGRATE_EMBEDDINGS.md
@@ -1,0 +1,143 @@
+# Migrating a store to a new embedding model
+
+`velesdb-memory migrate-embeddings` rebuilds an existing store against a new
+embedding model — new vectors, same facts, same ids, same metadata, same
+absolute expiries, same graph edges with their properties — and switches the
+rebuilt store into place. It exists because vectors from two different models
+are not comparable: pointing the daemon at a store built by another model makes
+recall silently return nonsense, which is why the daemon refuses to start on a
+model mismatch and points you at this command.
+
+Everything below is journalled, resumable, and refuses loudly rather than
+guessing. The one command is:
+
+```bash
+velesdb-memory migrate-embeddings --store <dir> --destination <dir> [--strategy auto|reuse|reembed]
+```
+
+## Before you start
+
+- **Stop the daemon.** The store is single-writer; a live daemon holds its
+  `flock` and the migration refuses to open the source. Do not race it: a
+  daemon started mid-migration can only lose.
+- **Pick a destination on the same filesystem** as the store — the final
+  switch is a filesystem rename, and a rename cannot cross volumes. An empty
+  or not-yet-existing directory; the migration refuses one that already holds
+  data no journal accounts for.
+- **Have room.** The diagnosis stages a verified copy of the store next to it,
+  and the rebuild writes a full second store.
+
+## Step 1 — dry-run
+
+```bash
+velesdb-memory migrate-embeddings --store <dir> --dry-run
+```
+
+Read the first line first: it names the **regime** this store resolves to.
+Then the blockers. Two of them (`disk_headroom`, `embedder_cost`) are
+permanently informational — they name measurements only you can take on your
+machine — and do not stop the run. The regime line does: a `REFUSE` regime
+exits 2, and its own text says which way out it leaves you. A refused *reuse*
+has no override — no flag turns it into a run, by design — while a store whose
+own records contradict each other can still be re-embedded explicitly
+(`--strategy reembed`), which reads nothing the contradiction touches.
+
+## The regimes
+
+- **`auto`** (default): re-embeds, unless reuse is *proven* safe — with one
+  refusal of its own: a store whose provenance record contradicts its measured
+  dimension is not decided on your behalf. `auto` refuses it and leaves the
+  explicit choice (`--strategy reembed`) to you.
+- **`reembed`**: every fact's `content` goes through the target embedder.
+- **`reuse`**: the source vectors are copied verbatim. This is allowed only
+  when the store's recorded provenance names the SAME model at the SAME
+  dimension as the target — anything less is refused, never downgraded to a
+  guess. **Reuse is not an embedding migration**: it never calls an embedder
+  (guaranteed structurally — the reuse path has no embedder to call, which a
+  test pins by running a whole migration with an embedder that panics on
+  use). It is a store rebuild that happens to keep the vectors, useful after
+  corruption or for compaction, and its cost is the reinsertion cost alone.
+
+There is deliberately no `--force-reuse`. A flag that overrides the proof
+would produce a store whose vectors and recorded model disagree — the exact
+condition this command exists to prevent.
+
+## Step 2 — the run
+
+A non-dry-run performs, in order, journalling each step durably:
+
+1. **Rebuild** into the destination, collection by collection, checkpointed
+   after every batch. Kill it anywhere; the re-run replays at most one batch,
+   visibly (reported as "already present"), and loses nothing.
+2. **Validation**: one pass comparing every fact (ids and payloads) and every
+   edge (complete tuples, properties included) between source and
+   destination. The destination is then stamped with the target model's
+   provenance — the record the daemon checks at startup.
+3. **The switch**: the source is renamed aside to `<store>.archive`, the
+   destination is renamed to the store's path, the activated store is
+   verified, and the archive is freed. Both renames are guarded by the
+   journalled source fingerprint: a tree that changed hands since the journal
+   was written refuses to move or be deleted, whoever changed it.
+
+Then **restart the daemon**. It holds its store as an in-memory handle taken
+at startup and never refreshed; until it restarts it keeps serving the old
+data from memory. The completion message says this too, every time.
+
+## If something stops
+
+**Re-run the same command.** The journal — a `<destination>.migration-journal`
+directory beside the destination path — records how far every stage got, and
+the re-run enters the chain exactly there, including after the switch's first
+rename (when the store's path is temporarily vacant).
+
+Refusals you may meet, and what they mean:
+
+- *"a migration lock record remains"* — a previous run crashed hard (a clean
+  failure releases the lock). Inspect, then delete
+  `<destination>.migration-journal/migration.lock` yourself; it is left as
+  evidence deliberately and is never stolen by a liveness guess.
+- *"the source changed since this migration was prepared"* — something wrote
+  to the source after the rebuild started. Start a fresh diagnosis; resuming
+  would rebuild from an inventory that no longer describes the store.
+- *"Same name, different vectors"* — the model behind the
+  target's name was updated in place (an `ollama pull` does this). The
+  journal carries a witness of what the embedder actually produces; resuming
+  across an update would mix two vector spaces in one store. Start fresh.
+- *"does not carry the target's provenance stamp"* / *"no longer fingerprints
+  as the store this journal describes"* — the disk does not match any state
+  this migration produced. Nothing was moved or deleted; inspect by hand.
+
+If you followed the recovery table's manual advice and moved the archive back
+to the store's name: re-running the switch recognises the restored source
+(fingerprint-checked), re-archives it, and completes.
+
+## What is left behind
+
+- The **journal** (`<destination>.migration-journal/`): the durable record of
+  what happened, including the lock guard file. Keep it as long as you want
+  the evidence; remove it when you no longer do.
+- The **archive** (`<store>.archive`) exists only between the switch's first
+  rename and the commit, which frees it — after verifying both that the
+  activated store opens and carries the target's stamp, and that the archive
+  still fingerprints as the source the journal knows. An archive that
+  received foreign writes refuses to die.
+
+## What it costs
+
+No duration is promised, because none transfers between machines. What has
+been measured (each figure on one machine, quoted with what it is):
+
+- **Re-insertion** — the whole cost under `reuse` — measured at ~16 µs/fact
+  (dimension 4, `--release`, batch 1024) after the batched-fsync fix (#1797);
+  the cost per fact *decreases* with volume as fixed costs amortise. A
+  million-fact rebuild is seconds-to-minutes territory, not hours.
+- **Re-embedding** was measured at roughly **23×** a re-insertion (bge-m3 at
+  1024 dimensions, one machine, one unbatched embedder call per fact, debug
+  build — and the dominant denominator term turned out to be BM25 text
+  indexing, not vector width). This is a ratio from one configuration, not a
+  promise: it does not transfer to another embedder, backend, or batch size.
+  Under `reembed`, the embedder is your budget; measure it with your model on
+  your machine before quoting a duration to anyone.
+
+The performance suite (`migration/tests/performance.rs`) carries the
+deliberately-run benchmarks behind `#[ignore]`; run them on a machine at rest.


### PR DESCRIPTION
Closes #1762 — PR D, the last of the campaign (#1818 → #1822 → #1824 → #1825).

## What this adds

**`docs/guides/MIGRATE_EMBEDDINGS.md`** — the operator's guide: the two-step flow (dry-run, then `--destination`), the three regimes and the one refusal `auto` keeps for itself, the journal and how re-running the same command resumes after any crash (including with the store's path vacant mid-switch), every refusal an operator can meet with its literal message, what is deliberately left behind (the journal as evidence, the archive freed only after both the stamp and the fingerprint verify), and the measured costs quoted with exactly the qualifiers their sources carry — never as promises.

**One structural test.** "Reuse is not an embedding migration" was #1815's arbitration; it is now pinned by `reuse_migrates_end_to_end_without_ever_calling_the_embedder`, which drives a whole migration — rebuild, witness, validation, switch — with an embedder that panics on use, plus a positive control asserting the regime actually resolved to `Reuse`.

**Two stale comments retired.** `cli.rs` still declared the command dry-run-only and `main.rs` still called the rebuild "not built yet" — both false since C3.

## Doc-truth review

Every verifiable claim in the guide was checked against the code before shipping; four were corrected (auto's third outcome — it can refuse a self-contradicting store; the scope of "no flag changes a refusal", which is true only of refused *reuse*; a stitched quote no grep would have found, replaced by the message's literal headline "Same name, different vectors"; and where the daemon's mismatch error actually points). The two figures survived with their qualifiers confirmed at source: ~16 µs/fact is `--release`, ×23 is debug/unbatched/BM25-dominated.

## Gates

fmt clean · clippy pedantic 0 · `check_prod_unwraps.py` PASSED · lizard clean on the diff · 155 migration tests, 35 binaries, 0 failures.

## The campaign, closed

C1 diagnosis and regime resolution → C2a lossless edge export → C2b resumable rebuild → C3 validation, switch and provenance → D the words. `migrate-embeddings` now takes a store from "wrong model" to "switched, stamped, journalled" in one resumable command.