### PR TITLE
docs(memory): recall's order is blended, not pure similarity, and metadata isn't always None

### DIFF
--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -200,7 +200,7 @@ impl McpServer {
         // rmcp derives an output schema when none is given, and that
         // derived form keeps `$ref`s a `$defs`-blind client cannot resolve.
         output_schema = crate::schema::wire_safe_output_schema::<RecallResult>(),
-        description = "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients."
+        description = "Recall memories semantically similar to a query (vector). Ranking blends similarity with each fact's learned confidence (see `feedback`), so the order is not pure similarity — the returned `score` is always the raw similarity, never the blended value. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients."
     )]
     async fn recall(
         &self,

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -112,7 +112,11 @@ impl From<Recollection> for RecollectionDto {
 /// Result of the `recall` tool.
 #[derive(Serialize, JsonSchema)]
 pub(super) struct RecallResult {
-    /// Recalled memories, most similar first.
+    /// Recalled memories, best match first. The two tools returning this
+    /// shape rank differently: `recall` blends similarity with learned
+    /// confidence (see `feedback`), while `recall_where` with filters
+    /// orders by pure similarity. Each `score` is the raw similarity,
+    /// never a blended value.
     pub(super) memories: Vec<RecollectionDto>,
 }
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2359,9 +2359,12 @@ class MemoryService:
 
         Returns:
             List of ``{"id": int, "score": float, "content": str,
-            "metadata": Optional[Dict[str, Any]]}`` dicts, ordered by
-            descending similarity score. ``metadata`` is always ``None``
-            here (only :meth:`recall_where` populates it).
+            "metadata": Optional[Dict[str, Any]]}`` dicts. Ranking blends
+            similarity with each fact's learned confidence (see
+            :meth:`feedback`), so the order is not pure similarity —
+            ``score`` is always the raw similarity, never the blended
+            value. ``metadata`` carries whatever the fact was stored
+            with, or ``None`` if it has none.
         """
         ...
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -119,8 +119,8 @@ from every read.
 
 ## `recall`
 
-Semantic (vector) retrieval, most similar first, with an optional exact-match
-metadata filter served by the ColumnStore.
+Semantic (vector) retrieval with an optional exact-match metadata filter
+served by the ColumnStore.
 
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
@@ -129,8 +129,9 @@ metadata filter served by the ColumnStore.
 | `filter` | object | no | Exact-match metadata, e.g. `{"project":"veles","status":"resolved"}`. |
 
 Returns `{ memories: [ { id, id_str, score, content, metadata } ] }`. Ranking
-also folds in each fact's learned confidence, so `feedback` changes future
-`recall` order.
+blends similarity with each fact's learned confidence, so `feedback` changes
+future `recall` order; the returned `score` stays the raw similarity, never
+the blended value.
 
 ```jsonc
 recall { "query": "billing retries", "limit": 5, "filter": { "project": "checkout" } }

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -2406,7 +2406,7 @@
       }
     },
     {
-      "description": "Recall memories semantically similar to a query (vector), most similar first. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
+      "description": "Recall memories semantically similar to a query (vector). Ranking blends similarity with each fact's learned confidence (see `feedback`), so the order is not pure similarity — the returned `score` is always the raw similarity, never the blended value. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
@@ -2435,7 +2435,7 @@
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "memories": {
-            "description": "Recalled memories, most similar first.",
+            "description": "Recalled memories, best match first. The two tools returning this\nshape rank differently: `recall` blends similarity with learned\nconfidence (see `feedback`), while `recall_where` with filters\norders by pure similarity. Each `score` is the raw similarity,\nnever a blended value.",
             "items": {
               "description": "Wire shape of one recalled memory: [`Recollection`] plus the `id_str`\ntwin (issue #1468). Built via `From<Recollection>` at the serialization\nboundary so the domain type itself stays untouched.",
               "properties": {
@@ -2658,7 +2658,7 @@
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "memories": {
-            "description": "Recalled memories, most similar first.",
+            "description": "Recalled memories, best match first. The two tools returning this\nshape rank differently: `recall` blends similarity with learned\nconfidence (see `feedback`), while `recall_where` with filters\norders by pure similarity. Each `score` is the raw similarity,\nnever a blended value.",
             "items": {
               "description": "Wire shape of one recalled memory: [`Recollection`] plus the `id_str`\ntwin (issue #1468). Built via `From<Recollection>` at the serialization\nboundary so the domain type itself stays untouched.",
               "properties": {


### PR DESCRIPTION
## Description

Two false claims lived in the same `recall` docstring (`crates/velesdb-python/python/velesdb/__init__.pyi`):

- **"ordered by descending similarity score"** — the real order comes from `rl_rerank` (`crates/velesdb-memory/src/service/reinforce.rs`), which blends similarity with each fact's learned confidence set via `feedback`. The `persistence` feature (on by default, and unconditional in both the Python build and the MCP server, whose `mcp` feature requires it) is what enables this blending. The returned `score` field itself is untouched: it always carries the raw similarity, never the blend.
- **"metadata is always None"** — `recall` populates it from the stored fact's own metadata; only a fact with none carries `None`.

The MCP surfaces carried the same unqualified "most similar first" claim, corrected with **one nuance the shared DTO forces**: `RecallResult` is returned by **both** `recall` and `recall_where`, and `recall_where` with filters goes through `query_columnar` without `rl_rerank` — pure similarity order. Trading one absolute claim for another would have made the doc false on the second surface, so:

- `crates/velesdb-memory/src/mcp.rs` — the `recall` tool's wire `description` gets the blend + raw-score wording (this surface is `recall`-only, no nuance needed).
- `crates/velesdb-memory/src/mcp/dto.rs` — `RecallResult::memories`'s doc comment states the per-tool split: `recall` blends, `recall_where` with filters is pure similarity.
- `docs/reference/MCP_TOOLS.md` — the `recall` section drops "most similar first" (it already disclosed the confidence folding two paragraphs later — a self-contradiction) and gains the raw-score clause.

`docs/reference/mcp-tools.json` is regenerated (`UPDATE_MCP_TOOLS_SNAPSHOT=1 cargo test -p velesdb-memory --test mcp_tools_drift`) so the drift test the doc-contract guard depends on stays honest against the changed wire descriptions.

Fixes #1738
Fixes #1739

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- `cargo fmt -p velesdb-memory -- --check` (clean)
- `cargo clippy -p velesdb-memory --features mcp,context,persistence --lib -- -D warnings -D clippy::pedantic` (clean)
- `cargo test -p velesdb-memory --features mcp,context,persistence --lib recall -- --test-threads=1` (16/16, including `mcp::tests::remember_then_recall_roundtrips_through_the_server` and both `reinforce::tests` confidence-blend tests)
- `cargo test -p velesdb-memory --features mcp,context,persistence --test mcp_tools_drift -- --test-threads=1` (regenerated artifact matches what the server actually publishes)
- `python3 scripts/check-mcp-doc-contract.py` (PASS — 231 surfaces swept)
- `python3 scripts/check-doc-freshness.py --guard stamp --mode strict` (PASS)
- `python3 scripts/check-promise-contract.py` (passed, no new claims introduced)

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS: Linux
- Rust version: per `rust-toolchain.toml` (MSRV 1.90)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

> Skipped — this PR does not add or modify `unsafe` code.

## High-Risk Change Checklist

> Skipped — this PR does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Both issues were opened by the same 2026-08-03 audit (`develop@e01d01f5`), which noted they carry two distinct false claims in the same docstring and should close together with one documentary PR. The `recall_where` nuance above surfaced during self-review of the shared `RecallResult` DTO — its own tool description ("Most similar first") stays untouched because it is true on that path.
