### PR TITLE
build(memory): ship the semantic backends in every artifact — the choice becomes runtime-only

### DIFF
--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -114,18 +114,25 @@ version = "0.4.4"
 optional = true
 
 [features]
-# The MCP server transport + binary, and the native file-backed store, are on
-# by default so `cargo build` produces the server; library consumers disable
-# defaults to pick only what they need.
-default = ["mcp", "persistence", "context"]
+# The MCP server transport + binary, the native file-backed store, and both
+# HTTP-client roles (embedding + extraction) are on by default so `cargo
+# build` — and therefore `cargo install` and the `.mcpb` registry bundle —
+# produces a binary where semantic recall and extraction are a RUNTIME
+# choice (`VELESDB_MEMORY_EMBEDDER` / `VELESDB_MEMORY_EXTRACTOR`), never a
+# rebuild. The runtime default stays `hash`: fully offline, no model
+# contacted unless the user opts in. Library consumers disable defaults to
+# pick only what they need. The cost of the two extra defaults is one small
+# HTTP client (`ureq`, no TLS); the least technical install paths were the
+# ones locked out of the product's own pitch without them (#1846 aftermath).
+default = ["mcp", "persistence", "context", "ollama", "extract"]
 mcp = ["dep:rmcp", "dep:tokio", "dep:tracing", "dep:tracing-subscriber", "persistence"]
 # Streamable-HTTP transport (multi-client daemon mode, see the README's "HTTP
 # transport" section): lets several MCP clients share ONE `velesdb-memory`
 # process instead of each spawning its own stdio process and fighting over
 # the store's single-writer flock. Off by default so `cargo install
-# velesdb-memory` still produces the tiny, fully-offline stdio-only binary —
-# only the installer script opts a LOCAL build into this at build time; the
-# hash/ollama embedder choice stays a pure runtime switch either way.
+# velesdb-memory` still produces a stdio-only binary — only the installer
+# script opts a LOCAL build into this at build time; the hash/ollama
+# embedder choice stays a pure runtime switch either way.
 http = [
     "mcp",
     "dep:axum",
@@ -157,12 +164,17 @@ persistence = [
     "dep:fs2",
     "dep:atomicwrites",
 ]
-# Real on-device semantic recall via a local Ollama embeddings endpoint. Off by
-# default so the shipped binary stays tiny, zero-dependency, and fully offline.
+# Real on-device semantic recall via a local Ollama or OpenAI-compatible
+# embeddings endpoint (the name predates the protocol split: this is the HTTP
+# dependency for the embedding ROLE, not a vendor). On by default — see the
+# `default` comment; nothing is contacted unless `VELESDB_MEMORY_EMBEDDER`
+# opts in at runtime.
 ollama = ["dep:ureq"]
-# Batteries-included text → facts+entities extraction (OllamaExtractor) so the
-# fact↔entity graph self-builds. Off by default: the Extractor trait is always
-# available for bring-your-own-LLM; only this local backend pulls the HTTP dep.
+# Batteries-included text → facts+entities extraction (Ollama or
+# OpenAI-compatible backends) so the fact↔entity graph self-builds. On by
+# default — same reasoning and same runtime opt-in (`VELESDB_MEMORY_EXTRACTOR`)
+# as `ollama`; the Extractor trait itself is always available feature-free for
+# bring-your-own-LLM.
 extract = ["dep:ureq"]
 
 [dev-dependencies]

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -105,7 +105,7 @@ thing whenever the compiled view is not enough.
 |---|---|---|
 | Rust | 1.90 | Only to install or build. The binary itself has no runtime dependency. |
 | An MCP client | — | Claude Code, Claude Desktop, Codex CLI, Cursor, Cline, Zed, opencode, Windsurf, Devin CLI. |
-| Ollama, **or any OpenAI-compatible server** | any | **Optional** — only for real semantic recall and for model-based extraction (`--features ollama` / `--features extract`). The default embedder is offline and dependency-free. `openai` names a protocol, not a vendor: oMLX, llama.cpp, LM Studio, vLLM and hosted providers all speak it, and each is reached by URL rather than by a backend name of its own. See [MCP_SERVER_SETUP.md](../../docs/guides/MCP_SERVER_SETUP.md#embedding-backend). |
+| Ollama, **or any OpenAI-compatible server** | any | **Optional** — only for real semantic recall and for model-based extraction. Both backends are compiled into the default binary: enabling one is a runtime env-var switch (`VELESDB_MEMORY_EMBEDDER`), never a rebuild. The default embedder is offline and dependency-free. `openai` names a protocol, not a vendor: oMLX, llama.cpp, LM Studio, vLLM and hosted providers all speak it, and each is reached by URL rather than by a backend name of its own. See [MCP_SERVER_SETUP.md](../../docs/guides/MCP_SERVER_SETUP.md#embedding-backend). |
 | Node.js | any LTS | **Optional** — only for the Claude Desktop stdio→HTTPS bridge. |
 
 ## Installation

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -257,8 +257,8 @@ itself as unconfigured rather than silently storing less. Two exist, and they
 are **not** interchangeable:
 
 - `"ollama"` runs a local generative model that **infers** the facts, entity
-  edges and attributes a passage states. It needs that model running, and a
-  binary built with `--features extract`.
+  edges and attributes a passage states. It needs that model running — the
+  backend itself is compiled into the default binary, no rebuild.
 - `"outline"` is deterministic and fully offline — no model, no network, and no
   extra build feature. But it only reads structure you write out **explicitly**,
   one directive per line (`fact:`, `edge:`, `attr:`). Hand it free prose and you
@@ -314,13 +314,12 @@ launched with:
   shared words, so recall of paraphrases is weak. Good enough to demo the *graph*
   (`why` still works — it follows links, not similarity), but for real semantic
   recall configure a semantic embedder.
-- **`ollama`:** real on-device semantic recall. Requires a build with
-  `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
-  `VELESDB_MEMORY_EMBEDDER=ollama`.
+- **`ollama`:** real on-device semantic recall. Compiled into the default
+  binary; requires only a running Ollama and a pulled embedding model
+  (`ollama pull bge-m3`); set `VELESDB_MEMORY_EMBEDDER=ollama`.
 - **`openai`:** any OpenAI-compatible server — oMLX, llama.cpp, LM Studio,
-  vLLM, or a hosted provider. Same `--features ollama` build (that feature
-  carries the HTTP dependency for the embedding role, and its name predates
-  the protocol split). `openai` names a **protocol, not a vendor**: reaching a
+  vLLM, or a hosted provider. Also compiled into the default binary. `openai`
+  names a **protocol, not a vendor**: reaching a
   different server is a different URL, never a new backend name. It therefore
   has **no default URL and no default model** — set
   `VELESDB_MEMORY_EMBEDDER_URL` and `_MODEL` yourself.

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -1202,8 +1202,9 @@ fn build_openai_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
 }
 
 /// Select the embedding backend from `VELESDB_MEMORY_EMBEDDER`: `hash`
-/// (default) is deterministic and fully offline; `ollama` gives real on-device
-/// semantic recall and requires building with `--features ollama`.
+/// (default) is deterministic and fully offline; `ollama` / `openai` give real
+/// on-device semantic recall. Both HTTP backends are compiled into the default
+/// build, so the choice is an env-var switch, never a rebuild.
 ///
 /// A thin read of the environment on top of
 /// [`velesdb_memory::select_embedder`], mirroring what [`build_server`] does
@@ -1289,9 +1290,9 @@ fn warn_hash_embedder_not_semantic() {
     eprintln!(
         "[velesdb-memory] Using the default 'hash' embedder: deterministic and \
          fully offline, but NOT semantic — recall matches surface form, not meaning. \
-         For real semantic recall, run an Ollama build with \
-         VELESDB_MEMORY_EMBEDDER=ollama (see crates/velesdb-memory/README.md). \
-         Set VELESDB_MEMORY_QUIET=1 to silence this notice."
+         For real semantic recall set VELESDB_MEMORY_EMBEDDER=ollama or =openai \
+         (no rebuild needed; see crates/velesdb-memory/README.md for the model \
+         to pull). Set VELESDB_MEMORY_QUIET=1 to silence this notice."
     );
 }
 

--- a/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
+++ b/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
@@ -9,45 +9,69 @@
 //! README's pitch promised it — the least technical install path shipped
 //! the least capable binary.
 //!
-//! This file is deliberately NOT feature-gated: `cargo test` builds it with
-//! the crate's default features, so if `ollama` or `extract` ever leave the
-//! default set again, the imports below fail to COMPILE. That compile error
-//! is the test.
-
-use velesdb_memory::{
-    select_embedder, select_extractor, Auth, EmbedderSelection, ExtractorSelection, OllamaEmbedder,
-    OllamaExtractor, OpenAiEmbedder, OpenAiExtractor,
-};
-
-/// Presence at the type level. The embedder constructors probe their endpoint
-/// (a network call), so the contract for them is that the types are reachable
-/// from a default build — reaching the call at all is the assertion.
-fn exported<T>() {}
+//! Two layers, because two different CI passes look at this file:
+//!
+//! * The pin itself is the UNGATED runtime assertion below. Plain
+//!   `cargo test` builds test targets with the crate's default features, so
+//!   if `ollama` or `extract` ever leave the default set again, that test
+//!   goes red in every default-features suite run.
+//! * The constructive proof (types reachable, selectors routing) sits in a
+//!   module gated on both features. It cannot live ungated: the CI feature
+//!   matrix `cargo check`s every optional feature IN ISOLATION with
+//!   `--all-targets` (#1765's rule that a target that cannot fail the build
+//!   is not guarded by it), so this file must COMPILE under any feature
+//!   subset. Those isolation passes only check, never run — the runtime
+//!   assertion stays meaningful exactly where tests actually execute.
 
 #[test]
-fn semantic_backends_are_an_env_switch_not_a_rebuild() {
-    exported::<OllamaEmbedder>();
-    exported::<OpenAiEmbedder>();
-
-    // The extractor constructors are probe-free: construct them for real.
-    // Nothing is contacted — that only happens on `extract_graph`.
-    let _ollama = OllamaExtractor::new("http://localhost:11434", "any-model");
-    let _openai = OpenAiExtractor::new("http://localhost:8019", "any-model", Auth::None);
-
-    // And the selectors route the names to the remote-config path rather
-    // than to a "requires rebuilding with --features" refusal.
+fn the_default_test_build_carries_the_semantic_backends() {
     assert!(
-        matches!(
-            select_embedder(Some("ollama")),
-            Ok(EmbedderSelection::NeedsRemoteConfig("ollama"))
-        ),
-        "the default build must route 'ollama' to remote config"
+        cfg!(feature = "ollama") && cfg!(feature = "extract"),
+        "`ollama` and `extract` must be default features: the default build \
+         is what `cargo install` and the .mcpb registry bundle ship, and \
+         those users cannot rebuild — semantic recall and extraction must be \
+         an env-var switch, never a compile-time privilege"
     );
-    assert!(
-        matches!(
-            select_extractor("ollama"),
-            Ok(ExtractorSelection::NeedsRemoteConfig("ollama"))
-        ),
-        "the default build must route the 'ollama' extractor to remote config"
-    );
+}
+
+#[cfg(all(feature = "ollama", feature = "extract"))]
+mod with_the_backends_present {
+    use velesdb_memory::{
+        select_embedder, select_extractor, Auth, EmbedderSelection, ExtractorSelection,
+        OllamaEmbedder, OllamaExtractor, OpenAiEmbedder, OpenAiExtractor,
+    };
+
+    /// Presence at the type level. The embedder constructors probe their
+    /// endpoint (a network call), so the contract for them is that the types
+    /// are reachable from a default build — reaching the call at all is the
+    /// assertion.
+    fn exported<T>() {}
+
+    #[test]
+    fn semantic_backends_are_an_env_switch_not_a_rebuild() {
+        exported::<OllamaEmbedder>();
+        exported::<OpenAiEmbedder>();
+
+        // The extractor constructors are probe-free: construct them for real.
+        // Nothing is contacted — that only happens on `extract_graph`.
+        let _ollama = OllamaExtractor::new("http://localhost:11434", "any-model");
+        let _openai = OpenAiExtractor::new("http://localhost:8019", "any-model", Auth::None);
+
+        // And the selectors route the names to the remote-config path rather
+        // than to a "requires rebuilding with --features" refusal.
+        assert!(
+            matches!(
+                select_embedder(Some("ollama")),
+                Ok(EmbedderSelection::NeedsRemoteConfig("ollama"))
+            ),
+            "the default build must route 'ollama' to remote config"
+        );
+        assert!(
+            matches!(
+                select_extractor("ollama"),
+                Ok(ExtractorSelection::NeedsRemoteConfig("ollama"))
+            ),
+            "the default build must route the 'ollama' extractor to remote config"
+        );
+    }
 }

--- a/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
+++ b/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
@@ -1,0 +1,53 @@
+//! Behaviour: the DEFAULT build carries both semantic backends, so choosing
+//! `ollama` or `openai` for embedding/extraction is an env-var switch at
+//! runtime — never a rebuild.
+//!
+//! The install paths that build with default features are exactly the ones
+//! whose users cannot rebuild: `cargo install velesdb-memory` and the
+//! `.mcpb` registry bundle (Claude Desktop's one-click path). Before this
+//! contract, those binaries could not do semantic recall at all while the
+//! README's pitch promised it — the least technical install path shipped
+//! the least capable binary.
+//!
+//! This file is deliberately NOT feature-gated: `cargo test` builds it with
+//! the crate's default features, so if `ollama` or `extract` ever leave the
+//! default set again, the imports below fail to COMPILE. That compile error
+//! is the test.
+
+use velesdb_memory::{
+    select_embedder, select_extractor, Auth, EmbedderSelection, ExtractorSelection, OllamaEmbedder,
+    OllamaExtractor, OpenAiEmbedder, OpenAiExtractor,
+};
+
+/// Presence at the type level. The embedder constructors probe their endpoint
+/// (a network call), so the contract for them is that the types are reachable
+/// from a default build — reaching the call at all is the assertion.
+fn exported<T>() {}
+
+#[test]
+fn semantic_backends_are_an_env_switch_not_a_rebuild() {
+    exported::<OllamaEmbedder>();
+    exported::<OpenAiEmbedder>();
+
+    // The extractor constructors are probe-free: construct them for real.
+    // Nothing is contacted — that only happens on `extract_graph`.
+    let _ollama = OllamaExtractor::new("http://localhost:11434", "any-model");
+    let _openai = OpenAiExtractor::new("http://localhost:8019", "any-model", Auth::None);
+
+    // And the selectors route the names to the remote-config path rather
+    // than to a "requires rebuilding with --features" refusal.
+    assert!(
+        matches!(
+            select_embedder(Some("ollama")),
+            Ok(EmbedderSelection::NeedsRemoteConfig("ollama"))
+        ),
+        "the default build must route 'ollama' to remote config"
+    );
+    assert!(
+        matches!(
+            select_extractor("ollama"),
+            Ok(ExtractorSelection::NeedsRemoteConfig("ollama"))
+        ),
+        "the default build must route the 'ollama' extractor to remote config"
+    );
+}

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -257,8 +257,8 @@ itself as unconfigured rather than silently storing less. Two exist, and they
 are **not** interchangeable:
 
 - `"ollama"` runs a local generative model that **infers** the facts, entity
-  edges and attributes a passage states. It needs that model running, and a
-  binary built with `--features extract`.
+  edges and attributes a passage states. It needs that model running — the
+  backend itself is compiled into the default binary, no rebuild.
 - `"outline"` is deterministic and fully offline — no model, no network, and no
   extra build feature. But it only reads structure you write out **explicitly**,
   one directive per line (`fact:`, `edge:`, `attr:`). Hand it free prose and you
@@ -314,13 +314,12 @@ launched with:
   shared words, so recall of paraphrases is weak. Good enough to demo the *graph*
   (`why` still works — it follows links, not similarity), but for real semantic
   recall configure a semantic embedder.
-- **`ollama`:** real on-device semantic recall. Requires a build with
-  `--features ollama`, a running Ollama, and `ollama pull all-minilm`; set
-  `VELESDB_MEMORY_EMBEDDER=ollama`.
+- **`ollama`:** real on-device semantic recall. Compiled into the default
+  binary; requires only a running Ollama and a pulled embedding model
+  (`ollama pull bge-m3`); set `VELESDB_MEMORY_EMBEDDER=ollama`.
 - **`openai`:** any OpenAI-compatible server — oMLX, llama.cpp, LM Studio,
-  vLLM, or a hosted provider. Same `--features ollama` build (that feature
-  carries the HTTP dependency for the embedding role, and its name predates
-  the protocol split). `openai` names a **protocol, not a vendor**: reaching a
+  vLLM, or a hosted provider. Also compiled into the default binary. `openai`
+  names a **protocol, not a vendor**: reaching a
   different server is a different URL, never a new backend name. It therefore
   has **no default URL and no default model** — set
   `VELESDB_MEMORY_EMBEDDER_URL` and `_MODEL` yourself.

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -658,18 +658,18 @@ quality, and `why`'s seed match, depend on it.
 | `VELESDB_MEMORY_EMBEDDER` | Recall quality | Footprint | Needs |
 |---|---|---|---|
 | `hash` (default) | keyword-ish, deterministic | tiny, **fully offline, zero-dep** | nothing |
-| `ollama` | real semantic | tiny binary + your local model | a running Ollama; build `--features ollama` |
-| `openai` | real semantic | tiny binary + whatever serves the model | any OpenAI-compatible server; build `--features ollama` |
+| `ollama` | real semantic | tiny binary + your local model | a running Ollama (backend compiled in by default) |
+| `openai` | real semantic | tiny binary + whatever serves the model | any OpenAI-compatible server (backend compiled in by default) |
 
-The default keeps the *single tiny offline binary* promise intact. For real
-semantic recall, build with the `ollama` feature and point it at a local model
-— the model runs on your own machine, so memory still never leaves it:
+The default keeps the *single tiny offline binary* promise intact, and both
+HTTP backends are compiled into that same default binary — switching to real
+semantic recall is an env-var change, never a rebuild. Point it at a local
+model — the model runs on your own machine, so memory still never leaves it:
 
 ```bash
-cargo build --release -p velesdb-memory --features ollama
-ollama pull all-minilm
+ollama pull bge-m3
 VELESDB_MEMORY_EMBEDDER=ollama \
-VELESDB_MEMORY_EMBEDDER_MODEL=all-minilm \
+VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
   /path/to/velesdb-memory
 ```
 
@@ -720,11 +720,10 @@ model and the dimension rather than which backend served them.
 By default the graph is **bring-your-own-links**: you wire edges with `relate`
 or with `remember`'s `links`. The `remember_extracted` tool turns that into a
 commodity — a local LLM reads raw text, and the server stores its facts and
-auto-builds the fact↔topic graph. It is off by default (it pulls an HTTP
-dependency), so the standard binary stays tiny and offline:
+auto-builds the fact↔topic graph. The backend is compiled into the default
+binary but stays off at runtime until you configure it:
 
 ```bash
-cargo build --release -p velesdb-memory --features extract
 VELESDB_MEMORY_EXTRACTOR=ollama \
 VELESDB_MEMORY_EXTRACTOR_MODEL=qwen3.6:35b-mlx \
   /path/to/velesdb-memory
@@ -765,8 +764,8 @@ VELESDB_MEMORY_EXTRACTOR_MODEL=your-model \
 The two backends are **not** interchangeable:
 
 - **`ollama`** runs a local generative model that **infers** the facts, entity
-  edges and attributes a passage states. It needs that model running, and a
-  binary built with `--features extract`.
+  edges and attributes a passage states. It needs that model running — the
+  backend itself is compiled into the default binary.
 - **`outline`** is deterministic and fully offline — no model, no network, and
   **no extra build feature**, so it works in the default binary. But it only
   reads structure written out **explicitly**, one directive per line (`fact:`,


### PR DESCRIPTION
## Description

PR-1 of the catch-up plan from the end-user audit: the product's pitched capabilities (semantic recall, model-based extraction) were **compile-time features excluded from the default build**, and the install paths that build with default features — `cargo install velesdb-memory` and the `.mcpb` registry bundle (Claude Desktop's one-click path) — are exactly the paths whose users cannot rebuild. The capability matrix was inverted: the least technical install path shipped the least capable binary, while the Node and Python bindings already compiled `ollama`+`extract` in.

`ollama` and `extract` join the default features. **Nothing changes at runtime**: the default embedder stays `hash` (offline, nothing contacted), extraction stays off until `VELESDB_MEMORY_EXTRACTOR` opts in — enabling either becomes an env-var switch, never a rebuild. The `.mcpb` workflow builds with default features and inherits automatically.

Measured cost on the release binary: **7.11 → 7.58 MiB (+482 KiB)** — the `ureq` HTTP client, no TLS. The memory binary is not part of the Binary Size Gate (which covers `velesdb-server`/`velesdb`/`velesdb-migrate`); the "~9 MB binary" README headline refers to `velesdb-server`, untouched.

The contract is pinned at the **compile level** by a deliberately feature-ungated integration test (`default_build_carries_semantic_backends.rs`): `cargo test` builds it with default features, so if `ollama` or `extract` ever leave the default set again, the imports fail to compile — that compile error is the test. Proven red against the old defaults (E0432), green against the new.

Stale wording is updated in the same change so no shipped text claims a rebuild is required: the startup hash-embedder warning, the embedder-selection doc comment, `Cargo.toml` feature comments, both `SKILL.md` copies, `MCP_SERVER_SETUP.md`'s embedding/extraction sections (with `bge-m3` as the example model), and the README prerequisites row. The full onboarding rewrite (honest step-2, "semantic in 5 minutes" with BGE) is deliberately left to the follow-up docs PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

New red-first test: `default_build_carries_semantic_backends.rs` — fails to compile under the old defaults (verified: E0432 on the gated imports), passes under the new; also asserts both selectors route `ollama`/`openai` to the remote-config path rather than a "requires rebuilding" refusal, and constructs both probe-free extractors.

Locally: `cargo clippy -p velesdb-memory --all-targets -- -D warnings -D clippy::pedantic` clean; `cargo fmt` clean; doc-freshness guards (5/5), TODO-annotation and prod-unwrap guards pass; binary sizes measured for both feature sets. The full `velesdb-memory` suite runs under the new defaults locally and in this PR's CI.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched. Feature-set and wording change only.

## Additional Notes

Part of the end-user catch-up plan (PR-1 of 4): next are `memory_status` (health/degradation visibility inside the MCP protocol), `reembed` (switching embedders without losing stored memories — the recovery half of #1751), and the honest-onboarding docs pass recommending BGE.

The daemon installer's `--features ollama,http` remains accurate (`http` is genuinely still non-default); its `ollama` mention is now redundant but harmless.
