### PR TITLE
test(memory): gate feature-hungry targets so every isolated feature builds --all-targets (#1765)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,18 @@ jobs:
       # `dep:ureq` but not `ollama`, while extract.rs calls a helper gated on
       # `ollama`. Each optional feature of velesdb-memory is therefore checked
       # in isolation.
+      #
+      # `--all-targets` is part of the contract, not an embellishment: without
+      # it this step never compiles the test and example targets, and sixteen
+      # BDD suites plus six examples sat broken under `context`/`ollama`/
+      # `extract` alone with this step green (#1765) — a target that cannot
+      # fail the build is not guarded by it.
       - name: Check each velesdb-memory feature in isolation
         run: |
           set -eu
           for feat in mcp http context persistence ollama extract; do
             echo "::group::--features $feat"
-            cargo check -p velesdb-memory --no-default-features --features "$feat"
+            cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
             echo "::endgroup::"
           done
 

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -226,7 +226,8 @@ required-features = ["context"]
 [[example]]
 name = "locomo"
 path = "examples/locomo/main.rs"
-required-features = ["ollama"]
+# `persistence` too: these examples open the file-backed store (#1765).
+required-features = ["ollama", "persistence"]
 
 [lib]
 name = "velesdb_memory"
@@ -291,22 +292,41 @@ name = "config_store_path_process"
 path = "tests/config_store_path_process.rs"
 required-features = ["http"]
 
+# Multi-hop write/read benchmark over the file-backed store; the Ollama
+# embedder path inside is feature-gated inline, so `persistence` is the
+# only build requirement (#1765).
+[[example]]
+name = "bench_multihop"
+path = "examples/bench_multihop.rs"
+required-features = ["persistence"]
+
+# Offline walkthrough over the file-backed store; same inline gating of the
+# optional Ollama path as bench_multihop (#1765).
+[[example]]
+name = "wow_offline"
+path = "examples/wow_offline.rs"
+required-features = ["persistence"]
+
 [[example]]
 name = "multihop"
 path = "examples/multihop/main.rs"
-required-features = ["ollama"]
+# `persistence` too: these examples open the file-backed store (#1765).
+required-features = ["ollama", "persistence"]
 
 [[example]]
 name = "colfilter"
 path = "examples/colfilter/main.rs"
-required-features = ["ollama"]
+# `persistence` too: these examples open the file-backed store (#1765).
+required-features = ["ollama", "persistence"]
 
 [[example]]
 name = "timeqa"
 path = "examples/timeqa/main.rs"
-required-features = ["ollama"]
+# `persistence` too: these examples open the file-backed store (#1765).
+required-features = ["ollama", "persistence"]
 
 [[example]]
 name = "triengine"
 path = "examples/triengine/main.rs"
-required-features = ["ollama"]
+# `persistence` too: these examples open the file-backed store (#1765).
+required-features = ["ollama", "persistence"]

--- a/crates/velesdb-memory/src/context/ingest_tests.rs
+++ b/crates/velesdb-memory/src/context/ingest_tests.rs
@@ -7,14 +7,9 @@ use std::fs;
 use std::path::Path;
 
 use super::{resolve_one, IngestRoots};
-use crate::context::model::{CompilePolicy, CompileRequest, ContextFragment};
-use crate::context::ContextCompiler;
-use crate::embedder::HashEmbedder;
+use crate::context::model::ContextFragment;
 use crate::error::MemoryError;
 use crate::limits::{MAX_INGEST_FILES, MAX_INGEST_FILE_BYTES, MAX_TOTAL_INGEST_BYTES};
-use crate::service::MemoryService;
-
-const DIM: usize = 384;
 
 fn path_fragment(path: &str) -> ContextFragment {
     ContextFragment {
@@ -283,6 +278,15 @@ fn ingest_caps_file_count_and_total_bytes() {
 #[cfg(feature = "persistence")]
 #[test]
 fn path_fragment_compiles_and_round_trips_source_handle() {
+    // Local to the one gated test: hoisting these to the module would leave
+    // them unused — an error under the CI's -Dwarnings — whenever `context`
+    // builds without `persistence` (#1765).
+    use crate::context::model::{CompilePolicy, CompileRequest};
+    use crate::context::ContextCompiler;
+    use crate::embedder::HashEmbedder;
+    use crate::service::MemoryService;
+    const DIM: usize = 384;
+
     let store_dir = tempfile::TempDir::new().expect("tempdir");
     let service =
         MemoryService::open(store_dir.path(), HashEmbedder::new(DIM)).expect("open memory store");

--- a/crates/velesdb-memory/src/context/ingest_tests.rs
+++ b/crates/velesdb-memory/src/context/ingest_tests.rs
@@ -277,6 +277,10 @@ fn ingest_caps_file_count_and_total_bytes() {
     }
 }
 
+// The one test of this module that opens the file-backed store: gated on
+// `persistence` so the lib test target still compiles under `context`
+// alone (#1765) — every other case here exercises pure path resolution.
+#[cfg(feature = "persistence")]
 #[test]
 fn path_fragment_compiles_and_round_trips_source_handle() {
     let store_dir = tempfile::TempDir::new().expect("tempdir");

--- a/crates/velesdb-memory/tests/auto_date_bdd.rs
+++ b/crates/velesdb-memory/tests/auto_date_bdd.rs
@@ -13,6 +13,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::{meta, service};

--- a/crates/velesdb-memory/tests/columnstore_bdd.rs
+++ b/crates/velesdb-memory/tests/columnstore_bdd.rs
@@ -4,6 +4,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::{meta, service};

--- a/crates/velesdb-memory/tests/entity_budget_bdd.rs
+++ b/crates/velesdb-memory/tests/entity_budget_bdd.rs
@@ -18,6 +18,8 @@
 //! the STORE reports (its raw scan window) reaches the profile even when the
 //! resolved list is small.
 
+#![cfg(feature = "persistence")]
+
 use std::fmt::Write as _;
 
 use tempfile::TempDir;

--- a/crates/velesdb-memory/tests/extract_bdd.rs
+++ b/crates/velesdb-memory/tests/extract_bdd.rs
@@ -6,6 +6,8 @@
 //! a deterministic, network-free `Extractor`: feed it a paragraph, and `why()`
 //! reaches a sibling fact through a shared topic with no manual `relate()`.
 
+#![cfg(feature = "persistence")]
+
 use serde_json::Value;
 use tempfile::TempDir;
 use velesdb_memory::{

--- a/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
+++ b/crates/velesdb-memory/tests/forget_orphan_hubs_bdd.rs
@@ -8,6 +8,8 @@
 //!
 //! Categories: Nominal, Edge, Negative.
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::service;

--- a/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
+++ b/crates/velesdb-memory/tests/graph_autocomplete_bdd.rs
@@ -12,6 +12,8 @@
 //! The extractor is a deterministic stub keyed on the sentence, so the whole
 //! behaviour is proven with no model, no network, and no flake.
 
+#![cfg(feature = "persistence")]
+
 use serde_json::{json, Value};
 use tempfile::TempDir;
 use velesdb_memory::{

--- a/crates/velesdb-memory/tests/kinship_forms_bdd.rs
+++ b/crates/velesdb-memory/tests/kinship_forms_bdd.rs
@@ -20,6 +20,8 @@
 //! The extractor is a deterministic stub keyed on the sentence, so the whole
 //! behaviour is proven with no model, no network and no flake.
 
+#![cfg(feature = "persistence")]
+
 use tempfile::TempDir;
 use velesdb_memory::{
     ExtractError, ExtractedFact, ExtractedRelation, Extraction, Extractor, HashEmbedder,

--- a/crates/velesdb-memory/tests/kinship_synonym_bdd.rs
+++ b/crates/velesdb-memory/tests/kinship_synonym_bdd.rs
@@ -19,6 +19,8 @@
 //! being re-pointed. Without that pair a "fix" that simply stopped re-orienting
 //! would pass every other assertion here.
 
+#![cfg(feature = "persistence")]
+
 use tempfile::TempDir;
 use velesdb_memory::{
     ExtractError, ExtractedFact, ExtractedRelation, Extraction, Extractor, HashEmbedder,

--- a/crates/velesdb-memory/tests/memory_service_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_service_bdd.rs
@@ -3,6 +3,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::{meta, service};

--- a/crates/velesdb-memory/tests/recall_fused_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_fused_bdd.rs
@@ -8,6 +8,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::service;

--- a/crates/velesdb-memory/tests/recall_threshold_bdd.rs
+++ b/crates/velesdb-memory/tests/recall_threshold_bdd.rs
@@ -17,6 +17,8 @@
 //!   recall_and_why_stay_live_across_1193_memories
 //! ```
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::{meta, service};

--- a/crates/velesdb-memory/tests/reinforce_persistence.rs
+++ b/crates/velesdb-memory/tests/reinforce_persistence.rs
@@ -7,6 +7,8 @@
 //! (`_veles_expires_at`). The core store path now carries reserved system keys
 //! forward across a re-store; this suite proves it through the public API.
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::service;

--- a/crates/velesdb-memory/tests/relation_orientation_bdd.rs
+++ b/crates/velesdb-memory/tests/relation_orientation_bdd.rs
@@ -20,6 +20,8 @@
 //! whatever triple the backend returned, the graph stores it with the same
 //! orientation.
 
+#![cfg(feature = "persistence")]
+
 use tempfile::TempDir;
 use velesdb_memory::{
     ExtractError, ExtractedFact, ExtractedRelation, Extraction, Extractor, HashEmbedder,

--- a/crates/velesdb-memory/tests/ttl_bdd.rs
+++ b/crates/velesdb-memory/tests/ttl_bdd.rs
@@ -2,6 +2,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use std::thread::sleep;

--- a/crates/velesdb-memory/tests/unrelate_bdd.rs
+++ b/crates/velesdb-memory/tests/unrelate_bdd.rs
@@ -7,6 +7,8 @@
 //!
 //! Categories: Nominal, Edge, Negative.
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::service;

--- a/crates/velesdb-memory/tests/why_bdd.rs
+++ b/crates/velesdb-memory/tests/why_bdd.rs
@@ -5,6 +5,8 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
+#![cfg(feature = "persistence")]
+
 mod common;
 
 use common::service;


### PR DESCRIPTION
## Le défaut

Le contrôle d'isolation de la CI (`ci.yml`) vérifiait chaque feature seule avec `cargo check` **sans** `--all-targets` : il ne compilait donc jamais les cibles de test ni les exemples. Résultat : **16 suites BDD et 6 exemples cassés** sous `context`, `ollama` ou `extract` isolées (48 erreurs au premier essai), l'étape verte pendant tout ce temps. Une cible que l'étape ne peut pas construire n'est pas gardée par elle — le trou exact que le commentaire de `ci.yml` décrivait déjà pour les tests unitaires d'`extract`.

## La correction, dans l'idiome du dépôt

- **16 suites BDD adossées au store** : `#![cfg(feature = "persistence")]` en tête — l'idiome inline que les suites `context` et `mcp` utilisent déjà (`#![cfg(all(feature = "mcp", …))]`).
- **Le seul test unitaire de `ingest_tests` qui ouvre le store** : gate individuel, le reste du module (résolution de chemins pure) continue de tourner sous `context` seule.
- **Exemples** : sections `required-features` dans `Cargo.toml` (un exemple vidé par `cfg` n'a plus de `main`). Trouvaille au passage : les **cinq exemples ollama déclaraient `["ollama"]` seul** alors qu'ils ouvrent le store fichier — ils ne compilaient que parce que le jeu de features par défaut leur passait `persistence` en contrebande. Déclaré explicitement.
- **Le câblage** : l'étape d'isolation passe à `--all-targets`, contrat écrit dans son commentaire.

## Preuves

- **Rouge d'abord** : la ligne étendue échouait sur `context`/`ollama`/`extract` (le rouge que l'issue rapporte) ; après correction, **6/6 features isolées à 0 erreur** avec `--all-targets`.
- **Refus du câblage prouvé par mutation** : un gate retiré délibérément → l'ancienne ligne reste verte (**0** erreur), la ligne étendue refuse (**5**). C'est bien `--all-targets` qui mord.
- **Parité des comptes** (garde anti-« tests disparus ») : 1045 tests sous `extract,ollama,persistence` et 1011 sous `http`, identiques à avant le gating — aucune suite n'a perdu ses features en silence.

## Note DRY

Le hook de duplication a signalé les harnais auto-contenus **préexistants** des suites BDD (stubs `ScriptedExtractor`/`service()` répétés entre fichiers), mis dans son champ par mes en-têtes de 2 lignes. Leur consolidation éventuelle dans `tests/common` est un refactor séparé — le faire ici brouillerait la preuve de parité des comptes qui fonde cette PR.

## Validation

fmt · clippy `-D warnings` · 6/6 features isolées `--all-targets` = 0 erreur · comptes de tests identiques · pre-commit complet.

Closes #1765