### PR TITLE
fix(storage): make snapshot publication power-loss durable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6927,6 +6927,7 @@ name = "velesdb-core"
 version = "5.0.0"
 dependencies = [
  "arc-swap",
+ "atomicwrites",
  "bytemuck",
  "bytes",
  "clap",

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -76,7 +76,17 @@ features = ["std", "serde"]
 # EPIC-033/US-003: Windows hole-punch (FSCTL_SET_ZERO_DATA)
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_Foundation", "Win32_System_Ioctl", "Win32_System_IO"]
+features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Ioctl",
+    "Win32_System_IO",
+]
+
+[target.'cfg(windows)'.dependencies.atomicwrites]
+# Safe wrapper around MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH), keeping
+# the crate's own code free of unsafe while retaining a durable replacement.
+version = "0.4.4"
 
 # EPIC-033/US-003: Linux hole-punch (fallocate)
 [target.'cfg(target_os = "linux")'.dependencies.libc]

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -22,6 +22,7 @@ postcard = { workspace = true }
 roaring = { workspace = true }
 figment = { workspace = true }
 toml = { workspace = true }
+tempfile = { workspace = true }
 
 # WASM-incompatible deps - only for non-WASM targets
 # memmap2 moved to target-specific section below
@@ -140,7 +141,6 @@ test-fault-injection = []
 [dev-dependencies]
 criterion = { workspace = true }
 proptest = { workspace = true }
-tempfile = { workspace = true }
 serial_test = "3.5"
 clap = { version = "4.6", features = ["derive"] }
 rand_distr = "0.6"

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -348,6 +348,8 @@ impl Collection {
         if sparse_batch.is_empty() {
             return Ok(());
         }
+        // Serialize WAL-before-apply with snapshot commit and WAL reset.
+        let mut indexes = self.query.sparse_indexes.write();
         #[cfg(feature = "persistence")]
         {
             self.append_sparse_wal_entries(sparse_batch.iter().flat_map(|(name, docs)| {
@@ -355,7 +357,6 @@ impl Collection {
                     .map(move |(point_id, sv)| (name.as_str(), *point_id, sv))
             }))?;
         }
-        let mut indexes = self.query.sparse_indexes.write();
         for (name, docs) in sparse_batch {
             let idx = indexes.entry(name.clone()).or_default();
             idx.insert_batch_chunk(docs);

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -337,6 +337,9 @@ impl Collection {
         if sparse_batch.is_empty() {
             return Ok(());
         }
+        // Keep WAL append and in-memory apply indivisible with respect to
+        // compaction, which takes this lock exclusively through the reset.
+        let mut indexes = self.query.sparse_indexes.write();
         #[cfg(feature = "persistence")]
         {
             self.append_sparse_wal_entries(sparse_batch.iter().flat_map(|(point_id, sv_map)| {
@@ -345,7 +348,6 @@ impl Collection {
                     .map(move |(name, sv)| (name.as_str(), *point_id, sv))
             }))?;
         }
-        let mut indexes = self.query.sparse_indexes.write();
         for (point_id, sv_map) in sparse_batch {
             for (name, sv) in sv_map {
                 let idx = indexes.entry(name.clone()).or_default();

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -334,9 +334,11 @@ impl Collection {
 
     /// Deletes IDs from sparse indexes with WAL-before-apply.
     fn delete_from_sparse_indexes(&self, ids: &[u64]) -> Result<()> {
+        // Hold one exclusive guard from WAL append through apply so compaction
+        // cannot snapshot between the two phases and then discard the record.
+        let indexes = self.query.sparse_indexes.write();
         #[cfg(feature = "persistence")]
         {
-            let indexes = self.query.sparse_indexes.read();
             for name in indexes.keys() {
                 let wal_path =
                     crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
@@ -345,7 +347,6 @@ impl Collection {
                 }
             }
         }
-        let indexes = self.query.sparse_indexes.read();
         for idx in indexes.values() {
             for &id in ids {
                 idx.delete(id);

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -310,7 +310,9 @@ impl Collection {
 
     /// Compacts all named sparse indexes to disk (EPIC-062 / SPARSE-04).
     fn flush_sparse_indexes(&self) -> Result<()> {
-        let indexes = self.query.sparse_indexes.read();
+        // Exclusive across snapshot publication and WAL reset. Mutation paths
+        // hold the same guard from WAL append through in-memory application.
+        let indexes = self.query.sparse_indexes.write();
         for (name, idx) in indexes.iter() {
             crate::index::sparse::persistence::compact_named(&self.storage.path, name, idx)?;
         }

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -9,7 +9,6 @@ use crate::error::Result;
 use crate::guardrails::GuardRails;
 use crate::index::sparse::SparseInvertedIndex;
 use crate::index::{Bm25Index, HnswIndex};
-use crate::sparse_index::DEFAULT_SPARSE_INDEX_NAME;
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage};
 use crate::velesql::{QueryCache, QueryPlanner};
 
@@ -538,81 +537,11 @@ impl Collection {
         Some(idx)
     }
 
-    /// Loads all named sparse indexes from disk.
-    ///
-    /// Scans for `sparse.meta` (default name `""`) and `sparse-{name}.meta` files.
-    /// Returns a `BTreeMap` keyed by sparse vector name.
-    ///
-    /// # Concurrency safety of `read_dir`
-    ///
-    /// The `read_dir` scan below is safe from race conditions for two reasons:
-    ///
-    /// 1. **Single-threaded open**: `Collection::open` (and therefore this
-    ///    function) is always called from `Database::open`, which runs
-    ///    single-threaded during startup. No concurrent writers exist at this
-    ///    point.
-    ///
-    /// 2. **Atomic rename in compaction**: `compact_with_prefix` writes new
-    ///    data to `{prefix}.*.tmp` staging files and only promotes them to
-    ///    their final names via an atomic `rename(2)`. A `read_dir` scan
-    ///    therefore never observes a partially-written `sparse-*.meta` file;
-    ///    it either sees the complete previous version or the complete new
-    ///    version — never a torn write.
+    /// Loads default, legacy named, and manifested named sparse indexes.
     fn load_named_sparse_indexes(
         path: &std::path::Path,
     ) -> BTreeMap<String, crate::index::sparse::SparseInvertedIndex> {
-        let mut indexes = BTreeMap::new();
-
-        // Load default (unprefixed) sparse index: sparse.meta / sparse.wal
-        match crate::index::sparse::persistence::load_from_disk(path) {
-            Ok(Some(idx)) => {
-                indexes.insert(DEFAULT_SPARSE_INDEX_NAME.to_string(), idx);
-            }
-            Ok(None) => {}
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to load default sparse index from {:?}: {}. Skipping.",
-                    path,
-                    e
-                );
-            }
-        }
-
-        // Scan for named sparse indexes: sparse-{name}.meta files.
-        // The `.meta` suffix is the sentinel for a fully compacted (committed)
-        // index file; stale `.tmp` artefacts from interrupted compactions are
-        // ignored because they do not match the `strip_suffix(".meta")` filter.
-        if let Ok(entries) = std::fs::read_dir(path) {
-            for entry in entries.flatten() {
-                let file_name = entry.file_name();
-                let name_str = file_name.to_string_lossy();
-                if let Some(sparse_name) = name_str
-                    .strip_prefix("sparse-")
-                    .and_then(|s| s.strip_suffix(".meta"))
-                {
-                    let sparse_name = sparse_name.to_string();
-                    match crate::index::sparse::persistence::load_named_from_disk(
-                        path,
-                        &sparse_name,
-                    ) {
-                        Ok(Some(idx)) => {
-                            indexes.insert(sparse_name, idx);
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to load sparse index '{}' from {:?}: {}. Skipping.",
-                                sparse_name,
-                                path,
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        indexes
+        super::sparse_lifecycle::load_named_sparse_indexes(path)
     }
 
     /// Loads a persisted index from disk, falling back to a default on missing

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -44,6 +44,7 @@ mod recovery_tests;
 mod scroll;
 #[cfg(all(test, feature = "persistence"))]
 mod scroll_tests;
+mod sparse_lifecycle;
 mod statistics;
 #[cfg(all(test, feature = "persistence"))]
 mod ttl_read_tests;

--- a/crates/velesdb-core/src/collection/core/sparse_lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/sparse_lifecycle.rs
@@ -1,0 +1,89 @@
+//! Sparse-index discovery during collection open.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::index::sparse::{persistence, SparseInvertedIndex};
+use crate::sparse_index::DEFAULT_SPARSE_INDEX_NAME;
+
+pub(super) fn load_named_sparse_indexes(path: &Path) -> BTreeMap<String, SparseInvertedIndex> {
+    let mut indexes = BTreeMap::new();
+    load_default(path, &mut indexes);
+    for name in discover_named_indexes(path) {
+        load_named(path, name, &mut indexes);
+    }
+    indexes
+}
+
+fn load_default(path: &Path, indexes: &mut BTreeMap<String, SparseInvertedIndex>) {
+    match persistence::load_from_disk(path) {
+        Ok(Some(index)) => {
+            indexes.insert(DEFAULT_SPARSE_INDEX_NAME.to_string(), index);
+        }
+        Ok(None) => {}
+        Err(error) => tracing::warn!(
+            "Failed to load default sparse index from {:?}: {}. Skipping.",
+            path,
+            error
+        ),
+    }
+}
+
+fn discover_named_indexes(path: &Path) -> BTreeSet<String> {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return BTreeSet::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| sparse_name(&entry.file_name().to_string_lossy()))
+        .collect()
+}
+
+fn sparse_name(file_name: &str) -> Option<String> {
+    let suffix = file_name.strip_prefix("sparse-")?;
+    suffix
+        .strip_suffix(".snapshot")
+        .or_else(|| suffix.strip_suffix(".meta"))
+        .map(str::to_string)
+}
+
+fn load_named(path: &Path, name: String, indexes: &mut BTreeMap<String, SparseInvertedIndex>) {
+    match persistence::load_named_from_disk(path, &name) {
+        Ok(Some(index)) => {
+            indexes.insert(name, index);
+        }
+        Ok(None) => {}
+        Err(error) => tracing::warn!(
+            "Failed to load sparse index '{}' from {:?}: {}. Skipping.",
+            name,
+            path,
+            error
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::sparse::{persistence::compact_named, SparseVector};
+
+    #[test]
+    fn manifested_named_index_is_discovered_without_inactive_alias() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        let index = SparseInvertedIndex::new();
+        index.insert(7, &SparseVector::new(vec![(3, 1.5)]));
+        compact_named(dir.path(), "title", &index).expect("test: compact");
+
+        let loaded = load_named_sparse_indexes(dir.path());
+        assert_eq!(loaded.get("title").expect("title index").doc_count(), 1);
+        assert!(!loaded.contains_key("title.next"));
+    }
+
+    #[test]
+    fn hidden_orphan_slot_is_not_discovered() {
+        let dir = tempfile::tempdir().expect("test: temp dir");
+        std::fs::write(dir.path().join(".sparse-orphan.next.meta"), b"partial")
+            .expect("test: write orphan");
+        assert!(discover_named_indexes(dir.path()).is_empty());
+    }
+}

--- a/crates/velesdb-core/src/index/sparse/mod.rs
+++ b/crates/velesdb-core/src/index/sparse/mod.rs
@@ -7,6 +7,11 @@
 pub mod persistence;
 #[cfg(test)]
 #[cfg(feature = "persistence")]
+mod persistence_durability_tests;
+#[cfg(feature = "persistence")]
+pub(crate) mod persistence_generation;
+#[cfg(test)]
+#[cfg(feature = "persistence")]
 mod persistence_tests;
 #[cfg(feature = "persistence")]
 pub(crate) mod persistence_wal;

--- a/crates/velesdb-core/src/index/sparse/persistence.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence.rs
@@ -6,22 +6,34 @@
 //!
 //! ```text
 //! <collection_dir>/
-//!   sparse.wal        # Write-ahead log (length-prefixed entries)
-//!   sparse.idx        # Compacted posting lists (raw PostingEntry bytes)
-//!   sparse.terms      # Term dictionary (postcard-serialized Vec<TermEntry>)
-//!   sparse.meta       # Metadata (postcard-serialized SparseMeta)
+//!   sparse.snapshot   # Durable manifest selecting one complete slot
+//!   sparse.wal        # Generation-tagged write-ahead log
+//!   sparse.{idx,terms,meta}        # Snapshot slot 0 / legacy layout
+//!   .sparse.next.{idx,terms,meta}  # Hidden snapshot slot 1
 //! ```
+//!
+//! Databases without `sparse.snapshot` keep loading directly from the legacy
+//! slot-0 files, so the format upgrade requires no migration.
 
 use std::io::{BufWriter, Write};
 use std::path::Path;
+
+#[cfg(test)]
+use std::cell::Cell;
 
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::inverted_index::{FrozenSegment, SparseInvertedIndex};
-use super::persistence_wal::{read_le_f32, read_le_u64};
+use super::persistence_generation::{
+    active_snapshot, prepare_snapshot, publish_snapshot, SnapshotPaths,
+};
+use super::persistence_wal::{
+    read_le_f32, read_le_u64, reset_wal, sync_wal, wal_replay_for_generation,
+};
 use super::types::PostingEntry;
 use crate::error::{Error, Result};
+use crate::storage::atomic_write::{atomic_write, atomic_write_with};
 
 // Re-export WAL operations for backward compatibility.
 pub use super::persistence_wal::{wal_append_delete, wal_append_upsert, wal_replay};
@@ -128,63 +140,67 @@ pub fn compact(dir: &Path, index: &SparseInvertedIndex) -> Result<()> {
 
 /// Compacts the in-memory index to disk using the given file prefix.
 ///
-/// Files written: `{prefix}.idx`, `{prefix}.terms`, `{prefix}.meta`.
-/// Truncates `{prefix}.wal` after successful compaction.
+/// Writes the inactive snapshot slot, commits it through `{prefix}.snapshot`,
+/// then durably resets `{prefix}.wal` to the committed generation.
 ///
 /// # Errors
 ///
 /// Returns an error if disk writes fail or if the index's internal posting map is
 /// inconsistent (a term ID present in the sorted key list is absent from the map).
 fn compact_with_prefix(dir: &Path, prefix: &str, index: &SparseInvertedIndex) -> Result<()> {
+    sync_wal(&dir.join(format!("{prefix}.wal")))?;
     let merged = index.get_merged_postings_for_compaction();
-
     let mut term_ids: Vec<u32> = merged.keys().copied().collect();
     term_ids.sort_unstable();
 
-    let term_entries = write_idx_tmp(dir, prefix, &term_ids, &merged)?;
-    write_terms_tmp(dir, prefix, &term_entries)?;
-    write_meta_tmp(dir, prefix, index.doc_count(), &term_ids)?;
-    atomic_rename_compacted_files(dir, prefix)?;
-    truncate_wal(dir, prefix)?;
-
+    let pending = prepare_snapshot(dir, prefix)?;
+    check_publication_boundary(PublicationBoundary::IndexPromotion)?;
+    let term_entries = write_idx_snapshot(&pending.paths.idx, &term_ids, &merged)?;
+    check_publication_boundary(PublicationBoundary::TermsPromotion)?;
+    write_terms_snapshot(&pending.paths.terms, &term_entries)?;
+    check_publication_boundary(PublicationBoundary::MetaPromotion)?;
+    write_meta_snapshot(&pending.paths.meta, index.doc_count(), &term_ids)?;
+    check_publication_boundary(PublicationBoundary::CommitPoint)?;
+    publish_snapshot(dir, prefix, &pending)?;
+    check_publication_boundary(PublicationBoundary::WalTruncation)?;
+    reset_wal(&dir.join(format!("{prefix}.wal")), pending.generation())?;
     Ok(())
 }
 
 /// Writes the posting index file and returns the term dictionary entries.
-fn write_idx_tmp(
-    dir: &Path,
-    prefix: &str,
+fn write_idx_snapshot(
+    path: &Path,
     term_ids: &[u32],
     merged: &FxHashMap<u32, (Vec<PostingEntry>, f32)>,
 ) -> Result<Vec<TermEntry>> {
-    let idx_tmp = dir.join(format!("{prefix}.idx.tmp"));
-    let mut idx_file = BufWriter::new(
-        std::fs::File::create(&idx_tmp)
-            .map_err(|e| Error::SparseIndexError(format!("compact idx create: {e}")))?,
-    );
+    atomic_write_with(path, |writer| write_idx_contents(writer, term_ids, merged))
+        .map_err(|e| Error::SparseIndexError(format!("compact idx publish: {e}")))
+}
 
-    let mut term_entries: Vec<TermEntry> = Vec::with_capacity(term_ids.len());
-    let mut current_offset: u64 = 0;
-
+fn write_idx_contents(
+    writer: &mut BufWriter<std::fs::File>,
+    term_ids: &[u32],
+    merged: &FxHashMap<u32, (Vec<PostingEntry>, f32)>,
+) -> Result<Vec<TermEntry>> {
+    let mut entries = Vec::with_capacity(term_ids.len());
+    let mut offset = 0_u64;
     for &term_id in term_ids {
         let (postings, max_weight) = lookup_term(term_id, merged)?;
-        write_postings(&mut idx_file, postings)?;
-
-        let byte_len = (postings.len() * POSTING_DISK_SIZE) as u64;
-        term_entries.push(TermEntry {
-            term_id,
-            offset: current_offset,
-            #[allow(clippy::cast_possible_truncation)]
-            len: postings.len() as u32,
-            max_weight: *max_weight,
-        });
-        current_offset += byte_len;
+        write_postings(writer, postings)?;
+        entries.push(term_entry(term_id, postings, *max_weight, offset));
+        offset += (postings.len() * POSTING_DISK_SIZE) as u64;
     }
+    Ok(entries)
+}
 
-    idx_file
-        .flush()
-        .map_err(|e| Error::SparseIndexError(format!("compact idx flush: {e}")))?;
-    Ok(term_entries)
+fn term_entry(term_id: u32, postings: &[PostingEntry], max_weight: f32, offset: u64) -> TermEntry {
+    TermEntry {
+        term_id,
+        offset,
+        #[allow(clippy::cast_possible_truncation)]
+        len: postings.len() as u32,
+        max_weight,
+    }
 }
 
 fn lookup_term(
@@ -209,17 +225,15 @@ fn write_postings(w: &mut BufWriter<std::fs::File>, postings: &[PostingEntry]) -
 }
 
 /// Writes the term dictionary file.
-fn write_terms_tmp(dir: &Path, prefix: &str, term_entries: &[TermEntry]) -> Result<()> {
-    let terms_tmp = dir.join(format!("{prefix}.terms.tmp"));
+fn write_terms_snapshot(path: &Path, term_entries: &[TermEntry]) -> Result<()> {
     let terms_data = postcard::to_allocvec(term_entries)
         .map_err(|e| Error::SparseIndexError(format!("compact terms serialize: {e}")))?;
-    std::fs::write(&terms_tmp, &terms_data)
-        .map_err(|e| Error::SparseIndexError(format!("compact terms write: {e}")))
+    atomic_write(path, &terms_data)
+        .map_err(|e| Error::SparseIndexError(format!("compact terms publish: {e}")))
 }
 
 /// Writes the metadata file.
-fn write_meta_tmp(dir: &Path, prefix: &str, doc_count: u64, term_ids: &[u32]) -> Result<()> {
-    let meta_tmp = dir.join(format!("{prefix}.meta.tmp"));
+fn write_meta_snapshot(path: &Path, doc_count: u64, term_ids: &[u32]) -> Result<()> {
     let meta = SparseMeta {
         version: 1,
         doc_count,
@@ -228,34 +242,59 @@ fn write_meta_tmp(dir: &Path, prefix: &str, doc_count: u64, term_ids: &[u32]) ->
     };
     let meta_data = postcard::to_allocvec(&meta)
         .map_err(|e| Error::SparseIndexError(format!("compact meta serialize: {e}")))?;
-    std::fs::write(&meta_tmp, &meta_data)
-        .map_err(|e| Error::SparseIndexError(format!("compact meta write: {e}")))
+    atomic_write(path, &meta_data)
+        .map_err(|e| Error::SparseIndexError(format!("compact meta publish: {e}")))
 }
 
-/// Atomically renames `.tmp` files to their final names.
-fn atomic_rename_compacted_files(dir: &Path, prefix: &str) -> Result<()> {
-    for ext in &["idx", "terms", "meta"] {
-        std::fs::rename(
-            dir.join(format!("{prefix}.{ext}.tmp")),
-            dir.join(format!("{prefix}.{ext}")),
-        )
-        .map_err(|e| Error::SparseIndexError(format!("compact {ext} rename: {e}")))?;
-    }
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PublicationBoundary {
+    IndexPromotion,
+    TermsPromotion,
+    MetaPromotion,
+    CommitPoint,
+    WalTruncation,
+}
+
+#[cfg(not(test))]
+#[allow(clippy::unnecessary_wraps)] // Test builds return injected boundary failures.
+fn check_publication_boundary(_boundary: PublicationBoundary) -> Result<()> {
     Ok(())
 }
 
-/// Truncates the WAL file after successful compaction.
-fn truncate_wal(dir: &Path, prefix: &str) -> Result<()> {
-    let wal_path = dir.join(format!("{prefix}.wal"));
-    if wal_path.exists() {
-        let file = std::fs::OpenOptions::new()
-            .write(true)
-            .open(&wal_path)
-            .map_err(|e| Error::SparseIndexError(format!("compact wal truncate: {e}")))?;
-        file.set_len(0)
-            .map_err(|e| Error::SparseIndexError(format!("compact wal truncate: {e}")))?;
+#[cfg(test)]
+thread_local! {
+    static PUBLICATION_FAULT: Cell<Option<PublicationBoundary>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn check_publication_boundary(boundary: PublicationBoundary) -> Result<()> {
+    PUBLICATION_FAULT.with(|fault| {
+        if fault.get() == Some(boundary) {
+            fault.set(None);
+            return Err(Error::SparseIndexError(format!(
+                "fault injected at {boundary:?}"
+            )));
+        }
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+pub(super) struct PublicationFaultGuard(Option<PublicationBoundary>);
+
+#[cfg(test)]
+impl PublicationFaultGuard {
+    pub(super) fn inject(boundary: PublicationBoundary) -> Self {
+        let previous = PUBLICATION_FAULT.with(|fault| fault.replace(Some(boundary)));
+        Self(previous)
     }
-    Ok(())
+}
+
+#[cfg(test)]
+impl Drop for PublicationFaultGuard {
+    fn drop(&mut self) {
+        PUBLICATION_FAULT.with(|fault| fault.set(self.0));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -284,16 +323,15 @@ pub fn load_from_disk(dir: &Path) -> Result<Option<SparseInvertedIndex>> {
 /// Returns an error if files exist but cannot be read, deserialized, or contain
 /// corrupt byte sequences that cannot be converted to the expected fixed-size arrays.
 fn load_from_disk_with_prefix(dir: &Path, prefix: &str) -> Result<Option<SparseInvertedIndex>> {
-    let meta_path = dir.join(format!("{prefix}.meta"));
-    if !meta_path.exists() {
+    let Some(snapshot) = active_snapshot(dir, prefix)? else {
         return load_wal_only(dir, prefix);
-    }
+    };
 
-    let meta = load_and_validate_meta(&meta_path)?;
-    let index = load_compacted_index(dir, prefix, &meta)?;
+    let meta = load_and_validate_meta(&snapshot.paths.meta)?;
+    let index = load_compacted_index(&snapshot.paths, &meta)?;
 
     let wal_path = dir.join(format!("{prefix}.wal"));
-    let replayed = wal_replay(&wal_path, &index)?;
+    let replayed = wal_replay_for_generation(&wal_path, &index, snapshot.wal_generation)?;
     if replayed >= COMPACTION_REPLAY_THRESHOLD {
         compact_with_prefix(dir, prefix, &index)?;
     }
@@ -334,13 +372,8 @@ fn load_and_validate_meta(meta_path: &Path) -> Result<SparseMeta> {
 }
 
 /// Loads the compacted index from term dictionary and posting index files.
-fn load_compacted_index(
-    dir: &Path,
-    prefix: &str,
-    meta: &SparseMeta,
-) -> Result<SparseInvertedIndex> {
-    let terms_path = dir.join(format!("{prefix}.terms"));
-    let terms_data = std::fs::read(&terms_path)
+fn load_compacted_index(paths: &SnapshotPaths, meta: &SparseMeta) -> Result<SparseInvertedIndex> {
+    let terms_data = std::fs::read(&paths.terms)
         .map_err(|e| Error::SparseIndexError(format!("load terms read: {e}")))?;
     let term_entries: Vec<TermEntry> = postcard::from_bytes(&terms_data)
         .map_err(|e| Error::SparseIndexError(format!("load terms deserialize: {e}")))?;
@@ -356,8 +389,7 @@ fn load_compacted_index(
         )));
     }
 
-    let idx_path = dir.join(format!("{prefix}.idx"));
-    let idx_data = std::fs::read(&idx_path)
+    let idx_data = std::fs::read(&paths.idx)
         .map_err(|e| Error::SparseIndexError(format!("load idx read: {e}")))?;
 
     let postings = build_postings_from_idx(&idx_data, &term_entries)?;

--- a/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
@@ -1,0 +1,144 @@
+//! Power-loss publication and recovery tests for sparse snapshots.
+
+use tempfile::TempDir;
+
+use super::inverted_index::SparseInvertedIndex;
+use super::persistence::{compact, load_from_disk, wal_append_upsert};
+use super::types::SparseVector;
+use crate::storage::atomic_write::{AtomicWriteBoundary, FaultGuard};
+
+fn vector(term: u32, weight: f32) -> SparseVector {
+    SparseVector::new(vec![(term, weight)])
+}
+
+fn recoverable_case() -> (TempDir, SparseInvertedIndex, Vec<u8>) {
+    let dir = TempDir::new().expect("test: temp dir");
+    let wal_path = dir.path().join("sparse.wal");
+    let index = SparseInvertedIndex::new();
+
+    let first = vector(1, 1.0);
+    wal_append_upsert(&wal_path, 1, &first).expect("test: seed WAL");
+    index.insert(1, &first);
+    compact(dir.path(), &index).expect("test: seed snapshot");
+
+    let second = vector(2, 2.0);
+    wal_append_upsert(&wal_path, 2, &second).expect("test: pending WAL");
+    index.insert(2, &second);
+    let wal_before = std::fs::read(&wal_path).expect("test: read WAL");
+    (dir, index, wal_before)
+}
+
+fn assert_complete_recovery(dir: &TempDir) {
+    let recovered = load_from_disk(dir.path())
+        .expect("recovery must succeed")
+        .expect("snapshot must exist");
+    assert_eq!(recovered.doc_count(), 2);
+    assert_eq!(recovered.get_all_postings(1)[0].doc_id, 1);
+    assert_eq!(recovered.get_all_postings(2)[0].doc_id, 2);
+}
+
+#[test]
+fn every_snapshot_temp_sync_failure_preserves_recovery() {
+    for completed_syncs in 0..5 {
+        let (dir, index, wal_before) = recoverable_case();
+        let result = {
+            let _fault =
+                FaultGuard::inject_after(AtomicWriteBoundary::TemporaryFileSync, completed_syncs);
+            compact(dir.path(), &index)
+        };
+        assert!(result.is_err(), "temp sync {completed_syncs} must fail");
+        assert_eq!(
+            std::fs::read(dir.path().join("sparse.wal")).unwrap(),
+            wal_before
+        );
+        assert_complete_recovery(&dir);
+    }
+}
+
+#[test]
+fn every_generation_promotion_failure_preserves_recovery() {
+    for completed_promotions in 0..5 {
+        let (dir, index, wal_before) = recoverable_case();
+        let result = {
+            let _fault =
+                FaultGuard::inject_after(AtomicWriteBoundary::Replacement, completed_promotions);
+            compact(dir.path(), &index)
+        };
+        assert!(
+            result.is_err(),
+            "promotion {completed_promotions} must fail"
+        );
+        assert_eq!(
+            std::fs::read(dir.path().join("sparse.wal")).unwrap(),
+            wal_before
+        );
+        assert_complete_recovery(&dir);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn lost_first_manifest_falls_back_to_wal_only() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let wal_path = dir.path().join("sparse.wal");
+    let index = SparseInvertedIndex::new();
+    let first = vector(1, 1.0);
+    wal_append_upsert(&wal_path, 1, &first).expect("test: seed WAL");
+    index.insert(1, &first);
+
+    let result = {
+        let _fault = FaultGuard::inject_after(AtomicWriteBoundary::ParentDirectorySync, 4);
+        compact(dir.path(), &index)
+    };
+    assert!(result.is_err(), "manifest directory barrier must fail");
+
+    std::fs::remove_file(dir.path().join("sparse.snapshot")).unwrap();
+    let recovered = load_from_disk(dir.path()).unwrap().unwrap();
+    assert_eq!(recovered.doc_count(), 1);
+    assert_eq!(recovered.get_all_postings(1)[0].doc_id, 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn every_directory_sync_failure_preserves_recovery() {
+    for completed_syncs in 0..6 {
+        let (dir, index, _) = recoverable_case();
+        let result = {
+            let _fault =
+                FaultGuard::inject_after(AtomicWriteBoundary::ParentDirectorySync, completed_syncs);
+            compact(dir.path(), &index)
+        };
+        assert!(
+            result.is_err(),
+            "directory sync {completed_syncs} must fail"
+        );
+        assert_complete_recovery(&dir);
+    }
+}
+
+#[test]
+fn append_after_wal_reset_failure_uses_committed_generation() {
+    let (dir, index, _) = recoverable_case();
+    let result = {
+        let _fault = FaultGuard::inject_after(AtomicWriteBoundary::TemporaryFileSync, 4);
+        compact(dir.path(), &index)
+    };
+    assert!(result.is_err(), "WAL reset sync failure must propagate");
+
+    let third = vector(3, 3.0);
+    wal_append_upsert(&dir.path().join("sparse.wal"), 3, &third)
+        .expect("next append must rebase the stale WAL");
+
+    let recovered = load_from_disk(dir.path()).unwrap().unwrap();
+    assert_eq!(recovered.doc_count(), 3);
+    assert_eq!(recovered.get_all_postings(3)[0].doc_id, 3);
+}
+
+#[test]
+fn stale_wal_generation_is_not_replayed_over_new_snapshot() {
+    let (dir, index, stale_wal) = recoverable_case();
+    compact(dir.path(), &index).expect("test: publish next generation");
+
+    std::fs::write(dir.path().join("sparse.wal"), stale_wal).expect("test: restore stale WAL");
+    assert_complete_recovery(&dir);
+}

--- a/crates/velesdb-core/src/index/sparse/persistence_generation.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_generation.rs
@@ -1,0 +1,162 @@
+//! Two-slot sparse snapshot publication metadata.
+//!
+//! Compaction writes the inactive slot completely, then atomically replaces a
+//! small manifest. The manifest is the only commit point, so restart never
+//! combines files from different snapshot generations.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::storage::atomic_write::atomic_write;
+
+const MANIFEST_VERSION: u8 = 1;
+const MAX_MANIFEST_BYTES: u64 = 64;
+
+#[derive(Clone, Debug)]
+pub(super) struct SnapshotPaths {
+    pub(super) idx: PathBuf,
+    pub(super) terms: PathBuf,
+    pub(super) meta: PathBuf,
+}
+
+#[derive(Debug)]
+pub(super) struct ActiveSnapshot {
+    pub(super) paths: SnapshotPaths,
+    pub(super) wal_generation: Option<u64>,
+}
+
+#[derive(Debug)]
+pub(super) struct PendingSnapshot {
+    pub(super) paths: SnapshotPaths,
+    manifest: SnapshotManifest,
+}
+
+impl PendingSnapshot {
+    pub(super) const fn generation(&self) -> u64 {
+        self.manifest.generation
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+struct SnapshotManifest {
+    version: u8,
+    generation: u64,
+    slot: u8,
+}
+
+pub(super) fn prepare_snapshot(dir: &Path, prefix: &str) -> Result<PendingSnapshot> {
+    let current = read_manifest(dir, prefix)?;
+    let (generation, slot) = match current {
+        Some(manifest) => (
+            manifest.generation.checked_add(1).ok_or_else(|| {
+                Error::SparseIndexError("sparse snapshot generation overflow".to_string())
+            })?,
+            1 - manifest.slot,
+        ),
+        // Slot 0 is the manifest-free legacy fallback. The first manifested
+        // snapshot must use slot 1 even for a new database: if the manifest is
+        // lost in a crash, restart can then recover from the old slot-0 files
+        // (when present) plus the WAL, or from the WAL alone.
+        None => (1, 1),
+    };
+    Ok(PendingSnapshot {
+        paths: slot_paths(dir, prefix, slot),
+        manifest: SnapshotManifest {
+            version: MANIFEST_VERSION,
+            generation,
+            slot,
+        },
+    })
+}
+
+pub(super) fn publish_snapshot(dir: &Path, prefix: &str, pending: &PendingSnapshot) -> Result<()> {
+    let bytes = postcard::to_allocvec(&pending.manifest)
+        .map_err(|e| sparse_error("manifest serialize", e))?;
+    atomic_write(&manifest_path(dir, prefix), &bytes)
+        .map_err(|e| sparse_error("manifest publish", e))
+}
+
+pub(super) fn active_snapshot(dir: &Path, prefix: &str) -> Result<Option<ActiveSnapshot>> {
+    if let Some(manifest) = read_manifest(dir, prefix)? {
+        return Ok(Some(ActiveSnapshot {
+            paths: slot_paths(dir, prefix, manifest.slot),
+            wal_generation: Some(manifest.generation),
+        }));
+    }
+    let paths = legacy_paths(dir, prefix);
+    Ok(paths.meta.exists().then_some(ActiveSnapshot {
+        paths,
+        wal_generation: None,
+    }))
+}
+
+pub(super) fn committed_generation_for_wal(wal_path: &Path) -> Result<Option<u64>> {
+    let parent = wal_path.parent().unwrap_or_else(|| Path::new("."));
+    let prefix = wal_prefix(wal_path)?;
+    Ok(read_manifest(parent, prefix)?.map(|manifest| manifest.generation))
+}
+
+fn read_manifest(dir: &Path, prefix: &str) -> Result<Option<SnapshotManifest>> {
+    let path = manifest_path(dir, prefix);
+    let metadata = match std::fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(sparse_error("manifest metadata", error)),
+    };
+    if metadata.len() > MAX_MANIFEST_BYTES {
+        return Err(Error::SparseIndexError(format!(
+            "sparse snapshot manifest exceeds {MAX_MANIFEST_BYTES} bytes"
+        )));
+    }
+    let bytes = std::fs::read(path).map_err(|e| sparse_error("manifest read", e))?;
+    let manifest: SnapshotManifest =
+        postcard::from_bytes(&bytes).map_err(|e| sparse_error("manifest deserialize", e))?;
+    validate_manifest(manifest).map(Some)
+}
+
+fn validate_manifest(manifest: SnapshotManifest) -> Result<SnapshotManifest> {
+    if manifest.version != MANIFEST_VERSION || manifest.slot > 1 || manifest.generation == 0 {
+        return Err(Error::SparseIndexError(format!(
+            "invalid sparse snapshot manifest: version={}, generation={}, slot={}",
+            manifest.version, manifest.generation, manifest.slot
+        )));
+    }
+    Ok(manifest)
+}
+
+fn wal_prefix(wal_path: &Path) -> Result<&str> {
+    wal_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.strip_suffix(".wal"))
+        .ok_or_else(|| {
+            Error::SparseIndexError(format!("invalid sparse WAL path: {}", wal_path.display()))
+        })
+}
+
+fn manifest_path(dir: &Path, prefix: &str) -> PathBuf {
+    dir.join(format!("{prefix}.snapshot"))
+}
+
+fn legacy_paths(dir: &Path, prefix: &str) -> SnapshotPaths {
+    slot_paths(dir, prefix, 0)
+}
+
+fn slot_paths(dir: &Path, prefix: &str, slot: u8) -> SnapshotPaths {
+    let stem = if slot == 0 {
+        prefix.to_string()
+    } else {
+        format!(".{prefix}.next")
+    };
+    SnapshotPaths {
+        idx: dir.join(format!("{stem}.idx")),
+        terms: dir.join(format!("{stem}.terms")),
+        meta: dir.join(format!("{stem}.meta")),
+    }
+}
+
+fn sparse_error(context: &str, error: impl std::fmt::Display) -> Error {
+    Error::SparseIndexError(format!("sparse snapshot {context}: {error}"))
+}

--- a/crates/velesdb-core/src/index/sparse/persistence_tests.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_tests.rs
@@ -179,8 +179,11 @@ fn test_meta_contains_correct_values() {
     }
     compact(dir.path(), &index).unwrap();
 
-    // Read meta directly
-    let meta_data = std::fs::read(dir.path().join("sparse.meta")).unwrap();
+    // Read metadata from the slot selected by the durable manifest.
+    let active = super::persistence_generation::active_snapshot(dir.path(), "sparse")
+        .unwrap()
+        .unwrap();
+    let meta_data = std::fs::read(active.paths.meta).unwrap();
     let meta: SparseMeta = postcard::from_bytes(&meta_data).unwrap();
     assert_eq!(meta.version, 1);
     assert_eq!(meta.doc_count, 25);
@@ -264,8 +267,92 @@ fn test_compaction_truncates_wal() {
 
     compact(dir.path(), &index).unwrap();
 
-    // WAL should be truncated
-    assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), 0);
+    // The old records are gone; the durable generation header is logically empty.
+    let replayed = wal_replay(&wal_path, &SparseInvertedIndex::new()).unwrap();
+    assert_eq!(replayed, 0);
+}
+
+fn compacted_index_with_pending_wal() -> (
+    tempfile::TempDir,
+    SparseInvertedIndex,
+    std::path::PathBuf,
+    Vec<u8>,
+) {
+    let dir = tempdir().unwrap();
+    let wal_path = dir.path().join("sparse.wal");
+    let index = SparseInvertedIndex::new();
+    let first = make_vector(vec![(1, 1.0)]);
+    wal_append_upsert(&wal_path, 1, &first).unwrap();
+    index.insert(1, &first);
+    compact(dir.path(), &index).unwrap();
+
+    let second = make_vector(vec![(2, 2.0)]);
+    wal_append_upsert(&wal_path, 2, &second).unwrap();
+    index.insert(2, &second);
+    let wal_before = std::fs::read(&wal_path).unwrap();
+    (dir, index, wal_path, wal_before)
+}
+
+fn assert_recovery_after_fault(boundary: PublicationBoundary) {
+    let (dir, index, wal_path, wal_before) = compacted_index_with_pending_wal();
+    let _fault = PublicationFaultGuard::inject(boundary);
+    compact(dir.path(), &index).expect_err("publication boundary must fail");
+
+    assert_eq!(std::fs::read(wal_path).unwrap(), wal_before);
+    let loaded = load_from_disk(dir.path()).unwrap().unwrap();
+    assert_eq!(loaded.doc_count(), 2);
+    assert_eq!(loaded.get_all_postings(1)[0].doc_id, 1);
+    assert_eq!(loaded.get_all_postings(2)[0].doc_id, 2);
+}
+
+#[test]
+fn every_publication_boundary_preserves_a_recoverable_generation() {
+    for boundary in [
+        PublicationBoundary::IndexPromotion,
+        PublicationBoundary::TermsPromotion,
+        PublicationBoundary::MetaPromotion,
+        PublicationBoundary::CommitPoint,
+        PublicationBoundary::WalTruncation,
+    ] {
+        assert_recovery_after_fault(boundary);
+    }
+}
+
+#[test]
+fn current_layout_loads_without_a_manifest() {
+    let dir = tempdir().unwrap();
+    let index = SparseInvertedIndex::new();
+    index.insert(7, &make_vector(vec![(3, 1.5)]));
+    compact(dir.path(), &index).unwrap();
+
+    for extension in ["idx", "terms", "meta"] {
+        std::fs::rename(
+            dir.path().join(format!(".sparse.next.{extension}")),
+            dir.path().join(format!("sparse.{extension}")),
+        )
+        .unwrap();
+    }
+    std::fs::remove_file(dir.path().join("sparse.snapshot")).unwrap();
+    std::fs::write(dir.path().join("sparse.wal"), []).unwrap();
+
+    let loaded = load_from_disk(dir.path()).unwrap().unwrap();
+    assert_eq!(loaded.doc_count(), 1);
+    assert_eq!(loaded.get_all_postings(3)[0].doc_id, 7);
+}
+
+#[test]
+fn manifest_selects_one_complete_snapshot_slot() {
+    let dir = tempdir().unwrap();
+    let index = SparseInvertedIndex::new();
+    index.insert(1, &make_vector(vec![(1, 1.0)]));
+    compact(dir.path(), &index).unwrap();
+    index.insert(2, &make_vector(vec![(2, 2.0)]));
+    compact(dir.path(), &index).unwrap();
+
+    std::fs::write(dir.path().join(".sparse.next.meta"), b"inactive-corruption").unwrap();
+    let loaded = load_from_disk(dir.path()).unwrap().unwrap();
+    assert_eq!(loaded.doc_count(), 2);
+    assert_eq!(loaded.get_all_postings(2)[0].doc_id, 2);
 }
 
 /// #897: a compacted `sparse.meta` whose `term_count` disagrees with the decoded
@@ -285,7 +372,11 @@ fn test_load_rejects_term_count_mismatch() {
 
     // Overwrite the metadata header with an inflated `term_count` that no longer
     // matches the on-disk term dictionary.
-    let meta_path = dir.path().join("sparse.meta");
+    let meta_path = super::persistence_generation::active_snapshot(dir.path(), "sparse")
+        .unwrap()
+        .unwrap()
+        .paths
+        .meta;
     let meta = super::persistence::SparseMeta {
         version: 1,
         doc_count: 10,

--- a/crates/velesdb-core/src/index/sparse/persistence_wal.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_wal.rs
@@ -3,14 +3,19 @@
 //! Extracted from `persistence.rs` to reduce NLOC below the 500 threshold.
 
 use super::inverted_index::SparseInvertedIndex;
+use super::persistence_generation::committed_generation_for_wal;
 use super::types::SparseVector;
 use crate::error::{Error, Result};
+use crate::storage::atomic_write::{atomic_write, sync_parent_directory};
 
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, Read, Write};
 use std::path::Path;
 
 const WAL_OP_UPSERT: u8 = 0x01;
 const WAL_OP_DELETE: u8 = 0x02;
+const WAL_HEADER_MAGIC: [u8; 4] = *b"VSWL";
+const WAL_HEADER_VERSION: u8 = 1;
+const WAL_HEADER_LEN: usize = 13;
 
 // ---------------------------------------------------------------------------
 // Byte-parsing helpers
@@ -112,12 +117,40 @@ fn compute_upsert_entry_len(nnz: u32) -> Result<u32> {
 
 /// Opens a WAL file for appending with buffered I/O.
 fn open_wal_writer(wal_path: &Path) -> Result<BufWriter<std::fs::File>> {
+    if let Some(generation) = committed_generation_for_wal(wal_path)? {
+        align_wal_generation(wal_path, generation)?;
+    }
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(wal_path)
         .map_err(|e| Error::SparseIndexError(format!("WAL open failed: {e}")))?;
     Ok(BufWriter::new(file))
+}
+
+/// Prevents post-compaction writes from extending a stale WAL generation.
+fn align_wal_generation(wal_path: &Path, expected: u64) -> Result<()> {
+    if read_wal_generation(wal_path)? != Some(expected) {
+        reset_wal(wal_path, expected)?;
+    }
+    Ok(())
+}
+
+fn read_wal_generation(wal_path: &Path) -> Result<Option<u64>> {
+    let file = match std::fs::File::open(wal_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(Error::SparseIndexError(format!(
+                "WAL generation read open failed: {error}"
+            )))
+        }
+    };
+    let mut bytes = Vec::with_capacity(WAL_HEADER_LEN);
+    file.take(WAL_HEADER_LEN as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| Error::SparseIndexError(format!("WAL generation read failed: {error}")))?;
+    read_wal_header(&bytes).map(|header| header.map(|(generation, _)| generation))
 }
 
 /// Writes bytes to a WAL writer, mapping I/O errors to `SparseIndexError`.
@@ -155,12 +188,64 @@ pub fn wal_replay(wal_path: &Path, index: &SparseInvertedIndex) -> Result<u64> {
     let Some(data) = data else {
         return Ok(0);
     };
+    let start = read_wal_header(&data)?.map_or(0, |(_, offset)| offset);
+    replay_wal_bytes(&data, start, index)
+}
 
-    let mut pos = 0usize;
-    let mut count = 0u64;
+pub(super) fn wal_replay_for_generation(
+    wal_path: &Path,
+    index: &SparseInvertedIndex,
+    expected_generation: Option<u64>,
+) -> Result<u64> {
+    let Some(data) = read_wal_file(wal_path)? else {
+        return Ok(0);
+    };
+    let header = read_wal_header(&data)?;
+    let Some(expected) = expected_generation else {
+        if header.is_some() {
+            return Err(Error::SparseIndexError(
+                "sparse WAL has a generation header but no snapshot manifest".to_string(),
+            ));
+        }
+        return replay_wal_bytes(&data, 0, index);
+    };
+    match header {
+        Some((generation, offset)) if generation == expected => {
+            replay_wal_bytes(&data, offset, index)
+        }
+        Some(_) | None => Ok(0),
+    }
+}
+
+pub(super) fn reset_wal(wal_path: &Path, generation: u64) -> Result<()> {
+    atomic_write(wal_path, &wal_header(generation))
+        .map_err(|e| Error::SparseIndexError(format!("sparse WAL durable reset: {e}")))
+}
+
+pub(super) fn sync_wal(wal_path: &Path) -> Result<()> {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(wal_path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(Error::SparseIndexError(format!(
+                "compact WAL sync open: {error}"
+            )))
+        }
+    };
+    file.sync_all()
+        .and_then(|()| sync_parent_directory(wal_path))
+        .map_err(|error| Error::SparseIndexError(format!("compact WAL sync: {error}")))
+}
+
+fn replay_wal_bytes(data: &[u8], mut pos: usize, index: &SparseInvertedIndex) -> Result<u64> {
+    let mut count = 0_u64;
 
     while pos < data.len() {
-        let Some((body_start, total_len)) = read_wal_entry_header(&data, pos) else {
+        let Some((body_start, total_len)) = read_wal_entry_header(data, pos) else {
             break;
         };
         pos += 4;
@@ -176,7 +261,7 @@ pub fn wal_replay(wal_path: &Path, index: &SparseInvertedIndex) -> Result<u64> {
         let op = data[pos];
         pos += 1;
 
-        let advanced = replay_single_entry(&data, op, pos, body_start, total_len, index)?;
+        let advanced = replay_single_entry(data, op, pos, body_start, total_len, index)?;
         if let Some((new_pos, counted)) = advanced {
             pos = new_pos;
             count += counted;
@@ -188,6 +273,38 @@ pub fn wal_replay(wal_path: &Path, index: &SparseInvertedIndex) -> Result<u64> {
     }
 
     Ok(count)
+}
+
+fn wal_header(generation: u64) -> [u8; WAL_HEADER_LEN] {
+    let mut header = [0_u8; WAL_HEADER_LEN];
+    header[..4].copy_from_slice(&WAL_HEADER_MAGIC);
+    header[4] = WAL_HEADER_VERSION;
+    header[5..].copy_from_slice(&generation.to_le_bytes());
+    header
+}
+
+fn read_wal_header(data: &[u8]) -> Result<Option<(u64, usize)>> {
+    if !data.starts_with(&WAL_HEADER_MAGIC) {
+        return Ok(None);
+    }
+    if data.len() < WAL_HEADER_LEN {
+        return Err(Error::SparseIndexError(
+            "sparse WAL generation header is truncated".to_string(),
+        ));
+    }
+    if data[4] != WAL_HEADER_VERSION {
+        return Err(Error::SparseIndexError(format!(
+            "unsupported sparse WAL header version: {}",
+            data[4]
+        )));
+    }
+    let generation = read_le_u64(data, 5, "sparse WAL generation bytes")?;
+    if generation == 0 {
+        return Err(Error::SparseIndexError(
+            "sparse WAL generation must be non-zero".to_string(),
+        ));
+    }
+    Ok(Some((generation, WAL_HEADER_LEN)))
 }
 
 /// Reads the WAL file, returning `None` for missing files.

--- a/crates/velesdb-core/src/quantization/pq_persistence.rs
+++ b/crates/velesdb-core/src/quantization/pq_persistence.rs
@@ -5,6 +5,7 @@
 //! the storage concern from the core PQ algorithm.
 
 use crate::error::Error;
+use crate::storage::atomic_write::atomic_write;
 use serde::{Deserialize, Serialize};
 
 use super::pq::ProductQuantizer;
@@ -20,7 +21,7 @@ const MAX_PQ_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 
 /// RF-2: Serializes `value` with postcard and atomically writes to `dir/filename`.
 ///
-/// Write goes to `.tmp` suffix first, then renamed for crash safety.
+/// Delegates to the shared durable replacement primitive.
 fn postcard_save_atomic<T: Serialize>(
     dir: &std::path::Path,
     filename: &str,
@@ -33,11 +34,13 @@ fn postcard_save_atomic<T: Serialize>(
             format!("failed to serialize {label}: {e}"),
         ))
     })?;
-    let tmp_path = dir.join(format!("{filename}.tmp"));
     let final_path = dir.join(filename);
-    std::fs::write(&tmp_path, &data)?;
-    std::fs::rename(&tmp_path, &final_path)?;
-    Ok(())
+    atomic_write(&final_path, &data).map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("failed to write {label}: {e}"),
+        ))
+    })
 }
 
 /// RF-2: Loads and deserializes a postcard file from `dir/filename`.

--- a/crates/velesdb-core/src/quantization/pq_tests.rs
+++ b/crates/velesdb-core/src/quantization/pq_tests.rs
@@ -601,6 +601,22 @@ fn save_codebook_uses_atomic_write() {
 
 #[cfg(feature = "persistence")]
 #[test]
+fn save_codebook_propagates_shared_durability_failure() {
+    use crate::storage::atomic_write::{AtomicWriteBoundary, FaultGuard};
+
+    let vectors = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
+    let pq = ProductQuantizer::train(&vectors, 2, 2).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    let _fault = FaultGuard::inject(AtomicWriteBoundary::TemporaryFileSync);
+    let error = pq
+        .save_codebook(dir.path())
+        .expect_err("sync failure must propagate");
+    assert!(error.to_string().contains("TemporaryFileSync"));
+}
+
+#[cfg(feature = "persistence")]
+#[test]
 fn rotation_save_load_roundtrip() {
     let vectors = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
     let mut pq = ProductQuantizer::train(&vectors, 2, 2).unwrap();
@@ -616,6 +632,23 @@ fn rotation_save_load_roundtrip() {
         .expect("rotation should exist");
 
     assert_eq!(loaded, pq.rotation.unwrap());
+}
+
+#[cfg(feature = "persistence")]
+#[test]
+fn save_rotation_propagates_shared_durability_failure() {
+    use crate::storage::atomic_write::{AtomicWriteBoundary, FaultGuard};
+
+    let vectors = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
+    let mut pq = ProductQuantizer::train(&vectors, 2, 2).unwrap();
+    pq.rotation = Some(vec![1.0; 16]);
+    let dir = tempfile::tempdir().unwrap();
+
+    let _fault = FaultGuard::inject(AtomicWriteBoundary::TemporaryFileSync);
+    let error = pq
+        .save_rotation(dir.path())
+        .expect_err("sync failure must propagate");
+    assert!(error.to_string().contains("TemporaryFileSync"));
 }
 
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -12,6 +12,8 @@
 //! | Compression ratio | 1x | 32x |
 
 use crate::error::Error;
+#[cfg(feature = "persistence")]
+use crate::storage::atomic_write::atomic_write;
 use serde::{Deserialize, Serialize};
 
 /// Scalar correction factors for a `RaBitQ`-encoded vector.
@@ -373,11 +375,13 @@ impl RaBitQIndex {
                 format!("failed to serialize RaBitQ index: {e}"),
             ))
         })?;
-        let tmp_path = dir.join("rabitq.idx.tmp");
         let final_path = dir.join("rabitq.idx");
-        std::fs::write(&tmp_path, &data)?;
-        std::fs::rename(&tmp_path, &final_path)?;
-        Ok(())
+        atomic_write(&final_path, &data).map_err(|e| {
+            Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("failed to write RaBitQ index: {e}"),
+            ))
+        })
     }
 
     /// Load `RaBitQ` index from `<dir>/rabitq.idx`. Returns `None` if file doesn't exist.

--- a/crates/velesdb-core/src/quantization/rabitq_tests.rs
+++ b/crates/velesdb-core/src/quantization/rabitq_tests.rs
@@ -472,6 +472,22 @@ fn rabitq_save_uses_atomic_write() {
     assert!(dir.path().join("rabitq.idx").exists());
 }
 
+#[cfg(feature = "persistence")]
+#[test]
+fn rabitq_save_propagates_shared_durability_failure() {
+    use crate::storage::atomic_write::{AtomicWriteBoundary, FaultGuard};
+
+    let vectors = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+    let index = RaBitQIndex::train(&vectors, 42).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    let _fault = FaultGuard::inject(AtomicWriteBoundary::TemporaryFileSync);
+    let error = index
+        .save(dir.path())
+        .expect_err("sync failure must propagate");
+    assert!(error.to_string().contains("TemporaryFileSync"));
+}
+
 // ====================================================================
 // Phase 2: SIMD-dispatched popcount regression tests
 // ====================================================================

--- a/crates/velesdb-core/src/storage/atomic_write.rs
+++ b/crates/velesdb-core/src/storage/atomic_write.rs
@@ -1,14 +1,16 @@
-//! Atomic file write: serialize to a unique sibling temp file, fsync, then
-//! rename over the target.
+//! Power-loss-durable atomic file replacement.
 //!
 //! Shared by every durable snapshot writer (HNSW, BM25, and the graph postcard
 //! snapshots — `EdgeStore` / `PropertyIndex` / `RangeIndex`) so the crash-safety
 //! guarantee lives in exactly one place instead of being re-implemented per
 //! module.
 
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::cell::Cell;
 
 /// Process-global counter making temp file names unique within a process.
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -16,26 +18,46 @@ static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 /// Writes `data` to `final_path` atomically.
 ///
 /// Serializes to a uniquely-named sibling temp file (same directory → same
-/// filesystem, so the `rename` is atomic and cannot fail with `EXDEV`), fsyncs
-/// it, then renames it over the target. A crash mid-write leaves the *previous*
-/// good file intact rather than a torn file. The temp file is best-effort
-/// removed if any step fails.
+/// filesystem, so the replacement is atomic and cannot fail with `EXDEV`),
+/// fsyncs it, replaces the target, then persists that namespace change. Unix
+/// uses a parent-directory fsync; Windows uses `MOVEFILE_WRITE_THROUGH`.
+/// A crash mid-write therefore leaves either the previous complete file or the
+/// replacement, never a torn file. The temp file is best-effort removed if any
+/// step fails.
 ///
 /// The temp name embeds PID + thread id + a process-global counter so
 /// concurrent writers (intra- and inter-process) never collide on it.
 ///
 /// # Errors
 ///
-/// Returns an error if creating, writing, or fsyncing the temp file fails, or
-/// if the final rename fails.
-pub(crate) fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+/// Returns an error if any write, file sync, replacement, or namespace
+/// durability barrier fails.
+pub(crate) fn atomic_write(final_path: &Path, data: &[u8]) -> io::Result<()> {
+    atomic_write_with(final_path, |writer| writer.write_all(data))
+}
+
+/// Streams a replacement file through `write`, then publishes it durably.
+///
+/// This variant avoids materializing large snapshots in memory. The closure's
+/// result is returned only after the file and its replacement are durable.
+///
+/// # Errors
+///
+/// Returns an error from the writer or any durability boundary.
+pub(crate) fn atomic_write_with<T, E>(
+    final_path: &Path,
+    write: impl FnOnce(&mut std::io::BufWriter<std::fs::File>) -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<io::Error>,
+{
     let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     let tid = std::thread::current().id();
     let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
     let tmp_path = final_path.with_file_name(format!("{file_name}.tmp.{pid}.{tid:?}.{seq}"));
 
-    let result = atomic_write_inner(&tmp_path, final_path, data);
+    let result = atomic_write_inner(&tmp_path, final_path, write);
     if result.is_err() {
         // Best-effort cleanup of the temp file on failure.
         let _ = std::fs::remove_file(&tmp_path);
@@ -43,18 +65,135 @@ pub(crate) fn atomic_write(final_path: &Path, data: &[u8]) -> std::io::Result<()
     result
 }
 
-fn atomic_write_inner(tmp_path: &Path, final_path: &Path, data: &[u8]) -> std::io::Result<()> {
+fn atomic_write_inner<T, E>(
+    tmp_path: &Path,
+    final_path: &Path,
+    write: impl FnOnce(&mut std::io::BufWriter<std::fs::File>) -> Result<T, E>,
+) -> Result<T, E>
+where
+    E: From<io::Error>,
+{
     let file = std::fs::File::create(tmp_path)?;
     let mut writer = std::io::BufWriter::new(file);
-    writer.write_all(data)?;
+    let value = write(&mut writer)?;
     writer.flush()?;
-    writer.get_ref().sync_all()?; // durable before the rename swaps it in
+    sync_temporary_file(writer.get_ref())?;
+    drop(writer);
+    replace_file(tmp_path, final_path)?;
+    sync_parent_directory(final_path)?;
+    Ok(value)
+}
+
+fn sync_temporary_file(file: &std::fs::File) -> io::Result<()> {
+    check_fault(AtomicWriteBoundary::TemporaryFileSync)?;
+    file.sync_all()
+}
+
+#[cfg(windows)]
+fn replace_file(tmp_path: &Path, final_path: &Path) -> io::Result<()> {
+    check_fault(AtomicWriteBoundary::Replacement)?;
+    atomicwrites::replace_atomic(tmp_path, final_path)
+}
+
+#[cfg(not(windows))]
+fn replace_file(tmp_path: &Path, final_path: &Path) -> io::Result<()> {
+    check_fault(AtomicWriteBoundary::Replacement)?;
     std::fs::rename(tmp_path, final_path)
+}
+
+#[cfg(unix)]
+pub(crate) fn sync_parent_directory(final_path: &Path) -> io::Result<()> {
+    check_fault(AtomicWriteBoundary::ParentDirectorySync)?;
+    std::fs::File::open(parent_directory(final_path))?.sync_all()
+}
+
+#[cfg(not(unix))]
+pub(crate) fn sync_parent_directory(_final_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn parent_directory(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AtomicWriteBoundary {
+    TemporaryFileSync,
+    Replacement,
+    #[cfg(unix)]
+    ParentDirectorySync,
+}
+
+#[cfg(not(test))]
+#[allow(clippy::unnecessary_wraps)] // Test builds return injected durability failures.
+fn check_fault(_boundary: AtomicWriteBoundary) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static INJECTED_FAULT: Cell<Option<InjectedFault>> = const { Cell::new(None) };
+}
+
+#[cfg(test)]
+fn check_fault(boundary: AtomicWriteBoundary) -> io::Result<()> {
+    INJECTED_FAULT.with(|fault| {
+        let Some(mut injected) = fault.get() else {
+            return Ok(());
+        };
+        if injected.boundary != boundary {
+            return Ok(());
+        }
+        if injected.remaining == 0 {
+            fault.set(None);
+            Err(io::Error::other(format!("fault injected at {boundary:?}")))
+        } else {
+            injected.remaining -= 1;
+            fault.set(Some(injected));
+            Ok(())
+        }
+    })
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+struct InjectedFault {
+    boundary: AtomicWriteBoundary,
+    remaining: usize,
+}
+
+#[cfg(test)]
+pub(crate) struct FaultGuard(Option<InjectedFault>);
+
+#[cfg(test)]
+impl FaultGuard {
+    pub(crate) fn inject(boundary: AtomicWriteBoundary) -> Self {
+        Self::inject_after(boundary, 0)
+    }
+
+    pub(crate) fn inject_after(boundary: AtomicWriteBoundary, remaining: usize) -> Self {
+        let injected = InjectedFault {
+            boundary,
+            remaining,
+        };
+        let previous = INJECTED_FAULT.with(|fault| fault.replace(Some(injected)));
+        Self(previous)
+    }
+}
+
+#[cfg(test)]
+impl Drop for FaultGuard {
+    fn drop(&mut self) {
+        INJECTED_FAULT.with(|fault| fault.set(self.0));
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::atomic_write;
+    use super::{atomic_write, AtomicWriteBoundary, FaultGuard};
 
     #[test]
     fn test_atomic_write_round_trips_and_leaves_no_temp() {
@@ -80,5 +219,27 @@ mod tests {
         atomic_write(&path, b"first").expect("test: first");
         atomic_write(&path, b"second").expect("test: overwrite");
         assert_eq!(std::fs::read(&path).expect("test: read"), b"second");
+    }
+
+    #[test]
+    fn temporary_sync_failure_preserves_previous_file() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snap.bin");
+        atomic_write(&path, b"previous").expect("test: seed file");
+
+        let _fault = FaultGuard::inject(AtomicWriteBoundary::TemporaryFileSync);
+        assert!(atomic_write(&path, b"replacement").is_err());
+        assert_eq!(std::fs::read(path).expect("test: read"), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parent_directory_sync_failure_is_propagated() {
+        let dir = tempfile::TempDir::new().expect("test: temp dir");
+        let path = dir.path().join("snap.bin");
+
+        let _fault = FaultGuard::inject(AtomicWriteBoundary::ParentDirectorySync);
+        let error = atomic_write(&path, b"replacement").expect_err("barrier must fail");
+        assert!(error.to_string().contains("ParentDirectorySync"));
     }
 }

--- a/crates/velesdb-core/src/storage/atomic_write.rs
+++ b/crates/velesdb-core/src/storage/atomic_write.rs
@@ -7,26 +7,20 @@
 
 use std::io::{self, Write};
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(test)]
 use std::cell::Cell;
 
-/// Process-global counter making temp file names unique within a process.
-static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
 /// Writes `data` to `final_path` atomically.
 ///
-/// Serializes to a uniquely-named sibling temp file (same directory → same
-/// filesystem, so the replacement is atomic and cannot fail with `EXDEV`),
-/// fsyncs it, replaces the target, then persists that namespace change. Unix
-/// uses a parent-directory fsync; Windows uses `MOVEFILE_WRITE_THROUGH`.
+/// Serializes to a securely-created, uniquely-named sibling temp file (same
+/// directory → same filesystem, so the replacement is atomic and cannot fail
+/// with `EXDEV`), fsyncs it, replaces the target, then persists that namespace
+/// change. Unix uses a parent-directory fsync; Windows uses
+/// `MOVEFILE_WRITE_THROUGH`.
 /// A crash mid-write therefore leaves either the previous complete file or the
 /// replacement, never a torn file. The temp file is best-effort removed if any
 /// step fails.
-///
-/// The temp name embeds PID + thread id + a process-global counter so
-/// concurrent writers (intra- and inter-process) never collide on it.
 ///
 /// # Errors
 ///
@@ -51,21 +45,21 @@ pub(crate) fn atomic_write_with<T, E>(
 where
     E: From<io::Error>,
 {
-    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let tid = std::thread::current().id();
-    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
-    let tmp_path = final_path.with_file_name(format!("{file_name}.tmp.{pid}.{tid:?}.{seq}"));
+    let (file, tmp_path) = create_temporary_file(final_path)?;
+    atomic_write_inner(file, tmp_path.as_ref(), final_path, write)
+}
 
-    let result = atomic_write_inner(&tmp_path, final_path, write);
-    if result.is_err() {
-        // Best-effort cleanup of the temp file on failure.
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-    result
+fn create_temporary_file(final_path: &Path) -> io::Result<(std::fs::File, tempfile::TempPath)> {
+    let file_name = final_path.file_name().unwrap_or_default().to_string_lossy();
+    let prefix = format!("{file_name}.tmp.");
+    tempfile::Builder::new()
+        .prefix(&prefix)
+        .tempfile_in(parent_directory(final_path))
+        .map(tempfile::NamedTempFile::into_parts)
 }
 
 fn atomic_write_inner<T, E>(
+    file: std::fs::File,
     tmp_path: &Path,
     final_path: &Path,
     write: impl FnOnce(&mut std::io::BufWriter<std::fs::File>) -> Result<T, E>,
@@ -73,7 +67,6 @@ fn atomic_write_inner<T, E>(
 where
     E: From<io::Error>,
 {
-    let file = std::fs::File::create(tmp_path)?;
     let mut writer = std::io::BufWriter::new(file);
     let value = write(&mut writer)?;
     writer.flush()?;
@@ -112,7 +105,6 @@ pub(crate) fn sync_parent_directory(_final_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 fn parent_directory(path: &Path) -> &Path {
     path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -230,6 +222,11 @@ mod tests {
         let _fault = FaultGuard::inject(AtomicWriteBoundary::TemporaryFileSync);
         assert!(atomic_write(&path, b"replacement").is_err());
         assert_eq!(std::fs::read(path).expect("test: read"), b"previous");
+        let leftovers = std::fs::read_dir(dir.path())
+            .expect("test: read dir")
+            .filter_map(std::result::Result::ok)
+            .any(|entry| entry.file_name().to_string_lossy().contains(".tmp."));
+        assert!(!leftovers, "failed writes must remove their temp file");
     }
 
     #[cfg(unix)]

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1,7 +1,7 @@
 # VelesDB Storage Format Specification
 
-**Version**: 1.0.0  
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0  
+**Version**: 1.0.0<br>
+Last updated: 2026-08-12 · Applies to: velesdb-core 5.0.0<br>
 **Status**: Stable
 
 ## Overview
@@ -31,7 +31,10 @@ collection_directory/
 ├── property_index.bin   # Graph property index (graph collections)
 ├── bm25.snapshot        # BM25 full-text index snapshot (when text-indexed)
 ├── bm25.wal             # BM25 WAL (when text-indexed)
-└── sparse[-name].{wal,idx,terms,meta}  # Sparse index files (when sparse-indexed)
+├── sparse[-name].snapshot             # Sparse generation manifest (commit point)
+├── sparse[-name].wal                  # Generation-tagged sparse WAL
+├── sparse[-name].{idx,terms,meta}      # Sparse slot 0 / legacy layout
+└── .sparse[-name].next.{idx,terms,meta} # Hidden sparse slot 1
 ```
 
 ## Configuration File (config.json)
@@ -243,6 +246,29 @@ Binary snapshot of the payload index for fast cold-start recovery.
 ### Snapshot Threshold
 
 Default: 10 MB of WAL since last snapshot triggers automatic snapshot creation.
+
+## Sparse Index Snapshots
+
+Sparse compaction publishes `idx`, `terms`, and `meta` as one logical
+generation. It first fsyncs the current WAL, writes every file into the
+inactive slot through the durable atomic-replacement primitive, and then
+atomically replaces the small `.snapshot` manifest. The manifest is the sole
+commit point and records both the active slot and its non-zero generation.
+
+Only after that manifest replacement is durable is the sparse WAL reset to a
+generation header. Replay applies a WAL only when its generation matches the
+committed snapshot, so a crash cannot combine files or mutations from
+different generations. A crash before the commit keeps the previous slot plus
+its WAL authoritative; a crash after it uses the new complete slot and ignores
+the now-stale WAL until the durable reset completes. Before a later mutation
+is appended, the writer verifies the WAL header and durably realigns any stale
+WAL to the committed generation.
+
+Collections without a `.snapshot` manifest remain backward compatible: the
+unprefixed or named `idx`/`terms`/`meta` files are loaded as the legacy slot,
+and the headerless WAL is replayed as before. The first manifested compaction
+uses the hidden slot so loss of that first manifest still leaves the legacy
+slot and WAL available.
 
 ## Endianness
 


### PR DESCRIPTION
## Summary

- make atomic replacement power-loss durable through securely-created sibling temp files, temporary-file sync, write-through replacement on Windows, and parent-directory sync on Unix
- publish sparse `idx` / `terms` / `meta` snapshots into alternating slots selected by one durable manifest
- bind sparse WAL replay and reset to the committed generation, including stale-WAL realignment before a later mutation
- route PQ codebook, PQ rotation, and RaBitQ persistence through the shared durable-write primitive
- preserve manifest-free sparse databases as a backward-compatible legacy layout and document the new on-disk protocol

## Root cause

A synced temporary file followed by rename did not make the directory entry durable on Unix. Sparse compaction also promoted three files independently and then truncated the WAL, so a power loss could expose a mixed snapshot generation or discard the only recoverable mutation history. Predictable temp paths opened with truncation also allowed collision or symlink-following; the shared writer now uses exclusive random temp-file creation and RAII cleanup.

## Recovery contract

Before publication, the current WAL is synced. A complete snapshot is written to the inactive slot, then the manifest is atomically replaced as the sole commit point. Only after that commit is durable is the WAL durably reset to the new generation. Restart therefore selects either the previous complete slot plus its matching WAL or the new complete slot; stale-generation WAL data is never replayed over a committed snapshot.

Successful persistence calls now represent durable publication rather than only durable temporary-file contents. Existing sparse stores continue to load without migration; the first manifested compaction deliberately preserves the legacy slot as fallback.

## Failure injection and mutation proof

- injected failures cover all 5 temporary-file syncs, all 5 replacements, and all 6 Unix parent-directory syncs in sparse publication
- recovery tests cover loss of the first manifest, a failed WAL reset followed by another append, and stale-generation WAL replay
- atomic-write tests verify both success-path and injected-failure temp-file cleanup
- removing the parent-directory barrier makes `parent_directory_sync_failure_is_propagated` fail
- moving WAL reset before manifest commit makes `every_generation_promotion_failure_preserves_recovery` fail because the pre-commit WAL is no longer preserved

## Validation

- `cargo fmt --all -- --check`
- strict `velesdb-core` Clippy across all targets with `persistence,gpu,update-check`, `-D warnings`, and `-D clippy::pedantic`
- full `velesdb-core` suite: 5,352 unit tests, all integration binaries, and 50 doctests passed; zero failures
- native and `wasm32-unknown-unknown` no-default-features checks with `RUSTFLAGS="-D warnings"`
- Linux and Windows feature-isolation matrix, including Windows all-features, passed in CI
- unsafe-template, production-unwrap, TODO-annotation, diff-integrity, and attribution guards passed
- Codacy Static Code Analysis: zero findings

Closes #1897