### PR TITLE
fix(node): ship npm package entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -883,6 +883,19 @@ jobs:
           npx napi build --platform
           npm test
 
+      # Mirror the release assembly before any tag exists: test the root
+      # tarball plus its native package from a clean npm install, never the
+      # build directory where generated entrypoints happen to be present.
+      - name: Smoke-test the packed Node package from a clean install
+        working-directory: crates/velesdb-node
+        run: |
+          mkdir -p artifacts
+          cp -- ./*.node artifacts/
+          npx napi create-npm-dirs
+          npx napi artifacts --output-dir ./artifacts
+          for d in npm/*/; do cp LICENSE README.md "$d"; done
+          node scripts/smoke-packed-package.mjs npm/linux-x64-gnu
+
       # EPIC-P-071/A1 non-regression gate: "the facts survive compilation".
       # Reuses the napi addon just built above (no second Rust build) — this
       # job is the cheapest place to run it: the "Tests" job never sets up

--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -295,6 +295,16 @@ jobs:
           path: crates/velesdb-node/*.node
           if-no-files-found: error
 
+      - name: Upload generated root package entrypoints
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-package-entrypoints
+          path: |
+            crates/velesdb-node/index.js
+            crates/velesdb-node/index.d.ts
+          if-no-files-found: error
+
   # ===========================================================================
   # 4. Assemble per-platform packages and publish to npm
   # ===========================================================================
@@ -329,6 +339,12 @@ jobs:
           pattern: bindings-*
           merge-multiple: true
 
+      - name: Restore generated root package entrypoints
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: node-package-entrypoints
+          path: crates/velesdb-node
+
       - name: Stage native binaries into per-platform npm dirs
         # Each per-platform package is published separately, so it must carry the
         # VelesDB Core License text itself — `create-npm-dirs` does not copy it.
@@ -339,6 +355,9 @@ jobs:
           npx napi artifacts --output-dir ./artifacts
           for d in npm/*/; do cp LICENSE README.md "$d"; done
           ls -R ./npm
+
+      - name: Smoke-test the packed root package from a clean install
+        run: node scripts/smoke-packed-package.mjs npm/linux-x64-gnu
 
       - name: Publish to npm
         # `prepublishOnly` (napi prepublish -t npm) publishes the per-platform

--- a/crates/velesdb-node/scripts/smoke-packed-package.mjs
+++ b/crates/velesdb-node/scripts/smoke-packed-package.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -17,7 +17,6 @@ function run(command, args, cwd) {
 }
 
 function pack(packageDir, destination) {
-  mkdirSync(destination)
   const output = run('npm', ['pack', '--json', '--pack-destination', destination], packageDir)
   const reports = JSON.parse(output)
   assert.equal(reports.length, 1, `expected one packed artifact, got ${reports.length}`)
@@ -32,8 +31,7 @@ function assertRootEntries(report) {
 }
 
 function installAndRequire(consumerDir, rootTarball, platformTarball) {
-  mkdirSync(consumerDir)
-  writeFileSync(join(consumerDir, 'package.json'), '{"private":true}\n')
+  run('npm', ['init', '-y'], consumerDir)
   run(
     'npm',
     [
@@ -48,15 +46,6 @@ function installAndRequire(consumerDir, rootTarball, platformTarball) {
     consumerDir,
   )
 
-  const installedRoot = join(
-    consumerDir,
-    'node_modules',
-    '@wiscale',
-    'velesdb-memory-node',
-  )
-  for (const file of REQUIRED_ROOT_FILES) {
-    assert.ok(existsSync(join(installedRoot, file)), `fresh install is missing ${file}`)
-  }
   run(
     process.execPath,
     [
@@ -70,18 +59,20 @@ function installAndRequire(consumerDir, rootTarball, platformTarball) {
 }
 
 const platformPackageDir = process.argv[2]
-assert.ok(platformPackageDir, 'usage: smoke-packed-package.mjs <platform-package-dir>')
+if (!platformPackageDir) {
+  throw new Error('usage: smoke-packed-package.mjs <platform-package-dir>')
+}
 
 const packageRoot = process.cwd()
 const platformRoot = resolve(packageRoot, platformPackageDir)
 
 const scratch = mkdtempSync(join(tmpdir(), 'velesdb-node-pack-'))
 try {
-  const root = pack(packageRoot, join(scratch, 'root'))
+  const root = pack(packageRoot, mkdtempSync(join(scratch, 'root-')))
   assertRootEntries(root.report)
-  assert.ok(existsSync(platformRoot), `platform package directory not found: ${platformRoot}`)
-  const platform = pack(platformRoot, join(scratch, 'platform'))
-  installAndRequire(join(scratch, 'consumer'), root.tarball, platform.tarball)
+  const platform = pack(platformRoot, mkdtempSync(join(scratch, 'platform-')))
+  const consumer = mkdtempSync(join(scratch, 'consumer-'))
+  installAndRequire(consumer, root.tarball, platform.tarball)
   console.log('packed root package installs and loads from a clean directory')
 } finally {
   rmSync(scratch, { recursive: true, force: true })

--- a/crates/velesdb-node/scripts/smoke-packed-package.mjs
+++ b/crates/velesdb-node/scripts/smoke-packed-package.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const REQUIRED_ROOT_FILES = ['index.js', 'index.d.ts']
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed (${result.status})\n${result.stdout}${result.stderr}`,
+    )
+  }
+  return result.stdout
+}
+
+function pack(packageDir, destination) {
+  mkdirSync(destination)
+  const output = run('npm', ['pack', '--json', '--pack-destination', destination], packageDir)
+  const reports = JSON.parse(output)
+  assert.equal(reports.length, 1, `expected one packed artifact, got ${reports.length}`)
+  return { report: reports[0], tarball: join(destination, reports[0].filename) }
+}
+
+function assertRootEntries(report) {
+  const paths = new Set(report.files.map(({ path }) => path))
+  for (const file of REQUIRED_ROOT_FILES) {
+    assert.ok(paths.has(file), `packed root package is missing ${file}`)
+  }
+}
+
+function installAndRequire(consumerDir, rootTarball, platformTarball) {
+  mkdirSync(consumerDir)
+  writeFileSync(join(consumerDir, 'package.json'), '{"private":true}\n')
+  run(
+    'npm',
+    [
+      'install',
+      '--offline',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      rootTarball,
+      platformTarball,
+    ],
+    consumerDir,
+  )
+
+  const installedRoot = join(
+    consumerDir,
+    'node_modules',
+    '@wiscale',
+    'velesdb-memory-node',
+  )
+  for (const file of REQUIRED_ROOT_FILES) {
+    assert.ok(existsSync(join(installedRoot, file)), `fresh install is missing ${file}`)
+  }
+  run(
+    process.execPath,
+    [
+      '-e',
+      "const addon = require('@wiscale/velesdb-memory-node'); " +
+        "if (typeof addon.MemoryService?.open !== 'function') " +
+        "throw new Error('MemoryService.open is missing')",
+    ],
+    consumerDir,
+  )
+}
+
+const platformPackageDir = process.argv[2]
+assert.ok(platformPackageDir, 'usage: smoke-packed-package.mjs <platform-package-dir>')
+
+const packageRoot = process.cwd()
+const platformRoot = resolve(packageRoot, platformPackageDir)
+
+const scratch = mkdtempSync(join(tmpdir(), 'velesdb-node-pack-'))
+try {
+  const root = pack(packageRoot, join(scratch, 'root'))
+  assertRootEntries(root.report)
+  assert.ok(existsSync(platformRoot), `platform package directory not found: ${platformRoot}`)
+  const platform = pack(platformRoot, join(scratch, 'platform'))
+  installAndRequire(join(scratch, 'consumer'), root.tarball, platform.tarball)
+  console.log('packed root package installs and loads from a clean directory')
+} finally {
+  rmSync(scratch, { recursive: true, force: true })
+}


### PR DESCRIPTION
## What changed

- Preserve the generated `index.js` and `index.d.ts` from the Linux N-API build as a dedicated workflow artifact, then restore them into the clean publication checkout.
- Add a tarball-level smoke guard to the required `node-binding-tests` job and to `publish-npm` immediately before publication.
- Pack the root and Linux native packages, assert both root entrypoints are present in the packed-file report, then install both tarballs into a fresh directory with `--offline --ignore-scripts` and load `MemoryService.open` through the public package name.

## Root cause

`napi build` generated both root entrypoints in each matrix build, but the workflow uploaded only `*.node`. The publication job started from a fresh checkout, so npm silently omitted the missing files declared in `files`. The existing smoke test loaded the build directory and could not detect the broken tarball.

## Impact

Future packages retain the generated loader and types without compiling Rust a second time in the publication job. There is no public API change. Publication of the 0.11.x patch remains a separate hotfix step from a compatible 0.11.x base; this PR does not publish or retag anything.

## Verification

- Reproduced `@wiscale/velesdb-memory-node@0.11.6`: installation succeeds, then `require()` fails because its 5-file tarball has neither entrypoint.
- Negative control: the new guard rejects the clean tree on missing `index.js`.
- Positive control: a packed root fixture plus the real Linux native package installs offline and loads from a fresh directory.
- `node --check` and both workflow YAML files parse.
- 428 Python guard tests pass (9 expected skips).
- Version, feature-claim, performance-claim, promise, MCP-doc, skill-reference, doc-freshness, unwrap, TODO and agent-hook guards pass.
- Codacy reports 0 new issues and complexity 7.
- The actual Rust/N-API build is delegated to the required Linux and Windows CI jobs because this runtime has no Rust toolchain.

Refs #1883