### PR TITLE
refactor(persistence): close fsync gaps in three snapshot writers

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/crud_helpers.rs
@@ -118,7 +118,9 @@ impl Collection {
                 .ok();
                 #[cfg(feature = "persistence")]
                 if let Some(ref pq) = trained {
-                    let _ = pq.save_codebook(&self.storage.path);
+                    if let Err(e) = pq.save_codebook(&self.storage.path) {
+                        tracing::warn!("PQ codebook save failed: {e}");
+                    }
                 }
                 *quantizer_guard = trained;
                 backfill_samples = buffer.drain(..).collect();

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -10,6 +10,10 @@ use crate::point::SearchResult;
 use crate::velesql::{CompareOp, Condition, GraphMatchPredicate};
 use std::collections::HashSet;
 
+/// Tolerance for `=`/`!=` comparisons against a similarity score threshold.
+/// Scores are floating-point, so exact equality is never the intent here.
+const SCORE_EQ_EPSILON: f32 = 0.001;
+
 /// Per-query evaluation cache shared across all result rows.
 ///
 /// Holds graph-predicate anchor sets and (#904) the `Filter` built for each
@@ -309,8 +313,8 @@ impl Collection {
                 CompareOp::Gte => score >= threshold,
                 CompareOp::Lt => score < threshold,
                 CompareOp::Lte => score <= threshold,
-                CompareOp::Eq => (score - threshold).abs() < 0.001,
-                CompareOp::NotEq => (score - threshold).abs() >= 0.001,
+                CompareOp::Eq => (score - threshold).abs() < SCORE_EQ_EPSILON,
+                CompareOp::NotEq => (score - threshold).abs() >= SCORE_EQ_EPSILON,
             }
         } else {
             match op {
@@ -318,8 +322,8 @@ impl Collection {
                 CompareOp::Gte => score <= threshold,
                 CompareOp::Lt => score > threshold,
                 CompareOp::Lte => score >= threshold,
-                CompareOp::Eq => (score - threshold).abs() < 0.001,
-                CompareOp::NotEq => (score - threshold).abs() >= 0.001,
+                CompareOp::Eq => (score - threshold).abs() < SCORE_EQ_EPSILON,
+                CompareOp::NotEq => (score - threshold).abs() >= SCORE_EQ_EPSILON,
             }
         }
     }

--- a/crates/velesdb-core/src/collection/streaming/delta_merge.rs
+++ b/crates/velesdb-core/src/collection/streaming/delta_merge.rs
@@ -48,8 +48,10 @@ pub fn merge_with_delta(
 /// Merges HNSW search results (as [`crate::ScoredResult`]) with delta buffer
 /// results.
 ///
-/// Zero-allocation variant that avoids the `ScoredResult` → `(u64, f32)` →
-/// `ScoredResult` round-trip in the search pipeline.
+/// Takes and returns `ScoredResult` directly so callers on the `ScoredResult`
+/// search pipeline don't need a separate conversion pass around the merge;
+/// internally this still merges on `(id, score)` tuples to share the sort/
+/// truncate logic with [`merge_with_delta`].
 #[must_use]
 pub fn merge_with_delta_scored(
     hnsw_results: Vec<crate::scored_result::ScoredResult>,

--- a/crates/velesdb-core/src/index/sparse/persistence.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence.rs
@@ -184,6 +184,10 @@ fn write_idx_tmp(
     idx_file
         .flush()
         .map_err(|e| Error::SparseIndexError(format!("compact idx flush: {e}")))?;
+    idx_file
+        .get_ref()
+        .sync_all()
+        .map_err(|e| Error::SparseIndexError(format!("compact idx fsync: {e}")))?;
     Ok(term_entries)
 }
 
@@ -208,13 +212,30 @@ fn write_postings(w: &mut BufWriter<std::fs::File>, postings: &[PostingEntry]) -
     Ok(())
 }
 
+/// Writes `data` to `path`, fsyncing before returning so the bytes survive a
+/// crash prior to the caller's later rename over the final file.
+fn write_tmp_fsync(path: &Path, data: &[u8], context: &str) -> Result<()> {
+    let file = std::fs::File::create(path)
+        .map_err(|e| Error::SparseIndexError(format!("{context} create: {e}")))?;
+    let mut writer = BufWriter::new(file);
+    writer
+        .write_all(data)
+        .map_err(|e| Error::SparseIndexError(format!("{context} write: {e}")))?;
+    writer
+        .flush()
+        .map_err(|e| Error::SparseIndexError(format!("{context} flush: {e}")))?;
+    writer
+        .get_ref()
+        .sync_all()
+        .map_err(|e| Error::SparseIndexError(format!("{context} fsync: {e}")))
+}
+
 /// Writes the term dictionary file.
 fn write_terms_tmp(dir: &Path, prefix: &str, term_entries: &[TermEntry]) -> Result<()> {
     let terms_tmp = dir.join(format!("{prefix}.terms.tmp"));
     let terms_data = postcard::to_allocvec(term_entries)
         .map_err(|e| Error::SparseIndexError(format!("compact terms serialize: {e}")))?;
-    std::fs::write(&terms_tmp, &terms_data)
-        .map_err(|e| Error::SparseIndexError(format!("compact terms write: {e}")))
+    write_tmp_fsync(&terms_tmp, &terms_data, "compact terms")
 }
 
 /// Writes the metadata file.
@@ -228,8 +249,7 @@ fn write_meta_tmp(dir: &Path, prefix: &str, doc_count: u64, term_ids: &[u32]) ->
     };
     let meta_data = postcard::to_allocvec(&meta)
         .map_err(|e| Error::SparseIndexError(format!("compact meta serialize: {e}")))?;
-    std::fs::write(&meta_tmp, &meta_data)
-        .map_err(|e| Error::SparseIndexError(format!("compact meta write: {e}")))
+    write_tmp_fsync(&meta_tmp, &meta_data, "compact meta")
 }
 
 /// Atomically renames `.tmp` files to their final names.

--- a/crates/velesdb-core/src/quantization/pq_persistence.rs
+++ b/crates/velesdb-core/src/quantization/pq_persistence.rs
@@ -5,6 +5,7 @@
 //! the storage concern from the core PQ algorithm.
 
 use crate::error::Error;
+use crate::storage::atomic_write::atomic_write;
 use serde::{Deserialize, Serialize};
 
 use super::pq::ProductQuantizer;
@@ -20,7 +21,8 @@ const MAX_PQ_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 
 /// RF-2: Serializes `value` with postcard and atomically writes to `dir/filename`.
 ///
-/// Write goes to `.tmp` suffix first, then renamed for crash safety.
+/// Delegates to [`atomic_write`] (write-tmp-fsync-rename) so a crash between
+/// the rename and the OS flushing dirty pages cannot leave a torn file.
 fn postcard_save_atomic<T: Serialize>(
     dir: &std::path::Path,
     filename: &str,
@@ -33,11 +35,13 @@ fn postcard_save_atomic<T: Serialize>(
             format!("failed to serialize {label}: {e}"),
         ))
     })?;
-    let tmp_path = dir.join(format!("{filename}.tmp"));
     let final_path = dir.join(filename);
-    std::fs::write(&tmp_path, &data)?;
-    std::fs::rename(&tmp_path, &final_path)?;
-    Ok(())
+    atomic_write(&final_path, &data).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("failed to write {label}: {e}"),
+        ))
+    })
 }
 
 /// RF-2: Loads and deserializes a postcard file from `dir/filename`.

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -12,6 +12,8 @@
 //! | Compression ratio | 1x | 32x |
 
 use crate::error::Error;
+#[cfg(feature = "persistence")]
+use crate::storage::atomic_write::atomic_write;
 use serde::{Deserialize, Serialize};
 
 /// Scalar correction factors for a `RaBitQ`-encoded vector.
@@ -363,6 +365,9 @@ impl RaBitQIndex {
 
     /// Save `RaBitQ` index to `<dir>/rabitq.idx` using postcard with atomic write.
     ///
+    /// Delegates to [`atomic_write`] (write-tmp-fsync-rename) so a crash between
+    /// the rename and the OS flushing dirty pages cannot leave a torn file.
+    ///
     /// # Errors
     ///
     /// Returns `Error::Io` if serialization or file I/O fails.
@@ -373,11 +378,13 @@ impl RaBitQIndex {
                 format!("failed to serialize RaBitQ index: {e}"),
             ))
         })?;
-        let tmp_path = dir.join("rabitq.idx.tmp");
         let final_path = dir.join("rabitq.idx");
-        std::fs::write(&tmp_path, &data)?;
-        std::fs::rename(&tmp_path, &final_path)?;
-        Ok(())
+        atomic_write(&final_path, &data).map_err(|e| {
+            Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to write RaBitQ index: {e}"),
+            ))
+        })
     }
 
     /// Load `RaBitQ` index from `<dir>/rabitq.idx`. Returns `None` if file doesn't exist.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Continuous code-quality review pass over `velesdb-core`, focused on the durable snapshot writers. Found that three writers skip the fsync-before-rename step that every other durable writer in the crate treats as mandatory:

- `quantization/pq_persistence.rs` (`ProductQuantizer::save_codebook` / `save_rotation`)
- `quantization/rabitq.rs` (`RaBitQIndex::save`)
- `index/sparse/persistence.rs` (`compact_with_prefix`'s idx/terms/meta writers)

All three did `std::fs::write(tmp)` + `std::fs::rename(tmp, final)` with no `sync_all()` in between — unlike `bm25_persistence.rs`, `hnsw/persistence.rs`, `storage/snapshot.rs`, `storage/compaction.rs`, and `collection/graph/helpers.rs`, which already route through the crate's own `storage::atomic_write::atomic_write` helper (or fsync explicitly) for exactly this reason. A crash between the rename and the OS flushing dirty pages could leave a torn PQ codebook, RaBitQ index, or sparse index file on disk. For the sparse index this was worse: `truncate_wal` runs immediately after compaction with no durability barrier in between, removing the WAL recovery safety net too.

**Fixes:**
- `pq_persistence.rs`, `rabitq.rs`: delegate to the existing `atomic_write` helper instead of a hand-rolled write+rename, matching the pattern already used elsewhere in the crate.
- `index/sparse/persistence.rs`: the idx/terms/meta writers batch-rename together at the end of compaction, so they can't drop straight into `atomic_write`'s single-file write+rename; added an explicit `sync_all()` after each tmp file write instead, closing the same durability gap without changing the compaction flow.

**Also fixed in the same pass (small, low-risk, found while reading the surrounding code):**
- `crud_helpers.rs`: PQ codebook save failures were silently discarded (`let _ = pq.save_codebook(...)`) — now logged via `tracing::warn!` so a failed save leaves a trace instead of silently falling back to re-training from scratch on restart.
- `where_eval.rs`: the repeated `0.001` float-equality tolerance for `Eq`/`NotEq` score comparisons is now a single named `SCORE_EQ_EPSILON` constant instead of a magic number duplicated in two branches.
- `delta_merge.rs`: fixed a stale doc comment on `merge_with_delta_scored` that claimed a "zero-allocation" round-trip the function doesn't actually perform.

No behavior change to the happy path — decoded bytes are identical; only the durability guarantee around the write itself changes.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — durability gap on crash

## How Has This Been Tested?

- [x] Unit tests
- `cargo build -p velesdb-core --features persistence` — clean
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt --all -- --check` — clean
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` — PASSED
- `python3 scripts/check-todo-annotations.py` — PASSED
- Targeted test runs, all passing: `quantization::pq::tests::*` (52), `quantization::rabitq::tests::*` (52), `index::sparse::persistence_tests::*` (13, including `test_partial_compaction_crash_recovery`), `collection::search::query::where_eval::tests::*`, `collection::streaming::delta::tests::*`, `storage::atomic_write::tests::*` — including the existing `save_codebook_uses_atomic_write` and `rabitq_save_uses_atomic_write` regression tests, which now exercise the new code path.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (MSRV, per `rust-toolchain.toml`)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes (see above; targeted modules covered — full single-threaded suite run in progress)
- [x] Any dependent changes have been merged and published (none — this is self-contained)

## High-Risk Change Checklist

> Touches `storage` durability semantics.

- [x] I listed the invariants impacted by this change: crash-safety of PQ codebook/rotation, RaBitQ index, and sparse index compaction files — previously a crash between rename and OS flush could leave a torn file; now data is fsynced before the file is visible at its final path.
- [x] I documented crash/durability semantics: see commit message and description above.
- [x] I added/updated tests for lifecycle: relied on and re-verified existing crash-recovery coverage (`test_partial_compaction_crash_recovery`, `rabitq_save_uses_atomic_write`, `save_codebook_uses_atomic_write`) rather than adding new ones, since the change reuses/extends already-tested helpers rather than introducing new durability mechanics.
- [ ] Requested review from 2 maintainers — flagging for maintainer review given the `storage`-adjacent label.