### PR TITLE
fix(scripts): stop escaped triple-backtick prose from blinding the unwrap guard

### DIFF
--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -760,15 +760,13 @@ fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
                 && last.range.len() + piece.range.len() <= MAX_FRAGMENT_BYTES
                 && (last.range.len() < min_bytes || piece.range.len() < min_bytes)
         });
-        if mergeable {
-            // Safe: `mergeable` only true when `merged` is non-empty.
-            merged
-                .last_mut()
-                .expect("checked non-empty above")
-                .range
-                .end = piece.range.end;
-        } else {
-            merged.push(piece);
+        // `mergeable` is only true when `merged` is non-empty, but branch on
+        // the `Option` rather than assume it: a future edit to `mergeable`
+        // that breaks the invariant then drops nothing silently and panics
+        // nowhere, it just falls back to pushing `piece` as its own entry.
+        match merged.last_mut() {
+            Some(last) if mergeable => last.range.end = piece.range.end,
+            _ => merged.push(piece),
         }
     }
     merged

--- a/scripts/check_prod_unwraps.py
+++ b/scripts/check_prod_unwraps.py
@@ -55,6 +55,25 @@ def is_cfg_test_gate(stripped: str) -> bool:
     return re.search(r"\btest\b", without_strings) is not None
 
 
+def is_doc_fence_marker(stripped: str) -> bool:
+    """True if a `///` line opens/closes a rustdoc example fence.
+
+    A genuine fence marker has the triple backtick as the first thing after
+    the `///` prefix (optionally followed by a language tag, e.g.
+    `/// ```rust`). A ``` occurring elsewhere on the line is prose, not a
+    fence — e.g. an inline code span that double-backtick-escapes a literal
+    triple backtick, as in `` `` ``` `` `` (segment.rs:112, chunk.rs:87),
+    used when a doc comment needs to talk *about* fence syntax without
+    opening one. The old substring check (`"```" in stripped`) toggled on
+    that occurrence and, finding no closing fence for the rest of the file,
+    stayed stuck open — silently exempting every remaining line (including
+    unrelated functions) from the unwrap/expect scan.
+    """
+    if not stripped.startswith("///"):
+        return False
+    return stripped[3:].lstrip().startswith("```")
+
+
 def is_production_file(path: Path) -> bool:
     name = path.name
     if name.endswith("_tests.rs") or name.endswith("_test.rs"):
@@ -138,9 +157,8 @@ def scan_file(path: Path) -> list[tuple[int, str]]:
         # Skip single-line comments
         if stripped.startswith("//"):
             # Track doc example fences
-            if stripped.startswith("///"):
-                if "```" in stripped:
-                    in_doc_example = not in_doc_example
+            if is_doc_fence_marker(stripped):
+                in_doc_example = not in_doc_example
             continue
 
         # Skip lines inside doc examples

--- a/scripts/tests/test_check_prod_unwraps.py
+++ b/scripts/tests/test_check_prod_unwraps.py
@@ -1,6 +1,6 @@
 """Tests for scripts/check_prod_unwraps.py.
 
-Pins two audit contracts:
+Pins three audit contracts:
 
 * F-3.10 — every production crate's `src/` is in the scan set (bindings and
   adapters were historically excluded, leaving an unwrap/expect blind spot).
@@ -9,6 +9,14 @@ Pins two audit contracts:
   gate. The old exact-string match only handled bare `#[cfg(test)]`, so
   `.expect()` calls inside those gated test modules were reported as false
   positives (e.g. velesdb-memory/src/reinforce.rs).
+* F-3.12 — a `///` line whose "```" is prose (an inline code span
+  double-backtick-escaping a literal triple backtick, not a fence marker)
+  must not toggle doc-example tracking. The old substring check
+  (`"```" in stripped`) treated any occurrence as a fence open, got stuck
+  "inside" a doc example with no closing fence for the rest of the file, and
+  silently exempted every remaining line — including real functions — from
+  the unwrap/expect scan (found live in velesdb-memory/src/context/
+  segment.rs, which was hiding a production `.expect()` this way).
 """
 
 from __future__ import annotations
@@ -185,6 +193,64 @@ class TestGatedBlockIsSkippedNotTheRestOfTheFile(unittest.TestCase):
             "#[cfg(test)]\nmod t2 { fn b() { z.unwrap(); } }\n"
         )
         self.assertEqual([line for line, _ in hits], [3])
+
+
+class TestDocFenceMarker(unittest.TestCase):
+    def test_bare_fence_open_is_a_marker(self) -> None:
+        self.assertTrue(cpu.is_doc_fence_marker("/// ```"))
+
+    def test_fence_open_with_language_tag_is_a_marker(self) -> None:
+        self.assertTrue(cpu.is_doc_fence_marker("/// ```rust"))
+
+    def test_double_backtick_escaped_literal_is_not_a_marker(self) -> None:
+        # segment.rs:112 / chunk.rs:87 — prose *about* the fence sequence,
+        # not a fence itself.
+        self.assertFalse(
+            cpu.is_doc_fence_marker("/// `` ``` `` (defense in depth).")
+        )
+
+    def test_non_doc_comment_is_not_a_marker(self) -> None:
+        self.assertFalse(cpu.is_doc_fence_marker('//! `` ``` ``'))
+
+
+class TestScanFileDocFenceFalsePositive(unittest.TestCase):
+    """F-3.12: a prose-only ``` inside a `///` line must not blind the rest
+    of the file's scan (regression for the segment.rs live finding)."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self) -> None:
+        self._tmpdir.cleanup()
+
+    def test_expect_after_an_escaped_triple_backtick_comment_is_flagged(
+        self,
+    ) -> None:
+        content = (
+            "/// `` ``` `` (defense in depth; it usually does).\n"
+            "pub fn a() {}\n"
+            "\n"
+            "fn merge_tiny() {\n"
+            '    merged.last_mut().expect("checked non-empty above");\n'
+            "}\n"
+        )
+        tmp = Path(self._tmpdir.name) / "segment_like.rs"
+        tmp.write_text(content, encoding="utf-8")
+        hits = cpu.scan_file(tmp)
+        self.assertEqual([line for line, _ in hits], [5])
+
+    def test_a_real_fenced_example_still_hides_its_contents(self) -> None:
+        content = (
+            "/// ```\n"
+            "/// let v = x.unwrap();\n"
+            "/// ```\n"
+            "pub fn a() {}\n"
+        )
+        tmp = Path(self._tmpdir.name) / "real_fence.rs"
+        tmp.write_text(content, encoding="utf-8")
+        self.assertEqual(cpu.scan_file(tmp), [])
 
 
 class TestScanDirsCoverage(unittest.TestCase):


### PR DESCRIPTION
## Description

`scripts/check_prod_unwraps.py` — the guard enforcing "no `.unwrap()`/`.expect()` in production code" — had a false-negative bug in its doc-comment fence tracker.

It toggled "inside a doc example" on *any* `///` line containing the substring `` ``` ``. Two files use the legitimate rustdoc idiom `` `` ``` `` `` (double-backtick-escaping a literal triple backtick) to talk *about* fence syntax in prose, not to open a fence:

- `crates/velesdb-memory/src/context/segment.rs:112`
- `crates/velesdb-memory/src/context/chunk.rs:87`

That single occurrence flipped the tracker on with no matching close, so the scanner silently treated the rest of the file as "inside a doc example" and stopped checking it — including unrelated functions further down. In `segment.rs` this was hiding a real `.expect("checked non-empty above")` in `merge_tiny()`, in violation of the project's own hard rule.

Fixed the detector to only treat a `///` line as a fence marker when the triple backtick is the first thing after the `///` prefix (how genuine fences are actually written), and fixed the now-exposed `.expect()` with a non-panicking `match` that falls back safely instead of assuming the invariant.

Fixes: latent false negative in `scripts/check_prod_unwraps.py` (no tracked issue — found via routine code review).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests (new regression tests in `scripts/tests/test_check_prod_unwraps.py` pinning both the fence-marker helper and the file-level scan behavior)
- [x] Manual testing

Verified locally:
- `python3 scripts/check_prod_unwraps.py` — now correctly flags the hidden `.expect()` before the fix, passes clean after
- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` — 404 tests, OK
- `cargo test -p velesdb-memory --lib context::segment -- --test-threads=1` — 20/20 pass
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p velesdb-memory --lib -- -D warnings -D clippy::pedantic` — clean

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (not needed — internal guard script behavior, no user-facing docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — this PR does not add or modify `unsafe` code.

## High-Risk Change Checklist

Skipped — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Two atomic commits:
1. `fix(scripts): ...` — the guard fix itself, with regression tests.
2. `fix(memory): ...` — the production `.expect()` the guard was hiding, replaced with a safe fallback.