### PR TITLE
feat(memory): per-request daemon logs behind VELESDB_MEMORY_LOG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6969,6 +6969,8 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
+ "tracing",
+ "tracing-subscriber",
  "ureq",
  "velesdb-core",
 ]

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -44,6 +44,14 @@ schemars = "1"
 # to get the memory core without the `rmcp`/`tokio` server dependencies.
 rmcp = { version = "2.0.0", features = ["server", "macros", "transport-io", "transport-streamable-http-server"], optional = true }
 tokio = { workspace = true, optional = true }
+# Per-request observability (#1780): `tracing` carries the events (one per MCP
+# request: tool, session, verdict, duration — never a payload), and
+# `tracing-subscriber` renders them to stderr when VELESDB_MEMORY_LOG is set
+# (see `src/logging.rs`). Both ride the `mcp` feature: `tracing` is already in
+# the server's dependency graph via rmcp/axum/hyper, so this adds no weight
+# there, and library consumers (`default-features = false`) stay free of both.
+tracing = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, optional = true }
 # Optional real-recall backend (off by default). HTTP-only to a local Ollama;
 # `default-features = false` drops TLS to keep the binary small.
 ureq = { version = "2", optional = true, default-features = false }
@@ -110,7 +118,7 @@ optional = true
 # by default so `cargo build` produces the server; library consumers disable
 # defaults to pick only what they need.
 default = ["mcp", "persistence", "context"]
-mcp = ["dep:rmcp", "dep:tokio", "persistence"]
+mcp = ["dep:rmcp", "dep:tokio", "dep:tracing", "dep:tracing-subscriber", "persistence"]
 # Streamable-HTTP transport (multi-client daemon mode, see the README's "HTTP
 # transport" section): lets several MCP clients share ONE `velesdb-memory`
 # process instead of each spawning its own stdio process and fighting over
@@ -162,6 +170,12 @@ tempfile = "3"
 serde_json = { workspace = true }
 tokio = { workspace = true }
 criterion = { workspace = true }
+# tests/daemon_logging.rs (#1780) installs a capturing global subscriber to
+# assert the per-request events exist, carry the promised fields, and never
+# leak a payload. Dev-only copies of the optional prod deps above, so the
+# tests build regardless of which features the prod side enabled.
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 # MCP client-side streamable-HTTP transport, dev-only: drives the `http`
 # feature's server transport in tests/http_transport.rs with a real client
 # (the same one exercised by rmcp's own upstream test suite) rather than
@@ -228,6 +242,16 @@ workspace = true
 [[test]]
 name = "http_transport"
 path = "tests/http_transport.rs"
+required-features = ["http"]
+
+# Per-request observability (#1780): proves the transport- and tool-level
+# trace events exist, distinguish refused from handled requests, and never
+# carry fact content. `http` because the three-cases contract (never
+# arrived / refused / handled) is only observable through the HTTP session
+# layer.
+[[test]]
+name = "daemon_logging"
+path = "tests/daemon_logging.rs"
 required-features = ["http"]
 
 # A second `--http` daemon against a store another process already holds

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -244,9 +244,64 @@ pub fn router_with_limits_and_keep_alive(
             Arc::new(session_manager),
             StreamableHttpServerConfig::default().with_cancellation_token(cancellation_token),
         );
+    // `route_layer` scopes the trace middleware to the routes added SO FAR —
+    // `/mcp` and nothing else. `/health`, added after, stays untraced on
+    // purpose: the installer and CI poll it, and a heartbeat line per poll
+    // would bury the requests an incident reader is looking for.
     Router::new()
         .nest_service("/mcp", RequestBodyLimit::new(mcp_service, max_body_bytes))
+        .route_layer(axum::middleware::from_fn(trace_mcp_http))
         .route("/health", get(health))
+}
+
+/// One transport-level trace event per `/mcp` request (#1780): HTTP method,
+/// `mcp-session-id`, response status, duration — never the body.
+///
+/// This is the event that tells the three outside-identical incident cases
+/// apart (#1727 was mis-diagnosed twice for lack of it): a request that
+/// **never arrived** leaves no line at all; one that arrived and was
+/// **refused** (unknown/expired session) leaves its `404`; one that was
+/// **handled** leaves its `2xx` — with the tool-level event (`crate::mcp`)
+/// alongside. The duration is measured to the response HEAD, so a streaming
+/// (SSE) response doesn't hold the event hostage until the stream closes.
+async fn trace_mcp_http(
+    request: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let method = request.method().clone();
+    let session = session_from_headers(request.headers());
+    let started = std::time::Instant::now();
+    let response = next.run(request).await;
+    // `%`-Display fields and a pinned target, for the reasons given at the
+    // tool-level event (`crate::mcp`'s `log_tool_call`): unquoted grep-able
+    // values, and log lines stable across module refactors.
+    tracing::info!(
+        target: "velesdb_memory::http",
+        %method,
+        session = %session.as_deref().unwrap_or(crate::logging::NO_SESSION),
+        status = response.status().as_u16(),
+        elapsed_ms = crate::logging::elapsed_millis(started),
+        "mcp http request"
+    );
+    response
+}
+
+/// The streamable-HTTP session header [`session_from_headers`] reads. Only
+/// that one derivation consumes it; it lives here, beside it, rather than in
+/// `crate::logging`'s shared-vocabulary set, which this feature-gated module
+/// could not contribute to in an HTTP-less build anyway.
+pub(crate) const MCP_SESSION_HEADER: &str = "mcp-session-id";
+
+/// The `mcp-session-id` a request carries, if any — the ONE derivation both
+/// trace points share: the middleware above reads it off the live request,
+/// the tool-level event (`crate::mcp`) off the `Parts` rmcp injects into the
+/// request's extensions. Centralized so the two can never diverge on
+/// anything beyond where the headers came from.
+pub(crate) fn session_from_headers(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get(MCP_SESSION_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
 }
 
 /// Liveness probe: 200 OK with no body semantics beyond "the process is up

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -79,6 +79,11 @@ pub(crate) mod id;
 /// Resource caps (DoS limits) shared by every adapter — the single source of
 /// truth for fact size, recall limit, and `why` hop depth.
 pub mod limits;
+/// Per-request observability, gated by `VELESDB_MEMORY_LOG` (#1780): silent
+/// by default, stderr only, never a payload. Rides the `mcp` feature with
+/// the server it observes.
+#[cfg(feature = "mcp")]
+pub mod logging;
 /// The MCP server transport. Gated behind the default `mcp` feature so library
 /// consumers (e.g. the language bindings) can depend on the memory core without
 /// pulling the `rmcp`/`tokio` server stack.

--- a/crates/velesdb-memory/src/logging.rs
+++ b/crates/velesdb-memory/src/logging.rs
@@ -1,0 +1,208 @@
+//! Per-request observability, gated by `VELESDB_MEMORY_LOG` (#1780).
+//!
+//! The daemon used to emit nothing per request: no `tracing` subscriber was
+//! ever installed, so both this crate's events and everything rmcp already
+//! emits about session lifecycles (idle timeouts, dead channels — exactly
+//! the signals #1727 needed) were discarded. #1727 was then diagnosed twice
+//! on a wrong cause, and settling it took a throwaway HTTP probe written
+//! outside the repository.
+//!
+//! This module is the deliberately narrow fix: one env var, silent by
+//! default.
+//!
+//! - `VELESDB_MEMORY_LOG` unset (or blank) installs **no subscriber at
+//!   all** — the daemon behaves byte-for-byte as before.
+//! - Set, its value is a standard `EnvFilter` directive list (e.g. `info`
+//!   or `info,rmcp=debug`), rendered to **stderr only**: on the stdio
+//!   transport stdout carries the MCP protocol itself, and one log byte
+//!   there would corrupt the stream. The HTTP daemon's stderr is already
+//!   captured by launchd (`~/Library/Logs/velesdb-memory/daemon.err.log`),
+//!   so a log line lands where an operator already looks.
+//!
+//! What gets traced lives at the call sites (`http::trace_mcp_http`,
+//! `mcp`'s `call_tool`): tool name, session id, verdict, duration — never
+//! an argument, a payload, or fact content (`tests/daemon_logging.rs`
+//! proves that with canaries). This module also owns the vocabulary those
+//! two events share — the absent-session placeholder, the duration helper —
+//! so the pair cannot drift apart.
+
+use std::time::Instant;
+
+/// The env var that turns logging on. Named (rather than `RUST_LOG`) so an
+/// ambient `RUST_LOG` in a developer's shell cannot make the daemon
+/// talkative by accident — enabling logs here is an explicit, per-daemon
+/// decision.
+pub const LOG_ENV_VAR: &str = "VELESDB_MEMORY_LOG";
+
+/// The filter an operator should run to diagnose a session incident (#1727):
+/// this crate's per-request events, plus rmcp's session-lifecycle signals —
+/// and **no client content, ever**, which is the property that makes it safe
+/// to leave on in a deployed daemon (`scripts/install-memory-daemon.sh`
+/// wires exactly this string into the launchd plist; a test below refuses
+/// drift). Directive by directive:
+///
+/// - `info` — this crate's own per-request events (transport and tool).
+/// - `rmcp::service=error` — NOT `warn` or the bare default: at `warn`,
+///   rmcp's `response error` event dumps the whole `ErrorData`, and several
+///   `MemoryError` messages quote client input verbatim (an invalid filter's
+///   field name, the full offending JSON value). The #1780 review proved
+///   that leak in execution; `tests/daemon_logging.rs` pins it with
+///   error-path canaries. At `info` the same target also dumps
+///   notifications. `error` keeps only content-free faults.
+/// - `rmcp::transport::worker=debug` — carries `WorkerQuitReason`, including
+///   the idle-timeout that is THE #1727 signal (a session whose worker died
+///   of inactivity while the session stayed in the table).
+/// - `rmcp::transport::streamable_http_server=debug` — session/channel
+///   lifecycle (open, close, dead channel), all content-free at that level.
+///
+/// Broader rmcp verbosity DUMPS REQUEST CONTENT: `rmcp::service` logs every
+/// request's full arguments — fact text included — at `debug`, and the
+/// transport tower logs whole messages at `trace`. So `rmcp=debug` is NOT a
+/// harmless step up from this preset; it is the payload firehose, acceptable
+/// only for deliberate wire debugging on data that may land in a log file.
+/// `tests/daemon_logging.rs` captures under THIS preset and asserts canaries
+/// (fact content on the happy path, client input on the error path) never
+/// reach the log — if a dependency upgrade (e.g. rmcp 3.x, #1789) moves a
+/// dump to a level this preset admits, those tests go red before the leak
+/// ships.
+pub const INCIDENT_PRESET: &str = "info,rmcp::service=error,rmcp::transport::worker=debug,rmcp::transport::streamable_http_server=debug";
+
+/// Read [`LOG_ENV_VAR`] and install the stderr subscriber it asks for.
+/// Unset or blank installs nothing — see the module docs.
+///
+/// # Errors
+/// A value that does not parse as `EnvFilter` directives, or a subscriber
+/// already installed for this process. Both abort startup rather than run
+/// the daemon with logging silently different from what the operator asked
+/// for — same posture as the config file (`crate::config`): a daemon
+/// quietly running on defaults the operator believes they overrode is worse
+/// than a loud failure at boot.
+pub fn init_from_env() -> Result<(), String> {
+    match filter_from_raw(std::env::var(LOG_ENV_VAR).ok().as_deref())? {
+        None => Ok(()),
+        Some(filter) => install(filter),
+    }
+}
+
+/// The parsing half of [`init_from_env`], taking the raw value instead of
+/// reading it — same testability idiom as `http::keep_alive_from_raw`
+/// (process-wide env vars are shared mutable state under a parallel test
+/// runner).
+///
+/// `None` and blank mean "no logging requested" and yield `Ok(None)`; any
+/// other value must be a valid `EnvFilter` directive list.
+///
+/// # Errors
+/// A set, non-blank value that `EnvFilter` refuses, with the exact
+/// directive text and the var's name in the message.
+fn filter_from_raw(raw: Option<&str>) -> Result<Option<tracing_subscriber::EnvFilter>, String> {
+    let Some(directives) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    tracing_subscriber::EnvFilter::try_new(directives)
+        .map(Some)
+        .map_err(|err| {
+            format!(
+                "{LOG_ENV_VAR}='{directives}' is not a valid filter ({err}) — use EnvFilter \
+                 directives, e.g. 'info' or 'info,rmcp=debug', or unset it for silence"
+            )
+        })
+}
+
+/// Install the stderr `fmt` subscriber filtered by `filter`.
+fn install(filter: tracing_subscriber::EnvFilter) -> Result<(), String> {
+    let subscriber = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|err| format!("{LOG_ENV_VAR}: cannot install the log subscriber: {err}"))
+}
+
+/// What the `session` field carries when a request has none (stdio, or an
+/// `initialize` that hasn't been assigned one yet). A stable placeholder
+/// rather than an omitted field, so `grep session=` matches every event.
+pub(crate) const NO_SESSION: &str = "-";
+
+/// Milliseconds since `started`, saturating instead of panicking — shared by
+/// the transport- and tool-level trace events so the two report durations
+/// that are comparable by construction.
+pub(crate) fn elapsed_millis(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::filter_from_raw;
+
+    #[test]
+    fn unset_or_blank_yields_no_filter() {
+        // The "silent by default" half of the contract: no filter, so
+        // `init_from_env` installs no subscriber — the daemon must behave
+        // byte-for-byte as before.
+        assert!(matches!(filter_from_raw(None), Ok(None)));
+        assert!(matches!(filter_from_raw(Some("")), Ok(None)));
+        assert!(matches!(filter_from_raw(Some("   ")), Ok(None)));
+    }
+
+    #[test]
+    fn a_directive_list_yields_a_filter() {
+        // Positive control for the silence test above: a function that
+        // answered `None` to everything would pass it vacuously.
+        assert!(matches!(filter_from_raw(Some("info")), Ok(Some(_))));
+        assert!(matches!(
+            filter_from_raw(Some("info,rmcp=debug")),
+            Ok(Some(_))
+        ));
+    }
+
+    #[test]
+    fn the_incident_preset_parses() {
+        // The preset is dead the day it stops parsing — the daemon would
+        // refuse to boot with it, which is exactly when an operator needs it.
+        assert!(matches!(
+            filter_from_raw(Some(super::INCIDENT_PRESET)),
+            Ok(Some(_))
+        ));
+    }
+
+    #[test]
+    fn the_installer_ships_the_incident_preset_verbatim() {
+        // The plist is written by a shell script that cannot read this
+        // constant, so the two CAN drift — and a drifted installer would
+        // deploy a daemon logging either nothing or, worse, a payload-leaking
+        // filter. Verbatim containment is the whole check.
+        //
+        // Read at runtime, not `include_str!`: `scripts/` is not packaged
+        // into the published .crate, so a compile-time include would make
+        // `cargo test` unbuildable from the .crate or a vendored source.
+        // Outside the repository there is no installer to drift against, so
+        // absence is a genuine pass — in the repository (and its CI, where
+        // this guard matters) the file always exists.
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../scripts/install-memory-daemon.sh"
+        );
+        let Ok(installer) = std::fs::read_to_string(path) else {
+            return;
+        };
+        assert!(
+            installer.contains(super::INCIDENT_PRESET),
+            "scripts/install-memory-daemon.sh must wire VELESDB_MEMORY_LOG to the \
+             incident preset exactly as src/logging.rs declares it"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_value_is_refused_with_the_var_name() {
+        // Refusal proven, not assumed: an operator who set a broken filter
+        // asked for logs and must not silently get silence instead.
+        let err = filter_from_raw(Some("velesdb=notalevel"))
+            .expect_err("an invalid level must be refused");
+        assert!(
+            err.contains("VELESDB_MEMORY_LOG"),
+            "the message must name the var to fix, got: {err}"
+        );
+    }
+}

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -18,6 +18,9 @@
 //! server is a different URL, never a new backend name. Tokens are read from
 //! the environment only, never from the config file. Set
 //! `VELESDB_MEMORY_DEFAULT_TTL` (seconds) to expire remembered facts by default.
+//! Set `VELESDB_MEMORY_LOG` (`EnvFilter` directives, e.g. `info`) for
+//! per-request stderr logging — unset is fully silent; see
+//! `velesdb_memory::logging` for the payload-safety contract.
 //! Set `VELESDB_MEMORY_INGEST_ROOTS` (a `PATH`-list of directories) to let
 //! `compile_context`/`explain_compilation` fragments reference a file by
 //! `path` instead of inline `content`; unset disables that field entirely.
@@ -84,6 +87,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         return run_migrate_embeddings(&args, &args[2..]);
     }
 
+    // Per-request observability (#1780), installed before anything below so
+    // the startup sequence itself (config file, embedder probe, store open)
+    // is already traceable. `VELESDB_MEMORY_LOG` unset stays byte-for-byte
+    // silent; env-only on purpose — the config file cannot carry it, since
+    // the file is only read further down and a boot problem is exactly what
+    // these logs must be able to see. Stderr only: on stdio, stdout carries
+    // the MCP protocol itself.
+    apply_logging();
+
     // Captured FIRST — before the (possibly seconds-long) embedder probe and
     // store open — so a client that exits during our own startup still
     // reparents us AFTER the baseline, and the watchdog sees the change. A
@@ -129,6 +141,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     })
+}
+
+/// Install the `VELESDB_MEMORY_LOG` subscriber, or exit with its actionable
+/// message. The exit path (prefixed `eprintln!` + status 1) matches every
+/// other startup refusal in this binary (`requested_http_bind`,
+/// `open_store_with_actionable_lock_error`) — bubbling the `String` up
+/// through `main`'s `Result` would print it as an unprefixed `Debug` quote
+/// instead.
+fn apply_logging() {
+    if let Err(err) = velesdb_memory::logging::init_from_env() {
+        eprintln!("[velesdb-memory] {err}");
+        std::process::exit(1);
+    }
 }
 
 /// A resolved `--http`/`VELESDB_MEMORY_HTTP=1` request: where to bind, and

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -496,10 +496,11 @@ impl McpServer {
     }
 }
 
-/// `#[tool_handler]` generates `call_tool` / `list_tools` from the router;
-/// `get_info` is overridden so the server identifies itself as `velesdb-memory`
-/// (the macro default falls back to rmcp's own identity). Per-tool guidance
-/// lives in each `#[tool(description = …)]`.
+/// `#[tool_handler]` generates `list_tools` from the router — `call_tool` is
+/// written by hand below (see its doc comment) and the macro skips what
+/// already exists. `get_info` is overridden so the server identifies itself
+/// as `velesdb-memory` (the macro default falls back to rmcp's own
+/// identity). Per-tool guidance lives in each `#[tool(description = …)]`.
 /// The server's one-shot vitrine to a connecting agent (V2a-1 quick win):
 /// must cover every tool family, not just memory — a `#[cfg(feature =
 /// "context")]` variant since the context-compiler tools only exist in that
@@ -520,6 +521,76 @@ impl ServerHandler for McpServer {
         info.instructions = Some(SERVER_INSTRUCTIONS.to_owned());
         info
     }
+
+    /// One trace event per tool call (#1780): tool name, session id, verdict,
+    /// duration — never an argument or fact content
+    /// (`tests/daemon_logging.rs` holds a canary against that). Written by
+    /// hand so the event wraps the dispatch — `#[tool_handler]` sees the
+    /// method already exists and only generates `list_tools`; the dispatch
+    /// below is exactly what the macro would have generated.
+    async fn call_tool(
+        &self,
+        request: rmcp::model::CallToolRequestParams,
+        context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> Result<rmcp::model::CallToolResult, ErrorData> {
+        let tool = request.name.clone();
+        let session = http_session_id(&context.extensions);
+        let started = std::time::Instant::now();
+        let tcc = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+        let outcome = self.tool_router.call(tcc).await;
+        log_tool_call(&tool, session.as_deref(), &outcome, started);
+        outcome
+    }
+}
+
+/// The tool-level trace event (#1780), split from `call_tool` so the verdict
+/// taxonomy is readable in one place. `Err` is a protocol-level failure, but
+/// a *refused* tool call comes back as `Ok` with `is_error` set INSIDE a
+/// valid result — reading only the outer `Result` would log every refusal as
+/// a success, the exact misreading this event exists to prevent.
+fn log_tool_call(
+    tool: &str,
+    session: Option<&str>,
+    outcome: &Result<rmcp::model::CallToolResult, ErrorData>,
+    started: std::time::Instant,
+) {
+    let verdict = match outcome {
+        Err(_) => "error",
+        Ok(result) if result.is_error == Some(true) => "tool_error",
+        Ok(_) => "ok",
+    };
+    // `%` (Display) rather than the default Debug capture: Debug renders
+    // strings quoted (`tool="recall"`), and these lines exist to be grepped
+    // (`grep tool=recall`) by an operator mid-incident. The target is pinned
+    // explicitly for the same operators: a module refactor must not silently
+    // rename the lines their tooling matches on.
+    tracing::info!(
+        target: "velesdb_memory::mcp",
+        tool = %tool,
+        session = %session.unwrap_or(crate::logging::NO_SESSION),
+        verdict = %verdict,
+        elapsed_ms = crate::logging::elapsed_millis(started),
+        "mcp tool call"
+    );
+}
+
+/// The `mcp-session-id` this call arrived under, read from the HTTP request
+/// parts rmcp injects into the request's extensions (its streamable-HTTP
+/// tower service does this for every incoming `POST`). HTTP transport only —
+/// there is no session id on stdio, and the event then reports `-`.
+#[cfg(feature = "http")]
+fn http_session_id(extensions: &rmcp::model::Extensions) -> Option<String> {
+    extensions
+        .get::<axum::http::request::Parts>()
+        .and_then(|parts| crate::http::session_from_headers(&parts.headers))
+}
+
+/// Without the HTTP transport nothing ever injects request parts, so there
+/// is no session id to read — same cfg-pair shape as the binary's
+/// transport-dependent helpers.
+#[cfg(not(feature = "http"))]
+fn http_session_id(_extensions: &rmcp::model::Extensions) -> Option<String> {
+    None
 }
 
 /// La post-condition du point de passage, verifiee SUR PLACE.

--- a/crates/velesdb-memory/tests/daemon_logging.rs
+++ b/crates/velesdb-memory/tests/daemon_logging.rs
@@ -1,0 +1,434 @@
+//! Per-request observability for the daemon (#1780).
+//!
+//! The daemon used to emit NOTHING per request — `#1727` was diagnosed twice
+//! on a wrong cause because no trace could answer the most elementary
+//! incident question: "did the request reach the daemon at all?". These
+//! tests pin the contract that closes that gap:
+//!
+//! - a handled tool call leaves one event carrying the tool name, a verdict
+//!   and a duration (T1);
+//! - a request on an unknown session leaves a transport event with its 404,
+//!   distinguishable from a handled request's 2xx (T2) — so the three
+//!   outside-identical cases (never arrived / refused / handled) are told
+//!   apart by the log alone;
+//! - no event ever carries fact content (T4) — the issue's privacy line:
+//!   a session id and a tool name suffice;
+//! - nor does any ERROR-path event carry client input (T5) — the leak the
+//!   #1780 review proved in execution before this preset pinned it out;
+//! - the idle retirement of a session worker — THE #1727 signal — is
+//!   actually visible under the preset (T6).
+//!
+//! T3 — the silence-by-default and invalid-filter-refusal contract — is a
+//! unit test in `src/logging.rs`, not here: it is about installing NO
+//! subscriber, which cannot be observed under this file's process-global
+//! capturing one.
+//!
+//! Capture mechanics: `tracing` events only reach a subscriber, and a
+//! process has ONE global subscriber slot — so a single capturing
+//! subscriber is installed once for the whole test binary, and the tests
+//! serialize on a lock and clear the buffer between runs. Thread-local
+//! (`with_default`) capture would silently MISS events from tasks the
+//! server spawns onto other worker threads, which is exactly where rmcp
+//! runs session workers — a capture that can't see the events it audits
+//! would pass vacuously.
+//!
+//! The capture filters with [`velesdb_memory::logging::INCIDENT_PRESET`]
+//! — the exact preset the installer deploys — NOT a blanket `trace`. That is
+//! the whole point of T4 and T5: rmcp itself dumps full request arguments
+//! (fact text included) at `rmcp::service=debug`, quotes client input in its
+//! `warn`-level `response error` event on the same target, and dumps whole
+//! messages at transport `trace` — so "no payload in the log" is only true
+//! OF A FILTER, and the filter these tests prove is the one operators
+//! actually run.
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use rmcp::model::{CallToolRequestParams, ClientInfo};
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{RoleClient, ServiceExt};
+use serde_json::{json, Map, Value};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use velesdb_memory::mcp::McpServer;
+use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
+
+// --- Capturing subscriber ---------------------------------------------------
+
+/// Shared byte buffer the capturing subscriber's writer appends to.
+#[derive(Clone, Default)]
+struct Capture {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Capture {
+    fn clear(&self) {
+        self.buffer.lock().expect("capture lock").clear();
+    }
+
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.buffer.lock().expect("capture lock")).into_owned()
+    }
+}
+
+/// One writer handle per fmt call — appends under the shared lock.
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture lock")
+            .extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter(Arc::clone(&self.buffer))
+    }
+}
+
+/// Install the process-wide capturing subscriber (once) and serialize the
+/// calling test until its `MutexGuard` drops. Every test MUST hold the guard
+/// for its whole body: the buffer is process-global, so two tests running
+/// concurrently would read each other's events.
+fn capture_for_test() -> (Capture, MutexGuard<'static, ()>) {
+    static CAPTURE: OnceLock<Capture> = OnceLock::new();
+    static SEQ: Mutex<()> = Mutex::new(());
+
+    // A failed test panics while holding the guard, poisoning it; the NEXT
+    // test must still fail on its own assertion, not on the poison — three
+    // real failures beat one real and two `PoisonError` echoes.
+    let guard = SEQ
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let capture = CAPTURE
+        .get_or_init(|| {
+            let capture = Capture::default();
+            let subscriber = tracing_subscriber::fmt()
+                .with_ansi(false)
+                .with_env_filter(tracing_subscriber::EnvFilter::new(
+                    velesdb_memory::logging::INCIDENT_PRESET,
+                ))
+                .with_writer(capture.clone())
+                .finish();
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("install the capturing subscriber once per process");
+            capture
+        })
+        .clone();
+    capture.clear();
+    (capture, guard)
+}
+
+// --- Server + client harness (same shape as tests/http_transport.rs) --------
+
+struct TestServer {
+    addr: SocketAddr,
+    handle: JoinHandle<()>,
+    ct: CancellationToken,
+    _store_dir: tempfile::TempDir,
+}
+
+async fn spawn_server() -> TestServer {
+    spawn_server_with_keep_alive(velesdb_memory::http::DEFAULT_HTTP_KEEP_ALIVE).await
+}
+
+/// [`spawn_server`], with the session idle timeout injected — T6 retires a
+/// session in milliseconds instead of the production hour.
+async fn spawn_server_with_keep_alive(keep_alive: std::time::Duration) -> TestServer {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let server = McpServer::new(service);
+
+    let ct = CancellationToken::new();
+    let app = velesdb_memory::http::router_with_limits_and_keep_alive(
+        server,
+        ct.child_token(),
+        velesdb_memory::http::DEFAULT_HTTP_MAX_BODY_BYTES,
+        velesdb_memory::http::DEFAULT_HTTP_MAX_SESSIONS,
+        Some(keep_alive),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("read bound local addr");
+
+    let shutdown_ct = ct.clone();
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled_owned().await })
+            .await;
+    });
+
+    TestServer {
+        addr,
+        handle,
+        ct,
+        _store_dir: store_dir,
+    }
+}
+
+async fn shutdown(server: TestServer) {
+    server.ct.cancel();
+    server
+        .handle
+        .await
+        .expect("http server task must not panic");
+}
+
+async fn connect(addr: SocketAddr) -> RunningService<RoleClient, ClientInfo> {
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!("http://{addr}/mcp")),
+    );
+    ClientInfo::default()
+        .serve(transport)
+        .await
+        .expect("MCP initialize handshake over HTTP")
+}
+
+fn as_args(value: Value) -> Map<String, Value> {
+    match value {
+        Value::Object(map) => map,
+        other => panic!("expected a JSON object, got {other:?}"),
+    }
+}
+
+// --- T1: a handled tool call is traceable ------------------------------------
+
+#[test]
+fn a_handled_tool_call_leaves_tool_verdict_and_duration() {
+    let (capture, _seq) = capture_for_test();
+    let rt = tokio::runtime::Runtime::new().expect("build tokio runtime");
+    rt.block_on(async {
+        let server = spawn_server().await;
+        let client = connect(server.addr).await;
+        client
+            .call_tool(
+                CallToolRequestParams::new("recall")
+                    .with_arguments(as_args(json!({ "query": "anything", "limit": 3 }))),
+            )
+            .await
+            .expect("recall call over HTTP");
+        client.cancel().await.expect("close the MCP client");
+        shutdown(server).await;
+    });
+
+    let log = capture.text();
+    assert!(
+        log.contains("tool=recall"),
+        "a handled call must leave an event naming the tool — got:\n{log}"
+    );
+    assert!(
+        log.contains("verdict=ok"),
+        "the event must carry the call's verdict — got:\n{log}"
+    );
+    assert!(
+        log.contains("elapsed_ms="),
+        "the event must carry the call's duration — got:\n{log}"
+    );
+}
+
+// --- T2: a refused request is distinguishable from a handled one -------------
+
+#[test]
+fn an_unknown_session_leaves_a_404_transport_event() {
+    let (capture, _seq) = capture_for_test();
+    let rt = tokio::runtime::Runtime::new().expect("build tokio runtime");
+    let (status, log) = rt.block_on(async {
+        let server = spawn_server().await;
+
+        // Positive control FIRST: a real handshake must leave 2xx transport
+        // events — it proves this test can see transport events at all, so
+        // the 404 assertion below cannot pass vacuously.
+        let client = connect(server.addr).await;
+        client.cancel().await.expect("close the MCP client");
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{}/mcp", server.addr))
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .header("mcp-session-id", "no-such-session")
+            .body(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": { "name": "recall", "arguments": { "query": "x" } }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .expect("POST to /mcp with an unknown session id");
+        let status = response.status().as_u16();
+        shutdown(server).await;
+        (status, capture.text())
+    });
+
+    assert_eq!(
+        status, 404,
+        "an unknown session id must be refused with 404"
+    );
+    assert!(
+        log.contains("status=200") || log.contains("status=202"),
+        "the handshake's transport events are the positive control — got:\n{log}"
+    );
+    assert!(
+        log.contains("status=404"),
+        "the refusal must leave a transport event carrying its 404 — got:\n{log}"
+    );
+    assert!(
+        log.contains("session=no-such-session"),
+        "the refused event must name the session that was refused — got:\n{log}"
+    );
+}
+
+// --- T4: no event ever carries fact content ----------------------------------
+
+#[test]
+fn events_never_carry_fact_content() {
+    const CANARY: &str = "CANARY-9f3a1c-le-contenu-ne-doit-jamais-fuiter";
+
+    let (capture, _seq) = capture_for_test();
+    let rt = tokio::runtime::Runtime::new().expect("build tokio runtime");
+    rt.block_on(async {
+        let server = spawn_server().await;
+        let client = connect(server.addr).await;
+        client
+            .call_tool(
+                CallToolRequestParams::new("remember")
+                    .with_arguments(as_args(json!({ "fact": CANARY }))),
+            )
+            .await
+            .expect("remember call over HTTP");
+        client.cancel().await.expect("close the MCP client");
+        shutdown(server).await;
+    });
+
+    let log = capture.text();
+    // Positive half first: the capture DID see this very call — without it,
+    // an empty capture would "prove" privacy vacuously.
+    assert!(
+        log.contains("tool=remember"),
+        "the call must be traced (positive control for the canary check) — got:\n{log}"
+    );
+    assert!(
+        !log.contains(CANARY),
+        "an event carried fact content — the issue's privacy line forbids \
+         payloads in traces:\n{log}"
+    );
+}
+
+// --- T5: the ERROR path never carries client content either ------------------
+
+#[test]
+fn error_responses_never_carry_client_content() {
+    // T4 proves the happy path; this is the leak adversarial review caught.
+    // A failing tool body propagates as `Err(ErrorData)`, and rmcp's service
+    // logs `response error` with the whole `ErrorData` — message included —
+    // at WARN under `rmcp::service`. Several `MemoryError` messages quote
+    // client input verbatim: `recall_where`'s column filters embed the
+    // offending FIELD name on an invalid identifier, and the full offending
+    // VALUE on a non-scalar (`validate_column_filter`, storage.rs). The
+    // incident preset must keep that WARN out of the log.
+    const FIELD_CANARY: &str = "CANARY-FIELD-7d2b1e not a valid identifier";
+    const VALUE_CANARY: &str = "CANARY-VALUE-4c9a0f-le-contenu-du-client";
+
+    let (capture, _seq) = capture_for_test();
+    let rt = tokio::runtime::Runtime::new().expect("build tokio runtime");
+    rt.block_on(async {
+        let server = spawn_server().await;
+        let client = connect(server.addr).await;
+        // Two REFUSED calls, each canary travelling in its own error: an
+        // invalid filter field (the message quotes the field name), then a
+        // non-scalar filter value (the message quotes the whole value).
+        for entry in [
+            json!({ "field": FIELD_CANARY, "op": "eq", "value": "x" }),
+            json!({ "field": "okfield", "op": "eq", "value": { "secret": VALUE_CANARY } }),
+        ] {
+            let refused = client
+                .call_tool(
+                    CallToolRequestParams::new("recall_where").with_arguments(as_args(
+                        json!({ "query": "anything", "filters": [entry] }),
+                    )),
+                )
+                .await;
+            assert!(
+                refused.is_err() || refused.is_ok_and(|r| r.is_error == Some(true)),
+                "the invalid filter must be refused — a filter silently \
+                 accepted means this test stopped exercising the error path"
+            );
+        }
+        client.cancel().await.expect("close the MCP client");
+        shutdown(server).await;
+    });
+
+    let log = capture.text();
+    // Positive control: the refused calls were traced with an error verdict —
+    // an empty capture would prove nothing.
+    assert!(
+        log.contains("tool=recall_where") && log.contains("verdict=error"),
+        "the refused calls must be traced with their verdict (positive \
+         control) — got:\n{log}"
+    );
+    assert!(
+        !log.contains("CANARY-FIELD") && !log.contains("CANARY-VALUE"),
+        "an error event carried client content under the incident preset — \
+         the preset must exclude rmcp's response-error dump:\n{log}"
+    );
+}
+
+// --- T6: the preset actually captures THE #1727 signal -----------------------
+
+#[test]
+fn an_idle_session_leaves_the_worker_quit_signal() {
+    // The preset's `rmcp::transport::worker=debug` directive exists for one
+    // event: a session worker dying of inactivity while the session stays in
+    // the table — the #1727 mechanism. A preset that promised that signal
+    // and filtered it out would be exactly the kind of claim nothing
+    // re-verifies, so this retires a real session (a keep-alive of
+    // milliseconds instead of the production hour) and reads the signal back.
+    let (capture, _seq) = capture_for_test();
+    let rt = tokio::runtime::Runtime::new().expect("build tokio runtime");
+    rt.block_on(async {
+        let server = spawn_server_with_keep_alive(std::time::Duration::from_millis(150)).await;
+        let client = connect(server.addr).await;
+        // Sit idle past the keep-alive and POLL for the signal instead of
+        // sleeping a fixed once: a loaded runner can stretch the retirement
+        // well past its nominal deadline, and a fixed sleep is how this
+        // transport's tests went flaky before (#1793). The client stays
+        // alive throughout — closing it first would end the session for the
+        // wrong reason and prove nothing about idleness.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let log = capture.text();
+            if log.contains("worker quit with reason") && log.contains("IdleTimeout") {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the idle retirement must be visible under the incident \
+                 preset within 10s — got:\n{log}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        drop(client);
+        shutdown(server).await;
+    });
+}

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -282,7 +282,31 @@ untouched with a warning.
 | `VELESDB_MEMORY_HTTP_MAX_BODY_BYTES` | Max size of a single `/mcp` request body (default 16 MiB). An oversized request is rejected instead of being buffered into memory unbounded. |
 | `VELESDB_MEMORY_HTTP_MAX_SESSIONS` | Max concurrent MCP sessions (default 64). Each session holds a worker task and a couple of small bounded channels — cheap individually, but a client that opens sessions without closing them could otherwise grow that without bound. |
 | `VELESDB_MEMORY_HTTP_KEEP_ALIVE_SECS` | How long a session may sit idle before it is retired (default 3600 — 60 minutes). See [Idle sessions, and why a timeout is not a failed write](#idle-sessions-and-why-a-timeout-is-not-a-failed-write). |
+| `VELESDB_MEMORY_LOG` | Per-request logging to stderr, as `EnvFilter` directives. Unset (the binary's default) is fully silent; the macOS installer deploys the daemon with the payload-safe incident preset on. See [Reading the daemon's log](#reading-the-daemons-log). |
 | `GET /health` | Plain 200 OK liveness probe, no MCP handshake needed — what the installer and CI use to confirm the daemon is up (over HTTPS too, once TLS is the transport). |
+
+### Reading the daemon's log
+
+With `VELESDB_MEMORY_LOG` set, every `/mcp` request leaves one stderr line
+(method, `mcp-session-id`, status, duration), and every tool call another
+(tool name, session, verdict, duration) — which is what tells the three
+outside-identical incident cases apart: a request that **never arrived**
+leaves no line, one **refused** (expired/unknown session) leaves its `404`,
+one **handled** leaves its `2xx` plus the tool line. On macOS the launchd
+daemon's stderr lands in `~/Library/Logs/velesdb-memory/daemon.err.log`, and
+the installer deploys with the incident preset
+(`info,rmcp::service=error,rmcp::transport::worker=debug,rmcp::transport::streamable_http_server=debug`)
+already on: those events never carry request content — canary tests hold the
+preset to that, on the happy path and on the error path — so the log is safe
+to keep. The `worker` target is what records a session worker dying of idle
+timeout, and `rmcp::service` is pinned to `error` because its `warn`-level
+`response error` event quotes the failing request's error message, client
+input included.
+
+Do **not** reach for `rmcp=debug` or a blanket `trace` on a store that holds
+anything sensitive: at those levels rmcp itself dumps full request arguments
+— fact text included — into the log. That verbosity is for deliberate wire
+debugging only.
 
 ### Idle sessions, and why a timeout is not a failed write
 

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -580,6 +580,23 @@ setup_daemon() {
     TTL_PLIST_ENTRY="    <key>VELESDB_MEMORY_DEFAULT_TTL</key><string>$TTL</string>"
   fi
 
+  # Per-request observability (#1780). The deployed daemon logs by default —
+  # its stderr already lands in ~/Library/Logs/velesdb-memory/daemon.err.log,
+  # and a daemon that says nothing is undiagnosable (#1727 cost two wrong
+  # diagnoses that way). The default filter below is the payload-safe incident
+  # preset declared in crates/velesdb-memory/src/logging.rs
+  # (INCIDENT_PRESET — a crate test refuses drift between these two
+  # files): per-request events plus rmcp's session lifecycle, never request
+  # content. Export VELESDB_MEMORY_LOG before running this installer to pick
+  # another filter, or export it EMPTY to deploy a silent daemon — the same
+  # blank-means-silence contract the daemon itself applies to the variable
+  # (hence `-`, not `:-`: only an UNSET variable gets the default).
+  LOG_FILTER="${VELESDB_MEMORY_LOG-info,rmcp::service=error,rmcp::transport::worker=debug,rmcp::transport::streamable_http_server=debug}"
+  LOG_PLIST_ENTRY=""
+  if [ -n "${LOG_FILTER// /}" ]; then
+    LOG_PLIST_ENTRY="    <key>VELESDB_MEMORY_LOG</key><string>$LOG_FILTER</string>"
+  fi
+
   cat > "$PLIST_PATH" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -602,6 +619,7 @@ setup_daemon() {
     <key>VELESDB_MEMORY_OLLAMA_MODEL</key><string>$OLLAMA_MODEL</string>
 $EXTRACTOR_PLIST_ENTRY
 $TTL_PLIST_ENTRY
+$LOG_PLIST_ENTRY
   </dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>


### PR DESCRIPTION
Closes #1780.

## Problem

The daemon emitted **nothing per request** — no `tracing` subscriber was ever installed, so its own events and rmcp's session-lifecycle events were all discarded. #1727 was diagnosed twice on a wrong cause because no trace could answer the most elementary incident question: *did the request reach the daemon at all?* Settling it took a throwaway HTTP probe written outside the repository.

## What this ships (deliberately narrow, per the issue)

- **`VELESDB_MEMORY_LOG`** (EnvFilter directives): installs a stderr-only `fmt` subscriber at startup. Unset stays **byte-for-byte silent** (proven at the binary level); an invalid value refuses boot with an actionable message (proven, exit 1). Stderr only — on stdio, stdout carries the MCP protocol.
- **One transport event per `/mcp` request** (method, `mcp-session-id`, status, duration) via an axum middleware scoped to `/mcp` — `/health` polls stay untraced. **One tool event per call** (tool, session, verdict, duration) via a hand-written `call_tool` that wraps exactly what `#[tool_handler]` generates. The three outside-identical cases are now told apart by the log alone: *never arrived* = no line, *refused* = its `404`, *handled* = `2xx` + tool line. A refused tool call surfaced as `Ok`-with-`is_error` logs `tool_error`, never `ok`. Both events share one session derivation (`http::session_from_headers`) and one duration/placeholder vocabulary (`logging`), so the pair cannot drift apart.
- **`INCIDENT_PRESET`** pins the content-safe filter (`info,rmcp::service=error,rmcp::transport::worker=debug,rmcp::transport::streamable_http_server=debug`). Review **proved in execution** that rmcp's warn-level `response error` event quotes client input verbatim (invalid filter field, full offending JSON value) — the preset holds `rmcp::service` to `error` and admits only content-free lifecycle targets, including the `transport::worker` target that carries the idle-timeout signal #1727 needs.
- **Installer**: the launchd plist deploys with the preset on (stderr already lands in `~/Library/Logs/velesdb-memory/daemon.err.log`); export `VELESDB_MEMORY_LOG` before installing to override — empty deploys silent, the same blank-means-silence contract the daemon itself applies.

## Proofs (each seen red first)

| Test | Red proven | Guards |
|---|---|---|
| T1 handled call → tool+verdict+duration | assertion failed pre-implementation | the tool event exists |
| T2 unknown session → 404 event (+2xx positive control) | idem | refused ≠ handled in the log |
| T3 (unit, `src/logging.rs`) unset/blank → no filter; invalid → refusal naming the var | stub red | silent-by-default; loud refusal |
| T4 canary fact never reaches the log | pre-implementation red | happy-path content safety |
| T5 error-path canaries (field + value) never reach the log | red against the pre-review preset, quoting the leaked WARN lines | error-path content safety, guards rmcp upgrades (#1789) |
| T6 idle retirement leaves the worker-quit signal (bounded poll, no fixed sleep — #1793's lesson) | red under a mutated preset without `transport::worker` | the #1727 signal is actually visible |
| drift guard (runtime read — `scripts/` is not packaged, so the published .crate's tests still build) | red before the installer carried the preset | installer ↔ constant can't drift |

Binary-level: invalid filter → exit 1 with the message; no var → zero trace bytes; with var → a probe request leaves its line.

## Review passes

Two independent adversarial passes before push: a correctness review (found the error-path content leak — fixed by tightening the preset, pinned by T5 — and the missing `transport::worker` target) and a design review (stale comment, test numbering, substring-fragile positive control, installer `:-`/`-` semantics, shared session derivation, naming — all applied).

## Gates

fmt ✅ · clippy pedantic workspace + `-p velesdb-memory --features http --all-targets` ✅ · 6/6 feature isolations ✅ · lizard `-C 8 -a 8` (only the two tolerated pre-existing warnings) ✅ · check_prod_unwraps ✅ · shellcheck ✅ · `--features http` suite **996 passed / 0 failed** · extract suite 35 suites 0 failed.

Next (P2.2): redeploy the daemon with these logs and run #1727's §4 instrumentation grid.