### PR TITLE
fix(memory): honest response budgets — observable truncation, entity caps, O(cap) expansion (#1820)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5864,7 +5864,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6864,7 +6864,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7004,7 +7004,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -7045,7 +7045,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7077,7 +7077,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.23"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "4.2.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "4.3.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-06-21 — covers v4.2.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
+> **Last updated:** 2026-06-21 — covers v4.3.0 (current). The horizon framing below predates the v2.0→v3.x line and is being re-baselined.
 
 ---
 

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="4.2.0"
+LABEL version="4.3.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -255,4 +255,4 @@ VelesDB engine and is governed by the Core License.
 
 ---
 
-`tauri-plugin-velesdb v4.0.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`tauri-plugin-velesdb v4.0.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -218,4 +218,4 @@ Licensed under the [VelesDB Core License 1.0](./LICENSE) (source-available).
 
 ---
 
-`velesdb-cli v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-cli v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -243,4 +243,4 @@ the platforms and toolchains the project builds and tests on.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-core/src/agent/episodic_memory.rs
+++ b/crates/velesdb-core/src/agent/episodic_memory.rs
@@ -272,6 +272,50 @@ impl EpisodicMemory {
         )
     }
 
+    /// Returns at most `cap` outgoing relations of an event, plus whether its
+    /// total degree exceeded the scan — work and transient allocation O(cap),
+    /// never O(degree) (#1820).
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Episodic,
+            cap,
+        )
+    }
+
+    /// Returns at most `cap` incoming relations of an event, plus whether its
+    /// total incoming degree exceeded the scan — the mirror of
+    /// [`Self::relations_bounded`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::incoming_relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Episodic,
+            cap,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/memory_helpers.rs
+++ b/crates/velesdb-core/src/agent/memory_helpers.rs
@@ -694,6 +694,39 @@ pub(super) fn relations_of(
         .collect())
 }
 
+/// Bounded twin of [`relations_of`] (#1820): resolves at most `cap` stored
+/// edges — work and transient allocation O(cap), never O(degree) — and says
+/// whether the point's total degree exceeded the scan.
+///
+/// The TTL filter runs on the scanned window only: an expired edge inside it
+/// is dropped without scanning further, because the O(cap) bound is the
+/// contract. `truncated` compares the TOTAL stored degree (read under the
+/// same shard guard as the edges) against `cap`, so a caller can tell
+/// "exactly `cap` edges" from "cut at `cap`" — the ambiguity the unbounded
+/// accessor structurally cannot resolve.
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn relations_of_bounded(
+    db: &Database,
+    collection_name: &str,
+    id: u64,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    cap: usize,
+) -> Result<super::BoundedRelations, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    let (edges, total) = collection.get_outgoing_edges_bounded(id, cap);
+    Ok(super::BoundedRelations {
+        edges: edges
+            .into_iter()
+            .filter(|edge| !ttl.is_expired(kind, edge.target()))
+            .collect(),
+        truncated: total > cap,
+    })
+}
+
 /// Returns the incoming relation edges of a memory point, filtering out edges
 /// whose source is TTL-expired in the given subsystem.
 ///
@@ -719,6 +752,33 @@ pub(super) fn incoming_relations_of(
         .into_iter()
         .filter(|edge| !ttl.is_expired(kind, edge.source()))
         .collect())
+}
+
+/// Bounded twin of [`incoming_relations_of`] — the incoming mirror of
+/// [`relations_of_bounded`], with the same O(cap) scan contract and the same
+/// window-only TTL filtering (here on `source()`, the far end of an incoming
+/// edge).
+///
+/// # Errors
+///
+/// Returns `CollectionError` when the collection cannot be resolved.
+pub(super) fn incoming_relations_of_bounded(
+    db: &Database,
+    collection_name: &str,
+    id: u64,
+    ttl: &super::ttl::MemoryTtl,
+    kind: super::ttl::MemoryKind,
+    cap: usize,
+) -> Result<super::BoundedRelations, AgentMemoryError> {
+    let collection = get_collection(db, collection_name)?;
+    let (edges, total) = collection.get_incoming_edges_bounded(id, cap);
+    Ok(super::BoundedRelations {
+        edges: edges
+            .into_iter()
+            .filter(|edge| !ttl.is_expired(kind, edge.source()))
+            .collect(),
+        truncated: total > cap,
+    })
 }
 
 /// Removes a relation edge from a memory collection.

--- a/crates/velesdb-core/src/agent/mod.rs
+++ b/crates/velesdb-core/src/agent/mod.rs
@@ -64,6 +64,26 @@ pub use memory::{
     AgentMemory, AgentMemoryError, EpisodicMemory, ProceduralMemory, ProcedureMatch,
     SemanticMemory, DEFAULT_DIMENSION,
 };
+
+/// At most `cap` relation edges of one memory point, plus the honest signal
+/// that the point carries more. Returned by the `relations_bounded` /
+/// `incoming_relations_bounded` accessors of every memory kind.
+///
+/// The signal is a separate field because `edges.len() == cap` cannot carry
+/// it: a node with exactly `cap` edges is indistinguishable from a truncated
+/// one (#1820). `truncated` compares the node's TOTAL stored degree — read
+/// under the same shard guard as the edges — against the scan cap, so it is
+/// true exactly when stored edges were left unread. Note that TTL-expired
+/// edges inside the scanned window are dropped without being replaced (the
+/// O(cap) scan bound outranks returning exactly `cap` live entries), so
+/// `edges.len() < cap` with `truncated == true` is a normal outcome.
+#[derive(Debug, Clone)]
+pub struct BoundedRelations {
+    /// At most `cap` edges, in index order, TTL-expired far ends dropped.
+    pub edges: Vec<crate::collection::graph::GraphEdge>,
+    /// Whether the node's total stored degree exceeded the scan cap.
+    pub truncated: bool,
+}
 pub use reinforcement::{
     power_law_decay, AdaptiveLearningRate, CompositeStrategy, ContextualReinforcement,
     DiminishingReturns, FixedRate, ReinforcementContext, ReinforcementStrategy, TemporalDecay,

--- a/crates/velesdb-core/src/agent/procedural_memory.rs
+++ b/crates/velesdb-core/src/agent/procedural_memory.rs
@@ -359,6 +359,50 @@ impl ProceduralMemory {
         )
     }
 
+    /// Returns at most `cap` outgoing relations of a procedure, plus whether
+    /// its total degree exceeded the scan — work and transient allocation
+    /// O(cap), never O(degree) (#1820).
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Procedural,
+            cap,
+        )
+    }
+
+    /// Returns at most `cap` incoming relations of a procedure, plus whether
+    /// its total incoming degree exceeded the scan — the mirror of
+    /// [`Self::relations_bounded`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::incoming_relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Procedural,
+            cap,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// # Errors

--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -429,6 +429,55 @@ impl SemanticMemory {
         )
     }
 
+    /// Returns at most `cap` outgoing relations of a fact, plus whether its
+    /// total degree exceeded the scan — work and transient allocation
+    /// O(cap), never O(degree) (#1820).
+    ///
+    /// Prefer this over [`Self::relations`] wherever the caller keeps only a
+    /// bounded prefix: on a super-node (an entity hub mentioned by thousands
+    /// of facts) the unbounded accessor materializes the whole degree before
+    /// the caller's own cap can apply.
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Semantic,
+            cap,
+        )
+    }
+
+    /// Returns at most `cap` incoming relations of a fact, plus whether its
+    /// total incoming degree exceeded the scan — the mirror of
+    /// [`Self::relations_bounded`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `CollectionError` when the collection cannot be resolved.
+    pub fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<super::BoundedRelations, AgentMemoryError> {
+        memory_helpers::incoming_relations_of_bounded(
+            &self.db,
+            &self.collection_name,
+            id,
+            &self.ttl,
+            MemoryKind::Semantic,
+            cap,
+        )
+    }
+
     /// Removes a relation edge created by [`Self::relate`].
     ///
     /// Returns `true` when the edge existed and was removed.

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -399,6 +399,39 @@ impl Collection {
         self.graph.edge_store.get_incoming(node_id)
     }
 
+    /// Gets at most `cap` outgoing edges from a node, plus the node's total
+    /// outgoing degree — work and allocation O(cap), never O(degree), read
+    /// consistently under one shard guard (#1820).
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - The source node ID
+    /// * `cap` - Maximum number of edges to resolve
+    ///
+    /// # Returns
+    ///
+    /// At most `cap` edges (cloned) and the node's total outgoing degree.
+    #[must_use]
+    pub fn get_outgoing_edges_bounded(&self, node_id: u64, cap: usize) -> (Vec<GraphEdge>, usize) {
+        self.graph.edge_store.get_outgoing_bounded(node_id, cap)
+    }
+
+    /// Gets at most `cap` incoming edges to a node, plus the node's total
+    /// incoming degree — the mirror of [`Self::get_outgoing_edges_bounded`].
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - The target node ID
+    /// * `cap` - Maximum number of edges to resolve
+    ///
+    /// # Returns
+    ///
+    /// At most `cap` edges (cloned) and the node's total incoming degree.
+    #[must_use]
+    pub fn get_incoming_edges_bounded(&self, node_id: u64, cap: usize) -> (Vec<GraphEdge>, usize) {
+        self.graph.edge_store.get_incoming_bounded(node_id, cap)
+    }
+
     /// Traverses the graph using BFS from a source node.
     ///
     /// # Arguments

--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -324,6 +324,41 @@ impl EdgeStore {
         self.resolve_edge_ids(self.incoming.get(&node_id))
     }
 
+    /// Gets at most `cap` outgoing edges from a node.
+    ///
+    /// The bound is applied to the index BEFORE any edge is resolved, so the
+    /// work and the allocation are O(cap) — never O(degree). This is what
+    /// makes reading a super-node affordable: [`Self::get_outgoing`] on a
+    /// million-edge node materializes a million entries even when the caller
+    /// keeps only the first 64 (#1820).
+    #[must_use]
+    pub fn get_outgoing_bounded(&self, node_id: u64, cap: usize) -> Vec<&GraphEdge> {
+        self.resolve_edge_ids_bounded(self.outgoing.get(&node_id), cap)
+    }
+
+    /// Gets at most `cap` incoming edges to a node — the mirror of
+    /// [`Self::get_outgoing_bounded`], with the same O(cap) guarantee.
+    #[must_use]
+    pub fn get_incoming_bounded(&self, node_id: u64, cap: usize) -> Vec<&GraphEdge> {
+        self.resolve_edge_ids_bounded(self.incoming.get(&node_id), cap)
+    }
+
+    /// [`Self::resolve_edge_ids`] with the id list truncated FIRST — the cap
+    /// bounds the scan itself, not just the result. A dangling id inside the
+    /// scanned window (defensively skipped, as in the unbounded resolver) is
+    /// not replaced by scanning further: the O(cap) guarantee outranks
+    /// returning exactly `cap` entries.
+    #[inline]
+    fn resolve_edge_ids_bounded(&self, ids: Option<&Vec<u64>>, cap: usize) -> Vec<&GraphEdge> {
+        ids.map(|ids| {
+            ids.iter()
+                .take(cap)
+                .filter_map(|id| self.edges.get(id))
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
     /// Gets outgoing edges filtered by label using composite index - O(k) where k = result count.
     ///
     /// Uses the `outgoing_by_label` composite index for fast lookup instead of

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs
@@ -31,6 +31,44 @@ impl ConcurrentEdgeStore {
         guard.get_incoming(node_id).into_iter().cloned().collect()
     }
 
+    /// Gets at most `cap` outgoing edges from a node, plus the node's TOTAL
+    /// outgoing degree (thread-safe).
+    ///
+    /// Work and allocation are O(cap), never O(degree) — the bound reaches
+    /// the shard's index scan itself (#1820). Both values are read under ONE
+    /// shard guard, so the pair cannot tear: the degree always describes the
+    /// same instant as the edges, which is what lets a caller derive an
+    /// honest `truncated = total > cap` signal.
+    #[must_use]
+    pub fn get_outgoing_bounded(&self, node_id: u64, cap: usize) -> (Vec<GraphEdge>, usize) {
+        let shard = &self.shards[self.shard_index(node_id)];
+        let guard = shard.read();
+        let total = guard.outgoing_degree(node_id);
+        let edges = guard
+            .get_outgoing_bounded(node_id, cap)
+            .into_iter()
+            .cloned()
+            .collect();
+        (edges, total)
+    }
+
+    /// Gets at most `cap` incoming edges to a node, plus the node's TOTAL
+    /// incoming degree (thread-safe) — the mirror of
+    /// [`Self::get_outgoing_bounded`], same O(cap) and same single-guard
+    /// consistency.
+    #[must_use]
+    pub fn get_incoming_bounded(&self, node_id: u64, cap: usize) -> (Vec<GraphEdge>, usize) {
+        let shard = &self.shards[self.shard_index(node_id)];
+        let guard = shard.read();
+        let total = guard.incoming_degree(node_id);
+        let edges = guard
+            .get_incoming_bounded(node_id, cap)
+            .into_iter()
+            .cloned()
+            .collect();
+        (edges, total)
+    }
+
     /// Gets neighbors (target nodes) of a given node.
     ///
     /// When a CSR read snapshot is available (see

--- a/crates/velesdb-core/tests/graph_bounded_reads.rs
+++ b/crates/velesdb-core/tests/graph_bounded_reads.rs
@@ -1,0 +1,167 @@
+//! Behaviour: reading a bounded prefix of a super-node's edges allocates
+//! O(cap), not O(degree) — MEASURED, not asserted from the signature (#1820).
+//!
+//! Issue #1743 bounded the RESPONSE of a graph walk, but the expansion cost
+//! stayed O(degree): `get_outgoing` materializes a node's whole edge list
+//! before any caller-side `.take(cap)` can apply, so one expansion of a
+//! million-edge hub still cost a million clones transiently. The bounded
+//! accessors push the cap into the shard's index scan itself; this file
+//! proves the difference with a counting global allocator rather than
+//! trusting the code shape.
+//!
+//! The whole file is ONE test on purpose: the allocator meter is global to
+//! the process, so a second test running on a sibling thread would bleed its
+//! allocations into whichever measurement is in flight. Sequential sections
+//! inside one `#[test]` are the only layout that keeps every delta clean.
+//!
+//! The positive control is what makes the measurement trustworthy: the
+//! UNBOUNDED read of the same hub must register at least the materialized
+//! edge buffer (`degree × size_of::<GraphEdge>()`). A meter that failed to
+//! see that much would fail the control rather than green-light the claim.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use velesdb_core::collection::graph::{ConcurrentEdgeStore, GraphEdge};
+
+/// [`System`] allocator with a monotonic count of bytes ever allocated.
+/// Deallocations are deliberately not subtracted: the meter measures
+/// allocation WORK (what #1820's residual is about), not peak footprint.
+struct CountingAllocator;
+
+static BYTES_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: `GlobalAlloc` demands that alloc/dealloc uphold the allocator
+// contract (valid layouts honoured, no aliasing invented).
+// - Condition 1: every call is forwarded verbatim to `System`, which upholds
+//   the full contract by definition.
+// - Condition 2: the only addition is a relaxed atomic increment, which
+//   cannot allocate, panic, or touch the pointers involved.
+// Reason: counting allocated bytes is the whole instrument of this test —
+// there is no safe hook into the global allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        BYTES_ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        // SAFETY: `System.alloc` requires the caller's layout obligations.
+        // - Condition 1: `layout` is passed through unmodified from our own
+        //   caller, who carries the same obligations.
+        // Reason: delegation to the real allocator is the entire body.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `System.dealloc` requires `ptr` to come from `System.alloc`
+        // with the same layout.
+        // - Condition 1: `alloc` above only ever returns `System.alloc`
+        //   pointers, and `ptr`/`layout` arrive unmodified from the runtime.
+        // Reason: delegation to the real allocator is the entire body.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Bytes allocated (anywhere in the process) while `f` runs.
+fn bytes_allocated_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    let before = BYTES_ALLOCATED.load(Ordering::Relaxed);
+    let value = f();
+    let after = BYTES_ALLOCATED.load(Ordering::Relaxed);
+    (value, after - before)
+}
+
+/// The hub's degree. Large enough that O(degree) and O(cap) differ by
+/// orders of magnitude, small enough to build in well under a second.
+const HUB_DEGREE: usize = 100_000;
+
+/// The bounded read's cap — the same order as the caps the memory layer
+/// applies (`MAX_WHY_NODE_DEGREE`, 64).
+const CAP: usize = 64;
+
+/// The hub node every edge leaves from.
+const HUB: u64 = 1;
+
+/// A store holding one hub with [`HUB_DEGREE`] outgoing edges, each pointing
+/// at a distinct target (which therefore carries one incoming edge from the
+/// hub — the incoming side is measured on the hub's own incoming edges,
+/// added separately below).
+fn dense_hub_store() -> ConcurrentEdgeStore {
+    let store = ConcurrentEdgeStore::new();
+    for i in 0..HUB_DEGREE {
+        let id = u64::try_from(i).expect("hub degree fits u64");
+        let edge = GraphEdge::new(id, HUB, 1_000_000 + id, "mentions").expect("valid label");
+        store.add_edge(edge).expect("edge insert");
+    }
+    (0..HUB_DEGREE).for_each(|i| {
+        let id = u64::try_from(HUB_DEGREE + i).expect("hub degree fits u64");
+        let edge = GraphEdge::new(id, 2_000_000 + id, HUB, "mentions").expect("valid label");
+        store.add_edge(edge).expect("edge insert");
+    });
+    store
+}
+
+/// How much smaller than the unbounded read's allocation the bounded read
+/// must measure. 100k-edge full reads allocate megabytes; 64-edge bounded
+/// reads allocate kilobytes — a 50× margin leaves room for allocator noise
+/// while still failing on any O(degree) regression.
+const REQUIRED_FACTOR: usize = 50;
+
+#[test]
+fn a_bounded_read_of_a_dense_hub_allocates_o_cap_not_o_degree() {
+    let store = dense_hub_store();
+
+    // --- Positive control: the meter must SEE the O(degree) materialization.
+    let (full, full_bytes) = bytes_allocated_during(|| store.get_outgoing(HUB));
+    assert_eq!(full.len(), HUB_DEGREE, "the hub holds its whole degree");
+    let materialized_floor = HUB_DEGREE * std::mem::size_of::<GraphEdge>();
+    assert!(
+        full_bytes >= materialized_floor,
+        "control failed: the unbounded read materializes at least its edge \
+         buffer ({materialized_floor} bytes), yet the meter saw only \
+         {full_bytes} — the measurement cannot be trusted"
+    );
+    drop(full);
+
+    // --- The claim, outgoing: O(cap) allocation, exact degree reported.
+    let ((bounded, total), bounded_bytes) =
+        bytes_allocated_during(|| store.get_outgoing_bounded(HUB, CAP));
+    assert_eq!(bounded.len(), CAP, "cap honoured");
+    assert_eq!(total, HUB_DEGREE, "total degree reported exactly");
+    assert!(
+        bounded_bytes * REQUIRED_FACTOR < full_bytes,
+        "bounded read allocated {bounded_bytes} bytes — not even {REQUIRED_FACTOR}x \
+         under the unbounded read's {full_bytes}: the cap is not reaching the scan"
+    );
+
+    // --- The claim, incoming: same contract on the mirror accessor.
+    let (incoming_full, incoming_full_bytes) = bytes_allocated_during(|| store.get_incoming(HUB));
+    assert_eq!(incoming_full.len(), HUB_DEGREE);
+    drop(incoming_full);
+    let ((bounded_in, total_in), bounded_in_bytes) =
+        bytes_allocated_during(|| store.get_incoming_bounded(HUB, CAP));
+    assert_eq!(bounded_in.len(), CAP, "incoming cap honoured");
+    assert_eq!(
+        total_in, HUB_DEGREE,
+        "incoming total degree reported exactly"
+    );
+    assert!(
+        bounded_in_bytes * REQUIRED_FACTOR < incoming_full_bytes,
+        "bounded incoming read allocated {bounded_in_bytes} bytes against the \
+         unbounded read's {incoming_full_bytes}: the cap is not reaching the scan"
+    );
+
+    // --- Honesty of the signal: under-cap nodes are NOT reported truncated.
+    let first_source = 2_000_000 + u64::try_from(HUB_DEGREE).expect("fits u64");
+    let (small, small_total) = store.get_outgoing_bounded(first_source, CAP);
+    assert_eq!(small.len(), 1, "a leaf has exactly its one edge");
+    assert_eq!(small_total, 1, "a leaf's degree is under the cap");
+
+    // --- The bounded prefix is a prefix of the unbounded read, not a resample.
+    let full_again = store.get_outgoing(HUB);
+    let prefix: Vec<u64> = full_again.iter().take(CAP).map(GraphEdge::id).collect();
+    let bounded_ids: Vec<u64> = bounded.iter().map(GraphEdge::id).collect();
+    assert_eq!(
+        bounded_ids, prefix,
+        "bounded returns the same leading edges"
+    );
+}

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -235,7 +235,12 @@ and evict a real fact from your results. So:
   attributes and every typed edge touching him, in BOTH directions:
   `relations` leave him, `relations_in` point AT him. Ask only the first and
   the graph looks half empty — it holds `camille --sister of--> theo`, so
-  Theo's outgoing edges never mention Camille.
+  Theo's outgoing edges never mention Camille. Each side is budget-bounded:
+  `relations_truncated` / `relations_in_truncated` tell you the list is a
+  PARTIAL view, which a list sitting exactly at the cap cannot tell you by
+  itself. Same rule on `why`: its `truncated` says a width budget cut the
+  walk, so an answer built on a cut subgraph is never mistaken for a
+  complete one.
 - *"Which notes mention Theo?"* → `recall("Theo Durand")` — returns sentences.
 
 Use `entity` for questions **about a thing**, `recall` for questions **about what

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -19,7 +19,7 @@ use super::*;
 use crate::context::model::CompilePolicy;
 use crate::context::{fragment_id, ContextAction};
 use crate::embedder::HashEmbedder;
-use crate::model::MemoryEdge;
+use crate::model::{BoundedMemoryEdges, MemoryEdge};
 use crate::storage::NativeStore;
 
 const DIM: usize = 384;
@@ -740,6 +740,22 @@ macro_rules! delegate_untouched_store_methods {
 
         fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
             self.inner.incoming_relations(id)
+        }
+
+        fn relations_bounded(
+            &self,
+            id: u64,
+            cap: usize,
+        ) -> Result<BoundedMemoryEdges, MemoryError> {
+            self.inner.relations_bounded(id, cap)
+        }
+
+        fn incoming_relations_bounded(
+            &self,
+            id: u64,
+            cap: usize,
+        ) -> Result<BoundedMemoryEdges, MemoryError> {
+            self.inner.incoming_relations_bounded(id, cap)
         }
 
         fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -178,9 +178,9 @@ pub use http_client::{Auth, HttpJsonClient};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
 pub use model::{
-    column_value_matches, ColumnFilter, ColumnOp, EntityProfile, EntityRelation, Explanation,
-    FusionOptions, Link, MemoryEdge, MemoryNode, Recollection, RememberedExtraction,
-    UnrelateOutcome,
+    column_value_matches, BoundedMemoryEdges, ColumnFilter, ColumnOp, EntityProfile,
+    EntityRelation, Explanation, FusionOptions, Link, MemoryEdge, MemoryNode, Recollection,
+    RememberedExtraction, UnrelateOutcome,
 };
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{MemoryService, Metadata};

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -97,6 +97,29 @@ pub const MAX_WHY_NODES: usize = 500;
 /// ceiling on the response, not a tuning knob.
 pub const MAX_WHY_EDGES: usize = MAX_WHY_NODES * 4;
 
+/// Maximum typed edges an `entity` profile resolves and returns PER
+/// DIRECTION (`relations` and `relations_in` each) — the same width grammar
+/// as [`MAX_WHY_NODE_DEGREE`], on the surface #1743 never covered: resolving
+/// an entity followed every non-scaffolding edge of its hub, full target
+/// content included, so `entity("X")` on a name mentioned by thousands of
+/// facts was a constructible multi-megabyte response (#1820). Truncation is
+/// REPORTED (`relations_truncated`/`relations_in_truncated` on the profile),
+/// never silent: a profile with exactly this many edges is otherwise
+/// indistinguishable from a cut one.
+pub const MAX_ENTITY_RELATIONS: usize = 64;
+
+/// Maximum RAW edges an `entity` profile may scan per direction while
+/// looking for its [`MAX_ENTITY_RELATIONS`] typed ones. A hub's edges are
+/// mostly bipartite scaffolding (`mentions`/`about`, one per mentioning
+/// fact), filtered out AFTER the store hands them over — so the resolution
+/// cap alone would leave the scan O(degree), and a scan capped at the
+/// resolution cap would return scaffolding-only windows on any busy hub.
+/// Two named numbers, one per concern: this one bounds the transient scan
+/// (the #1743 cost class), the other bounds the resolved response. A typed
+/// edge sitting past this window is not found — that blindness is declared
+/// by the same truncation flags, not masked.
+pub const MAX_ENTITY_SCAN_EDGES: usize = 4_096;
+
 /// Maximum accepted size of a single context-compiler fragment (1 MiB, the
 /// same ceiling as [`MAX_FACT_BYTES`]) — prevents a single fragment from
 /// forcing huge allocations in the compile pipeline.

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -475,6 +475,13 @@ pub(super) struct EntityProfileDto {
     /// label needs the gender, which the graph does not hold; this reports
     /// only what is stored.
     pub(super) relations_in: Vec<EntityRelationDto>,
+    /// Whether `relations` is a PARTIAL view — true when a response budget
+    /// cut the outgoing side. A list holding exactly the cap is otherwise
+    /// indistinguishable from a cut one (#1820).
+    pub(super) relations_truncated: bool,
+    /// Whether `relations_in` is a PARTIAL view — the incoming mirror of
+    /// `relations_truncated`.
+    pub(super) relations_in_truncated: bool,
 }
 
 impl EntityProfileDto {
@@ -496,6 +503,8 @@ impl EntityProfileDto {
                 attributes: Metadata::new(),
                 relations: Vec::new(),
                 relations_in: Vec::new(),
+                relations_truncated: false,
+                relations_in_truncated: false,
             };
         };
         Self {
@@ -514,6 +523,8 @@ impl EntityProfileDto {
                 .into_iter()
                 .map(EntityRelationDto::from)
                 .collect(),
+            relations_truncated: profile.relations_truncated,
+            relations_in_truncated: profile.relations_in_truncated,
         }
     }
 }

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -537,6 +537,9 @@ pub(super) struct ExplanationDto {
     pub(super) nodes: Vec<MemoryNodeDto>,
     /// Typed edges connecting the nodes.
     pub(super) edges: Vec<MemoryEdgeDto>,
+    /// Whether a width budget cut the walk — a subgraph sitting exactly at
+    /// a cap is otherwise indistinguishable from a complete one (#1820).
+    pub(super) truncated: bool,
 }
 
 impl From<Explanation> for ExplanationDto {
@@ -552,6 +555,7 @@ impl From<Explanation> for ExplanationDto {
                 .into_iter()
                 .map(MemoryEdgeDto::from)
                 .collect(),
+            truncated: explanation.truncated,
         }
     }
 }

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -315,6 +315,24 @@ pub struct MemoryEdge {
     pub relation: String,
 }
 
+/// At most `cap` edges of one memory point, plus the honest signal that the
+/// point carries more — returned by the bounded accessors of
+/// [`MemoryStore`](crate::storage::MemoryStore) (#1820).
+///
+/// `truncated` is a separate field because `edges.len() == cap` cannot carry
+/// the signal: a node with exactly `cap` edges is indistinguishable from a
+/// truncated one. It compares the node's TOTAL stored degree against the
+/// scan cap, so expired far ends dropped inside the scanned window (never
+/// replaced — the O(cap) bound is the contract) can leave `edges.len() <
+/// cap` with `truncated == true` as a normal outcome.
+#[derive(Debug, Clone)]
+pub struct BoundedMemoryEdges {
+    /// At most `cap` edges, in storage index order.
+    pub edges: Vec<MemoryEdge>,
+    /// Whether the node's total stored degree exceeded the scan cap.
+    pub truncated: bool,
+}
+
 /// Outcome of [`MemoryService::unrelate`](crate::service::MemoryService::unrelate):
 /// idempotent by design, so an absent edge is a `found: false` answer, not an
 /// error — a cleanup must be replayable.
@@ -372,12 +390,23 @@ pub struct EntityProfile {
     pub name: String,
     /// Attributes learned about this entity, reserved keys stripped.
     pub attributes: crate::service::Metadata,
-    /// Typed edges leaving this entity (bipartite scaffolding excluded).
+    /// Typed edges leaving this entity (bipartite scaffolding excluded), at
+    /// most [`crate::limits::MAX_ENTITY_RELATIONS`] of them.
     pub relations: Vec<EntityRelation>,
-    /// Typed edges pointing AT this entity (bipartite scaffolding excluded).
+    /// Typed edges pointing AT this entity (bipartite scaffolding excluded),
+    /// at most [`crate::limits::MAX_ENTITY_RELATIONS`] of them.
     /// Here [`EntityRelation::target_id`]/[`EntityRelation::target`] name the
     /// far end the edge comes FROM — its source.
     pub relations_in: Vec<EntityRelation>,
+    /// Whether `relations` is a PARTIAL view: true when the resolution cap
+    /// ([`crate::limits::MAX_ENTITY_RELATIONS`]) or the raw scan window
+    /// ([`crate::limits::MAX_ENTITY_SCAN_EDGES`]) cut the outgoing side. A
+    /// list holding exactly the cap is otherwise indistinguishable from a
+    /// cut one (#1820).
+    pub relations_truncated: bool,
+    /// Whether `relations_in` is a PARTIAL view — the incoming mirror of
+    /// [`Self::relations_truncated`].
+    pub relations_in_truncated: bool,
 }
 
 /// The connected answer to a `why` question: the best-matching seed memory plus

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -419,6 +419,20 @@ pub struct Explanation {
     pub nodes: Vec<MemoryNode>,
     /// Typed edges connecting the nodes.
     pub edges: Vec<MemoryEdge>,
+    /// Whether a width budget cut this walk before it exhausted the
+    /// reachable graph (#1820). A subgraph sitting exactly at a cap
+    /// ([`crate::limits::MAX_WHY_NODES`], [`crate::limits::MAX_WHY_EDGES`],
+    /// [`crate::limits::MAX_WHY_NODE_DEGREE`]) is otherwise
+    /// indistinguishable from a complete one — counts at a ceiling were the
+    /// only signal, and they are ambiguous by construction.
+    ///
+    /// True when a node's degree exceeded the per-node budget, or when the
+    /// node/edge budget stopped the walk while unexpanded work remained.
+    /// The latter is conservative: expanding the rest is exactly what the
+    /// budget forbids, so whether it held anything unseen is unknowable —
+    /// and a rare cautious `true` is harmless where a false "complete" is
+    /// the defect this field exists to close.
+    pub truncated: bool,
 }
 
 #[cfg(test)]

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1177,6 +1177,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 hop: 0,
             }],
             edges: Vec::new(),
+            truncated: false,
         };
         let mut visited: HashSet<u64> = HashSet::from([seed_id]);
         let mut frontier = vec![seed_id];
@@ -1191,6 +1192,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES
                     || explanation.edges.len() >= crate::limits::MAX_WHY_EDGES
                 {
+                    // Unexpanded frontier work remained — the response is a
+                    // partial view and must SAY so (#1820); whether the rest
+                    // held anything unseen is exactly what the budget forbids
+                    // finding out, so the cautious true is the honest one.
+                    explanation.truncated = true;
                     break 'hops; // width budget spent — depth left in max_hops is moot
                 }
                 self.expand(node_id, hop, &mut explanation, &mut visited, &mut next)?;
@@ -1218,8 +1224,19 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         visited: &mut HashSet<u64>,
         next: &mut Vec<u64>,
     ) -> Result<(), MemoryError> {
-        let edges = self.store.relations(node_id)?;
-        for edge in edges.into_iter().take(crate::limits::MAX_WHY_NODE_DEGREE) {
+        // The bounded read pushes the per-node budget into the store's own
+        // index scan: the old full fetch materialized a super-node's whole
+        // degree before `.take()` could apply — O(store size) transient
+        // allocation at a single hop, the cost half of #1743 that #1820
+        // closes. The store also reports whether the degree exceeded the
+        // budget, which is what makes the cut OBSERVABLE.
+        let bounded = self
+            .store
+            .relations_bounded(node_id, crate::limits::MAX_WHY_NODE_DEGREE)?;
+        if bounded.truncated {
+            explanation.truncated = true;
+        }
+        for edge in bounded.edges {
             // The budgets are ceilings, not suggestions: once either is spent,
             // this node's expansion stops MID-NODE rather than finishing. The
             // caller's check between nodes cannot provide that — an expansion
@@ -1227,6 +1244,9 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             if explanation.nodes.len() >= crate::limits::MAX_WHY_NODES
                 || explanation.edges.len() >= crate::limits::MAX_WHY_EDGES
             {
+                // An edge was in hand and not followed — an exact cut, not
+                // a conservative one.
+                explanation.truncated = true;
                 break;
             }
             let target = edge.to;

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -468,26 +468,38 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // Reserved system keys (the hub flag itself) are scaffolding, not
         // attributes the caller ever wrote — strip them exactly as every other
         // caller-facing read path does.
+        let (relations, relations_truncated) = self.outgoing_entity_relations(id)?;
+        let (relations_in, relations_in_truncated) = self.incoming_entity_relations(id)?;
         Ok(Some(EntityProfile {
             id,
             name: key,
             attributes: strip_reserved_keys(self.store.get_metadata(id)?).unwrap_or_default(),
-            relations: self.outgoing_entity_relations(id)?,
-            relations_in: self.incoming_entity_relations(id)?,
+            relations,
+            relations_in,
+            relations_truncated,
+            relations_in_truncated,
         }))
     }
 
-    /// The typed edges leaving `id`, resolved to their target's content.
+    /// The typed edges leaving `id`, resolved to their target's content, and
+    /// whether that list is a partial view.
     ///
     /// Scaffolding edges (`mentions`, and `about` for symmetry — a hub never
     /// has an outgoing `about`) are dropped: they point at the facts that
     /// tagged this entity, not at a statement *about* it.
-    fn outgoing_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
-        self.resolve_entity_relations(self.store.relations(id)?, |edge| edge.to)
+    fn outgoing_entity_relations(
+        &self,
+        id: u64,
+    ) -> Result<(Vec<EntityRelation>, bool), MemoryError> {
+        let scanned = self
+            .store
+            .relations_bounded(id, crate::limits::MAX_ENTITY_SCAN_EDGES)?;
+        self.resolve_entity_relations(scanned, |edge| edge.to)
     }
 
     /// The typed edges pointing at `id`, resolved to their SOURCE's content —
-    /// for an incoming edge the far end is where it comes *from*.
+    /// for an incoming edge the far end is where it comes *from* — and
+    /// whether that list is a partial view.
     ///
     /// Without these, a question is only answerable from one side: the graph
     /// holds `camille --soeur de--> theo`, so reading Theo's outgoing edges
@@ -497,22 +509,40 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// [`Self::outgoing_entity_relations`]'s: `about` edges are dropped (they
     /// are the fact → hub half of the `about`/`mentions` pair), and `mentions`
     /// with them for symmetry.
-    fn incoming_entity_relations(&self, id: u64) -> Result<Vec<EntityRelation>, MemoryError> {
-        self.resolve_entity_relations(self.store.incoming_relations(id)?, |edge| edge.from)
+    fn incoming_entity_relations(
+        &self,
+        id: u64,
+    ) -> Result<(Vec<EntityRelation>, bool), MemoryError> {
+        let scanned = self
+            .store
+            .incoming_relations_bounded(id, crate::limits::MAX_ENTITY_SCAN_EDGES)?;
+        self.resolve_entity_relations(scanned, |edge| edge.from)
     }
 
     /// Shared resolver for both edge directions: skip the bipartite
     /// scaffolding labels, resolve each edge's far end (`far_end` picks which
-    /// endpoint that is) to its stored content.
+    /// endpoint that is) to its stored content — at most
+    /// [`crate::limits::MAX_ENTITY_RELATIONS`] of them — and say whether the
+    /// result is a partial view (#1820).
+    ///
+    /// Truncated when either budget bit: the store's raw scan window
+    /// ([`crate::limits::MAX_ENTITY_SCAN_EDGES`]) left edges unread, or a
+    /// typed edge past the resolution cap was seen and dropped. Both cuts
+    /// are the same honest signal — "there is more than this view shows".
     fn resolve_entity_relations(
         &self,
-        edges: Vec<MemoryEdge>,
+        scanned: crate::model::BoundedMemoryEdges,
         far_end: impl Fn(&MemoryEdge) -> u64,
-    ) -> Result<Vec<EntityRelation>, MemoryError> {
+    ) -> Result<(Vec<EntityRelation>, bool), MemoryError> {
         let mut relations = Vec::new();
-        for edge in edges {
+        let mut truncated = scanned.truncated;
+        for edge in scanned.edges {
             if edge.relation == MENTIONS_RELATION || edge.relation == ABOUT_RELATION {
                 continue;
+            }
+            if relations.len() >= crate::limits::MAX_ENTITY_RELATIONS {
+                truncated = true;
+                break;
             }
             let far = far_end(&edge);
             let content = self.store.get(far)?.map(|(content, _)| content);
@@ -522,7 +552,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
                 target: content.unwrap_or_default(),
             });
         }
-        Ok(relations)
+        Ok((relations, truncated))
     }
 
     /// Wire each extracted `subject -[predicate]-> object` triple as a typed

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -23,7 +23,7 @@ use velesdb_core::agent::AgentMemory;
 use velesdb_core::{Database, SearchResult};
 
 use crate::error::MemoryError;
-use crate::model::{ColumnFilter, MemoryEdge, Recollection};
+use crate::model::{BoundedMemoryEdges, ColumnFilter, MemoryEdge, Recollection};
 use crate::service::Metadata;
 
 /// The storage primitives [`crate::service::MemoryService`] needs: write,
@@ -204,6 +204,32 @@ pub trait MemoryStore {
     /// # Errors
     /// Returns [`MemoryError`] if storage access fails.
     fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError>;
+
+    /// At most `cap` outgoing edges of `id`, plus whether its total degree
+    /// exceeded the scan — the bounded twin of [`Self::relations`] (#1820).
+    ///
+    /// The contract is on COST, not just shape: an implementation must keep
+    /// work and transient allocation O(cap), never O(degree) — a super-node
+    /// (an entity hub mentioned by thousands of facts) is exactly where this
+    /// accessor is reached for. `truncated` is a separate signal because
+    /// `edges.len() == cap` cannot carry it: a node with exactly `cap` edges
+    /// is indistinguishable from a truncated one.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn relations_bounded(&self, id: u64, cap: usize) -> Result<BoundedMemoryEdges, MemoryError>;
+
+    /// At most `cap` incoming edges of `id`, plus whether its total incoming
+    /// degree exceeded the scan — the mirror of [`Self::relations_bounded`],
+    /// same O(cap) cost contract.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<BoundedMemoryEdges, MemoryError>;
 
     /// Remove the edge with `edge_id`. Returns `true` when it existed —
     /// idempotent: removing an absent edge is `Ok(false)`, never an error.
@@ -393,6 +419,26 @@ impl MemoryStore for NativeStore {
         Ok(to_memory_edges(
             self.memory.semantic().incoming_relations(id)?,
         ))
+    }
+
+    fn relations_bounded(&self, id: u64, cap: usize) -> Result<BoundedMemoryEdges, MemoryError> {
+        let bounded = self.memory.semantic().relations_bounded(id, cap)?;
+        Ok(BoundedMemoryEdges {
+            edges: to_memory_edges(bounded.edges),
+            truncated: bounded.truncated,
+        })
+    }
+
+    fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<BoundedMemoryEdges, MemoryError> {
+        let bounded = self.memory.semantic().incoming_relations_bounded(id, cap)?;
+        Ok(BoundedMemoryEdges {
+            edges: to_memory_edges(bounded.edges),
+            truncated: bounded.truncated,
+        })
     }
 
     fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {

--- a/crates/velesdb-memory/tests/entity_budget_bdd.rs
+++ b/crates/velesdb-memory/tests/entity_budget_bdd.rs
@@ -35,6 +35,17 @@ fn service() -> (TempDir, MemoryService<HashEmbedder>) {
     (dir, svc)
 }
 
+/// The profile of `name`, which must exist — the lookup boilerplate every
+/// case shares, whatever store the service runs on.
+fn profile_of<S: MemoryStore>(
+    svc: &MemoryService<HashEmbedder, S>,
+    name: &str,
+) -> velesdb_memory::EntityProfile {
+    svc.entity_profile(name)
+        .expect("profile lookup")
+        .unwrap_or_else(|| panic!("{name} has a hub"))
+}
+
 /// An outline passage wiring `count` typed edges out of one hub, each to a
 /// distinct person.
 fn hub_with_typed_edges(count: usize) -> String {
@@ -52,10 +63,7 @@ fn a_hub_past_the_resolution_cap_is_cut_at_the_named_budget_and_says_so() {
     svc.remember_extracted(&hub_with_typed_edges(over_cap), &OutlineExtractor, None)
         .expect("outline remember");
 
-    let profile = svc
-        .entity_profile("hub corp")
-        .expect("profile lookup")
-        .expect("hub exists");
+    let profile = profile_of(&svc, "hub corp");
     assert_eq!(
         profile.relations.len(),
         MAX_ENTITY_RELATIONS,
@@ -71,10 +79,7 @@ fn a_hub_past_the_resolution_cap_is_cut_at_the_named_budget_and_says_so() {
     );
 
     // The far end of one edge still sees the hub from its own side, whole.
-    let person = svc
-        .entity_profile("person 0")
-        .expect("profile lookup")
-        .expect("person exists");
+    let person = profile_of(&svc, "person 0");
     assert_eq!(person.relations_in.len(), 1, "one edge points at person 0");
     assert!(
         !person.relations_in_truncated && !person.relations_truncated,
@@ -92,10 +97,7 @@ fn a_profile_under_every_cap_is_not_reported_truncated() {
     )
     .expect("outline remember");
 
-    let profile = svc
-        .entity_profile("alice martin")
-        .expect("profile lookup")
-        .expect("alice exists");
+    let profile = profile_of(&svc, "alice martin");
     assert_eq!(profile.relations.len(), 1);
     assert!(
         !profile.relations_truncated && !profile.relations_in_truncated,
@@ -238,10 +240,7 @@ fn a_scan_window_cut_reported_by_the_store_reaches_the_profile() {
     )
     .expect("outline remember");
 
-    let profile = svc
-        .entity_profile("alice martin")
-        .expect("profile lookup")
-        .expect("alice exists");
+    let profile = profile_of(&svc, "alice martin");
     assert_eq!(
         profile.relations.len(),
         1,

--- a/crates/velesdb-memory/tests/entity_budget_bdd.rs
+++ b/crates/velesdb-memory/tests/entity_budget_bdd.rs
@@ -1,0 +1,259 @@
+//! Behaviour: an entity profile is BOUNDED and says when it is partial
+//! (#1820, résidu 2).
+//!
+//! Resolving an entity used to follow every non-scaffolding edge of its hub,
+//! full target content included — the same explosion class #1743 bounded on
+//! the `why` walk, on a surface that fix never covered: `entity("X")` on a
+//! name mentioned by thousands of facts was a constructible multi-megabyte
+//! response. The caps are named constants
+//! ([`velesdb_memory::limits::MAX_ENTITY_RELATIONS`],
+//! [`velesdb_memory::limits::MAX_ENTITY_SCAN_EDGES`]) and the honesty
+//! criterion is the walk's own: truncation is REPORTED
+//! (`relations_truncated`/`relations_in_truncated`), never silent — a list
+//! holding exactly the cap being otherwise indistinguishable from a cut one.
+//!
+//! Three behaviours, each with its refusal proven by mutation during
+//! development: the resolution cap cuts and says so; an under-cap profile is
+//! NOT reported truncated (the flag must never cry wolf); and a truncation
+//! the STORE reports (its raw scan window) reaches the profile even when the
+//! resolved list is small.
+
+use std::fmt::Write as _;
+
+use tempfile::TempDir;
+use velesdb_memory::limits::MAX_ENTITY_RELATIONS;
+use velesdb_memory::{
+    BoundedMemoryEdges, ColumnFilter, HashEmbedder, MemoryEdge, MemoryError, MemoryService,
+    MemoryStore, Metadata, OutlineExtractor, Recollection, DEFAULT_DIMENSION,
+};
+
+/// A fresh service over a temp store. The [`TempDir`] must outlive the service.
+fn service() -> (TempDir, MemoryService<HashEmbedder>) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = MemoryService::open(dir.path(), HashEmbedder::new(DEFAULT_DIMENSION))
+        .expect("open service");
+    (dir, svc)
+}
+
+/// An outline passage wiring `count` typed edges out of one hub, each to a
+/// distinct person.
+fn hub_with_typed_edges(count: usize) -> String {
+    let mut passage = String::new();
+    for i in 0..count {
+        writeln!(passage, "edge: Hub Corp | emploie | Person {i}").expect("write to string");
+    }
+    passage
+}
+
+#[test]
+fn a_hub_past_the_resolution_cap_is_cut_at_the_named_budget_and_says_so() {
+    let (_dir, svc) = service();
+    let over_cap = MAX_ENTITY_RELATIONS + 6;
+    svc.remember_extracted(&hub_with_typed_edges(over_cap), &OutlineExtractor, None)
+        .expect("outline remember");
+
+    let profile = svc
+        .entity_profile("hub corp")
+        .expect("profile lookup")
+        .expect("hub exists");
+    assert_eq!(
+        profile.relations.len(),
+        MAX_ENTITY_RELATIONS,
+        "the outgoing list is cut at the named cap"
+    );
+    assert!(
+        profile.relations_truncated,
+        "a cut list must SAY it is partial — silence here is the defect #1820 names"
+    );
+    assert!(
+        !profile.relations_in_truncated,
+        "the incoming side is under every cap and must not cry wolf"
+    );
+
+    // The far end of one edge still sees the hub from its own side, whole.
+    let person = svc
+        .entity_profile("person 0")
+        .expect("profile lookup")
+        .expect("person exists");
+    assert_eq!(person.relations_in.len(), 1, "one edge points at person 0");
+    assert!(
+        !person.relations_in_truncated && !person.relations_truncated,
+        "an under-cap profile carries no truncation flag"
+    );
+}
+
+#[test]
+fn a_profile_under_every_cap_is_not_reported_truncated() {
+    let (_dir, svc) = service();
+    svc.remember_extracted(
+        "edge: Alice Martin | travaille chez | Wiscale",
+        &OutlineExtractor,
+        None,
+    )
+    .expect("outline remember");
+
+    let profile = svc
+        .entity_profile("alice martin")
+        .expect("profile lookup")
+        .expect("alice exists");
+    assert_eq!(profile.relations.len(), 1);
+    assert!(
+        !profile.relations_truncated && !profile.relations_in_truncated,
+        "an exact, complete profile must not claim to be partial"
+    );
+}
+
+// --- The store's own scan truncation must reach the profile ----------------
+
+/// A store double whose bounded OUTGOING scan always reports truncation —
+/// the case where the raw window ([`MAX_ENTITY_SCAN_EDGES`]) cut before the
+/// resolution cap ever filled. The inner store answers everything else.
+struct ScanCutStore {
+    inner: velesdb_memory::NativeStore,
+}
+
+impl MemoryStore for ScanCutStore {
+    fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
+        self.inner.store(id, content, embedding)
+    }
+
+    fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+    ) -> Result<(), MemoryError> {
+        self.inner
+            .store_with_metadata(id, content, embedding, metadata)
+    }
+
+    fn store_with_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.inner
+            .store_with_ttl(id, content, embedding, ttl_seconds)
+    }
+
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        self.inner.get(id)
+    }
+
+    fn get_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
+        self.inner.get_metadata(id)
+    }
+
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        self.inner.get_metadata_batch(ids)
+    }
+
+    fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError> {
+        self.inner.update_metadata(id, metadata)
+    }
+
+    fn delete(&self, id: u64) -> Result<(), MemoryError> {
+        self.inner.delete(id)
+    }
+
+    fn query_filtered(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filter: &Metadata,
+        offset: usize,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.inner.query_filtered(embedding, k, filter, offset)
+    }
+
+    fn query_excluding(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        exclude: &Metadata,
+    ) -> Result<Vec<(u64, f32, String)>, MemoryError> {
+        self.inner.query_excluding(embedding, k, exclude)
+    }
+
+    fn query_columnar(
+        &self,
+        embedding: &[f32],
+        k: usize,
+        filters: &[ColumnFilter],
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        self.inner.query_columnar(embedding, k, filters)
+    }
+
+    fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.inner.relate(from, to, relation)
+    }
+
+    fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        self.inner.relations(id)
+    }
+
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        self.inner.incoming_relations(id)
+    }
+
+    fn relations_bounded(&self, id: u64, cap: usize) -> Result<BoundedMemoryEdges, MemoryError> {
+        let mut bounded = self.inner.relations_bounded(id, cap)?;
+        bounded.truncated = true;
+        Ok(bounded)
+    }
+
+    fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<BoundedMemoryEdges, MemoryError> {
+        self.inner.incoming_relations_bounded(id, cap)
+    }
+
+    fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
+        self.inner.unrelate(edge_id)
+    }
+
+    fn count(&self) -> usize {
+        self.inner.count()
+    }
+}
+
+#[test]
+fn a_scan_window_cut_reported_by_the_store_reaches_the_profile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let native = velesdb_memory::NativeStore::open(dir.path(), DEFAULT_DIMENSION)
+        .expect("open native store");
+    let svc = MemoryService::with_store(
+        ScanCutStore { inner: native },
+        HashEmbedder::new(DEFAULT_DIMENSION),
+    );
+    svc.remember_extracted(
+        "edge: Alice Martin | travaille chez | Wiscale",
+        &OutlineExtractor,
+        None,
+    )
+    .expect("outline remember");
+
+    let profile = svc
+        .entity_profile("alice martin")
+        .expect("profile lookup")
+        .expect("alice exists");
+    assert_eq!(
+        profile.relations.len(),
+        1,
+        "the resolved list itself is tiny — the cut happened in the raw scan"
+    );
+    assert!(
+        profile.relations_truncated,
+        "a truncation the store reports must reach the caller, however small \
+         the resolved list — this is the OR the resolver must not drop"
+    );
+    assert!(
+        !profile.relations_in_truncated,
+        "the untouched incoming side keeps its honest false"
+    );
+}

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -348,4 +348,56 @@ fn why_caps_the_total_edges_across_the_whole_walk() {
         "a walk over a dense subgraph must stop recording edges at the edge \
          budget; without one, 60 nodes can still return thousands of edges"
     );
+    assert!(
+        explanation.truncated,
+        "the edge budget stopped this walk mid-node — an exact cut that \
+         must be reported (#1820)"
+    );
+}
+
+// --- Truncation is observable, never silent (#1820) -------------------------
+
+#[test]
+fn a_walk_cut_by_a_width_budget_reports_truncation() {
+    // A seed whose degree exceeds the per-node budget: the walk follows only
+    // MAX_WHY_NODE_DEGREE of its edges, and before #1820 that cut was
+    // structurally invisible — a subgraph at exactly the cap read the same
+    // as a complete one.
+    let (_dir, svc) = service();
+    let seed = svc.remember(DECISION, &[], None).expect("remember seed");
+    for i in 0..=MAX_WHY_NODE_DEGREE {
+        let target = svc
+            .remember(&format!("satellite fact {i}"), &[], None)
+            .expect("remember satellite");
+        svc.relate(seed, target, "cites").expect("relate");
+    }
+
+    let explanation = svc.why(DECISION, 1, None).expect("why");
+    assert_eq!(
+        explanation.edges.len(),
+        MAX_WHY_NODE_DEGREE,
+        "sanity: the per-node budget did cut the expansion"
+    );
+    assert!(
+        explanation.truncated,
+        "a cut walk must SAY it is partial — counts at a cap are ambiguous \
+         by construction, which is the defect #1820 names"
+    );
+}
+
+#[test]
+fn a_walk_under_every_budget_is_not_reported_truncated() {
+    // The honesty control: the flag must never cry wolf. The canonical
+    // three-node chain sits far under every width budget.
+    let (_dir, svc, _decision, _pr, _ticket) = seeded_chain();
+    let explanation = svc.why(DECISION, 2, None).expect("why");
+    assert_eq!(
+        explanation.nodes.len(),
+        3,
+        "sanity: the whole chain is here"
+    );
+    assert!(
+        !explanation.truncated,
+        "a complete subgraph must not claim to be partial"
+    );
 }

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -244,4 +244,4 @@ Developed by Julien Lange, WiScale France.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -220,4 +220,4 @@ the VelesDB engine and are governed by that license.
 
 ---
 
-`velesdb-mobile v4.1.0` · Last updated: 2026-07-23 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-mobile v4.1.0` · Last updated: 2026-07-23 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -324,4 +324,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-node v0.12.0` (npm `@wiscale/velesdb-memory-node@0.12.0`) · Last updated: 2026-07-30 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-node v0.12.0` (npm `@wiscale/velesdb-memory-node@0.12.0`) · Last updated: 2026-07-30 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -235,7 +235,12 @@ and evict a real fact from your results. So:
   attributes and every typed edge touching him, in BOTH directions:
   `relations` leave him, `relations_in` point AT him. Ask only the first and
   the graph looks half empty — it holds `camille --sister of--> theo`, so
-  Theo's outgoing edges never mention Camille.
+  Theo's outgoing edges never mention Camille. Each side is budget-bounded:
+  `relations_truncated` / `relations_in_truncated` tell you the list is a
+  PARTIAL view, which a list sitting exactly at the cap cannot tell you by
+  itself. Same rule on `why`: its `truncated` says a width budget cut the
+  walk, so an answer built on a cut subgraph is never mistaken for a
+  complete one.
 - *"Which notes mention Theo?"* → `recall("Theo Durand")` — returns sentences.
 
 Use `entity` for questions **about a thing**, `recall` for questions **about what

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -140,6 +140,9 @@ pub struct ExplanationJs {
     pub nodes: Vec<MemoryNodeJs>,
     /// Typed edges connecting the nodes.
     pub edges: Vec<MemoryEdgeJs>,
+    /// Whether a width budget cut the walk — a subgraph sitting exactly at
+    /// a cap is otherwise indistinguishable from a complete one (#1820).
+    pub truncated: bool,
 }
 
 impl From<Explanation> for ExplanationJs {
@@ -147,6 +150,7 @@ impl From<Explanation> for ExplanationJs {
         Self {
             nodes: e.nodes.into_iter().map(MemoryNodeJs::from).collect(),
             edges: e.edges.into_iter().map(MemoryEdgeJs::from).collect(),
+            truncated: e.truncated,
         }
     }
 }

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -202,6 +202,13 @@ pub struct EntityProfileJs {
     /// Nothing is inferred — the converse of a kinship label would need a
     /// gender the graph does not hold; this reports only what is stored.
     pub relations_in: Vec<EntityRelationJs>,
+    /// Whether `relations` is a PARTIAL view — true when a response budget
+    /// cut the outgoing side. A list holding exactly the cap is otherwise
+    /// indistinguishable from a cut one (#1820).
+    pub relations_truncated: bool,
+    /// Whether `relationsIn` is a PARTIAL view — the incoming mirror of
+    /// `relationsTruncated`.
+    pub relations_in_truncated: bool,
 }
 
 impl EntityProfileJs {
@@ -217,6 +224,8 @@ impl EntityProfileJs {
                 attributes: Value::Object(serde_json::Map::new()),
                 relations: Vec::new(),
                 relations_in: Vec::new(),
+                relations_truncated: false,
+                relations_in_truncated: false,
             };
         };
         Self {
@@ -234,6 +243,8 @@ impl EntityProfileJs {
                 .into_iter()
                 .map(EntityRelationJs::from)
                 .collect(),
+            relations_truncated: profile.relations_truncated,
+            relations_in_truncated: profile.relations_in_truncated,
         }
     }
 }

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -217,4 +217,4 @@ so `except velesdb.VelesDBError` is a safe catch-all.
 
 ---
 
-`velesdb-python v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-python v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "4.2.0"
+version = "4.3.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2571,7 +2571,9 @@ class MemoryService:
                "attributes": Dict[str, Any],
                "relations": [{"predicate": str, "target_id": int,
                               "target": str}, ...],
-               "relations_in": [...the same shape...]}``.
+               "relations_in": [...the same shape...],
+               "relations_truncated": bool,
+               "relations_in_truncated": bool}``.
             ``found`` is ``False`` when nothing has ever mentioned that name;
             ``name`` still echoes the query in its canonical (trimmed,
             lowercased) form, so several lookups can be told apart.
@@ -2582,6 +2584,10 @@ class MemoryService:
             is only answerable from one side: the graph holds
             ``camille --sister of--> theo``, so reading Theo's outgoing edges
             never finds Camille. Both are present on a miss too, empty.
+
+            The ``*_truncated`` booleans say when the matching list is a
+            PARTIAL view cut by a response budget — a list holding exactly
+            the cap is otherwise indistinguishable from a cut one.
         """
         ...
 

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2549,7 +2549,11 @@ class MemoryService:
 
         Returns:
             ``{"nodes": [{"id": int, "content": str, "hop": int}, ...],
-               "edges": [{"from": int, "to": int, "relation": str}, ...]}``
+               "edges": [{"from": int, "to": int, "relation": str}, ...],
+               "truncated": bool}``.
+            ``truncated`` is ``True`` when a width budget cut the walk — a
+            subgraph sitting exactly at a cap is otherwise indistinguishable
+            from a complete one.
         """
         ...
 

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -240,6 +240,7 @@ fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
     let out = PyDict::new(py);
     out.set_item(PyString::intern(py, "nodes"), nodes)?;
     out.set_item(PyString::intern(py, "edges"), edges)?;
+    out.set_item(PyString::intern(py, "truncated"), e.truncated)?;
     Ok(out.into())
 }
 
@@ -566,7 +567,10 @@ impl PyMemoryService {
     }
 
     /// Explain a decision: the best-matching memory plus its connected subgraph
-    /// (multi-hop). Returns `{nodes, edges}` — the wedge a plain recall misses.
+    /// (multi-hop). Returns `{nodes, edges, truncated}` — the wedge a plain
+    /// recall misses. `truncated` is `True` when a width budget cut the walk:
+    /// a subgraph sitting exactly at a cap is otherwise indistinguishable
+    /// from a complete one.
     ///
     /// `max_hops` is silently capped at 10 to prevent unbounded traversal on
     /// dense graphs (same limit as the MCP server).

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -244,7 +244,8 @@ fn explanation_to_dict(py: Python<'_>, e: &Explanation) -> PyResult<Py<PyAny>> {
 }
 
 /// An [`EntityProfile`] lookup as
-/// `{found, id, name, attributes, relations, relations_in}`, where each edge
+/// `{found, id, name, attributes, relations, relations_in,
+/// relations_truncated, relations_in_truncated}`, where each edge
 /// is `{predicate, target_id, target}`.
 ///
 /// `relations` are the edges LEAVING the entity, `relations_in` those
@@ -274,6 +275,8 @@ fn entity_profile_to_value(queried: &str, profile: Option<EntityProfile>) -> ser
             "attributes": {},
             "relations": [],
             "relations_in": [],
+            "relations_truncated": false,
+            "relations_in_truncated": false,
         });
     };
     serde_json::json!({
@@ -283,6 +286,8 @@ fn entity_profile_to_value(queried: &str, profile: Option<EntityProfile>) -> ser
         "attributes": serde_json::Value::Object(profile.attributes),
         "relations": entity_relations_to_value(profile.relations),
         "relations_in": entity_relations_to_value(profile.relations_in),
+        "relations_truncated": profile.relations_truncated,
+        "relations_in_truncated": profile.relations_in_truncated,
     })
 }
 
@@ -597,11 +602,14 @@ impl PyMemoryService {
     ///         it is stable across sessions).
     ///
     /// Returns:
-    ///     `{found, id, name, attributes, relations, relations_in}`, each
+    ///     `{found, id, name, attributes, relations, relations_in,
+    ///     relations_truncated, relations_in_truncated}`, each
     ///     edge being `{predicate, target_id, target}`. `found` is `False`
     ///     when nothing has ever mentioned that name; `name` still echoes the
     ///     query in its canonical (trimmed, lowercased) form, so several
-    ///     lookups can be told apart.
+    ///     lookups can be told apart. The `*_truncated` booleans say when a
+    ///     list is a PARTIAL view cut by a response budget — a list holding
+    ///     exactly the cap is otherwise indistinguishable from a cut one.
     ///
     ///     `relations` are the edges LEAVING the entity, `relations_in` those
     ///     pointing AT it — there, `target_id`/`target` name the far end the

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -187,4 +187,4 @@ VelesDB Core License 1.0 — see [LICENSE](../../LICENSE).
 
 ---
 
-`velesdb-server v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-server v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -215,4 +215,4 @@ artifact embeds the engine and is governed by the Core License.
 
 ---
 
-`velesdb-wasm v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-wasm v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -373,6 +373,13 @@ struct EntityProfileOut {
     /// holds `camille --sister of--> theo`, so asking what Theo's outgoing
     /// edges say never finds Camille.
     relations_in: Vec<EntityRelationOut>,
+    /// Whether `relations` is a PARTIAL view — true when a response budget
+    /// cut the outgoing side. A list holding exactly the cap is otherwise
+    /// indistinguishable from a cut one (#1820).
+    relations_truncated: bool,
+    /// Whether `relationsIn` is a PARTIAL view — the incoming mirror of
+    /// `relationsTruncated`.
+    relations_in_truncated: bool,
 }
 
 impl EntityProfileOut {
@@ -388,6 +395,8 @@ impl EntityProfileOut {
                 attributes: Value::Object(serde_json::Map::new()),
                 relations: Vec::new(),
                 relations_in: Vec::new(),
+                relations_truncated: false,
+                relations_in_truncated: false,
             };
         };
         Self {
@@ -405,6 +414,8 @@ impl EntityProfileOut {
                 .into_iter()
                 .map(EntityRelationOut::from)
                 .collect(),
+            relations_truncated: profile.relations_truncated,
+            relations_in_truncated: profile.relations_in_truncated,
         }
     }
 }

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -424,6 +424,9 @@ impl EntityProfileOut {
 struct ExplanationOut {
     nodes: Vec<MemoryNodeOut>,
     edges: Vec<MemoryEdgeOut>,
+    /// Whether a width budget cut the walk — a subgraph sitting exactly at
+    /// a cap is otherwise indistinguishable from a complete one (#1820).
+    truncated: bool,
 }
 
 impl From<Explanation> for ExplanationOut {
@@ -431,6 +434,7 @@ impl From<Explanation> for ExplanationOut {
         Self {
             nodes: e.nodes.into_iter().map(MemoryNodeOut::from).collect(),
             edges: e.edges.into_iter().map(MemoryEdgeOut::from).collect(),
+            truncated: e.truncated,
         }
     }
 }

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -586,6 +586,8 @@ fn test_entity_serializes_to_the_documented_camel_case_wire_shape() {
             target_id: "43".to_owned(),
             target: "Entity: camille martin".to_owned(),
         }],
+        relations_truncated: true,
+        relations_in_truncated: false,
     };
     let wire = serde_json::to_value(&out).expect("EntityProfileOut is serializable");
     assert_eq!(
@@ -607,7 +609,12 @@ fn test_entity_serializes_to_the_documented_camel_case_wire_shape() {
                 "predicate": "sister of",
                 "targetId": "43",
                 "target": "Entity: camille martin"
-            }]
+            }],
+            // The truncation flags cross in camelCase like every other
+            // multi-word key, and an asymmetric pair here proves neither
+            // mirrors the other.
+            "relationsTruncated": true,
+            "relationsInTruncated": false
         })
     );
 }

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 
 use serde_json::{Map, Value};
 use velesdb_memory::{
-    column_value_matches, ColumnFilter, MemoryEdge, MemoryError, MemoryStore, Metadata,
-    Recollection,
+    column_value_matches, BoundedMemoryEdges, ColumnFilter, MemoryEdge, MemoryError, MemoryStore,
+    Metadata, Recollection,
 };
 
 use crate::graph_store::WasmGraphStore;
@@ -339,6 +339,49 @@ impl MemoryStore for WasmStore {
             .filter(|e| e.target == id && inner.live_fact(e.source).is_some())
             .map(to_memory_edge)
             .collect())
+    }
+
+    fn relations_bounded(&self, id: u64, cap: usize) -> Result<BoundedMemoryEdges, MemoryError> {
+        let inner = self.inner.borrow();
+        // This store has no adjacency index, so the SCAN is O(total edges)
+        // either way — what the bound guarantees here is the ALLOCATION:
+        // at most `cap` edges are materialized, and `truncated` compares the
+        // node's full stored degree against the cap exactly as the native
+        // backend does (TTL-dead edges inside the window are dropped without
+        // being replaced, same contract).
+        let mut total = 0usize;
+        let mut edges = Vec::new();
+        for e in inner.graph.edges().iter().filter(|e| e.source == id) {
+            total += 1;
+            if total <= cap && inner.live_fact(e.target).is_some() {
+                edges.push(to_memory_edge(e));
+            }
+        }
+        Ok(BoundedMemoryEdges {
+            edges,
+            truncated: total > cap,
+        })
+    }
+
+    fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<BoundedMemoryEdges, MemoryError> {
+        let inner = self.inner.borrow();
+        // Mirror of `relations_bounded`: the far end is the SOURCE here.
+        let mut total = 0usize;
+        let mut edges = Vec::new();
+        for e in inner.graph.edges().iter().filter(|e| e.target == id) {
+            total += 1;
+            if total <= cap && inner.live_fact(e.source).is_some() {
+                edges.push(to_memory_edge(e));
+            }
+        }
+        Ok(BoundedMemoryEdges {
+            edges,
+            truncated: total > cap,
+        })
     }
 
     fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "4.2.0"
+version = "4.3.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="4.2.0",
+    version="4.3.0",
     lifespan=lifespan
 )
 

--- a/docs/ANN_SOTA_AUDIT.md
+++ b/docs/ANN_SOTA_AUDIT.md
@@ -94,4 +94,4 @@ Short answer: **partially yes**.
 - A latency-aware rerank controller is in place (`rerank_latency_target_us` + `adapt_rerank_k_to_latency`); a full benchmark-driven, recall-aware SLO controller is still future work.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,4 +185,4 @@ across all three kinds. The distinct public surfaces (`VectorCollection` /
 shared backing store is a deliberate, honest design choice, not residual debt.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: 2026-07-26 · Applies to: velesdb-core 4.2.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: 2026-07-26 · Applies to: velesdb-core 4.3.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 

--- a/docs/BUSINESS_MODEL.md
+++ b/docs/BUSINESS_MODEL.md
@@ -116,4 +116,4 @@ This design ensures:
 | Enterprise | On-premise cluster with SLA | Commercial |
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -888,4 +888,4 @@ invariants, see [SOUNDNESS.md: HNSW Batch Insertion Ordering](SOUNDNESS.md#hnsw-
 
 ---
 
-*Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0 (previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*
+*Last updated: 2026-06-12 · Applies to: velesdb-core 4.3.0 (previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*

--- a/docs/CORE_PREMIUM_SPLIT.md
+++ b/docs/CORE_PREMIUM_SPLIT.md
@@ -152,4 +152,4 @@ provenance** — not re-architect.
 
 ---
 
-*Last updated: 2026-07-27 · Applies to: velesdb-core 4.2.0 (this stamp tracks the document revision, not a re-verification of the split).*
+*Last updated: 2026-07-27 · Applies to: velesdb-core 4.3.0 (this stamp tracks the document revision, not a re-verification of the split).*

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -407,6 +407,6 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 
 ---
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 (this stamp tracks
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 (this stamp tracks
 the document revision; the inventory itself was last re-verified against the
 code on 2026-06-14, as stated at the top of this page)*

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # VelesDB Frequently Asked Questions
 
-Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-06-12 · Applies to: velesdb-core 4.3.0
 
 ---
 

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -324,4 +324,4 @@ thread 'main' panicked at ...
 
 ---
 
-*Last updated: 2026-03-20 · Applies to: velesdb-core 4.2.0 (introduced: EPIC-025)*
+*Last updated: 2026-03-20 · Applies to: velesdb-core 4.3.0 (introduced: EPIC-025)*

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,6 +1,6 @@
 # GPU Acceleration Guide
 
-> Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0 (feature introduced: VelesDB v2.0.0)
+> Last updated: 2026-06-12 · Applies to: velesdb-core 4.3.0 (feature introduced: VelesDB v2.0.0)
 
 VelesDB supports optional GPU acceleration for batch vector operations via the `gpu` feature.
 
@@ -30,7 +30,7 @@ Enable the `gpu` feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-velesdb-core = { version = "4.2.0", features = ["gpu"] }
+velesdb-core = { version = "4.3.0", features = ["gpu"] }
 ```
 
 ## Usage

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -59,4 +59,4 @@ already-published exposure (and any yank/deprecation of affected versions) is
 tracked in the licensing issues and should be reviewed by IP counsel.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -106,4 +106,4 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [E-commerce Example](../examples/ecommerce_recommendation/) — Full Vector + Graph + Filter demo in Rust
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -182,4 +182,4 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 *VelesDB — the explainable, local-first memory engine for AI agents. (Microsecond vector search is the proof, not the pitch.)*
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -1049,6 +1049,6 @@ let data_as_bytes: &mut [u8] = unsafe {
 
 ---
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 (this stamp tracks
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 (this stamp tracks
 the document revision; the underlying unsafe audit was last run in full on
 2026-06-12, as stated at the top of this page)*

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1,7 +1,7 @@
 # VelesDB Storage Format Specification
 
 **Version**: 1.0.0  
-Last updated: 2026-06-12 · Applies to: velesdb-core 4.2.0  
+Last updated: 2026-06-12 · Applies to: velesdb-core 4.3.0  
 **Status**: Stable
 
 ## Overview

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | Last updated: 2026-07-26 · Applies to: velesdb-core 4.2.0
+**Version**: 3.10.0 | Last updated: 2026-07-26 · Applies to: velesdb-core 4.3.0
 
 ---
 

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -128,4 +128,4 @@ See [BENCHMARKS.md](./BENCHMARKS.md) for detailed numbers and methodology.
 - You only need simple vector search without graph or column queries (ChromaDB)
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "4.2.0"
+  "version": "4.3.0"
 }
 ```
 
@@ -301,4 +301,4 @@ curl -X POST http://localhost:8080/query \
 - **GitHub Discussions**: Ask questions and share ideas
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CLI_COMMAND_REFERENCE.md
+++ b/docs/guides/CLI_COMMAND_REFERENCE.md
@@ -547,4 +547,4 @@ Numeric `VELES-*` codes are listed in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CLI_REPL_REFERENCE.md
+++ b/docs/guides/CLI_REPL_REFERENCE.md
@@ -287,4 +287,4 @@ executed successfully.`, `Admin statement executed successfully.`, or
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CLI_VELESQL_COOKBOOK.md
+++ b/docs/guides/CLI_VELESQL_COOKBOOK.md
@@ -455,4 +455,4 @@ SELECT "select", "from", "order" FROM docs LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 4.2.0 — May 2026*
+*Version 4.3.0 — May 2026*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 4.2.0
+# Version: 4.3.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------

--- a/docs/guides/CORE_AGENT_MEMORY_RUST.md
+++ b/docs/guides/CORE_AGENT_MEMORY_RUST.md
@@ -155,4 +155,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_API_MAP.md
+++ b/docs/guides/CORE_API_MAP.md
@@ -125,4 +125,4 @@ use velesdb_core::{recall_at_k, precision_at_k, mrr, ndcg_at_k};
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
+++ b/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
@@ -184,4 +184,4 @@ lock-free CAS entry-point promotion.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_PERFORMANCE.md
+++ b/docs/guides/CORE_PERFORMANCE.md
@@ -115,4 +115,4 @@ It also downloads a ~168 MB tarball on first run.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_QUERY_PLAN_CACHE.md
+++ b/docs/guides/CORE_QUERY_PLAN_CACHE.md
@@ -97,4 +97,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_SPARSE_AND_FUSION.md
+++ b/docs/guides/CORE_SPARSE_AND_FUSION.md
@@ -121,4 +121,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_STREAMING_INSERTS.md
+++ b/docs/guides/CORE_STREAMING_INSERTS.md
@@ -86,4 +86,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/CORE_VELESQL_REFERENCE.md
+++ b/docs/guides/CORE_VELESQL_REFERENCE.md
@@ -132,4 +132,4 @@ EXPLAIN SELECT * FROM docs WHERE VECTOR NEAR $v LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 4.2.0 -- May 2026*
+*Version 4.3.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.2.0/velesdb-4.2.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v4.3.0/velesdb-4.3.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-4.2.0-amd64.deb
+sudo dpkg -i velesdb-4.3.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -136,7 +136,7 @@ results = collection.search_request(velesdb.SearchOptions(vector=query_vector, t
 ```toml
 # Cargo.toml
 [dependencies]
-velesdb-core = "4.2.0"
+velesdb-core = "4.3.0"
 ```
 
 ### As CLI Tools
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:4.2.0
+docker pull ghcr.io/cyberlife-coder/velesdb:4.3.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:4.2.0
+  ghcr.io/cyberlife-coder/velesdb:4.3.0
 ```
 
 ### Build locally

--- a/docs/guides/MIGRATE_CLI.md
+++ b/docs/guides/MIGRATE_CLI.md
@@ -275,4 +275,4 @@ elsewhere) before re-running.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_OPERATIONS.md
+++ b/docs/guides/MIGRATE_OPERATIONS.md
@@ -162,4 +162,4 @@ A completed migration deletes its own checkpoint.
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_SOURCES.md
+++ b/docs/guides/MIGRATE_SOURCES.md
@@ -400,4 +400,4 @@ Common embedding dimensions:
 
 ---
 
-`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v4.1.0` · Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MOBILE_API.md
+++ b/docs/guides/MOBILE_API.md
@@ -431,4 +431,4 @@ not a measurement.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/MOBILE_BUILD.md
+++ b/docs/guides/MOBILE_BUILD.md
@@ -173,4 +173,4 @@ Expected on a host with default features: `123 passed` (lib target), `8 passed`
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/NODE_ADDON.md
+++ b/docs/guides/NODE_ADDON.md
@@ -320,4 +320,4 @@ silently reduced instead.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/NODE_ADDON_BUILD.md
+++ b/docs/guides/NODE_ADDON_BUILD.md
@@ -120,4 +120,4 @@ import { MemoryService } from '@wiscale/velesdb-memory-node'
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_AGENT_MEMORY.md
+++ b/docs/guides/PYTHON_AGENT_MEMORY.md
@@ -143,4 +143,4 @@ memory.procedural.reinforce(procedure_id=1, success=False)
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_API_REFERENCE.md
+++ b/docs/guides/PYTHON_API_REFERENCE.md
@@ -439,4 +439,4 @@ see [PYTHON_PERFORMANCE.md](PYTHON_PERFORMANCE.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_CONTEXT_COMPILER.md
+++ b/docs/guides/PYTHON_CONTEXT_COMPILER.md
@@ -131,4 +131,4 @@ shapes), see [CONTEXT_COMPILER.md](CONTEXT_COMPILER.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
+++ b/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
@@ -33,4 +33,4 @@ VelesDB is built in Rust with explicit SIMD optimizations:
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_GRAPH.md
+++ b/docs/guides/PYTHON_GRAPH.md
@@ -233,4 +233,4 @@ Query patterns: [GRAPH_PATTERNS.md](GRAPH_PATTERNS.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_RAG_PIPELINE.md
+++ b/docs/guides/PYTHON_RAG_PIPELINE.md
@@ -91,4 +91,4 @@ so you can drop in your own implementation. `dimension` is inferred after the fi
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_REMOTE_SERVER.md
+++ b/docs/guides/PYTHON_REMOTE_SERVER.md
@@ -33,4 +33,4 @@ setup.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/PYTHON_VELESQL.md
+++ b/docs/guides/PYTHON_VELESQL.md
@@ -101,4 +101,4 @@ Executing (rather than inspecting) VelesQL from Python is documented in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 4.2.0 -- 2026-06-12*
+*Version 4.3.0 -- 2026-06-12*
 
 Complete guide to configuring the **recall vs latency** trade-off in VelesDB. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 

--- a/docs/guides/SERVER_DEPLOYMENT.md
+++ b/docs/guides/SERVER_DEPLOYMENT.md
@@ -172,4 +172,4 @@ enabled = false
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/SERVER_REST_TOUR.md
+++ b/docs/guides/SERVER_REST_TOUR.md
@@ -519,20 +519,20 @@ public when API keys are configured.
 `/v1/health` always answers `200` while the process is up:
 
 ```json
-{"status": "ok", "version": "4.2.0"}
+{"status": "ok", "version": "4.3.0"}
 ```
 
 `/v1/ready` answers `200` once every collection is loaded from disk:
 
 ```json
-{"status": "ready", "version": "4.2.0"}
+{"status": "ready", "version": "4.3.0"}
 ```
 
 …and `503` until then, which is what makes it usable as a Kubernetes
 readiness probe:
 
 ```json
-{"status": "not_ready", "version": "4.2.0"}
+{"status": "not_ready", "version": "4.3.0"}
 ```
 
 ---
@@ -579,4 +579,4 @@ Numbers match the canonical contract in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -319,7 +319,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "4.2.0"
+  "version": "4.3.0"
 }
 ```
 
@@ -338,7 +338,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "4.2.0"
+  "version": "4.3.0"
 }
 ```
 
@@ -347,7 +347,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "4.2.0"
+  "version": "4.3.0"
 }
 ```
 

--- a/docs/guides/TAURI_PLUGIN_RECIPES.md
+++ b/docs/guides/TAURI_PLUGIN_RECIPES.md
@@ -1,6 +1,6 @@
 # Tauri plugin — recipes
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0*
 
 Copy-pasteable snippets for [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md),
 beyond the 60-second first success in the crate README. Command names, payload

--- a/docs/guides/TAURI_PLUGIN_REFERENCE.md
+++ b/docs/guides/TAURI_PLUGIN_REFERENCE.md
@@ -1,6 +1,6 @@
 # Tauri plugin — command, event and permission reference
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0*
 
 Complete surface of [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md):
 every IPC command, every event, the permission model, and the storage/metric

--- a/docs/guides/WASM_API.md
+++ b/docs/guides/WASM_API.md
@@ -268,12 +268,15 @@ Contract details:
 
 - `entity(name)` answers a question ABOUT a named thing — a person, a place,
   an organisation — rather than about the sentences mentioning it. It returns
-  `{found, id, name, attributes, relations, relationsIn}`, each edge
+  `{found, id, name, attributes, relations, relationsIn, relationsTruncated,
+  relationsInTruncated}`, each edge
   `{predicate, targetId, target}`. `relations` LEAVE the entity;
   `relationsIn` point AT it, and there `targetId`/`target` name the far end
   the edge comes FROM. Reading only the first makes the graph look half
   empty: it holds `camille --sister of--> theo`, so Theo's own outgoing edges
-  never mention Camille.
+  never mention Camille. Each direction is budget-bounded, and its
+  `*Truncated` flag says when the list is a PARTIAL view — a list holding
+  exactly the cap is otherwise indistinguishable from a cut one.
 - `rememberExtracted(text, metadata?, extractor?)` returns
   `{ids, skippedOverCap}` and is the WRITE side of `entity` — entity hubs are
   born only of extraction. `extractor` defaults to `"outline"`, the

--- a/docs/guides/WASM_API.md
+++ b/docs/guides/WASM_API.md
@@ -377,4 +377,4 @@ that runs VelesQL (`executeQuery`). See
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/WASM_PERSISTENCE.md
+++ b/docs/guides/WASM_PERSISTENCE.md
@@ -162,4 +162,4 @@ different shape from the table above; expect different absolute numbers.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/WASM_VELESQL.md
+++ b/docs/guides/WASM_VELESQL.md
@@ -240,4 +240,4 @@ version you run.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 4.2.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0

--- a/docs/guides/tutorials/MINI_RECOMMENDER.md
+++ b/docs/guides/tutorials/MINI_RECOMMENDER.md
@@ -37,7 +37,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-velesdb-core = "4.2.0"
+velesdb-core = "4.3.0"
 serde_json = "1.0"
 tempfile = "3.10"
 ```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "4.2.0"
+    "version": "4.3.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 4.2.0
+  version: 4.3.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v4.2.0
+# VelesDB Architecture Diagrams — v4.3.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-07-30 (v4.2.0; velesdb-memory 0.12.0)
+Last updated: 2026-08-07 (v4.3.0; velesdb-memory 0.12.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -262,7 +262,8 @@ attributes merged onto its node and the typed edges leaving it.
 |---|---|---|---|
 | `name` | string | yes | Matched case-insensitively (trimmed, lowercased). |
 
-Returns `{ found, id, id_str, name, attributes, relations, relations_in }`.
+Returns `{ found, id, id_str, name, attributes, relations, relations_in,
+relations_truncated, relations_in_truncated }`.
 `found: false` means nothing has ever mentioned that entity; `name` always
 echoes the canonicalized queried name so parallel lookups stay pairable.
 `relations` are the typed edges **leaving** the entity; `relations_in` those
@@ -270,6 +271,14 @@ echoes the canonicalized queried name so parallel lookups stay pairable.
 loses half the graph: the store holds `camille --soeur de--> theo`, so "who is
 Theo's sister?" is answered by his `relations_in`, never by his `relations`.
 The bipartite `mentions` scaffolding is excluded from both.
+
+Each direction is budget-bounded: at most 64 resolved edges
+(`MAX_ENTITY_RELATIONS`) found within a scan window of 4096 raw edges
+(`MAX_ENTITY_SCAN_EDGES`) — an entity mentioned by thousands of facts would
+otherwise be a constructible multi-megabyte response. A cut is REPORTED, not
+silent: `relations_truncated` / `relations_in_truncated` say when the
+matching list is a partial view, since a list holding exactly the cap is
+otherwise indistinguishable from a cut one.
 
 ```jsonc
 entity { "name": "Theo Durand" }

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -298,15 +298,16 @@ subgraph** reachable from it through typed links.
 | `max_hops` | integer | no | Default 2 (`DEFAULT_WHY_HOPS`), capped at 10 (`MAX_WHY_HOPS`). |
 | `filter` | object | no | Exact-match metadata filter scoping the seed, e.g. `{"project":"veles"}`. |
 
-Returns `{ nodes: [ { id, id_str, content, hop } ], edges: [ { from, from_str, to, to_str, relation } ] }`
+Returns `{ nodes: [ { id, id_str, content, hop } ], edges: [ { from, from_str, to, to_str, relation } ], truncated }`
 — the seed is `hop: 0`.
 
 The walk is width-bounded as well as depth-bounded: at most 64 outgoing edges
 are followed from any one node (`MAX_WHY_NODE_DEGREE`), at most 500 nodes
 (`MAX_WHY_NODES`) and 2000 edges (`MAX_WHY_EDGES`) are returned per walk. A
-walk that hits a budget is cut silently — a response whose counts sit at a cap
-is the signal that more of the graph exists than was returned. The same
-budgets bound the graph half of `recall_fused`.
+walk that hits a budget SAYS so: `truncated: true` means a cap cut the walk
+before it exhausted the reachable graph — the signal counts alone cannot
+carry, a subgraph sitting exactly at a cap being indistinguishable from a
+complete one. The same budgets bound the graph half of `recall_fused`.
 
 This is what a pure vector search cannot do: it surfaces the PR, the ticket,
 or the benchmark reachable through typed links **even when they share no

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -22,7 +22,7 @@ No feature flags needed. Native HNSW is the only implementation:
 
 ```toml
 [dependencies]
-velesdb-core = "4.2.0"
+velesdb-core = "4.3.0"
 ```
 
 ## API

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 4.2.0
+> **VelesDB version:** 4.3.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-07-29 (VelesDB v4.2.0)
+> Last updated: 2026-08-07 (VelesDB v4.3.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "4.2.0"
+  "version": "4.3.0"
 }
 ```
 

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -1549,6 +1549,14 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "relations_in_truncated": {
+            "description": "Whether `relations_in` is a PARTIAL view — the incoming mirror of\n`relations_truncated`.",
+            "type": "boolean"
+          },
+          "relations_truncated": {
+            "description": "Whether `relations` is a PARTIAL view — true when a response budget\ncut the outgoing side. A list holding exactly the cap is otherwise\nindistinguishable from a cut one (#1820).",
+            "type": "boolean"
           }
         },
         "required": [
@@ -1558,7 +1566,9 @@
           "name",
           "attributes",
           "relations",
-          "relations_in"
+          "relations_in",
+          "relations_truncated",
+          "relations_in_truncated"
         ],
         "type": "object"
       }

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -3375,11 +3375,16 @@
               "type": "object"
             },
             "type": "array"
+          },
+          "truncated": {
+            "description": "Whether a width budget cut the walk — a subgraph sitting exactly at\na cap is otherwise indistinguishable from a complete one (#1820).",
+            "type": "boolean"
           }
         },
         "required": [
           "nodes",
-          "edges"
+          "edges",
+          "truncated"
         ],
         "type": "object"
       }

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@4.3.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@4.3.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.2.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@4.3.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@4.3.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "4.2.0"
+version = "4.3.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "4.2.0"
+version = "4.3.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "4.2.0"
+version = "4.3.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "4.2.0"
+version = "4.3.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "4.2.0"
+version = "4.3.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "4.2.0"
+__version__ = "4.3.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@4.2.0
+cargo add --quiet velesdb-core@4.3.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@4.2.0
+cargo install --quiet --locked velesdb-server@4.3.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`unrelate`/`forget`/`entity`/`rememberExtracted`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v4.2.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v4.3.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^4.1.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -439,6 +439,12 @@ export interface MemoryExplanation {
   nodes: MemoryNode[];
   /** Typed edges connecting the nodes. */
   edges: MemoryEdge[];
+  /**
+   * `true` when a width budget cut the walk before it exhausted the reachable
+   * graph. Counts alone cannot say it: a subgraph sitting exactly at a cap is
+   * indistinguishable from a complete one.
+   */
+  truncated: boolean;
 }
 
 /** What {@link MemoryService.unrelate} actually removed. */
@@ -482,6 +488,14 @@ export interface MemoryEntityProfile {
    * so reading Theo's outgoing edges never finds Camille.
    */
   relationsIn: MemoryEntityRelation[];
+  /**
+   * `true` when {@link MemoryEntityProfile.relations} is a PARTIAL view — a
+   * response budget cut the outgoing side. A list holding exactly the cap is
+   * otherwise indistinguishable from a cut one.
+   */
+  relationsTruncated: boolean;
+  /** `true` when {@link MemoryEntityProfile.relationsIn} is a partial view. */
+  relationsInTruncated: boolean;
 }
 
 /** Outcome of {@link MemoryService.rememberExtracted}. */

--- a/sdks/typescript/tests/memory.test.ts
+++ b/sdks/typescript/tests/memory.test.ts
@@ -45,12 +45,17 @@ class MockWasmMemoryService {
     relationsIn: [
       { predicate: 'sister of', targetId: '43', target: 'Entity: camille durand' },
     ],
+    // Asymmetric on purpose: a mock repeating one value for both would keep
+    // a SDK that mirrored the two flags green.
+    relationsTruncated: true,
+    relationsInTruncated: false,
   }));
   rememberExtracted = vi.fn(() => ({ ids: ['1'], skippedOverCap: 0 }));
   forget = vi.fn(() => true);
   why = vi.fn(() => ({
     nodes: [{ id: '1', content: 'we chose parking_lot', hop: 0 }],
     edges: [],
+    truncated: false,
   }));
   compileContext = vi.fn(() => ({
     content: 'compiled',
@@ -326,6 +331,11 @@ describe('MemoryService', () => {
         { predicate: 'sister of', targetId: '43', target: 'Entity: camille durand' },
       ]);
       expect(profile.relations).toEqual([]);
+      // A budget cut must reach the SDK caller: an empty `relations` that was
+      // TRUNCATED means "more exist", and reads identically to a genuinely
+      // empty one without this flag.
+      expect(profile.relationsTruncated).toBe(true);
+      expect(profile.relationsInTruncated).toBe(false);
       expect(lastMockInstance!.entity).toHaveBeenCalledWith('Theo Durand');
     });
 


### PR DESCRIPTION
Ferme les trois résidus de #1820 (sibling de #1743 — n'en rouvre rien), en quatre commits dans l'ordre de dépendance, cause racine à chaque étage.

## 1. Le coût d'expansion n'est plus O(degré) — prouvé par mesure

`get_outgoing`/`get_incoming` matérialisaient le degré complet avant tout `.take()` de l'appelant. Les lectures bornées poussent le cap **dans le scan d'index du shard** (la liste d'ids est tronquée avant toute résolution) et remontent le degré total, lu sous le même guard — la paire ne peut pas se déchirer, et c'est elle qui rend `truncated = total > cap` dérivable honnêtement. Traversée : `EdgeStore` → `ConcurrentEdgeStore` → API graphe de collection → `memory_helpers` (jumeaux bornés, TTL filtré dans la fenêtre seule) → les trois genres de mémoire (`relations_bounded`/`incoming_relations_bounded`, type `BoundedRelations`).

**Mesure, pas affirmation** (critère de clôture n°3) : un binaire de test dédié installe un allocateur global compteur sur un hub de 100 000 arêtes. Contrôles positifs des deux côtés — la lecture non bornée doit enregistrer au moins son buffer matérialisé (sinon le compteur lui-même est faux), et la mutation « cap après matérialisation » a été exécutée et refusée (`2103776` octets vus là où l'invariant exige 50× sous `12497120`).

## 2. `entity()` porte des caps nommés et dit sa troncature

**Deux caps par direction, un par préoccupation** — parce que les arêtes d'un hub sont majoritairement du scaffolding `mentions`/`about` filtré APRÈS lecture : `MAX_ENTITY_SCAN_EDGES` (4096) borne le scan brut (la classe de coût), `MAX_ENTITY_RELATIONS` (64, la grammaire de `MAX_WHY_NODE_DEGREE`) borne les arêtes résolues contenu compris (la classe de réponse). Un seul cap à l'un ou l'autre étage serait faux : au scan seul il rend des fenêtres tout-scaffolding sur un hub actif, à la résolution seule il laisse le scan O(degré). La politique de scaffolding reste dans la couche memory — core demeure policy-free.

`relations_truncated` / `relations_in_truncated` sur le profil : une liste à exactement 64 est indistinguable d'une liste coupée — le critère d'honnêteté de l'issue. Rouge-d'abord sur hub dense (70 arêtes typées → 64 + drapeau), mutations refusées : coupe silencieuse au cap de résolution → rouge ; OR du drapeau store perdu → rouge.

## 3. `truncated` sur `Explanation` — la marche ne coupe plus en silence

Posé depuis trois sites, deux précisions documentées sur le champ : signal de degré du store (exact), rupture à mi-nœud avec une arête en main (exacte), rupture entre nœuds avec du travail de frontière restant (conservatrice — l'expanser est précisément ce que le budget interdit). `recall_fused` partage `traverse` : coût borné et signal gratuits pour sa moitié graphe.

## Surface API-parity entière (critère n°1)

DTO + `outputSchema` publié (`mcp-tools.json` régénéré via `mcp_tools_drift`) + les trois bindings + `.pyi` + `MCP_TOOLS.md` (la prose « cut silently » remplacée par le champ). `binding_parity_bdd` est passé ROUGE sur les champs manquants (4 paires champ×binding exigées) avant que chaque binding ne les relaie — le garde a prouvé son refus en conditions réelles. Garde `check-mcp-doc-contract` vert (235 surfaces balayées).

## Trait public et notes

- `MemoryStore` gagne deux méthodes requises (le changement de trait que l'issue avait explicitement sorti du périmètre de #1817) ; impls : `NativeStore` (core borné), `WasmStore` (allocation O(cap), scan O(E) — limite structurelle du store navigateur, documentée), doubles de test.
- **Gate DRY** : la duplication introduite par ce lot (lookup répété dans la table de tests) a été factorisée ; les findings restants sont le motif de délégation parallèle **établi** des trois genres de mémoire core (les méthodes préexistantes dupliquent déjà à l'identique — un macro-refactor serait un sujet séparé) et des blocs de fixtures wasm préexistants hors des lignes touchées.

## Validation

fmt · clippy workspace `-D warnings` · memory `extract,ollama,persistence` : **1045/0** · `http` : **1011/0** · wasm lib : 658/0 · parité bindings 21/21 · doc-contract ✅ · lizard 0 dépassement · pre-commit complet sur chacun des commits.

Closes #1820