### PR TITLE
fix(node): disable GitHub release during npm prepublish

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -360,9 +360,11 @@ jobs:
         run: node scripts/smoke-packed-package.mjs npm/linux-x64-gnu
 
       - name: Publish to npm
-        # `prepublishOnly` (napi prepublish -t npm) publishes the per-platform
+        # `prepublishOnly` publishes the per-platform
         # @wiscale/velesdb-memory-node-<triple> packages and injects them as
-        # optionalDependencies before the root package is published here. The
+        # optionalDependencies before the root package is published here. It
+        # passes `--no-gh-release`: this workflow owns no GitHub release and
+        # napi enables that unrelated side effect by default (#1903). The
         # already-published guard below mirrors release.yml so a re-run is idempotent
         # for the ROOT package.
         #

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -44,7 +44,7 @@
     "build": "napi build --platform --profile release-node",
     "build:debug": "napi build --platform",
     "test": "node --test __test__/*.spec.mjs",
-    "prepublishOnly": "napi prepublish -t npm"
+    "prepublishOnly": "napi prepublish -t npm --no-gh-release"
   },
   "devDependencies": {
     "@napi-rs/cli": "^3.0.0"

--- a/scripts/tests/test_node_prepublish_contract.py
+++ b/scripts/tests/test_node_prepublish_contract.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""The npm-only memory release must not create a GitHub release."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_JSON = ROOT / "crates" / "velesdb-node" / "package.json"
+
+
+def github_release_is_disabled(command: str) -> bool:
+    """Return whether the napi prepublish hook explicitly opts out."""
+    return "--no-gh-release" in command.split()
+
+
+class NodePrepublishContract(unittest.TestCase):
+    def test_napi_github_release_side_effect_is_disabled(self) -> None:
+        package = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))
+        command = package["scripts"]["prepublishOnly"]
+
+        self.assertEqual(command.split()[:4], ["napi", "prepublish", "-t", "npm"])
+        self.assertTrue(
+            github_release_is_disabled(command),
+            "napi enables GitHub releases by default; npm-only publication must opt out",
+        )
+
+    def test_previous_implicit_default_is_refused(self) -> None:
+        self.assertFalse(github_release_is_disabled("napi prepublish -t npm"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1903.

## What changed

- Passes `--no-gh-release` to the Node package's `napi prepublish` hook.
- Adds a deterministic contract that accepts the explicit opt-out and rejects the previous implicit default.
- Documents the boundary in the npm release workflow.

## Root cause

`@napi-rs/cli 3.7.2` enables GitHub release creation by default. On GitHub Actions, `GITHUB_REPOSITORY` makes that path reachable even in the npm-only job. Because that job intentionally has `contents: read`, the unrelated release attempt returned 401 and the CLI swallowed it before continuing with npm publication.

## Validation

- `python3 -m unittest scripts.tests.test_node_prepublish_contract` — 2 passed.
- Full guard suite — 430 passed, 9 skipped.
- Pinned CLI dry-run with `--no-gh-release` — passed and resolved `ghRelease: false`.
- Attribution and whitespace guards — passed.

## Scope

No tag, release, registry version, or native-package idempotence behavior changes.
