### PR TITLE
fix(memory): surface lexical embedder fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ mem.remember("Booked the aisle seat on Robert's flight", links=[(reason, "becaus
 mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason — recall() can't
 ```
 
+> `MemoryService` defaults to the offline `hash` embedder: deterministic, but
+> **lexical rather than semantic**, so unrelated wording can score `0.000`.
+> Opening it now says so once on stderr. For meaning-based recall, pass
+> `embedder="ollama"`; follow [Real semantic recall in 5 minutes](crates/velesdb-memory/README.md#real-semantic-recall-in-5-minutes).
+
 ![recall() finds the booking but misses the reason; why() reaches it through typed links, across a session restart](examples/agent_memory/why_across_sessions.gif)
 
 Memories are permanent by default; `forget(id)` deletes one, `ttl_seconds` gives a fact a durable expiry. Every `remember` auto-stamps its storage day, so recency-weighted recall works with zero setup. Same wedge in **Python**, **Node**, the [**MCP server**](crates/velesdb-memory), and in-memory in the [**TypeScript SDK**](sdks/typescript).

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -33,6 +33,12 @@ pub trait Embedder {
     fn embed(&self, text: &str) -> Result<Vec<f32>, EmbedError>;
 }
 
+/// Transport-neutral part of the startup notice adapters emit for `hash`.
+/// The library itself never writes to stderr; each owning binary or language
+/// binding adds the configuration syntax its caller can actually use.
+pub const HASH_EMBEDDER_NOTICE: &str = "Using the offline 'hash' embedder: deterministic and \
+    fully offline, but NOT semantic — recall matches surface form, not meaning.";
+
 /// Deterministic, network-free embedder (token-hashing into L2-normalized
 /// buckets). Not semantically strong — its purpose is reproducible tests and
 /// offline behavior, exactly like the `fake_embed` used in the repo's

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -170,6 +170,7 @@ pub use context::ContextCompiler;
 pub use dated_context::{format_dated_context, DatedContext};
 pub use embedder::{
     select_embedder, DynEmbedder, EmbedError, Embedder, EmbedderSelection, HashEmbedder,
+    HASH_EMBEDDER_NOTICE,
 };
 #[cfg(feature = "ollama")]
 pub use embedder::{OllamaEmbedder, OpenAiEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -1331,11 +1331,11 @@ fn warn_hash_embedder_not_semantic() {
         return;
     }
     eprintln!(
-        "[velesdb-memory] Using the default 'hash' embedder: deterministic and \
-         fully offline, but NOT semantic — recall matches surface form, not meaning. \
-         For real semantic recall set VELESDB_MEMORY_EMBEDDER=ollama or =openai \
+        "[velesdb-memory] {} For real semantic recall set \
+         VELESDB_MEMORY_EMBEDDER=ollama or =openai \
          (no rebuild needed; see crates/velesdb-memory/README.md for the model \
-         to pull). Set VELESDB_MEMORY_QUIET=1 to silence this notice."
+         to pull). Set VELESDB_MEMORY_QUIET=1 to silence this notice.",
+        velesdb_memory::HASH_EMBEDDER_NOTICE
     );
 }
 

--- a/crates/velesdb-node/__test__/index.spec.mjs
+++ b/crates/velesdb-node/__test__/index.spec.mjs
@@ -5,12 +5,17 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs'
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { MemoryService } from '../index.js'
+
+// Most tests deliberately use the lexical hash backend. Keep their output
+// quiet; the notice contract is exercised in isolated child processes below.
+process.env.VELESDB_MEMORY_QUIET = '1'
 
 /**
  * Remove a temp store dir, tolerating Windows lock semantics: the store's
@@ -55,6 +60,20 @@ function inChildProcess(dir, body) {
   const child = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8' })
   assert.equal(child.status, 0, `child process failed: ${child.stderr}`)
   return child.stdout.trim()
+}
+
+/** Run one addon script without blocking this process's mock HTTP server. */
+function runNodeChild(script, env) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ['-e', script], { env })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('close', (status) => resolve({ status, stdout, stderr }))
+  })
 }
 
 /** Sleep, to cross a real one-second boundary (saved_at has second granularity). */
@@ -200,6 +219,80 @@ test('open defaults to the offline hash embedder when none is named', async () =
       'the default store must recall what it stored, offline',
     )
   } finally {
+    rmStoreDir(dir)
+  }
+})
+
+test('open with hash warns once and names the semantic argument', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-'))
+  const env = { ...process.env }
+  delete env.VELESDB_MEMORY_QUIET
+  try {
+    const script = `
+      const { MemoryService } = require(${JSON.stringify(ADDON_ENTRY)})
+      MemoryService.open(${JSON.stringify(dir)})
+    `
+    const child = spawnSync(process.execPath, ['-e', script], { encoding: 'utf8', env })
+    assert.equal(child.status, 0, child.stderr)
+    assert.equal((child.stderr.match(/NOT semantic/g) ?? []).length, 1)
+    assert.match(child.stderr, /MemoryService\.open\(path, "ollama"\)/)
+    assert.match(child.stderr, /VELESDB_MEMORY_QUIET=1/)
+  } finally {
+    rmStoreDir(dir)
+  }
+})
+
+test('quiet environment suppresses the hash notice', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-'))
+  try {
+    const script = `
+      const { MemoryService } = require(${JSON.stringify(ADDON_ENTRY)})
+      MemoryService.open(${JSON.stringify(dir)}, 'hash')
+    `
+    const child = spawnSync(process.execPath, ['-e', script], {
+      encoding: 'utf8',
+      env: process.env,
+    })
+    assert.equal(child.status, 0, child.stderr)
+    assert.doesNotMatch(child.stderr, /NOT semantic/)
+  } finally {
+    rmStoreDir(dir)
+  }
+})
+
+test('open with ollama emits no degraded hash notice', async () => {
+  const server = createServer((request, response) => {
+    request.on('end', () => {
+      response.writeHead(200, { 'Content-Type': 'application/json' })
+      response.end(JSON.stringify({ embedding: [0.1, 0.2, 0.3, 0.4] }))
+    })
+    request.resume()
+  })
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+
+  const dir = mkdtempSync(join(tmpdir(), 'velesdb-node-'))
+  const env = { ...process.env }
+  delete env.VELESDB_MEMORY_QUIET
+  try {
+    const { port } = server.address()
+    const script = `
+      const { MemoryService } = require(${JSON.stringify(ADDON_ENTRY)})
+      // The backend, not an arbitrary remote model name, decides semantics.
+      const store = MemoryService.open(
+        ${JSON.stringify(dir)}, 'ollama', 'http://127.0.0.1:${port}', 'hash'
+      )
+      store.memoryStatus().then((status) => {
+        if (!status.embedder.semantic) process.exitCode = 1
+      })
+    `
+    const child = await runNodeChild(script, env)
+    assert.equal(child.status, 0, child.stderr)
+    assert.doesNotMatch(child.stderr, /NOT semantic/)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
     rmStoreDir(dir)
   }
 })

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -54,7 +54,7 @@ use velesdb_memory::context::{
 use velesdb_memory::{
     embedder_env_endpoint, select_embedder, DynEmbedder, Embedder, EmbedderSelection,
     MemoryService, OllamaEmbedder, OllamaExtractor, OpenAiEmbedder, OutlineExtractor,
-    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL, HASH_EMBEDDER_NOTICE,
 };
 
 use crate::dto::{
@@ -64,8 +64,8 @@ use crate::dto::{
 use crate::error::{invalid_input, to_napi_err, CODE_INTERNAL};
 use crate::tasks::{Job, JsonOut};
 
-/// Resolve and build the requested embedder, returning it alongside the
-/// model name [`MemoryStore::memory_status`] reports.
+/// Resolve and build the requested embedder, returning it alongside the model
+/// name and semantic flag [`MemoryStore::memory_status`] reports.
 ///
 /// `kind` is the factory's explicit `embedder` argument; when `None`,
 /// `VELESDB_MEMORY_EMBEDDER` takes over — the explicit argument always wins,
@@ -79,13 +79,19 @@ fn build_embedder(
     kind: Option<&str>,
     url: Option<String>,
     model: Option<String>,
-) -> napi::Result<(DynEmbedder, String)> {
+) -> napi::Result<(DynEmbedder, String, bool)> {
     let backend_env = std::env::var("VELESDB_MEMORY_EMBEDDER").ok();
     let selection = select_embedder(kind.or(backend_env.as_deref())).map_err(invalid_input)?;
     match selection {
-        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned())),
-        EmbedderSelection::NeedsRemoteConfig("ollama") => build_ollama_embedder(url, model),
-        EmbedderSelection::NeedsRemoteConfig("openai") => build_openai_embedder(),
+        EmbedderSelection::Ready(name, embedder) => {
+            Ok((embedder, name.to_owned(), name != "hash"))
+        }
+        EmbedderSelection::NeedsRemoteConfig("ollama") => {
+            build_ollama_embedder(url, model).map(|(embedder, model)| (embedder, model, true))
+        }
+        EmbedderSelection::NeedsRemoteConfig("openai") => {
+            build_openai_embedder().map(|(embedder, model)| (embedder, model, true))
+        }
         EmbedderSelection::NeedsRemoteConfig(other) => Err(napi::Error::from_reason(format!(
             "[{CODE_INTERNAL}] the embedding backend '{other}' is accepted by velesdb-memory's \
              selector but this binding has no builder for it — this is a bug in \
@@ -127,6 +133,18 @@ fn build_openai_embedder() -> napi::Result<(DynEmbedder, String)> {
     Ok((Box::new(embedder), model))
 }
 
+/// Surface the lexical fallback once per successfully opened Node instance.
+fn warn_hash_embedder_not_semantic(semantic: bool) {
+    if semantic || std::env::var_os("VELESDB_MEMORY_QUIET").is_some() {
+        return;
+    }
+    eprintln!(
+        "[velesdb-memory-node] {HASH_EMBEDDER_NOTICE} For real semantic recall \
+         reopen with MemoryService.open(path, \"ollama\") or configure \
+         VELESDB_MEMORY_EMBEDDER=ollama. Set VELESDB_MEMORY_QUIET=1 to silence this notice."
+    );
+}
+
 /// Local-first agent memory with the `why()` graph wedge.
 ///
 /// All methods are async (return a Promise) and run off the event-loop thread.
@@ -142,6 +160,7 @@ pub struct MemoryStore {
     /// ever sees `&[f32]`, so the factory is the one place that knows.
     embedder_model: String,
     embedder_dimension: usize,
+    embedder_semantic: bool,
     /// Where the store lives, for the provenance block of
     /// [`Self::memory_status`] (#1751's on-disk record).
     store_dir: std::path::PathBuf,
@@ -162,7 +181,8 @@ impl MemoryStore {
     /// This factory is synchronous: with a remote `embedder` it performs a
     /// one-time blocking probe of the embedding endpoint (as the `PyO3` binding
     /// does). The default `"hash"` embedder does no I/O. Per-operation methods
-    /// are all async.
+    /// are all async. Opening with `hash` emits one degraded-recall notice on
+    /// stderr; `VELESDB_MEMORY_QUIET=1` suppresses it for deliberate offline use.
     #[napi(factory)]
     pub fn open(
         path: String,
@@ -170,13 +190,16 @@ impl MemoryStore {
         ollama_url: Option<String>,
         ollama_model: Option<String>,
     ) -> napi::Result<Self> {
-        let (emb, embedder_model) = build_embedder(embedder.as_deref(), ollama_url, ollama_model)?;
+        let (emb, embedder_model, embedder_semantic) =
+            build_embedder(embedder.as_deref(), ollama_url, ollama_model)?;
         let embedder_dimension = emb.dimension();
         let svc = MemoryService::open(&path, emb).map_err(to_napi_err)?;
+        warn_hash_embedder_not_semantic(embedder_semantic);
         Ok(Self {
             inner: Arc::new(svc),
             embedder_model,
             embedder_dimension,
+            embedder_semantic,
             store_dir: std::path::PathBuf::from(path),
         })
     }
@@ -757,6 +780,7 @@ impl MemoryStore {
         let svc = Arc::clone(&self.inner);
         let model = self.embedder_model.clone();
         let dimension = self.embedder_dimension;
+        let semantic = self.embedder_semantic;
         let store_dir = self.store_dir.clone();
         AsyncTask::new(Job::new(move || {
             let recorded = velesdb_memory::embedding_provenance::read(&store_dir)
@@ -774,7 +798,7 @@ impl MemoryStore {
                 "embedder": {
                     "model": model,
                     "dimension": dimension,
-                    "semantic": model != "hash",
+                    "semantic": semantic,
                 },
                 "provenance": provenance,
                 "extraction": {

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -83,9 +83,7 @@ fn build_embedder(
     let backend_env = std::env::var("VELESDB_MEMORY_EMBEDDER").ok();
     let selection = select_embedder(kind.or(backend_env.as_deref())).map_err(invalid_input)?;
     match selection {
-        EmbedderSelection::Ready(name, embedder) => {
-            Ok((embedder, name.to_owned(), name != "hash"))
-        }
+        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned(), name != "hash")),
         EmbedderSelection::NeedsRemoteConfig("ollama") => {
             build_ollama_embedder(url, model).map(|(embedder, model)| (embedder, model, true))
         }

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -2305,6 +2305,9 @@ class MemoryService:
             ollama_url: Ollama server URL (used when ``embedder="ollama"``).
             ollama_model: Ollama model name (used when ``embedder="ollama"``).
 
+        Opening with ``"hash"`` emits one degraded-recall notice on stderr.
+        Set ``VELESDB_MEMORY_QUIET=1`` to suppress it for deliberate offline use.
+
         Raises:
             ValueError: If ``embedder`` is not ``"hash"`` or ``"ollama"``.
             RuntimeError: If the store cannot be opened or the Ollama embedder

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -23,7 +23,7 @@ use velesdb_memory::{
     DatedContext, DynEmbedder, EmbedderSelection, EntityProfile, EntityRelation, ErrorCategory,
     Explanation, FusionOptions, Link, MemoryEdge, MemoryError, MemoryNode, MemoryService, Metadata,
     OllamaEmbedder, OllamaExtractor, OpenAiEmbedder, OutlineExtractor, Recollection,
-    RememberedExtraction, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL,
+    RememberedExtraction, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL, HASH_EMBEDDER_NOTICE,
 };
 
 use crate::collection::query::convert_params;
@@ -103,8 +103,8 @@ fn to_column_filters(
         .collect()
 }
 
-/// Resolve and build the requested embedder, returning it alongside the
-/// model name `memory_status` reports.
+/// Resolve and build the requested embedder, returning it alongside the model
+/// name and semantic flag `memory_status` reports.
 ///
 /// `kind` is the constructor's explicit `embedder` argument; when `None`,
 /// `VELESDB_MEMORY_EMBEDDER` takes over — the explicit argument always wins,
@@ -118,14 +118,20 @@ fn build_embedder(
     kind: Option<&str>,
     url: Option<String>,
     model: Option<String>,
-) -> PyResult<(DynEmbedder, String)> {
+) -> PyResult<(DynEmbedder, String, bool)> {
     let backend_env = std::env::var("VELESDB_MEMORY_EMBEDDER").ok();
     let selection =
         select_embedder(kind.or(backend_env.as_deref())).map_err(PyValueError::new_err)?;
     match selection {
-        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned())),
-        EmbedderSelection::NeedsRemoteConfig("ollama") => build_ollama_embedder(url, model),
-        EmbedderSelection::NeedsRemoteConfig("openai") => build_openai_embedder(),
+        EmbedderSelection::Ready(name, embedder) => {
+            Ok((embedder, name.to_owned(), name != "hash"))
+        }
+        EmbedderSelection::NeedsRemoteConfig("ollama") => {
+            build_ollama_embedder(url, model).map(|(embedder, model)| (embedder, model, true))
+        }
+        EmbedderSelection::NeedsRemoteConfig("openai") => {
+            build_openai_embedder().map(|(embedder, model)| (embedder, model, true))
+        }
         EmbedderSelection::NeedsRemoteConfig(other) => Err(PyRuntimeError::new_err(format!(
             "the embedding backend '{other}' is accepted by velesdb-memory's selector but \
              this binding has no builder for it — this is a bug in velesdb-memory, not a \
@@ -165,6 +171,18 @@ fn build_openai_embedder() -> PyResult<(DynEmbedder, String)> {
     let embedder = OpenAiEmbedder::new(url, model.clone(), auth)
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     Ok((Box::new(embedder), model))
+}
+
+/// Surface the lexical fallback once per successfully opened Python instance.
+fn warn_hash_embedder_not_semantic(semantic: bool) {
+    if semantic || std::env::var_os("VELESDB_MEMORY_QUIET").is_some() {
+        return;
+    }
+    eprintln!(
+        "[velesdb] {HASH_EMBEDDER_NOTICE} For real semantic recall reopen with \
+         MemoryService(path, embedder=\"ollama\") or configure \
+         VELESDB_MEMORY_EMBEDDER=ollama. Set VELESDB_MEMORY_QUIET=1 to silence this notice."
+    );
 }
 
 /// Build the requested extractor and run it, releasing the GIL for the call.
@@ -411,6 +429,7 @@ pub struct PyMemoryService {
     /// sees `&[f32]`, so the constructor is the one place that knows.
     embedder_model: String,
     embedder_dimension: usize,
+    embedder_semantic: bool,
     /// Where the store lives, for the provenance block of `memory_status`
     /// (#1751's on-disk record).
     store_dir: std::path::PathBuf,
@@ -429,6 +448,8 @@ impl PyMemoryService {
     ///         explicit value wins over `VELESDB_MEMORY_EMBEDDER_URL`/`_MODEL`.
     ///         embedder="openai" reads its URL, model and credential from the
     ///         environment exclusively — see `crates/velesdb-memory/README.md`.
+    ///     Opening with `hash` emits one degraded-recall notice on stderr;
+    ///         `VELESDB_MEMORY_QUIET=1` suppresses it for deliberate offline use.
     #[new]
     #[pyo3(signature = (path, embedder = None, ollama_url = None, ollama_model = None))]
     fn new(
@@ -437,13 +458,16 @@ impl PyMemoryService {
         ollama_url: Option<String>,
         ollama_model: Option<String>,
     ) -> PyResult<Self> {
-        let (emb, embedder_model) = build_embedder(embedder, ollama_url, ollama_model)?;
+        let (emb, embedder_model, embedder_semantic) =
+            build_embedder(embedder, ollama_url, ollama_model)?;
         let embedder_dimension = emb.dimension();
         let svc = MemoryService::open(&path, emb).map_err(to_py_err)?;
+        warn_hash_embedder_not_semantic(embedder_semantic);
         Ok(Self {
             svc,
             embedder_model,
             embedder_dimension,
+            embedder_semantic,
             store_dir: std::path::PathBuf::from(path),
         })
     }
@@ -965,7 +989,7 @@ impl PyMemoryService {
             "embedder": {
                 "model": self.embedder_model,
                 "dimension": self.embedder_dimension,
-                "semantic": self.embedder_model != "hash",
+                "semantic": self.embedder_semantic,
             },
             "provenance": provenance,
             "extraction": {

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -123,9 +123,7 @@ fn build_embedder(
     let selection =
         select_embedder(kind.or(backend_env.as_deref())).map_err(PyValueError::new_err)?;
     match selection {
-        EmbedderSelection::Ready(name, embedder) => {
-            Ok((embedder, name.to_owned(), name != "hash"))
-        }
+        EmbedderSelection::Ready(name, embedder) => Ok((embedder, name.to_owned(), name != "hash")),
         EmbedderSelection::NeedsRemoteConfig("ollama") => {
             build_ollama_embedder(url, model).map(|(embedder, model)| (embedder, model, true))
         }

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -5,6 +5,9 @@ The offline `hash` embedder keeps them deterministic and network-free.
 """
 
 import json
+import os
+import subprocess
+import sys
 import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -155,27 +158,42 @@ def test_quiet_environment_suppresses_the_hash_notice(tmp_path, capfd, monkeypat
     assert "NOT semantic" not in capfd.readouterr().err
 
 
-def test_open_with_ollama_emits_no_degraded_hash_notice(tmp_path, capfd, monkeypatch):
+def test_open_with_ollama_emits_no_degraded_hash_notice(tmp_path, monkeypatch):
     monkeypatch.delenv("VELESDB_MEMORY_QUIET", raising=False)
     server = ThreadingHTTPServer(("127.0.0.1", 0), _EmbeddingHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
         host, port = server.server_address
-        memory = MemoryService(
-            str(tmp_path / "ollama-store"),
-            embedder="ollama",
-            ollama_url=f"http://{host}:{port}",
-            # The backend, not an arbitrary remote model name, decides semantics.
-            ollama_model="hash",
+        # The constructor's blocking Ollama probe currently holds the PyO3 GIL.
+        # Use a child so this process's Python server thread can answer it, and
+        # so the binding's exact stderr stays isolated for the assertion.
+        script = f"""
+from velesdb import MemoryService
+
+memory = MemoryService(
+    {json.dumps(str(tmp_path / "ollama-store"))},
+    embedder="ollama",
+    ollama_url={json.dumps(f"http://{host}:{port}")},
+    # The backend, not an arbitrary remote model name, decides semantics.
+    ollama_model="hash",
+)
+raise SystemExit(0 if memory.memory_status()["embedder"]["semantic"] else 1)
+"""
+        child = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+            timeout=10,
+            check=False,
         )
-        assert memory.memory_status()["embedder"]["semantic"] is True
+        assert child.returncode == 0, child.stderr
+        assert "NOT semantic" not in child.stderr
     finally:
         server.shutdown()
         server.server_close()
         thread.join(timeout=2)
-
-    assert "NOT semantic" not in capfd.readouterr().err
 
 
 def test_why_huge_max_hops_is_silently_capped(mem):

--- a/crates/velesdb-python/tests/test_memory_service.py
+++ b/crates/velesdb-python/tests/test_memory_service.py
@@ -4,10 +4,30 @@ These exercise the Python binding over the same hardened Rust the MCP server use
 The offline `hash` embedder keeps them deterministic and network-free.
 """
 
+import json
 import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 from velesdb import MemoryService
+
+
+class _EmbeddingHandler(BaseHTTPRequestHandler):
+    """Minimal Ollama-compatible probe endpoint for constructor tests."""
+
+    def do_POST(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        payload = json.dumps({"embedding": [0.1, 0.2, 0.3, 0.4]}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format, *_args):
+        """Keep the fixture silent so only binding stderr is asserted."""
 
 
 @pytest.fixture()
@@ -114,6 +134,48 @@ def test_unknown_link_target_raises_key_error(mem):
 def test_unknown_embedder_raises_value_error():
     with pytest.raises(ValueError):
         MemoryService(tempfile.mkdtemp(), embedder="nope")
+
+
+def test_open_with_hash_warns_once_and_names_the_semantic_argument(
+    tmp_path, capfd, monkeypatch
+):
+    monkeypatch.delenv("VELESDB_MEMORY_QUIET", raising=False)
+    MemoryService(str(tmp_path / "hash-store"), embedder="hash")
+
+    stderr = capfd.readouterr().err
+    assert stderr.count("NOT semantic") == 1
+    assert 'embedder="ollama"' in stderr
+    assert "VELESDB_MEMORY_QUIET=1" in stderr
+
+
+def test_quiet_environment_suppresses_the_hash_notice(tmp_path, capfd, monkeypatch):
+    monkeypatch.setenv("VELESDB_MEMORY_QUIET", "1")
+    MemoryService(str(tmp_path / "quiet-store"), embedder="hash")
+
+    assert "NOT semantic" not in capfd.readouterr().err
+
+
+def test_open_with_ollama_emits_no_degraded_hash_notice(tmp_path, capfd, monkeypatch):
+    monkeypatch.delenv("VELESDB_MEMORY_QUIET", raising=False)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _EmbeddingHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        memory = MemoryService(
+            str(tmp_path / "ollama-store"),
+            embedder="ollama",
+            ollama_url=f"http://{host}:{port}",
+            # The backend, not an arbitrary remote model name, decides semantics.
+            ollama_model="hash",
+        )
+        assert memory.memory_status()["embedder"]["semantic"] is True
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert "NOT semantic" not in capfd.readouterr().err
 
 
 def test_why_huge_max_hops_is_silently_capped(mem):

--- a/docs/guides/PYTHON_AGENT_MEMORY.md
+++ b/docs/guides/PYTHON_AGENT_MEMORY.md
@@ -33,6 +33,12 @@ mem.remember("Booked the aisle seat on Robert's flight", links=[(reason, "becaus
 mem.why("why the aisle seat on Robert's flight?")   # walks booking → reason — recall() can't
 ```
 
+> The default `embedder="hash"` is deterministic and offline, but **lexical,
+> not semantic**; a paraphrase with no shared words can therefore score
+> `0.000`. `MemoryService` reports this once on stderr when it opens. Pass
+> `embedder="ollama"` for meaning-based recall and follow
+> [Real semantic recall in 5 minutes](../../crates/velesdb-memory/README.md#real-semantic-recall-in-5-minutes).
+
 Full runnable demo:
 [`examples/agent_memory/why_across_sessions.py`](https://github.com/cyberlife-coder/VelesDB/blob/develop/examples/agent_memory/why_across_sessions.py).
 The same wedge ships for


### PR DESCRIPTION
## Summary

- emit one actionable stderr notice when Python or Node opens the offline `hash` embedder
- keep deliberate offline runs quiet with `VELESDB_MEMORY_QUIET=1`, while semantic backends remain silent
- document the lexical-recall caveat beside the root and Python-guide promises
- report semantic status from the selected backend rather than from an arbitrary remote model name

## Why

The default remains deterministic and offline, but it is lexical rather than semantic. A paraphrase can therefore return `0.000` scores without shared words. Python and Node users previously received no signal at open time.

## Validation

- 440 repository guard-contract tests
- version, feature, performance, promise, MCP documentation, route documentation, and freshness guards
- Python test syntax and Node test syntax
- dedicated Python and Node regression coverage for hash warning, quiet mode, and silent Ollama open

Closes #1887