### PR TITLE
ci(gates): the perf gate's no-op leg stops dying on its own hash sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1453,7 +1453,11 @@ jobs:
       - name: Skipped — search hot path unchanged
         if: needs.perf-path-changed.outputs.relevant != 'true'
         shell: bash
-        run: echo "Search hot path unchanged; perf gate no-ops green (required checks must always run, #1465)."
+        # Block scalar, not a plain one: on a plain `run:` line a bare `#`
+        # starts a YAML comment, which truncated this echo before its closing
+        # quote and failed every no-op leg with `unexpected EOF` (#1857-era).
+        run: |
+          echo "Search hot path unchanged; perf gate no-ops green (required checks must always run, #1465)."
 
   # Last of the fold, and the one #1698 named: Git Flow, branch freshness and
   # the AI-attribution guard ran beside the required check, so none of them


### PR DESCRIPTION
## Description

The `perf-gate-e2e` job folded into `CI Success` by #1854 has a no-op leg for PRs that don't touch the search hot path. Its echo sat on a plain-scalar `run:` line, where a bare `#` starts a YAML comment — so `#1465).` was parsed away, the string lost its closing quote, and **every PR not touching the hot path failed the gate with `unexpected EOF`** — the exact opposite of the no-op-green contract. #1854's own run never executed that leg (its diff includes `ci.yml`, so the filter was true and the real benchmark ran and passed), which is how the defect slipped through.

One-line fix: the echo moves into a block scalar (`run: |`), where `#` is just text. A comment above the step pins the lesson.

Currently failing on this: #1855 and #1856 (both docs-only). They will be updated onto develop once this merges.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

`yaml.safe_load` confirms the step's `run` string now contains the full echo including `#1465`; `bash -n` parses the extracted script; the 48 `test_ci_gate_reachability` tests pass. This PR's own CI run exercises the *real* (non-skipped) gate leg, since `ci.yml` is in its diff.

**Test Configuration:**
- OS: Linux
- Rust version: n/a (workflow-only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
