### PR TITLE
fix(memory): bound extraction generation to stop runaway completions (#1846)

### DIFF
--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -971,6 +971,18 @@ const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 #[cfg(feature = "extract")]
 const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Ceiling on how many tokens one extraction call may generate.
+///
+/// Unbounded, the real graph-extraction prompt measured 3 933 completion
+/// tokens for a twelve-word sentence — 1 min 59 s spent generating JSON to
+/// store one fact (#1846). The same call capped at 600 tokens measured
+/// 14.9 s. 512 sits just under that, comfortably above what any realistic
+/// sentence's worth of triples needs, and turns the worst case into a
+/// bounded one instead of a tuning knob callers have to discover by timing
+/// out.
+#[cfg(feature = "extract")]
+const MAX_GENERATION_TOKENS: u32 = 512;
+
 /// The knobs that actually configure the extractor, named in its failures.
 ///
 /// **Not** the embedder's variables. `main.rs`'s `build_ollama_extractor` reads
@@ -1144,7 +1156,7 @@ impl OpenAiExtractor {
 
     /// POST one prompt and return the assistant's reply.
     fn generate(&self, prompt: &str) -> Result<String, ExtractError> {
-        let body = crate::openai::chat_body(&self.model, prompt);
+        let body = crate::openai::chat_body(&self.model, prompt, MAX_GENERATION_TOKENS);
         let payload = self
             .client
             .post_json(crate::openai::CHAT_COMPLETIONS_PATH, &body)
@@ -1198,7 +1210,7 @@ impl OllamaExtractor {
             // cost, not the generation. Shares the embedder's knob so one
             // setting governs every Ollama call the daemon makes.
             "keep_alive": crate::embedder::keep_alive(),
-            "options": { "temperature": 0 },
+            "options": { "temperature": 0, "num_predict": MAX_GENERATION_TOKENS },
         })
         .to_string();
         let attempt = || {

--- a/crates/velesdb-memory/src/openai.rs
+++ b/crates/velesdb-memory/src/openai.rs
@@ -58,13 +58,15 @@ pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
 ///
 /// `temperature: 0` for the same reason the Ollama backend pins it: a backend
 /// that answers differently to the same text turns one stored fact into two
-/// on a re-run.
+/// on a re-run. `max_tokens` caps runaway generation the same way the Ollama
+/// backend's `num_predict` does — see `extract::MAX_GENERATION_TOKENS` (#1846).
 #[cfg(feature = "extract")]
-pub(crate) fn chat_body(model: &str, prompt: &str) -> String {
+pub(crate) fn chat_body(model: &str, prompt: &str, max_tokens: u32) -> String {
     json!({
         "model": model,
         "messages": [{ "role": "user", "content": prompt }],
         "temperature": 0,
+        "max_tokens": max_tokens,
     })
     .to_string()
 }

--- a/crates/velesdb-memory/src/openai_tests.rs
+++ b/crates/velesdb-memory/src/openai_tests.rs
@@ -24,12 +24,22 @@ fn an_embeddings_body_carries_the_model_and_the_input() {
 fn a_chat_body_pins_temperature_to_zero() {
     // Same reason the Ollama backend pins it: a backend that answers
     // differently to the same text turns one stored fact into two on a re-run.
-    let body = chat_body("qwen3", "extract facts");
+    let body = chat_body("qwen3", "extract facts", 512);
     let json: Value = serde_json::from_str(&body).expect("valid json");
     assert_eq!(json["model"], "qwen3");
     assert_eq!(json["messages"][0]["role"], "user");
     assert_eq!(json["messages"][0]["content"], "extract facts");
     assert_eq!(json["temperature"], 0);
+}
+
+#[test]
+#[cfg(feature = "extract")]
+fn a_chat_body_caps_completion_tokens() {
+    // Unbounded, the real extraction prompt measured 3 933 completion tokens
+    // for a twelve-word sentence — 1 min 59 s to store one fact (#1846).
+    let body = chat_body("qwen3", "extract facts", 512);
+    let json: Value = serde_json::from_str(&body).expect("valid json");
+    assert_eq!(json["max_tokens"], 512);
 }
 
 #[test]


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets **`develop`**.

## Description

#1846 documented two independent problems behind `remember`'s 46-52 s latency: autograph running synchronously on the response path (fixed separately in #1851), and the extraction generation itself being unbounded. This PR closes the second, still-open half.

Neither extraction backend capped how many tokens one call could generate. Replaying the real graph-extraction prompt on a twelve-word sentence, unbounded, measured **3 933 completion tokens — 1 min 59 s** to store one fact. The same call capped at 600 tokens measured **14.9 s** (numbers from the issue).

Adds `MAX_GENERATION_TOKENS = 512` in `crates/velesdb-memory/src/extract.rs` — comfortably above what any realistic sentence's worth of triples needs — and wires it through both backends:
- Ollama: `options.num_predict`
- OpenAI-compatible: `max_tokens` on the chat-completions body (`openai::chat_body` gained a `max_tokens: u32` parameter; its one call site and its test were updated)

No behavior change for normal-sized extractions; bounds the pathological case that previously ran for minutes.

Fixes # (partially closes #1846 — the "generation is bounded" closure criterion; decoupling from the response path was already shipped in #1851)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests — `cargo test -p velesdb-memory --features extract --lib` (added `a_chat_body_caps_completion_tokens`, updated `a_chat_body_pins_temperature_to_zero`); full `extract`/`openai` module suites green
- [x] `cargo clippy -p velesdb-memory --lib --all-features -- -D warnings -D clippy::pedantic` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `python3 scripts/check_prod_unwraps.py`, `check-todo-annotations.py` — pass

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

N/A — no `unsafe` touched.

## High-Risk Change Checklist

N/A — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Leaves item 3 of #1846 (updating the `autograph` config doc comment's latency claim now that it runs off the response path) and the standalone `examples/locomo/ollama_gen.rs` benchmark harness untouched — out of scope for this surgical fix; the harness is a separate code path with its own `num_ctx` knob already.
