### PR TITLE
fix(core): preserve concurrent HNSW mappings

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -145,8 +145,9 @@ impl HnswIndex {
         if assigned_id != result.idx {
             // Remove stale reverse mapping before restoring the correct one.
             // upsert_mapping created idx_to_id[result.idx] = id, but the graph
-            // assigned a different node_id, so result.idx is now orphaned.
-            self.mappings.remove_reverse(result.idx);
+            // assigned a different node_id, so result.idx is now stale unless
+            // another concurrent correction already owns it.
+            self.mappings.remove_reverse(result.idx, id);
             self.mappings.restore(id, assigned_id);
         }
         true

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
@@ -271,11 +271,18 @@ impl ShardedMappings {
 
     /// Removes a stale reverse mapping (`idx` -> `id`) without touching the forward mapping.
     ///
-    /// Used when `insert_and_correct_mapping` detects a concurrent race: the
-    /// forward mapping `id -> idx` was already corrected by `restore()`, but the
-    /// old `idx_to_id[old_idx]` entry is still dangling.
-    pub fn remove_reverse(&self, idx: usize) {
-        self.idx_to_id.remove(&idx);
+    /// Removal is conditional because another concurrent insertion may already
+    /// have corrected this slot to its own ID. Deleting by index alone would
+    /// erase that valid mapping and make the other vector unreachable.
+    pub fn remove_reverse(&self, idx: usize, expected_id: u64) {
+        use dashmap::mapref::entry::Entry;
+
+        let Entry::Occupied(entry) = self.idx_to_id.entry(idx) else {
+            return;
+        };
+        if *entry.get() == expected_id {
+            entry.remove();
+        }
     }
 
     /// Removes an ID and returns its internal index if it existed.

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings_tests.rs
@@ -338,7 +338,7 @@ fn test_remove_reverse_cleans_stale_idx_to_id() {
     assert_eq!(mappings.get_id(idx), Some(42));
 
     // remove_reverse only removes the reverse mapping (idx -> id)
-    mappings.remove_reverse(idx);
+    mappings.remove_reverse(idx, 42);
 
     // Forward mapping (id -> idx) must survive
     assert_eq!(mappings.get_idx(42), Some(idx));
@@ -354,7 +354,7 @@ fn test_remove_reverse_nonexistent_idx_is_noop() {
     mappings.register(42).expect("register");
 
     // Removing a reverse mapping for an idx that doesn't exist is a no-op
-    mappings.remove_reverse(999);
+    mappings.remove_reverse(999, 42);
 
     assert_eq!(mappings.len(), 1);
     assert_eq!(mappings.get_idx(42), Some(0));
@@ -375,7 +375,7 @@ fn test_remove_reverse_then_restore_fixes_divergence() {
     let correct_idx: usize = 5;
 
     // Step 3: remove stale reverse mapping
-    mappings.remove_reverse(stale_idx);
+    mappings.remove_reverse(stale_idx, 42);
     assert_eq!(mappings.get_id(stale_idx), None);
 
     // Step 4: restore with correct idx
@@ -384,6 +384,17 @@ fn test_remove_reverse_then_restore_fixes_divergence() {
     assert_eq!(mappings.get_id(correct_idx), Some(42));
     // Stale reverse mapping still gone
     assert_eq!(mappings.get_id(stale_idx), None);
+}
+
+#[test]
+fn test_remove_reverse_preserves_a_concurrently_corrected_owner() {
+    let mappings = ShardedMappings::new();
+    let idx = mappings.register(42).expect("register original owner");
+
+    mappings.restore(84, idx);
+    mappings.remove_reverse(idx, 42);
+
+    assert_eq!(mappings.get_id(idx), Some(84));
 }
 
 // -------------------------------------------------------------------------

--- a/crates/velesdb-core/src/index/hnsw/upsert.rs
+++ b/crates/velesdb-core/src/index/hnsw/upsert.rs
@@ -127,7 +127,7 @@ pub(crate) fn reconcile_batch_mappings(
             // Graph assigned a different node ID than upsert_mapping expected.
             // Remove the stale reverse mapping (result.idx -> ext_id) and
             // establish the correct mapping (ext_id <-> assigned_id).
-            mappings.remove_reverse(result.idx);
+            mappings.remove_reverse(result.idx, *ext_id);
             mappings.restore(*ext_id, *assigned_id);
         }
     }

--- a/crates/velesdb-core/src/index/hnsw/upsert_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/upsert_tests.rs
@@ -1,7 +1,9 @@
 //! Tests for `upsert` module — shared upsert-mapping logic.
 
 use super::sharded_mappings::ShardedMappings;
-use super::upsert::{rollback_upsert, upsert_mapping, upsert_mapping_batch};
+use super::upsert::{
+    reconcile_batch_mappings, rollback_upsert, upsert_mapping, upsert_mapping_batch,
+};
 
 // -------------------------------------------------------------------------
 // upsert_mapping_batch tests (issue #375)
@@ -88,6 +90,21 @@ fn test_upsert_mapping_batch_single_element() {
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].old_idx, None);
     assert_eq!(mappings.len(), 1);
+}
+
+#[test]
+fn test_crossed_reconciliations_preserve_both_reverse_mappings() {
+    let mappings = ShardedMappings::new();
+    let first = upsert_mapping(&mappings, 10);
+    let second = upsert_mapping(&mappings, 20);
+
+    reconcile_batch_mappings(&mappings, &[(10, first.clone())], &[second.idx]);
+    reconcile_batch_mappings(&mappings, &[(20, second.clone())], &[first.idx]);
+
+    assert_eq!(mappings.get_idx(10), Some(second.idx));
+    assert_eq!(mappings.get_id(second.idx), Some(10));
+    assert_eq!(mappings.get_idx(20), Some(first.idx));
+    assert_eq!(mappings.get_id(first.idx), Some(20));
 }
 
 // -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1907.

## What changed

- remove a stale reverse HNSW mapping only when the slot still belongs to the insertion being reconciled
- preserve a mapping that another concurrent reconciliation has already corrected
- add a deterministic crossed-reconciliation regression test plus a focused conditional-removal test

## Why

The exact `main` commit prepared for the `velesdb-memory` 0.12.0 release exposed a successful concurrent write that vector recall could no longer reach. Two insertions can reserve mapping indices in one order and receive graph node IDs in the opposite order; unconditional cleanup let the second reconciliation erase the first one's valid reverse mapping.

## Validation

- `git diff --check`
- production unwrap guard
- TODO annotation guard
- attribution guard
- full Rust formatting, clippy, tests, and concurrency transport coverage delegated to required CI because the local environment does not provide `cargo`

Blocks #1884.