### PR TITLE
fix(bindings): honor VELESDB_MEMORY_EMBEDDER and add the openai backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_Nothing yet — the 5.0.0 train departed here._
+### Fixed
+
+- **Python and Node bindings now read `VELESDB_MEMORY_EMBEDDER*` and gain the
+  `openai` backend (#1886).** The embedder was documented everywhere as an
+  environment-variable choice, but only the MCP daemon actually read one:
+  `MemoryService(path)` on Python and `MemoryService.open(path)` on Node
+  silently used the offline `hash` embedder regardless of
+  `VELESDB_MEMORY_EMBEDDER`, and `openai` did not exist as a binding-level
+  backend at all. Both bindings now resolve the backend through the same
+  `velesdb_memory::select_embedder`/`embedder_env_endpoint` the daemon uses
+  (moved into the library, `crates/velesdb-memory/src/remote_endpoint.rs`),
+  with an explicit constructor argument always winning over the environment.
+  `openai`'s URL and credential are read from the environment only — never a
+  constructor argument — matching the rule already enforced for the daemon.
+  *Migration*: Python's `embedder` constructor argument default changed from
+  the literal `"hash"` to `None`; passing `embedder="hash"` explicitly is
+  unaffected, and `None`/omitted now falls back to `VELESDB_MEMORY_EMBEDDER`
+  before defaulting to `hash`.
 
 ## [5.0.0] — 2026-08-10
 

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -119,6 +119,11 @@ mod openai;
 /// neither dependency.
 #[cfg(any(feature = "ollama", feature = "extract"))]
 pub mod reachability;
+/// Where a remote embedding/extraction backend's URL, model and credential
+/// come from, resolved from the environment once so the daemon and the
+/// language bindings read the same variables the same way (#1886).
+#[cfg(any(feature = "ollama", feature = "extract"))]
+pub mod remote_endpoint;
 /// Optional second-stage re-scoring of a fused recall pool (bring your own
 /// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].
 pub mod rerank;
@@ -184,6 +189,10 @@ pub use model::{
     EntityRelation, Explanation, FusionOptions, Link, MemoryEdge, MemoryNode, Recollection,
     RememberedExtraction, UnrelateOutcome,
 };
+#[cfg(feature = "ollama")]
+pub use remote_endpoint::embedder_env_endpoint;
+#[cfg(any(feature = "ollama", feature = "extract"))]
+pub use remote_endpoint::{role_auth, RemoteEndpoint};
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{AutographWorkerHandle, MemoryService, Metadata};
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -1151,91 +1151,31 @@ fn build_remote_extractor(
 
 // --- Where a remote backend's URL, model and credential come from -----------
 //
-// One shape for both roles, on purpose. The two were configured differently
-// for historical reasons only — extraction by role, embedding by product —
-// and an operator who has configured one should not have to learn the other
-// (#1751, arbitration C1).
-
-/// A remote backend's configuration, read from one role's environment.
-#[cfg(any(feature = "ollama", feature = "extract"))]
-struct RemoteEndpoint {
-    /// Server origin and port, no path. `None` when unset.
-    url: Option<String>,
-    /// Model identifier the server expects. `None` when unset.
-    model: Option<String>,
-    /// The credential, already resolved to what the transport puts on the wire.
-    auth: velesdb_memory::Auth,
-}
-
-#[cfg(any(feature = "ollama", feature = "extract"))]
-impl RemoteEndpoint {
-    /// The URL and model, both **required** — the `openai` shape.
-    ///
-    /// Neither has a default, and that is the design rather than an omission:
-    /// `openai` names a *protocol*, spoken by oMLX, llama.cpp, LM Studio, vLLM
-    /// and a dozen hosted providers. Guessing a URL would pick one of them for
-    /// the operator, and guessing a model would send a name no server on that
-    /// list is obliged to know. Ollama keeps its defaults because it genuinely
-    /// has one canonical local address.
-    ///
-    /// # Errors
-    /// A message naming the exact variable that is missing, per role.
-    fn require(self, prefix: &str) -> Result<(String, String, velesdb_memory::Auth), String> {
-        let url = self.url.ok_or_else(|| {
-            format!(
-                "{prefix}=openai requires {prefix}_URL — the server's origin and port, \
-                 no path (e.g. http://localhost:8020). There is no default: `openai` \
-                 is a protocol, and only you know which server speaks it here."
-            )
-        })?;
-        let model = self.model.ok_or_else(|| {
-            format!(
-                "{prefix}=openai requires {prefix}_MODEL — the model identifier the server expects"
-            )
-        })?;
-        Ok((url, model, self.auth))
-    }
-}
+// `RemoteEndpoint`/`role_auth` live in `velesdb_memory` (#1886): the daemon
+// and the Python/Node bindings all resolve the embedding role's remote
+// backend through the same library function now, instead of each reading (or,
+// until #1886, simply not reading) the four `VELESDB_MEMORY_EMBEDDER*`
+// variables on its own.
 
 /// The embedding role's endpoint, honouring the legacy
-/// `VELESDB_MEMORY_OLLAMA_*` aliases (C1).
+/// `VELESDB_MEMORY_OLLAMA_*` aliases (C1). Thin wrapper over
+/// [`velesdb_memory::embedder_env_endpoint`] that adds the one thing a
+/// library must not do on a caller's behalf: print the alias-conflict notice
+/// to stderr, gated on `VELESDB_MEMORY_QUIET` like every other startup notice.
 ///
 /// # Errors
 /// An `_API_TOKEN` that is set but empty.
 #[cfg(feature = "ollama")]
-fn embedder_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
-    use velesdb_memory::config::{alias_conflict_notice, resolve_alias};
-
-    let url = resolve_alias(
-        env_opt("VELESDB_MEMORY_EMBEDDER_URL").as_deref(),
-        env_opt("VELESDB_MEMORY_OLLAMA_URL").as_deref(),
-    );
-    let model = resolve_alias(
-        env_opt("VELESDB_MEMORY_EMBEDDER_MODEL").as_deref(),
-        env_opt("VELESDB_MEMORY_OLLAMA_MODEL").as_deref(),
-    );
-    let mut conflicts = Vec::new();
-    if url.conflicting {
-        conflicts.push(("VELESDB_MEMORY_EMBEDDER_URL", "VELESDB_MEMORY_OLLAMA_URL"));
-    }
-    if model.conflicting {
-        conflicts.push((
-            "VELESDB_MEMORY_EMBEDDER_MODEL",
-            "VELESDB_MEMORY_OLLAMA_MODEL",
-        ));
-    }
+fn embedder_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::error::Error>> {
+    let (endpoint, notice) = velesdb_memory::embedder_env_endpoint()?;
     // Once, at startup, and only when the two genuinely disagree. Called from
     // `build_remote_embedder`, which runs exactly once per process.
-    if let Some(notice) = alias_conflict_notice(&conflicts) {
+    if let Some(notice) = notice {
         if std::env::var_os("VELESDB_MEMORY_QUIET").is_none() {
             eprintln!("{notice}");
         }
     }
-    Ok(RemoteEndpoint {
-        url: url.value,
-        model: model.value,
-        auth: role_auth("VELESDB_MEMORY_EMBEDDER_API_TOKEN")?,
-    })
+    Ok(endpoint)
 }
 
 /// The extraction role's endpoint. No aliases to resolve: these variables were
@@ -1245,11 +1185,11 @@ fn embedder_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
 /// # Errors
 /// An `_API_TOKEN` that is set but empty.
 #[cfg(feature = "extract")]
-fn extractor_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
-    Ok(RemoteEndpoint {
+fn extractor_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::error::Error>> {
+    Ok(velesdb_memory::RemoteEndpoint {
         url: env_opt("VELESDB_MEMORY_EXTRACTOR_URL"),
         model: env_opt("VELESDB_MEMORY_EXTRACTOR_MODEL"),
-        auth: role_auth("VELESDB_MEMORY_EXTRACTOR_API_TOKEN")?,
+        auth: velesdb_memory::role_auth("VELESDB_MEMORY_EXTRACTOR_API_TOKEN")?,
     })
 }
 
@@ -1257,36 +1197,6 @@ fn extractor_endpoint() -> Result<RemoteEndpoint, Box<dyn std::error::Error>> {
 #[cfg(any(feature = "ollama", feature = "extract"))]
 fn env_opt(name: &str) -> Option<String> {
     std::env::var(name).ok()
-}
-
-/// Read a role's API token and turn it into what the transport will send.
-///
-/// The token lives in the environment and **nowhere else** — never in the TOML
-/// (arbitration B1, enforced by `velesdb_memory::config`'s
-/// `deny_unknown_fields` and its redacted refusal).
-///
-/// Note for the Ollama backends: they take no credential, so a token set
-/// alongside `backend = "ollama"` is read here and then goes unused. That is
-/// harmless — Ollama authenticates nothing — and refusing it would reject a
-/// configuration that works.
-///
-/// # Errors
-/// A variable that is set to an empty or blank value. That is not the same as
-/// unset: unset means "send no credential", while empty is a caller whose
-/// shell expansion produced nothing, and silently sending no credential would
-/// surface as a `401` they cannot explain.
-#[cfg(any(feature = "ollama", feature = "extract"))]
-fn role_auth(name: &str) -> Result<velesdb_memory::Auth, Box<dyn std::error::Error>> {
-    match env_opt(name) {
-        None => Ok(velesdb_memory::Auth::None),
-        Some(token) if token.trim().is_empty() => Err(format!(
-            "{name} is set but empty — unset it entirely to send no credential. An \
-             empty token would go out as `Authorization: Bearer `, which a server \
-             rejects as a bad credential rather than a missing one."
-        )
-        .into()),
-        Some(token) => Ok(velesdb_memory::Auth::Bearer(token)),
-    }
 }
 
 /// A backend name the library accepts but this binary has no builder for.
@@ -1450,7 +1360,7 @@ fn build_ollama_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Err
 }
 
 /// Build the OpenAI-compatible embedder. Both the URL and the model are
-/// required — see [`RemoteEndpoint::require`].
+/// required — see [`velesdb_memory::RemoteEndpoint::require`].
 #[cfg(feature = "ollama")]
 fn build_openai_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::OpenAiEmbedder;

--- a/crates/velesdb-memory/src/remote_endpoint.rs
+++ b/crates/velesdb-memory/src/remote_endpoint.rs
@@ -11,6 +11,7 @@
 //! it was until #1886, simply never reading) the resolution the daemon
 //! already had.
 
+#[cfg(feature = "ollama")]
 use crate::config::{alias_conflict_notice, resolve_alias};
 use crate::http_client::Auth;
 

--- a/crates/velesdb-memory/src/remote_endpoint.rs
+++ b/crates/velesdb-memory/src/remote_endpoint.rs
@@ -1,0 +1,128 @@
+//! Where a remote embedding/extraction backend's URL, model and credential
+//! come from — one shape for both roles, on purpose. The two were configured
+//! differently for historical reasons only — extraction by role, embedding by
+//! product — and an operator who has configured one should not have to learn
+//! the other (#1751, arbitration C1).
+//!
+//! Lives in the library, not the daemon binary, so every caller that resolves
+//! the embedding role's remote backend reads the same four
+//! `VELESDB_MEMORY_EMBEDDER*` variables the same way: the daemon and both
+//! language bindings (#1886), instead of the bindings reimplementing (or, as
+//! it was until #1886, simply never reading) the resolution the daemon
+//! already had.
+
+use crate::config::{alias_conflict_notice, resolve_alias};
+use crate::http_client::Auth;
+
+/// A remote backend's configuration, read from one role's environment.
+#[derive(Debug)]
+pub struct RemoteEndpoint {
+    /// Server origin and port, no path. `None` when unset.
+    pub url: Option<String>,
+    /// Model identifier the server expects. `None` when unset.
+    pub model: Option<String>,
+    /// The credential, already resolved to what the transport puts on the wire.
+    pub auth: Auth,
+}
+
+impl RemoteEndpoint {
+    /// The URL and model, both **required** — the `openai` shape.
+    ///
+    /// Neither has a default, and that is the design rather than an omission:
+    /// `openai` names a *protocol*, spoken by oMLX, llama.cpp, LM Studio, vLLM
+    /// and a dozen hosted providers. Guessing a URL would pick one of them for
+    /// the caller, and guessing a model would send a name no server on that
+    /// list is obliged to know. Ollama keeps its defaults because it genuinely
+    /// has one canonical local address.
+    ///
+    /// # Errors
+    /// A message naming the exact variable that is missing, per role.
+    pub fn require(self, prefix: &str) -> Result<(String, String, Auth), String> {
+        let url = self.url.ok_or_else(|| {
+            format!(
+                "{prefix}=openai requires {prefix}_URL — the server's origin and port, \
+                 no path (e.g. http://localhost:8020). There is no default: `openai` \
+                 is a protocol, and only you know which server speaks it here."
+            )
+        })?;
+        let model = self.model.ok_or_else(|| {
+            format!(
+                "{prefix}=openai requires {prefix}_MODEL — the model identifier the server expects"
+            )
+        })?;
+        Ok((url, model, self.auth))
+    }
+}
+
+/// A variable's value, or `None` when it is unset.
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok()
+}
+
+/// Read a role's API token and turn it into what the transport will send.
+///
+/// The token lives in the environment and **nowhere else** — never in the
+/// TOML (arbitration B1, enforced by [`crate::config`]'s `deny_unknown_fields`
+/// and its redacted refusal), and never as a language-binding constructor
+/// argument either, for the same reason: an argument sits in the caller's own
+/// source, one `git add .` away from a public history the way a TOML value
+/// would be.
+///
+/// # Errors
+/// A variable that is set to an empty or blank value. That is not the same as
+/// unset: unset means "send no credential", while empty is a caller whose
+/// shell expansion produced nothing, and silently sending no credential would
+/// surface as a `401` they cannot explain.
+pub fn role_auth(name: &str) -> Result<Auth, String> {
+    match env_opt(name) {
+        None => Ok(Auth::None),
+        Some(token) if token.trim().is_empty() => Err(format!(
+            "{name} is set but empty — unset it entirely to send no credential. An \
+             empty token would go out as `Authorization: Bearer `, which a server \
+             rejects as a bad credential rather than a missing one."
+        )),
+        Some(token) => Ok(Auth::Bearer(token)),
+    }
+}
+
+/// The embedding role's endpoint, honouring the legacy `VELESDB_MEMORY_OLLAMA_*`
+/// aliases (C1), plus an alias-conflict notice for the caller to print.
+///
+/// The notice is returned rather than printed here: a library must not write
+/// to a caller's stderr on its behalf (the daemon prints it gated on
+/// `VELESDB_MEMORY_QUIET`; a language binding embedded in someone else's
+/// process gets to decide for itself, and today chooses not to).
+///
+/// # Errors
+/// An `_API_TOKEN` that is set but empty.
+#[cfg(feature = "ollama")]
+pub fn embedder_env_endpoint() -> Result<(RemoteEndpoint, Option<String>), String> {
+    let url = resolve_alias(
+        env_opt("VELESDB_MEMORY_EMBEDDER_URL").as_deref(),
+        env_opt("VELESDB_MEMORY_OLLAMA_URL").as_deref(),
+    );
+    let model = resolve_alias(
+        env_opt("VELESDB_MEMORY_EMBEDDER_MODEL").as_deref(),
+        env_opt("VELESDB_MEMORY_OLLAMA_MODEL").as_deref(),
+    );
+    let mut conflicts = Vec::new();
+    if url.conflicting {
+        conflicts.push(("VELESDB_MEMORY_EMBEDDER_URL", "VELESDB_MEMORY_OLLAMA_URL"));
+    }
+    if model.conflicting {
+        conflicts.push((
+            "VELESDB_MEMORY_EMBEDDER_MODEL",
+            "VELESDB_MEMORY_OLLAMA_MODEL",
+        ));
+    }
+    let endpoint = RemoteEndpoint {
+        url: url.value,
+        model: model.value,
+        auth: role_auth("VELESDB_MEMORY_EMBEDDER_API_TOKEN")?,
+    };
+    Ok((endpoint, alias_conflict_notice(&conflicts)))
+}
+
+#[cfg(all(test, feature = "ollama"))]
+#[path = "remote_endpoint_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/remote_endpoint_tests.rs
+++ b/crates/velesdb-memory/src/remote_endpoint_tests.rs
@@ -1,0 +1,110 @@
+//! Tests for [`role_auth`] and [`embedder_env_endpoint`] — the resolution the
+//! daemon and the Python/Node bindings now share (#1886), where before only
+//! the daemon read any of these variables at all.
+
+use super::*;
+
+/// Every variable [`embedder_env_endpoint`] reads, cleared so one test's
+/// setup cannot leak into the next (tests run `--test-threads=1`, so the
+/// risk is ordering, not races).
+fn clear_embedder_vars() {
+    for key in [
+        "VELESDB_MEMORY_EMBEDDER_URL",
+        "VELESDB_MEMORY_OLLAMA_URL",
+        "VELESDB_MEMORY_EMBEDDER_MODEL",
+        "VELESDB_MEMORY_OLLAMA_MODEL",
+        "VELESDB_MEMORY_EMBEDDER_API_TOKEN",
+    ] {
+        std::env::remove_var(key);
+    }
+}
+
+#[test]
+fn role_auth_reads_no_credential_when_unset() {
+    let key = "VELESDB_MEMORY_TEST_TOKEN_UNSET";
+    std::env::remove_var(key);
+    let auth = role_auth(key).expect("an unset token is not an error");
+    assert!(matches!(auth, Auth::None));
+}
+
+#[test]
+fn role_auth_refuses_a_blank_value() {
+    let key = "VELESDB_MEMORY_TEST_TOKEN_BLANK";
+    std::env::set_var(key, "   ");
+    let err = role_auth(key).expect_err("a blank token must be refused, not sent as-is");
+    assert!(
+        err.contains(key),
+        "the refusal must name the variable, got: {err}"
+    );
+    std::env::remove_var(key);
+}
+
+#[test]
+fn role_auth_carries_a_set_token_as_bearer() {
+    let key = "VELESDB_MEMORY_TEST_TOKEN_SET";
+    std::env::set_var(key, "sk-secret");
+    let auth = role_auth(key).expect("a real token is accepted");
+    match auth {
+        Auth::Bearer(token) => assert_eq!(token, "sk-secret"),
+        other => panic!("expected a bearer token, got {other:?}"),
+    }
+    std::env::remove_var(key);
+}
+
+#[test]
+fn embedder_env_endpoint_prefers_the_role_named_variables() {
+    clear_embedder_vars();
+    std::env::set_var("VELESDB_MEMORY_EMBEDDER_URL", "http://role");
+    std::env::set_var("VELESDB_MEMORY_OLLAMA_URL", "http://legacy");
+    std::env::set_var("VELESDB_MEMORY_EMBEDDER_MODEL", "role-model");
+
+    let (endpoint, notice) = embedder_env_endpoint().expect("no token set is not an error");
+
+    assert_eq!(endpoint.url.as_deref(), Some("http://role"));
+    assert_eq!(endpoint.model.as_deref(), Some("role-model"));
+    assert!(
+        notice.is_some(),
+        "the URL disagreeing between the two names must be reported"
+    );
+    clear_embedder_vars();
+}
+
+#[test]
+fn embedder_env_endpoint_falls_back_to_the_legacy_ollama_alias() {
+    clear_embedder_vars();
+    std::env::set_var("VELESDB_MEMORY_OLLAMA_URL", "http://legacy-only");
+    std::env::set_var("VELESDB_MEMORY_OLLAMA_MODEL", "legacy-model");
+
+    let (endpoint, notice) = embedder_env_endpoint().expect("no token set is not an error");
+
+    assert_eq!(endpoint.url.as_deref(), Some("http://legacy-only"));
+    assert_eq!(endpoint.model.as_deref(), Some("legacy-model"));
+    assert!(notice.is_none(), "using only the alias is not a conflict");
+    clear_embedder_vars();
+}
+
+#[test]
+fn embedder_env_endpoint_propagates_a_blank_token() {
+    clear_embedder_vars();
+    std::env::set_var("VELESDB_MEMORY_EMBEDDER_API_TOKEN", " ");
+
+    let err = embedder_env_endpoint().expect_err("a blank token must fail resolution");
+    assert!(
+        err.contains("VELESDB_MEMORY_EMBEDDER_API_TOKEN"),
+        "got: {err}"
+    );
+    clear_embedder_vars();
+}
+
+#[test]
+fn require_reports_which_variable_is_missing() {
+    let endpoint = RemoteEndpoint {
+        url: None,
+        model: Some("m".to_owned()),
+        auth: Auth::None,
+    };
+    let err = endpoint
+        .require("VELESDB_MEMORY_EMBEDDER")
+        .expect_err("a missing url must fail");
+    assert!(err.contains("VELESDB_MEMORY_EMBEDDER_URL"), "got: {err}");
+}

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -52,8 +52,9 @@ use velesdb_memory::context::{
     WorkingContext,
 };
 use velesdb_memory::{
-    DynEmbedder, Embedder, HashEmbedder, MemoryService, OllamaEmbedder, OllamaExtractor,
-    OutlineExtractor, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    embedder_env_endpoint, select_embedder, DynEmbedder, Embedder, EmbedderSelection,
+    MemoryService, OllamaEmbedder, OllamaExtractor, OpenAiEmbedder, OutlineExtractor,
+    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::dto::{
@@ -63,26 +64,67 @@ use crate::dto::{
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
 use crate::tasks::{Job, JsonOut};
 
-/// Build the requested embedder. `"hash"` is deterministic and offline;
-/// `"ollama"` calls a local embedding model (real semantic recall).
+/// Resolve and build the requested embedder, returning it alongside the
+/// model name [`MemoryStore::memory_status`] reports.
+///
+/// `kind` is the factory's explicit `embedder` argument; when `None`,
+/// `VELESDB_MEMORY_EMBEDDER` takes over — the explicit argument always wins,
+/// the same precedence and the same [`velesdb_memory::select_embedder`] the
+/// daemon resolves the backend name through (#1886: previously this binding
+/// read no environment variable at all, so a shell that had semantic recall
+/// configured for the MCP daemon silently got the offline default here).
+/// `"hash"` is deterministic and offline; `"ollama"` and `"openai"` reach a
+/// local or remote embedding model for real semantic recall.
 fn build_embedder(
-    kind: &str,
+    kind: Option<&str>,
     url: Option<String>,
     model: Option<String>,
-) -> napi::Result<DynEmbedder> {
-    match kind {
-        "hash" => Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION))),
-        "ollama" => {
-            let url = url.unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
-            let model = model.unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
-            let embedder = OllamaEmbedder::new(url, model)
-                .map_err(|e| napi::Error::from_reason(format!("[{CODE_INTERNAL}] {e}")))?;
-            Ok(Box::new(embedder))
-        }
-        other => Err(invalid_input(format!(
-            "unknown embedder '{other}' (expected 'hash' or 'ollama')"
+) -> napi::Result<(DynEmbedder, String)> {
+    let backend_env = std::env::var("VELESDB_MEMORY_EMBEDDER").ok();
+    let selection = select_embedder(kind.or(backend_env.as_deref())).map_err(invalid_input)?;
+    match selection {
+        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned())),
+        EmbedderSelection::NeedsRemoteConfig("ollama") => build_ollama_embedder(url, model),
+        EmbedderSelection::NeedsRemoteConfig("openai") => build_openai_embedder(),
+        EmbedderSelection::NeedsRemoteConfig(other) => Err(napi::Error::from_reason(format!(
+            "[{CODE_INTERNAL}] the embedding backend '{other}' is accepted by velesdb-memory's \
+             selector but this binding has no builder for it — this is a bug in \
+             velesdb-memory, not a configuration error; please report it quoting this message"
         ))),
     }
+}
+
+/// Build the Ollama-backed embedder: an explicit argument wins, then the
+/// environment (honouring the legacy `VELESDB_MEMORY_OLLAMA_*` aliases, C1),
+/// then the built-in local defaults.
+fn build_ollama_embedder(
+    url: Option<String>,
+    model: Option<String>,
+) -> napi::Result<(DynEmbedder, String)> {
+    let (env_endpoint, _alias_conflict) = embedder_env_endpoint().map_err(invalid_input)?;
+    let url = url
+        .or(env_endpoint.url)
+        .unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
+    let model = model
+        .or(env_endpoint.model)
+        .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
+    let embedder = OllamaEmbedder::new(url, model.clone())
+        .map_err(|e| napi::Error::from_reason(format!("[{CODE_INTERNAL}] {e}")))?;
+    Ok((Box::new(embedder), model))
+}
+
+/// Build the OpenAI-compatible embedder. The URL, model and credential come
+/// from the environment only — never from a factory argument, so a caller can
+/// never end up with a token sitting in their own source file — see
+/// [`velesdb_memory::RemoteEndpoint::require`].
+fn build_openai_embedder() -> napi::Result<(DynEmbedder, String)> {
+    let (env_endpoint, _alias_conflict) = embedder_env_endpoint().map_err(invalid_input)?;
+    let (url, model, auth) = env_endpoint
+        .require("VELESDB_MEMORY_EMBEDDER")
+        .map_err(invalid_input)?;
+    let embedder = OpenAiEmbedder::new(url, model.clone(), auth)
+        .map_err(|e| napi::Error::from_reason(format!("[{CODE_INTERNAL}] {e}")))?;
+    Ok((Box::new(embedder), model))
 }
 
 /// Local-first agent memory with the `why()` graph wedge.
@@ -109,10 +151,15 @@ pub struct MemoryStore {
 impl MemoryStore {
     /// Open (or create) a memory store at `path`.
     ///
-    /// `embedder` is `"hash"` (default, offline) or `"ollama"` (real semantic
-    /// recall); `ollamaUrl`/`ollamaModel` apply when `embedder="ollama"`.
+    /// `embedder` is `"hash"` (default, offline), `"ollama"` or `"openai"`
+    /// (real semantic recall). Omit it to fall back to
+    /// `VELESDB_MEMORY_EMBEDDER` — an explicit value here always wins over the
+    /// environment. `ollamaUrl`/`ollamaModel` apply to `embedder="ollama"`
+    /// only; an explicit value wins over `VELESDB_MEMORY_EMBEDDER_URL`/`_MODEL`.
+    /// `embedder="openai"` reads its URL, model and credential from the
+    /// environment exclusively — see `crates/velesdb-memory/README.md`.
     ///
-    /// This factory is synchronous: with `embedder="ollama"` it performs a
+    /// This factory is synchronous: with a remote `embedder` it performs a
     /// one-time blocking probe of the embedding endpoint (as the `PyO3` binding
     /// does). The default `"hash"` embedder does no I/O. Per-operation methods
     /// are all async.
@@ -123,14 +170,7 @@ impl MemoryStore {
         ollama_url: Option<String>,
         ollama_model: Option<String>,
     ) -> napi::Result<Self> {
-        let kind = embedder.as_deref().unwrap_or("hash");
-        let embedder_model = match kind {
-            "hash" => "hash".to_owned(),
-            _ => ollama_model
-                .clone()
-                .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned()),
-        };
-        let emb = build_embedder(kind, ollama_url, ollama_model)?;
+        let (emb, embedder_model) = build_embedder(embedder.as_deref(), ollama_url, ollama_model)?;
         let embedder_dimension = emb.dimension();
         let svc = MemoryService::open(&path, emb).map_err(to_napi_err)?;
         Ok(Self {

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -19,11 +19,11 @@ use velesdb_memory::context::{
 };
 use velesdb_memory::service::canonical_entity_name;
 use velesdb_memory::{
-    format_dated_context, limits, ColumnFilter, ColumnOp, DatedContext, DynEmbedder, EntityProfile,
-    EntityRelation, ErrorCategory, Explanation, FusionOptions, HashEmbedder, Link, MemoryEdge,
-    MemoryError, MemoryNode, MemoryService, Metadata, OllamaEmbedder, OllamaExtractor,
-    OutlineExtractor, Recollection, RememberedExtraction, DEFAULT_DIMENSION, DEFAULT_OLLAMA_MODEL,
-    DEFAULT_OLLAMA_URL,
+    embedder_env_endpoint, format_dated_context, limits, select_embedder, ColumnFilter, ColumnOp,
+    DatedContext, DynEmbedder, EmbedderSelection, EntityProfile, EntityRelation, ErrorCategory,
+    Explanation, FusionOptions, Link, MemoryEdge, MemoryError, MemoryNode, MemoryService, Metadata,
+    OllamaEmbedder, OllamaExtractor, OpenAiEmbedder, OutlineExtractor, Recollection,
+    RememberedExtraction, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
 };
 
 use crate::collection::query::convert_params;
@@ -103,22 +103,68 @@ fn to_column_filters(
         .collect()
 }
 
-/// Build the requested embedder. `"hash"` is deterministic and offline;
-/// `"ollama"` calls a local embedding model (real semantic recall).
-fn build_embedder(kind: &str, url: Option<String>, model: Option<String>) -> PyResult<DynEmbedder> {
-    match kind {
-        "hash" => Ok(Box::new(HashEmbedder::new(DEFAULT_DIMENSION))),
-        "ollama" => {
-            let url = url.unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
-            let model = model.unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
-            let embedder = OllamaEmbedder::new(url, model)
-                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-            Ok(Box::new(embedder))
-        }
-        other => Err(PyValueError::new_err(format!(
-            "unknown embedder '{other}' (expected 'hash' or 'ollama')"
+/// Resolve and build the requested embedder, returning it alongside the
+/// model name `memory_status` reports.
+///
+/// `kind` is the constructor's explicit `embedder` argument; when `None`,
+/// `VELESDB_MEMORY_EMBEDDER` takes over — the explicit argument always wins,
+/// the same precedence and the same [`velesdb_memory::select_embedder`] the
+/// daemon resolves the backend name through (#1886: previously this binding
+/// read no environment variable at all, so a shell that had semantic recall
+/// configured for the MCP daemon silently got the offline default here).
+/// `"hash"` is deterministic and offline; `"ollama"` and `"openai"` reach a
+/// local or remote embedding model for real semantic recall.
+fn build_embedder(
+    kind: Option<&str>,
+    url: Option<String>,
+    model: Option<String>,
+) -> PyResult<(DynEmbedder, String)> {
+    let backend_env = std::env::var("VELESDB_MEMORY_EMBEDDER").ok();
+    let selection =
+        select_embedder(kind.or(backend_env.as_deref())).map_err(PyValueError::new_err)?;
+    match selection {
+        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned())),
+        EmbedderSelection::NeedsRemoteConfig("ollama") => build_ollama_embedder(url, model),
+        EmbedderSelection::NeedsRemoteConfig("openai") => build_openai_embedder(),
+        EmbedderSelection::NeedsRemoteConfig(other) => Err(PyRuntimeError::new_err(format!(
+            "the embedding backend '{other}' is accepted by velesdb-memory's selector but \
+             this binding has no builder for it — this is a bug in velesdb-memory, not a \
+             configuration error; please report it quoting this message"
         ))),
     }
+}
+
+/// Build the Ollama-backed embedder: an explicit argument wins, then the
+/// environment (honouring the legacy `VELESDB_MEMORY_OLLAMA_*` aliases, C1),
+/// then the built-in local defaults.
+fn build_ollama_embedder(
+    url: Option<String>,
+    model: Option<String>,
+) -> PyResult<(DynEmbedder, String)> {
+    let (env_endpoint, _alias_conflict) = embedder_env_endpoint().map_err(PyValueError::new_err)?;
+    let url = url
+        .or(env_endpoint.url)
+        .unwrap_or_else(|| DEFAULT_OLLAMA_URL.to_owned());
+    let model = model
+        .or(env_endpoint.model)
+        .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned());
+    let embedder = OllamaEmbedder::new(url, model.clone())
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok((Box::new(embedder), model))
+}
+
+/// Build the OpenAI-compatible embedder. The URL, model and credential come
+/// from the environment only — never from a constructor argument, so a
+/// caller can never end up with a token sitting in their own source file —
+/// see [`velesdb_memory::RemoteEndpoint::require`].
+fn build_openai_embedder() -> PyResult<(DynEmbedder, String)> {
+    let (env_endpoint, _alias_conflict) = embedder_env_endpoint().map_err(PyValueError::new_err)?;
+    let (url, model, auth) = env_endpoint
+        .require("VELESDB_MEMORY_EMBEDDER")
+        .map_err(PyValueError::new_err)?;
+    let embedder = OpenAiEmbedder::new(url, model.clone(), auth)
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok((Box::new(embedder), model))
 }
 
 /// Build the requested extractor and run it, releasing the GIL for the call.
@@ -376,23 +422,22 @@ impl PyMemoryService {
     ///
     /// Args:
     ///     path: store directory (created if missing; memory never leaves it).
-    ///     embedder: "hash" (default, offline) or "ollama" (real semantic recall).
-    ///     ollama_url / ollama_model: used when embedder="ollama".
+    ///     embedder: "hash" (default, offline), "ollama" or "openai" (real
+    ///         semantic recall). Omit to fall back to `VELESDB_MEMORY_EMBEDDER`
+    ///         — an explicit value here always wins over the environment.
+    ///     ollama_url / ollama_model: apply to embedder="ollama" only; an
+    ///         explicit value wins over `VELESDB_MEMORY_EMBEDDER_URL`/`_MODEL`.
+    ///         embedder="openai" reads its URL, model and credential from the
+    ///         environment exclusively — see `crates/velesdb-memory/README.md`.
     #[new]
-    #[pyo3(signature = (path, embedder = "hash", ollama_url = None, ollama_model = None))]
+    #[pyo3(signature = (path, embedder = None, ollama_url = None, ollama_model = None))]
     fn new(
         path: String,
-        embedder: &str,
+        embedder: Option<&str>,
         ollama_url: Option<String>,
         ollama_model: Option<String>,
     ) -> PyResult<Self> {
-        let embedder_model = match embedder {
-            "hash" => "hash".to_owned(),
-            _ => ollama_model
-                .clone()
-                .unwrap_or_else(|| DEFAULT_OLLAMA_MODEL.to_owned()),
-        };
-        let emb = build_embedder(embedder, ollama_url, ollama_model)?;
+        let (emb, embedder_model) = build_embedder(embedder, ollama_url, ollama_model)?;
         let embedder_dimension = emb.dimension();
         let svc = MemoryService::open(&path, emb).map_err(to_py_err)?;
         Ok(Self {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Closes #1886.

The embedder backend is documented everywhere as an environment-variable
choice (`VELESDB_MEMORY_EMBEDDER`), but only the MCP daemon actually read
it. `MemoryService(path)` on Python and `MemoryService.open(path)` on Node
silently used the offline `hash` embedder regardless of the environment,
with no warning, and `openai` did not exist as a binding-level backend at
all even though the library underneath has shipped `OpenAiEmbedder` since
the daemon gained it.

**Fix, in three commits:**

1. `refactor(memory)` — moves `RemoteEndpoint`, `role_auth` and the
   embedding role's env resolution (`VELESDB_MEMORY_EMBEDDER_URL`/`_MODEL`
   with the legacy `OLLAMA_*` aliases, plus the API token) out of the
   daemon's `main.rs` and into a new `velesdb_memory::remote_endpoint`
   module, alongside the existing `select_embedder` seam. The
   alias-conflict notice is returned as data instead of being printed,
   since a library must not write to a caller's stderr on its behalf —
   `main.rs` keeps that one behaviour as a thin wrapper. Behavior-preserving
   for the daemon; adds direct unit coverage that the daemon-only shape
   could not get without starting the process and reading its stderr.
2. `fix(python)` / `fix(node)` — both bindings now resolve the backend
   through `select_embedder`/`embedder_env_endpoint`, the same functions
   the daemon uses. An explicit constructor/factory argument always wins
   over the environment. `openai`'s URL and credential are read from the
   environment only — never a constructor argument — matching the rule
   already enforced daemon-side (a token must never sit in a caller's own
   source file).

**Migration note:** Python's `embedder` constructor argument default
changes from the literal `"hash"` to `None`, which is what's needed to
tell "caller did not specify" (env, then `hash`) apart from "caller
explicitly asked for `hash`". Existing callers who pass nothing are
unaffected unless `VELESDB_MEMORY_EMBEDDER` happens to be set in their
environment — which is exactly the behaviour this fixes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes) — the library extraction commit

## How Has This Been Tested?

- [x] Unit tests — 7 new tests for `role_auth`/`embedder_env_endpoint`
      (precedence, alias fallback, blank-token refusal); full
      `velesdb-memory` suite (681 passed, 0 failed) and doctests green.
- [ ] Integration tests — the Python/Node binding test suites
      (`pytest`, `node --test`) need a built extension/addon; not run in
      this sandbox (no `maturin`/`napi` toolchain available here). Both
      crates compile and lint clean (`cargo check`/`cargo clippy -D
      warnings` for `velesdb-python` and `velesdb-node`), and the
      existing Node contract test for the unknown-embedder error message
      (`'INVALID_INPUT'`, `'hash'`, `'ollama'` substrings) still holds
      against the new message from `select_embedder`.
- [x] Manual testing — traced the precedence logic by hand against the
      issue's reproduction case.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90.0 (pinned toolchain)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings (`cargo clippy --workspace
      --all-targets --features persistence,gpu,update-check --exclude
      velesdb-python --exclude velesdb-node --exclude tauri-plugin-velesdb
      -- -D warnings -D clippy::pedantic`, plus `velesdb-python` and
      `velesdb-node` linted separately, all clean; `tauri-plugin-velesdb`
      excluded only because this sandbox lacks its GTK system deps,
      unrelated to this change)
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — this PR adds no `unsafe` code.

## Additional Notes

`cargo deny` and the Node/Python integration test suites could not run in
this sandbox (missing tool / toolchain); CI covers both.
