### PR TITLE
feat(memory): memory_status — the server's health becomes readable inside the protocol

### DIFF
--- a/crates/velesdb-core/src/agent/semantic_memory.rs
+++ b/crates/velesdb-core/src/agent/semantic_memory.rs
@@ -737,6 +737,20 @@ impl SemanticMemory {
         self.stored_ids.read().is_empty()
     }
 
+    /// Returns the total number of graph edges in this memory's collection,
+    /// without materializing them.
+    ///
+    /// The observable difference between a memory whose `why()` can walk
+    /// somewhere and one where it degrades to plain similarity search: zero
+    /// edges means nothing ever wired the graph.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the collection cannot be accessed.
+    pub fn edge_count(&self) -> Result<usize, AgentMemoryError> {
+        Ok(memory_helpers::get_collection(&self.db, &self.collection_name)?.edge_count())
+    }
+
     /// Removes all facts and their tracking entries.
     ///
     /// # Errors

--- a/crates/velesdb-memory/ARCHITECTURE.md
+++ b/crates/velesdb-memory/ARCHITECTURE.md
@@ -21,7 +21,7 @@ invariants that hold the design together.
 │                                                                            │
 │   src/main.rs ── env config (store path, embedder, extractor) ──┐          │
 │                                                                 ▼          │
-│   src/mcp.rs ── McpServer: 20 tools (memory + graph + context compiler)    │
+│   src/mcp.rs ── McpServer: 21 tools (memory + graph + context compiler)    │
 │     remember · recall · relate · forget · why · remember_extracted · …    │
 │        │                                                                   │
 │        ▼                                                                   │
@@ -66,7 +66,7 @@ Mermaid view (renders on GitHub):
 flowchart TD
   C["MCP clients (Claude Code, Cursor, Zed…)"] -- "stdio JSON-RPC" --> M
   subgraph VM["velesdb-memory (this crate)"]
-    M["mcp.rs · McpServer — 20 tools"] --> S["service.rs · MemoryService&lt;E&gt;"]
+    M["mcp.rs · McpServer — 21 tools"] --> S["service.rs · MemoryService&lt;E&gt;"]
     EMB["embedder.rs · Embedder (Hash | Ollama)"] --> S
     EXT["extract.rs · Extractor (Ollama | BYO)"] --> S
     S --> LB{{"License boundary: memory semantics only"}}

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -220,11 +220,11 @@ end-to-end *extraction* comparison on the real
 
 ## What the server exposes
 
-20 MCP tools in the default build, in three families:
+21 MCP tools in the default build, in three families:
 
 | Family | Tools |
 |---|---|
-| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `unrelate`, `forget`, `entity`, `why`, `feedback`, `remember_extracted` |
+| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `unrelate`, `forget`, `entity`, `why`, `feedback`, `remember_extracted`, `memory_status` |
 | Context compiler | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `suggest_budget` |
 | Session resumption | `save_working_context`, `load_working_context`, `list_working_contexts` |
 

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // All synchronous setup (config file, env probing, blocking HTTP to
     // Ollama, disk open) happens in here, before the async runtime starts, so
     // we never block a tokio worker thread on a synchronous operation.
-    let service = build_configured_service(&args)?;
+    let configured = build_configured_service(&args)?;
 
     // Read AFTER the config file has been applied, since the file can set
     // `VELESDB_MEMORY_HTTP`. Same manual-parsing style as `--version` above
@@ -116,7 +116,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the server is *served*, further down, since store opening (and its
     // `flock`) is identical either way.
     let http_bind = requested_http_bind(&args);
-    let server = apply_ingest_roots(apply_default_ttl(build_server(service)?)?)?;
+    let ConfiguredService {
+        service,
+        store_path,
+        embedder_model,
+        embedder_dimension,
+    } = configured;
+    let server = apply_ingest_roots(apply_default_ttl(
+        build_server(service)?
+            .with_embedder_identity(embedder_model, embedder_dimension)
+            .with_store_dir(store_path),
+    )?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {
         match http_bind {
@@ -528,14 +538,37 @@ fn record_embedding_model(
 /// `command line > environment > file > default`.
 fn build_configured_service(
     args: &[String],
-) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
+) -> Result<ConfiguredService, Box<dyn std::error::Error>> {
     apply_config_file(args)?;
     let store_path = std::env::var("VELESDB_MEMORY_PATH").unwrap_or_else(|_| default_store_path());
     let configured = build_embedder()?;
-    apply_autograph(open_store_with_actionable_lock_error(
+    // Kept for `memory_status`, which reports the RUNNING embedder: the
+    // `ConfiguredEmbedder` itself is consumed by the store-open path below,
+    // and the service only ever sees `&[f32]` — this is the one place the
+    // resolved identity still exists.
+    let embedder_model = configured.model.clone();
+    let embedder_dimension = configured.embedder.dimension();
+    let service = apply_autograph(open_store_with_actionable_lock_error(
         &store_path,
         configured,
-    )?)
+    )?)?;
+    Ok(ConfiguredService {
+        service,
+        store_path,
+        embedder_model,
+        embedder_dimension,
+    })
+}
+
+/// A built service plus the resolved configuration `memory_status` reports:
+/// which embedder actually runs, and where the store (and its provenance
+/// record) lives. Exists because the service deliberately does not know its
+/// embedder's name — only this binary does.
+struct ConfiguredService {
+    service: MemoryService<DynEmbedder>,
+    store_path: String,
+    embedder_model: String,
+    embedder_dimension: usize,
 }
 
 /// Run `migrate-embeddings`: diagnose a store against the configured target

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -38,14 +38,15 @@ mod context_tools;
 mod dto;
 mod wire;
 use dto::{
-    EntityParams, EntityProfileDto, ExplanationDto, FeedbackParams, FeedbackResult, ForgetParams,
-    ForgetResult, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
+    EmbedderStatus, EntityParams, EntityProfileDto, ExplanationDto, ExtractionStatus,
+    FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, MemoryCounts, MemoryStatusResult,
+    ProvenanceStatus, RecallFusedParams, RecallFusedResult, RecallParams, RecallResult,
     RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
     RememberExtractedResult, RememberParams, RememberResult, UnrelateParams, UnrelateResult,
     WhyParams,
 };
 
-/// Le constructeur de schema d'ENTREE, unique pour les vingt outils :
+/// Le constructeur de schema d'ENTREE, unique pour les vingt-et-un outils :
 /// [`crate::schema::wire_safe_input_schema`].
 ///
 /// `keys` nomme les proprietes que CET outil accepte en chaine decimale
@@ -80,6 +81,18 @@ pub struct McpServer {
     /// specify their own `ttl_seconds`. `None` (the default) stores permanently.
     /// Set from `VELESDB_MEMORY_DEFAULT_TTL` by the binary.
     default_ttl: Option<u64>,
+    /// The embedder identity the host declared (model name + dimension) —
+    /// what `memory_status` reports as the RUNNING embedder. `None` when the
+    /// host embedded this server without declaring one; the status then says
+    /// "unreported" rather than guessing. Set via
+    /// [`Self::with_embedder_identity`] by the binary, which is the one
+    /// place that knows what `VELESDB_MEMORY_EMBEDDER` resolved to.
+    embedder_identity: Option<(String, usize)>,
+    /// The store directory, for reading the embedding-provenance record
+    /// (#1751) in `memory_status`. `None` disables the provenance block
+    /// (reported as unrecorded — a store nobody can locate has no readable
+    /// record either way).
+    store_dir: Option<std::path::PathBuf>,
     /// Allowlisted filesystem roots for `path`-referenced context fragments
     /// (V2b-1). `None` (the default) disables path ingestion entirely — every
     /// `path` fragment fails with an explicit error. Set from
@@ -116,10 +129,31 @@ impl McpServer {
             _autograph_worker: autograph_worker,
             extractor: None,
             default_ttl: None,
+            embedder_identity: None,
+            store_dir: None,
             #[cfg(all(feature = "context", not(target_arch = "wasm32")))]
             ingest_roots: None,
             tool_router: Self::combined_router(),
         }
+    }
+
+    /// Declare the running embedder's identity (model name + vector width)
+    /// so `memory_status` can name it — and say whether recall is semantic.
+    /// Undeclared, the status reports the embedder as unreported rather than
+    /// guessing from the service, which only ever sees `&[f32]`.
+    #[must_use]
+    pub fn with_embedder_identity(mut self, model: impl Into<String>, dimension: usize) -> Self {
+        self.embedder_identity = Some((model.into(), dimension));
+        self
+    }
+
+    /// Point `memory_status` at the store directory so it can relay the
+    /// embedding-provenance record (#1751). Without it the provenance block
+    /// reports `recorded: false`.
+    #[must_use]
+    pub fn with_store_dir(mut self, dir: impl Into<std::path::PathBuf>) -> Self {
+        self.store_dir = Some(dir.into());
+        self
     }
 
     /// The full tool router: the memory tools, plus the context compiler's
@@ -477,7 +511,7 @@ impl McpServer {
         // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
         // or les SDK MCP valident structuredContent contre ce schema.
         output_schema = crate::schema::wire_safe_output_schema::<RememberExtractedResult>(),
-        description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts."
+        description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR — compiled into the default build, no rebuild). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts."
     )]
     async fn remember_extracted(
         &self,
@@ -518,6 +552,67 @@ impl McpServer {
             skipped_over_cap: outcome.skipped_over_cap,
         }))
     }
+
+    #[tool(
+        name = "memory_status",
+        // Sans declaration explicite, rmcp derive un schema de sortie qui
+        // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
+        // or les SDK MCP valident structuredContent contre ce schema.
+        output_schema = crate::schema::wire_safe_output_schema::<MemoryStatusResult>(),
+        description = "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether an extraction backend is configured (`remember_extracted` works iff `extraction.configured`), whether the background autograph worker is active and how many enrichments a full queue dropped, and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters."
+    )]
+    async fn memory_status(&self) -> Result<Json<MemoryStatusResult>, ErrorData> {
+        let embedder = match &self.embedder_identity {
+            Some((model, dimension)) => EmbedderStatus {
+                model: Some(model.clone()),
+                dimension: Some(*dimension),
+                semantic: Some(model != "hash"),
+            },
+            None => EmbedderStatus {
+                model: None,
+                dimension: None,
+                semantic: None,
+            },
+        };
+        // The provenance record and the counts both touch the filesystem —
+        // off the async workers, like every other tool body.
+        let service = Arc::clone(&self.service);
+        let store_dir = self.store_dir.clone();
+        let (provenance, facts, edges) = tokio::task::spawn_blocking(move || {
+            let recorded = store_dir
+                .as_deref()
+                .and_then(|dir| crate::embedding_provenance::read(dir).ok().flatten());
+            (recorded, service.fact_count(), service.edge_count())
+        })
+        .await
+        .map_err(join_error)?;
+        let provenance = match provenance {
+            Some(record) => ProvenanceStatus {
+                recorded: true,
+                model: Some(record.model),
+                dimension: Some(record.dimension),
+            },
+            None => ProvenanceStatus {
+                recorded: false,
+                model: None,
+                dimension: None,
+            },
+        };
+        Ok(Json(MemoryStatusResult {
+            embedder,
+            provenance,
+            extraction: ExtractionStatus {
+                // Exactly the `remember_extracted` gate — the autograph
+                // extractor is attached separately and reports through the
+                // two autograph fields, so an autograph-only configuration
+                // never claims a tool that would refuse.
+                configured: self.extractor.is_some(),
+                autograph_active: self.service.autograph_queue_open(),
+                autograph_dropped: self.service.autograph_dropped(),
+            },
+            memory: MemoryCounts { facts, edges },
+        }))
+    }
 }
 
 /// `#[tool_handler]` generates `list_tools` from the router — `call_tool` is
@@ -530,11 +625,13 @@ impl McpServer {
 /// "context")]` variant since the context-compiler tools only exist in that
 /// build.
 #[cfg(feature = "context")]
-const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, remember_extracted, recall, recall_fused, recall_where, relate, unrelate, forget, feedback, entity, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); remember_extracted reads the entities, typed edges and attributes a passage STATES and wires them into the graph, and entity(name) answers a question ABOUT a named thing rather than about the sentences mentioning it; (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
+const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, remember_extracted, recall, recall_fused, recall_where, relate, unrelate, forget, feedback, entity, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); remember_extracted reads the entities, typed edges and attributes a passage STATES and wires them into the graph, and entity(name) answers a question ABOUT a named thing rather than about the sentences mentioning it; memory_status reports the server's health — which embedder runs and whether recall is semantic, extraction wiring, and graph size; (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
 
 #[cfg(not(feature = "context"))]
 const SERVER_INSTRUCTIONS: &str = "Local-first memory for AI agents: remember facts, recall them \
-     semantically, relate them, forget them, and ask why a decision was made (connected subgraph).";
+     semantically, relate them, forget them, ask why a decision was made (connected subgraph), \
+     and read memory_status for the server's health — embedder semantics, extraction wiring, \
+     graph size.";
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for McpServer {
@@ -542,7 +639,24 @@ impl ServerHandler for McpServer {
         let mut info = ServerInfo::default();
         info.server_info = Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         info.capabilities = ServerCapabilities::builder().enable_tools().build();
-        info.instructions = Some(SERVER_INSTRUCTIONS.to_owned());
+        let mut instructions = SERVER_INSTRUCTIONS.to_owned();
+        // The one channel a client is REQUIRED to read. The stderr warning
+        // for the same fact is swallowed by every mainstream MCP harness, so
+        // a degraded server that only warned there was indistinguishable
+        // from a healthy one — the audit finding memory_status closes, and
+        // this note is its push half (the tool is the pull half).
+        if let Some(("hash", _)) = self
+            .embedder_identity
+            .as_ref()
+            .map(|(model, dim)| (model.as_str(), dim))
+        {
+            instructions.push_str(
+                " NOTE: this server is running the offline 'hash' embedder — recall matches \
+                 surface form, NOT meaning. If recall quality matters to the user, say so: a \
+                 semantic embedder is an env-var switch away (call memory_status for details).",
+            );
+        }
+        info.instructions = Some(instructions);
         info
     }
 

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -586,3 +586,77 @@ pub(super) struct RememberExtractedResult {
     /// it stored.
     pub(super) skipped_over_cap: usize,
 }
+
+/// The `embedder` block of [`MemoryStatusResult`].
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct EmbedderStatus {
+    /// The model identifier actually running — `hash` for the built-in
+    /// offline embedder, otherwise as configured (`bge-m3`, `all-minilm`).
+    /// `null` when the host embedded this server without declaring one
+    /// (a binding constructing [`McpServer`](super::McpServer) directly).
+    pub(super) model: Option<String>,
+    /// The vector width the embedder produces. Reported with the model so a
+    /// mismatch diagnosis never needs a second call.
+    pub(super) dimension: Option<usize>,
+    /// Whether recall is SEMANTIC. `false` means the `hash` embedder: recall
+    /// matches surface form, not meaning — the single most common "why is
+    /// recall bad?" answer, now readable by the agent instead of dying on a
+    /// swallowed stderr. `null` when no identity was declared.
+    pub(super) semantic: Option<bool>,
+}
+
+/// The `provenance` block of [`MemoryStatusResult`].
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct ProvenanceStatus {
+    /// Whether the store carries an embedding-provenance record (#1751).
+    /// `false` on a store that predates the record or was filled outside the
+    /// daemon — the check then degrades to dimension alone.
+    pub(super) recorded: bool,
+    /// The recorded model, when there is a record.
+    pub(super) model: Option<String>,
+    /// The recorded vector width, when there is a record.
+    pub(super) dimension: Option<usize>,
+}
+
+/// The `extraction` block of [`MemoryStatusResult`].
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct ExtractionStatus {
+    /// Whether an extraction backend is attached — `remember_extracted`
+    /// works iff this is `true`.
+    pub(super) configured: bool,
+    /// Whether the background autograph worker is consuming the queue
+    /// (#1846): `remember`'s graph enrichment runs behind the response.
+    pub(super) autograph_active: bool,
+    /// Enrichments refused by a FULL queue since startup — the facts were
+    /// stored, only their wiring was skipped (#1846's counted-drop rule).
+    pub(super) autograph_dropped: u64,
+}
+
+/// The `memory` block of [`MemoryStatusResult`].
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct MemoryCounts {
+    /// Live tracked facts, internal entity hubs included.
+    pub(super) facts: usize,
+    /// Total graph edges, or `null` when the backend cannot say without
+    /// materializing them. `0` is the meaningful value: it is the state in
+    /// which `why()` degrades to plain similarity search.
+    pub(super) edges: Option<usize>,
+}
+
+/// Result of the `memory_status` tool.
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct MemoryStatusResult {
+    /// Which embedder is running and whether recall is semantic.
+    pub(super) embedder: EmbedderStatus,
+    /// What embedder the store was filled by, per its on-disk record.
+    pub(super) provenance: ProvenanceStatus,
+    /// Extraction and autograph wiring.
+    pub(super) extraction: ExtractionStatus,
+    /// Corpus and graph size.
+    pub(super) memory: MemoryCounts,
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -476,6 +476,22 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     pub fn has_autograph(&self) -> bool {
         self.autograph.is_some()
     }
+
+    /// The total number of live tracked facts, internal entity hubs included
+    /// — the store's [`MemoryStore::count`], relayed for `memory_status`.
+    #[must_use]
+    pub fn fact_count(&self) -> usize {
+        self.store.count()
+    }
+
+    /// The total number of graph edges, when the backend can say —
+    /// [`MemoryStore::edge_count`], relayed for `memory_status`. `None`
+    /// means "cannot say", never "zero": the two answers tell a caller
+    /// different things about `why()`.
+    #[must_use]
+    pub fn edge_count(&self) -> Option<usize> {
+        self.store.edge_count()
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -241,6 +241,20 @@ pub trait MemoryStore {
     /// The total number of live (non-expired) tracked facts, including
     /// internal entity hubs — used as a corpus-size proxy for idf weighting.
     fn count(&self) -> usize;
+
+    /// The total number of graph edges, when the backend can answer without
+    /// materializing them — the observable difference between a store whose
+    /// `why()` can walk somewhere and one where it degrades to plain
+    /// similarity search.
+    ///
+    /// Defaulted to `None` ("cannot say") rather than required, deliberately:
+    /// a backend outside this crate (velesdb-wasm's in-memory store) must
+    /// keep compiling when this surface grows, and a wrong-but-cheap answer
+    /// here would flag healthy graphs as flat. `memory_status` reports the
+    /// distinction to the caller instead of papering over it.
+    fn edge_count(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// The default [`MemoryStore`]: the native, file-backed engine
@@ -450,6 +464,13 @@ impl MemoryStore for NativeStore {
 
     fn count(&self) -> usize {
         self.memory.semantic().count()
+    }
+
+    fn edge_count(&self) -> Option<usize> {
+        // A collection-access failure here means the store is unusable for
+        // every other call too; for a status readout "cannot say" is the
+        // honest degradation, not an error path of its own.
+        self.memory.semantic().edge_count().ok()
     }
 }
 

--- a/crates/velesdb-memory/tests/binding_parity_bdd.rs
+++ b/crates/velesdb-memory/tests/binding_parity_bdd.rs
@@ -162,14 +162,40 @@ struct Exemption {
     reason: &'static str,
 }
 
-const EXEMPTIONS: &[Exemption] = &[Exemption {
-    binding: "velesdb-wasm",
-    tool: "feedback",
-    reason: "a durable learned confidence is meaningless on the in-memory WASM backend: \
+const EXEMPTIONS: &[Exemption] = &[
+    Exemption {
+        binding: "velesdb-wasm",
+        tool: "feedback",
+        reason: "a durable learned confidence is meaningless on the in-memory WASM backend: \
                  MemoryService::feedback lives in the `persistence`-gated `reinforce` module and \
                  is not compiled for wasm32 at all — exposing it would mean pulling \
                  NativeStore/filesystem code into the very bundle this binding exists to avoid",
-}];
+    },
+    Exemption {
+        binding: "velesdb-node",
+        tool: "memory_status",
+        reason: "memory_status reports SERVER-RUNTIME state a binding host already holds in its \
+                 own hands: the embedder identity is whatever the host constructed (there is no \
+                 env-var resolution to reveal), and the daemon's provenance record lives with the \
+                 daemon's store. The counts (facts/edges) would be genuinely useful here — a \
+                 language-level stats accessor is its own change, tracked with the reembed work",
+    },
+    Exemption {
+        binding: "velesdb-python",
+        tool: "memory_status",
+        reason: "same as velesdb-node: the host constructs its embedder explicitly, so the \
+                 status tool's central answer (which embedder actually runs, is recall semantic) \
+                 is the caller's own constructor argument; a stats accessor for the counts is \
+                 tracked as its own change",
+    },
+    Exemption {
+        binding: "velesdb-wasm",
+        tool: "memory_status",
+        reason: "the WASM backend is in-memory and persistence-free: no provenance record, no \
+                 store directory, no autograph worker — every block of the status except the \
+                 fact count is structurally absent from that build",
+    },
+];
 
 /// One `output_schema` root field a binding deliberately does NOT relay.
 ///
@@ -836,7 +862,7 @@ fn server_output_types() -> BTreeMap<String, String> {
     assert!(
         types.len() >= 20,
         "only {} tool output type(s) parsed out of the server source — the scan is broken, \
-         not the server (it publishes 20 tools)",
+         not the server (it publishes 21 tools)",
         types.len(),
     );
     types

--- a/crates/velesdb-memory/tests/memory_status_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_status_bdd.rs
@@ -1,0 +1,169 @@
+//! Behaviour: `memory_status` answers, INSIDE the protocol, the questions a
+//! user otherwise discovers only through degraded recall — which embedder is
+//! actually running, whether recall is semantic or lexical, whether
+//! extraction is wired, and whether the graph has any edges at all.
+//!
+//! The audit finding this closes: the hash-embedder warning goes to stderr
+//! of a stdio server, and every mainstream MCP client swallows that stream.
+//! A user on the default build experiences "recall is bad", never sees why,
+//! and cannot ask. The agent can — if the server exposes the answer as a
+//! tool. Same story for a flat graph: `why()` silently degrades to search
+//! when nothing ever wired an edge, and only an edge count says so.
+//!
+//! Wire-level like the other BDD suites: the REAL server over an in-memory
+//! duplex, raw tool calls, assertions on `structuredContent`.
+
+#![cfg(feature = "persistence")]
+
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::ServiceExt;
+use serde_json::Value;
+use tempfile::TempDir;
+use velesdb_memory::{DynEmbedder, HashEmbedder, McpServer, MemoryService, DEFAULT_DIMENSION};
+
+/// Boot the real server over a duplex, with the embedder identity the binary
+/// would attach (`hash` at [`DEFAULT_DIMENSION`]), and hand back the client.
+async fn connected() -> (
+    TempDir,
+    rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
+) {
+    let store_dir = tempfile::tempdir().expect("create scratch store dir");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(DEFAULT_DIMENSION));
+    let service =
+        MemoryService::open(store_dir.path(), embedder).expect("open scratch memory store");
+    let server = McpServer::new(service)
+        .with_embedder_identity("hash", DEFAULT_DIMENSION)
+        .with_store_dir(store_dir.path());
+    let (server_side, client_side) = tokio::io::duplex(1 << 20);
+    tokio::spawn(async move {
+        if let Ok(running) = server.serve(server_side).await {
+            let _ = running.waiting().await;
+        }
+    });
+    let client = ().serve(client_side).await.expect("MCP initialize handshake over duplex");
+    (store_dir, client)
+}
+
+async fn call(
+    client: &rmcp::service::RunningService<rmcp::service::RoleClient, ()>,
+    tool: &str,
+    args: Value,
+) -> Value {
+    let mut request = CallToolRequestParams::new(tool.to_owned());
+    if let Value::Object(map) = args {
+        request = request.with_arguments(map);
+    }
+    let result = client
+        .call_tool(request)
+        .await
+        .unwrap_or_else(|e| panic!("tool {tool} failed: {e}"));
+    result
+        .structured_content
+        .unwrap_or_else(|| panic!("tool {tool} returned no structuredContent"))
+}
+
+#[tokio::test]
+async fn status_names_the_embedder_and_says_recall_is_not_semantic() {
+    let (_dir, client) = connected().await;
+    let status = call(&client, "memory_status", Value::Null).await;
+
+    let embedder = &status["embedder"];
+    assert_eq!(embedder["model"], "hash", "the running model is named");
+    assert_eq!(
+        embedder["dimension"],
+        Value::from(DEFAULT_DIMENSION as u64),
+        "the vector width is reported"
+    );
+    assert_eq!(
+        embedder["semantic"], false,
+        "hash must be reported as NOT semantic — this flag is the whole \
+         point: it is what the stderr warning says into the void"
+    );
+}
+
+#[tokio::test]
+async fn status_reports_the_stores_provenance_record() {
+    let (_dir, client) = connected().await;
+    let status = call(&client, "memory_status", Value::Null).await;
+
+    // `MemoryService::open` in this test writes no provenance record — only
+    // the daemon's startup path does. The status must SAY it is unrecorded
+    // rather than invent one: an absent record is a fact about the store.
+    assert_eq!(
+        status["provenance"]["recorded"], false,
+        "no provenance was written, so none may be reported"
+    );
+}
+
+#[tokio::test]
+async fn status_counts_facts_and_edges_and_flags_the_flat_graph() {
+    let (_dir, client) = connected().await;
+
+    let before = call(&client, "memory_status", Value::Null).await;
+    assert_eq!(before["memory"]["facts"], 0, "a fresh store holds no facts");
+    assert_eq!(
+        before["memory"]["edges"], 0,
+        "a fresh store's graph has no edges"
+    );
+
+    let first = call(
+        &client,
+        "remember",
+        serde_json::json!({"fact": "le port API est 6333 car 3000 etait pris"}),
+    )
+    .await;
+    let second = call(
+        &client,
+        "remember",
+        serde_json::json!({"fact": "le choix du port vient de l'incident INC-42"}),
+    )
+    .await;
+
+    let stored = call(&client, "memory_status", Value::Null).await;
+    assert_eq!(
+        stored["memory"]["facts"], 2,
+        "both remembered facts are counted"
+    );
+    assert_eq!(
+        stored["memory"]["edges"], 0,
+        "remember alone wires nothing — this zero is the observable 'why() \
+         will behave like plain search' state the tool exists to surface"
+    );
+
+    call(
+        &client,
+        "relate",
+        serde_json::json!({
+            "from": first["id_str"],
+            "to": second["id_str"],
+            "relation": "explique"
+        }),
+    )
+    .await;
+
+    let wired = call(&client, "memory_status", Value::Null).await;
+    let edges = wired["memory"]["edges"]
+        .as_u64()
+        .expect("edge count is a number");
+    assert!(edges >= 1, "the wired edge shows up in the count");
+}
+
+#[tokio::test]
+async fn status_says_whether_extraction_is_configured() {
+    let (_dir, client) = connected().await;
+    let status = call(&client, "memory_status", Value::Null).await;
+
+    assert_eq!(
+        status["extraction"]["configured"], false,
+        "no extractor was attached, and the status must say so — \
+         remember_extracted refusals become explainable"
+    );
+    assert_eq!(
+        status["extraction"]["autograph_active"], false,
+        "no autograph worker without an extractor"
+    );
+    assert_eq!(
+        status["extraction"]["autograph_dropped"], 0,
+        "the drop counter starts at zero and is relayed"
+    );
+}

--- a/crates/velesdb-memory/tests/memory_status_bdd.rs
+++ b/crates/velesdb-memory/tests/memory_status_bdd.rs
@@ -13,7 +13,10 @@
 //! Wire-level like the other BDD suites: the REAL server over an in-memory
 //! duplex, raw tool calls, assertions on `structuredContent`.
 
-#![cfg(feature = "persistence")]
+// `mcp` (which implies `persistence`), not `persistence`: this file boots the
+// MCP server itself, and the feature-isolation matrix checks `persistence`
+// ALONE with --all-targets — under which `McpServer` does not exist.
+#![cfg(feature = "mcp")]
 
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::ServiceExt;

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -21,12 +21,14 @@ The tool surface is feature-gated at build time:
 
 | Feature | Default? | Tools it adds |
 |---|---|---|
-| `mcp` | yes | `remember`, `recall`, `recall_where`, `recall_fused`, `feedback`, `relate`, `unrelate`, `forget`, `entity`, `why`, `remember_extracted` |
+| `mcp` | yes | `remember`, `recall`, `recall_where`, `recall_fused`, `feedback`, `relate`, `unrelate`, `forget`, `entity`, `why`, `remember_extracted`, `memory_status` |
 | `context` | yes | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context`, `list_working_contexts`, `suggest_budget` |
 | `extract` | no | none — it enables the *backend* `remember_extracted` needs (see that tool) |
 
-`default = ["mcp", "persistence", "context"]`, so a plain
-`cargo install velesdb-memory` advertises all **20** tools. They are served by
+`default = ["mcp", "persistence", "context", "ollama", "extract"]` (the last
+two carry the HTTP backends for embedding and extraction — runtime-switched,
+off until their env vars opt in), so a plain `cargo install velesdb-memory`
+advertises all **21** tools. They are served by
 one MCP server: the context router is combined into the memory router in
 `McpServer::new`, never a second server.
 
@@ -361,8 +363,34 @@ for exceeding the 2048-byte embeddable-text cap. It is always present, and it
 is the only way to tell a drop from the model simply extracting fewer facts —
 read it, or you will believe you stored a passage you stored only part of.
 
-**Opt-in.** The server must be built with `--features extract` *and* started
-with `VELESDB_MEMORY_EXTRACTOR` set. Without a backend the tool returns an
+## `memory_status`
+
+Report the server's health and configuration — the answers a user otherwise
+discovers only through degraded recall. Takes no parameters.
+
+Returns `{ embedder, provenance, extraction, memory }`:
+
+- `embedder` — `{ model, dimension, semantic }`: what is RUNNING.
+  `semantic: false` means the offline `hash` default — recall matches surface
+  form, not meaning, and switching to a semantic embedder is an env-var
+  change, never a rebuild. All three are `null` when the host embedded the
+  server without declaring an identity.
+- `provenance` — `{ recorded, model, dimension }`: what the store was FILLED
+  by, per its on-disk record (#1751). `recorded: false` on a store predating
+  the record; the mismatch check then degrades to dimension alone.
+- `extraction` — `{ configured, autograph_active, autograph_dropped }`:
+  `remember_extracted` works iff `configured`; the two autograph fields
+  report the background enrichment worker and its counted drops.
+- `memory` — `{ facts, edges }`: corpus size. `edges: 0` is the meaningful
+  reading — nothing ever wired the graph, so `why` has nothing to walk and
+  degrades to plain search. `edges: null` means the backend cannot count
+  without materializing (not the same statement as `0`).
+
+Call it at session start, and whenever recall quality or `why`'s evidence
+trails surprise you.
+
+**Opt-in at runtime.** The backend is compiled into the default build; the
+server must be started with `VELESDB_MEMORY_EXTRACTOR` set. Without a backend the tool returns an
 explicit "extraction backend not configured" error rather than silently doing
 nothing. Configuration: [MCP server setup →
 auto-extraction](../guides/MCP_SERVER_SETUP.md#auto-extraction-backend-opt-in).

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -2416,6 +2416,128 @@
       }
     },
     {
+      "description": "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether an extraction backend is configured (`remember_extracted` works iff `extraction.configured`), whether the background autograph worker is active and how many enrichments a full queue dropped, and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters.",
+      "inputSchema": {
+        "properties": {},
+        "type": "object"
+      },
+      "name": "memory_status",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "embedder": {
+            "description": "Which embedder is running and whether recall is semantic.",
+            "properties": {
+              "dimension": {
+                "description": "The vector width the embedder produces. Reported with the model so a\nmismatch diagnosis never needs a second call.",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "model": {
+                "description": "The model identifier actually running — `hash` for the built-in\noffline embedder, otherwise as configured (`bge-m3`, `all-minilm`).\n`null` when the host embedded this server without declaring one\n(a binding constructing [`McpServer`](super::McpServer) directly).",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "semantic": {
+                "description": "Whether recall is SEMANTIC. `false` means the `hash` embedder: recall\nmatches surface form, not meaning — the single most common \"why is\nrecall bad?\" answer, now readable by the agent instead of dying on a\nswallowed stderr. `null` when no identity was declared.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              }
+            },
+            "type": "object"
+          },
+          "extraction": {
+            "description": "Extraction and autograph wiring.",
+            "properties": {
+              "autograph_active": {
+                "description": "Whether the background autograph worker is consuming the queue\n(#1846): `remember`'s graph enrichment runs behind the response.",
+                "type": "boolean"
+              },
+              "autograph_dropped": {
+                "description": "Enrichments refused by a FULL queue since startup — the facts were\nstored, only their wiring was skipped (#1846's counted-drop rule).",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "configured": {
+                "description": "Whether an extraction backend is attached — `remember_extracted`\nworks iff this is `true`.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "configured",
+              "autograph_active",
+              "autograph_dropped"
+            ],
+            "type": "object"
+          },
+          "memory": {
+            "description": "Corpus and graph size.",
+            "properties": {
+              "edges": {
+                "description": "Total graph edges, or `null` when the backend cannot say without\nmaterializing them. `0` is the meaningful value: it is the state in\nwhich `why()` degrades to plain similarity search.",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "facts": {
+                "description": "Live tracked facts, internal entity hubs included.",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "facts"
+            ],
+            "type": "object"
+          },
+          "provenance": {
+            "description": "What embedder the store was filled by, per its on-disk record.",
+            "properties": {
+              "dimension": {
+                "description": "The recorded vector width, when there is a record.",
+                "minimum": 0,
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              },
+              "model": {
+                "description": "The recorded model, when there is a record.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "recorded": {
+                "description": "Whether the store carries an embedding-provenance record (#1751).\n`false` on a store that predates the record or was filled outside the\ndaemon — the check then degrades to dimension alone.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "recorded"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "embedder",
+          "provenance",
+          "extraction",
+          "memory"
+        ],
+        "type": "object"
+      }
+    },
+    {
       "description": "Recall memories semantically similar to a query (vector). Ranking blends similarity with each fact's learned confidence (see `feedback`), so the order is not pure similarity — the returned `score` is always the raw similarity, never the blended value. Optionally narrow to exact-match metadata via `filter` (ColumnStore), e.g. {\"project\":\"veles\",\"status\":\"resolved\"}. Ids exceed 2^53 — always relay them as strings (`id_str`); passing a JSON-number id read from a previous response will fail on float-lossy clients.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2831,7 +2953,7 @@
       }
     },
     {
-      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR; build with --features extract). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts.",
+      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Requires the server to be started with an extraction backend (set VELESDB_MEMORY_EXTRACTOR — compiled into the default build, no rebuild). Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {

--- a/scripts/check-mcp-doc-contract.py
+++ b/scripts/check-mcp-doc-contract.py
@@ -24,7 +24,7 @@ It also only sees *literal* shape declarations (``Returns `{a, b, c}` ``) —
 a TypeScript ``interface`` or a Rust ``struct`` is a type declaration, left to
 the binding-parity gate.
 
-**Second written limit: the registry is FOURTEEN tools of the twenty
+**Second written limit: the registry is FIFTEEN tools of the twenty-one
 published, and the six still held out are ``compile_context``, ``entity``,
 ``recall``, ``remember``, ``remember_extracted`` and ``why`` — each is waiting
 on the nested-shape treatment (#1695, lots 2-3) before its literals can be
@@ -203,6 +203,11 @@ POLICED_TOOLS: "tuple[PolicedTool, ...]" = (
     ),
     PolicedTool(
         "forget",
+        (),
+        ("docs/reference/MCP_TOOLS.md",),
+    ),
+    PolicedTool(
+        "memory_status",
         (),
         ("docs/reference/MCP_TOOLS.md",),
     ),

--- a/scripts/tests/test_check_mcp_doc_contract.py
+++ b/scripts/tests/test_check_mcp_doc_contract.py
@@ -759,6 +759,7 @@ class RealRepositoryTests(unittest.TestCase):
                 "docs/guides/NODE_ADDON.md",
                 "docs/reference/MCP_TOOLS.md",
             },
+            "memory_status": {"docs/reference/MCP_TOOLS.md"},
             "load_working_context": {
                 # The two `velesdb-context-optimizer` copies used to be here.
                 # Resumption moved to the memory skill, and the pin moved with


### PR DESCRIPTION
## Description

PR-2 of the end-user catch-up plan (after #1862). The audit finding it closes: the hash-embedder warning goes to **stderr of a stdio server, and every mainstream MCP client swallows that stream**. A user on the default build experiences "recall is bad", never sees why, and cannot ask — the degraded state is invisible exactly where users start. Same story for a flat graph: `why()` silently degrades to plain search when nothing ever wired an edge, and nothing said so.

One new tool, **`memory_status`** (registered unconditionally like the other twenty), reports:

- **`embedder`** — which model actually RUNS, its dimension, and `semantic: false` for the offline `hash` default. The binary declares the resolved identity via a new `with_embedder_identity` builder — the service only ever sees `&[f32]`, and `main.rs` is the one place that knows what `VELESDB_MEMORY_EMBEDDER` resolved to.
- **`provenance`** — what the store was FILLED by, per the on-disk record (#1751), read via `with_store_dir`.
- **`extraction`** — exactly the `remember_extracted` gate (an autograph-only configuration never claims a tool that would refuse), plus the autograph worker's state and counted drops (#1846).
- **`memory`** — facts and the graph's **edge count**. `edges: 0` is the observable "`why()` has nothing to walk" state; `null` means "backend cannot say", deliberately distinct.

The edge count is the one new primitive: `SemanticMemory::edge_count()` in core (a one-line delegation to the collection's materialization-free count), relayed through a **defaulted** `MemoryStore` method so `velesdb-wasm`'s out-of-crate impl keeps compiling and a healthy graph is never misreported as flat.

The push half of the same fix: `get_info` appends a degraded-mode note to the server instructions when the declared embedder is `hash` — the one channel a client is required to read — and both `SERVER_INSTRUCTIONS` variants name the tool. The stale `--features extract` claim in `remember_extracted`'s description and `MCP_TOOLS.md` entry is corrected to the runtime opt-in (#1862's contract).

Guards fed rather than fought: the wire snapshot (`mcp-tools.json`) is regenerated through `UPDATE_MCP_TOOLS_SNAPSHOT`, `memory_status` joins the doc-contract registry as its fifteenth policed tool, the three bindings carry motivated `binding_parity_bdd` exemptions (a binding host constructs its embedder explicitly — there is no hidden runtime state to reveal; a language-level stats accessor is tracked as its own change), and every tool-count mention moves 20 → 21 (`README`, `ARCHITECTURE.md`, `MCP_TOOLS.md`, code comments).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

New wire-level BDD suite `memory_status_bdd.rs` (4 tests over the REAL server on an in-memory duplex, asserting on `structuredContent`): the embedder is named and flagged non-semantic; the provenance block refuses to invent a record; facts and edges count up through `remember`/`relate` with the flat-graph zero pinned; extraction wiring is reported truthfully. **Red-first**: the suite fails with E0599 against the pre-change tree (`with_embedder_identity` absent); green after.

Also green locally: lib suite (604 tests), `mcp_tools_drift`, `binding_parity_bdd` (21 tests, including exemption-staleness checks), `mcp_schema_bdd`, `daemon_logging` (under `--features http`), `cargo clippy -D warnings -D clippy::pedantic` on both touched crates, `cargo fmt --check`, doc-freshness guards, MCP doc-contract guard, prod-unwrap guard.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#1862 is merged; this branch is rebased on it)

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`-engine, `Drop`, `unsafe`, or SIMD dispatch paths touched: the storage-layer change is a read-only counting accessor.

## Additional Notes

The license boundary holds: `memory_status` exposes memory semantics only — no raw database capability, and the core addition is a policy-free count.

Next in the plan: the `reembed` recovery path (PR-3 — investigation shows `migrate-embeddings` already carries most of it) and the honest-onboarding docs pass recommending BGE (PR-4).
