### PR TITLE
fix: no operation may wedge another — the stall-class sweep across every crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,6 +5908,7 @@ dependencies = [
  "tauri-plugin",
  "tempfile",
  "thiserror 2.0.19",
+ "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "velesdb-core",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,7 +64,7 @@ The `velesdb-memory` 0.12.0 result-envelope break (`load_working_context` now re
 
 | Entry | State | Target outcome |
 |---|---|---|
-| 1 — `WalBatchConfig` / `WalBatcher` | code exists, **zero call sites**; TOML parsed and ignored | execute the declared premium transfer — or drop the dormant `enabled` field in the 5.0.0 break |
+| 1 — `WalBatchConfig` / `WalBatcher` | code exists, **zero call sites**, now `pub(crate)` (off the public surface); TOML parsed and ignored | execute the declared premium transfer — or drop the dormant `enabled` field in the 5.0.0 break |
 | 3 — `deferred_indexing` / `async_index_builder` | runtime-wired; no TOML/create-time surface | the "Streaming Ingestion Configuration" RFC |
 | 4 — `SearchConfig` global defaults | hard-coded local defaults shadow the runtime config | consolidate the fallback chain through one helper |
 

--- a/crates/tauri-plugin-velesdb/Cargo.toml
+++ b/crates/tauri-plugin-velesdb/Cargo.toml
@@ -29,6 +29,9 @@ velesdb-core = { workspace = true }
 [dev-dependencies]
 tempfile = "3.14"
 toml = "1.1"
+# Used by tests/nonblocking_state.rs to build a single-worker async runtime
+# and prove blocking core operations never starve runtime workers.
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "time", "sync"] }
 # `test` feature unlocks `tauri::test::{mock_builder, mock_context, noop_assets}`
 # and `MockRuntime`, used by command integration tests to build an
 # `App<MockRuntime>` and exercise the `#[command]` handlers directly.

--- a/crates/tauri-plugin-velesdb/src/commands.rs
+++ b/crates/tauri-plugin-velesdb/src/commands.rs
@@ -60,7 +60,7 @@ pub async fn create_collection<R: Runtime>(
     let storage_mode = parse_storage_mode(&request.storage_mode).map_err(CommandError::from)?;
 
     let result = state
-        .with_db(|db| {
+        .run_db(move |db| {
             if has_advanced_params(&request) {
                 let hnsw_params = build_hnsw_params(&request, storage_mode);
                 // Reject out-of-range tunables (e.g. hnsw_alpha < 1.0 or
@@ -90,6 +90,7 @@ pub async fn create_collection<R: Runtime>(
                 storage_mode: storage_mode_to_string(storage_mode).to_string(),
             })
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(result)
@@ -103,16 +104,17 @@ pub async fn create_metadata_collection<R: Runtime>(
     request: CreateMetadataCollectionRequest,
 ) -> std::result::Result<CollectionInfo, CommandError> {
     let result = state
-        .with_db(|db| {
+        .run_db(move |db| {
             db.create_metadata_collection(&request.name)?;
             Ok(CollectionInfo {
-                name: request.name.clone(),
+                name: request.name,
                 dimension: 0,
                 metric: "none".to_string(),
                 count: 0,
                 storage_mode: "metadata_only".to_string(),
             })
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(result)
@@ -126,10 +128,11 @@ pub async fn delete_collection<R: Runtime>(
     name: String,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             db.delete_collection(&name)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(())
@@ -142,7 +145,7 @@ pub async fn list_collections<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<CollectionInfo>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let names = db.list_collections();
             let mut collections = Vec::new();
             for name in names {
@@ -159,6 +162,7 @@ pub async fn list_collections<R: Runtime>(
             }
             Ok(collections)
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -170,7 +174,7 @@ pub async fn get_collection<R: Runtime>(
     name: String,
 ) -> std::result::Result<CollectionInfo, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &name)?;
             let config = coll.config();
             Ok(CollectionInfo {
@@ -181,6 +185,7 @@ pub async fn get_collection<R: Runtime>(
                 storage_mode: storage_mode_to_string(config.storage_mode).to_string(),
             })
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -189,34 +194,38 @@ pub async fn get_collection<R: Runtime>(
 ///
 /// Shared skeleton of [`upsert`] and [`upsert_metadata`]: only the per-point
 /// construction and the core insert method differ between callers.
-fn upsert_points<R, B, I>(
+async fn upsert_points<R, B, I>(
     app: &AppHandle<R>,
     state: &State<'_, VelesDbState>,
-    collection: &str,
+    collection: String,
     event: &str,
     build: B,
     insert: I,
 ) -> std::result::Result<usize, CommandError>
 where
     R: Runtime,
-    B: FnOnce() -> Vec<velesdb_core::Point>,
+    B: FnOnce() -> Vec<velesdb_core::Point> + Send + 'static,
     I: FnOnce(
-        &velesdb_core::VectorCollection,
-        Vec<velesdb_core::Point>,
-    ) -> crate::error::Result<()>,
+            &velesdb_core::VectorCollection,
+            Vec<velesdb_core::Point>,
+        ) -> crate::error::Result<()>
+        + Send
+        + 'static,
 {
+    let coll_name = collection.clone();
     let count = state
-        .with_db(|db| {
-            let coll = require_collection(&db, collection)?;
+        .run_db(move |db| {
+            let coll = require_collection(&db, &coll_name)?;
 
             let points = build();
             let count = points.len();
             insert(&coll, points)?;
             Ok(count)
         })
+        .await
         .map_err(CommandError::from)?;
 
-    emit_collection_updated(app, collection, event, count);
+    emit_collection_updated(app, &collection, event, count);
     Ok(count)
 }
 
@@ -231,9 +240,9 @@ pub async fn upsert<R: Runtime>(
     upsert_points(
         &app,
         &state,
-        &collection_name,
+        collection_name,
         "upsert",
-        || {
+        move || {
             request
                 .points
                 .into_iter()
@@ -242,6 +251,7 @@ pub async fn upsert<R: Runtime>(
         },
         |coll, points| coll.upsert(points).map_err(crate::error::Error::Database),
     )
+    .await
 }
 
 /// Upserts metadata-only points into a collection.
@@ -255,9 +265,9 @@ pub async fn upsert_metadata<R: Runtime>(
     upsert_points(
         &app,
         &state,
-        &collection_name,
+        collection_name,
         "upsert_metadata",
-        || {
+        move || {
             request
                 .points
                 .into_iter()
@@ -269,6 +279,7 @@ pub async fn upsert_metadata<R: Runtime>(
                 .map_err(crate::error::Error::Database)
         },
     )
+    .await
 }
 
 /// Gets points by their IDs.
@@ -279,7 +290,7 @@ pub async fn get_points<R: Runtime>(
     request: GetPointsRequest,
 ) -> std::result::Result<Vec<Option<PointOutput>>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
 
             let points = coll.get(&request.ids);
@@ -294,6 +305,7 @@ pub async fn get_points<R: Runtime>(
                 })
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -305,12 +317,13 @@ pub async fn delete_points<R: Runtime>(
     request: DeletePointsRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
 
             coll.delete(&request.ids)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -388,7 +401,7 @@ pub async fn search<R: Runtime>(
     let parsed_quality: Option<()> = None;
 
     let results = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
             let search_results = search_full(
                 &coll,
@@ -398,6 +411,7 @@ pub async fn search<R: Runtime>(
             )?;
             Ok(map_core_results(search_results))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(timed_search_response(results, start))
@@ -434,7 +448,7 @@ pub async fn search_ids<R: Runtime>(
     let parsed_quality: Option<()> = None;
 
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
             // Optimized id-only path only when no filter and no quality; both
             // require the full search that hydrates results before projecting.
@@ -457,6 +471,7 @@ pub async fn search_ids<R: Runtime>(
             };
             Ok(scored)
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -475,9 +490,9 @@ pub async fn batch_search<R: Runtime>(
     let has_quality = request.searches.iter().any(|s| s.quality.is_some());
 
     let batch_results = if has_quality {
-        batch_search_per_query(&state, &request)?
+        batch_search_per_query(&state, request).await?
     } else {
-        batch_search_bulk(&state, &request)?
+        batch_search_bulk(&state, request).await?
     };
 
     let timing_ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -488,12 +503,12 @@ pub async fn batch_search<R: Runtime>(
 }
 
 /// Per-query batch search with per-search quality dispatch.
-fn batch_search_per_query(
+async fn batch_search_per_query(
     state: &VelesDbState,
-    request: &BatchSearchRequest,
+    request: BatchSearchRequest,
 ) -> std::result::Result<Vec<Vec<crate::types::SearchResult>>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
             let mut all_results = Vec::with_capacity(request.searches.len());
             for s in &request.searches {
@@ -518,16 +533,17 @@ fn batch_search_per_query(
             }
             Ok(all_results)
         })
+        .await
         .map_err(CommandError::from)
 }
 
 /// Optimized bulk batch search (no per-query quality).
-fn batch_search_bulk(
+async fn batch_search_bulk(
     state: &VelesDbState,
-    request: &BatchSearchRequest,
+    request: BatchSearchRequest,
 ) -> std::result::Result<Vec<Vec<crate::types::SearchResult>>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
 
             let query_refs: Vec<&[f32]> = request
@@ -558,43 +574,39 @@ fn batch_search_bulk(
                 })
                 .collect::<Vec<_>>())
         })
+        .await
         .map_err(CommandError::from)
 }
 
 /// Runs a filter-aware search on `collection` and wraps the mapped results in a
 /// timed [`SearchResponse`].
 ///
-/// Shared skeleton of [`text_search`] and [`hybrid_search`]: when a filter is
-/// present `filtered` is invoked with it, otherwise `unfiltered` is used. Only
-/// those two core calls differ between callers.
-fn run_filtered_search<Filtered, Unfiltered>(
+/// Shared skeleton of [`text_search`] and [`hybrid_search`]: `search` receives
+/// the collection plus the parsed filter (if any) and dispatches to the
+/// matching core call. The whole search runs on the blocking pool via
+/// [`VelesDbState::run_db`].
+async fn run_filtered_search<F>(
     state: &State<'_, VelesDbState>,
-    collection: &str,
-    parsed_filter: Option<&velesdb_core::Filter>,
-    filtered: Filtered,
-    unfiltered: Unfiltered,
+    collection: String,
+    parsed_filter: Option<velesdb_core::Filter>,
+    search: F,
 ) -> std::result::Result<SearchResponse, CommandError>
 where
-    Filtered: FnOnce(
-        &velesdb_core::VectorCollection,
-        &velesdb_core::Filter,
-    ) -> crate::error::Result<Vec<velesdb_core::SearchResult>>,
-    Unfiltered: FnOnce(
-        &velesdb_core::VectorCollection,
-    ) -> crate::error::Result<Vec<velesdb_core::SearchResult>>,
+    F: FnOnce(
+            &velesdb_core::VectorCollection,
+            Option<&velesdb_core::Filter>,
+        ) -> crate::error::Result<Vec<velesdb_core::SearchResult>>
+        + Send
+        + 'static,
 {
     let start = std::time::Instant::now();
     let results = state
-        .with_db(|db| {
-            let coll = require_collection(&db, collection)?;
-
-            let search_results = if let Some(f) = parsed_filter {
-                filtered(&coll, f)?
-            } else {
-                unfiltered(&coll)?
-            };
+        .run_db(move |db| {
+            let coll = require_collection(&db, &collection)?;
+            let search_results = search(&coll, parsed_filter.as_ref())?;
             Ok(map_core_results(search_results))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(timed_search_response(results, start))
@@ -608,20 +620,16 @@ pub async fn text_search<R: Runtime>(
     request: TextSearchRequest,
 ) -> std::result::Result<SearchResponse, CommandError> {
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+    let collection = request.collection.clone();
 
-    run_filtered_search(
-        &state,
-        &request.collection,
-        parsed_filter.as_ref(),
-        |coll, f| {
-            coll.text_search_with_filter(&request.query, request.top_k, f)
-                .map_err(crate::error::Error::Database)
-        },
-        |coll| {
-            coll.text_search(&request.query, request.top_k)
-                .map_err(crate::error::Error::Database)
-        },
-    )
+    run_filtered_search(&state, collection, parsed_filter, move |coll, filter| {
+        match filter {
+            Some(f) => coll.text_search_with_filter(&request.query, request.top_k, f),
+            None => coll.text_search(&request.query, request.top_k),
+        }
+        .map_err(crate::error::Error::Database)
+    })
+    .await
 }
 
 /// Hybrid search combining vector similarity and BM25.
@@ -632,31 +640,27 @@ pub async fn hybrid_search<R: Runtime>(
     request: HybridSearchRequest,
 ) -> std::result::Result<SearchResponse, CommandError> {
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
+    let collection = request.collection.clone();
 
-    run_filtered_search(
-        &state,
-        &request.collection,
-        parsed_filter.as_ref(),
-        |coll, f| {
-            coll.hybrid_search_with_filter(
+    run_filtered_search(&state, collection, parsed_filter, move |coll, filter| {
+        match filter {
+            Some(f) => coll.hybrid_search_with_filter(
                 &request.vector,
                 &request.query,
                 request.top_k,
                 Some(request.vector_weight),
                 f,
-            )
-            .map_err(crate::error::Error::Database)
-        },
-        |coll| {
-            coll.hybrid_search(
+            ),
+            None => coll.hybrid_search(
                 &request.vector,
                 &request.query,
                 request.top_k,
                 Some(request.vector_weight),
-            )
-            .map_err(crate::error::Error::Database)
-        },
-    )
+            ),
+        }
+        .map_err(crate::error::Error::Database)
+    })
+    .await
 }
 
 // NOTE: VelesQL query command moved to commands_query.rs (NLOC refactoring)
@@ -670,10 +674,11 @@ pub async fn is_empty<R: Runtime>(
     name: String,
 ) -> std::result::Result<bool, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &name)?;
             Ok(coll.is_empty())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -685,11 +690,12 @@ pub async fn flush<R: Runtime>(
     name: String,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &name)?;
             coll.flush()?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -702,11 +708,12 @@ pub async fn compact_storage<R: Runtime>(
     name: String,
 ) -> std::result::Result<u64, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &name)?;
             let freed = coll.compact_storage()?;
             Ok(u64::try_from(freed).unwrap_or(u64::MAX))
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -720,10 +727,11 @@ pub async fn update_guardrails<R: Runtime>(
     limits: GuardrailLimits,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             db.update_guardrails(&limits.into());
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -735,10 +743,11 @@ pub async fn get_guardrails<R: Runtime>(
     name: String,
 ) -> std::result::Result<GuardrailLimits, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &name)?;
             Ok(GuardrailLimits::from(coll.guard_rails().limits()))
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -752,7 +761,7 @@ pub async fn scroll_collection<R: Runtime>(
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
 
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
             let batch =
                 coll.scroll_batch(request.cursor, request.batch_size, parsed_filter.as_ref())?;
@@ -769,6 +778,7 @@ pub async fn scroll_collection<R: Runtime>(
                 next_cursor: batch.next_cursor,
             })
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -785,7 +795,7 @@ pub async fn multi_query_search<R: Runtime>(
     let parsed_filter = parse_filter(&request.filter).map_err(CommandError::from)?;
 
     let results = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
 
             let vector_refs: Vec<&[f32]> = request.vectors.iter().map(Vec::as_slice).collect();
@@ -799,6 +809,7 @@ pub async fn multi_query_search<R: Runtime>(
 
             Ok(map_core_results(search_results))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(timed_search_response(results, start))
@@ -819,7 +830,7 @@ pub async fn train_pq<R: Runtime>(
     request: TrainPqRequest,
 ) -> std::result::Result<String, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             use velesdb_core::velesql::{Query, TrainStatement, WithValue};
 
             let mut params = std::collections::HashMap::new();
@@ -850,6 +861,7 @@ pub async fn train_pq<R: Runtime>(
 
             Ok("PQ training complete".to_string())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -870,7 +882,7 @@ pub async fn stream_insert<R: Runtime>(
 ) -> std::result::Result<usize, CommandError> {
     let collection_name = request.collection.clone();
     let count = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
 
             let mut inserted = 0;
@@ -883,6 +895,7 @@ pub async fn stream_insert<R: Runtime>(
             }
             Ok(inserted)
         })
+        .await
         .map_err(CommandError::from)?;
 
     emit_collection_updated(&app, &collection_name, "stream_insert", count);
@@ -918,11 +931,12 @@ pub async fn enable_streaming<R: Runtime>(
     let collection_name = request.collection.clone();
     let config = streaming_config_from_request(&request);
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
             coll.enable_streaming(config);
             Ok(())
         })
+        .await
         .map_err(CommandError::from)?;
 
     emit_collection_updated(&app, &collection_name, "enable_streaming", 0);

--- a/crates/tauri-plugin-velesdb/src/commands_graph.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_graph.rs
@@ -33,7 +33,7 @@ pub async fn create_graph_collection<R: Runtime>(
     };
 
     let result = state
-        .with_db(|db| {
+        .run_db(move |db| {
             if let Some(dim) = request.dimension {
                 let metric = parse_metric(&request.metric)?;
                 db.create_graph_collection_with_embeddings(&request.name, schema, dim, metric)?;
@@ -48,6 +48,7 @@ pub async fn create_graph_collection<R: Runtime>(
                 storage_mode: "graph".to_string(),
             })
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(result)
@@ -107,7 +108,7 @@ pub async fn add_edge<R: Runtime>(
     request: AddEdgeRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
             let edge = build_edge(
                 request.id,
@@ -119,6 +120,7 @@ pub async fn add_edge<R: Runtime>(
             coll.add_edge(edge)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -132,7 +134,7 @@ pub async fn add_edges_batch<R: Runtime>(
     request: AddEdgesBatchRequest,
 ) -> std::result::Result<u64, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
             let edges = request
                 .edges
@@ -142,6 +144,7 @@ pub async fn add_edges_batch<R: Runtime>(
             let added = coll.add_edges_batch(edges)?;
             Ok(u64::try_from(added).unwrap_or(u64::MAX))
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -153,7 +156,7 @@ pub async fn get_edges<R: Runtime>(
     request: GetEdgesRequest,
 ) -> std::result::Result<Vec<EdgeOutput>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
             let edges = if let Some(label) = &request.label {
@@ -177,6 +180,7 @@ pub async fn get_edges<R: Runtime>(
                 })
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -188,7 +192,7 @@ pub async fn traverse_graph<R: Runtime>(
     request: TraverseGraphRequest,
 ) -> std::result::Result<Vec<TraversalOutput>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
             let config =
@@ -202,6 +206,7 @@ pub async fn traverse_graph<R: Runtime>(
 
             Ok(to_traversal_outputs(results))
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -213,7 +218,7 @@ pub async fn get_node_degree<R: Runtime>(
     request: GetNodeDegreeRequest,
 ) -> std::result::Result<NodeDegreeOutput, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
             let (in_degree, out_degree) = coll.node_degree(request.node_id);
@@ -224,6 +229,7 @@ pub async fn get_node_degree<R: Runtime>(
                 out_degree,
             })
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -235,7 +241,7 @@ pub async fn traverse_graph_parallel<R: Runtime>(
     request: TraverseGraphParallelRequest,
 ) -> std::result::Result<Vec<TraversalOutput>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_graph_collection(&db, &request.collection)?;
 
             let config =
@@ -245,6 +251,7 @@ pub async fn traverse_graph_parallel<R: Runtime>(
 
             Ok(to_traversal_outputs(results))
         })
+        .await
         .map_err(CommandError::from)
 }
 

--- a/crates/tauri-plugin-velesdb/src/commands_index.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_index.rs
@@ -16,12 +16,13 @@ pub async fn create_index<R: Runtime>(
     request: crate::types::CreateIndexRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
             coll.create_index(&request.field_name)
                 .map_err(|e| Error::InvalidConfig(e.to_string()))?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -33,10 +34,11 @@ pub async fn drop_index<R: Runtime>(
     request: crate::types::DropIndexRequest,
 ) -> std::result::Result<bool, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
             Ok(coll.drop_secondary_index(&request.field_name))
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -48,7 +50,7 @@ pub async fn list_indexes<R: Runtime>(
     request: crate::types::ListIndexesRequest,
 ) -> std::result::Result<Vec<crate::types::IndexInfoOutput>, CommandError> {
     state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
             let indexes = coll.list_indexes();
             Ok(indexes
@@ -62,5 +64,6 @@ pub async fn list_indexes<R: Runtime>(
                 })
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }

--- a/crates/tauri-plugin-velesdb/src/commands_memory.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_memory.rs
@@ -7,7 +7,7 @@
 //! conversion in [`crate::error`].
 //!
 //! All commands route through the single persistent [`AgentMemory`] handle held
-//! in [`VelesDbState`] (see `state::with_memory`), so the in-memory TTL registry,
+//! in [`VelesDbState`] (see `state::run_memory`), so the in-memory TTL registry,
 //! temporal index, and snapshot manager survive across invocations. Re-opening a
 //! fresh memory per command silently dropped the TTL registry, which is why TTL,
 //! auto-expire, and snapshot versioning previously had no effect.
@@ -38,11 +38,12 @@ pub async fn semantic_store<R: Runtime>(
     request: SemanticStoreRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.semantic()
                 .store(request.id, &request.content, &request.embedding)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -54,7 +55,7 @@ pub async fn semantic_store_with_ttl<R: Runtime>(
     request: SemanticStoreWithTtlRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.semantic().store_with_ttl(
                 request.id,
                 &request.content,
@@ -63,6 +64,7 @@ pub async fn semantic_store_with_ttl<R: Runtime>(
             )?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -74,13 +76,14 @@ pub async fn semantic_query<R: Runtime>(
     request: SemanticQueryRequest,
 ) -> std::result::Result<Vec<SemanticQueryResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem.semantic().query(&request.embedding, request.top_k)?;
             Ok(results
                 .into_iter()
                 .map(|(id, score, content)| SemanticQueryResult { id, score, content })
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -92,10 +95,11 @@ pub async fn semantic_delete<R: Runtime>(
     request: SemanticDeleteRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.semantic().delete(request.id)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -106,7 +110,8 @@ pub async fn semantic_dimension<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<usize, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.semantic().dimension()))
+        .run_memory(move |mem| Ok(mem.semantic().dimension()))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -117,7 +122,8 @@ pub async fn semantic_serialize<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<u8>, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.semantic().serialize()?))
+        .run_memory(move |mem| Ok(mem.semantic().serialize()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -129,10 +135,11 @@ pub async fn semantic_deserialize<R: Runtime>(
     data: Vec<u8>,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.semantic().deserialize(&data)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -148,7 +155,7 @@ pub async fn episodic_record<R: Runtime>(
     request: EpisodicRecordRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.episodic().record(
                 request.event_id,
                 &request.content,
@@ -157,6 +164,7 @@ pub async fn episodic_record<R: Runtime>(
             )?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -168,12 +176,13 @@ pub async fn episodic_recent<R: Runtime>(
     request: EpisodicRecentRequest,
 ) -> std::result::Result<Vec<EpisodicResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem
                 .episodic()
                 .recent(request.limit, request.since_timestamp)?;
             Ok(results.into_iter().map(to_episodic_result).collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -185,7 +194,7 @@ pub async fn episodic_recall_similar<R: Runtime>(
     request: EpisodicRecallSimilarRequest,
 ) -> std::result::Result<Vec<EpisodicSimilarResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem
                 .episodic()
                 .recall_similar(&request.embedding, request.top_k)?;
@@ -199,6 +208,7 @@ pub async fn episodic_recall_similar<R: Runtime>(
                 })
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -210,12 +220,13 @@ pub async fn episodic_older_than<R: Runtime>(
     request: EpisodicOlderThanRequest,
 ) -> std::result::Result<Vec<EpisodicResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem
                 .episodic()
                 .older_than(request.timestamp, request.limit)?;
             Ok(results.into_iter().map(to_episodic_result).collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -227,10 +238,11 @@ pub async fn episodic_delete<R: Runtime>(
     request: EpisodicDeleteRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.episodic().delete(request.event_id)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -241,7 +253,8 @@ pub async fn episodic_serialize<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<u8>, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.episodic().serialize()?))
+        .run_memory(move |mem| Ok(mem.episodic().serialize()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -253,10 +266,11 @@ pub async fn episodic_deserialize<R: Runtime>(
     data: Vec<u8>,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.episodic().deserialize(&data)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -272,7 +286,7 @@ pub async fn procedural_learn<R: Runtime>(
     request: ProceduralLearnRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.procedural().learn(
                 request.procedure_id,
                 &request.name,
@@ -282,6 +296,7 @@ pub async fn procedural_learn<R: Runtime>(
             )?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -293,7 +308,7 @@ pub async fn procedural_recall<R: Runtime>(
     request: ProceduralRecallRequest,
 ) -> std::result::Result<Vec<ProceduralMatchResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem.procedural().recall(
                 &request.embedding,
                 request.top_k,
@@ -301,6 +316,7 @@ pub async fn procedural_recall<R: Runtime>(
             )?;
             Ok(results.into_iter().map(to_match_result).collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -312,11 +328,12 @@ pub async fn procedural_reinforce<R: Runtime>(
     request: ProceduralReinforceRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.procedural()
                 .reinforce(request.procedure_id, request.success)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -327,10 +344,11 @@ pub async fn procedural_list_all<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<ProceduralMatchResult>, CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let results = mem.procedural().list_all()?;
             Ok(results.into_iter().map(to_match_result).collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -342,10 +360,11 @@ pub async fn procedural_delete<R: Runtime>(
     request: ProceduralDeleteRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.procedural().delete(request.procedure_id)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -356,7 +375,8 @@ pub async fn procedural_serialize<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<u8>, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.procedural().serialize()?))
+        .run_memory(move |mem| Ok(mem.procedural().serialize()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -368,10 +388,11 @@ pub async fn procedural_deserialize<R: Runtime>(
     data: Vec<u8>,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.procedural().deserialize(&data)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -390,7 +411,7 @@ pub async fn memory_set_ttl<R: Runtime>(
     request: MemoryTtlRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             match request.kind {
                 MemoryKindDto::Semantic => mem.set_semantic_ttl(request.id, request.ttl_seconds),
                 MemoryKindDto::Episodic => mem.set_episodic_ttl(request.id, request.ttl_seconds),
@@ -400,6 +421,7 @@ pub async fn memory_set_ttl<R: Runtime>(
             }
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -410,7 +432,8 @@ pub async fn memory_auto_expire<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<ExpireResultDto, CommandError> {
     state
-        .with_memory(|mem| Ok(ExpireResultDto::from(mem.auto_expire()?)))
+        .run_memory(move |mem| Ok(ExpireResultDto::from(mem.auto_expire()?)))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -422,7 +445,8 @@ pub async fn memory_evict_low_confidence<R: Runtime>(
     request: EvictLowConfidenceRequest,
 ) -> std::result::Result<usize, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.evict_low_confidence_procedures(request.min_confidence)?))
+        .run_memory(move |mem| Ok(mem.evict_low_confidence_procedures(request.min_confidence)?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -437,7 +461,8 @@ pub async fn memory_snapshot<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<u64, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.snapshot()?))
+        .run_memory(move |mem| Ok(mem.snapshot()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -448,7 +473,8 @@ pub async fn memory_load_latest_snapshot<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<u64, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.load_latest_snapshot()?))
+        .run_memory(move |mem| Ok(mem.load_latest_snapshot()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -460,10 +486,11 @@ pub async fn memory_load_snapshot_version<R: Runtime>(
     request: LoadSnapshotVersionRequest,
 ) -> std::result::Result<(), CommandError> {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             mem.load_snapshot_version(request.version)?;
             Ok(())
         })
+        .await
         .map_err(CommandError::from)
 }
 
@@ -474,7 +501,8 @@ pub async fn memory_list_snapshot_versions<R: Runtime>(
     state: State<'_, VelesDbState>,
 ) -> std::result::Result<Vec<u64>, CommandError> {
     state
-        .with_memory(|mem| Ok(mem.list_snapshot_versions()?))
+        .run_memory(move |mem| Ok(mem.list_snapshot_versions()?))
+        .await
         .map_err(CommandError::from)
 }
 
@@ -489,9 +517,10 @@ pub async fn memory_query_semantic<R: Runtime>(
     state: State<'_, VelesDbState>,
     request: MemoryQueryRequest,
 ) -> std::result::Result<Vec<HybridResult>, CommandError> {
-    run_memory_query(&state, |mem| {
+    run_memory_query(&state, move |mem| {
         mem.query_semantic(&request.sql, &request.params)
     })
+    .await
 }
 
 /// Executes a `VelesQL` query against episodic memory.
@@ -501,9 +530,10 @@ pub async fn memory_query_episodic<R: Runtime>(
     state: State<'_, VelesDbState>,
     request: MemoryQueryRequest,
 ) -> std::result::Result<Vec<HybridResult>, CommandError> {
-    run_memory_query(&state, |mem| {
+    run_memory_query(&state, move |mem| {
         mem.query_episodic(&request.sql, &request.params)
     })
+    .await
 }
 
 /// Executes a `VelesQL` query against procedural memory.
@@ -513,34 +543,37 @@ pub async fn memory_query_procedural<R: Runtime>(
     state: State<'_, VelesDbState>,
     request: MemoryQueryRequest,
 ) -> std::result::Result<Vec<HybridResult>, CommandError> {
-    run_memory_query(&state, |mem| {
+    run_memory_query(&state, move |mem| {
         mem.query_procedural(&request.sql, &request.params)
     })
+    .await
 }
 
 /// Runs a memory `VelesQL` query and maps the rows into `HybridResult` DTOs.
 ///
 /// RF-DEDUP: shared by the semantic / episodic / procedural bridge commands.
-fn run_memory_query<F>(
+async fn run_memory_query<F>(
     state: &VelesDbState,
     query: F,
 ) -> std::result::Result<Vec<HybridResult>, CommandError>
 where
     F: FnOnce(
-        &velesdb_core::agent::AgentMemory,
-    ) -> std::result::Result<
-        Vec<velesdb_core::SearchResult>,
-        velesdb_core::agent::AgentMemoryError,
-    >,
+            &velesdb_core::agent::AgentMemory,
+        ) -> std::result::Result<
+            Vec<velesdb_core::SearchResult>,
+            velesdb_core::agent::AgentMemoryError,
+        > + Send
+        + 'static,
 {
     state
-        .with_memory(|mem| {
+        .run_memory(move |mem| {
             let rows = query(mem).map_err(Error::from)?;
             Ok(rows
                 .iter()
                 .map(crate::commands_query::search_result_to_hybrid)
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 

--- a/crates/tauri-plugin-velesdb/src/commands_query.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_query.rs
@@ -56,7 +56,7 @@ pub async fn query<R: Runtime>(
     let parsed = velesdb_core::velesql::Parser::parse(&request.query)
         .map_err(|e| Error::InvalidConfig(format!("VelesQL parse error: {}", e.message)))?;
 
-    let results = dispatch_tauri_query(&state, &parsed, &request)?;
+    let results = dispatch_tauri_query(&state, parsed, request).await?;
 
     Ok(QueryResponse {
         results,
@@ -65,41 +65,40 @@ pub async fn query<R: Runtime>(
 }
 
 /// Dispatches a tauri query to aggregation or standard execution path.
-fn dispatch_tauri_query(
+async fn dispatch_tauri_query(
     state: &VelesDbState,
-    parsed: &velesdb_core::velesql::Query,
-    request: &QueryRequest,
+    parsed: velesdb_core::velesql::Query,
+    request: QueryRequest,
 ) -> std::result::Result<Vec<HybridResult>, CommandError> {
-    let collection_name = &parsed.select.from;
-
-    if is_aggregation_query(parsed) && !collection_name.is_empty() {
-        return execute_tauri_aggregation(state, parsed, request, collection_name);
+    if is_aggregation_query(&parsed) && !parsed.select.from.is_empty() {
+        return execute_tauri_aggregation(state, parsed, request).await;
     }
 
     state
-        .with_db(|db| {
-            let search_results = db.execute_query(parsed, &request.params)?;
+        .run_db(move |db| {
+            let search_results = db.execute_query(&parsed, &request.params)?;
             Ok(search_results
                 .into_iter()
                 .map(|r| search_result_to_hybrid(&r))
                 .collect())
         })
+        .await
         .map_err(CommandError::from)
 }
 
 /// Executes an aggregation query through the collection API.
-fn execute_tauri_aggregation(
+async fn execute_tauri_aggregation(
     state: &VelesDbState,
-    parsed: &velesdb_core::velesql::Query,
-    request: &QueryRequest,
-    collection_name: &str,
+    parsed: velesdb_core::velesql::Query,
+    request: QueryRequest,
 ) -> std::result::Result<Vec<HybridResult>, CommandError> {
     let agg_json = state
-        .with_db(|db| {
-            let coll = require_collection(&db, collection_name)?;
-            coll.execute_aggregate(parsed, &request.params)
+        .run_db(move |db| {
+            let coll = require_collection(&db, &parsed.select.from)?;
+            coll.execute_aggregate(&parsed, &request.params)
                 .map_err(|e| Error::InvalidConfig(format!("Aggregation error: {e}")))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(vec![HybridResult {

--- a/crates/tauri-plugin-velesdb/src/commands_sparse.rs
+++ b/crates/tauri-plugin-velesdb/src/commands_sparse.rs
@@ -25,7 +25,7 @@ pub async fn sparse_search<R: Runtime>(
     let start = std::time::Instant::now();
 
     let results = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
 
             let core_sv = parse_sparse_vector(&request.sparse_vector)?;
@@ -34,6 +34,7 @@ pub async fn sparse_search<R: Runtime>(
             let search_results = coll.sparse_search(&core_sv, request.top_k, &idx_name)?;
             Ok(map_core_results(search_results))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(timed_search_response(results, start))
@@ -49,7 +50,7 @@ pub async fn hybrid_sparse_search<R: Runtime>(
     let start = std::time::Instant::now();
 
     let results = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_vector_collection(&db, &request.collection)?;
 
             let core_sv = parse_sparse_vector(&request.sparse_vector)?;
@@ -59,6 +60,7 @@ pub async fn hybrid_sparse_search<R: Runtime>(
                 coll.hybrid_sparse_search(&request.vector, &core_sv, request.top_k, "", &strategy)?;
             Ok(map_core_results(search_results))
         })
+        .await
         .map_err(CommandError::from)?;
 
     Ok(timed_search_response(results, start))
@@ -73,7 +75,7 @@ pub async fn sparse_upsert<R: Runtime>(
 ) -> std::result::Result<usize, CommandError> {
     let collection_name = request.collection.clone();
     let count = state
-        .with_db(|db| {
+        .run_db(move |db| {
             let coll = require_collection(&db, &request.collection)?;
 
             let mut points = Vec::with_capacity(request.points.len());
@@ -95,6 +97,7 @@ pub async fn sparse_upsert<R: Runtime>(
             coll.upsert(points)?;
             Ok(count)
         })
+        .await
         .map_err(CommandError::from)?;
 
     emit_collection_updated(&app, &collection_name, "sparse_upsert", count);

--- a/crates/tauri-plugin-velesdb/src/error.rs
+++ b/crates/tauri-plugin-velesdb/src/error.rs
@@ -46,6 +46,11 @@ pub enum Error {
         source: velesdb_core::config::ConfigError,
     },
 
+    /// A blocking task could not be joined (it panicked or the async
+    /// runtime is shutting down).
+    #[error("Blocking task failed: {0}")]
+    TaskJoin(String),
+
     /// Serialization error.
     #[error("Serialization error: {0}")]
     Serialization(String),
@@ -72,6 +77,7 @@ impl From<Error> for CommandError {
             Error::NotFound(_) => "NOT_FOUND",
             Error::DimensionMismatch { .. } => "DIMENSION_MISMATCH",
             Error::InvalidConfig(_) | Error::ConfigLoad { .. } => "INVALID_CONFIG",
+            Error::TaskJoin(_) => "TASK_JOIN",
             Error::Serialization(_) => "SERIALIZATION_ERROR",
             Error::Io(_) => "VELES-011",
         };

--- a/crates/tauri-plugin-velesdb/src/state.rs
+++ b/crates/tauri-plugin-velesdb/src/state.rs
@@ -19,11 +19,13 @@ const MEMORY_SNAPSHOT_DIR: &str = "_memory_snapshots";
 /// Maximum number of versioned memory snapshots retained on disk.
 const MEMORY_SNAPSHOT_MAX: usize = 16;
 
-/// Plugin state holding the database instance.
+/// Shared inner state, reference-counted so blocking tasks can own a handle.
 ///
-/// This struct is managed by Tauri and provides thread-safe access
-/// to the `VelesDB` database from all commands.
-pub struct VelesDbState {
+/// [`VelesDbState`] wraps this in an [`Arc`] so [`VelesDbState::run_db`] /
+/// [`VelesDbState::run_memory`] can move an owned clone into
+/// `tauri::async_runtime::spawn_blocking` closures (`'static` bound) without
+/// borrowing the Tauri-managed state.
+struct StateInner {
     /// The database instance wrapped in Arc<RwLock> for thread-safe access.
     db: Arc<RwLock<Option<Arc<Database>>>>,
     /// Persistent unified `AgentMemory` handle.
@@ -33,7 +35,7 @@ pub struct VelesDbState {
     /// snapshot manager survive between invocations. Re-opening a fresh memory
     /// per command (the previous behaviour) silently dropped the in-memory TTL
     /// registry, so TTL / auto-expire / snapshot versioning never worked.
-    memory: Arc<RwLock<Option<Arc<AgentMemory>>>>,
+    memory: RwLock<Option<Arc<AgentMemory>>>,
     /// Path to the database directory.
     path: PathBuf,
     /// Optional lifecycle observer injected when the database is opened.
@@ -47,6 +49,82 @@ pub struct VelesDbState {
     /// `None` preserves the historical behaviour: the database opens with
     /// core defaults, exactly as before config wiring existed.
     config: Option<VelesConfig>,
+}
+
+impl StateInner {
+    /// Opens the database if it is not open yet (double-checked under the
+    /// write lock). Idempotent.
+    fn open(&self) -> Result<()> {
+        let mut db_guard = self.db.write();
+        if db_guard.is_none() {
+            let db = match (&self.observer, &self.config) {
+                (Some(observer), Some(config)) => Database::open_with_observer_and_config(
+                    &self.path,
+                    Arc::clone(observer),
+                    config.clone(),
+                )?,
+                (Some(observer), None) => {
+                    Database::open_with_observer(&self.path, Arc::clone(observer))?
+                }
+                (None, Some(config)) => Database::open_with_config(&self.path, config.clone())?,
+                (None, None) => Database::open(&self.path)?,
+            };
+            *db_guard = Some(Arc::new(db));
+            tracing::info!("VelesDB opened at {:?}", self.path);
+        }
+        Ok(())
+    }
+
+    /// Returns an owned handle to the database, opening it if necessary.
+    ///
+    /// Lock scoping: the `db` read guard is held only long enough to clone the
+    /// inner [`Arc<Database>`] and is dropped before the handle is returned, so
+    /// no state lock is ever held across a core operation.
+    fn db_handle(&self) -> Result<Arc<Database>> {
+        if let Some(db) = self.db.read().as_ref() {
+            return Ok(Arc::clone(db));
+        }
+        self.open()?;
+        let db_guard = self.db.read();
+        db_guard
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| Error::InvalidConfig("Database not initialized".to_string()))
+    }
+
+    /// Returns the shared `AgentMemory`, building it on first use.
+    ///
+    /// Lock ordering: the `db` lock (via [`Self::db_handle`]) is fully released
+    /// before the `memory` write lock is taken, so the two are never nested.
+    /// The `memory` write lock is held across the one-time construction only —
+    /// racing initializers would otherwise both create memory collections in
+    /// the database. Every later call takes the read lock just long enough to
+    /// clone the existing [`Arc`].
+    fn memory_handle(&self) -> Result<Arc<AgentMemory>> {
+        if let Some(existing) = self.memory.read().clone() {
+            return Ok(existing);
+        }
+        let db = self.db_handle()?;
+        let snapshot_dir = self.path.join(MEMORY_SNAPSHOT_DIR);
+        let mut guard = self.memory.write();
+        if let Some(existing) = guard.clone() {
+            return Ok(existing);
+        }
+        let snapshot_dir = snapshot_dir.to_string_lossy().into_owned();
+        let memory =
+            Arc::new(AgentMemory::new(db)?.with_snapshots(&snapshot_dir, MEMORY_SNAPSHOT_MAX));
+        *guard = Some(Arc::clone(&memory));
+        Ok(memory)
+    }
+}
+
+/// Plugin state holding the database instance.
+///
+/// This struct is managed by Tauri and provides thread-safe access
+/// to the `VelesDB` database from all commands.
+pub struct VelesDbState {
+    /// Shared inner state; cloned into blocking tasks by the `run_*` methods.
+    inner: Arc<StateInner>,
 }
 
 impl VelesDbState {
@@ -99,11 +177,13 @@ impl VelesDbState {
         config: Option<VelesConfig>,
     ) -> Self {
         Self {
-            db: Arc::new(RwLock::new(None)),
-            memory: Arc::new(RwLock::new(None)),
-            path,
-            observer,
-            config,
+            inner: Arc::new(StateInner {
+                db: Arc::new(RwLock::new(None)),
+                memory: RwLock::new(None),
+                path,
+                observer,
+                config,
+            }),
         }
     }
 
@@ -113,24 +193,7 @@ impl VelesDbState {
     ///
     /// Returns an error if the database cannot be opened.
     pub fn open(&self) -> Result<()> {
-        let mut db_guard = self.db.write();
-        if db_guard.is_none() {
-            let db = match (&self.observer, &self.config) {
-                (Some(observer), Some(config)) => Database::open_with_observer_and_config(
-                    &self.path,
-                    Arc::clone(observer),
-                    config.clone(),
-                )?,
-                (Some(observer), None) => {
-                    Database::open_with_observer(&self.path, Arc::clone(observer))?
-                }
-                (None, Some(config)) => Database::open_with_config(&self.path, config.clone())?,
-                (None, None) => Database::open(&self.path)?,
-            };
-            *db_guard = Some(Arc::new(db));
-            tracing::info!("VelesDB opened at {:?}", self.path);
-        }
-        Ok(())
+        self.inner.open()
     }
 
     /// Returns a reference to the database, opening it if necessary.
@@ -139,18 +202,18 @@ impl VelesDbState {
     ///
     /// Returns an error if the database cannot be accessed.
     pub fn get_db(&self) -> Result<Arc<RwLock<Option<Arc<Database>>>>> {
-        // Ensure database is open
-        {
-            let db_guard = self.db.read();
-            if db_guard.is_none() {
-                drop(db_guard);
-                self.open()?;
-            }
-        }
-        Ok(Arc::clone(&self.db))
+        self.inner.db_handle()?;
+        Ok(Arc::clone(&self.inner.db))
     }
 
-    /// Executes a function with read access to the database.
+    /// Executes a function against an owned database handle.
+    ///
+    /// The internal state lock is held only long enough to clone the
+    /// [`Arc<Database>`]; it is released before `f` runs, so a long core
+    /// operation never blocks other state accesses (including `open`).
+    ///
+    /// Prefer [`Self::run_db`] inside async Tauri commands: `f` runs on the
+    /// caller's thread here, which must not be an async runtime worker.
     ///
     /// # Errors
     ///
@@ -159,12 +222,35 @@ impl VelesDbState {
     where
         F: FnOnce(Arc<Database>) -> Result<T>,
     {
-        self.open()?;
-        let db_guard = self.db.read();
-        let db = db_guard
-            .as_ref()
-            .ok_or_else(|| Error::InvalidConfig("Database not initialized".to_string()))?;
-        f(Arc::clone(db))
+        let db = self.inner.db_handle()?;
+        f(db)
+    }
+
+    /// Runs a synchronous database operation on Tauri's blocking thread pool.
+    ///
+    /// Core operations are synchronous and may fsync; running them inline in an
+    /// async command starves the async runtime under load. This method moves
+    /// the operation (and the lazy first open) onto
+    /// `tauri::async_runtime::spawn_blocking`, keeping runtime workers free.
+    /// The state lock is held only long enough to clone the database handle,
+    /// never across the operation itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database is not available, if `f` fails, or if
+    /// the blocking task cannot be joined.
+    pub async fn run_db<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(Arc<Database>) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        tauri::async_runtime::spawn_blocking(move || {
+            let db = inner.db_handle()?;
+            f(db)
+        })
+        .await
+        .map_err(|e| Error::TaskJoin(e.to_string()))?
     }
 
     /// Executes a function with the persistent unified `AgentMemory` handle.
@@ -172,7 +258,10 @@ impl VelesDbState {
     /// The handle is built once (lazily) using the default embedding dimension
     /// and a snapshot directory under the database path, then reused for every
     /// later call. This keeps the TTL registry, temporal index, and snapshot
-    /// manager alive across commands.
+    /// manager alive across commands. No state lock is held while `f` runs.
+    ///
+    /// Prefer [`Self::run_memory`] inside async Tauri commands: `f` runs on
+    /// the caller's thread here, which must not be an async runtime worker.
     ///
     /// # Errors
     ///
@@ -181,35 +270,45 @@ impl VelesDbState {
     where
         F: FnOnce(&AgentMemory) -> Result<T>,
     {
-        let memory = self.memory_handle()?;
+        let memory = self.inner.memory_handle()?;
         f(&memory)
     }
 
-    /// Returns the shared `AgentMemory`, building it on first use.
+    /// Runs a synchronous `AgentMemory` operation on Tauri's blocking pool.
     ///
-    /// Lock ordering: the `db` lock (via `with_db`) is fully released before the
-    /// `memory` write lock is taken, so the two are never nested.
+    /// Same rationale as [`Self::run_db`]: memory operations hit the same
+    /// synchronous, fsync-bearing core paths and must not run inline on the
+    /// async runtime. The lazy first construction of the handle also happens
+    /// off-runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory subsystem cannot be opened, if `f`
+    /// fails, or if the blocking task cannot be joined.
+    pub async fn run_memory<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&AgentMemory) -> Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let inner = Arc::clone(&self.inner);
+        tauri::async_runtime::spawn_blocking(move || {
+            let memory = inner.memory_handle()?;
+            f(&memory)
+        })
+        .await
+        .map_err(|e| Error::TaskJoin(e.to_string()))?
+    }
+
+    /// Returns the shared `AgentMemory`, building it on first use.
+    #[cfg(test)]
     fn memory_handle(&self) -> Result<Arc<AgentMemory>> {
-        if let Some(existing) = self.memory.read().clone() {
-            return Ok(existing);
-        }
-        let db = self.with_db(Ok)?;
-        let snapshot_dir = self.path.join(MEMORY_SNAPSHOT_DIR);
-        let mut guard = self.memory.write();
-        if let Some(existing) = guard.clone() {
-            return Ok(existing);
-        }
-        let snapshot_dir = snapshot_dir.to_string_lossy().into_owned();
-        let memory =
-            Arc::new(AgentMemory::new(db)?.with_snapshots(&snapshot_dir, MEMORY_SNAPSHOT_MAX));
-        *guard = Some(Arc::clone(&memory));
-        Ok(memory)
+        self.inner.memory_handle()
     }
 
     /// Returns the database path.
     #[must_use]
     pub fn path(&self) -> &PathBuf {
-        &self.path
+        &self.inner.path
     }
 }
 

--- a/crates/tauri-plugin-velesdb/tests/nonblocking_state.rs
+++ b/crates/tauri-plugin-velesdb/tests/nonblocking_state.rs
@@ -1,0 +1,153 @@
+//! Regression tests for the async-runtime starvation fix in `VelesDbState`.
+//!
+//! Two properties are locked in at the state layer (no Tauri app needed):
+//!
+//! 1. `run_db` executes core operations on the blocking pool, so a slow
+//!    operation never stalls async runtime workers: with the runtime
+//!    constrained to a single worker thread, a fast command completes while a
+//!    slow one is still in flight.
+//! 2. Neither `run_db` nor `with_db` holds the internal state lock across the
+//!    operation: while a slow operation is paused mid-flight, `open()` (which
+//!    takes the state's write lock) and a second `with_db` both succeed
+//!    immediately instead of blocking behind a held read guard.
+//!
+//! Every wait is bounded by a watchdog timeout so a regression fails the test
+//! instead of hanging it.
+
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tauri_plugin_velesdb::VelesDbState;
+
+/// Upper bound for any single wait; generous so slow CI never flakes.
+const WATCHDOG: Duration = Duration::from_secs(30);
+
+/// Bound within which the fast operation must finish while the slow one is
+/// still in flight. Generous (the fast op takes microseconds; the slow op is
+/// gated on a channel, not a timer, so there is no race to win).
+const FAST_BOUND: Duration = Duration::from_secs(10);
+
+fn opened_state(dir: &std::path::Path) -> Arc<VelesDbState> {
+    let state = Arc::new(VelesDbState::new(dir.to_path_buf()));
+    // Warm the lazy open so measurements below exclude first-open cost.
+    state.open().expect("open database");
+    state
+}
+
+/// With a single-worker async runtime, a fast `run_db` call must complete
+/// while a slow `run_db` call is still executing. Before the fix, the slow
+/// synchronous core call ran inline on the (only) runtime worker, so the fast
+/// command could not even start until the slow one finished.
+#[test]
+fn fast_command_completes_while_slow_operation_is_in_flight() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let state = opened_state(dir.path());
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .expect("build single-worker runtime");
+
+    runtime.block_on(async move {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+
+        // Slow operation: signals once it is running, then blocks until
+        // released. It runs on the blocking pool, not on the async worker.
+        let slow_state = Arc::clone(&state);
+        let slow = tokio::spawn(async move {
+            slow_state
+                .run_db(move |_db| {
+                    let _ = started_tx.send(());
+                    let _ = release_rx.recv_timeout(WATCHDOG);
+                    Ok(())
+                })
+                .await
+        });
+
+        // Watchdog: the slow operation must actually be in flight.
+        tokio::time::timeout(WATCHDOG, started_rx)
+            .await
+            .expect("watchdog: slow operation never started")
+            .expect("slow operation dropped its start signal");
+
+        // Fast operation on the same single-worker runtime, while the slow
+        // one is still blocked inside its core call.
+        let fast_started = Instant::now();
+        let collections = tokio::time::timeout(
+            FAST_BOUND,
+            state.run_db(|db| Ok(db.list_collections().len())),
+        )
+        .await
+        .expect("fast command starved: runtime worker blocked by slow operation")
+        .expect("fast command failed");
+        assert_eq!(collections, 0);
+        assert!(
+            fast_started.elapsed() < FAST_BOUND,
+            "fast command took {:?}, exceeding the {FAST_BOUND:?} bound",
+            fast_started.elapsed()
+        );
+
+        // Release the slow operation and check it finishes cleanly.
+        release_tx.send(()).expect("release slow operation");
+        tokio::time::timeout(WATCHDOG, slow)
+            .await
+            .expect("watchdog: slow operation never finished")
+            .expect("join slow task")
+            .expect("slow operation failed");
+    });
+}
+
+/// The state lock must not be held while an operation runs: with a `with_db`
+/// operation paused mid-flight, `open()` (write lock) and a second `with_db`
+/// (read lock) must both return promptly. Before the fix, `with_db` held the
+/// state's read guard across the whole operation, so `open()` would block
+/// until the operation finished.
+#[test]
+fn state_lock_is_not_held_across_with_db_operation() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let state = opened_state(dir.path());
+
+    let (started_tx, started_rx) = mpsc::channel::<()>();
+    let (release_tx, release_rx) = mpsc::channel::<()>();
+
+    // Slow operation paused mid-flight on a plain thread (sync API).
+    let slow_state = Arc::clone(&state);
+    let slow = std::thread::spawn(move || {
+        slow_state.with_db(move |_db| {
+            let _ = started_tx.send(());
+            let _ = release_rx.recv_timeout(WATCHDOG);
+            Ok(())
+        })
+    });
+    started_rx
+        .recv_timeout(WATCHDOG)
+        .expect("watchdog: slow operation never started");
+
+    // open() takes the state's write lock; run it on a helper thread with a
+    // watchdog so a held read guard fails the test instead of hanging it.
+    let (open_done_tx, open_done_rx) = mpsc::channel();
+    let open_state = Arc::clone(&state);
+    let opener = std::thread::spawn(move || {
+        let result = open_state.open();
+        let _ = open_done_tx.send(result);
+    });
+    open_done_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("state lock still held during with_db operation: open() blocked")
+        .expect("concurrent open failed");
+    opener.join().expect("join opener thread");
+
+    // A second with_db-style access also succeeds while the slow op runs.
+    let collections = state
+        .with_db(|db| Ok(db.list_collections().len()))
+        .expect("concurrent with_db failed");
+    assert_eq!(collections, 0);
+
+    release_tx.send(()).expect("release slow operation");
+    slow.join()
+        .expect("join slow thread")
+        .expect("slow with_db failed");
+}

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -269,6 +269,27 @@ impl Collection {
         crate::index::bm25_persistence_wal::wal_append_remove_document(&wal_path, id)
     }
 
+    /// Appends `remove_document` mutations for a whole batch to the BM25 WAL
+    /// under ONE durability barrier.
+    ///
+    /// Batched counterpart of [`Self::append_bm25_wal_remove`]: calling that
+    /// in a loop pays one `open` + one fsync PER ID (the #1797 failure mode,
+    /// resurfacing on the delete path — finding C3). The frames are identical
+    /// to N sequential appends; only the syscall count differs. Callers keep
+    /// WAL-before-apply at batch granularity: let this return `Ok` first,
+    /// then remove the documents from the in-memory index.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any WAL open / write / flush / fsync failure; nothing was
+    /// acknowledged in that case and the in-memory index must not be touched.
+    #[cfg(feature = "persistence")]
+    pub(super) fn append_bm25_wal_remove_batch(&self, ids: &[u64]) -> Result<()> {
+        use crate::index::bm25_persistence_wal::{wal_append_batch, wal_path_for_bm25, WalOp};
+        let ops: Vec<WalOp<'_>> = ids.iter().map(|&id| WalOp::Remove { id }).collect();
+        wal_append_batch(&wal_path_for_bm25(&self.storage.path), &ops)
+    }
+
     /// Appends `(name, point_id, sparse_vector)` triples to the per-index
     /// sparse WAL under WAL-before-apply semantics.
     ///

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -179,17 +179,31 @@ impl Collection {
     }
 
     /// Deletes metadata-only points.
+    ///
+    /// Durability discipline and crash contract are identical to
+    /// [`delete_vector_core_stores`](Self::delete_vector_core_stores) minus
+    /// the vector store: one WAL barrier for the payload tombstones, one for
+    /// the BM25 removes — O(1) fsyncs per batch under the write locks, not
+    /// O(N) (finding C3).
     fn delete_metadata_only(&self, ids: &[u64]) -> Result<()> {
         // LOCK ORDER: payload_storage(3) → label_index(7).
         let mut payload_storage = self.storage.payload_storage.write();
         let mut label_idx = self.graph.label_index.write();
-        for &id in ids {
-            let old_payload = payload_storage.retrieve(id).ok().flatten();
-            payload_storage.delete(id)?;
-            // Issue #389: WAL-before-apply for BM25 removes so crash
-            // recovery replays the remove.
-            #[cfg(feature = "persistence")]
-            self.append_bm25_wal_remove(id)?;
+
+        // Old payloads must be read before the tombstones land — they feed
+        // the secondary-index and label-index removals below.
+        let old_payloads: Vec<Option<serde_json::Value>> = ids
+            .iter()
+            .map(|&id| payload_storage.retrieve(id).ok().flatten())
+            .collect();
+
+        payload_storage.delete_batch(ids)?;
+        // Issue #389: WAL-before-apply for BM25 removes so crash recovery
+        // replays the remove — batched, one barrier for the whole batch.
+        #[cfg(feature = "persistence")]
+        self.append_bm25_wal_remove_batch(ids)?;
+
+        for (&id, old_payload) in ids.iter().zip(&old_payloads) {
             self.storage.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {
@@ -212,6 +226,47 @@ impl Collection {
     }
 
     /// Removes points from vector/payload storage, HNSW index, caches, and label index.
+    ///
+    /// # Durability: one barrier per touched store per batch (finding C3)
+    ///
+    /// This used to call each store's per-point `delete()` inside the loop,
+    /// paying ~3 fsyncs PER POINT (vector WAL + payload WAL + BM25 WAL)
+    /// while holding every write lock below — a batch of N points wedged all
+    /// concurrent readers/writers of the collection behind ~3N synchronous
+    /// fsyncs. Now each store receives the whole batch under a single
+    /// durability barrier ([`crate::storage::MmapStorage::delete_batch`],
+    /// [`crate::storage::LogPayloadStorage::delete_batch`], BM25
+    /// `wal_append_batch`), mirroring the bulk-upsert discipline
+    /// (`store_batch` + one sync, #1797): exactly 3 fsyncs per batch, with
+    /// the rest of the lock hold being in-memory/mmap work.
+    ///
+    /// The barriers stay under the locks because the mmap store's hole-punch
+    /// is destructive and MUST follow a durable delete frame (#898) — but
+    /// they are O(1) per batch, which removes the seconds-to-minutes wedge.
+    ///
+    /// # Crash contract
+    ///
+    /// A crash mid-batch may lose the (not yet synced) tail of the batch but
+    /// never corrupts:
+    ///
+    /// * Deletes that did not reach their barrier are lost wholesale — the
+    ///   points remain fully live after reopen. All three replay paths
+    ///   CRC-check each frame and stop cleanly at a torn tail: vector WAL
+    ///   (`storage/mmap/wal_replay.rs::replay_wal_to_index`, op=2 frames),
+    ///   payload WAL (`storage/log_payload.rs::replay_wal_from` via
+    ///   `WalEntry`, 0xC4 tombstones), BM25 (`bm25_persistence_wal::
+    ///   wal_replay`, Remove frames on top of the snapshot).
+    /// * `MmapStorage::delete_batch` syncs every delete frame BEFORE any
+    ///   hole-punch, so a punched region is always shadowed by a durable
+    ///   delete record — no zero-vector resurrection (#898 invariant).
+    /// * A crash BETWEEN the barriers (vector → payload → BM25) can leave a
+    ///   point deleted in one store but not the next. That window is not
+    ///   new — pre-fix it existed per point, between its three fsyncs — and
+    ///   reopen converges: `get()`/search require the (deleted) vector, HNSW
+    ///   orphans are removed by the 3-pass reconciliation in
+    ///   `collection/core/recovery.rs`, and the leftover payload/BM25
+    ///   entries are exactly what a re-issued delete of the same ids cleans
+    ///   up.
     fn delete_vector_core_stores(&self, ids: &[u64]) -> Result<()> {
         // LOCK ORDER: vector_storage(2) → payload_storage(3) → caches(4) → label_index(7).
         let mut vector_storage = self.storage.vector_storage.write();
@@ -221,18 +276,26 @@ impl Collection {
         let mut pq_cache = self.storage.pq_cache.write();
         let mut label_idx = self.graph.label_index.write();
 
-        for &id in ids {
-            let old_payload = payload_storage.retrieve(id).ok().flatten();
-            vector_storage.delete(id)?;
-            payload_storage.delete(id)?;
+        // Old payloads must be read before the tombstones land — they feed
+        // the secondary-index and label-index removals below.
+        let old_payloads: Vec<Option<serde_json::Value>> = ids
+            .iter()
+            .map(|&id| payload_storage.retrieve(id).ok().flatten())
+            .collect();
+
+        // ONE durability barrier per store for the whole batch (see rustdoc).
+        vector_storage.delete_batch(ids)?;
+        payload_storage.delete_batch(ids)?;
+        // Issue #389: WAL-before-apply for BM25 removes so crash recovery
+        // replays the remove — batched, applied in-memory only below.
+        #[cfg(feature = "persistence")]
+        self.append_bm25_wal_remove_batch(ids)?;
+
+        for (&id, old_payload) in ids.iter().zip(&old_payloads) {
             self.storage.index.remove(id);
             sq8_cache.remove(&id);
             binary_cache.remove(&id);
             pq_cache.remove(&id);
-            // Issue #389: WAL-before-apply for BM25 removes so crash
-            // recovery replays the remove.
-            #[cfg(feature = "persistence")]
-            self.append_bm25_wal_remove(id)?;
             self.storage.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
             if let Some(ref old) = old_payload {

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -378,6 +378,76 @@ impl LogPayloadStorage {
         self.maybe_auto_snapshot();
         Ok(())
     }
+
+    /// Deletes multiple payloads under ONE durability barrier.
+    ///
+    /// Batched counterpart of [`PayloadStorage::delete`], which syncs the WAL
+    /// per id: calling it in a loop cost one fsync PER POINT on this store
+    /// (finding C3). Here every CRC-protected tombstone (`Marker(0xC4) |
+    /// ID(8) | CRC32(4)`) is built into one buffer, written with a single
+    /// `write_all`, and synced once via [`Self::sync_wal_or_resync`] — the
+    /// bytes are identical to N sequential `delete` calls, so WAL replay is
+    /// unchanged. Ids absent from the index are skipped (no tombstone),
+    /// mirroring the single-delete guard.
+    ///
+    /// # Crash contract
+    ///
+    /// The batch's tombstones become durable together: a crash before the
+    /// sync loses ALL of them (the payloads simply remain live on replay —
+    /// nothing is half-applied), a crash after it persists all. A torn tail
+    /// inside the record group is skipped by CRC framing on replay. Index
+    /// entries are removed only after the sync succeeded, so acknowledged
+    /// in-memory state never runs ahead of the WAL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the WAL write or sync fails; the index is left
+    /// untouched in that case.
+    pub fn delete_batch(&mut self, ids: &[u64]) -> io::Result<()> {
+        /// Tombstone record size: Marker(1) + ID(8) + CRC32(4).
+        const TOMBSTONE_BYTES: u64 = 1 + 8 + 4;
+
+        // SAFETY: `&mut self` serializes all writers, so the read-then-write
+        // gap below cannot race a concurrent `store(id)` (same argument as
+        // the single-`delete` guard).
+        let live: Vec<u64> = {
+            let index = self.index.read();
+            ids.iter()
+                .copied()
+                .filter(|id| index.contains_key(id))
+                .collect()
+        };
+        if live.is_empty() {
+            return Ok(());
+        }
+
+        // Scoped block: all lock guards are released before the auto-snapshot
+        // check, which itself acquires locks (see `create_snapshot`).
+        {
+            let mut wal = self.wal.write();
+            let mut index = self.index.write();
+            let mut offset = self.write_offset.write();
+
+            let mut records = Vec::with_capacity(live.len() * 13);
+            for &id in &live {
+                records.push(CRC_DELETE_MARKER);
+                records.extend_from_slice(&id.to_le_bytes());
+                records.extend_from_slice(&compute_delete_crc(id).to_le_bytes());
+            }
+            wal.write_all(&records)?;
+
+            // ONE sync for the whole batch (resync offset on failure).
+            Self::sync_wal_or_resync(&mut wal, self.durability, &mut offset)?;
+
+            for &id in &live {
+                *offset += TOMBSTONE_BYTES;
+                index.remove(&id);
+            }
+        }
+
+        self.maybe_auto_snapshot();
+        Ok(())
+    }
 }
 
 impl PayloadStorage for LogPayloadStorage {

--- a/crates/velesdb-core/src/storage/mmap/vector_io.rs
+++ b/crates/velesdb-core/src/storage/mmap/vector_io.rs
@@ -111,6 +111,32 @@ fn write_wal_delete_entry(
     wal.write_all(&crc.to_le_bytes())
 }
 
+/// Per-entry WAL delete frame size: op(1) + id(8) + crc(4) = 13 bytes.
+const WAL_DELETE_ENTRY_SIZE: usize = 13;
+
+/// Serializes multiple CRC32-framed delete entries and writes them to the
+/// WAL in a single `write_all` call.
+///
+/// Each entry retains the standard per-entry CRC32 frame of
+/// [`write_wal_delete_entry`], so replay is unchanged — only the I/O is
+/// coalesced (one syscall instead of 2N). Mirrors
+/// [`write_wal_store_entries_grouped`].
+fn write_wal_delete_entries_grouped(wal: &mut io::BufWriter<File>, ids: &[u64]) -> io::Result<()> {
+    let mut entry_buf = Vec::with_capacity(1 + 8);
+    let mut group_buf = Vec::with_capacity(ids.len() * WAL_DELETE_ENTRY_SIZE);
+
+    for &id in ids {
+        entry_buf.clear();
+        entry_buf.push(2u8);
+        entry_buf.extend_from_slice(&id.to_le_bytes());
+        let crc = crc32_hash(&entry_buf);
+        group_buf.extend_from_slice(&entry_buf);
+        group_buf.extend_from_slice(&crc.to_le_bytes());
+    }
+
+    wal.write_all(&group_buf)
+}
+
 /// RF-2: Shared dimension validation for `store` and `store_batch`.
 #[inline]
 fn validate_dimension(expected: usize, actual: usize) -> io::Result<()> {
@@ -293,26 +319,8 @@ impl VectorStorage for MmapStorage {
             }
         }
 
-        // 2. Get offset before removing from index (for hole-punch)
-        // EPIC-033/US-004: Use sharded index for reduced contention
-        let offset = self.index.get(id);
-
-        // 3. Remove from Index
-        self.index.remove(id);
-
-        // 4. EPIC-033/US-003: Hole-punch to reclaim disk space immediately
-        // This releases disk blocks back to the filesystem without rewriting the file
-        if let Some(offset) = offset {
-            let vector_size = self.dimension * std::mem::size_of::<f32>();
-            // Best-effort: ignore errors (space will be reclaimed on compact())
-            // Reason: offset and vector_size are bounded by file size, always fit in u64 on 64-bit
-            let offset_u64 = u64::try_from(offset).unwrap_or(u64::MAX);
-            let size_u64 = u64::try_from(vector_size).unwrap_or(u64::MAX);
-            if offset_u64 != u64::MAX && size_u64 != u64::MAX {
-                let _ =
-                    crate::storage::compaction::punch_hole(&self.data_file, offset_u64, size_u64);
-            }
-        }
+        // 2-4. Remove from index and hole-punch (shared with `delete_batch`).
+        self.remove_from_index_and_punch(id);
 
         Ok(())
     }
@@ -358,6 +366,82 @@ impl VectorStorage for MmapStorage {
 }
 
 impl MmapStorage {
+    /// Deletes a whole batch of vectors under ONE durability barrier.
+    ///
+    /// Batched counterpart of [`VectorStorage::delete`], which pays one WAL
+    /// `flush` + `sync_all` PER ID: calling it in a loop is what made a batch
+    /// delete of N points cost N fsyncs on this store alone (finding C3).
+    /// Here every CRC32-framed delete entry is serialized into one buffer,
+    /// written with a single `write_all`, and synced once — byte-for-byte
+    /// identical to what N sequential [`VectorStorage::delete`] calls would
+    /// have written, so [`super::wal_replay`] needs no change.
+    ///
+    /// # Crash-safety ordering (#898 invariant, batch granularity)
+    ///
+    /// Every delete entry reaches the WAL — flushed unconditionally, fsynced
+    /// under [`DurabilityMode::Fsync`] — BEFORE any hole-punch below zeroes
+    /// on-disk bytes. A crash before the barrier loses the whole batch's
+    /// deletes (the vectors simply remain live; nothing was punched yet);
+    /// a crash after it replays every delete. A punched region is therefore
+    /// always shadowed by a durable delete record — no id can be resurrected
+    /// as a zero vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the WAL write, flush, or fsync fails. On error
+    /// nothing has been applied: the index and data file are untouched.
+    pub(crate) fn delete_batch(&mut self, ids: &[u64]) -> io::Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        // 1. Group WAL write: all delete frames, one syscall, one barrier.
+        if self.durability != DurabilityMode::None {
+            let mut wal = self.wal.write();
+            write_wal_delete_entries_grouped(&mut wal, ids)?;
+            wal.flush()?;
+            if self.durability == DurabilityMode::Fsync {
+                wal.get_ref().sync_all()?;
+            }
+        }
+
+        // 2. Apply: index removal + hole-punch, only after the WAL barrier.
+        for &id in ids {
+            self.remove_from_index_and_punch(id);
+        }
+
+        Ok(())
+    }
+
+    /// Removes `id` from the index and hole-punches its data region.
+    ///
+    /// Shared apply step of [`VectorStorage::delete`] and
+    /// [`Self::delete_batch`]. Callers MUST have made the corresponding WAL
+    /// delete entry durable (per their durability mode) before calling — the
+    /// hole-punch is destructive (see the #898 note in `delete`).
+    fn remove_from_index_and_punch(&self, id: u64) {
+        // Get offset before removing from index (for hole-punch).
+        // EPIC-033/US-004: Use sharded index for reduced contention.
+        let offset = self.index.get(id);
+
+        self.index.remove(id);
+
+        // EPIC-033/US-003: Hole-punch to reclaim disk space immediately.
+        // This releases disk blocks back to the filesystem without rewriting
+        // the file.
+        if let Some(offset) = offset {
+            let vector_size = self.dimension * std::mem::size_of::<f32>();
+            // Best-effort: ignore errors (space will be reclaimed on compact())
+            // Reason: offset and vector_size are bounded by file size, always fit in u64 on 64-bit
+            let offset_u64 = u64::try_from(offset).unwrap_or(u64::MAX);
+            let size_u64 = u64::try_from(vector_size).unwrap_or(u64::MAX);
+            if offset_u64 != u64::MAX && size_u64 != u64::MAX {
+                let _ =
+                    crate::storage::compaction::punch_hole(&self.data_file, offset_u64, size_u64);
+            }
+        }
+    }
+
     /// Computes offsets for new vectors (not yet in the index).
     ///
     /// Returns a map of `(id -> offset)` for new vectors and the total

--- a/crates/velesdb-core/src/storage/mod.rs
+++ b/crates/velesdb-core/src/storage/mod.rs
@@ -33,7 +33,11 @@ mod traits;
 pub mod vector_bytes;
 #[cfg(test)]
 mod vector_bytes_tests;
-pub mod wal_batcher;
+// Dormant by design (CORE_WIRING_DEBT entry 1): zero production call sites,
+// kept for the declared premium transfer. Only tests exercise it, so the
+// non-test build must tolerate the unused items.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) mod wal_batcher;
 #[cfg(test)]
 mod wal_batcher_tests;
 pub mod wal_cursor;

--- a/crates/velesdb-core/src/storage/wal_batcher.rs
+++ b/crates/velesdb-core/src/storage/wal_batcher.rs
@@ -75,7 +75,7 @@ struct PendingBatch {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```ignore (crate-internal API — doctests compile as an external crate)
 /// use velesdb_core::config::WalBatchConfig;
 /// use velesdb_core::storage::wal_batcher::WalBatcher;
 ///

--- a/crates/velesdb-core/tests/batch_delete_contention.rs
+++ b/crates/velesdb-core/tests/batch_delete_contention.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "persistence")]
+//! Batch-delete durability and lock-contention tests (finding C3).
+//!
+//! The batch delete path used to pay ~3 synchronous fsyncs PER POINT
+//! (vector WAL + payload WAL + BM25 WAL) while holding every collection
+//! write lock, wedging all concurrent readers and writers for the whole
+//! batch. The fix pays one durability barrier per touched store per batch.
+//!
+//! Two guarantees are pinned here:
+//! 1. Correctness: a batch delete is durable across reopen, and surviving
+//!    points remain intact (vector + payload).
+//! 2. Contention: while a large batch delete runs on one thread, a
+//!    concurrent reader completes within a generous bound instead of being
+//!    wedged behind O(N) fsyncs. A watchdog (`recv_timeout`) guarantees the
+//!    test itself can never hang.
+
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tempfile::TempDir;
+use velesdb_core::distance::DistanceMetric;
+use velesdb_core::quantization::StorageMode;
+use velesdb_core::{Point, VectorCollection};
+
+/// Deterministic vector so survivors can be checked byte-for-byte.
+fn make_vector(seed: u64, dimension: usize) -> Vec<f32> {
+    #[allow(clippy::cast_precision_loss)] // test data generation only
+    (0..dimension)
+        .map(|i| ((seed as f32) * 0.3 + (i as f32) * 0.1).sin())
+        .collect()
+}
+
+/// Points `0..n` with a text-bearing payload (exercises the BM25 WAL path).
+fn make_points(n: u64, dimension: usize) -> Vec<Point> {
+    (0..n)
+        .map(|id| {
+            Point::new(
+                id,
+                make_vector(id, dimension),
+                Some(json!({ "title": format!("document {id}"), "rank": id })),
+            )
+        })
+        .collect()
+}
+
+fn create_collection(dir: &std::path::Path, dimension: usize) -> VectorCollection {
+    VectorCollection::create(
+        dir.to_path_buf(),
+        "batch_delete_test",
+        dimension,
+        DistanceMetric::Euclidean,
+        StorageMode::Full,
+    )
+    .expect("create collection")
+}
+
+/// Batch-deleting half the points must survive a drop + reopen: deleted ids
+/// stay gone (their WAL tombstones were fsynced by the delete itself — no
+/// explicit `flush()` after the delete on purpose), survivors keep their
+/// exact vector and payload.
+#[test]
+fn batch_delete_persists_across_reopen() {
+    let dir = TempDir::new().expect("tempdir");
+    let coll_dir = dir.path().join("coll");
+    let dimension = 8;
+    let total: u64 = 200;
+    let deleted: Vec<u64> = (0..total / 2).collect();
+    let survivors: Vec<u64> = (total / 2..total).collect();
+
+    {
+        let coll = create_collection(&coll_dir, dimension);
+        coll.upsert_bulk(&make_points(total, dimension))
+            .expect("upsert");
+        coll.flush().expect("flush after upsert");
+        coll.delete(&deleted).expect("batch delete");
+        // Intentionally NO flush here: the delete barrier itself must have
+        // made the tombstones durable before `delete()` returned.
+    }
+
+    let coll = VectorCollection::open(coll_dir).expect("reopen");
+
+    for (id, got) in deleted.iter().zip(coll.get(&deleted)) {
+        assert!(got.is_none(), "deleted point {id} resurrected after reopen");
+    }
+    for (id, got) in survivors.iter().copied().zip(coll.get(&survivors)) {
+        let point = got.unwrap_or_else(|| panic!("survivor {id} lost after reopen"));
+        assert_eq!(
+            point.vector,
+            make_vector(id, dimension),
+            "vector of {id} changed"
+        );
+        let payload = point.payload.expect("survivor payload lost");
+        assert_eq!(payload["rank"], json!(id), "payload of {id} changed");
+    }
+    assert_eq!(
+        coll.all_point_ids(),
+        survivors,
+        "storage id set diverged after reopen"
+    );
+}
+
+/// Generous ceiling for one concurrent `get()` racing a large batch delete.
+///
+/// Post-fix the delete holds the write locks for the in-memory batch work
+/// plus THREE fsyncs total, so the reader completes in well under a second
+/// even on slow disks. Pre-fix the same delete held the locks across
+/// ~3 fsyncs per victim (~24000 fsyncs here) and the reader was wedged
+/// for the full duration — an order of magnitude (or more) past this bound.
+const CONCURRENT_READ_BOUND: Duration = Duration::from_secs(5);
+
+/// Hard watchdog so a regression can never hang the suite.
+const WATCHDOG: Duration = Duration::from_secs(300);
+
+/// While a batch delete of thousands of points runs on one thread, a reader
+/// on another thread must complete within [`CONCURRENT_READ_BOUND`].
+#[test]
+fn concurrent_reader_completes_during_batch_delete() {
+    let dir = TempDir::new().expect("tempdir");
+    let coll_dir = dir.path().join("coll");
+    let dimension = 16;
+    let total: u64 = 8000;
+    let keeper = total - 1;
+    let victims: Vec<u64> = (0..keeper).collect();
+
+    let coll = create_collection(&coll_dir, dimension);
+    coll.upsert_bulk(&make_points(total, dimension))
+        .expect("upsert");
+    coll.flush().expect("flush after upsert");
+    let coll = Arc::new(coll);
+
+    let deleter = {
+        let coll = Arc::clone(&coll);
+        thread::spawn(move || {
+            let started = Instant::now();
+            coll.delete(&victims).expect("batch delete");
+            started.elapsed()
+        })
+    };
+
+    let (tx, rx) = mpsc::channel();
+    let reader = {
+        let coll = Arc::clone(&coll);
+        thread::spawn(move || {
+            // Give the delete thread a head start so the read overlaps the
+            // lock-holding window instead of sneaking in before it.
+            thread::sleep(Duration::from_millis(100));
+            let started = Instant::now();
+            let got = coll.get(&[keeper]);
+            let latency = started.elapsed();
+            tx.send((latency, got[0].is_some())).expect("send result");
+        })
+    };
+
+    // Watchdog: `recv_timeout` guarantees the test fails loudly instead of
+    // hanging if the reader is wedged behind the delete.
+    let (read_latency, keeper_visible) = rx
+        .recv_timeout(WATCHDOG)
+        .expect("concurrent reader wedged behind batch delete (watchdog hit)");
+    let delete_duration = deleter.join().expect("deleter thread panicked");
+    reader.join().expect("reader thread panicked");
+
+    eprintln!(
+        "batch delete of {keeper} points: {delete_duration:?}; \
+         concurrent get latency: {read_latency:?}"
+    );
+    assert!(keeper_visible, "surviving point invisible during delete");
+    assert!(
+        read_latency < CONCURRENT_READ_BOUND,
+        "concurrent reader took {read_latency:?} (bound {CONCURRENT_READ_BOUND:?}) — \
+         batch delete is holding write locks across per-point fsyncs again"
+    );
+}

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -1059,6 +1059,17 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// the same lock and in the same read-modify-write that was already
     /// paid for. Reads never mutate it.
     fn update_working_index(&self, project: &str, session: &str) -> Result<(), MemoryError> {
+        // The index slot's embedding derives from the PROJECT NAME alone,
+        // never from the index content, so it is computed here, BEFORE the
+        // lock: an embedder can be a network round-trip (or a hung one), and
+        // holding the global write lock across it stalls every working-index
+        // write in the process behind one slow call. Racing saves may embed
+        // concurrently, but they embed the same text, so whichever vector
+        // lands is equivalent — no re-check under the lock is needed. The
+        // index CONTENT read-modify-write stays entirely under the lock.
+        let embedding = self
+            .embedder
+            .embed(&format!("working context index {project}"))?;
         // Read-modify-write of a single shared fact: held for the whole
         // sequence, otherwise a concurrent save silently erases this entry.
         let _guard = WORKING_INDEX_WRITE.lock();
@@ -1087,24 +1098,28 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         index.sessions = self.live_sessions(project, index.sessions)?;
         let content = serde_json::to_string(&index)
             .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))?;
-        self.write_working_index(project, &content)
+        self.write_working_index(project, &content, &embedding)
     }
 
     /// Persist a serialized index into `project`'s reserved index slot —
     /// always with the [`CTX_WORKING_INDEX_FIELD`] marker, since an index
     /// written without it would be treated as a squatter and read back as
     /// empty. Only [`Self::update_working_index`] (which holds
-    /// [`WORKING_INDEX_WRITE`]) calls this.
-    fn write_working_index(&self, project: &str, content: &str) -> Result<(), MemoryError> {
+    /// [`WORKING_INDEX_WRITE`] and supplies the slot `embedding` it computed
+    /// before taking that lock) calls this: nothing in here may call the
+    /// embedder, or the lock would again be held across a network hop.
+    fn write_working_index(
+        &self,
+        project: &str,
+        content: &str,
+        embedding: &[f32],
+    ) -> Result<(), MemoryError> {
         let slot = working_index_id(project);
-        let embedding = self
-            .embedder
-            .embed(&format!("working context index {project}"))?;
         let meta = system_meta(&[
             (CTX_WORKING_INDEX_FIELD, Value::Bool(true)),
             (CTX_PROJECT_FIELD, Value::String(project.to_owned())),
         ]);
-        self.store_fact(slot, content, &embedding, Some(&meta), None)?;
+        self.store_fact(slot, content, embedding, Some(&meta), None)?;
         Ok(())
     }
 }

--- a/crates/velesdb-memory/tests/autograph_async_bdd.rs
+++ b/crates/velesdb-memory/tests/autograph_async_bdd.rs
@@ -33,6 +33,12 @@ use velesdb_memory::{
 /// exactly one `extract_graph` through.
 struct GatedExtractor {
     gate: Mutex<Receiver<()>>,
+    /// Incremented BEFORE the gate blocks: the observable "the worker has
+    /// dequeued this job and is now stuck in its generation". Tests that need
+    /// a job to be IN FLIGHT (rather than still queued) must wait on this —
+    /// `calls` only rises once the gate opens, which is too late to
+    /// distinguish the two states.
+    entered: AtomicUsize,
     calls: AtomicUsize,
 }
 
@@ -42,6 +48,7 @@ impl GatedExtractor {
         (
             Arc::new(Self {
                 gate: Mutex::new(rx),
+                entered: AtomicUsize::new(0),
                 calls: AtomicUsize::new(0),
             }),
             tx,
@@ -55,6 +62,7 @@ impl Extractor for GatedExtractor {
     }
 
     fn extract_graph(&self, _text: &str) -> Result<Extraction, ExtractError> {
+        self.entered.fetch_add(1, Ordering::SeqCst);
         self.gate
             .lock()
             .expect("gate lock")
@@ -148,12 +156,26 @@ fn a_full_queue_drops_counted_and_never_blocks_the_write() {
     // the queue (capacity 2); job 3 must be dropped — counted, and the
     // writes themselves still instant.
     let started = Instant::now();
-    for i in 0..4 {
+    svc.remember("fait en rafale numero 0", &[], None)
+        .expect("remember");
+    let first_write = started.elapsed();
+    // Job 0 must be IN FLIGHT before the rest are submitted, or the capacity
+    // arithmetic is a race: a job 0 still sitting in the queue occupies a slot,
+    // and the drop lands on job 2 instead of job 3.
+    assert!(
+        wait_until(Duration::from_secs(10), || extractor
+            .entered
+            .load(Ordering::SeqCst)
+            == 1),
+        "the worker must have entered the gated generation"
+    );
+    let burst = Instant::now();
+    for i in 1..4 {
         svc.remember(&format!("fait en rafale numero {i}"), &[], None)
             .expect("remember");
     }
     assert!(
-        started.elapsed() < Duration::from_secs(2),
+        first_write < Duration::from_secs(2) && burst.elapsed() < Duration::from_secs(2),
         "four writes against a stuck extractor must not block on the queue"
     );
     let observed = wait_until(Duration::from_secs(5), || svc.autograph_dropped() == 1);
@@ -206,6 +228,18 @@ fn a_forgotten_fact_is_not_resurrected_by_its_stale_enrichment() {
     let fact_id = svc
         .remember("Alice Martin travaille chez Wiscale.", &[], None)
         .expect("remember");
+    // Wait for the job to be IN FLIGHT, not merely queued: the scenario is a
+    // generation that outlives a forget, and only a dequeued job survives the
+    // bounded shutdown below (a still-queued one is skipped by design, which
+    // would leave `calls` at 0 for a reason that has nothing to do with the
+    // resurrection this test is about).
+    assert!(
+        wait_until(Duration::from_secs(10), || extractor
+            .entered
+            .load(Ordering::SeqCst)
+            == 1),
+        "the worker must have entered the gated generation"
+    );
 
     // Forget while the generation is stuck behind the gate. The fact is gone
     // and its (yet-unwired) hubs collect nothing — this is the permanent

--- a/crates/velesdb-memory/tests/working_index_lock_contention_bdd.rs
+++ b/crates/velesdb-memory/tests/working_index_lock_contention_bdd.rs
@@ -1,0 +1,148 @@
+//! Regression: the global `WORKING_INDEX_WRITE` lock must never be held
+//! across an embedder call.
+//!
+//! The working-context index write needs an embedding for its slot, and an
+//! embedder can be a network round-trip — hundreds of milliseconds, seconds,
+//! or a hung connection. Before the fix, `update_working_index` acquired the
+//! process-global index lock and THEN embedded, so one slow embedder call
+//! stalled every working-index write in the process (all sessions, all
+//! projects — the lock is global by design). The fix computes the embedding
+//! before taking the lock, which then only covers the in-memory/local
+//! read-modify-write of the index fact.
+//!
+//! The scenario: save A blocks inside its (gated) embedder while save B, on
+//! an independent store with a fast embedder, contends only on the global
+//! lock. B must complete while A is still stuck; releasing A must let it
+//! finish correctly. Every wait is a bounded `recv_timeout`, so the test can
+//! time out red but can never hang.
+
+#![cfg(all(feature = "context", feature = "persistence"))]
+
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use velesdb_memory::context::WorkingContext;
+use velesdb_memory::{EmbedError, Embedder, HashEmbedder, MemoryService};
+
+/// Small dimension: recall quality is irrelevant here.
+const DIM: usize = 16;
+
+/// Generous bound for steps that must complete promptly; far below the
+/// gated embedder's own 30 s watchdog, so a stalled B is unambiguous.
+const STEP: Duration = Duration::from_secs(10);
+
+/// The prefix of the text `update_working_index` embeds for the index slot.
+const INDEX_EMBED_PREFIX: &str = "working context index";
+
+/// An embedder that signals and then BLOCKS (as a hung network call would)
+/// the first time it is asked to embed the working-index slot text, until
+/// the test releases it. All other embeds pass straight through to the
+/// deterministic [`HashEmbedder`]. The internal wait is itself bounded so
+/// even a buggy test run terminates.
+struct GatedIndexEmbedder {
+    inner: HashEmbedder,
+    entered: mpsc::Sender<()>,
+    release: parking_lot::Mutex<mpsc::Receiver<()>>,
+}
+
+impl Embedder for GatedIndexEmbedder {
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        if text.starts_with(INDEX_EMBED_PREFIX) {
+            // Signal the test we are inside the "network call", then hang
+            // until released (bounded: a lost release cannot hang the run).
+            let _ = self.entered.send(());
+            let _ = self.release.lock().recv_timeout(Duration::from_secs(30));
+        }
+        self.inner.embed(text)
+    }
+}
+
+fn working_state(goal: &str) -> WorkingContext {
+    WorkingContext {
+        goal: Some(goal.to_owned()),
+        ..WorkingContext::default()
+    }
+}
+
+#[test]
+fn test_save_working_context_is_not_stalled_by_a_peer_hung_in_its_embedder() {
+    // Given service A whose embedder hangs on the index-slot embed, and an
+    // independent service B with a fast embedder. The two share nothing but
+    // the process-global working-index write lock.
+    let dir_a = tempfile::TempDir::new().expect("tempdir a");
+    let dir_b = tempfile::TempDir::new().expect("tempdir b");
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let svc_a = Arc::new(
+        MemoryService::open(
+            dir_a.path(),
+            GatedIndexEmbedder {
+                inner: HashEmbedder::new(DIM),
+                entered: entered_tx,
+                release: parking_lot::Mutex::new(release_rx),
+            },
+        )
+        .expect("open service a"),
+    );
+    let svc_b = Arc::new(
+        MemoryService::open(dir_b.path(), HashEmbedder::new(DIM)).expect("open service b"),
+    );
+
+    // When save A reaches its embedder and hangs there
+    let (a_done_tx, a_done_rx) = mpsc::channel();
+    let a = Arc::clone(&svc_a);
+    let join_a = std::thread::spawn(move || {
+        let result = a.save_working_context("proj-a", "s1", &working_state("goal a"));
+        let _ = a_done_tx.send(result);
+    });
+    entered_rx
+        .recv_timeout(STEP)
+        .expect("save A must reach its index embed");
+
+    // ... and save B runs concurrently
+    let (b_done_tx, b_done_rx) = mpsc::channel();
+    let b = Arc::clone(&svc_b);
+    let join_b = std::thread::spawn(move || {
+        let result = b.save_working_context("proj-b", "s1", &working_state("goal b"));
+        let _ = b_done_tx.send(result);
+    });
+
+    // Then B completes while A is still blocked in its embedder. (Release A
+    // before asserting, so a red run also terminates cleanly.)
+    let b_outcome = b_done_rx.recv_timeout(STEP);
+    let _ = release_tx.send(());
+    let b_result = b_outcome.expect(
+        "save B stalled behind save A: the working-index lock is being held \
+         across A's embedder call",
+    );
+    b_result.expect("save B must succeed");
+
+    // And once released, A finishes correctly too — the lock still fully
+    // protects the index read-modify-write it exists for.
+    let a_result = a_done_rx
+        .recv_timeout(STEP)
+        .expect("save A must finish after its embedder is released");
+    a_result.expect("save A must succeed");
+    join_a.join().expect("thread A must not panic");
+    join_b.join().expect("thread B must not panic");
+    assert_saved_and_indexed(&svc_a, "proj-a", "goal a");
+    assert_saved_and_indexed(&svc_b, "proj-b", "goal b");
+}
+
+/// Both the fact and its index entry must be intact after the race.
+fn assert_saved_and_indexed<E: Embedder>(svc: &MemoryService<E>, project: &str, goal: &str) {
+    let loaded = svc
+        .load_working_context(project, "s1")
+        .expect("load must not error")
+        .expect("the saved working context must be present");
+    assert_eq!(loaded.goal.as_deref(), Some(goal));
+    let sessions = svc
+        .list_working_contexts(project)
+        .expect("the index must list the saved session");
+    assert_eq!(sessions.len(), 1, "exactly one session in {project}");
+    assert_eq!(sessions[0].session, "s1");
+}

--- a/crates/velesdb-python/src/collection/query.rs
+++ b/crates/velesdb-python/src/collection/query.rs
@@ -427,7 +427,11 @@ impl Collection {
         let parsed = parse_velesql(query_str)?;
         validate_query(&parsed)?;
         let indexed = self.inner.config().indexed_fields.iter().cloned().collect();
-        let stats = self.inner.analyze().ok();
+        // `analyze()` computes fresh statistics (cardinality, size histograms)
+        // by walking the column store — the same work as `Database.analyze_collection`,
+        // which crosses the 1-second mark on large collections. Release the GIL
+        // so other Python threads keep running while the plan is calibrated.
+        let stats = py.detach(|| self.inner.analyze().ok());
         Ok(build_explain_dict(py, &parsed, &indexed, stats.as_ref()))
     }
 

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -530,7 +530,14 @@ impl Database {
     ///     >>> db.train_pq("documents", m=8, k=256)
     ///     >>> db.train_pq("documents", m=16, k=128, opq=True)
     #[pyo3(signature = (collection_name, m=8, k=256, opq=false))]
-    fn train_pq(&self, collection_name: &str, m: usize, k: usize, opq: bool) -> PyResult<String> {
+    fn train_pq(
+        &self,
+        py: Python<'_>,
+        collection_name: &str,
+        m: usize,
+        k: usize,
+        opq: bool,
+    ) -> PyResult<String> {
         // Validate collection_name to prevent VelesQL injection via string interpolation.
         if !collection_name
             .chars()
@@ -552,10 +559,16 @@ impl Database {
             PyValueError::new_err(format!("Failed to construct TRAIN query: {}", e.message))
         })?;
 
-        let empty_params = std::collections::HashMap::new();
-        let results = self
-            .inner
-            .execute_query(&parsed, &empty_params)
+        // Drop the GIL for the training run: k-means codebook fitting is
+        // CPU-bound Rust work that scales with the collection size and easily
+        // reaches multi-second latency — holding the GIL for that long would
+        // freeze every other Python thread.
+        let inner = Arc::clone(&self.inner);
+        let results = py
+            .detach(move || {
+                let empty_params = std::collections::HashMap::new();
+                inner.execute_query(&parsed, &empty_params)
+            })
             .map_err(core_err)?;
 
         Ok(format!("PQ training complete: {} results", results.len()))

--- a/crates/velesdb-server/src/handlers/collections.rs
+++ b/crates/velesdb-server/src/handlers/collections.rs
@@ -13,7 +13,9 @@ use crate::AppState;
 use velesdb_core::index::HnswParams;
 use velesdb_core::{DistanceMetric, StorageMode};
 
-use super::helpers::{auto_core_error_response, error_response, get_collection_or_404};
+use super::helpers::{
+    auto_core_error_response, error_response, get_collection_or_404, run_blocking,
+};
 
 /// List all collections.
 #[utoipa::path(
@@ -54,15 +56,18 @@ pub async fn create_collection(
         Err(resp) => return resp,
     };
 
-    let result = match dispatch_create(&state, &req, metric, storage_mode) {
-        Ok(r) => r,
-        Err(resp) => return resp,
-    };
-
-    match result {
-        Ok(()) => create_collection_success_response(&req),
-        Err(e) => auto_core_error_response(&e),
-    }
+    // Collection creation is synchronous core code (registry locks + disk
+    // I/O + fsync) — run it on the blocking pool.
+    let state_clone = Arc::clone(&state);
+    run_blocking(
+        move || match dispatch_create(&state_clone, &req, metric, storage_mode) {
+            Ok(Ok(())) => create_collection_success_response(&req),
+            Ok(Err(e)) => auto_core_error_response(&e),
+            Err(resp) => resp,
+        },
+    )
+    .await
+    .unwrap_or_else(|resp| resp)
 }
 
 /// Parse a distance metric string into the core enum.
@@ -481,13 +486,18 @@ pub async fn delete_collection(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> impl IntoResponse {
-    match state.db.delete_collection(&name) {
-        Ok(()) => Json(serde_json::json!({
+    // Collection deletion is synchronous core code (registry locks + disk
+    // I/O) — run it on the blocking pool.
+    let state_clone = Arc::clone(&state);
+    let coll_name = name.clone();
+    match run_blocking(move || state_clone.db.delete_collection(&coll_name)).await {
+        Ok(Ok(())) => Json(serde_json::json!({
             "message": "Collection deleted",
             "name": name
         }))
         .into_response(),
-        Err(e) => auto_core_error_response(&e),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }
 

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -16,7 +16,7 @@ use axum::{
 use velesdb_core::collection::graph::{GraphEdge, TraversalConfig};
 use velesdb_core::observer::QueryOperationKind;
 
-use crate::handlers::helpers::auto_core_error_response;
+use crate::handlers::helpers::{auto_core_error_response, run_blocking, run_blocking_typed};
 use crate::types::ErrorResponse;
 use crate::AppState;
 
@@ -155,8 +155,10 @@ pub async fn get_edges(
 
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
-    let edges: Vec<EdgeResponse> = coll
-        .get_edges(Some(&label))
+    // Edge listing takes graph store locks — run it on the blocking pool.
+    let raw_edges = run_blocking_typed(move || coll.get_edges(Some(&label))).await?;
+
+    let edges: Vec<EdgeResponse> = raw_edges
         .into_iter()
         .map(|e| EdgeResponse {
             id: e.id(),
@@ -199,11 +201,13 @@ pub async fn add_edge(
         Err(resp) => return resp.into_response(),
     };
 
-    // Route the core error through `auto_core_error_response` so e.g.
+    // Edge insertion takes write locks and persists — run it on the blocking
+    // pool. Route the core error through `auto_core_error_response` so e.g.
     // `EdgeExists` surfaces as 409 + VELES-019 instead of a generic 500 string.
-    match coll.add_edge(edge) {
-        Ok(()) => StatusCode::CREATED.into_response(),
-        Err(e) => auto_core_error_response(&e),
+    match run_blocking(move || coll.add_edge(edge)).await {
+        Ok(Ok(())) => StatusCode::CREATED.into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }
 
@@ -274,11 +278,15 @@ pub async fn add_edges_batch(
         Err(resp) => return resp.into_response(),
     };
 
-    // Route the core error through `auto_core_error_response` so e.g.
-    // `EdgeExists` surfaces as 409 + VELES-019 instead of a generic 500 string.
-    match coll.add_edges_batch(edges) {
-        Ok(added) => (StatusCode::CREATED, Json(AddEdgesBatchResponse { added })).into_response(),
-        Err(e) => auto_core_error_response(&e),
+    // Batch edge insertion takes write locks and persists — run it on the
+    // blocking pool. Route the core error through `auto_core_error_response`
+    // so e.g. `EdgeExists` surfaces as 409 + VELES-019 instead of a 500 string.
+    match run_blocking(move || coll.add_edges_batch(edges)).await {
+        Ok(Ok(added)) => {
+            (StatusCode::CREATED, Json(AddEdgesBatchResponse { added })).into_response()
+        }
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }
 
@@ -302,13 +310,9 @@ pub async fn traverse_graph(
 ) -> Result<Json<TraverseResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
-    let config = TraversalConfig::with_range(1, request.max_depth)
-        .with_limit(request.limit)
-        .with_rel_types(request.rel_types);
-
-    let raw_results = match request.strategy.to_lowercase().as_str() {
-        "bfs" => coll.traverse_bfs(request.source, &config),
-        "dfs" => coll.traverse_dfs(request.source, &config),
+    let use_bfs = match request.strategy.to_lowercase().as_str() {
+        "bfs" => true,
+        "dfs" => false,
         _ => {
             return Err((
                 StatusCode::BAD_REQUEST,
@@ -323,6 +327,23 @@ pub async fn traverse_graph(
         }
     };
 
+    let limit = request.limit;
+    let source = request.source;
+    let config = TraversalConfig::with_range(1, request.max_depth)
+        .with_limit(limit)
+        .with_rel_types(request.rel_types);
+
+    // Traversal is synchronous, lock-taking core code — run it on the
+    // blocking pool so the async workers stay responsive.
+    let raw_results = run_blocking_typed(move || {
+        if use_bfs {
+            coll.traverse_bfs(source, &config)
+        } else {
+            coll.traverse_dfs(source, &config)
+        }
+    })
+    .await?;
+
     let results: Vec<super::types::TraversalResultItem> = raw_results
         .into_iter()
         .map(|r| super::types::TraversalResultItem {
@@ -334,7 +355,7 @@ pub async fn traverse_graph(
 
     let depth_reached = results.iter().map(|r| r.depth).max().unwrap_or(0);
     let visited = results.len();
-    let has_more = visited >= request.limit;
+    let has_more = visited >= limit;
 
     Ok(Json(TraverseResponse {
         results,
@@ -366,7 +387,8 @@ pub async fn get_node_degree(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DegreeResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
-    let (in_degree, out_degree) = coll.node_degree(node_id);
+    // Degree lookup takes edge-store shard locks — run it on the blocking pool.
+    let (in_degree, out_degree) = run_blocking_typed(move || coll.node_degree(node_id)).await?;
     Ok(Json(DegreeResponse {
         in_degree,
         out_degree,

--- a/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers_extended.rs
@@ -13,6 +13,7 @@ use axum::{
 use velesdb_core::collection::graph::TraversalConfig;
 use velesdb_core::observer::QueryOperationKind;
 
+use crate::handlers::helpers::run_blocking_typed;
 use crate::types::ErrorResponse;
 use crate::AppState;
 
@@ -43,7 +44,8 @@ pub async fn remove_edge(
     State(state): State<Arc<AppState>>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_preamble(&state, &name)?;
-    if coll.remove_edge(edge_id) {
+    // Edge removal takes write locks and persists — run it on the blocking pool.
+    if run_blocking_typed(move || coll.remove_edge(edge_id)).await? {
         Ok(StatusCode::NO_CONTENT)
     } else {
         // PR #586 Devin fix: emit `VELES-020 EdgeNotFound` with the
@@ -80,9 +82,9 @@ pub async fn get_edge_count(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<EdgeCountResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
-    Ok(Json(EdgeCountResponse {
-        count: coll.edge_count(),
-    }))
+    // Edge counting takes edge-store shard locks — run it on the blocking pool.
+    let count = run_blocking_typed(move || coll.edge_count()).await?;
+    Ok(Json(EdgeCountResponse { count }))
 }
 
 /// List all node IDs in the graph.
@@ -103,7 +105,8 @@ pub async fn list_nodes(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodeListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
-    let node_ids = coll.all_node_ids();
+    // Node enumeration takes node-store locks — run it on the blocking pool.
+    let node_ids = run_blocking_typed(move || coll.all_node_ids()).await?;
     let count = node_ids.len();
     Ok(Json(NodeListResponse { node_ids, count }))
 }
@@ -130,7 +133,9 @@ pub async fn get_node_edges(
 ) -> Result<Json<EdgesResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
-    let raw_edges = match params.direction.to_lowercase().as_str() {
+    // Edge listing takes edge-store shard locks — run it on the blocking pool.
+    let direction = params.direction.to_lowercase();
+    let raw_edges = run_blocking_typed(move || match direction.as_str() {
         "in" => coll.get_incoming(node_id),
         "both" => {
             let mut all = coll.get_outgoing(node_id);
@@ -138,7 +143,8 @@ pub async fn get_node_edges(
             all
         }
         _ => coll.get_outgoing(node_id),
-    };
+    })
+    .await?;
 
     let edges: Vec<EdgeResponse> = raw_edges
         .into_iter()
@@ -183,7 +189,9 @@ pub async fn upsert_node_payload(
     Json(request): Json<UpsertNodePayloadRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_preamble(&state, &name)?;
-    coll.upsert_node_payload(node_id, &request.payload)
+    // Payload upsert takes write locks and persists — run it on the blocking pool.
+    run_blocking_typed(move || coll.upsert_node_payload(node_id, &request.payload))
+        .await?
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -216,15 +224,18 @@ pub async fn get_node_payload(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<NodePayloadResponse>, (StatusCode, Json<ErrorResponse>)> {
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
-    let payload = coll.get_node_payload(node_id).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: format!("Failed to get payload: {e}"),
-                code: None,
-            }),
-        )
-    })?;
+    // Payload lookup takes storage locks — run it on the blocking pool.
+    let payload = run_blocking_typed(move || coll.get_node_payload(node_id))
+        .await?
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("Failed to get payload: {e}"),
+                    code: None,
+                }),
+            )
+        })?;
     Ok(Json(NodePayloadResponse { node_id, payload }))
 }
 
@@ -257,11 +268,16 @@ pub async fn traverse_parallel(
 
     let coll = graph_read_preamble(&state, &name, QueryOperationKind::GraphTraversal)?;
 
+    let limit = request.limit;
     let config = TraversalConfig::with_range(1, request.max_depth)
-        .with_limit(request.limit)
+        .with_limit(limit)
         .with_rel_types(request.rel_types);
 
-    let raw_results = coll.traverse_bfs_parallel(&request.sources, &config);
+    // Parallel traversal is synchronous, rayon-dispatching core code — run
+    // it on the blocking pool so the async workers stay responsive.
+    let sources = request.sources;
+    let raw_results =
+        run_blocking_typed(move || coll.traverse_bfs_parallel(&sources, &config)).await?;
 
     let results: Vec<super::types::TraversalResultItem> = raw_results
         .into_iter()
@@ -274,7 +290,7 @@ pub async fn traverse_parallel(
 
     let depth_reached = results.iter().map(|r| r.depth).max().unwrap_or(0);
     let visited = results.len();
-    let has_more = visited >= request.limit;
+    let has_more = visited >= limit;
 
     Ok(Json(TraverseResponse {
         results,
@@ -339,17 +355,20 @@ pub async fn graph_search(
         }
     }
 
-    let search_results = coll
-        .search_by_embedding(&request.vector, request.top_k)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: format!("Graph search failed: {e}"),
-                    code: None,
-                }),
-            )
-        })?;
+    // Embedding search is CPU-bound, lock-taking core code — run it on the
+    // blocking pool so the async workers stay responsive.
+    let search_results =
+        run_blocking_typed(move || coll.search_by_embedding(&request.vector, request.top_k))
+            .await?
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("Graph search failed: {e}"),
+                        code: None,
+                    }),
+                )
+            })?;
 
     let results: Vec<GraphSearchResultItem> = search_results
         .into_iter()

--- a/crates/velesdb-server/src/handlers/helpers.rs
+++ b/crates/velesdb-server/src/handlers/helpers.rs
@@ -20,6 +20,46 @@ pub(crate) fn error_response(status: StatusCode, message: String) -> axum::respo
         .into_response()
 }
 
+/// Runs a synchronous, potentially lock-taking or fsync-bearing core call on
+/// the blocking pool so it cannot starve the async runtime workers.
+///
+/// Mirrors the established discipline in `points::upsert_points` and
+/// `search::workers`: the closure is moved onto `tokio::task::spawn_blocking`
+/// and a panic or cancellation of the blocking task maps to the canonical
+/// 500 "Task panicked" response.
+pub(crate) async fn run_blocking<T, F>(work: F) -> Result<T, axum::response::Response>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(work).await.map_err(|e| {
+        error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Task panicked: {e}"),
+        )
+    })
+}
+
+/// Same as [`run_blocking`] but for handlers whose error type is the
+/// `(StatusCode, Json<ErrorResponse>)` tuple used by the graph endpoints.
+pub(crate) async fn run_blocking_typed<T, F>(
+    work: F,
+) -> Result<T, (StatusCode, Json<ErrorResponse>)>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    tokio::task::spawn_blocking(work).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("Task panicked: {e}"),
+                code: None,
+            }),
+        )
+    })
+}
+
 /// Build an error response from a [`velesdb_core::Error`], including the
 /// VELES-XXX code in the JSON body.
 ///

--- a/crates/velesdb-server/src/handlers/indexes.rs
+++ b/crates/velesdb-server/src/handlers/indexes.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 use crate::types::{CreateIndexRequest, ErrorResponse, IndexResponse, ListIndexesResponse};
 use crate::AppState;
 
-use super::helpers::{auto_core_error_response, error_response, get_vector_collection_or_404};
+use super::helpers::{
+    auto_core_error_response, error_response, get_vector_collection_or_404, run_blocking,
+};
 
 /// Create a property index on a graph collection.
 #[utoipa::path(
@@ -38,7 +40,20 @@ pub async fn create_index(
         Err(resp) => return resp,
     };
 
-    let result = match dispatch_index_creation(&collection, &req) {
+    // Index creation scans the collection under write locks — run it on
+    // the blocking pool.
+    run_blocking(move || create_index_sync(&collection, req))
+        .await
+        .unwrap_or_else(|resp| resp)
+}
+
+/// Synchronous body of [`create_index`]: dispatches the index build and
+/// reads back the created index's stats. Runs on the blocking pool.
+fn create_index_sync(
+    collection: &velesdb_core::collection::VectorCollection,
+    req: CreateIndexRequest,
+) -> axum::response::Response {
+    let result = match dispatch_index_creation(collection, &req) {
         Ok(r) => r,
         Err(resp) => return resp,
     };
@@ -106,7 +121,12 @@ pub async fn list_indexes(
         Err(resp) => return resp,
     };
 
-    let core_indexes = collection.list_indexes();
+    // Index metadata reads take the index registry lock, which long index
+    // builds hold — run it on the blocking pool.
+    let core_indexes = match run_blocking(move || collection.list_indexes()).await {
+        Ok(indexes) => indexes,
+        Err(resp) => return resp,
+    };
     let indexes: Vec<IndexResponse> = core_indexes
         .into_iter()
         .map(|i| IndexResponse {
@@ -146,22 +166,24 @@ pub async fn delete_index(
         Err(resp) => return resp,
     };
 
-    match collection.drop_index(&label, &property) {
-        Ok(dropped) => {
-            if dropped {
-                Json(serde_json::json!({
-                    "message": "Index deleted",
-                    "label": label,
-                    "property": property
-                }))
-                .into_response()
-            } else {
-                error_response(
-                    StatusCode::NOT_FOUND,
-                    format!("Index on {}.{} not found", label, property),
-                )
-            }
-        }
-        Err(e) => auto_core_error_response(&e),
+    // Index removal takes the index registry write lock and persists — run
+    // it on the blocking pool.
+    let dropped_label = label.clone();
+    let dropped_property = property.clone();
+    let result =
+        run_blocking(move || collection.drop_index(&dropped_label, &dropped_property)).await;
+    match result {
+        Ok(Ok(true)) => Json(serde_json::json!({
+            "message": "Index deleted",
+            "label": label,
+            "property": property
+        }))
+        .into_response(),
+        Ok(Ok(false)) => error_response(
+            StatusCode::NOT_FOUND,
+            format!("Index on {label}.{property} not found"),
+        ),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }

--- a/crates/velesdb-server/src/handlers/match_query.rs
+++ b/crates/velesdb-server/src/handlers/match_query.rs
@@ -117,9 +117,18 @@ pub async fn match_query(
     State(state): State<Arc<AppState>>,
     Json(request): Json<MatchQueryRequest>,
 ) -> axum::response::Response {
-    match run_match(&state, &collection_name, &request) {
-        Ok(response) => Json(response).into_response(),
-        Err(e) => auto_core_error_response(&e),
+    // MATCH execution is a synchronous graph traversal (lock-taking core
+    // code) — run it on the blocking pool so the async workers stay
+    // responsive.
+    let state_clone = Arc::clone(&state);
+    let outcome = crate::handlers::helpers::run_blocking(move || {
+        run_match(&state_clone, &collection_name, &request)
+    })
+    .await;
+    match outcome {
+        Ok(Ok(response)) => Json(response).into_response(),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }
 

--- a/crates/velesdb-server/src/handlers/points/mod.rs
+++ b/crates/velesdb-server/src/handlers/points/mod.rs
@@ -28,7 +28,7 @@ use velesdb_core::api_types::serde_id;
 use velesdb_core::Point;
 
 use crate::handlers::helpers::{
-    auto_core_error_response, error_response, get_vector_collection_or_404,
+    auto_core_error_response, error_response, get_vector_collection_or_404, run_blocking,
 };
 
 use velesdb_core::index::sparse::SparseVector;
@@ -211,7 +211,11 @@ pub async fn get_point(
         Err(resp) => return resp,
     };
 
-    let points = collection.get(&[id]);
+    // Point lookup takes storage read locks — run it on the blocking pool.
+    let points = match run_blocking(move || collection.get(&[id])).await {
+        Ok(p) => p,
+        Err(resp) => return resp,
+    };
 
     match points.into_iter().next().flatten() {
         // ID as a string for JS precision-safety above 2^53-1, consistent with
@@ -252,15 +256,17 @@ pub async fn delete_point(
         Err(resp) => return resp,
     };
 
-    match collection.delete(&[id]) {
+    // Deletion takes write locks and fsyncs — run it on the blocking pool.
+    match run_blocking(move || collection.delete(&[id])).await {
         // ID as a string for JS precision-safety (see `serde_id`), consistent
         // with the string ID accepted in the path and returned by reads.
-        Ok(()) => Json(serde_json::json!({
+        Ok(Ok(())) => Json(serde_json::json!({
             "message": "Point deleted",
             "id": id.to_string()
         }))
         .into_response(),
-        Err(e) => auto_core_error_response(&e),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
     }
 }
 

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -21,7 +21,9 @@ use velesdb_core::point::Point;
 use crate::types::ErrorResponse;
 use crate::AppState;
 
-use super::super::helpers::{auto_core_error_response, error_response, get_collection_or_404};
+use super::super::helpers::{
+    auto_core_error_response, error_response, get_collection_or_404, run_blocking,
+};
 
 use velesdb_core::EXPIRES_AT_KEY;
 
@@ -134,9 +136,11 @@ pub async fn relate_points(
         }
     };
 
-    match insert_edge_with_retry(&coll, &req, properties) {
-        Ok(edge_id) => (StatusCode::CREATED, Json(RelateResponse { edge_id })).into_response(),
-        Err(r) => r,
+    // Edge allocation + insertion take write locks and persist — run them on
+    // the blocking pool.
+    match run_blocking(move || insert_edge_with_retry(&coll, &req, properties)).await {
+        Ok(Ok(edge_id)) => (StatusCode::CREATED, Json(RelateResponse { edge_id })).into_response(),
+        Ok(Err(r)) | Err(r) => r,
     }
 }
 
@@ -210,7 +214,12 @@ pub async fn unrelate_points(
         Err(r) => return r,
     };
 
-    if coll.remove_edge(edge_id) {
+    // Edge removal takes write locks and persists — run it on the blocking pool.
+    let removed = match run_blocking(move || coll.remove_edge(edge_id)).await {
+        Ok(removed) => removed,
+        Err(resp) => return resp,
+    };
+    if removed {
         StatusCode::NO_CONTENT.into_response()
     } else {
         let err = velesdb_core::Error::EdgeNotFound(edge_id);
@@ -249,7 +258,11 @@ pub async fn get_point_relations(
         Err(r) => return r,
     };
 
-    let raw_edges = coll.get_outgoing_edges(id);
+    // Edge listing takes edge-store shard locks — run it on the blocking pool.
+    let raw_edges = match run_blocking(move || coll.get_outgoing_edges(id)).await {
+        Ok(edges) => edges,
+        Err(resp) => return resp,
+    };
     let edges: Vec<RelationEdge> = raw_edges
         .into_iter()
         .map(|e| RelationEdge {
@@ -297,6 +310,21 @@ pub async fn set_point_ttl(
         Err(r) => return r,
     };
 
+    // The read-modify-write (get + upsert with fsync) is synchronous core
+    // code — run it on the blocking pool.
+    run_blocking(move || set_point_ttl_sync(&coll, id, req.ttl_seconds, &name))
+        .await
+        .unwrap_or_else(|resp| resp)
+}
+
+/// Synchronous body of [`set_point_ttl`]: reads the point, stamps the durable
+/// expiry, and upserts it back. Runs on the blocking pool.
+fn set_point_ttl_sync(
+    coll: &velesdb_core::AnyCollection,
+    id: u64,
+    ttl_seconds: u64,
+    name: &str,
+) -> axum::response::Response {
     let point = match coll.get(&[id]).into_iter().flatten().next() {
         Some(p) => p,
         None => {
@@ -312,8 +340,8 @@ pub async fn set_point_ttl(
         }
     };
 
-    let expires_at = now_secs().saturating_add(req.ttl_seconds);
-    let updated = match stamp_ttl(point, id, expires_at, &name) {
+    let expires_at = now_secs().saturating_add(ttl_seconds);
+    let updated = match stamp_ttl(point, id, expires_at, name) {
         Ok(p) => p,
         Err(r) => return r,
     };

--- a/crates/velesdb-server/src/handlers/query/aggregation.rs
+++ b/crates/velesdb-server/src/handlers/query/aggregation.rs
@@ -115,7 +115,6 @@ pub(crate) fn resolve_aggregate_collection(
         (status = 404, description = "Collection not found", body = crate::types::VelesqlErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn aggregate(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
     Json(req): Json<QueryRequest>,
@@ -151,5 +150,12 @@ pub async fn aggregate(
         }
     };
 
-    execute_aggregation_query(&state, &collection_name, &parsed, &req.params, start)
+    // The aggregation scan is synchronous core code — run it on the
+    // blocking pool so the async workers stay responsive.
+    let state_clone = Arc::clone(&state);
+    crate::handlers::helpers::run_blocking(move || {
+        execute_aggregation_query(&state_clone, &collection_name, &parsed, &req.params, start)
+    })
+    .await
+    .unwrap_or_else(|resp| resp)
 }

--- a/crates/velesdb-server/src/handlers/query/explain.rs
+++ b/crates/velesdb-server/src/handlers/query/explain.rs
@@ -30,7 +30,6 @@ use velesdb_core::Error as CoreError;
         (status = 404, description = "Collection not found", body = crate::types::VelesqlErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn explain(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ExplainRequest>,
@@ -40,6 +39,21 @@ pub async fn explain(
         Err(resp) => return resp,
     };
 
+    // Plan building and (with `analyze`) query execution call synchronous
+    // core code that can take locks — run them on the blocking pool so the
+    // async workers stay responsive.
+    let state_clone = Arc::clone(&state);
+    crate::handlers::helpers::run_blocking(move || explain_parsed(&state_clone, &req, &parsed))
+        .await
+        .unwrap_or_else(|resp| resp)
+}
+
+/// Synchronous post-parse body of [`explain`]. Runs on the blocking pool.
+fn explain_parsed(
+    state: &AppState,
+    req: &ExplainRequest,
+    parsed: &velesdb_core::velesql::Query,
+) -> axum::response::Response {
     let select = &parsed.select;
 
     let collection_exists = state.db.get_any_collection(&select.from).is_some();
@@ -48,10 +62,10 @@ pub async fn explain(
     }
 
     if req.analyze {
-        return explain_with_analyze(&state, &req, &parsed);
+        return explain_with_analyze(state, req, parsed);
     }
 
-    explain_plan_only(&state, &req, &parsed)
+    explain_plan_only(state, req, parsed)
 }
 
 /// Computes the EXPLAIN preamble shared by the plan-only and ANALYZE paths:

--- a/crates/velesdb-server/src/handlers/query/mod.rs
+++ b/crates/velesdb-server/src/handlers/query/mod.rs
@@ -20,6 +20,7 @@ use crate::types::{
 };
 use crate::AppState;
 
+use crate::handlers::helpers::run_blocking;
 use aggregation::execute_aggregation_query;
 use explain::condition_has_vector_search;
 use velesql_helpers::{parse_and_validate, velesql_collection_not_found, velesql_error};
@@ -74,7 +75,6 @@ fn is_ast_routed_dml(parsed: &Query) -> bool {
         (status = 404, description = "Collection not found", body = crate::types::VelesqlErrorResponse)
     )
 )]
-#[allow(clippy::unused_async)]
 pub async fn query(
     State(state): State<Arc<AppState>>,
     Json(req): Json<QueryRequest>,
@@ -90,14 +90,32 @@ pub async fn query(
         }
     };
 
+    // Query execution calls synchronous core code (locks, and fsync on the
+    // DML/DDL paths) — run it on the blocking pool so the async workers stay
+    // responsive, mirroring the points/search handler discipline.
+    let state_clone = Arc::clone(&state);
+    run_blocking(move || dispatch_parsed_query(&state_clone, &parsed, &req, start))
+        .await
+        .unwrap_or_else(|resp| resp)
+}
+
+/// Synchronous post-parse dispatch for [`query`]: routes the parsed query to
+/// the mutation, aggregation, or standard execution path and builds the
+/// response. Runs on the blocking pool.
+fn dispatch_parsed_query(
+    state: &Arc<AppState>,
+    parsed: &Query,
+    req: &QueryRequest,
+    start: std::time::Instant,
+) -> axum::response::Response {
     // DDL/Introspection/Admin/graph-mutation bypass: these extract collection from
     // the SQL AST, not from the request body.  INSERT INTO, UPSERT, and UPDATE flow
     // through the standard path because they return meaningful result rows.
-    if requires_mutation_dispatch(&parsed) {
-        return execute_mutation_query(&state, &parsed, &req.params, start);
+    if requires_mutation_dispatch(parsed) {
+        return execute_mutation_query(state, parsed, &req.params, start);
     }
 
-    let collection_name = match resolve_collection_name(&parsed, &req) {
+    let collection_name = match resolve_collection_name(parsed, req) {
         Ok(name) => name,
         Err(resp) => {
             state.operational_metrics.inc_errors();
@@ -107,10 +125,10 @@ pub async fn query(
 
     // BUG-1 FIX: Detect aggregation queries and route to execute_aggregate
     if parsed.select.is_aggregation_query() {
-        return execute_aggregation_query(&state, &collection_name, &parsed, &req.params, start);
+        return execute_aggregation_query(state, &collection_name, parsed, &req.params, start);
     }
 
-    let results = match execute_standard_query(&state, &parsed, &collection_name, &req) {
+    let results = match execute_standard_query(state, parsed, &collection_name, req) {
         Ok(r) => r,
         Err(resp) => {
             state.operational_metrics.inc_errors();
@@ -118,7 +136,7 @@ pub async fn query(
         }
     };
 
-    build_query_response(&state, start, results, &parsed.select.columns)
+    build_query_response(state, start, results, &parsed.select.columns)
 }
 
 /// Execute a DDL, graph/delete DML, introspection, admin, or TRAIN query.

--- a/crates/velesdb-server/tests/handler_blocking_discipline.rs
+++ b/crates/velesdb-server/tests/handler_blocking_discipline.rs
@@ -1,0 +1,205 @@
+//! Regression test for the blocking-call discipline (audit finding C1).
+//!
+//! Every handler that calls synchronous, lock-taking or fsync-bearing
+//! `velesdb-core` code must run that call on `tokio::task::spawn_blocking`
+//! instead of inline on the async runtime. This test runs the server router
+//! on a multi-thread runtime with a SINGLE worker thread, fires a wave of
+//! fsync-bearing `/query` DML statements (single-row INSERTs — the `/query`
+//! handler used to run its core call inline) and, while the wave is still
+//! in flight, a trivial `/health` probe.
+//!
+//! Detection is by ordering, not absolute timing:
+//!
+//! * Inline (buggy) code: each INSERT (write locks + WAL fsync) occupies
+//!   the sole runtime worker for its whole duration, and the probe task —
+//!   enqueued after the wave — cannot run until every statement has
+//!   completed. The probe therefore observes the entire wave as finished.
+//! * Offloaded (fixed) code: every handler parks on `spawn_blocking`, the
+//!   worker stays free, and the probe completes in microseconds while most
+//!   of the wave is still queued behind the collection write lock on the
+//!   blocking pool.
+//!
+//! A hard watchdog thread (independent of the tokio timer, which itself
+//! stalls when the sole worker is blocked) guarantees the test can never
+//! hang the suite.
+
+mod common;
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::create_test_app_with_state;
+use serde_json::json;
+use tempfile::TempDir;
+use tower::ServiceExt;
+use velesdb_core::Point;
+
+/// Rows pre-seeded into the target collection so the INSERTs land in a
+/// collection with realistic storage state.
+const ROW_COUNT: u64 = 2_000;
+
+/// Batch size for seeding, well under the ingest limits.
+const INSERT_BATCH: u64 = 2_000;
+
+/// Number of concurrent fsync-bearing `/query` INSERT statements. Sized so
+/// the wave keeps the blocking pool busy for far longer than the probe
+/// needs — while an inline (buggy) handler serializes the whole wave on the
+/// sole runtime worker ahead of the probe.
+const SLOW_REQUESTS: usize = 64;
+
+/// Builds a POST /query request with the given `VelesQL` text.
+fn query_request(query: &str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/query")
+        .header("content-type", "application/json")
+        .body(Body::from(json!({ "query": query }).to_string()))
+        .expect("build /query request")
+}
+
+/// Seeds a metadata-only collection with `ROW_COUNT` payload rows.
+async fn seed_metadata_collection(state: &Arc<velesdb_server::AppState>) {
+    state
+        .db
+        .create_metadata_collection("bulk")
+        .expect("create metadata collection");
+    let coll = state
+        .db
+        .get_any_collection("bulk")
+        .expect("collection registered");
+    tokio::task::spawn_blocking(move || {
+        let mut start = 0u64;
+        while start < ROW_COUNT {
+            let end = (start + INSERT_BATCH).min(ROW_COUNT);
+            let points: Vec<Point> = (start..end)
+                .map(|i| {
+                    Point::new(
+                        i,
+                        vec![],
+                        Some(json!({
+                            "category": format!("cat-{}", i % 50),
+                            "value": i,
+                            "note": format!("padding payload for row {i} to make the scan cost real"),
+                        })),
+                    )
+                })
+                .collect();
+            coll.upsert(points).expect("seed upsert");
+            start = end;
+        }
+    })
+    .await
+    .expect("seeding task");
+}
+
+/// Aborts the whole process if the test overruns. This is deliberately a
+/// plain OS thread: the tokio timer cannot be trusted here because a
+/// starved single-worker runtime stops driving it — which is the very bug
+/// under test.
+fn spawn_hard_watchdog(done: Arc<AtomicBool>) {
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(300));
+        if !done.load(Ordering::SeqCst) {
+            eprintln!(
+                "handler_blocking_discipline: hard watchdog fired after 300s — aborting process"
+            );
+            std::process::exit(1);
+        }
+    });
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn health_stays_responsive_while_slow_query_scans_run() {
+    let done = Arc::new(AtomicBool::new(false));
+    spawn_hard_watchdog(Arc::clone(&done));
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let (app, state) = create_test_app_with_state(&temp_dir);
+    seed_metadata_collection(&state).await;
+
+    // Fire the wave of slow requests: fsync-bearing single-row INSERT
+    // statements. Before the fix these ran inline on the sole async worker.
+    let completed = Arc::new(AtomicUsize::new(0));
+    let wave_started = Instant::now();
+    let mut slow_handles = Vec::with_capacity(SLOW_REQUESTS);
+    for i in 0..SLOW_REQUESTS {
+        let slow_app = app.clone();
+        let counter = Arc::clone(&completed);
+        // Each request inserts a distinct row: write locks + WAL fsync on
+        // every statement, so caches cannot collapse the wave.
+        let id = 1_000_000 + i;
+        let sql = format!("INSERT INTO bulk (id, category, value) VALUES ({id}, 'cat-slow', {i})");
+        slow_handles.push(tokio::spawn(async move {
+            let response = slow_app
+                .oneshot(query_request(&sql))
+                .await
+                .expect("slow /query request");
+            counter.fetch_add(1, Ordering::SeqCst);
+            response.status()
+        }));
+    }
+
+    // Trivial fast probe, spawned AFTER the wave. Tasks spawned from this
+    // (non-worker) thread land in the runtime's injection queue in spawn
+    // order, so the sole worker polls every wave task before the probe:
+    //
+    // * inline (buggy) handlers run each INSERT to completion inside its
+    //   poll, so by the time the probe runs the whole wave has finished;
+    // * offloaded (fixed) handlers park on spawn_blocking at their first
+    //   poll, so the probe completes while the wave is still in flight.
+    let health_app = app.clone();
+    let probe_started = Instant::now();
+    let health_status = tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::spawn(async move {
+            health_app
+                .oneshot(
+                    Request::builder()
+                        .uri("/health")
+                        .body(Body::empty())
+                        .expect("build /health request"),
+                )
+                .await
+                .expect("health request")
+                .status()
+        }),
+    )
+    .await
+    .expect("watchdog: /health did not complete within 30s — the async worker is starved")
+    .expect("health task panicked");
+    let health_latency = probe_started.elapsed();
+    let completed_at_probe = completed.load(Ordering::SeqCst);
+
+    // Drain the wave and validate every statement actually did the work.
+    for handle in slow_handles {
+        let status = tokio::time::timeout(Duration::from_secs(120), handle)
+            .await
+            .expect("watchdog: slow /query did not finish within 120s")
+            .expect("slow query task panicked");
+        assert_eq!(status, StatusCode::OK, "every /query INSERT must succeed");
+    }
+    let wave_elapsed = wave_started.elapsed();
+    done.store(true, Ordering::SeqCst);
+
+    println!(
+        "health latency: {health_latency:?}; wave total: {wave_elapsed:?}; \
+         inserts completed when probe returned: {completed_at_probe}/{SLOW_REQUESTS}"
+    );
+
+    assert_eq!(health_status, StatusCode::OK, "/health must succeed");
+    assert!(
+        completed_at_probe < SLOW_REQUESTS,
+        "/health only completed after all {SLOW_REQUESTS} fsync-bearing /query \
+         INSERTs had finished (health latency {health_latency:?}, wave total \
+         {wave_elapsed:?}): the sole runtime worker was blocked by inline core \
+         calls in the /query handler instead of parking on spawn_blocking"
+    );
+    assert!(
+        health_latency < Duration::from_secs(5),
+        "/health took {health_latency:?} while the /query wave was in flight — \
+         the sole runtime worker was blocked by an inline core call"
+    );
+}

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -52,6 +52,11 @@ Every entry below names its target outcome explicitly.
 **What is missing**:
 - No call site uses `WalBatcher`. It is a dormant utility (re-verified
   2026-06-12: still zero call sites outside `wal_batcher.rs`).
+- 2026-08-09: demoted from `pub` to `pub(crate)` — a dormant concurrency
+  primitive must not be part of the public API surface going into 5.0.0.
+  The code and its tests are kept intact pending the declared premium
+  transfer; re-promoting is a one-line change if the transfer lands the
+  wiring instead.
 
 **Why wiring is non-trivial**:
 - `LogPayloadStorage` uses a `RwLock<BufWriter<File>>` with offset tracking


### PR DESCRIPTION
## Description

Companion to #1860. That PR killed the four deadlock-class findings; this one closes the **stall class** the same audit traced but deliberately left out of scope — the places where nothing deadlocks but one operation wedges every other, which for a caller is indistinguishable from a hang. Every fix removes the mechanism rather than shortening the window, and each carries a regression test proved red-first against the pre-fix code.

The database level was audited too and needed no change: the only two file locks in the tree (`velesdb.lock` in `Database::open_impl`, and the migration workspace guard) are `try_lock_exclusive` — they fail immediately with an actionable error instead of waiting, release by RAII, and are released by the kernel on crash. Every surface already translates that into a clean refusal (server 503, `DatabaseLockedError`, the daemon's retry-then-diagnose path), and `docs/guides/CONCURRENCY_LOCKING.md` matches the code.

**1 — every sync-core handler leaves the async workers** (`fix(server)`). The `spawn_blocking` discipline existed for search/upsert/flush/admin, but 22 handlers still ran lock-taking, fsync-bearing core calls inline on the tokio workers: `/query`'s whole post-parse dispatch (mutations, DDL, MATCH, aggregation), EXPLAIN and EXPLAIN ANALYZE, the MATCH endpoint, all graph CRUD and traversal endpoints including `traverse_parallel`'s rayon dispatch, `get_point`/`delete_point`, relations and `set_point_ttl`, collection create/delete, and index create/delete/list (which shares the registry lock long builds hold). Two shared helpers (`run_blocking`, and `run_blocking_typed` for the graph error tuple) mirror the established `points::upsert_points` pattern; no HTTP contract, status code or response body changes — only the executing thread. Cheap in-memory registry reads stay inline, consistent with the pre-existing tree. Red-first: on a single worker, a `/health` probe fired behind 64 concurrent fsync-bearing INSERTs waited for all 64 pre-fix (3/3 runs) and answers mid-wave post-fix, 17–24 ms with ~20/64 done (3/3 runs).

**2 — batch delete pays one durability barrier per store, not three fsyncs per point** (`fix(core)`). `delete_vector_core_stores` looped a per-point `delete()` on every store while holding all the collection's write locks — ~3 fsyncs per point, so deleting N points wedged every concurrent reader and writer behind ~3N synchronous barriers. Each store now takes the whole batch under a single barrier, mirroring the bulk-upsert discipline (#1797): `MmapStorage::delete_batch` groups the CRC-framed entries into one write + one sync **before** any hole-punch (the #898 invariant, kept at batch granularity), `LogPayloadStorage::delete_batch` writes all tombstones in one buffer + one sync (replay-identical bytes), BM25 removes go through `wal_append_batch`. Exactly 3 barriers per batch, 2 for metadata-only; they stay under the locks because the destructive punch must follow a durable delete frame. WAL-before-apply (#389) and the decreed lock order are unchanged, and the crash contract is stated in the rustdoc against the actual replay paths. Red-first, 8000 points: delete 45.4 s with the concurrent reader stalled 45.3 s → 141 ms with the reader at 33 ms.

**3 — the Tauri plugin stops serializing itself** (`fix(tauri)`). The plugin had zero `spawn_blocking` — every command ran sync core inline on the async runtime — and `with_db` held the state's `db` read guard across the whole operation, blocking even `open()`. State is now a shared `Arc<StateInner>`: the handle accessors hold their lock only long enough to clone the `Arc` (memory's write lock spans just the one-time memoized construction, `db` before `memory`, never nested), and new `run_db`/`run_memory` move an owned handle into `tauri::async_runtime::spawn_blocking` with join failures mapped to a new `TASK_JOIN` variant. All 70+ commands go through them; no signature, event or payload changes. Two watchdog-guarded tests pin it, both gated on a channel rather than a timer.

**4 — the working-index lock no longer spans a network call** (`fix(memory)`). `update_working_index` took the process-global `WORKING_INDEX_WRITE` mutex and only then called the embedder, so one slow — or hung — embedding call stalled every working-index write in the process, across all projects and sessions. The slot's embedding derives from the project name alone, never from index content, so it is computed before the lock; `write_working_index` receives it and may no longer embed (stated in its doc, since that is exactly what would reintroduce the stall). Racing saves embed the same text, so no re-check under the lock is needed, and the read-modify-write the lock exists for stays wholly inside it.

**5 — PQ training stops freezing the Python process** (`fix(python)`). `train_pq` ran the whole k-means codebook fit — multi-second CPU-bound Rust work — while holding the GIL, freezing every other Python thread; `Collection.explain` did the same on its `analyze()` statistics walk. Both now follow the crate's established `py.detach` discipline (~133 existing sites). A full-crate sweep confirmed every other >10 ms path already detaches; the remaining GIL-held methods are AST-only or slot-constrained and cheap.

**6 — a dormant concurrency primitive leaves the public API** (`refactor(core)`). `WalBatcher` has zero call sites (`CORE_WIRING_DEBT` entry 1) yet shipped as public surface users could build on going into 5.0.0. Demoted to `pub(crate)`; code and tests kept intact pending the declared premium transfer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

Four new regression tests, each proved red-first against the pre-fix code and each watchdog-guarded so it can go red but never hang: `handler_blocking_discipline.rs` (hard OS-thread watchdog, because a starved single-worker runtime stops driving the tokio timer), `batch_delete_contention.rs` (plus a reopen-persistence correctness test), `nonblocking_state.rs` (two tests), `working_index_lock_contention_bdd.rs`.

Green locally: `cargo test -p velesdb-memory -- --test-threads=1` (40 binaries, 0 failures), `cargo test -p velesdb-server -- --test-threads=1` (21 binaries, 320+ tests), `cargo test -p tauri-plugin-velesdb --features persistence -- --test-threads=1`, and for core the batch-delete suite plus the `crud` / `recovery` / `wal_` / `log_payload` / `durability` / `delete` / `metadata` filters and the `crash_recovery_tests`, `crud_dedup_parity_tests`, `secondary_index_persistence` integration suites. `cargo clippy -- -D warnings -D clippy::pedantic` clean per touched crate; `cargo fmt --all --check` clean; the doc-contract, doc-freshness (all five guards), TODO-annotation and AI-attribution guards pass.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#1860 is merged; this branch is rebuilt on it)

## High-Risk Change Checklist

- [x] I listed the invariants impacted by this change (the #898 delete-frame-before-punch ordering, WAL-before-apply #389, the collection-tier lock order, and the Tauri state's db→memory ordering).
- [x] I documented crash/durability semantics — the batch-delete crash contract is written into the rustdoc and checked against the three replay paths and recovery's HNSW reconciliation.
- [x] I added/updated tests for concurrency or lifecycle where applicable.
- [ ] I requested review from at least 2 maintainers/reviewers for this risky path — flagging for maintainer attention: this changes storage delete durability batching.

## Additional Notes

Left deliberately, with reason: the sparse-index WAL deletes still open a per-index WAL per id, but they perform no fsync and run outside the storage write locks, so they are not part of this wedge — batching them is a separate perf nicety. The autograph respawn-during-drop latch window remains library-API-only and unreachable through the daemon.

One environment note for reviewers, not a code concern: the shared build volume hit ENOSPC during this work; only rebuildable artifacts and caches were cleared.