### PR TITLE
fix(scripts): the doc-contract sweep reads what git TRACKS, not what the tree contains (#1730)

### DIFF
--- a/scripts/check-mcp-doc-contract.py
+++ b/scripts/check-mcp-doc-contract.py
@@ -120,6 +120,7 @@ import argparse
 import bisect
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -404,11 +405,48 @@ def _is_scanned(root: Path, path: Path) -> bool:
     return not SURFACE_EXCLUDED_NAMES.match(path.name)
 
 
+def _tracked_files(root: Path) -> "set[Path] | None":
+    """The set of git-tracked files under `root`, or `None` outside a repo.
+
+    The sweep's perimeter is what git TRACKS, not what the working tree
+    happens to contain (#1730): the same commit used to sweep 218 files from
+    the main repository and 214 from a clean worktree, the four extras being
+    untracked artifacts (`integrations/**/.pytest_cache/README.md`). An
+    exclusion list enumerates incidents; the tracked set states the rule.
+
+    `None` (not a git repository, or no git binary) falls back to the raw
+    globs — the sandboxed unit tests of this guard run in plain temp dirs,
+    and a tarball consumer still gets the historical behavior. Inside a
+    repository the filter always applies, which is the case CI and every
+    developer checkout are in.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return {
+        root / name
+        for name in out.stdout.decode("utf-8", "surrogateescape").split("\0")
+        if name
+    }
+
+
 def surface_files(root: Path) -> "list[Path]":
     """Every file the sweep reads, deduplicated and sorted."""
+    tracked = _tracked_files(root)
     matched: "set[Path]" = set()
     for glob in SURFACE_GLOBS:
-        matched.update(p for p in root.glob(glob) if p.is_file() and _is_scanned(root, p))
+        matched.update(
+            p
+            for p in root.glob(glob)
+            if p.is_file()
+            and _is_scanned(root, p)
+            and (tracked is None or p in tracked)
+        )
     return sorted(matched)
 
 

--- a/scripts/tests/test_check_mcp_doc_contract.py
+++ b/scripts/tests/test_check_mcp_doc_contract.py
@@ -30,6 +30,7 @@ import importlib.util
 import io
 import json
 import shutil
+import subprocess
 import sys
 import tempfile
 import types
@@ -136,6 +137,98 @@ class DocContractTestCase(unittest.TestCase):
         for needle in expected_substrings:
             self.assertIn(needle, joined)
         return failures
+
+
+class TrackedPerimeterTests(DocContractTestCase):
+    """#1730: the sweep's perimeter is what git TRACKS, not what the working
+    tree happens to contain.
+
+    Measured on 2026-07-31: the same commit swept 218 surface files from the
+    main repository and 214 from a clean worktree — the four extras were
+    untracked artifacts like `integrations/langchain/.pytest_cache/README.md`.
+    A guard whose perimeter depends on what lies around in the tree gives a
+    different verdict locally and in CI, and in the WRONG direction: CI
+    sweeps less than the developer's machine. The root-cause rule is to
+    refuse what git does not track — not to grow the exclusion list by one
+    cache directory per incident.
+    """
+
+    UNTRACKED_DECLARATION = (
+        "# pytest cache\n\n`demo_tool` returns `{found, wrong_key}`.\n"
+    )
+    CACHE_PATH = "integrations/langchain/.pytest_cache/README.md"
+
+    def _git(self, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(self.tmp), *args],
+            check=True,
+            capture_output=True,
+        )
+
+    def _init_repo_tracking_baseline(self) -> None:
+        self._git("init", "-q")
+        self._git("add", "-A")
+        self._git(
+            "-c",
+            "user.email=guard@test",
+            "-c",
+            "user.name=guard",
+            "commit",
+            "-qm",
+            "baseline",
+        )
+
+    def test_an_untracked_file_is_invisible_to_the_sweep(self) -> None:
+        # The exact class from the issue: a regenerable cache README carrying
+        # what the attribution would read as a WRONG declaration.
+        self._init_repo_tracking_baseline()
+        self.write(self.CACHE_PATH, self.UNTRACKED_DECLARATION)
+
+        swept = {p.relative_to(self.tmp).as_posix() for p in cmdc.surface_files(self.tmp)}
+        self.assertNotIn(
+            self.CACHE_PATH,
+            swept,
+            "an UNTRACKED file must be outside the sweep's perimeter — a guard "
+            "that reads it gives a different verdict here than in CI (#1730)",
+        )
+        self.assertGuardPasses()
+
+    def test_the_same_file_tracked_is_swept_and_refused(self) -> None:
+        # The positive control the invisibility above is worthless without:
+        # committed, the very same content must be seen AND its wrong shape
+        # refused — proving the planted declaration is potent, so the
+        # untracked case is invisible for the RIGHT reason.
+        self._init_repo_tracking_baseline()
+        self.write(self.CACHE_PATH, self.UNTRACKED_DECLARATION)
+        # `-f`: a machine-global gitignore may ignore `.pytest_cache` (that is
+        # WHY such files lie around untracked in real trees) — what this
+        # control needs is the tracked STATUS, however obtained.
+        self._git("add", "-f", self.CACHE_PATH)
+        self._git(
+            "-c",
+            "user.email=guard@test",
+            "-c",
+            "user.name=guard",
+            "commit",
+            "-qm",
+            "track the cache file",
+        )
+
+        swept = {p.relative_to(self.tmp).as_posix() for p in cmdc.surface_files(self.tmp)}
+        self.assertIn(self.CACHE_PATH, swept, "a tracked file must stay in the sweep")
+        self.assertGuardFails("wrong_key")
+
+    def test_a_sandbox_without_git_keeps_the_unfiltered_sweep(self) -> None:
+        # The fallback the rest of this suite depends on: no repository means
+        # no tracked-set to intersect with, so the sweep reads the raw globs
+        # (this sandbox has no .git — every other test here exercises it).
+        self.write(self.CACHE_PATH, self.UNTRACKED_DECLARATION)
+        swept = {p.relative_to(self.tmp).as_posix() for p in cmdc.surface_files(self.tmp)}
+        self.assertIn(
+            self.CACHE_PATH,
+            swept,
+            "outside a git repository the sweep falls back to the raw globs",
+        )
 
 
 class ReturnShapeRuleTests(DocContractTestCase):


### PR DESCRIPTION
## Le défaut mesuré

Le même commit balayait **218** fichiers de surface depuis le dépôt principal et **214** depuis un worktree propre — les 4 d'écart étaient des artefacts non suivis (`integrations/langchain/.pytest_cache/README.md`), ramassés parce que `SURFACE_EXCLUDED_PARTS` énumère les caches un incident à la fois. Un garde dont le périmètre dépend de ce qui traîne dans l'arbre rend un verdict différent en local et en CI — et dans le mauvais sens : la CI balaie MOINS que le poste du développeur.

## La règle qui remplace l'énumération

`surface_files` intersecte ses globs avec `git ls-files`. Hors dépôt (les tests unitaires sandboxés du garde, un consommateur de tarball), repli documenté sur les globs bruts ; dans un dépôt — la CI et tout checkout — le filtre s'applique toujours. La liste d'exclusions reste pour ce qui est suivi mais exclu par conception (`/archive/`, `/tests/`).

## Preuves, exactement celles que l'issue exige

- **Le test demandé** : un fichier non suivi portant une déclaration sous une surface balayée → invisible au sweep. **Rouge avant le fix** (le fichier était balayé, assertion citée dans le run).
- **Contrôle positif** : le même fichier **commité** → balayé ET refusé (`wrong_key`) — l'invisibilité a la bonne cause. `git add -f`, parce qu'un gitignore global machine ignorant `.pytest_cache` est précisément la raison pour laquelle ces fichiers traînent non suivis.
- **Repli sans git** : sandbox sans dépôt → sweep brut conservé (les 52 autres tests du garde en dépendent).
- **Mutation refusée** : filtre retiré → le test d'invisibilité rougit.
- **Symptôme re-mesuré** : dépôt principal et worktree propre balaient désormais tous deux **231**.

## Validation

55/55 tests du garde · garde réel vert sur le dépôt (`PASS (return-shape)`, 231 surfaces) · pre-commit complet.

Closes #1730