### PR TITLE
refactor: flatten the train's five complexity hotspots along their seams

### DIFF
--- a/crates/velesdb-memory/src/context/ingest.rs
+++ b/crates/velesdb-memory/src/context/ingest.rs
@@ -119,6 +119,34 @@ impl IngestRoots {
     }
 }
 
+/// The per-fragment shape rules of [`resolve_fragments`]. Two rules, and
+/// they are NOT the same rule read twice:
+///
+/// (a) `path` is EXCLUSIVE. It is resolved into `content` later, so a
+///     fragment carrying both would have its inline text silently
+///     overwritten by the file's.
+/// (b) a fragment must carry SOMETHING. `content` + `media` together is
+///     the supported shape, not a violation — the caption is the only
+///     text lexical relevance can read for an image, and the packer
+///     bills both (`image_tokens` + the caption's estimate). What is
+///     refused is the fragment that carries none of the three: it can
+///     only ever contribute an empty section, and letting it through
+///     turns a caller's typo into a silent no-op.
+fn check_fragment_shape(fragment: &ContextFragment) -> Result<(), MemoryError> {
+    if fragment.path.is_some() && (!fragment.content.is_empty() || fragment.media.is_some()) {
+        return Err(MemoryError::IngestPath(
+            "a fragment may set `path`, or inline `content`/`media` — never both".to_owned(),
+        ));
+    }
+    if fragment.path.is_none() && fragment.content.is_empty() && fragment.media.is_none() {
+        return Err(MemoryError::IngestPath(
+            "a fragment must carry `path`, non-empty `content`, or `media` — this one carries none"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 /// Resolve every `path`-carrying fragment of `fragments` into `content`, in
 /// place, in one pre-pass — see the module docs for the full ordered
 /// pipeline. A no-op (and roots-independent) when no fragment carries a
@@ -137,31 +165,9 @@ pub fn resolve_fragments(
     roots: Option<&IngestRoots>,
 ) -> Result<(), MemoryError> {
     // Step 1 (shape), checked for every fragment up front, independent of
-    // whether ingestion is enabled at all. Two rules, and they are NOT the
-    // same rule read twice:
-    //
-    // (a) `path` is EXCLUSIVE. It is resolved into `content` below, so a
-    //     fragment carrying both would have its inline text silently
-    //     overwritten by the file's.
-    // (b) a fragment must carry SOMETHING. `content` + `media` together is
-    //     the supported shape, not a violation — the caption is the only
-    //     text lexical relevance can read for an image, and the packer
-    //     bills both (`image_tokens` + the caption's estimate). What is
-    //     refused is the fragment that carries none of the three: it can
-    //     only ever contribute an empty section, and letting it through
-    //     turns a caller's typo into a silent no-op.
+    // whether ingestion is enabled at all.
     for fragment in fragments.iter() {
-        if fragment.path.is_some() && (!fragment.content.is_empty() || fragment.media.is_some()) {
-            return Err(MemoryError::IngestPath(
-                "a fragment may set `path`, or inline `content`/`media` — never both".to_owned(),
-            ));
-        }
-        if fragment.path.is_none() && fragment.content.is_empty() && fragment.media.is_none() {
-            return Err(MemoryError::IngestPath(
-                "a fragment must carry `path`, non-empty `content`, or `media` — this one carries none"
-                    .to_owned(),
-            ));
-        }
+        check_fragment_shape(fragment)?;
     }
 
     let indices: Vec<usize> = fragments

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -751,15 +751,9 @@ fn log_piece(source: &RawPiece, range: Range<usize>) -> RawPiece {
 fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
     let mut merged: Vec<RawPiece> = Vec::new();
     for piece in pieces {
-        let mergeable = merged.last().is_some_and(|last: &RawPiece| {
-            last.turn == piece.turn
-                && last.kind == piece.kind
-                && last.content_override.is_none()
-                && piece.content_override.is_none()
-                && last.range.end == piece.range.start
-                && last.range.len() + piece.range.len() <= MAX_FRAGMENT_BYTES
-                && (last.range.len() < min_bytes || piece.range.len() < min_bytes)
-        });
+        let mergeable = merged
+            .last()
+            .is_some_and(|last| can_absorb(last, &piece, min_bytes));
         // `mergeable` is only true when `merged` is non-empty, but branch on
         // the `Option` rather than assume it: a future edit to `mergeable`
         // that breaks the invariant then drops nothing silently and panics
@@ -770,6 +764,20 @@ fn merge_tiny(pieces: Vec<RawPiece>, min_bytes: usize) -> Vec<RawPiece> {
         }
     }
     merged
+}
+
+/// [`merge_tiny`]'s absorption predicate, one clause per rule the doc above
+/// it narrates: same turn and kind, neither side override-bearing, byte
+/// ranges adjacent, the combined size under [`MAX_FRAGMENT_BYTES`], and at
+/// least one side actually tiny.
+fn can_absorb(last: &RawPiece, next: &RawPiece, min_bytes: usize) -> bool {
+    last.turn == next.turn
+        && last.kind == next.kind
+        && last.content_override.is_none()
+        && next.content_override.is_none()
+        && last.range.end == next.range.start
+        && last.range.len() + next.range.len() <= MAX_FRAGMENT_BYTES
+        && (last.range.len() < min_bytes || next.range.len() < min_bytes)
 }
 
 // --- Assembly ------------------------------------------------------------

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -174,29 +174,43 @@ pub fn column_value_matches(stored: &Value, op: ColumnOp, target: &Value) -> boo
         return false;
     }
     if let (Some(left), Some(right)) = (stored.as_f64(), target.as_f64()) {
-        return match op {
-            ColumnOp::Eq => (left - right).abs() < f64::EPSILON,
-            ColumnOp::Ne => (left - right).abs() >= f64::EPSILON,
-            ColumnOp::Lt => left < right,
-            ColumnOp::Le => left <= right,
-            ColumnOp::Gt => left > right,
-            ColumnOp::Ge => left >= right,
-        };
+        return compare_f64(op, left, right);
     }
     if let (Some(left), Some(right)) = (stored.as_str(), target.as_str()) {
-        return match op {
-            ColumnOp::Eq => left == right,
-            ColumnOp::Ne => left != right,
-            ColumnOp::Lt => left < right,
-            ColumnOp::Le => left <= right,
-            ColumnOp::Gt => left > right,
-            ColumnOp::Ge => left >= right,
-        };
+        return compare_ordered(op, &left, &right);
     }
     match op {
         ColumnOp::Eq => stored == target,
         ColumnOp::Ne => stored != target,
         ColumnOp::Lt | ColumnOp::Le | ColumnOp::Gt | ColumnOp::Ge => false,
+    }
+}
+
+/// The numeric arm of [`column_value_matches`], split out for its one real
+/// difference from the ordered arm: equality is epsilon-based, so `Eq`/`Ne`
+/// cannot be expressed through `PartialOrd` without changing what a
+/// float-rounded stored value matches.
+fn compare_f64(op: ColumnOp, left: f64, right: f64) -> bool {
+    match op {
+        ColumnOp::Eq => (left - right).abs() < f64::EPSILON,
+        ColumnOp::Ne => (left - right).abs() >= f64::EPSILON,
+        ColumnOp::Lt => left < right,
+        ColumnOp::Le => left <= right,
+        ColumnOp::Gt => left > right,
+        ColumnOp::Ge => left >= right,
+    }
+}
+
+/// The ordered arm of [`column_value_matches`]: any type whose native
+/// comparisons ARE the predicate semantics (strings today).
+fn compare_ordered<T: PartialOrd>(op: ColumnOp, left: &T, right: &T) -> bool {
+    match op {
+        ColumnOp::Eq => left == right,
+        ColumnOp::Ne => left != right,
+        ColumnOp::Lt => left < right,
+        ColumnOp::Le => left <= right,
+        ColumnOp::Gt => left > right,
+        ColumnOp::Ge => left >= right,
     }
 }
 

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -174,6 +174,22 @@ pub async fn get_edges(
 }
 
 /// Add an edge to a collection's graph.
+/// The write-result match [`add_edge`] and [`add_edges_batch`] share: the
+/// blocking-pool outcome routed through `auto_core_error_response` (so e.g.
+/// `EdgeExists` surfaces as 409 + VELES-019, never a 500 string), success
+/// shaped by the caller. One copy, so the two handlers cannot drift on the
+/// error route.
+fn created_or_core_error<T>(
+    outcome: Result<Result<T, velesdb_core::Error>, axum::response::Response>,
+    success: impl FnOnce(T) -> axum::response::Response,
+) -> axum::response::Response {
+    match outcome {
+        Ok(Ok(value)) => success(value),
+        Ok(Err(e)) => auto_core_error_response(&e),
+        Err(resp) => resp,
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/collections/{name}/graph/edges",
@@ -204,11 +220,9 @@ pub async fn add_edge(
     // Edge insertion takes write locks and persists — run it on the blocking
     // pool. Route the core error through `auto_core_error_response` so e.g.
     // `EdgeExists` surfaces as 409 + VELES-019 instead of a generic 500 string.
-    match run_blocking(move || coll.add_edge(edge)).await {
-        Ok(Ok(())) => StatusCode::CREATED.into_response(),
-        Ok(Err(e)) => auto_core_error_response(&e),
-        Err(resp) => resp,
-    }
+    created_or_core_error(run_blocking(move || coll.add_edge(edge)).await, |()| {
+        StatusCode::CREATED.into_response()
+    })
 }
 
 /// Converts an [`AddEdgeRequest`] into a core [`GraphEdge`], validating the
@@ -281,13 +295,10 @@ pub async fn add_edges_batch(
     // Batch edge insertion takes write locks and persists — run it on the
     // blocking pool. Route the core error through `auto_core_error_response`
     // so e.g. `EdgeExists` surfaces as 409 + VELES-019 instead of a 500 string.
-    match run_blocking(move || coll.add_edges_batch(edges)).await {
-        Ok(Ok(added)) => {
-            (StatusCode::CREATED, Json(AddEdgesBatchResponse { added })).into_response()
-        }
-        Ok(Err(e)) => auto_core_error_response(&e),
-        Err(resp) => resp,
-    }
+    created_or_core_error(
+        run_blocking(move || coll.add_edges_batch(edges)).await,
+        |added| (StatusCode::CREATED, Json(AddEdgesBatchResponse { added })).into_response(),
+    )
 }
 
 /// Traverse the graph using BFS or DFS from a source node.

--- a/crates/velesdb-server/src/handlers/graph/handlers.rs
+++ b/crates/velesdb-server/src/handlers/graph/handlers.rs
@@ -173,7 +173,6 @@ pub async fn get_edges(
     Ok(Json(EdgesResponse { edges, count }))
 }
 
-/// Add an edge to a collection's graph.
 /// The write-result match [`add_edge`] and [`add_edges_batch`] share: the
 /// blocking-pool outcome routed through `auto_core_error_response` (so e.g.
 /// `EdgeExists` surfaces as 409 + VELES-019, never a 500 string), success
@@ -190,6 +189,7 @@ fn created_or_core_error<T>(
     }
 }
 
+/// Add an edge to a collection's graph.
 #[utoipa::path(
     post,
     path = "/collections/{name}/graph/edges",

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -96,10 +96,6 @@ pub struct SetTtlRequest {
 // Handler implementations
 // ---------------------------------------------------------------------------
 
-/// Create a relation edge between two points in a collection.
-///
-/// Works on vector, graph, and metadata collections alike.
-/// The edge ID is auto-assigned; the response body carries the allocated value.
 /// The `properties` coercion of [`relate_points`]: an object passes through,
 /// `null` means none, anything else is the caller's error — split out so the
 /// handler reads as its three phases (resolve, coerce, insert).
@@ -119,6 +115,10 @@ fn relation_properties(
     }
 }
 
+/// Create a relation edge between two points in a collection.
+///
+/// Works on vector, graph, and metadata collections alike.
+/// The edge ID is auto-assigned; the response body carries the allocated value.
 #[utoipa::path(
     post,
     path = "/collections/{name}/relations",

--- a/crates/velesdb-server/src/handlers/points/relations.rs
+++ b/crates/velesdb-server/src/handlers/points/relations.rs
@@ -100,6 +100,25 @@ pub struct SetTtlRequest {
 ///
 /// Works on vector, graph, and metadata collections alike.
 /// The edge ID is auto-assigned; the response body carries the allocated value.
+/// The `properties` coercion of [`relate_points`]: an object passes through,
+/// `null` means none, anything else is the caller's error — split out so the
+/// handler reads as its three phases (resolve, coerce, insert).
+#[allow(clippy::result_large_err)]
+fn relation_properties(
+    value: &serde_json::Value,
+) -> Result<std::collections::HashMap<String, serde_json::Value>, axum::response::Response> {
+    match value {
+        serde_json::Value::Object(map) => {
+            Ok(map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        }
+        serde_json::Value::Null => Ok(std::collections::HashMap::new()),
+        _ => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "properties must be an object or null".to_string(),
+        )),
+    }
+}
+
 #[utoipa::path(
     post,
     path = "/collections/{name}/relations",
@@ -123,17 +142,9 @@ pub async fn relate_points(
         Err(r) => return r,
     };
 
-    let properties: std::collections::HashMap<String, serde_json::Value> = match req.properties {
-        serde_json::Value::Object(ref map) => {
-            map.iter().map(|(k, v)| (k.clone(), v.clone())).collect()
-        }
-        serde_json::Value::Null => std::collections::HashMap::new(),
-        _ => {
-            return error_response(
-                StatusCode::BAD_REQUEST,
-                "properties must be an object or null".to_string(),
-            )
-        }
+    let properties = match relation_properties(&req.properties) {
+        Ok(map) => map,
+        Err(resp) => return resp,
     };
 
     // Edge allocation + insertion take write locks and persist — run them on

--- a/crates/velesdb-server/src/handlers/query/aggregation.rs
+++ b/crates/velesdb-server/src/handlers/query/aggregation.rs
@@ -103,6 +103,29 @@ pub(crate) fn resolve_aggregate_collection(
 /// Execute an aggregation-only VelesQL query.
 ///
 /// This endpoint is explicit and stable for GROUP BY / HAVING / aggregate workloads.
+/// The refuse-or-proceed phase of [`aggregate`], one rule per step: the
+/// query parses, it IS an aggregation (row/search/graph belong on
+/// `/query`), and it names exactly one resolvable collection. Split out so
+/// the handler charges the error metric in ONE place instead of once per
+/// refusal arm.
+#[allow(clippy::result_large_err)]
+fn prepare_aggregation(
+    req: &QueryRequest,
+) -> Result<(velesdb_core::velesql::Query, String), axum::response::Response> {
+    let parsed = parse_and_validate(&req.query)?;
+    if parsed.is_match_query() || !parsed.select.is_aggregation_query() {
+        return Err(velesql_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "VELESQL_AGGREGATION_ERROR",
+            "Only aggregation queries are accepted on /aggregate",
+            "Use /query for row/search/graph queries; use /aggregate for GROUP BY/aggregate workloads.",
+            Some(serde_json::json!({ "endpoint": "/aggregate" })),
+        ));
+    }
+    let collection_name = resolve_aggregate_collection(&parsed, req)?;
+    Ok((parsed, collection_name))
+}
+
 #[utoipa::path(
     post,
     path = "/aggregate",
@@ -122,28 +145,8 @@ pub async fn aggregate(
     let start = std::time::Instant::now();
     state.operational_metrics.inc_queries();
 
-    let parsed = match parse_and_validate(&req.query) {
-        Ok(q) => q,
-        Err(resp) => {
-            state.operational_metrics.inc_errors();
-            return resp;
-        }
-    };
-
-    if parsed.is_match_query() || !parsed.select.is_aggregation_query() {
-        state.operational_metrics.inc_errors();
-        return velesql_error(
-            StatusCode::UNPROCESSABLE_ENTITY,
-            "VELESQL_AGGREGATION_ERROR",
-            "Only aggregation queries are accepted on /aggregate",
-            "Use /query for row/search/graph queries; use /aggregate for GROUP BY/aggregate workloads.",
-            Some(serde_json::json!({ "endpoint": "/aggregate" })),
-        );
-    }
-
-    let collection_name = resolve_aggregate_collection(&parsed, &req);
-    let collection_name = match collection_name {
-        Ok(name) => name,
+    let (parsed, collection_name) = match prepare_aggregation(&req) {
+        Ok(prepared) => prepared,
         Err(resp) => {
             state.operational_metrics.inc_errors();
             return resp;

--- a/crates/velesdb-server/src/handlers/query/aggregation.rs
+++ b/crates/velesdb-server/src/handlers/query/aggregation.rs
@@ -100,9 +100,6 @@ pub(crate) fn resolve_aggregate_collection(
         })
 }
 
-/// Execute an aggregation-only VelesQL query.
-///
-/// This endpoint is explicit and stable for GROUP BY / HAVING / aggregate workloads.
 /// The refuse-or-proceed phase of [`aggregate`], one rule per step: the
 /// query parses, it IS an aggregation (row/search/graph belong on
 /// `/query`), and it names exactly one resolvable collection. Split out so
@@ -126,6 +123,9 @@ fn prepare_aggregation(
     Ok((parsed, collection_name))
 }
 
+/// Execute an aggregation-only VelesQL query.
+///
+/// This endpoint is explicit and stable for GROUP BY / HAVING / aggregate workloads.
 #[utoipa::path(
     post,
     path = "/aggregate",


### PR DESCRIPTION
## Description

The chore the maintainer approved after Codacy's aggregate gate on the 5.0.0 release PR (#1874) counted **five medium complexity findings** across the `develop → main` diff. Done **on `develop`, deliberately** — the release branch must not carry code `develop` never reviewed; #1874 stays a pure version/changelog/docs train.

One honest caveat, stated rather than hidden: Codacy's dashboard is egress-blocked from this environment, so the five findings were **mapped by a local cyclomatic scan** of the train-touched functions (comments excluded — a first pass amusingly counted the branch keywords inside doc-comment contract tables) rather than read off Codacy's list. The five worst train-touched functions were flattened along seams that already existed, behavior identical:

- **`column_value_matches`** (memory `model.rs`) splits its three arms into `compare_f64` — the epsilon-equality arm `PartialOrd` cannot express — and a generic `compare_ordered`, taken by reference.
- **`merge_tiny`** (context `segment.rs`): the seven-clause absorption predicate becomes `can_absorb`, one clause per rule the function's own doc already narrates.
- **`aggregate`** (server): three refuse-or-proceed steps collapse into `prepare_aggregation`, charging the error metric in **one** place instead of once per refusal arm.
- **`relate_points`** (server): the `properties` coercion becomes `relation_properties`.
- **`add_edge` / `add_edges_batch`** (server) share `created_or_core_error` — the two handlers can no longer drift on the `EdgeExists`-is-409 error route.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests

Behavior-preserving splits only. Green locally: memory lib suite (671), server lib suite (156), the `segment`/`model`/`column_filter_conformance` filters, `clippy -D warnings -D clippy::pedantic` on both crates (the two new `Response`-erroring helpers carry the crate's established `result_large_err` allow; `compare_ordered` passes by reference per `needless_pass_by_value`), `fmt --check` clean. One trap dodged and worth recording: a helper inserted between a `#[utoipa::path]` attribute block and its handler breaks the generated `__path_*` export — helpers go above the attribute.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — pure extract-function refactors on validation/response paths; no storage, locking or dispatch semantics touched.

## Additional Notes

If Codacy's actual five differ from this mapping, its next aggregate run will say so and the residue can follow the same treatment. This PR does not need to gate #1874 — the release train ships as-is, and this lands on `develop` for the next one.
