### PR TITLE
fix(deps): bump nanoid past GHSA-2v37-7h3g-55p8 in every lockfile

### DIFF
--- a/demos/tauri-rag-app/package-lock.json
+++ b/demos/tauri-rag-app/package-lock.json
@@ -1429,9 +1429,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/examples/react-wasm-search/package-lock.json
+++ b/examples/react-wasm-search/package-lock.json
@@ -1265,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -3156,9 +3156,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Advisory high publié en amont contre `nanoid <3.3.17` : le gate npm advisories rougissait toute PR quel que soit son diff — première victime une PR purement Rust (#1849). Entre deux runs, la base d'avis s'est élargie : `examples/react-wasm-search` et `demos/tauri-rag-app` sont tombés à leur tour.

Balayage de TOUS les package-lock.json suivis : ces trois-là sont les seuls porteurs de nanoid. Après ce lot, chacun résout 3.3.18 et la commande exacte de la CI (`npm audit --package-lock-only --audit-level=high`) rend 0 vulnérabilité sur chacun. Lockfiles seuls, aucun code touché. À merger en premier pour débloquer la file.