### PR TITLE
docs(memory): the onboarding tells the truth and recommends bge-m3

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -68,7 +68,11 @@ It is written to a local file store. No model call, no network.
 
 **2. It finds them by meaning, not keywords.** `recall` matches on sense, so
 asking about *"which port did we settle on"* finds that fact even though the
-words differ. This uses a local embedding model of your choosing.
+words differ. This uses a local embedding model of your choosing — and the
+honest caveat is that until you pick one, the out-of-the-box default is a
+deterministic offline embedder that matches **surface form, not meaning**
+(great for zero-dependency demos, wrong for real recall). Picking a real
+model is one env var, no rebuild: [two commands, below](#real-semantic-recall-in-5-minutes).
 
 **3. It connects them, which is the part that matters.** Facts are linked to
 the topics they mention. `why` starts from the best match and then *walks those
@@ -152,6 +156,40 @@ writable. (`_veles_date` is stamped automatically — see
 Every other client — Cursor, Zed, Codex CLI, Claude Desktop, Windsurf, Devin
 CLI — is one config block away in
 [MCP server setup](../../docs/guides/MCP_SERVER_SETUP.md#configure-your-client-stdio).
+
+## Real semantic recall in 5 minutes
+
+The 60-second setup above runs the offline `hash` embedder: deterministic,
+zero-dependency — and **lexical**, not semantic. Both semantic backends are
+compiled into the binary you just installed, so upgrading is configuration,
+not a rebuild. With [Ollama](https://ollama.com) installed, the recommended
+model is `bge-m3` (multilingual, 1024-dim):
+
+```bash
+ollama pull bge-m3
+claude mcp add velesdb-memory \
+  --env VELESDB_MEMORY_PATH="$HOME/.velesdb-memory" \
+  --env VELESDB_MEMORY_EMBEDDER=ollama \
+  --env VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
+  -- ~/.cargo/bin/velesdb-memory
+```
+
+No Ollama? Any OpenAI-compatible server (oMLX, llama.cpp, LM Studio, vLLM)
+works with `VELESDB_MEMORY_EMBEDDER=openai` and a URL — the model still runs
+on your machine, and memory still never leaves it. All options:
+[embedding backend](../../docs/guides/MCP_SERVER_SETUP.md#embedding-backend).
+
+Two things to know when switching:
+
+- **Your agent can check.** The `memory_status` tool reports which embedder
+  actually runs and whether recall is semantic — ask *"call memory_status"*
+  and read `embedder.semantic`. The server also flags a degraded (hash) run
+  in its instructions to every connecting client.
+- **Your memories survive the switch.** The store records which model filled
+  it; on a mismatch the server refuses to serve nonsense and names the
+  migration command (`velesdb-memory migrate-embeddings`, dry-run first),
+  which re-embeds every fact under its original id. Switching embedders
+  never costs you your memories.
 
 ## See the wedge (offline, one command)
 

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -3,7 +3,7 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity)
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity/memory_status)
   are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
@@ -44,6 +44,15 @@ The npm package bundles it too, at
 Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
 
 ## The loop (run it every task)
+
+0. **Know what you are running on — once per session.** Call `memory_status`
+   at the start of the first task. Read three things: `embedder.semantic`
+   (`false` = the offline `hash` default — recall matches surface form, and
+   the USER should be told if recall quality matters, since fixing it is one
+   env var); `memory.edges` (`0` = the graph is flat, so `why` degrades to
+   plain search until something wires links); `extraction.configured`
+   (whether `remember_extracted` will work at all). Do not re-poll it every
+   turn — it answers configuration questions, not content ones.
 
 1. **Recall before you act.** At the start of a task, retrieve what's already
    known before doing anything else.
@@ -307,8 +316,9 @@ code — memory that survived the process restart is exactly the point.
 
 ## Setup notes (know your embedder)
 
-Recall quality depends entirely on the embedding backend the server was built and
-launched with:
+Recall quality depends entirely on the embedding backend the server was
+launched with — and you never have to guess which one that is:
+`memory_status` names it and answers `embedder.semantic` directly.
 
 - **`hash` (default in the prebuilt binary): lexical, NOT semantic.** It matches on
   shared words, so recall of paraphrases is weak. Good enough to demo the *graph*

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -3,7 +3,7 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity)
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity/memory_status)
   are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
@@ -44,6 +44,15 @@ The npm package bundles it too, at
 Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB/blob/main/crates/velesdb-memory/README.md#configure-your-client).
 
 ## The loop (run it every task)
+
+0. **Know what you are running on — once per session.** Call `memory_status`
+   at the start of the first task. Read three things: `embedder.semantic`
+   (`false` = the offline `hash` default — recall matches surface form, and
+   the USER should be told if recall quality matters, since fixing it is one
+   env var); `memory.edges` (`0` = the graph is flat, so `why` degrades to
+   plain search until something wires links); `extraction.configured`
+   (whether `remember_extracted` will work at all). Do not re-poll it every
+   turn — it answers configuration questions, not content ones.
 
 1. **Recall before you act.** At the start of a task, retrieve what's already
    known before doing anything else.
@@ -307,8 +316,9 @@ code — memory that survived the process restart is exactly the point.
 
 ## Setup notes (know your embedder)
 
-Recall quality depends entirely on the embedding backend the server was built and
-launched with:
+Recall quality depends entirely on the embedding backend the server was
+launched with — and you never have to guess which one that is:
+`memory_status` names it and answers `embedder.semantic` directly.
 
 - **`hash` (default in the prebuilt binary): lexical, NOT semantic.** It matches on
   shared words, so recall of paraphrases is weak. Good enough to demo the *graph*

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -663,7 +663,10 @@ quality, and `why`'s seed match, depend on it.
 
 The default keeps the *single tiny offline binary* promise intact, and both
 HTTP backends are compiled into that same default binary — switching to real
-semantic recall is an env-var change, never a rebuild. Point it at a local
+semantic recall is an env-var change, never a rebuild. The recommended model
+is **`bge-m3`** (multilingual, 1024-dim, strong retrieval quality for its
+size); `all-minilm` remains the smaller/faster fallback and the historical
+default of `VELESDB_MEMORY_EMBEDDER_MODEL`. Point the daemon at a local
 model — the model runs on your own machine, so memory still never leaves it:
 
 ```bash


### PR DESCRIPTION
## Description

PR-4, the last of the end-user catch-up plan. The audit's founding finding: the README's step 2 promised *"finds them by meaning"* while the golden-path install ran a lexical hash embedder — and nothing between the two said so. The gap is now closed from both ends (#1862 made the semantic backends a runtime switch in every artifact; #1863 made the running state readable; #1864 pinned that switching never loses memories), so the docs can finally say something that is **true at every point of the journey**.

- **README** — step 2 carries the honest caveat inline (the default matches surface form, not meaning — great for zero-dependency demos, wrong for real recall) and links the fix. A new **"Real semantic recall in 5 minutes"** section lands right after the 60-second setup: `ollama pull bge-m3` plus two env vars on the same `claude mcp add` the reader just ran, the openai-protocol alternative for oMLX/llama.cpp/LM Studio/vLLM, and the two things worth knowing when switching — `memory_status` answers whether recall is semantic, and the provenance + `migrate-embeddings` chain means the switch never costs stored memories.
- **MCP_SERVER_SETUP** — **`bge-m3`** is named as the recommended model (multilingual, 1024-dim); `all-minilm` stays documented as the smaller fallback and the historical env-var default.
- **SKILL.md** (both bundled copies) — `memory_status` joins the frontmatter trigger list, and the agent loop gains **step 0**: read `embedder.semantic`, `memory.edges` and `extraction.configured` once per session, tell the user when the server runs degraded, don't re-poll a configuration answer every turn.

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Manual testing

Docs-only. All doc guards green locally: MCP doc-contract (plus its 60-test unit suite), doc-freshness (all five), README runtime contract (34 routes), TODO-annotation and prod-unwrap hygiene. Every command in the new README section was verified against the shipped binary's actual flags and defaults (`VELESDB_MEMORY_EMBEDDER`/`_MODEL`, compiled-in backends from #1862, `memory_status` from #1863).

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#1862, #1863, #1864 are all merged; this branch is on top of them)

## Unsafe Code Checklist

Skipped — docs only.

## High-Risk Change Checklist

Skipped — docs only.

## Additional Notes

This closes the catch-up plan: every artifact carries the full runtime (#1862), the server's health is readable inside the protocol (#1863), the embedder-switch journey is pinned end to end (#1864), and the onboarding now matches what the binary actually does — with BGE as the recommended semantic path.
