### PR TITLE
docs(security): route reports to contact@wiscale.fr with a triage subject marker

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,16 @@
 
 | Version | Supported |
 |---------|-----------|
-| 3.12.x  | Yes       |
-| 3.11.x  | Security fixes only |
-| 3.10.x  | Security fixes only |
-| < 3.10  | No        |
+| 4.2.x   | Yes       |
+| 4.1.x   | Security fixes only |
+| 4.0.x   | Security fixes only |
+| < 4.0   | No        |
 
 > VelesDB ships weekly; this table is updated at every minor release. The latest minor always receives full support, and the two previous minors receive security fixes.
+>
+> `velesdb-memory` (the MCP memory server) follows its own release line,
+> decoupled from the engine's: only its **latest published release** is
+> supported.
 
 ## Reporting a Vulnerability
 
@@ -19,7 +23,11 @@ If you discover a security vulnerability in VelesDB, please report it responsibl
 
 ### How to Report
 
-Send an email to **security@wiscale.fr** with:
+Send an email to **contact@wiscale.fr** with a subject line starting with
+**`[SECURITY][VelesDB]`** — this exact marker is what routes your report to
+security triage; a report without it may sit unread in a general inbox.
+
+Include:
 
 1. A description of the vulnerability
 2. Steps to reproduce (proof of concept if possible)
@@ -43,11 +51,15 @@ The following components are in scope:
 |-----------|----------------|
 | Core engine | `crates/velesdb-core/` |
 | HTTP server | `crates/velesdb-server/` |
+| MCP memory server (incl. its HTTP daemon) | `crates/velesdb-memory/` |
+| Embedding migration tool | `crates/velesdb-migrate/` |
 | Python bindings | `crates/velesdb-python/` |
+| Node.js bindings | `crates/velesdb-node/` |
 | WASM bindings | `crates/velesdb-wasm/` |
 | Mobile bindings | `crates/velesdb-mobile/` |
 | CLI | `crates/velesdb-cli/` |
 | TypeScript SDK | `sdks/typescript/` |
+| Tauri plugin | `tauri-plugin-velesdb/` |
 
 ### What Qualifies as a Vulnerability
 


### PR DESCRIPTION
Requested review of the [security policy page](https://github.com/cyberlife-coder/VelesDB?tab=security-ov-file).

## The ask
- Reports were pointed at **security@wiscale.fr**; the monitored inbox is **contact@wiscale.fr** — a vulnerability report could sit unread at a dead address, the worst failure mode a security policy can have.
- Reports must now carry a **`[SECURITY][VelesDB]`** subject marker so they route to security triage instead of the general mail flow (the policy says explicitly that a report without the marker may be missed).

## What the review surfaced on top
- **Supported-versions table two major lines stale**: it said 3.12/3.11/3.10 while the engine ships **4.2.0** — on a table whose own caption promises updates at every minor. Now 4.2.x (full) / 4.1.x / 4.0.x (security fixes) / <4.0 (no), matching the actual tags (v4.2.0, v4.1.0, v4.0.0). The `velesdb-memory` release line is stated explicitly (own cadence, latest published release supported).
- **Scope table omitted four shipped components** — including `crates/velesdb-memory/`, an unauthenticated-by-design local HTTP daemon, exactly the surface a security reporter looks at first. Added it plus `velesdb-migrate`, the Node bindings, and the Tauri plugin.

Docs-only change; no code touched.