### PR TITLE
fix: the lock audit's blocking findings — three deadlocks and a forget-resurrection, at the root

### DIFF
--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -93,7 +93,11 @@ impl Collection {
         self.update_secondary_indexes_from_raw(ids, payloads, &old_payloads);
 
         let inserted = self.bulk_index_or_defer(&vector_refs);
-        self.storage.config.write().point_count = self.storage.vector_storage.read().len();
+        // Two statements so the guards never overlap: the one-liner form
+        // evaluates the RHS first, holding vector_storage (rank 2) while
+        // acquiring config (rank 1) — a decreed-order inversion.
+        let point_count = self.storage.vector_storage.read().len();
+        self.storage.config.write().point_count = point_count;
 
         self.maintain_histograms_for_raw(ids, payloads, &old_payloads);
 

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -191,7 +191,11 @@ impl Collection {
         old_payloads: &[Option<serde_json::Value>],
         sparse_batch: &BTreeMap<String, Vec<(u64, crate::index::sparse::SparseVector)>>,
     ) -> Result<()> {
-        self.storage.config.write().point_count = self.storage.vector_storage.read().len();
+        // Two statements so the guards never overlap: the one-liner form
+        // evaluates the RHS first, holding vector_storage (rank 2) while
+        // acquiring config (rank 1) — a decreed-order inversion.
+        let point_count = self.storage.vector_storage.read().len();
+        self.storage.config.write().point_count = point_count;
         self.apply_sparse_batch_bulk(sparse_batch)?;
         // Incremental histogram maintenance (Bug #47 + Bug #49): dedup by id
         // so only the final payload counts, then atomic decrement + increment.

--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -11,6 +11,7 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 
+use super::super::match_exec::MatchStorageGuards;
 use super::super::where_eval::GraphMatchEvalCache;
 use super::GroupKey;
 use crate::collection::types::Collection;
@@ -66,10 +67,17 @@ impl Collection {
         let filter = Self::build_static_filter(where_clause, use_runtime, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
-        // LOCK ORDER: vector_storage(2) before payload_storage(3) — was
+        // LOCK ORDER: metric snapshot (config, rank 1) first, then
+        // vector_storage(2) before payload_storage(3) — the pair was
         // reversed here. See .investigation/http-deadlock-2026-07-22/.
+        let metric = self.storage.config.read().metric;
         let vector_storage = self.storage.vector_storage.read();
         let payload_storage = self.storage.payload_storage.read();
+        let match_guards = MatchStorageGuards {
+            metric,
+            vector_guard: &vector_storage,
+            payload_guard: &payload_storage,
+        };
         let ids = vector_storage.ids();
         let mut graph_cache = GraphMatchEvalCache::default();
         let mut groups: HashMap<GroupKey, Aggregator> = HashMap::new();
@@ -83,6 +91,7 @@ impl Collection {
                     params,
                     needs_vector_eval,
                     graph_cache: &mut graph_cache,
+                    match_guards: &match_guards,
                 };
                 self.runtime_where_passes(id, payload.as_ref(), &mut rt_ctx)?
             } else if let Some(ref f) = filter {

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -20,6 +20,7 @@ mod having;
 #[cfg(test)]
 mod having_tests;
 
+use super::match_exec::MatchStorageGuards;
 use super::where_eval::GraphMatchEvalCache;
 use crate::collection::types::Collection;
 use crate::error::Result;
@@ -103,6 +104,11 @@ pub(super) struct RuntimeWhereCtx<'a> {
     pub(super) params: &'a HashMap<String, serde_json::Value>,
     pub(super) needs_vector_eval: bool,
     pub(super) graph_cache: &'a mut GraphMatchEvalCache,
+    /// The scan loop's hoisted vector/payload guards (decree order),
+    /// forwarded into MATCH-in-WHERE evaluation so the nested traversal
+    /// never re-acquires the locks this loop already holds — a nested read
+    /// acquisition on the same thread deadlocks once a writer queues.
+    pub(super) match_guards: &'a MatchStorageGuards<'a>,
 }
 
 /// Context for sequential aggregation over a set of IDs.
@@ -115,6 +121,8 @@ struct SequentialAggCtx<'a> {
     columns_to_aggregate: &'a [String],
     has_count_star: bool,
     use_runtime_where_eval: bool,
+    /// See [`RuntimeWhereCtx::match_guards`].
+    match_guards: &'a MatchStorageGuards<'a>,
 }
 
 /// Threshold for switching to parallel aggregation.
@@ -210,12 +218,19 @@ impl Collection {
         let filter = Self::build_static_filter(where_clause, use_runtime_where_eval, params)?;
         let (columns_vec, has_count_star) = Self::prepare_agg_columns(aggregations);
 
-        // LOCK ORDER: vector_storage(2) before payload_storage(3) — was
+        // LOCK ORDER: metric snapshot (config, rank 1) first, then
+        // vector_storage(2) before payload_storage(3) — the pair was
         // reversed here. See .investigation/http-deadlock-2026-07-22/. This
         // site also feeds `run_parallel_path` (rayon `par_chunks`), so the
         // wrong order compounded the ABBA risk with rayon-pool exhaustion.
+        let metric = self.storage.config.read().metric;
         let vector_storage = self.storage.vector_storage.read();
         let payload_storage = self.storage.payload_storage.read();
+        let match_guards = MatchStorageGuards {
+            metric,
+            vector_guard: &vector_storage,
+            payload_guard: &payload_storage,
+        };
         let ids: Vec<u64> = vector_storage.ids();
 
         if ids.len() >= PARALLEL_THRESHOLD && !use_runtime_where_eval {
@@ -236,6 +251,7 @@ impl Collection {
                 columns_to_aggregate: &columns_vec,
                 has_count_star,
                 use_runtime_where_eval,
+                match_guards: &match_guards,
             };
             self.aggregate_sequential(&ids, &ctx)
         }
@@ -349,6 +365,7 @@ impl Collection {
                 ctx.params,
                 &ctx.stmt.from_alias,
                 ctx.graph_cache,
+                Some(ctx.match_guards),
             ),
             None => Ok(true),
         }
@@ -370,6 +387,7 @@ impl Collection {
                 params: ctx.params,
                 needs_vector_eval,
                 graph_cache,
+                match_guards: ctx.match_guards,
             };
             self.runtime_where_passes(id, payload, &mut where_ctx)
         } else if let Some(f) = ctx.filter {

--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -3,19 +3,27 @@ use super::{Collection, HashSet, QuerySearchOptions, Result, SearchResult, MAX_L
 impl Collection {
     // Metadata index query strategy is in metadata_query.rs
 
-    pub(crate) fn evaluate_graph_match_anchor_ids(
+    pub(in crate::collection::search::query) fn evaluate_graph_match_anchor_ids(
         &self,
         predicate: &crate::velesql::GraphMatchPredicate,
         params: &std::collections::HashMap<String, serde_json::Value>,
         from_aliases: &[String],
+        guards: Option<&super::match_exec::MatchStorageGuards<'_>>,
     ) -> Result<HashSet<u64>> {
         let anchor_alias = Self::resolve_anchor_alias(predicate, from_aliases)?;
         let clause = Self::build_anchor_match_clause(predicate);
 
         // Anchor evaluation needs the full unordered match set (it collects bound
         // ids into a set), so use the raw primitive rather than the ORDER BY/LIMIT
-        // entry point.
-        let matches = self.execute_match_with_context(&clause, params, None)?;
+        // entry point. A caller that already holds the vector/payload guards
+        // (the aggregation runtime WHERE loop evaluating MATCH-in-WHERE) passes
+        // them through so the nested MATCH does not re-acquire either lock —
+        // a nested read acquisition on the same thread deadlocks once a writer
+        // queues (parking_lot task-fair semantics).
+        let matches = match guards {
+            Some(g) => self.execute_match_with_guards(&clause, params, None, g)?,
+            None => self.execute_match_with_context(&clause, params, None)?,
+        };
         let mut ids = HashSet::with_capacity(matches.len());
         for m in matches {
             if let Some(id) = m.bindings.get(&anchor_alias) {

--- a/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
+++ b/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
@@ -74,14 +74,16 @@ impl Collection {
         let Some((first, rest)) = predicates.split_first() else {
             return Ok(None);
         };
+        // No storage guard is held at this dispatch level — the nested MATCH
+        // traversal acquires its own guards (`guards: None`).
         let mut anchors = cache
-            .get_or_compute(self, first, params, from_aliases)?
+            .get_or_compute(self, first, params, from_aliases, None)?
             .clone();
         for predicate in rest {
             if anchors.is_empty() {
                 break;
             }
-            let ids = cache.get_or_compute(self, predicate, params, from_aliases)?;
+            let ids = cache.get_or_compute(self, predicate, params, from_aliases, None)?;
             anchors.retain(|id| ids.contains(id));
         }
         Ok(Some(anchors))
@@ -233,6 +235,7 @@ impl Collection {
                     params,
                     from_aliases,
                     cache,
+                    None,
                 )?;
                 if passes {
                     results.push(SearchResult::new(point, 1.0));

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -199,7 +199,7 @@ impl Collection {
         let Some(node) = walk.pattern.nodes.get(rel_idx + 1) else {
             return Ok(());
         };
-        if !Self::node_matches_bound_pattern(node_id, node, walk.ctx.payload_guard) {
+        if !Self::node_matches_bound_pattern(node_id, node, walk.ctx.guards.payload_guard) {
             return Ok(());
         }
         let inserted = Self::bind_node_alias(walk.bindings, node, node_id);
@@ -224,7 +224,7 @@ impl Collection {
                 },
                 where_clause,
                 walk.ctx.params,
-                walk.ctx.payload_guard,
+                walk.ctx.guards,
             )? {
                 return Ok(());
             }
@@ -244,7 +244,7 @@ impl Collection {
             walk.edge_bindings,
             walk.edge_paths,
             &walk.ctx.match_clause.return_clause,
-            walk.ctx.payload_guard,
+            walk.ctx.guards.payload_guard,
         );
         walk.ctx.all_results.push(result);
         Ok(())

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -20,11 +20,38 @@ mod vector_first;
 pub(in crate::collection::search::query) mod where_eval;
 
 use crate::collection::types::Collection;
+use crate::distance::DistanceMetric;
 use crate::error::{Error, Result};
 use crate::guardrails::QueryContext;
-use crate::storage::LogPayloadStorage;
+use crate::storage::{LogPayloadStorage, MmapStorage};
 use crate::velesql::{GraphPattern, MatchClause};
 use std::collections::{HashMap, HashSet};
+
+/// Storage guards hoisted once per MATCH execution, in the decreed lock
+/// order: `vector_storage` (rank 2) before `payload_storage` (rank 3) — the
+/// same order writers such as `delete_vector_core_stores` use (see LOCK
+/// ORDERING in `collection/types.rs`).
+///
+/// The top frame acquires both guards exactly once and passes this bundle
+/// down the whole execution tree; no callee may re-acquire either lock.
+/// A nested `read()` on a lock whose guard is already held by the same
+/// thread deadlocks as soon as one writer queues (parking_lot's task-fair
+/// `RwLock` is not re-entrant — see
+/// `graph_api.rs::validate_edge_endpoints_exist`), and acquiring the pair
+/// in the reversed order is the ABBA half of a hold-and-wait cycle with
+/// the delete path.
+///
+/// `metric` is resolved from `config` (rank 1) BEFORE either guard is
+/// acquired, so similarity evaluation never takes the rank-1 lock while
+/// ranks 2/3 are held.
+pub(in crate::collection::search::query) struct MatchStorageGuards<'a> {
+    /// Distance metric snapshot (from `config`, rank 1) taken before the guards.
+    pub(in crate::collection::search::query) metric: DistanceMetric,
+    /// `vector_storage` read guard (rank 2).
+    pub(in crate::collection::search::query) vector_guard: &'a MmapStorage,
+    /// `payload_storage` read guard (rank 3).
+    pub(in crate::collection::search::query) payload_guard: &'a LogPayloadStorage,
+}
 
 /// Result of a MATCH query traversal.
 ///
@@ -170,7 +197,7 @@ pub fn parse_property_path(expression: &str) -> Option<(&str, &str)> {
 struct SingleNodeCtx<'a> {
     match_clause: &'a MatchClause,
     params: &'a HashMap<String, serde_json::Value>,
-    payload_guard: &'a LogPayloadStorage,
+    guards: &'a MatchStorageGuards<'a>,
     seen_pairs: &'a mut std::collections::HashSet<(u64, u64)>,
     all_results: &'a mut Vec<MatchResult>,
     limit: usize,
@@ -182,7 +209,7 @@ struct SingleNodeCtx<'a> {
 struct TraversalCtx<'a> {
     match_clause: &'a MatchClause,
     params: &'a HashMap<String, serde_json::Value>,
-    payload_guard: &'a LogPayloadStorage,
+    guards: &'a MatchStorageGuards<'a>,
     guardrail: Option<&'a QueryContext>,
     all_results: &'a mut Vec<MatchResult>,
     limit: usize,
@@ -238,9 +265,16 @@ impl Collection {
     /// relationships, enforces guard-rail limits, filters by WHERE, and
     /// projects RETURN properties.
     ///
-    /// Hoists `payload_storage.read()` once before the traversal loop to avoid
-    /// per-node lock acquisitions. The `ConcurrentEdgeStore` manages its own
-    /// internal shard locks — no outer lock is needed.
+    /// Hoists both storage read guards once, in the decreed lock order —
+    /// `vector_storage` (2) before `payload_storage` (3) — and passes them
+    /// down via [`MatchStorageGuards`] so no callee re-acquires either lock.
+    /// The `ConcurrentEdgeStore` manages its own internal shard locks — no
+    /// outer lock is needed.
+    ///
+    /// Callers that already hold both guards (e.g. the aggregation runtime
+    /// WHERE evaluation running a MATCH-in-WHERE predicate) must use
+    /// [`Self::execute_match_with_guards`] instead of this entry point, which
+    /// would re-acquire the locks under them.
     ///
     /// # Errors
     ///
@@ -250,6 +284,33 @@ impl Collection {
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
         ctx: Option<&QueryContext>,
+    ) -> Result<Vec<MatchResult>> {
+        // Metric snapshot (config, rank 1) BEFORE the guards, then both
+        // guards in decree order (2 then 3). See `MatchStorageGuards`.
+        let metric = self.storage.config.read().metric;
+        let vector_guard = self.storage.vector_storage.read();
+        let payload_guard = self.storage.payload_storage.read();
+        let guards = MatchStorageGuards {
+            metric,
+            vector_guard: &vector_guard,
+            payload_guard: &payload_guard,
+        };
+        self.execute_match_with_guards(match_clause, params, ctx, &guards)
+    }
+
+    /// Guard-accepting MATCH execution: the body of
+    /// [`Self::execute_match_with_context`], for callers that already hold the
+    /// storage guards in decree order and must not re-acquire them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query cannot be executed or a guard-rail is violated.
+    pub(in crate::collection::search::query) fn execute_match_with_guards(
+        &self,
+        match_clause: &MatchClause,
+        params: &HashMap<String, serde_json::Value>,
+        ctx: Option<&QueryContext>,
+        guards: &MatchStorageGuards<'_>,
     ) -> Result<Vec<MatchResult>> {
         if match_clause.patterns.is_empty() {
             return Err(Error::Query(
@@ -265,9 +326,6 @@ impl Collection {
         let mut iteration_count: u32 = 0;
         let mut reported_cardinality: usize = 0;
 
-        // Hoist payload_storage lock once for the entire query.
-        let payload_guard = self.storage.payload_storage.read();
-
         for pattern in &match_clause.patterns {
             if all_results.len() >= limit {
                 break;
@@ -277,7 +335,7 @@ impl Collection {
                 match_clause,
                 params,
                 ctx,
-                &payload_guard,
+                guards,
                 &self.graph.edge_store,
                 limit,
                 &mut all_results,
@@ -310,14 +368,14 @@ impl Collection {
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
         ctx: Option<&QueryContext>,
-        payload_guard: &LogPayloadStorage,
+        guards: &MatchStorageGuards<'_>,
         edge_store: &crate::collection::graph::ConcurrentEdgeStore,
         limit: usize,
         all_results: &mut Vec<MatchResult>,
         iteration_count: &mut u32,
         reported_cardinality: &mut usize,
     ) -> Result<()> {
-        let start_nodes = self.find_start_nodes(pattern)?;
+        let start_nodes = self.find_start_nodes(pattern, guards)?;
         if start_nodes.is_empty() {
             return Ok(());
         }
@@ -337,7 +395,7 @@ impl Collection {
             let mut sn_ctx = SingleNodeCtx {
                 match_clause,
                 params,
-                payload_guard,
+                guards,
                 seen_pairs: &mut seen_pairs,
                 all_results,
                 limit,
@@ -349,7 +407,7 @@ impl Collection {
         let mut trav_ctx = TraversalCtx {
             match_clause,
             params,
-            payload_guard,
+            guards,
             guardrail: ctx,
             all_results,
             limit,
@@ -362,8 +420,8 @@ impl Collection {
 
     /// Collects results for single-node patterns (no relationships).
     ///
-    /// Uses the pre-acquired `payload_guard` from the context to avoid
-    /// per-node lock acquisitions.
+    /// Uses the pre-acquired guards from the context to avoid per-node lock
+    /// acquisitions.
     fn collect_single_node_results(
         &self,
         start_nodes: &[(u64, HashMap<String, u64>)],
@@ -384,7 +442,7 @@ impl Collection {
                     where_eval::EdgeAliasBindings::NONE,
                     where_clause,
                     ctx.params,
-                    ctx.payload_guard,
+                    ctx.guards,
                 )? {
                     continue;
                 }
@@ -401,7 +459,7 @@ impl Collection {
                 &HashMap::new(),
                 &HashMap::new(),
                 &ctx.match_clause.return_clause,
-                ctx.payload_guard,
+                ctx.guards.payload_guard,
             );
             ctx.all_results.push(result);
         }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -349,6 +349,15 @@ impl Collection {
             higher_is_better,
         )?;
 
+        // Release both guards BEFORE ordering: the ORDER BY paths
+        // (`order_by.rs`) acquire `config`, `vector_storage` and
+        // `payload_storage` themselves, so keeping these guards alive across
+        // `apply_match_order_by` would re-acquire locks this thread already
+        // holds — a deadlock as soon as one writer queues (parking_lot
+        // task-fair semantics) — and take `config` (rank 1) under ranks 2/3.
+        drop(vector_storage);
+        drop(payload_guard);
+
         Self::sort_by_score(&mut scored_results, higher_is_better);
 
         // A RETURN ORDER BY (when present) overrides the implicit score sort;

--- a/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
@@ -3,6 +3,7 @@
 //! Extracted from `match_exec/mod.rs` to reduce NLOC.
 //! Contains `find_start_nodes`, label/property matching, and pattern helpers.
 
+use super::MatchStorageGuards;
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::storage::{PayloadStorage, VectorStorage};
@@ -20,17 +21,20 @@ impl Collection {
     ///
     /// # Lock note
     ///
-    /// The caller (`execute_match_with_context`) already holds a
-    /// `payload_storage.read()` guard. This method (and its delegates
-    /// `find_start_nodes_indexed`, `find_start_nodes_full_scan`) may acquire
-    /// a second concurrent read lock on the same `payload_storage`. This is
-    /// safe because `parking_lot::RwLock` allows unlimited concurrent readers
-    /// with no poisoning or deadlock risk. Refactoring to pass the existing
-    /// guard down would require changing 4+ function signatures for minimal
-    /// runtime benefit (read locks are non-blocking).
+    /// `guards` carries the `vector_storage` (rank 2) and `payload_storage`
+    /// (rank 3) read guards acquired ONCE by the top frame in decree order
+    /// and passed down. This method and its delegates
+    /// (`find_start_nodes_indexed`, `find_start_nodes_full_scan`) must use
+    /// them and never re-acquire either lock: parking_lot's task-fair
+    /// `RwLock` blocks a second read acquisition on the same thread as soon
+    /// as one writer is queued, so a nested `payload_storage.read()` under
+    /// the already-held guard deadlocks against any concurrent writer (the
+    /// same rule `graph_api.rs::validate_edge_endpoints_exist` documents for
+    /// the edge-write path).
     pub(super) fn find_start_nodes(
         &self,
         pattern: &GraphPattern,
+        guards: &MatchStorageGuards<'_>,
     ) -> Result<Vec<(u64, HashMap<String, u64>)>> {
         let first_node = pattern
             .nodes
@@ -40,29 +44,29 @@ impl Collection {
         // Fast path: use label index when labels are specified.
         if !first_node.labels.is_empty() {
             let has_large = self.graph.label_index.read().has_large_ids();
-            let indexed = self.find_start_nodes_indexed(first_node);
+            let indexed = self.find_start_nodes_indexed(first_node, guards.payload_guard);
 
             if has_large {
                 // RoaringBitmap cannot index IDs > u32::MAX, so the bitmap
                 // result may be incomplete. Fall back to a full scan and
                 // merge the results to avoid silently missing large-ID nodes.
-                return Ok(self.merge_with_full_scan(indexed, first_node));
+                return Ok(Self::merge_with_full_scan(indexed, first_node, guards));
             }
             return Ok(indexed);
         }
 
         // Slow path: full scan (no labels in pattern).
-        Ok(self.find_start_nodes_full_scan(first_node))
+        Ok(Self::find_start_nodes_full_scan(first_node, guards))
     }
 
     /// Merges indexed bitmap results with a full scan to capture nodes whose
     /// IDs exceed `u32::MAX` (not representable in `RoaringBitmap`).
     fn merge_with_full_scan(
-        &self,
         indexed: Vec<(u64, HashMap<String, u64>)>,
         first_node: &crate::velesql::NodePattern,
+        guards: &MatchStorageGuards<'_>,
     ) -> Vec<(u64, HashMap<String, u64>)> {
-        let full = self.find_start_nodes_full_scan(first_node);
+        let full = Self::find_start_nodes_full_scan(first_node, guards);
         if indexed.is_empty() {
             return full;
         }
@@ -77,9 +81,13 @@ impl Collection {
     }
 
     /// O(k) label-indexed lookup for start nodes.
+    ///
+    /// Uses the caller's hoisted `payload_guard` — never re-acquires the
+    /// payload lock (see the lock note on [`Self::find_start_nodes`]).
     fn find_start_nodes_indexed(
         &self,
         first_node: &crate::velesql::NodePattern,
+        payload_guard: &crate::storage::LogPayloadStorage,
     ) -> Vec<(u64, HashMap<String, u64>)> {
         let label_idx = self.graph.label_index.read();
         let bitmap = label_idx.lookup_intersection(&first_node.labels);
@@ -96,14 +104,13 @@ impl Collection {
                 .collect();
         }
 
-        let payload_storage = self.storage.payload_storage.read();
         bitmap
             .iter()
             .filter(|&id| {
                 Self::node_matches_properties_by_id(
                     u64::from(id),
                     &first_node.properties,
-                    &payload_storage,
+                    payload_guard,
                 )
             })
             .map(|id| Self::build_start_binding(u64::from(id), first_node))
@@ -111,26 +118,26 @@ impl Collection {
     }
 
     /// O(N) full scan fallback for start nodes (no labels, or large-ID fallback).
+    ///
+    /// Reads only through the hoisted guards — never re-acquires
+    /// `vector_storage` or `payload_storage` (see the lock note on
+    /// [`Self::find_start_nodes`]).
     fn find_start_nodes_full_scan(
-        &self,
         first_node: &crate::velesql::NodePattern,
+        guards: &MatchStorageGuards<'_>,
     ) -> Vec<(u64, HashMap<String, u64>)> {
-        // LOCK ORDER: vector_storage(2) before payload_storage(3) — was
-        // reversed here. See .investigation/http-deadlock-2026-07-22/.
-        let vector_storage = self.storage.vector_storage.read();
-        let payload_storage = self.storage.payload_storage.read();
         let needs_payload = !first_node.properties.is_empty() || !first_node.labels.is_empty();
 
         let mut all_ids: std::collections::HashSet<u64> =
-            vector_storage.ids().into_iter().collect();
-        for id in payload_storage.ids() {
+            guards.vector_guard.ids().into_iter().collect();
+        for id in guards.payload_guard.ids() {
             all_ids.insert(id);
         }
 
         all_ids
             .into_iter()
             .filter(|id| {
-                Self::node_matches_pattern(*id, first_node, needs_payload, &payload_storage)
+                Self::node_matches_pattern(*id, first_node, needs_payload, guards.payload_guard)
             })
             .map(|id| Self::build_start_binding(id, first_node))
             .collect()

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -15,7 +15,7 @@
 #![allow(clippy::cast_precision_loss)]
 
 use super::where_eval::resolve_query_vector;
-use super::MatchResult;
+use super::{MatchResult, MatchStorageGuards};
 use crate::collection::graph::{concurrent_bfs_stream, StreamingConfig};
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
@@ -53,9 +53,11 @@ impl Collection {
 
         let candidates = self.search(&query_vector, top_k)?;
 
-        let config = self.storage.config.read();
-        let higher_is_better = config.metric.higher_is_better();
-        drop(config);
+        // Metric snapshot (config, rank 1) — also reused by
+        // `filter_candidates_by_graph` for its guard bundle, so the rank-1
+        // lock is never taken under the storage guards.
+        let metric = self.storage.config.read().metric;
+        let higher_is_better = metric.higher_is_better();
 
         let above_threshold: Vec<_> = candidates
             .into_iter()
@@ -68,18 +70,16 @@ impl Collection {
             .and_then(|l| usize::try_from(l).ok())
             .unwrap_or(100);
 
-        self.filter_candidates_by_graph(
-            &above_threshold,
-            match_clause,
-            params,
-            ctx,
-            limit,
-            higher_is_better,
-        )
+        self.filter_candidates_by_graph(&above_threshold, match_clause, params, ctx, limit, metric)
     }
 
     /// Validates each vector candidate against the graph pattern and builds
     /// `MatchResult` entries for those that pass.
+    ///
+    /// Hoists both storage guards once, in decree order — `vector_storage`
+    /// (2) before `payload_storage` (3) — and passes them down so WHERE
+    /// evaluation (including similarity re-checks) never re-acquires a
+    /// storage lock under them.
     fn filter_candidates_by_graph(
         &self,
         candidates: &[crate::point::SearchResult],
@@ -87,9 +87,15 @@ impl Collection {
         params: &HashMap<String, serde_json::Value>,
         ctx: &QueryContext,
         limit: usize,
-        higher_is_better: bool,
+        metric: crate::distance::DistanceMetric,
     ) -> Result<Vec<MatchResult>> {
+        let vector_guard = self.storage.vector_storage.read();
         let payload_guard = self.storage.payload_storage.read();
+        let guards = MatchStorageGuards {
+            metric,
+            vector_guard: &vector_guard,
+            payload_guard: &payload_guard,
+        };
         let mut results = Vec::new();
         let mut examined = 0u64;
 
@@ -102,7 +108,7 @@ impl Collection {
             examined += 1;
 
             if let Some(mr) =
-                self.try_match_candidate(candidate, match_clause, params, ctx, &payload_guard)?
+                self.try_match_candidate(candidate, match_clause, params, ctx, &guards)?
             {
                 results.push(mr);
             }
@@ -112,7 +118,7 @@ impl Collection {
         // nodes_visited (the per-candidate BFS adds the nodes/edges it reaches),
         // so EXPLAIN ANALYZE reports real traversal counts for this strategy too.
         ctx.add_traversal(examined, 0);
-        Self::sort_by_score(&mut results, higher_is_better);
+        Self::sort_by_score(&mut results, metric.higher_is_better());
         Ok(results)
     }
 
@@ -125,28 +131,21 @@ impl Collection {
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
         ctx: &QueryContext,
-        payload_guard: &crate::storage::LogPayloadStorage,
+        guards: &MatchStorageGuards<'_>,
     ) -> Result<Option<MatchResult>> {
         let node_id = candidate.point.id;
         let Some(pattern) = match_clause.patterns.first() else {
             return Ok(None);
         };
 
-        if !self.candidate_matches_start_pattern(node_id, pattern, payload_guard) {
+        if !self.candidate_matches_start_pattern(node_id, pattern, guards.payload_guard) {
             return Ok(None);
         }
 
         let graph_ok = if pattern.relationships.is_empty() {
-            self.candidate_passes_where(node_id, match_clause, params, payload_guard, pattern)?
+            self.candidate_passes_where(node_id, match_clause, params, guards, pattern)?
         } else {
-            self.candidate_has_graph_path(
-                node_id,
-                match_clause,
-                params,
-                ctx,
-                payload_guard,
-                pattern,
-            )?
+            self.candidate_has_graph_path(node_id, match_clause, params, ctx, guards, pattern)?
         };
 
         if !graph_ok {
@@ -164,7 +163,7 @@ impl Collection {
             &mr.edge_paths,
             &match_clause.return_clause,
             Some(candidate.score),
-            payload_guard,
+            guards.payload_guard,
         );
         Ok(Some(mr))
     }
@@ -206,7 +205,7 @@ impl Collection {
         node_id: u64,
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
-        payload_guard: &crate::storage::LogPayloadStorage,
+        guards: &MatchStorageGuards<'_>,
         pattern: &crate::velesql::GraphPattern,
     ) -> Result<bool> {
         let non_sim = strip_similarity_from_where(match_clause.where_clause.as_ref());
@@ -222,7 +221,7 @@ impl Collection {
                 super::where_eval::EdgeAliasBindings::NONE,
                 cond,
                 params,
-                payload_guard,
+                guards,
             )
         } else {
             Ok(true)
@@ -241,7 +240,7 @@ impl Collection {
         match_clause: &MatchClause,
         params: &HashMap<String, serde_json::Value>,
         ctx: &QueryContext,
-        payload_guard: &crate::storage::LogPayloadStorage,
+        guards: &MatchStorageGuards<'_>,
         pattern: &crate::velesql::GraphPattern,
     ) -> Result<bool> {
         let max_depth = Self::compute_max_depth(pattern);
@@ -274,7 +273,7 @@ impl Collection {
                     super::where_eval::EdgeAliasBindings::NONE,
                     cond,
                     params,
-                    payload_guard,
+                    guards,
                 )? {
                     return Ok(true);
                 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -4,11 +4,12 @@
 //! Fix #492: metadata conditions (IN, BETWEEN, LIKE, IS NULL) are now evaluated
 //! against node payloads instead of being silently ignored by a catch-all arm.
 
+use super::MatchStorageGuards;
 use crate::collection::graph::GraphEdge;
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::filter;
-use crate::storage::{LogPayloadStorage, PayloadStorage, VectorStorage};
+use crate::storage::{PayloadStorage, VectorStorage};
 use std::collections::HashMap;
 
 /// Applies an ordering comparison operator to an `Ord` pair.
@@ -134,7 +135,9 @@ struct MatchWhereCtx<'a> {
     /// when at least one traversed edge satisfies it.
     edge_paths: Option<&'a HashMap<String, Vec<u64>>>,
     params: &'a HashMap<String, serde_json::Value>,
-    payload_guard: &'a LogPayloadStorage,
+    /// Hoisted storage guards (decree order) from the top MATCH frame; WHERE
+    /// evaluation reads through them and never re-acquires a storage lock.
+    guards: &'a MatchStorageGuards<'a>,
 }
 
 impl MatchWhereCtx<'_> {
@@ -168,22 +171,24 @@ impl Collection {
     /// conditions (IN, BETWEEN, LIKE, ILIKE, IS NULL, IS NOT NULL, MATCH).
     /// Parameters are resolved from the `params` map.
     ///
-    /// The caller must pass a pre-acquired `payload_guard` to avoid
-    /// per-node lock acquisitions during BFS traversal.
+    /// The caller must pass the pre-acquired storage `guards` (hoisted once
+    /// at the top MATCH frame in decree order) to avoid per-node lock
+    /// acquisitions during BFS traversal — and because re-acquiring a lock
+    /// whose guard is already held deadlocks once a writer queues.
     ///
     /// Fix #492: metadata conditions are now evaluated via the filter engine
     /// instead of being silently ignored by a catch-all arm.
     ///
     /// `edge_bindings` maps relationship aliases to traversed edge ids so
     /// `r.prop` resolves against the EDGE's properties (audit 2026-06 F).
-    pub(crate) fn evaluate_where_condition(
+    pub(in crate::collection::search::query) fn evaluate_where_condition(
         &self,
         node_id: u64,
         bindings: Option<&HashMap<String, u64>>,
         edges: EdgeAliasBindings<'_>,
         condition: &crate::velesql::Condition,
         params: &HashMap<String, serde_json::Value>,
-        payload_guard: &LogPayloadStorage,
+        guards: &MatchStorageGuards<'_>,
     ) -> Result<bool> {
         let ctx = MatchWhereCtx {
             node_id,
@@ -191,7 +196,7 @@ impl Collection {
             edge_bindings: edges.scalar,
             edge_paths: edges.paths,
             params,
-            payload_guard,
+            guards,
         };
         self.eval_match_condition(&ctx, condition)
     }
@@ -216,7 +221,7 @@ impl Collection {
                 // score is computed on the aliased node, not the traversal
                 // target. Unbound/bare fields keep the previous behaviour.
                 let target_id = resolve_target_id(&sim.field, ctx.bindings, ctx.node_id);
-                self.evaluate_similarity_condition(target_id, sim, ctx.params)
+                Self::evaluate_similarity_condition(target_id, sim, ctx.params, ctx.guards)
             }
             // Fix #492: metadata conditions converted to filter engine evaluation.
             Condition::In(_)
@@ -284,7 +289,8 @@ impl Collection {
 
         let target_id = resolve_target_id(&cmp.column, ctx.bindings, ctx.node_id);
 
-        let Some(target_payload) = ctx.payload_guard.retrieve(target_id).ok().flatten() else {
+        let Some(target_payload) = ctx.guards.payload_guard.retrieve(target_id).ok().flatten()
+        else {
             return Ok(false);
         };
 
@@ -347,7 +353,7 @@ impl Collection {
             resolve_target_id(col, ctx.bindings, ctx.node_id)
         });
 
-        let Some(payload) = ctx.payload_guard.retrieve(target_id).ok().flatten() else {
+        let Some(payload) = ctx.guards.payload_guard.retrieve(target_id).ok().flatten() else {
             return Ok(false);
         };
 
@@ -407,19 +413,24 @@ impl Collection {
     }
 
     /// Evaluates a similarity condition against a node's vector (EPIC-052 US-007).
+    ///
+    /// Reads the node vector through the hoisted `vector_guard` and the
+    /// metric from the config snapshot taken BEFORE the guards — this frame
+    /// runs under the rank-2/rank-3 guards, so acquiring `vector_storage`
+    /// or `config` here would either deadlock (nested re-acquisition with a
+    /// queued writer) or invert the decreed lock order.
     fn evaluate_similarity_condition(
-        &self,
         node_id: u64,
         sim: &crate::velesql::SimilarityCondition,
         params: &HashMap<String, serde_json::Value>,
+        guards: &MatchStorageGuards<'_>,
     ) -> Result<bool> {
         let query_vector = resolve_query_vector(&sim.vector, params)?;
         if query_vector.is_empty() {
             return Ok(false);
         }
 
-        let vector_storage = self.storage.vector_storage.read();
-        let Some(node_vector) = vector_storage.retrieve(node_id)? else {
+        let Some(node_vector) = guards.vector_guard.retrieve(node_id)? else {
             return Ok(false);
         };
 
@@ -427,10 +438,8 @@ impl Collection {
             return Ok(false);
         }
 
-        let config = self.storage.config.read();
-        let metric = config.metric;
+        let metric = guards.metric;
         let higher_is_better = metric.higher_is_better();
-        drop(config);
 
         let score = metric.calculate(&node_vector, &query_vector);
 

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -3,6 +3,7 @@
 //! This module is used when a query includes graph predicates (`MATCH (...)`)
 //! inside SELECT WHERE so boolean semantics are preserved for AND/OR/NOT.
 
+use super::match_exec::MatchStorageGuards;
 use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
@@ -24,18 +25,24 @@ pub(crate) struct GraphMatchEvalCache {
 }
 
 impl GraphMatchEvalCache {
+    /// `guards`: pass `Some` when the caller already holds the storage
+    /// guards (vector then payload, decree order) so the nested MATCH
+    /// traversal reuses them instead of re-acquiring the locks; `None`
+    /// otherwise (the traversal then acquires its own guards).
     pub(super) fn get_or_compute(
         &mut self,
         collection: &Collection,
         predicate: &GraphMatchPredicate,
         params: &std::collections::HashMap<String, serde_json::Value>,
         from_aliases: &[String],
+        guards: Option<&MatchStorageGuards<'_>>,
     ) -> Result<&HashSet<u64>> {
         if let Some(idx) = self.entries.iter().position(|(p, _)| p == predicate) {
             return Ok(&self.entries[idx].1);
         }
 
-        let ids = collection.evaluate_graph_match_anchor_ids(predicate, params, from_aliases)?;
+        let ids =
+            collection.evaluate_graph_match_anchor_ids(predicate, params, from_aliases, guards)?;
         self.entries.push((predicate.clone(), ids));
         let entry_idx = self.entries.len() - 1;
         Ok(&self.entries[entry_idx].1)
@@ -70,6 +77,9 @@ struct WhereEvalCtx<'a> {
     vector: Option<&'a [f32]>,
     params: &'a std::collections::HashMap<String, serde_json::Value>,
     from_aliases: &'a [String],
+    /// Storage guards already held by the caller (decree order), forwarded to
+    /// nested MATCH-in-WHERE traversals so they never re-acquire the locks.
+    guards: Option<&'a MatchStorageGuards<'a>>,
 }
 
 impl Collection {
@@ -161,6 +171,7 @@ impl Collection {
                 params,
                 from_aliases,
                 cache,
+                None,
             )? {
                 filtered.push(result);
             }
@@ -170,8 +181,13 @@ impl Collection {
     }
 
     /// Evaluate WHERE condition for one record.
+    ///
+    /// `guards`: `Some` when the caller already holds the storage guards in
+    /// decree order (aggregation scan loops) — forwarded so a nested
+    /// MATCH-in-WHERE traversal reuses them instead of re-acquiring the
+    /// locks; `None` when no storage guard is held.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn evaluate_where_condition_for_record(
+    pub(in crate::collection::search::query) fn evaluate_where_condition_for_record(
         &self,
         condition: &Condition,
         id: u64,
@@ -180,6 +196,7 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
         from_aliases: &[String],
         graph_cache: &mut GraphMatchEvalCache,
+        guards: Option<&MatchStorageGuards<'_>>,
     ) -> Result<bool> {
         let ctx = WhereEvalCtx {
             id,
@@ -187,6 +204,7 @@ impl Collection {
             vector,
             params,
             from_aliases,
+            guards,
         };
         self.eval_condition(condition, &ctx, graph_cache)
     }
@@ -200,8 +218,13 @@ impl Collection {
     ) -> Result<bool> {
         match condition {
             Condition::GraphMatch(predicate) => {
-                let ids =
-                    graph_cache.get_or_compute(self, predicate, ctx.params, ctx.from_aliases)?;
+                let ids = graph_cache.get_or_compute(
+                    self,
+                    predicate,
+                    ctx.params,
+                    ctx.from_aliases,
+                    ctx.guards,
+                )?;
                 Ok(ids.contains(&ctx.id))
             }
             Condition::And(left, right) => {

--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
@@ -19,10 +19,16 @@
 //!
 //! # Release Build Behavior (F-25)
 //!
-//! In release builds, lock-rank tracking is a no-op for maximum
-//! search throughput. Only the atomic violation counter is incremented
-//! (no thread-local stack overhead). In debug builds, full stack-based
-//! tracking with tracing warnings is enabled.
+//! In release builds, lock-rank tracking is a complete no-op for maximum
+//! search throughput: `record_lock_acquire`/`record_lock_release` discard the
+//! rank and touch nothing — no thread-local stack, and (contrary to an earlier
+//! version of this note) no atomic counter either. The violation counter is
+//! incremented **only** inside the `#[cfg(debug_assertions)]` block. In debug
+//! builds, full stack-based tracking is enabled, but it only *warns* via
+//! `tracing::warn!` — it never panics — and only for the ranks that actually
+//! have a `record_lock_acquire` call site (`GpuVectorsSnapshot`, `Vectors`,
+//! `Layers`; `Columnar` and `Neighbors` are `#[allow(dead_code)]` and never
+//! recorded).
 //!
 //! # Higher-level synchronization layered on top of these ranks
 //!

--- a/crates/velesdb-core/src/storage/guard.rs
+++ b/crates/velesdb-core/src/storage/guard.rs
@@ -77,6 +77,9 @@ pub struct VectorSliceGuard<'a> {
 // - Condition 1: `_guard` pins the mapping and prevents concurrent remap mutation.
 // - Condition 2: Epoch checks reject stale pointers after remap.
 // SAFETY: Transferring read-only guard ownership across threads preserves invariants.
+// SAFETY: sound only while parking_lot's `deadlock_detection`/`send_guard` features
+// stay off — moving a guard across threads corrupts the detector's per-thread
+// bookkeeping; do not enable those features without revisiting this impl.
 unsafe impl Send for VectorSliceGuard<'_> {}
 #[allow(clippy::non_send_fields_in_send_ty)]
 // SAFETY: `VectorSliceGuard` is `Sync` because shared access is immutable.

--- a/crates/velesdb-core/tests/tokio_blocking_lock_contention_repro.rs
+++ b/crates/velesdb-core/tests/tokio_blocking_lock_contention_repro.rs
@@ -301,3 +301,112 @@ async fn concurrent_spawn_blocking_semantic_memory_store_and_query_within_bound(
     assert_eq!(stores_completed.load(Ordering::SeqCst), 20);
     assert_eq!(queries_completed.load(Ordering::SeqCst), 10);
 }
+
+/// Regression guard for the MATCH-path deadlocks fixed in the 2026-08 lock
+/// audit (`match_exec`): the query used to hoist `payload_storage.read()`
+/// (rank 3) for the whole traversal and, UNDER that guard, both re-acquire
+/// `payload_storage.read()` (`find_start_nodes` — re-entrant read that
+/// deadlocks 2 threads once a writer queues under `parking_lot`'s task-fair
+/// `RwLock`) and acquire `vector_storage.read()` (rank 2) in the label-less
+/// full scan and per-candidate similarity evaluation — an effective 3→2
+/// order that ABBAs against `delete()`'s decreed `vector.write()` →
+/// `payload.write()` (rank 2 → 3) pair. Both storage guards are now hoisted
+/// once at the top MATCH frame in decree order and passed down.
+///
+/// The load shape: label-less MATCH with a similarity WHERE (full scan +
+/// per-node vector read) racing delete/upsert writers on one shared
+/// collection. Pre-fix this cycles; post-fix it must finish in the bound.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_match_full_scan_and_deletes_complete_within_bound() {
+    const DIMENSION: usize = 8;
+    const SEED_POINTS: u64 = 64;
+    let (collection, _tempdir) = open_collection("match_delete_repro", DIMENSION);
+
+    for i in 0..SEED_POINTS {
+        let payload = serde_json::json!({ "idx": i, "text": format!("node {i}") });
+        let point = Point::new(i, make_vector(DIMENSION, i), Some(payload));
+        collection.upsert(vec![point]).expect("seed upsert");
+    }
+
+    let clause = velesdb_core::velesql::Parser::parse(
+        "MATCH (n) WHERE similarity(n, $v) > 0.0 RETURN n LIMIT 5",
+    )
+    .expect("parse MATCH")
+    .match_clause
+    .expect("MATCH clause present");
+
+    let matches_completed = Arc::new(AtomicUsize::new(0));
+    let writes_completed = Arc::new(AtomicUsize::new(0));
+    let mut tasks = tokio::task::JoinSet::new();
+
+    for i in 0..10u64 {
+        let collection = Arc::clone(&collection);
+        let counter = Arc::clone(&matches_completed);
+        let clause = clause.clone();
+        tasks.spawn(async move {
+            tokio::task::spawn_blocking(move || {
+                let mut params = std::collections::HashMap::new();
+                params.insert(
+                    "v".to_string(),
+                    serde_json::json!(make_vector(DIMENSION, i)),
+                );
+                for _ in 0..25 {
+                    collection.execute_match(&clause, &params)?;
+                }
+                Ok::<_, velesdb_core::error::Error>(())
+            })
+            .await
+            .expect("match task must not panic")
+            .expect("match must succeed");
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+    }
+
+    for i in 0..6u64 {
+        let collection = Arc::clone(&collection);
+        let counter = Arc::clone(&writes_completed);
+        tasks.spawn(async move {
+            tokio::task::spawn_blocking(move || {
+                let id = i % SEED_POINTS;
+                for _ in 0..25 {
+                    collection.delete(&[id])?;
+                    let payload = serde_json::json!({ "idx": id, "text": format!("node {id}") });
+                    collection.upsert(vec![Point::new(
+                        id,
+                        make_vector(DIMENSION, id),
+                        Some(payload),
+                    )])?;
+                }
+                Ok::<_, velesdb_core::error::Error>(())
+            })
+            .await
+            .expect("writer task must not panic")
+            .expect("delete/upsert must succeed");
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+    }
+
+    let all = async {
+        while let Some(result) = tasks.join_next().await {
+            result.expect("spawned task must not panic");
+        }
+    };
+
+    let outcome = tokio::time::timeout(Duration::from_secs(30), all).await;
+
+    if outcome.is_err() {
+        // `process::exit`, not `panic!` — see the first test's comment on
+        // uncancellable `spawn_blocking` stragglers during runtime teardown.
+        print_to_real_stderr_before_exit(format!(
+            "HANG REPRODUCED (MATCH full-scan vs delete): 16 concurrent spawn_blocking \
+             MATCH/delete loops on a shared VectorCollection did not complete within 30s. \
+             Completed before timeout: {}/10 match loops, {}/6 writer loops.",
+            matches_completed.load(Ordering::SeqCst),
+            writes_completed.load(Ordering::SeqCst),
+        ));
+        std::process::exit(1);
+    }
+
+    assert_eq!(matches_completed.load(Ordering::SeqCst), 10);
+    assert_eq!(writes_completed.load(Ordering::SeqCst), 6);
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -609,6 +609,17 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let Ok(mut extraction) = extractor.extract_graph(fact) else {
             return;
         };
+        // Privacy invariant: autograph derives structure FROM a stored fact, so
+        // if the fact no longer exists, none of its derived structure may be
+        // created. With a background worker a job can sit queued for
+        // minutes-to-hours and its generation runs for tens of seconds, so a
+        // `forget` issued in between must win — a permanent deletion cannot be
+        // undone by a stale enrichment resurrecting the entity hubs. Re-check
+        // once the generation has returned, before any wiring: this closes the
+        // whole queue-plus-generation window, the common case, completely.
+        if !self.fact_exists(fact_id) {
+            return;
+        }
         crate::extract::orient_kinship(fact, &mut extraction.relations);
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64, String)> = HashSet::new();
@@ -619,8 +630,27 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         for extracted in &extraction.facts {
             let _ = self.wire_entities(fact_id, &extracted.entities, &mut entity_ids, &mut edges);
         }
+        // A concurrent `forget` can still race the wiring writes above between
+        // the first check and here. Re-check once more before the hub↔hub and
+        // attribute writes — neither of which references the source fact, so
+        // `ensure_exists` cannot catch a retired fact for them — leaving a
+        // residual window of a single already-committed generation, not the
+        // whole job.
+        if !self.fact_exists(fact_id) {
+            return;
+        }
         let _ = self.wire_relations(&extraction.relations, &mut entity_ids, &mut edges);
         let _ = self.wire_attributes(&extraction.attributes, &mut entity_ids);
+    }
+
+    /// Cheap "is this fact still stored?" probe gating [`Self::autograph`]'s
+    /// wiring: the same `store.get` existence check [`Self::forget`] and
+    /// [`Self::ensure_exists`] use. A store read error answers `false` —
+    /// autograph must never fabricate structure for a fact it cannot prove is
+    /// still there, and a missing (or unprovable) fact is a clean skip, never
+    /// an error on this deliberately-infallible path.
+    fn fact_exists(&self, fact_id: u64) -> bool {
+        matches!(self.store.get(fact_id), Ok(Some(_)))
     }
 
     /// Create each outgoing link from `fact_id`.

--- a/crates/velesdb-memory/tests/autograph_async_bdd.rs
+++ b/crates/velesdb-memory/tests/autograph_async_bdd.rs
@@ -190,6 +190,59 @@ fn a_full_queue_drops_counted_and_never_blocks_the_write() {
 }
 
 #[test]
+fn a_forgotten_fact_is_not_resurrected_by_its_stale_enrichment() {
+    // A queued enrichment can sit for minutes-to-hours and its generation runs
+    // for tens of seconds. If a `forget` lands in that window, the deletion is
+    // durable and cannot be undone — the stale job must NOT wire the entity
+    // hubs its extraction states, or `entity()` would serve structure derived
+    // from a fact the user permanently deleted.
+    let (_dir, svc, extractor, release) = gated_service();
+    let worker = svc
+        .spawn_autograph_worker(8)
+        .expect("spawn autograph worker");
+
+    // The write returns at once; the worker takes the job and BLOCKS in the
+    // gated generation, having wired nothing yet.
+    let fact_id = svc
+        .remember("Alice Martin travaille chez Wiscale.", &[], None)
+        .expect("remember");
+
+    // Forget while the generation is stuck behind the gate. The fact is gone
+    // and its (yet-unwired) hubs collect nothing — this is the permanent
+    // deletion the stale job must respect.
+    assert!(svc.forget(fact_id).expect("forget"), "the fact existed");
+
+    // Release the generation and drain: dropping the handle closes the queue
+    // and joins the worker, so the in-flight job's autograph has fully run (or
+    // been skipped) by the time the join returns — a controlled order, no
+    // wall-clock guess.
+    release.send(()).expect("release the gated extraction");
+    drop(worker);
+    assert_eq!(
+        extractor.calls.load(Ordering::SeqCst),
+        1,
+        "the released generation ran exactly once"
+    );
+
+    // The entity the retired fact would have introduced must not exist: a
+    // permanently forgotten fact cannot be resurrected through the graph.
+    assert!(
+        svc.entity_profile("alice martin")
+            .expect("entity lookup")
+            .is_none(),
+        "a stale enrichment resurrected the hubs of a forgotten fact — deletion \
+         must be durable, and autograph derives structure only from a fact that \
+         still exists"
+    );
+    assert!(
+        svc.entity_profile("wiscale")
+            .expect("entity lookup")
+            .is_none(),
+        "the second endpoint hub was resurrected too"
+    );
+}
+
+#[test]
 fn a_second_worker_is_refused_but_a_respawn_after_drop_works() {
     let (_dir, svc, extractor, release) = gated_service();
     let first = svc.spawn_autograph_worker(4).expect("first worker");

--- a/crates/velesdb-mobile/src/graph.rs
+++ b/crates/velesdb-mobile/src/graph.rs
@@ -135,11 +135,22 @@ impl MobileGraphStore {
 
     /// Persists the current nodes and edges to `path` as JSON so the graph
     /// survives an app restart (the store is otherwise in-memory only).
+    ///
+    /// # Lock Order
+    ///
+    /// Acquires and RELEASES each read guard in turn — `edges` first, then
+    /// `nodes` — so no two of this store's locks are ever held at once. The
+    /// earlier form built the snapshot in one struct literal, whose temporary
+    /// guards both lived to the end of the statement, taking `nodes` then
+    /// `edges` — the exact reverse of the `edges → outgoing → incoming → nodes`
+    /// order every mutator uses (`add_edge`, `remove_node`, `clear`). A
+    /// concurrent `save`/`remove_node` from two UniFFI-called threads was a
+    /// textbook ABBA deadlock; holding at most one lock here cannot deadlock
+    /// against any acquisition order.
     pub fn save(&self, path: String) -> Result<(), crate::VelesError> {
-        let snapshot = GraphSnapshot {
-            nodes: self.nodes.read().values().cloned().collect(),
-            edges: self.edges.read().values().cloned().collect(),
-        };
+        let edges: Vec<MobileGraphEdge> = self.edges.read().values().cloned().collect();
+        let nodes: Vec<MobileGraphNode> = self.nodes.read().values().cloned().collect();
+        let snapshot = GraphSnapshot { nodes, edges };
         let bytes = serde_json::to_vec(&snapshot)
             .map_err(|e| crate::VelesError::database(format!("Graph serialize failed: {e}")))?;
         std::fs::write(&path, bytes)
@@ -765,5 +776,68 @@ mod tests {
 
         assert_eq!(store.node_count(), 0);
         assert_eq!(store.edge_count(), 0);
+    }
+
+    /// Regression: `save()` must never deadlock against a concurrent mutator.
+    ///
+    /// `save()` used to take `nodes` then `edges` (the reverse of every
+    /// mutator's `edges → … → nodes`), so a `save` on one UniFFI-called thread
+    /// racing a `remove_node`/`clear` on another was an ABBA deadlock with no
+    /// recovery. This runs both in tight loops from two threads and fails via a
+    /// watchdog if they lock up. On the pre-fix code the workers wedge and the
+    /// `recv_timeout` elapses; on the fixed code (save holds one lock at a
+    /// time) it completes in well under the timeout.
+    #[test]
+    fn save_never_deadlocks_against_concurrent_mutation() {
+        use std::sync::mpsc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("g.json").to_string_lossy().into_owned();
+        let store = store_with_nodes(8);
+        for i in 0..7 {
+            let _ = store.add_edge(knows_edge(1000 + i, i + 1, i + 2));
+        }
+
+        let iters = 2_000;
+        let (done_tx, done_rx) = mpsc::channel::<()>();
+
+        let saver = {
+            let store = Arc::clone(&store);
+            let path = path.clone();
+            let done_tx = done_tx.clone();
+            std::thread::spawn(move || {
+                for _ in 0..iters {
+                    let _ = store.save(path.clone());
+                }
+                let _ = done_tx.send(());
+            })
+        };
+        let mutator = {
+            let store = Arc::clone(&store);
+            std::thread::spawn(move || {
+                for i in 0..iters {
+                    // Alternate the two mutators that take edges→…→nodes, the
+                    // order save() used to invert.
+                    if i % 2 == 0 {
+                        store.remove_node(((i % 8) + 1) as u64);
+                        store.add_node(person_node(((i % 8) + 1) as u64));
+                    } else {
+                        store.clear();
+                        store.add_node(person_node(1));
+                    }
+                }
+                let _ = done_tx.send(());
+            })
+        };
+
+        // Both workers must report within the watchdog window or the locks
+        // deadlocked (parking_lot has no recovery — the threads never return).
+        for _ in 0..2 {
+            done_rx
+                .recv_timeout(std::time::Duration::from_secs(30))
+                .expect("save/mutation deadlocked: worker did not finish within 30s");
+        }
+        saver.join().unwrap();
+        mutator.join().unwrap();
     }
 }

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -112,14 +112,40 @@ When multiple locks are needed, acquire them in this order:
 
 ### Global Lock Order (HNSW + Storage)
 
-The rank ordinals below are **not a documentation-only convention**: they are
-first-class, typed ranks defined by the `LockRank` newtype in
-`crates/velesdb-core/src/lock_rank.rs`. `LockRank` derives a total ordering
-over its ordinals, and the debug-only `assert_lock_order` helper panics on any
-out-of-order acquisition in debug builds (compiling to nothing in release, so
-there is zero release overhead). This section is the **single authoritative
-record** of the total rank ordering; the code constants and this table are kept
-in lock-step and MUST NOT diverge.
+The rank ordinals below mirror the typed `LockRank` newtype defined in
+`crates/velesdb-core/src/lock_rank.rs`, which derives a total ordering over its
+ordinals. That newtype and its public `assert_lock_order` helper are a *typed
+vocabulary* for the intended order, **not a wired runtime check**:
+`assert_lock_order` has **zero production call sites** — it is exercised only by
+`lock_rank_tests.rs` and `tests/concurrency_lock_order.rs`. No production
+binary, debug or release, calls it, so it never fires on a real acquisition.
+
+Enforcement in practice, by build and by tier:
+
+- **Production (release) binaries have no runtime lock-order check at all.**
+  This is zero-overhead by design — no thread-local stack and no atomic on the
+  hot search path.
+- **The HNSW tier** has a debug-only, *warn-only*, *partial* tracker — a
+  private mechanism separate from `assert_lock_order`. The `record_lock_acquire`
+  function in
+  `crates/velesdb-core/src/index/hnsw/native/graph/locking.rs` is
+  `#[cfg(debug_assertions)]`; on an out-of-order acquisition it increments an
+  atomic violation counter and emits a `tracing::warn!` — it **never panics**.
+  It is also partial: only the `GpuVectorsSnapshot`, `Vectors`, and `Layers`
+  ranks are ever recorded. `Columnar` and `Neighbors` are `#[allow(dead_code)]`
+  with no `record_lock_acquire` call site, so 2 of the 5 core ranks are
+  untracked even in debug.
+- **The collection tier** — `Collection`'s own field order (`config`,
+  `vector_storage`, `payload_storage`, ...; the `=== LOCK ORDERING ===` block
+  in `crates/velesdb-core/src/collection/types.rs`, and the "Collection-level
+  lock order" section below) — is **convention-only, backed by no assertion of
+  any kind.** This is the tier whose vector/payload pair actually deadlocked
+  (2026-07); its lock-order correctness rests on code review plus the regression
+  tests, not on any runtime mechanism.
+
+The ordinal table below is the human-readable record of the intended order; it
+is not enforced by a compiled assertion at acquisition time. The code constants
+and this table are still kept in lock-step and MUST NOT diverge.
 
 For HNSW index operations that touch the GPU snapshot cache, vector storage,
 the PDX columnar layout, graph layers, and neighbor lists, the global lock
@@ -139,9 +165,12 @@ gpu_vectors_snapshot (rank 5) → vectors (rank 10) → columnar (rank 15)
 | `neighbors` | 30 | `LockRank::NEIGHBORS` | Per-node neighbor lists (`RwLock`) | Fine-grained, acquired last |
 
 **Rule**: Never acquire a lower-rank lock while holding a higher-rank lock.
-For example, acquiring `vectors` while holding `neighbors` is forbidden.
-`assert_lock_order(previously_held, about_to_acquire)` encodes this rule
-directly and fires a debug assertion when it is violated.
+For example, acquiring `vectors` while holding `neighbors` is forbidden. The
+typed `assert_lock_order(previously_held, about_to_acquire)` helper *expresses*
+this rule but is **not wired into any acquisition path** (see the enforcement
+note above). In debug builds the HNSW tier's `record_lock_acquire` will *warn*
+(never panic) on a violation — and only among the tracked ranks
+(`GpuVectorsSnapshot` / `Vectors` / `Layers`).
 
 ### Reserved Premium Rank Range [40, 59]
 
@@ -399,13 +428,32 @@ falling back to per-shard lookup — debouncing trades a slightly slower fallbac
 read for avoiding a full rebuild on every interleaved read/write. A completed
 rebuild clears the dirty flag and resets the counter to 0.
 
-**Thread safety** (ConcurrentEdgeStore): The snapshot is stored under the
-same `RwLock` as the shard data. A read lock on the snapshot shard is
-sufficient for BFS access. Write operations acquire write locks and
-invalidate the snapshot as part of the same critical section. The deferred
-rebuild path acquires `edge_ids` **read-only** (never write) and releases
-per-shard read locks promptly, so it never violates the `edge_ids → shards`
-ordering and the caller must not hold an `edge_ids` write lock across it.
+**Thread safety** (ConcurrentEdgeStore): The read snapshot is **not** stored
+under the shard `RwLock`s. It lives in a lock-free `ArcSwap<CsrSnapshot>`
+(`csr_snapshot`) paired with an `AtomicBool` dirty flag (`csr_dirty`) and an
+`AtomicU64` write counter (`pending_writes`). Readers `load()` the current
+`Arc<CsrSnapshot>` with zero contention. Every mutation (`add_edge`,
+`remove_edge`, `remove_node_edges`) sets `csr_dirty` and bumps `pending_writes`;
+the rebuild is deferred (issue #905 debounce) and `store`s a fresh snapshot into
+the `ArcSwap`. Two rebuild paths clear the dirty flag under different
+guarantees, and both are correct:
+
+- `build_read_snapshot()` (`snapshot.rs`) holds `edge_ids.read()` for the whole
+  build **and across the flag clear** — it walks every edge under that one read
+  guard, `store`s the snapshot, and only afterwards resets `pending_writes` to 0
+  and clears `csr_dirty`, all while still holding the guard. No writer can
+  interleave, so a blanket reset is sound.
+- `ensure_csr_fresh()` (`query.rs`) holds **no** such lock. It therefore *clears
+  the dirty flag first* (`csr_dirty.swap(false, AcqRel)`), snapshots the observed
+  `pending_writes` **before** reading the shards, rebuilds, then subtracts only
+  that observed count (`fetch_update` with `saturating_sub`). A concurrent
+  `fetch_add` landing during the rebuild is preserved rather than clobbered, so
+  the next reader still observes the snapshot as due for rebuild.
+
+The deferred rebuild path acquires `edge_ids` **read-only** (never write) and
+releases per-shard read locks promptly, so it never violates the
+`edge_ids → shards` ordering and the caller must not hold an `edge_ids` write
+lock across it.
 
 ## Performance vs Safety Tradeoffs
 
@@ -888,4 +936,4 @@ invariants, see [SOUNDNESS.md: HNSW Batch Insertion Ordering](SOUNDNESS.md#hnsw-
 
 ---
 
-*Last updated: 2026-06-12 · Applies to: velesdb-core 4.3.0 (previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*
+*Last updated: 2026-08-09 · Applies to: velesdb-core 4.3.0 (this revision: corrected the lock-order enforcement section — `assert_lock_order` is unwired in production, the HNSW tracker is debug-only, warn-only and partial, the collection tier is convention-only — and the CSR snapshot thread-safety section to describe the lock-free `ArcSwap` + dirty-flag protocol; previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -385,6 +385,60 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 
 ---
 
+## 7. Lock-order enforcement — typed `LockRank` unwired, collection tier comment-only
+
+**Outcome**: **Wired in a future velesdb-core sprint** (enforcement mechanism;
+correctness itself holds today via review + regression tests).
+
+**What exists**:
+- `crates/velesdb-core/src/lock_rank.rs` defines a public `LockRank` newtype
+  with a total ordering and a debug-only `assert_lock_order(previously_held,
+  about_to_acquire)` helper that `debug_assert!`s ascending acquisition.
+- `crates/velesdb-core/src/index/hnsw/native/graph/locking.rs` defines a
+  *separate*, private `record_lock_acquire`/`record_lock_release` pair (its own
+  `LockRank` enum) that tracks a per-thread rank stack in debug builds.
+- `crates/velesdb-core/src/collection/types.rs` carries a plain-comment
+  `=== LOCK ORDERING ===` block enumerating the collection-tier order
+  (positions 1, 1b, 2, 3, 3b, 4–12).
+
+**What is missing**:
+- The public `assert_lock_order` has **zero production call sites** — it is
+  referenced only by `lock_rank_tests.rs` and
+  `tests/concurrency_lock_order.rs`. No production path, debug or release,
+  invokes it.
+- The HNSW `record_lock_acquire` tracker is **debug-only and warn-only**: on a
+  violation it increments an atomic counter and emits `tracing::warn!`, never
+  panics. It is also **partial** — only `GpuVectorsSnapshot`, `Vectors`, and
+  `Layers` are recorded; `Columnar` and `Neighbors` are `#[allow(dead_code)]`
+  and never recorded (2 of 5 core ranks dead).
+- The **collection tier** (the one that deadlocked in 2026-07) is
+  **comment-enforced only** — no typed rank, no assertion of any kind guards it.
+
+**Why wiring is non-trivial**:
+- The two rank vocabularies (`lock_rank.rs::LockRank` and the HNSW
+  `locking.rs::LockRank`) are disjoint and cover different lock sets; unifying
+  them and threading `assert_lock_order` through every acquisition site touches
+  the hot search path, where F-25 deliberately removed per-acquire overhead in
+  release builds.
+- The collection tier has no lock-guard wrapper to hook an assertion into;
+  adding one means intercepting every `RwLock`/`Mutex` acquisition on
+  `Collection` fields across ~25 files.
+
+**Current behavior / coverage**: the 2↔3 (vector/payload) pair is
+regression-pinned by the tokio repro tests and the new MATCH deadlock tests;
+positions 1, 1b, 3b, 4–12 are unpinned. Release binaries carry no runtime
+lock-order check at all (zero-overhead by design). See
+`docs/CONCURRENCY_MODEL.md` ("Global Lock Order" and "Collection-level lock
+order") for the full narrative.
+
+**Future action**: scope a mechanism that either (a) wires a unified typed rank
+through a lock-guard wrapper with a debug-only assertion covering both the HNSW
+and collection tiers, or (b) records the decision to keep enforcement at
+review + regression-test level and removes the unwired `assert_lock_order` to
+avoid implying a guarantee that does not exist. Community-scope.
+
+---
+
 ## Summary table
 
 | Config | Wired? | Outcome | Effort | Target |
@@ -395,6 +449,7 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 | `SearchConfig` global defaults | Partial | Consolidation cleanup | 1-2 commits | Community (future sprint) |
 | `LimitsConfig` (5/5 fields) | Yes | Wired — all 5 fields enforced (creation + runtime ingest/search caps) 2026-06-14 | done | Community |
 | Binding API-parity gaps (6.1–6.11) | DONE | Closed via 4 PRs #1096/#1098/#1099 + consistency (6.11 = verified no-gap); see §6 | 4 PRs (embedded-ops / ops-observability / recall-gated / consistency) | Community |
+| Lock-order enforcement (`LockRank`/`assert_lock_order`) | No | Wire a debug-only assertion or record review+tests as the mechanism | Unscoped | Community (future sprint) |
 
 ## Conventions
 
@@ -407,6 +462,7 @@ consistency-cleanup PR. Each binding glue must pass that crate's CI line
 
 ---
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 4.3.0 (this stamp tracks
-the document revision; the inventory itself was last re-verified against the
-code on 2026-06-14, as stated at the top of this page)*
+*Last updated: 2026-08-09 · Applies to: velesdb-core 4.3.0 (this stamp tracks
+the document revision; this revision adds entry 7, lock-order enforcement debt.
+The rest of the inventory was last re-verified against the code on 2026-06-14,
+as stated at the top of this page)*

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -636,6 +636,17 @@ unsafe impl Send for VectorSliceGuard<'_> {}
 unsafe impl Sync for VectorSliceGuard<'_> {}
 ```
 
+**Additional invariant — `parking_lot` features must stay off**: the `Send`
+impl moves a `parking_lot::RwLockReadGuard<'a, MmapMut>` across threads. This is
+sound **only** because the workspace enables no `parking_lot` features. With
+`deadlock_detection` or `send_guard` enabled, a `RwLockReadGuard` carries
+per-thread bookkeeping that is corrupted when the guard is released on a thread
+other than the one that acquired it. Do not enable either feature without
+revisiting this impl. (Verified: no `Cargo.toml` in the workspace enables a
+`parking_lot` feature — every dependant pins the bare `parking_lot = "0.12"` /
+version-only form, and `velesdb-core`'s `[dependencies.parking_lot]` table
+declares `version` only.)
+
 ---
 
 ## Pointer Operations
@@ -1051,6 +1062,7 @@ let data_as_bytes: &mut [u8] = unsafe {
 
 ---
 
-*Last updated: 2026-08-08 · Applies to: velesdb-core 4.3.0 (this stamp tracks
-the document revision; the underlying unsafe audit was last run in full on
+*Last updated: 2026-08-09 · Applies to: velesdb-core 4.3.0 (this stamp tracks
+the document revision; this revision adds the `parking_lot`-features invariant to
+the `VectorSliceGuard` entry. The underlying unsafe audit was last run in full on
 2026-06-12, as stated at the top of this page)*


### PR DESCRIPTION
## Description

Pre-5.0.0 concurrency audit (6 specialist passes + adversarial re-verification of every deadlock-class claim). Four findings survived refutation as blockers; each is fixed at the root — killing the mechanism, not patching the symptom — and pinned by a deterministic regression test proved red-first. Two other claims (a CSR "lost-update" and a config-inversion cycle) were **refuted** in verification and are not in this PR; the config one-liners were tidied anyway as a latent-order cleanup.

**1 — `MobileGraphStore::save()` ABBA deadlock** (`fix(mobile)`). `save()` built its snapshot in one struct literal whose two temporary read guards both lived to the statement's end — taking `nodes` then `edges`, the reverse of every mutator's `edges → outgoing → incoming → nodes`. A `save` racing a `remove_node`/`clear` from two UniFFI-called threads was an unrecoverable ANR. `save()` is a read-only snapshot with no need to hold two locks; it now reads edges, then nodes, each guard released before the next. Red-first: the pre-fix form fails the 30s watchdog at 30.36s, the fix passes in 0.10s.

**2 — MATCH execution vector/payload lock inversion** (`fix(core)`). `execute_match_with_context` hoisted `payload_storage.read()` (rank 3) for the whole query, then callees took `vector_storage.read()` (rank 2) under it (the ABBA the 2026-07 investigation decreed against, against a concurrent `delete`) **and** re-acquired `payload_storage.read()` on the same thread (which parking_lot forbids once a writer queues — a self-deadlock on one queued upsert; the "Lock note" claiming it was safe was false). Root cause: a `MatchStorageGuards` bundle acquires metric(1)/vector(2)/payload(3) once at the top frame in decree order and is threaded through every callee, so nothing under the MATCH tree re-acquires — globally vector→payload, both deadlocks impossible by construction. A third re-entrant instance (`execute_match_with_similarity` across `apply_match_order_by`) and the config-inversion one-liners were fixed in the same sweep. Red-first: `concurrent_match_full_scan_and_deletes_complete_within_bound` deadlocks at ~39s with the nested acquisition reintroduced, passes in ~0.5s fixed.

**3 — autograph resurrects forgotten facts** (`fix(memory)`). A queued enrichment job outliving a `forget()` (durable, documented-irreversible) recreated the fact's entity hubs and hub→hub edges from its deleted content — a privacy break new in #1846. Root cause: autograph derives structure from a stored fact, so it must create none when the fact is gone. It now re-checks existence after extraction (closes the whole queue window) and again before the fact-independent writes (shrinks the residual race to one already-committed generation). Red-first: resurrects the hubs on pristine HEAD; both endpoint hubs are `None` with the fix. Inline path unaffected (remember has not returned, no forget can interleave).

**4 — the enforcement docs stop overstating themselves** (`docs(concurrency)`). `CONCURRENCY_MODEL.md` claimed `assert_lock_order` "panics on any out-of-order acquisition in debug builds" — it has zero production call sites; production has no runtime check (zero-overhead by design), the HNSW tier's tracker is debug-only/warn-only/records 2 of 5 ranks, and the collection tier is convention-only. The CSR-snapshot paragraph (a lock-free `ArcSwap`, not "under the same RwLock") is corrected. The gap is registered as `CORE_WIRING_DEBT` entry 7, and the `VectorSliceGuard: Send` ↔ parking_lot-features invariant is pinned in `SOUNDNESS.md` and at `guard.rs:80`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Each of the three deadlock/contract fixes carries a deterministic regression test proved red-first (watchdog for the two ABBAs, gated stub extractor for the forget race). Verified green: `cargo test -p velesdb-core --features persistence --test tokio_blocking_lock_contention_repro` (3/3), the MATCH suite (430+), `cargo test -p velesdb-memory --test autograph_async_bdd` (4/4, incl. the new one), `cargo test -p velesdb-mobile --lib` (incl. the new watchdog test); `cargo clippy -p velesdb-core -p velesdb-memory --features persistence,gpu,update-check --all-targets -- -D warnings -D clippy::pedantic` clean; `cargo fmt --all --check` clean; doc-contract + freshness (stamp/versions/index/tracked) guards pass.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

- [x] I listed the invariants impacted (the collection-tier and mobile lock orders; the autograph derive-from-fact invariant).
- [x] I added tests for concurrency (three deterministic red-first regression tests).
- [ ] I requested review from ≥2 reviewers for the HNSW/storage/lock paths — flagging for maintainer attention: this touches the decreed lock order.

## Additional Notes

Deliberately NOT in this PR (below the blocking bar, all traced for 5.0.x): the stall-class findings — velesdb-server's `/query`/MATCH/EXPLAIN/traversal/DDL handlers and the entire Tauri plugin run fsync-bearing sync core inline on their async runtimes (worker-pool starvation, not deadlock; the `spawn_blocking` discipline exists but isn't applied uniformly); the batch-delete `~3N fsyncs under all write locks`; the `WalBatcher` dead-code concurrency primitive in the public surface (remove or `pub(crate)` before GA); and the autograph respawn-during-drop latch window (library-API-only, unreachable through the daemon). The verified-clean surfaces (Node addon, Python GIL⇄observer path, the autograph SyncSender queue) needed no change.