### PR TITLE
fix(core): one aggregated LabelIndex warning per rebuild, not one per node (#1834)

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -673,6 +673,19 @@ impl Collection {
                 index.index_from_payload(id, &payload);
             }
         }
+        // ONE aggregated line for the whole rebuild, not one per node: on a
+        // memory store every hashed u64 id exceeds u32::MAX, so the per-node
+        // form described the NOMINAL state 788 times per startup and buried
+        // the incident log #1780 exists to keep readable (#1834). Per-node
+        // detail stays available at DEBUG.
+        let skipped = index.unindexable_labeled();
+        if skipped > 0 {
+            tracing::warn!(
+                skipped,
+                "LabelIndex: {skipped} labeled node(s) exceed u32::MAX and are not \
+                 indexed — label lookups fall back to a full scan"
+            );
+        }
         index
     }
 

--- a/crates/velesdb-core/src/collection/graph/label_index.rs
+++ b/crates/velesdb-core/src/collection/graph/label_index.rs
@@ -16,8 +16,14 @@ use std::collections::HashMap;
 ///
 /// # Limitations
 ///
-/// `RoaringBitmap` only supports u32 IDs. Node IDs exceeding `u32::MAX`
-/// are silently skipped (logged at warn level on insert).
+/// `RoaringBitmap` only supports u32 IDs. Node IDs exceeding `u32::MAX` are
+/// skipped: counted (and logged at DEBUG) when the node carries `_labels` —
+/// an unlabeled node had nothing to index, so its oversized id costs
+/// nothing and is not an event. Per-node WARN here used to describe the
+/// NOMINAL state of a memory store (hashed u64 ids are all but guaranteed
+/// past `u32::MAX` — 788 lines on one startup) and drowned the incident
+/// log #1780 exists to keep readable; the caller that rebuilds the index
+/// emits ONE aggregated warning instead (#1834).
 ///
 /// # Example
 ///
@@ -35,10 +41,13 @@ use std::collections::HashMap;
 pub struct LabelIndex {
     /// label_name -> set of node IDs with that label.
     labels: HashMap<String, RoaringBitmap>,
-    /// Set to `true` when any `index_from_payload` call encounters a node ID
-    /// exceeding `u32::MAX`. Callers should fall back to a full scan when this
-    /// flag is set and the bitmap lookup returns no results.
-    has_large_ids: bool,
+    /// How many LABELED nodes an `index_from_payload` call skipped for an ID
+    /// exceeding `u32::MAX`. Callers should fall back to a full scan when
+    /// this is non-zero and the bitmap lookup returns no results; the index
+    /// rebuild reports it once, aggregated, instead of one line per node
+    /// (#1834). Unlabeled oversized ids are not counted: they had nothing
+    /// to index, so nothing was lost.
+    unindexable_labeled: u64,
 }
 
 impl LabelIndex {
@@ -56,20 +65,24 @@ impl LabelIndex {
     /// Returns the number of labels successfully indexed (0 if payload has
     /// no `_labels` array or node ID exceeds `u32::MAX`).
     pub fn index_from_payload(&mut self, node_id: u64, payload: &serde_json::Value) -> usize {
+        let labels = payload.get("_labels").and_then(|v| v.as_array());
         let Some(safe_id) = safe_bitmap_id(node_id) else {
-            tracing::warn!(
-                node_id,
-                "LabelIndex: node_id exceeds u32::MAX, cannot index"
-            );
-            // Track that we have unindexable IDs so callers can fall back
-            // to a full scan instead of returning silently incomplete results.
-            if payload.get("_labels").and_then(|v| v.as_array()).is_some() {
-                self.has_large_ids = true;
+            // Count (and detail at DEBUG) only when something was actually
+            // lost — the node carried labels this index cannot hold. The
+            // caller falls back to a full scan off the counter, and the
+            // rebuild reports the total ONCE instead of per node (#1834).
+            if labels.is_some() {
+                self.unindexable_labeled += 1;
+                tracing::debug!(
+                    node_id,
+                    "LabelIndex: labeled node_id exceeds u32::MAX, not indexed — \
+                     label lookups fall back to a full scan"
+                );
             }
             return 0;
         };
 
-        let Some(labels_arr) = payload.get("_labels").and_then(|v| v.as_array()) else {
+        let Some(labels_arr) = labels else {
             return 0;
         };
 
@@ -129,7 +142,16 @@ impl LabelIndex {
     /// this is `true` and the bitmap lookup returns empty results.
     #[must_use]
     pub fn has_large_ids(&self) -> bool {
-        self.has_large_ids
+        self.unindexable_labeled > 0
+    }
+
+    /// How many labeled nodes were skipped for an ID exceeding `u32::MAX` —
+    /// what the index rebuild reports once, aggregated, instead of one WARN
+    /// per node (#1834). Unlabeled oversized ids are not counted: they had
+    /// nothing to index.
+    #[must_use]
+    pub fn unindexable_labeled(&self) -> u64 {
+        self.unindexable_labeled
     }
 
     /// Returns the bitmap of node IDs carrying the given label.

--- a/crates/velesdb-core/tests/label_index_log_noise.rs
+++ b/crates/velesdb-core/tests/label_index_log_noise.rs
@@ -1,0 +1,160 @@
+//! Behaviour: an unindexable node id is not a WARN-worthy event — the
+//! AGGREGATE is (#1834).
+//!
+//! velesdb-memory ids are hashed u64s, so exceeding `u32::MAX` is the
+//! NOMINAL state of every node of a memory store — yet each one used to emit
+//! its own WARN at startup: 788 lines before the first request, in the very
+//! log the incident preset (#1780/#1727) exists to keep readable. A warning
+//! that describes the normal state of the world is not a warning; at that
+//! volume it buries the `mcp http request` / `worker quit` lines an operator
+//! greps for.
+//!
+//! The contract proven here, phase by phase under a counting subscriber:
+//!
+//! * an UNLABELED node with an oversized id emits NO warning at all — it had
+//!   nothing to index, so nothing was lost (this is the memory-store nominal
+//!   case, the 788);
+//! * a rebuild that really did skip labeled nodes emits EXACTLY ONE warning,
+//!   carrying the aggregated count — never one line per node. Per-node
+//!   detail stays available at DEBUG for whoever turns it on.
+//!
+//! One `#[test]` on purpose: the counting subscriber must be the process
+//! global (the rebuild may not run on the test thread), and a global can be
+//! installed once — sequential phases inside one test keep every count
+//! attributable.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use serde_json::json;
+use velesdb_core::collection::graph::LabelIndex;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+/// Counts WARN events from the label-index code paths (`label_index` for the
+/// per-node site, `lifecycle` for the rebuild aggregate) and records the
+/// `skipped` field of the last such WARN — `u64::MAX` meaning "never seen".
+struct WarnCounter {
+    warns: Arc<AtomicUsize>,
+    last_skipped: Arc<AtomicU64>,
+}
+
+/// Field visitor pulling the `skipped` count out of the aggregate WARN.
+struct SkippedVisitor<'a>(&'a AtomicU64);
+
+impl tracing::field::Visit for SkippedVisitor<'_> {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "skipped" {
+            self.0.store(value, Ordering::Relaxed);
+        }
+    }
+
+    fn record_debug(&mut self, _: &tracing::field::Field, _: &dyn std::fmt::Debug) {}
+}
+
+impl tracing::Subscriber for WarnCounter {
+    fn enabled(&self, _: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let metadata = event.metadata();
+        let target = metadata.target();
+        if !(target.contains("label_index") || target.contains("lifecycle")) {
+            return;
+        }
+        if *metadata.level() == tracing::Level::WARN {
+            self.warns.fetch_add(1, Ordering::Relaxed);
+            event.record(&mut SkippedVisitor(&self.last_skipped));
+        }
+    }
+
+    fn enter(&self, _: &tracing::span::Id) {}
+
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// The first id past the bitmap's reach; every memory-store hash lands here.
+const OVERSIZED: u64 = (u32::MAX as u64) + 1;
+
+#[test]
+fn an_unindexable_id_warns_in_aggregate_never_per_node() {
+    let warns = Arc::new(AtomicUsize::new(0));
+    let last_skipped = Arc::new(AtomicU64::new(u64::MAX));
+    tracing::subscriber::set_global_default(WarnCounter {
+        warns: Arc::clone(&warns),
+        last_skipped: Arc::clone(&last_skipped),
+    })
+    .expect("install the counting subscriber");
+
+    // --- Phase A: the memory-store nominal case. 50 UNLABELED nodes with
+    // hashed-range ids must not emit a single warning — this is the exact
+    // shape of the 788-line startup.
+    let mut index = LabelIndex::new();
+    for i in 0..50 {
+        index.index_from_payload(OVERSIZED + i, &json!({ "content": "a fact" }));
+    }
+    assert_eq!(
+        warns.load(Ordering::Relaxed),
+        0,
+        "an unlabeled node with an oversized id lost nothing and must not warn — \
+         at memory-store scale this line IS the noise #1834 measured (788/startup)"
+    );
+    assert!(
+        !index.has_large_ids(),
+        "nothing indexable was skipped, so lookups need no full-scan fallback"
+    );
+
+    // --- Phase B: a store whose rebuild really does lose labeled nodes.
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let db = Database::open(dir.path()).expect("open db");
+        db.create_collection("g", 4, DistanceMetric::Cosine)
+            .expect("create collection");
+        let coll = db.get_vector_collection("g").expect("collection");
+        let mut points: Vec<Point> = Vec::new();
+        for i in 0..5 {
+            points.push(Point {
+                id: OVERSIZED + i,
+                vector: vec![0.1, 0.2, 0.3, 0.4],
+                payload: Some(json!({ "_labels": ["Person"] })),
+                sparse_vectors: None,
+            });
+        }
+        for i in 0..20 {
+            points.push(Point {
+                id: OVERSIZED + 100 + i,
+                vector: vec![0.4, 0.3, 0.2, 0.1],
+                payload: Some(json!({ "content": "unlabeled" })),
+                sparse_vectors: None,
+            });
+        }
+        coll.upsert(points).expect("upsert");
+    }
+
+    let before = warns.load(Ordering::Relaxed);
+    let db = Database::open(dir.path()).expect("reopen db");
+    let _coll = db
+        .get_vector_collection("g")
+        .expect("collection after reopen");
+    let emitted = warns.load(Ordering::Relaxed) - before;
+
+    assert_eq!(
+        emitted, 1,
+        "a rebuild that skipped 5 labeled and scanned 20 unlabeled oversized \
+         nodes must warn EXACTLY once, aggregated — one line per node is the \
+         788-line failure mode, zero lines would hide a real indexing loss"
+    );
+    assert_eq!(
+        last_skipped.load(Ordering::Relaxed),
+        5,
+        "the aggregate warning must carry the exact count of labeled nodes lost"
+    );
+}


### PR DESCRIPTION
## Le défaut

Le WARN par nœud sur un id au-delà de `u32::MAX` décrivait l'état **nominal** d'un magasin mémoire (ids u64 hachés) : **788 lignes à un démarrage**, avant la première requête, dans le journal précisément conçu (#1780/#1727) pour rester greppable en incident. Pire : il partait **avant** de vérifier si le nœud portait des `_labels` — un nœud non étiqueté n'était pas indexable et ne perdait rien, son warning était du bruit pur.

## La correction, à la racine du signal

- `LabelIndex` compte ce qui est réellement **perdu** : `unindexable_labeled` s'incrémente seulement pour un nœud étiqueté hors bitmap (détail par nœud rétrogradé en DEBUG). Un nœud non étiqueté surdimensionné — le cas mémoire, les 788 — n'est **pas un événement**.
- `has_large_ids()` garde son contrat exact (dérivé du compteur) : le repli full-scan de `start_nodes` et les tests crud existants sont intouchés (23 + 39 tests verts).
- `rebuild_label_index` émet **UNE** ligne agrégée portant le compte, seulement si non nul : « N labeled node(s) exceed u32::MAX … fall back to a full scan ».

Résultat sur un magasin mémoire : **zéro ligne** au démarrage (rien d'indexable n'est perdu), au lieu de 788.

## Preuves

- **Rouge d'abord contre l'ancien code** (fix remisé, test exécuté) : 50 nœuds non étiquetés surdimensionnés → **50 WARN** là où le contrat en exige 0.
- **Deux mutations refusées** : retour du warn par nœud → l'assertion « exactement 1 » voit **6** ; suppression de l'agrégat → elle voit **0**. Le garde mord dans les deux sens.
- Instrument : subscriber compteur (sans nouvelle dépendance) sur le **vrai chemin de réouverture** (`Database::open` → rebuild), avec extraction du champ `skipped` pour vérifier que l'agrégat porte le compte exact (5).

## Reste ouvert (volontairement)

La question performance de l'issue — un LabelIndex 64-bit (RoaringTreemap) vaut-il son coût pour les magasins mémoire — est **à instruire séparément** ; ce fix ferme le volet bruit, qui était le volet urgent (il enterrait le journal d'incident).

## Validation

fmt · clippy `-D warnings` (core, all-targets) · label_index 23/23 · crud_tests 39/39 · lizard 0 dépassement · pre-commit complet.

Closes #1834