### PR TITLE
fix(docs): route MCPB installs through registry

### DIFF
--- a/.github/workflows/promise-contract.yml
+++ b/.github/workflows/promise-contract.yml
@@ -10,6 +10,7 @@ on:
     branches: [main, develop]
     paths:
       - 'README.md'
+      - 'docs/**/*.md'
       - 'crates/velesdb-core/README.md'
       - 'crates/velesdb-core/src/quantization/mod.rs'
       - 'docs/guides/QUANTIZATION.md'

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ claude mcp add velesdb-memory -- ~/.cargo/bin/velesdb-memory    # any MCP client
 curl -L https://github.com/cyberlife-coder/VelesDB/releases/latest/download/velesdb-skills.tar.gz | tar -xz -C ~/.claude/skills/
 ```
 
-No Rust toolchain? `npm i @wiscale/velesdb-memory-node`, or grab a prebuilt `.mcpb` bundle from the [latest release](https://github.com/cyberlife-coder/VelesDB/releases/latest).
+No Rust toolchain? `npm i @wiscale/velesdb-memory-node`, or grab a prebuilt `.mcpb` bundle from the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=velesdb-memory) (`io.github.cyberlife-coder/velesdb-memory`).
 
 <details>
 <summary><strong>Other paths — always-on hooks, shared daemon, Rust, Docker, WASM, REST</strong></summary>
@@ -210,7 +210,7 @@ No figure here is an estimate from a slide; each links to the log or script in t
 |---|---|---|
 | Try it in one file | [`velesdb`](https://pypi.org/project/velesdb/) (Python 3.9+) | Fastest onboarding path |
 | Embed the engine | [`velesdb-core`](https://crates.io/crates/velesdb-core) (Rust) | The engine itself |
-| Give my agent memory | [`velesdb-memory`](crates/velesdb-memory) | MCP server + context compiler, any MCP client; `.mcpb` bundles on the [MCP registry](https://registry.modelcontextprotocol.io) |
+| Give my agent memory | [`velesdb-memory`](crates/velesdb-memory) | MCP server + context compiler, any MCP client; `.mcpb` bundles on the [MCP Registry](https://registry.modelcontextprotocol.io/?q=velesdb-memory) |
 | Call it from Node | [`@wiscale/velesdb-memory-node`](https://www.npmjs.com/package/@wiscale/velesdb-memory-node) | Memory wedge ([full engine via server + TS SDK](crates/velesdb-node/README.md#need-the-full-engine)) |
 | Run it in a browser | [`@wiscale/velesdb-sdk`](https://www.npmjs.com/package/@wiscale/velesdb-sdk) | WASM, ~674 KB gzipped, fully client-side |
 | Serve it over HTTP | [`velesdb-server`](https://crates.io/crates/velesdb-server) | 54 REST endpoints — [API reference](docs/reference/api-reference.md) · [OpenAPI](docs/openapi.yaml) · [server security](docs/guides/SERVER_SECURITY.md) |

--- a/docs/guides/INSTALL_OPTIONS.md
+++ b/docs/guides/INSTALL_OPTIONS.md
@@ -31,7 +31,7 @@ decision aid, not a replacement.
 ## Recommended paths
 
 - **Just want to try VelesDB as a Python developer?** `pip install velesdb` — zero build step, matches the README's 60-second quick start.
-- **Want your coding agent to have persistent memory, no Rust toolchain?** Grab the `.mcpb` bundle from the [latest release](https://github.com/cyberlife-coder/VelesDB/releases/latest), or `npm i @wiscale/velesdb-memory-node`.
+- **Want your coding agent to have persistent memory, no Rust toolchain?** Grab the `.mcpb` bundle from the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=velesdb-memory) (`io.github.cyberlife-coder/velesdb-memory`), or `npm i @wiscale/velesdb-memory-node`.
 - **Running the full server in production?** Docker (`ghcr.io/cyberlife-coder/velesdb`) or `cargo install velesdb-server` if you need a native binary outside a container.
 - **Several MCP clients on the same machine, want one shared memory store?** `scripts/install-memory-daemon.sh` (macOS) or `scripts/install-memory-daemon.ps1` (Windows).
 

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -37,7 +37,6 @@ Five independent gates run here:
 from __future__ import annotations
 
 import argparse
-from concurrent.futures import ThreadPoolExecutor
 import json
 import pathlib
 import re
@@ -101,6 +100,7 @@ GENERIC_LATEST_RELEASE_URL = (
 )
 MARKDOWN_EXCLUDED_PARTS = frozenset({".git", "node_modules", "target"})
 RELEASE_ASSET_TIMEOUT_SECONDS = 20
+RELEASE_ASSET_ATTEMPTS = 3
 
 
 def _doc_lines(rel_path: str, text: str) -> list[tuple[int, str]]:
@@ -312,17 +312,23 @@ def check_mcpb_release_links(root: pathlib.Path) -> list[str]:
 def _probe_release_asset(item, opener) -> str | None:
     url, locations = item
     request = Request(url, method="HEAD", headers={"User-Agent": "VelesDB-doc-guard"})
-    try:
-        with opener(request, timeout=RELEASE_ASSET_TIMEOUT_SECONDS) as response:
-            status = getattr(response, "status", None)
-            status = response.getcode() if status is None else status
-    except HTTPError as exc:
-        status = exc.code
-    except (URLError, TimeoutError, OSError) as exc:
-        return f"[release-asset] {', '.join(locations)}: {url} is unreachable: {exc}"
-    if status == 200:
-        return None
-    return f"[release-asset] {', '.join(locations)}: {url} returned HTTP {status}"
+    for attempt in range(RELEASE_ASSET_ATTEMPTS):
+        try:
+            with opener(request, timeout=RELEASE_ASSET_TIMEOUT_SECONDS) as response:
+                status = getattr(response, "status", None)
+                status = response.getcode() if status is None else status
+        except HTTPError as exc:
+            status = exc.code
+        except (URLError, TimeoutError, OSError) as exc:
+            if attempt + 1 < RELEASE_ASSET_ATTEMPTS:
+                continue
+            return f"[release-asset] {', '.join(locations)}: {url} is unreachable: {exc}"
+        if status == 200:
+            return None
+        if status >= 500 and attempt + 1 < RELEASE_ASSET_ATTEMPTS:
+            continue
+        return f"[release-asset] {', '.join(locations)}: {url} returned HTTP {status}"
+    raise AssertionError("release-asset retry loop did not return")
 
 
 def check_latest_release_assets(root: pathlib.Path, opener=None) -> list[str]:
@@ -331,9 +337,7 @@ def check_latest_release_assets(root: pathlib.Path, opener=None) -> list[str]:
     if not citations:
         return []
     open_url = opener or urlopen
-    workers = min(4, len(citations))
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        results = pool.map(lambda item: _probe_release_asset(item, open_url), citations.items())
+    results = (_probe_release_asset(item, open_url) for item in citations.items())
     return sorted(result for result in results if result is not None)
 
 

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Validate docs promise contract registry against repository content.
 
-Three independent gates run here:
+Five independent gates run here:
 
 1. Registry gate — every claim in ``docs/reference/promise-contract.json`` must
    still be present in the file it points at, so benchmark/headline promises
@@ -25,16 +25,26 @@ Three independent gates run here:
    download) stay ``"executable": false`` — documentary only — and are
    explicitly skipped with a visible message naming the claim and the
    unverified command, rather than being silently ignored.
+4. Release-asset gate (issue #1885) — every documented
+   ``releases/latest/download/<asset>`` URL must resolve to HTTP 200. A release
+   train can otherwise take over ``latest`` without carrying assets promised
+   by the docs.
+5. MCPB-train gate (issue #1885) — ``.mcpb`` documentation must not link to
+   the repository-wide ``releases/latest`` page because memory bundles ship on
+   the independent ``velesdb-memory-vX.Y.Z`` train.
 """
 
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 import json
 import pathlib
 import re
 import subprocess
 import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 #: Default tree to check. `--root` overrides it so the guard can be pointed at a
 #: fixture tree and be SEEN refusing (#1715); the default keeps CI byte-identical.
@@ -81,6 +91,16 @@ NEGATION_WINDOW = 40
 # be fast local grep/file-comparison checks only — anything needing longer
 # than this has no business being marked "executable": true.
 EXECUTABLE_CLAIM_TIMEOUT_SECONDS = 30
+
+LATEST_RELEASE_ASSET_RE = re.compile(
+    r"https://github\.com/[\w.-]+/[\w.-]+/releases/latest/download/"
+    r"[^\s<>()\]`\"']+"
+)
+GENERIC_LATEST_RELEASE_URL = (
+    "https://github.com/cyberlife-coder/VelesDB/releases/latest"
+)
+MARKDOWN_EXCLUDED_PARTS = frozenset({".git", "node_modules", "target"})
+RELEASE_ASSET_TIMEOUT_SECONDS = 20
 
 
 def _doc_lines(rel_path: str, text: str) -> list[tuple[int, str]]:
@@ -259,6 +279,64 @@ def check_capacity_mode_overclaim(root: pathlib.Path) -> list[str]:
     return failed
 
 
+def _markdown_lines(root: pathlib.Path):
+    """Yield every human-facing Markdown line with its repository location."""
+    for path in sorted(root.rglob("*.md")):
+        if MARKDOWN_EXCLUDED_PARTS.intersection(path.relative_to(root).parts):
+            continue
+        rel_path = path.relative_to(root).as_posix()
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            yield rel_path, number, line
+
+
+def latest_release_asset_citations(root: pathlib.Path) -> dict[str, list[str]]:
+    """Map each documented ``releases/latest/download`` URL to its citations."""
+    citations: dict[str, list[str]] = {}
+    for rel_path, number, line in _markdown_lines(root):
+        for match in LATEST_RELEASE_ASSET_RE.finditer(line):
+            url = match.group(0).rstrip(".,;:")
+            citations.setdefault(url, []).append(f"{rel_path}:{number}")
+    return citations
+
+
+def check_mcpb_release_links(root: pathlib.Path) -> list[str]:
+    """Reject MCPB links to the unrelated repository-wide latest release."""
+    return [
+        f"[mcpb-release-train] {rel_path}:{number} links .mcpb to "
+        "repository-wide releases/latest"
+        for rel_path, number, line in _markdown_lines(root)
+        if ".mcpb" in line.lower() and GENERIC_LATEST_RELEASE_URL in line
+    ]
+
+
+def _probe_release_asset(item, opener) -> str | None:
+    url, locations = item
+    request = Request(url, method="HEAD", headers={"User-Agent": "VelesDB-doc-guard"})
+    try:
+        with opener(request, timeout=RELEASE_ASSET_TIMEOUT_SECONDS) as response:
+            status = getattr(response, "status", None)
+            status = response.getcode() if status is None else status
+    except HTTPError as exc:
+        status = exc.code
+    except (URLError, TimeoutError, OSError) as exc:
+        return f"[release-asset] {', '.join(locations)}: {url} is unreachable: {exc}"
+    if status == 200:
+        return None
+    return f"[release-asset] {', '.join(locations)}: {url} returned HTTP {status}"
+
+
+def check_latest_release_assets(root: pathlib.Path, opener=None) -> list[str]:
+    """Require every cited latest-release download to resolve to HTTP 200."""
+    citations = latest_release_asset_citations(root)
+    if not citations:
+        return []
+    open_url = opener or urlopen
+    workers = min(4, len(citations))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        results = pool.map(lambda item: _probe_release_asset(item, open_url), citations.items())
+    return sorted(result for result in results if result is not None)
+
+
 def run_validation_commands(
     claims: list[dict],
     root: pathlib.Path,
@@ -340,6 +418,8 @@ def _report(title: str, messages: "list[str]") -> None:
 def run(root: pathlib.Path) -> int:
     registry_failures = check_registry(root)
     overclaim_failures = check_capacity_mode_overclaim(root)
+    release_asset_failures = check_latest_release_assets(root)
+    mcpb_link_failures = check_mcpb_release_links(root)
 
     # Read the registry only if it is there. This used to be an unconditional
     # `json.loads(REGISTRY.read_text())`, which raised FileNotFoundError before
@@ -355,6 +435,8 @@ def run(root: pathlib.Path) -> int:
     _report("Provenance check failed — every claim must record its measurement:", provenance_failures)
     _report("Promise contract check failed:", registry_failures)
     _report("Anti-overclaim check failed (Requirement 10.4):", overclaim_failures)
+    _report("Latest-release asset check failed:", release_asset_failures)
+    _report("MCPB release-train check failed:", mcpb_link_failures)
     _report("Executable validation_command check failed:", execution_failures)
     _report("Documentary claims not auto-verified:", skipped)
 
@@ -365,12 +447,15 @@ def run(root: pathlib.Path) -> int:
     stale = stale_claims(claims, version)
     _report(f"Claims measured on an older release than {version} (re-measure):", stale)
 
-    if (
-        registry_failures
-        or overclaim_failures
-        or execution_failures
-        or provenance_failures
-    ):
+    failure_groups = (
+        registry_failures,
+        overclaim_failures,
+        release_asset_failures,
+        mcpb_link_failures,
+        execution_failures,
+        provenance_failures,
+    )
+    if any(failure_groups):
         return 1
 
     claim_count = len(claims)

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -480,6 +480,29 @@
             "--root",
             "{root}"
           ]
+        },
+        {
+          "vector": "an .mcpb recommendation pointing at the repository-wide latest release instead of the independent memory release train",
+          "files": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "README.md": "Get the `.mcpb` bundle from https://github.com/cyberlife-coder/VelesDB/releases/latest.\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ]\n}\n"
+          },
+          "accepts": {
+            "Cargo.toml": "[workspace.package]\nversion = \"1.0.0\"\n",
+            "README.md": "Get the `.mcpb` bundle from https://registry.modelcontextprotocol.io/.\n",
+            "docs/guides/QUANTIZATION.md": "# Quantization\n\nsq8 delivers no higher throughput.\n",
+            "docs/VELESQL_SPEC.md": "# VelesQL\n",
+            "crates/velesdb-core/src/quantization/mod.rs": "//! Quantization.\n",
+            "docs/reference/promise-contract.json": "{\n  \"claims\": [\n    {\n      \"id\": \"quantization-is-documented\",\n      \"file\": \"docs/guides/QUANTIZATION.md\",\n      \"must_contain\": \"# Quantization\",\n      \"executable\": false,\n      \"measured_on\": \"2026-07-31\",\n      \"measured_machine\": \"fixture\",\n      \"measured_version\": \"1.0.0\"\n    }\n  ]\n}\n"
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
         }
       ]
     },

--- a/scripts/tests/test_check_promise_contract.py
+++ b/scripts/tests/test_check_promise_contract.py
@@ -27,7 +27,7 @@ import tempfile
 import types
 import unittest
 from pathlib import Path
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-promise-contract.py"
 
@@ -188,6 +188,39 @@ class ReleaseLinkGuardTests(unittest.TestCase):
         self.assertEqual(len(failures), 1)
         self.assertIn("README.md:1", failures[0])
         self.assertIn("HTTP 404", failures[0])
+
+    def test_latest_asset_transient_network_error_is_retried(self) -> None:
+        url = (
+            "https://github.com/cyberlife-coder/VelesDB/releases/latest/"
+            "download/example.tar.gz"
+        )
+        attempts = 0
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def opener(request, timeout):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise HTTPError(request.full_url, 502, "Bad Gateway", {}, None)
+            if attempts < cpc.RELEASE_ASSET_ATTEMPTS:
+                raise URLError("temporary disconnect")
+            return Response()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(f"download {url}\n", encoding="utf-8")
+            failures = cpc.check_latest_release_assets(root, opener=opener)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(attempts, cpc.RELEASE_ASSET_ATTEMPTS)
 
 
 class RealRegistryExecutableClaimsTests(unittest.TestCase):

--- a/scripts/tests/test_check_promise_contract.py
+++ b/scripts/tests/test_check_promise_contract.py
@@ -23,9 +23,11 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
+from urllib.error import HTTPError
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-promise-contract.py"
 
@@ -109,6 +111,83 @@ class RunValidationCommandsTests(unittest.TestCase):
         self.assertEqual(executed, [])
         self.assertEqual(len(skipped), 1)
         self.assertEqual(failures, [])
+
+
+class ReleaseLinkGuardTests(unittest.TestCase):
+    """Issue #1885: release trains must not make documented downloads lie."""
+
+    def test_mcpb_link_to_repository_wide_latest_release_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(
+                "Get the `.mcpb` from "
+                "https://github.com/cyberlife-coder/VelesDB/releases/latest\n",
+                encoding="utf-8",
+            )
+            failures = cpc.check_mcpb_release_links(root)
+        self.assertEqual(len(failures), 1)
+        self.assertIn("README.md:1", failures[0])
+
+    def test_mcpb_link_to_registry_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(
+                "Get the `.mcpb` from https://registry.modelcontextprotocol.io/\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(cpc.check_mcpb_release_links(root), [])
+
+    def test_latest_asset_urls_are_deduplicated_and_must_return_200(self) -> None:
+        url = (
+            "https://github.com/cyberlife-coder/VelesDB/releases/latest/"
+            "download/example.tar.gz"
+        )
+        requests = []
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def opener(request, timeout):
+            requests.append((request, timeout))
+            return Response()
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(f"download {url}\n", encoding="utf-8")
+            docs = root / "docs"
+            docs.mkdir()
+            (docs / "INSTALL.md").write_text(f"download {url}\n", encoding="utf-8")
+            failures = cpc.check_latest_release_assets(root, opener=opener)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0][0].get_method(), "HEAD")
+        self.assertEqual(requests[0][0].full_url, url)
+        self.assertEqual(requests[0][1], cpc.RELEASE_ASSET_TIMEOUT_SECONDS)
+
+    def test_latest_asset_non_200_is_refused_with_citation(self) -> None:
+        url = (
+            "https://github.com/cyberlife-coder/VelesDB/releases/latest/"
+            "download/missing.zip"
+        )
+
+        def opener(request, timeout):
+            raise HTTPError(request.full_url, 404, "Not Found", {}, None)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "README.md").write_text(f"download {url}\n", encoding="utf-8")
+            failures = cpc.check_latest_release_assets(root, opener=opener)
+
+        self.assertEqual(len(failures), 1)
+        self.assertIn("README.md:1", failures[0])
+        self.assertIn("HTTP 404", failures[0])
 
 
 class RealRegistryExecutableClaimsTests(unittest.TestCase):


### PR DESCRIPTION
## Résumé

- remplace les liens `.mcpb` vers la release générale par la fiche VelesDB Memory du registre MCP officiel
- refuse toute nouvelle recommandation `.mcpb` pointant vers `releases/latest`
- vérifie en CI que chaque URL documentée `releases/latest/download/<asset>` répond en HTTP 200
- étend le déclenchement du contrat aux changements de documentation

## Validation

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` (439 tests, 9 ignorés)
- `python3 scripts/check-promise-contract.py`
- `python3 scripts/check-version-sync.py`
- `python3 scripts/check-feature-claims.py`
- `python3 scripts/check-perf-claims.py --no-criterion`
- contrats MCP, documentation et fraîcheur des docs

Closes #1885