### PR TITLE
fix(release): verify memory registry publication (#1884)

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -392,7 +392,36 @@ jobs:
           fi
 
   # ===========================================================================
-  # 5. Build the daemon binary for each platform (--features ollama,http,extract)
+  # 5. Verify the release is actually visible from both public registries
+  # ===========================================================================
+  verify-registries:
+    name: Verify public registries
+    runs-on: ubuntu-latest
+    needs: [validate, publish-crate, publish-npm]
+    if: |
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.publish-crate.result == 'success' &&
+      needs.publish-npm.result == 'success'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Wait for crates.io and npm propagation
+        run: |
+          set -euo pipefail
+          for attempt in {1..12}; do
+            if python3 scripts/check-version-sync.py --check-memory-registries; then
+              echo "✅ Public registries publish every velesdb-memory ${{ needs.validate.outputs.version }} artifact"
+              exit 0
+            fi
+            echo "⚠️ Registry propagation incomplete (attempt $attempt/12)"
+            if [ "$attempt" -lt 12 ]; then sleep 15; fi
+          done
+          echo "❌ Public registry versions still disagree with the release manifest"
+          exit 1
+
+  # ===========================================================================
+  # 6. Build the daemon binary for each platform (--features ollama,http,extract)
   # ===========================================================================
   #
   # Same crate/bin as the default-feature .mcpb bundles in release-mcpb.yml,
@@ -502,7 +531,7 @@ jobs:
           if-no-files-found: error
 
   # ===========================================================================
-  # 6. Attach the daemon archives to the GitHub Release
+  # 7. Attach the daemon archives to the GitHub Release
   # ===========================================================================
   #
   # release-mcpb.yml separately creates/updates the SAME velesdb-memory-vX.Y.Z

--- a/scripts/check-version-sync.py
+++ b/scripts/check-version-sync.py
@@ -7,6 +7,8 @@ import re
 import sys
 from pathlib import Path
 
+from version_registry import memory_registry_mismatches
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # NOTE: TARGETS is a list of (path, format) tuples — NOT a dict — because
@@ -663,7 +665,7 @@ def _compare_targets(
             )
 
 
-def run(root: Path) -> int:
+def run(root: Path, check_memory_registries: bool = False) -> int:
     expected = _read_cargo_version(root)
     print(f"Workspace version (Cargo.toml): {expected}")
 
@@ -680,6 +682,16 @@ def run(root: Path) -> int:
             print(f"  - {m}")
         return 1
 
+    if check_memory_registries:
+        print("\nPublic velesdb-memory registries:")
+        registry_mismatches = memory_registry_mismatches(memory_expected)
+        if registry_mismatches:
+            print("Registry publication mismatch(es) detected:")
+            for mismatch in registry_mismatches:
+                print(f"  - {mismatch}")
+            return 1
+        print(f"  OK    crates.io and all npm packages publish {memory_expected}")
+
     print("\nAll versions match.")
     return 0
 
@@ -687,13 +699,18 @@ def run(root: Path) -> int:
 def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(description="Check version stamps stay in sync.")
     parser.add_argument("--root", default=str(REPO_ROOT), help="repository root to scan")
+    parser.add_argument(
+        "--check-memory-registries",
+        action="store_true",
+        help="also require the public memory crate and npm packages to match",
+    )
     args = parser.parse_args(argv)
     # A tree this guard cannot read answers 2, never 1. Both anchor files are
     # read unguarded (`Cargo.toml`, the memory crate manifest), and a missing
     # one used to surface as a FileNotFoundError traceback — which also exits 1
     # and would have passed for a refusal it never made.
     try:
-        return run(Path(args.root).resolve())
+        return run(Path(args.root).resolve(), args.check_memory_registries)
     except (OSError, RuntimeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/tests/test_check_version_sync.py
+++ b/scripts/tests/test_check_version_sync.py
@@ -24,6 +24,8 @@ import unittest
 from pathlib import Path
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-version-sync.py"
+if str(SCRIPT_PATH.parent) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_PATH.parent))
 
 
 def _load_script() -> types.ModuleType:

--- a/scripts/tests/test_version_registry.py
+++ b/scripts/tests/test_version_registry.py
@@ -1,0 +1,83 @@
+"""Tests for the velesdb-memory public-registry publication guard."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts import version_registry as registry
+
+EXPECTED = "0.12.0"
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-memory.yml"
+
+
+def _responses(version: str = EXPECTED) -> dict[str, dict]:
+    responses = {registry.CRATES_URL: {"crate": {"max_version": version}}}
+    for package in registry.NPM_PACKAGES:
+        responses[registry._npm_url(package)] = {"dist-tags": {"latest": version}}
+    return responses
+
+
+class MemoryRegistryTests(unittest.TestCase):
+    def test_all_public_artifacts_at_the_manifest_version_pass(self):
+        responses = _responses()
+
+        self.assertEqual(
+            registry.memory_registry_mismatches(EXPECTED, responses.__getitem__),
+            [],
+        )
+
+    def test_stale_crate_root_and_native_package_are_all_reported(self):
+        responses = _responses()
+        responses[registry.CRATES_URL]["crate"]["max_version"] = "0.11.6"
+        root_url = registry._npm_url(registry.NPM_PACKAGES[0])
+        responses[root_url]["dist-tags"]["latest"] = "0.11.7"
+        native = registry.NPM_PACKAGES[-1]
+        responses[registry._npm_url(native)]["dist-tags"]["latest"] = "0.11.7"
+
+        mismatches = registry.memory_registry_mismatches(
+            EXPECTED, responses.__getitem__
+        )
+
+        self.assertEqual(len(mismatches), 3)
+        self.assertTrue(any("crates.io" in mismatch for mismatch in mismatches))
+        self.assertTrue(any("latest" in mismatch for mismatch in mismatches))
+        self.assertTrue(any(native in mismatch for mismatch in mismatches))
+
+    def test_missing_registry_metadata_is_an_infrastructure_error(self):
+        responses = _responses()
+        responses[registry.CRATES_URL] = {"crate": {}}
+
+        with self.assertRaises(registry.RegistryError):
+            registry.memory_registry_mismatches(EXPECTED, responses.__getitem__)
+
+    def test_every_release_workflow_native_package_is_covered(self):
+        self.assertEqual(
+            set(registry.NPM_PACKAGES[1:]),
+            {
+                "@wiscale/velesdb-memory-node-darwin-arm64",
+                "@wiscale/velesdb-memory-node-darwin-x64",
+                "@wiscale/velesdb-memory-node-linux-arm64-gnu",
+                "@wiscale/velesdb-memory-node-linux-x64-gnu",
+                "@wiscale/velesdb-memory-node-win32-x64-msvc",
+            },
+        )
+
+    def test_release_waits_for_both_publication_jobs_then_runs_the_guard(self):
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        block = workflow.split("  verify-registries:", 1)[1].split(
+            "\n  # ===========================================================================",
+            1,
+        )[0]
+
+        self.assertIn("needs: [validate, publish-crate, publish-npm]", block)
+        self.assertIn("needs.publish-crate.result == 'success'", block)
+        self.assertIn("needs.publish-npm.result == 'success'", block)
+        self.assertIn(
+            "scripts/check-version-sync.py --check-memory-registries", block
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/version_registry.py
+++ b/scripts/version_registry.py
@@ -1,0 +1,86 @@
+"""Read the public registries for the independently versioned memory packages."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+CRATES_URL = "https://crates.io/api/v1/crates/velesdb-memory"
+NPM_REGISTRY = "https://registry.npmjs.org"
+NPM_PACKAGES = (
+    "@wiscale/velesdb-memory-node",
+    "@wiscale/velesdb-memory-node-darwin-arm64",
+    "@wiscale/velesdb-memory-node-darwin-x64",
+    "@wiscale/velesdb-memory-node-linux-arm64-gnu",
+    "@wiscale/velesdb-memory-node-linux-x64-gnu",
+    "@wiscale/velesdb-memory-node-win32-x64-msvc",
+)
+
+JsonObject = dict[str, Any]
+JsonFetcher = Callable[[str], JsonObject]
+
+
+class RegistryError(RuntimeError):
+    """The registry could not provide trustworthy version metadata."""
+
+
+def _fetch_json(url: str) -> JsonObject:
+    request = Request(url, headers={"User-Agent": "VelesDB-version-sync/1"})
+    try:
+        with urlopen(request, timeout=15) as response:
+            payload = json.load(response)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RegistryError(f"Could not query {url}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RegistryError(f"Registry response from {url} is not a JSON object")
+    return payload
+
+
+def _field(payload: JsonObject, path: tuple[str, ...], source: str) -> str:
+    value: Any = payload
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            dotted = ".".join(path)
+            raise RegistryError(f"Missing {dotted} in registry response from {source}")
+        value = value[key]
+    if not isinstance(value, str) or not value:
+        dotted = ".".join(path)
+        raise RegistryError(f"Invalid {dotted} in registry response from {source}")
+    return value
+
+
+def _npm_url(package: str) -> str:
+    return f"{NPM_REGISTRY}/{quote(package, safe='@')}"
+
+
+def read_public_memory_versions(
+    fetch_json: JsonFetcher | None = None,
+) -> list[tuple[str, str]]:
+    """Return every public version needed by a working memory installation."""
+    fetch = fetch_json or _fetch_json
+    crates = fetch(CRATES_URL)
+    versions = [
+        ("crates.io velesdb-memory", _field(crates, ("crate", "max_version"), CRATES_URL)),
+    ]
+    for package in NPM_PACKAGES:
+        url = _npm_url(package)
+        payload = fetch(url)
+        latest = _field(payload, ("dist-tags", "latest"), url)
+        versions.append((f"npm {package} latest", latest))
+    return versions
+
+
+def memory_registry_mismatches(
+    expected: str,
+    fetch_json: JsonFetcher | None = None,
+) -> list[str]:
+    """Describe public artifacts that do not match the memory manifest."""
+    versions = read_public_memory_versions(fetch_json)
+    return [
+        f"{label}: expected {expected}, found {actual}"
+        for label, actual in versions
+        if actual != expected
+    ]


### PR DESCRIPTION
## Summary

- add an opt-in public-registry check to `scripts/check-version-sync.py`
- verify crates.io, the root npm package, and all five native npm packages
- make the memory release wait for both publication jobs and fail if public versions drift

## Verification

- 435 script contract tests pass (9 skipped)
- normal version-sync remains offline and passes
- public-registry mode refuses the current 0.11.6/0.11.7 registry state against the 0.12.0 manifests
- feature, performance, promise, MCP documentation, skill-reference, doc-contract, and freshness guards pass
- workflow YAML parses with the new `verify-registries` job

Part of #1884. The issue stays open until `velesdb-memory-v0.12.0` is published and verified from both public registries.