### PR TITLE
chore(sdk): raise @wiscale/velesdb-wasm floor to ^5.0.0

### DIFF
--- a/docs/guides/MIGRATION_v5.0.0.md
+++ b/docs/guides/MIGRATION_v5.0.0.md
@@ -43,13 +43,13 @@ if ctx is None: start_fresh()           if not out["found"]:
 The TypeScript SDK and the LangGraph toolkit detect a version skew at call
 time and reject with an actionable error rather than handing back an object
 whose `found` is `undefined` — but that guard is a net. Upgrade the
-packages together. The LangGraph floor enforces it now
-(`velesdb>=5.0.0`); the SDK's `@wiscale/velesdb-wasm` floor moves to
-`^5.0.0` in the first SDK release AFTER npm carries the 5.0.0 wasm bundle —
-a floor CI must be able to resolve cannot name a version that does not
-exist yet, which is the same constraint the changelog recorded when it
-deferred the raise to this train. Until then the runtime guard is the
-enforcement.
+packages together. Both floors now enforce it: the LangGraph toolkit
+requires `velesdb>=5.0.0`, and the SDK requires
+`@wiscale/velesdb-wasm@^5.0.0` (raised once npm carried the 5.0.0 wasm
+bundle — a floor CI must be able to resolve cannot name a version that
+does not exist yet, which is why the raise trailed the publish by one
+step). A fresh `npm install` can no longer pair the SDK with a 4.x wasm;
+the runtime guard remains as defense in depth for already-installed trees.
 
 ---
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@wiscale/velesdb-wasm": "^4.2.0"
+        "@wiscale/velesdb-wasm": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -907,9 +907,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -927,9 +924,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -947,9 +941,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -967,9 +958,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,9 +975,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,9 +992,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1188,9 +1170,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1205,9 +1184,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,9 +1198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1239,9 +1212,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,9 +1226,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1273,9 +1240,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1290,9 +1254,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,9 +1268,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1324,9 +1282,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,9 +1296,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,9 +1310,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,9 +1324,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,9 +1338,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1930,9 +1873,9 @@
       }
     },
     "node_modules/@wiscale/velesdb-wasm": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-4.2.0.tgz",
-      "integrity": "sha512-TRM6qrdkm2vxTSpbeFkvq/VKirjMrKwyPUt5hW2EdSU0Y2htG0f0l/XBnO56Mqz13YXLqxCGMIAF03ocp4q+jw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@wiscale/velesdb-wasm/-/velesdb-wasm-5.0.0.tgz",
+      "integrity": "sha512-YYZEg4sWbw4YwpAIDo/H/g40xldKNL9kplf1CBk5euQq0nHYZh7vTtmhlV4qxM9YAGJLvBeqwIyqgFPjoYVR7Q==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/acorn": {
@@ -2893,9 +2836,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2917,9 +2857,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2941,9 +2878,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2965,9 +2899,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -69,7 +69,7 @@
     "vitest": "^4.0.16"
   },
   "dependencies": {
-    "@wiscale/velesdb-wasm": "^4.2.0"
+    "@wiscale/velesdb-wasm": "^5.0.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## What

Raises the TypeScript SDK's `@wiscale/velesdb-wasm` dependency floor from `^4.2.0` to `^5.0.0`, regenerates the lockfile against the registry, and settles the migration guide's deferred-raise caveat.

## Why

The 5.0.0 release train had to defer this raise: pointing the floor at an unpublished version broke `npm ci` with `ETARGET` in TS SDK Check (#1874), so the runtime version-skew guard carried the enforcement alone. `release.yml` run 31399647146 has now published `@wiscale/velesdb-wasm@5.0.0` (verified `latest` on the registry), which unblocks the floor — a fresh install can no longer pair the SDK with a 4.x wasm that returns the pre-envelope `load_working_context` shape. The runtime guard stays as defense in depth for already-installed trees.

## Validation

- `npm install --package-lock-only` resolves `@wiscale/velesdb-wasm@5.0.0` from the registry
- `npm ci && npm test` locally: 37 files, 927 tests passed — the exact surface TS SDK Check runs

Closes #1877. Last unticked code item on the #1879 post-release checklist.
