### PR TITLE
refactor(memory): the five findings Codacy actually counted, resolved

### DIFF
--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -601,19 +601,32 @@ fn run_export(argv: &[String], flags: &[String]) -> Result<(), Box<dyn std::erro
         .or_else(|| std::env::var("VELESDB_MEMORY_PATH").ok())
         .unwrap_or_else(default_store_path);
     let store = std::path::Path::new(&store);
-    let (output, include_internal) = (options.output, options.include_internal);
-    let written = if let Some(path) = output {
-        let mut file = std::io::BufWriter::new(std::fs::File::create(&path)?);
+    let written = write_export(store, options.output.as_deref(), options.include_internal)?;
+    eprintln!("[velesdb-memory] exported {written} memories");
+    Ok(())
+}
+
+/// The destination half of [`run_export`]: a named file (buffered, flushed)
+/// or stdout (locked — on this subcommand stdout carries data, not MCP).
+fn write_export(
+    store: &std::path::Path,
+    output: Option<&str>,
+    include_internal: bool,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    if let Some(path) = output {
+        let mut file = std::io::BufWriter::new(std::fs::File::create(path)?);
         let written = velesdb_memory::export::export_jsonl(store, &mut file, include_internal)?;
         std::io::Write::flush(&mut file)?;
-        written
+        Ok(written)
     } else {
         let stdout = std::io::stdout();
         let mut lock = stdout.lock();
-        velesdb_memory::export::export_jsonl(store, &mut lock, include_internal)?
-    };
-    eprintln!("[velesdb-memory] exported {written} memories");
-    Ok(())
+        Ok(velesdb_memory::export::export_jsonl(
+            store,
+            &mut lock,
+            include_internal,
+        )?)
+    }
 }
 
 /// The `export` subcommand's parsed flags — split from [`run_export`] so

--- a/crates/velesdb-memory/src/migration/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis.rs
@@ -367,6 +367,24 @@ pub(super) fn diagnose_copy(
     ))
 }
 
+/// The strategy resolution of [`report_from_inventory`]: what the caller
+/// asked for, arbitrated against what the store's provenance and dimension
+/// actually permit.
+fn resolved_strategy(
+    target: &TargetContract,
+    inventory: &inventory::StoreInventory,
+) -> crate::migration::strategy::Resolution {
+    resolve(
+        target.strategy,
+        assess(
+            &inventory.source_provenance,
+            inventory.source_dimension,
+            &target.model,
+            target.dimension,
+        ),
+    )
+}
+
 fn report_from_inventory(
     source: &Path,
     target: &TargetContract,
@@ -374,6 +392,7 @@ fn report_from_inventory(
     copy: &DiagnosticCopy,
     inventory: inventory::StoreInventory,
 ) -> DiagnosisReport {
+    let resolution = resolved_strategy(target, &inventory);
     let capabilities = capabilities::capability_map(
         &inventory.source_provenance,
         inventory.source_dimension,
@@ -384,15 +403,6 @@ fn report_from_inventory(
         copy,
     );
     let blockers = capabilities::blockers_for(&capabilities, &inventory.collections);
-    let resolution = resolve(
-        target.strategy,
-        assess(
-            &inventory.source_provenance,
-            inventory.source_dimension,
-            &target.model,
-            target.dimension,
-        ),
-    );
     DiagnosisReport {
         format_version: DIAGNOSIS_FORMAT_VERSION,
         source_path: source.to_path_buf(),

--- a/crates/velesdb-memory/src/migration/diagnosis/report.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis/report.rs
@@ -45,56 +45,64 @@ impl TryFrom<UncheckedDiagnosisReport> for DiagnosisReport {
     type Error = String;
 
     fn try_from(unchecked: UncheckedDiagnosisReport) -> Result<Self, Self::Error> {
-        let UncheckedDiagnosisReport {
-            format_version,
-            source_path,
-            source_fingerprint,
-            source_dimension,
-            source_provenance,
-            target_model,
-            target_dimension,
-            requested_strategy,
-            resolution,
-            collections,
-            facts,
-            edges,
-            working_contexts,
-            reserved_metadata,
-            ttl_summary,
-            bytes_on_disk,
-            diagnostic_staging_required,
-            diagnostic_staging_available,
-            disk_headroom,
-            same_filesystem,
-            capabilities,
-            blockers,
-        } = unchecked;
-        let report = Self {
-            format_version,
-            source_path,
-            source_fingerprint,
-            source_dimension,
-            source_provenance,
-            target_model,
-            target_dimension,
-            requested_strategy,
-            resolution,
-            collections,
-            facts,
-            edges,
-            working_contexts,
-            reserved_metadata,
-            ttl_summary,
-            bytes_on_disk,
-            diagnostic_staging_required,
-            diagnostic_staging_available,
-            disk_headroom,
-            same_filesystem,
-            capabilities,
-            blockers,
-        };
+        let report = assemble(unchecked);
         report.validate()?;
         Ok(report)
+    }
+}
+
+/// The field-by-field mirror of [`TryFrom`], kept as a FULL destructure on
+/// purpose: a field added to [`UncheckedDiagnosisReport`] without its
+/// assignment here fails to compile, which is the one-sided-drift guard the
+/// mirror-struct pattern exists for.
+fn assemble(unchecked: UncheckedDiagnosisReport) -> DiagnosisReport {
+    let UncheckedDiagnosisReport {
+        format_version,
+        source_path,
+        source_fingerprint,
+        source_dimension,
+        source_provenance,
+        target_model,
+        target_dimension,
+        requested_strategy,
+        resolution,
+        collections,
+        facts,
+        edges,
+        working_contexts,
+        reserved_metadata,
+        ttl_summary,
+        bytes_on_disk,
+        diagnostic_staging_required,
+        diagnostic_staging_available,
+        disk_headroom,
+        same_filesystem,
+        capabilities,
+        blockers,
+    } = unchecked;
+    DiagnosisReport {
+        format_version,
+        source_path,
+        source_fingerprint,
+        source_dimension,
+        source_provenance,
+        target_model,
+        target_dimension,
+        requested_strategy,
+        resolution,
+        collections,
+        facts,
+        edges,
+        working_contexts,
+        reserved_metadata,
+        ttl_summary,
+        bytes_on_disk,
+        diagnostic_staging_required,
+        diagnostic_staging_available,
+        disk_headroom,
+        same_filesystem,
+        capabilities,
+        blockers,
     }
 }
 

--- a/crates/velesdb-memory/src/migration/state.rs
+++ b/crates/velesdb-memory/src/migration/state.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 mod lock;
+mod resume;
 mod switch;
 
 #[cfg(test)]
@@ -165,10 +166,10 @@ impl MigrationState {
         .map_err(|reason| {
             format!("cannot resume against an invalid requested identity: {reason}")
         })?;
-        validate_resume_source(self, source_path)?;
-        validate_resume_fingerprint(self, source_fingerprint)?;
-        validate_resume_model(self, target_model)?;
-        validate_resume_dimension(self, target_dimension)?;
+        resume::validate_resume_source(self, source_path)?;
+        resume::validate_resume_fingerprint(self, source_fingerprint)?;
+        resume::validate_resume_model(self, target_model)?;
+        resume::validate_resume_dimension(self, target_dimension)?;
         Ok(())
     }
 
@@ -226,47 +227,6 @@ impl MigrationState {
             state_durability_barrier,
         )
     }
-}
-
-fn validate_resume_source(state: &MigrationState, requested: &Path) -> Result<(), String> {
-    if state.source_path == requested {
-        return Ok(());
-    }
-    Err(format!(
-        "this migration was prepared for source '{}' and the request names '{}'. A journal cannot be transferred between stores. Start a fresh diagnosis.",
-        state.source_path.display(),
-        requested.display()
-    ))
-}
-
-fn validate_resume_fingerprint(state: &MigrationState, requested: &str) -> Result<(), String> {
-    if state.source_fingerprint == requested {
-        return Ok(());
-    }
-    Err(format!(
-        "the source changed since this migration was prepared: it was fingerprinted '{}' and is now '{}'. Resuming would rebuild from an inventory that no longer describes the store. Start a fresh diagnosis.",
-        state.source_fingerprint, requested
-    ))
-}
-
-fn validate_resume_model(state: &MigrationState, requested: &str) -> Result<(), String> {
-    if state.target_model == requested {
-        return Ok(());
-    }
-    Err(format!(
-        "this migration was prepared for the model '{}' and the request names '{}'. Half a store embedded by one model and half by another is not searchable. Either point the request back at '{}', or start a fresh migration.",
-        state.target_model, requested, state.target_model
-    ))
-}
-
-fn validate_resume_dimension(state: &MigrationState, requested: usize) -> Result<(), String> {
-    if state.target_dimension == requested {
-        return Ok(());
-    }
-    Err(format!(
-        "this migration was prepared for target dimension {} and the request names {}. Changing vector width mid-migration would make the rebuilt store unreadable. Start a fresh migration.",
-        state.target_dimension, requested
-    ))
 }
 
 fn read_state_value(workspace: &Path) -> Result<Option<Value>, String> {

--- a/crates/velesdb-memory/src/migration/state/resume.rs
+++ b/crates/velesdb-memory/src/migration/state/resume.rs
@@ -1,0 +1,59 @@
+//! The resume-identity validators of [`MigrationState`]: a journal may only
+//! be resumed by the request it was prepared for — same source, same
+//! fingerprint, same target model, same width. Each refusal names what
+//! diverged and what to do about it. Split from `state.rs` as its own
+//! concern (and to keep that file under the size gate).
+
+use std::path::Path;
+
+use super::MigrationState;
+
+pub(super) fn validate_resume_source(
+    state: &MigrationState,
+    requested: &Path,
+) -> Result<(), String> {
+    if state.source_path == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "this migration was prepared for source '{}' and the request names '{}'. A journal cannot be transferred between stores. Start a fresh diagnosis.",
+        state.source_path.display(),
+        requested.display()
+    ))
+}
+
+pub(super) fn validate_resume_fingerprint(
+    state: &MigrationState,
+    requested: &str,
+) -> Result<(), String> {
+    if state.source_fingerprint == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "the source changed since this migration was prepared: it was fingerprinted '{}' and is now '{}'. Resuming would rebuild from an inventory that no longer describes the store. Start a fresh diagnosis.",
+        state.source_fingerprint, requested
+    ))
+}
+
+pub(super) fn validate_resume_model(state: &MigrationState, requested: &str) -> Result<(), String> {
+    if state.target_model == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "this migration was prepared for the model '{}' and the request names '{}'. Half a store embedded by one model and half by another is not searchable. Either point the request back at '{}', or start a fresh migration.",
+        state.target_model, requested, state.target_model
+    ))
+}
+
+pub(super) fn validate_resume_dimension(
+    state: &MigrationState,
+    requested: usize,
+) -> Result<(), String> {
+    if state.target_dimension == requested {
+        return Ok(());
+    }
+    Err(format!(
+        "this migration was prepared for target dimension {} and the request names {}. Changing vector width mid-migration would make the rebuilt store unreadable. Start a fresh migration.",
+        state.target_dimension, requested
+    ))
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -534,6 +534,39 @@ where
     E: Embedder + Send + Sync + 'static,
     S: MemoryStore + Send + Sync + 'static,
 {
+    /// The autograph worker's whole life, run on the spawned thread: ends
+    /// when every sender is gone — i.e. when the handle's drop takes the
+    /// sender back out of the service. Once the closing latch is up,
+    /// still-queued jobs are SKIPPED: the exit pays for the job in flight,
+    /// never for the queue.
+    fn autograph_worker_loop(&self, rx: &std::sync::mpsc::Receiver<AutographJob>) {
+        let mut skipped_on_close: u64 = 0;
+        for job in rx {
+            if self
+                .autograph_queue
+                .closing
+                .load(std::sync::atomic::Ordering::Acquire)
+            {
+                skipped_on_close += 1;
+                continue;
+            }
+            self.autograph(job.fact_id, &job.fact);
+        }
+        if skipped_on_close > 0 {
+            self.autograph_queue
+                .dropped
+                .fetch_add(skipped_on_close, std::sync::atomic::Ordering::Relaxed);
+            // ONE aggregated line, not one per job (#1834's rule).
+            #[cfg(feature = "mcp")]
+            tracing::warn!(
+                skipped = skipped_on_close,
+                "autograph worker closing: queued enrichments skipped — \
+                 the facts are stored, their graph structure is not; \
+                 re-remembering rebuilds it"
+            );
+        }
+    }
+
     /// Move autograph off the response path: spawn ONE background worker
     /// consuming a bounded queue, so `remember` returns as soon as the fact
     /// is durably stored and the graph is wired behind (#1846).
@@ -582,38 +615,7 @@ where
         let worker_service = std::sync::Arc::clone(self);
         let join = std::thread::Builder::new()
             .name("velesdb-autograph".to_owned())
-            .spawn(move || {
-                // Ends when every sender is gone — i.e. when the handle's
-                // drop takes the sender back out of the service. Once the
-                // closing latch is up, still-queued jobs are SKIPPED: the
-                // exit pays for the job in flight, never for the queue.
-                let mut skipped_on_close: u64 = 0;
-                for job in rx {
-                    if worker_service
-                        .autograph_queue
-                        .closing
-                        .load(std::sync::atomic::Ordering::Acquire)
-                    {
-                        skipped_on_close += 1;
-                        continue;
-                    }
-                    worker_service.autograph(job.fact_id, &job.fact);
-                }
-                if skipped_on_close > 0 {
-                    worker_service
-                        .autograph_queue
-                        .dropped
-                        .fetch_add(skipped_on_close, std::sync::atomic::Ordering::Relaxed);
-                    // ONE aggregated line, not one per job (#1834's rule).
-                    #[cfg(feature = "mcp")]
-                    tracing::warn!(
-                        skipped = skipped_on_close,
-                        "autograph worker closing: queued enrichments skipped — \
-                         the facts are stored, their graph structure is not; \
-                         re-remembering rebuilds it"
-                    );
-                }
-            })
+            .spawn(move || worker_service.autograph_worker_loop(&rx))
             .map_err(|err| {
                 MemoryError::Extract(crate::extract::ExtractError::Backend(format!(
                     "spawn autograph worker: {err}"


### PR DESCRIPTION
## Description

The maintainer pasted the release gate's **real** finding list from the Codacy dashboard (egress-blocked from this environment), and it shares almost nothing with the cyclomatic guesses #1875 flattened — Codacy's Rust gate turns out to measure three different rulers: **method length (50 lines), file NCLOC (500), and cyclomatic 8**. The five, each resolved at its seam, behavior identical:

| Finding | Resolution |
|---|---|
| `report_from_inventory` — 51 lines | strategy resolution → `resolved_strategy`, computed **before** `capability_map` partially moves the inventory (the borrow checker insisted; the original ordering obscured it) |
| `spawn_autograph_worker` — 64 lines | the spawned thread's whole life → `autograph_worker_loop`, closing-latch narration kept as its doc; the spawner reads install-sender / spawn / build-handle |
| `migration/state.rs` — over the 500-NCLOC file gate | the four resume validators (one concern: a journal only resumes for the request it was prepared for) → the existing `state/` module dir as `state/resume.rs` |
| `run_export` — cyclomatic 9 | the destination `if/else` → `write_export` |
| `DiagnosisReport::try_from` — 52 lines | the field mirror → `assemble()`, **intact** — the full destructure is the one-sided-drift compile guard the mirror-struct pattern exists for; `try_from` is now read-validate-return |

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests

Green locally: migration suite (155), service (30), export (6), the autograph BDD suite, `clippy -D warnings -D clippy::pedantic`, `fmt --check`. The fifth displaced-doc-block trap of this session (helper inserted between a doc comment and its fn) was caught by the `# Errors` lint and re-placed.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — extract-function/extract-module refactors; the one execution-order change (`resolved_strategy` before `capability_map`) is over pure reads of the inventory.

## Additional Notes

Once merged, `develop` folds into `release/5.0.0` and the release PR's Codacy counter is re-read — the maintainer's rule is zero findings, and the counter on #1874 is the ground truth being driven there.
