### PR TITLE
fix(guards): exclude hidden directories from the doc-contract sweep

### DIFF
--- a/scripts/check-mcp-doc-contract.py
+++ b/scripts/check-mcp-doc-contract.py
@@ -297,6 +297,14 @@ SURFACE_EXCLUDED_PARTS: "tuple[str, ...]" = (
     "/node_modules/",
     "/target/",
     "/__pycache__/",
+    # Any hidden directory (issue #1730): regenerable tool caches —
+    # `.pytest_cache/`, `.mypy_cache/`, `.venv/`, … — are UNTRACKED, so a
+    # sweep that reads them sees a different surface count on a dev machine
+    # than in a clean worktree of the same commit. Excluding the dot-dir
+    # convention wholesale (rather than naming caches one by one) is what
+    # keeps the next cache tool from re-opening the gap; measured on this
+    # tree, no declared glob reaches a legitimate surface through one.
+    "/.",
 )
 SURFACE_EXCLUDED_NAMES = re.compile(r"^(CHANGELOG|MIGRATION_)", re.IGNORECASE)
 

--- a/scripts/tests/test_check_mcp_doc_contract.py
+++ b/scripts/tests/test_check_mcp_doc_contract.py
@@ -205,6 +205,25 @@ class ReturnShapeRuleTests(DocContractTestCase):
         )
 
 
+class UntrackedCacheScopeTests(DocContractTestCase):
+    """The sweep must read the same surface set from a dev machine and from a
+    clean worktree of the same commit (issue #1730): regenerable tool caches
+    (`.pytest_cache/`, `.mypy_cache/`, …) are untracked, live under globbed
+    roots, and must never enter the sweep."""
+
+    DRIFTED = REFERENCE_CLEAN.replace("{ found, working, other_sessions }", "{ working }")
+
+    def test_a_drifted_declaration_inside_a_hidden_cache_dir_is_not_swept(self) -> None:
+        self.write("docs/.pytest_cache/README.md", self.DRIFTED)
+        self.assertGuardPasses()
+
+    def test_positive_control_the_same_file_outside_the_cache_is_refused(self) -> None:
+        # Proves the mutation above is potent — the pass is the exclusion's
+        # doing, not a blind spot in the drift rule.
+        self.write("docs/reference/CACHED.md", self.DRIFTED)
+        self.assertGuardFails("docs/reference/CACHED.md")
+
+
 class AntiDisarmTests(DocContractTestCase):
     """Every way this guard could quietly verify nothing must be red."""
 


### PR DESCRIPTION
## Description

The doc-contract sweep's scope depended on **untracked** files (#1730): the same commit swept from the main repository counted 218 surface files, from a clean worktree 214 — the 4 extra being regenerable artifacts like `integrations/langchain/.pytest_cache/README.md`, which the `integrations/**/*.md` glob picks up. A guard whose perimeter varies with the developer machine's cache state is a guard whose failures cannot be reproduced from the commit alone.

`SURFACE_EXCLUDED_PARTS` gains `"/."`: every regenerable tool cache (`.pytest_cache/`, `.mypy_cache/`, `.venv/`, …) follows the dot-directory convention, so excluding the convention — rather than naming caches one by one — is the one fix of the issue's three options that prevents the question from being re-asked at the next cache tool (its "deriver l'un de l'autre" spirit). Measured on this tree: no declared glob reaches a legitimate surface through a hidden directory, so the exclusion costs nothing.

Pinned by two tests in the guard's own harness (`UntrackedCacheScopeTests`):
- a drifted declaration inside `docs/.pytest_cache/README.md` leaves the guard green;
- the **same** drifted file at `docs/reference/CACHED.md` turns it red — the positive control proving the pass is the exclusion's doing, not a blind spot in the drift rule.

Fixes #1730

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `python3 -m unittest scripts.tests.test_check_mcp_doc_contract -v` — 54/54, including the two new tests
- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` — 406 tests OK (9 skipped, pre-existing)
- `python3 scripts/check-mcp-doc-contract.py` — real sweep still PASS on the clean tree

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS: Linux
- Rust version: n/a (Python guard only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

> Skipped — this PR does not add or modify `unsafe` code.

## High-Risk Change Checklist

> Skipped — this PR does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

The exclusion also covers hidden **files** (a `docs/.hidden.md` would be skipped) — intended: a dot-file is no more a reader-facing surface than a dot-directory's contents.
