### PR TITLE
ci(release): add guarded tag fallback (#1878)

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,68 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (for example v5.1.0 or v5.1.0-rc.1)'
+        required: true
+        type: string
+      sha:
+        description: 'Full SHA of the CI-green commit on main'
+        required: true
+        type: string
+      message:
+        description: 'Annotated tag message'
+        required: true
+        type: string
+
+concurrency:
+  group: create-release-tag-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  create-tag:
+    name: Create tag and start release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Refuse dispatches outside develop or main
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          case "$DISPATCH_REF" in
+            refs/heads/develop|refs/heads/main) ;;
+            *)
+              echo "::error::Run this workflow from develop or main, not $DISPATCH_REF"
+              exit 1
+              ;;
+          esac
+
+      - name: Configure annotated-tag identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push guarded tag
+        env:
+          TAG: ${{ inputs.tag }}
+          SHA: ${{ inputs.sha }}
+          MESSAGE: ${{ inputs.message }}
+        run: bash scripts/create-release-tag.sh "$TAG" "$SHA" "$MESSAGE"
+
+      - name: Dispatch release workflow on the new tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          gh workflow run release.yml \
+            --ref "$TAG" \
+            --field version="${TAG#v}"

--- a/docs/contributing/RELEASE.md
+++ b/docs/contributing/RELEASE.md
@@ -4,11 +4,12 @@ Guide simplifié pour publier une nouvelle version de VelesDB.
 
 ## Workflow Architecture
 
-VelesDB utilise **3 workflows GitHub Actions** :
+VelesDB utilise **4 workflows GitHub Actions** :
 
 | Workflow | Trigger | Fonction |
 |----------|---------|----------|
 | `ci.yml` | Push/PR sur main | Tests, lint, security audit |
+| `tag-release.yml` | Déclenchement manuel sur develop/main | Création gardée du tag quand le push Git direct est impossible |
 | `release.yml` | Tag `v*` | Publication complète |
 | `bench-regression.yml` | Push sur main | Benchmarks de régression |
 
@@ -20,7 +21,7 @@ VelesDB utilise **3 workflows GitHub Actions** :
 # Apply the bump to every policed manifest (X.Y.Z = target release version)
 python3 scripts/bump_version.py X.Y.Z
 # Regenerate the OpenAPI snapshots (derived from the crate version)
-cargo test -p velesdb-server --features openapi generate_openapi_spec_files -- --test-threads=1
+cargo test -p velesdb-server --features openapi generate_openapi_spec_files -- --include-ignored --test-threads=1
 cargo build  # refresh Cargo.lock
 python3 scripts/check-version-sync.py  # must report: All versions match
 ```
@@ -69,6 +70,28 @@ de version n'est nécessaire.
 git tag -a vX.Y.Z -m "vX.Y.Z - Description"
 git push origin vX.Y.Z
 ```
+
+Le push Git direct reste le chemin principal : il déclenche automatiquement
+`release.yml` sur le nouveau tag.
+
+#### Solution de repli depuis GitHub Actions
+
+Certaines sessions distantes peuvent pousser une branche mais pas un ref de
+tag. Dans ce cas, utiliser le workflow permanent `tag-release.yml` :
+
+1. Ouvrir **Actions → Create Release Tag → Run workflow**.
+2. Sélectionner `develop` ou `main` comme branche du workflow.
+3. Saisir le tag `vX.Y.Z`, le SHA complet du commit dont le CI est vert sur
+   `main`, et le message du tag annoté.
+
+Le workflow refuse un SHA qui n'est pas dans l'historique de `main` et un tag
+qui existe déjà. Après avoir poussé le tag, il déclenche explicitement
+`release.yml` sur ce tag : un tag créé avec `GITHUB_TOKEN` ne déclenche pas à
+lui seul un workflow écoutant `push.tags`.
+
+Si le tag a été créé mais que ce second déclenchement échoue, relancer
+manuellement **Release** avec le tag comme ref et `X.Y.Z` comme version. Ne pas
+recréer ni déplacer le tag.
 
 ### 6. The `release.yml` workflow publishes automatically
 

--- a/scripts/create-release-tag.sh
+++ b/scripts/create-release-tag.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Create one guarded annotated release tag, then push that exact ref.
+
+set -euo pipefail
+
+readonly TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'
+readonly SHA_PATTERN='^[0-9A-Fa-f]{40}$'
+
+die() {
+  echo "create-release-tag: $*" >&2
+  exit 1
+}
+
+validate_inputs() {
+  local tag=$1
+  local sha=$2
+  local message=$3
+
+  [[ "$tag" =~ $TAG_PATTERN ]] || die "tag '$tag' must match vX.Y.Z or vX.Y.Z-prerelease"
+  [[ "$sha" =~ $SHA_PATTERN ]] || die "sha must be a full 40-character commit SHA"
+  [[ -n "$message" ]] || die "message must not be empty"
+}
+
+resolve_main_commit() {
+  local sha=$1
+
+  git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+  git cat-file -e "${sha}^{commit}" 2>/dev/null || die "sha '$sha' is not a commit"
+  git rev-parse --verify "${sha}^{commit}"
+}
+
+ensure_main_ancestor() {
+  local sha=$1
+
+  git merge-base --is-ancestor "$sha" origin/main \
+    || die "sha '$sha' is not an ancestor of origin/main"
+}
+
+ensure_tag_absent() {
+  local tag=$1
+  local remote_refs
+
+  git show-ref --verify --quiet "refs/tags/$tag" \
+    && die "tag '$tag' already exists locally"
+  remote_refs=$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}") \
+    || die "unable to query tags on origin"
+  [[ -z "$remote_refs" ]] || die "tag '$tag' already exists on origin"
+}
+
+create_and_push_tag() {
+  local tag=$1
+  local sha=$2
+  local message=$3
+
+  git tag --annotate "$tag" "$sha" --message "$message"
+  if ! git push origin "refs/tags/$tag:refs/tags/$tag"; then
+    git tag --delete "$tag" >/dev/null
+    die "failed to push tag '$tag'"
+  fi
+}
+
+main() {
+  [[ $# -eq 3 ]] || die "usage: create-release-tag.sh <tag> <sha> <message>"
+  local tag=$1
+  local requested_sha=$2
+  local message=$3
+  local resolved_sha
+
+  validate_inputs "$tag" "$requested_sha" "$message"
+  resolved_sha=$(resolve_main_commit "$requested_sha")
+  ensure_main_ancestor "$resolved_sha"
+  ensure_tag_absent "$tag"
+  create_and_push_tag "$tag" "$resolved_sha" "$message"
+  echo "Created and pushed annotated tag $tag at $resolved_sha"
+}
+
+main "$@"

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -715,6 +715,11 @@
   ],
   "unwired": [
     {
+      "script": "scripts/create-release-tag.sh",
+      "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag after main CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves both refusal guards and the positive control against a real bare remote.",
+      "issue": null
+    },
+    {
       "script": "scripts/check-crates-io-versions.sh",
       "reason": "Release-time only, by design: it checks a version collision on crates.io before publishing (release.yml:345, release-memory.yml:187). There is nothing for it to assert on a pull request.",
       "issue": null

--- a/scripts/tests/test_create_release_tag.py
+++ b/scripts/tests/test_create_release_tag.py
@@ -1,0 +1,176 @@
+"""Behavioral contract for the guarded release-tag fallback (#1878)."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "create-release-tag.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "tag-release.yml"
+RELEASE_DOC = ROOT / "docs" / "contributing" / "RELEASE.md"
+
+
+def run(command: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run one command with captured output for exact refusal assertions."""
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def git(repo: Path, *arguments: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    """Run git in ``repo`` without relying on machine-level configuration."""
+    return run(["git", *arguments], repo, check)
+
+
+def commit_file(repo: Path, name: str, content: str, message: str) -> str:
+    """Commit one deterministic fixture file and return the commit SHA."""
+    (repo / name).write_text(content, encoding="utf-8")
+    git(repo, "add", name)
+    git(repo, "commit", "-m", message)
+    return git(repo, "rev-parse", "HEAD").stdout.strip()
+
+
+class ReleaseTagScriptTests(unittest.TestCase):
+    """Exercise both guards against a real bare remote."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.remote = self.root / "origin.git"
+        self.repo = self.root / "work"
+        self._create_repository()
+
+    def _create_repository(self) -> None:
+        run(["git", "init", "--bare", "--initial-branch=main", str(self.remote)], self.root)
+        run(["git", "init", "--initial-branch=main", str(self.repo)], self.root)
+        git(self.repo, "config", "user.name", "Release Test")
+        git(self.repo, "config", "user.email", "release-test@example.invalid")
+        git(self.repo, "remote", "add", "origin", str(self.remote))
+        self.main_sha = commit_file(self.repo, "main.txt", "main\n", "seed main")
+        git(self.repo, "push", "--set-upstream", "origin", "main")
+        git(self.repo, "switch", "--create", "side")
+        self.side_sha = commit_file(self.repo, "side.txt", "side\n", "seed side")
+        git(self.repo, "switch", "main")
+
+    def invoke(self, tag: str, sha: str, message: str = "Release test") -> subprocess.CompletedProcess[str]:
+        """Invoke the production script through Bash so mode bits are irrelevant."""
+        return run(["bash", str(SCRIPT), tag, sha, message], self.repo, check=False)
+
+    def remote_tag(self, tag: str, peeled: bool = False) -> str:
+        """Resolve a remote tag object or its peeled commit."""
+        suffix = "^{}" if peeled else ""
+        result = git(self.repo, "--git-dir", str(self.remote), "rev-parse", f"refs/tags/{tag}{suffix}")
+        return result.stdout.strip()
+
+    def assert_remote_tag_absent(self, tag: str) -> None:
+        result = git(
+            self.repo,
+            "--git-dir",
+            str(self.remote),
+            "for-each-ref",
+            "--format=%(refname)",
+            f"refs/tags/{tag}",
+        )
+        self.assertEqual("", result.stdout.strip())
+
+    def test_creates_annotated_tag_on_exact_main_commit(self) -> None:
+        result = self.invoke("v1.2.3", self.main_sha, "v1.2.3 - Fixture release")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(self.main_sha, self.remote_tag("v1.2.3", peeled=True))
+        object_type = git(
+            self.repo,
+            "--git-dir",
+            str(self.remote),
+            "cat-file",
+            "-t",
+            self.remote_tag("v1.2.3"),
+        ).stdout.strip()
+        self.assertEqual("tag", object_type)
+        message = git(
+            self.repo,
+            "--git-dir",
+            str(self.remote),
+            "for-each-ref",
+            "--format=%(contents)",
+            "refs/tags/v1.2.3",
+        ).stdout.strip()
+        self.assertEqual("v1.2.3 - Fixture release", message)
+
+    def test_refuses_commit_that_is_not_an_ancestor_of_main(self) -> None:
+        result = self.invoke("v1.2.3", self.side_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("not an ancestor of origin/main", result.stderr)
+        self.assert_remote_tag_absent("v1.2.3")
+
+    def test_refuses_tag_that_already_exists_on_remote(self) -> None:
+        git(self.repo, "tag", "--annotate", "v1.2.3", self.main_sha, "--message", "existing")
+        git(self.repo, "push", "origin", "refs/tags/v1.2.3")
+        git(self.repo, "tag", "--delete", "v1.2.3")
+
+        result = self.invoke("v1.2.3", self.main_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("already exists on origin", result.stderr)
+
+    def test_refuses_invalid_tag_before_any_git_write(self) -> None:
+        result = self.invoke("release/latest", self.main_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("must match vX.Y.Z", result.stderr)
+        self.assert_remote_tag_absent("release/latest")
+
+
+class ReleaseTagWorkflowContractTests(unittest.TestCase):
+    """Pin the Actions wiring that a green shell-script test cannot prove."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.release_doc = RELEASE_DOC.read_text(encoding="utf-8")
+
+    def test_workflow_exposes_exact_inputs_and_permissions(self) -> None:
+        for name in ("tag", "sha", "message"):
+            self.assertIn(f"      {name}:", self.workflow)
+        self.assertIn("  contents: write", self.workflow)
+        self.assertIn("  actions: write", self.workflow)
+
+    def test_workflow_refuses_dispatch_outside_develop_or_main(self) -> None:
+        self.assertIn("refs/heads/develop", self.workflow)
+        self.assertIn("refs/heads/main", self.workflow)
+
+    def test_workflow_passes_inputs_via_environment(self) -> None:
+        self.assertIn("fetch-depth: 0", self.workflow)
+        self.assertIn("fetch-tags: true", self.workflow)
+        self.assertIn("TAG: ${{ inputs.tag }}", self.workflow)
+        self.assertIn("SHA: ${{ inputs.sha }}", self.workflow)
+        self.assertIn("MESSAGE: ${{ inputs.message }}", self.workflow)
+        self.assertIn(
+            'bash scripts/create-release-tag.sh "$TAG" "$SHA" "$MESSAGE"',
+            self.workflow,
+        )
+
+    def test_workflow_explicitly_dispatches_release_on_new_tag(self) -> None:
+        self.assertIn("gh workflow run release.yml", self.workflow)
+        self.assertIn('--ref "$TAG"', self.workflow)
+        self.assertIn('version="${TAG#v}"', self.workflow)
+
+    def test_release_guide_keeps_direct_push_primary_and_documents_fallback(self) -> None:
+        self.assertIn("git push origin vX.Y.Z", self.release_doc)
+        self.assertIn("tag-release.yml", self.release_doc)
+        self.assertIn("solution de repli", self.release_doc.lower())
+        self.assertIn("--include-ignored", self.release_doc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a permanent manually dispatched release-tag workflow
- validate the tag, full commit SHA, main ancestry, and tag absence before creating an annotated tag
- explicitly dispatch `release.yml` after the tag push
- document the direct-push primary path, the fallback, and recovery
- add real bare-remote refusal and positive-control tests

## Why

Remote execution gateways can reject tag refs even when branch pushes are available. In addition, a tag pushed with `GITHUB_TOKEN` does not trigger another workflow from its `push.tags` event, so the fallback must dispatch `release.yml` explicitly.

## Issue checklist

- [x] Permanent `workflow_dispatch` path with `tag`, `sha`, and `message` inputs
- [x] Guards require a valid release tag, a full SHA on `main`, and an absent local/remote tag
- [x] Release documentation keeps direct annotated-tag push as the primary path and describes fallback/recovery
- [x] Legacy `ci/tag-release` branch is absent from the remote

## Impact

Maintainers keep the existing direct annotated-tag push as the primary release path and gain a guarded Actions-side fallback when tag push access is unavailable.

## Validation

- `cargo fmt --all -- --check`
- strict Clippy workspace, Node, Python, and unsafe-block gates
- workspace tests with `persistence,gpu,update-check`: all executable tests pass; one unchanged Unix-socket test cannot run in the restricted local sandbox (`EPERM`)
- no-default and per-feature isolation with `RUSTFLAGS="-D warnings"`
- WASM Node runner: 76 passed, 5 ignored
- Python guard suite: 428 tests, 9 skipped
- OpenAPI regeneration with `--include-ignored` produced no diff
- ShellCheck, YAML parsing, hooks, attribution, documentation, promise, and freshness contracts
- `cargo deny`: advisories, bans, licenses, and sources

Closes #1878