### PR TITLE
docs: add real-text Python quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ curl -O https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/examples/
 python hello_velesdb.py
 ```
 
+To search your own text instead of hand-written vectors, install the opt-in local adapter (`pip install "velesdb[embed-sentence-transformers]"`) and run [`hello_velesdb_text.py`](examples/python/hello_velesdb_text.py); its first run downloads `all-MiniLM-L6-v2`.
+
 Expected output, byte-for-byte ([read the script](examples/python/hello_velesdb.py) — no server, no embedding model):
 
 ```
@@ -41,6 +43,8 @@ Query: "tech + music"
   score=0.707  Rust 1.89 release notes
   score=0.707  Miles Davis discography
 ```
+
+An embedding model determines the vector dimension, while your similarity semantics determine the metric. Both are fixed when a collection is created; to change either, create a new collection and re-index your documents.
 
 **Give your agent a persistent memory — three more commands:**
 
@@ -248,6 +252,7 @@ Tool parity per surface is published honestly — including where a surface is s
 | **Metadata filtering** | Typed ColumnStore + secondary indexes | JSON scan | JSON payload | SQL |
 | **Graph support** | Native (`MATCH` clause) | No | No | No |
 | **Query language** | VelesQL (SQL + NEAR + MATCH) | Python API | JSON API / gRPC | SQL + operators |
+| **Embeddings from text** | Opt-in [local / OpenAI adapters](crates/velesdb-python/python/velesdb/embed.py); no bundled model | [Embedding functions](https://docs.trychroma.com/docs/embeddings/embedding-functions), with a default local model in Python/TypeScript | Opt-in client-side [FastEmbed](https://qdrant.tech/documentation/fastembed/fastembed-semantic-search/) | None; bring vectors from an external model |
 | **Deployment** | Embedded / Server / WASM / Mobile | Server (Python) | Server (Rust) | Requires PostgreSQL |
 | **Binary size** | ~10 MB | ~500 MB (with deps) | ~50 MB | N/A (PG extension) |
 | **Browser / Mobile** | Yes / Yes | No | No | No |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,27 @@ Query: "tech + music"
 
 No server, no JSON, no embedding model. The full script is [`examples/python/hello_velesdb.py`](../examples/python/hello_velesdb.py) — read it, it is ~25 lines.
 
+### Next step: search your own text
+
+Use VelesDB's opt-in local adapter when your input is text rather than vectors:
+
+```bash
+pip install "velesdb[embed-sentence-transformers]"
+curl -O https://raw.githubusercontent.com/cyberlife-coder/VelesDB/main/examples/python/hello_velesdb_text.py
+python hello_velesdb_text.py
+```
+
+The first run downloads `all-MiniLM-L6-v2`; VelesDB does not bundle an embedding model. The example derives the collection dimension from the model, stores ordinary sentences, and searches them without a server or API key.
+
+Expected output:
+
+```
+Query: "How do I find documents with similar meaning?"
+  Semantic search finds documents with similar meaning.
+```
+
+The embedding model determines vector dimension, while your similarity semantics determine the metric. Both are fixed when the collection is created; to change either, create a new collection and re-index your documents.
+
 Want to keep going in Python? See [`examples/python/`](../examples/python/) for fusion, graph traversal, VelesQL, and hybrid queries.
 
 The rest of this page is the **REST API** path — useful if you want to drive VelesDB from a non-Python language, or run it as a shared service.

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -13,6 +13,15 @@ python hello_velesdb.py
 
 A self-contained ~25-line script: open a database, store five tiny documents, run two searches, print results. No NumPy import needed, no server, no embedding model. If this works, your VelesDB install is healthy.
 
+## Next step — `hello_velesdb_text.py`
+
+```bash
+pip install "velesdb[embed-sentence-transformers]"
+python hello_velesdb_text.py
+```
+
+This sibling example replaces hand-written vectors with ordinary sentences and the opt-in local `SentenceTransformerEmbedder`. Its first run downloads `all-MiniLM-L6-v2`; VelesDB does not bundle the model, and no API key or server is required.
+
 ## Prerequisites (other examples)
 
 - Python 3.9+
@@ -41,13 +50,14 @@ pip install -r requirements.txt
 
 ## Examples
 
-All examples use synthetic data (random vectors via NumPy) and create temporary
-directories that are cleaned up automatically. No external embedding models or
-API keys are needed (except for the GraphRAG examples).
+Most examples use synthetic data (random vectors via NumPy) and create temporary
+directories that are cleaned up automatically. `hello_velesdb_text.py` uses an
+opt-in local embedding model; only the GraphRAG examples require an API key.
 
 | File | Description |
 |---|---|
 | `hello_velesdb.py` | **Start here.** 25-line first-search example, no NumPy required. |
+| `hello_velesdb_text.py` | **Then use real text.** Local SentenceTransformers embeddings; no API key or server. |
 | `fusion_strategies.py` | Multi-query search with RRF, Average, Maximum, Weighted, and Relative Score fusion strategies |
 | `graph_traversal.py` | Persistent GraphCollection: edges, BFS/DFS traversal, node payloads, degree analysis |
 | `hybrid_queries.py` | Dense vector search, VelesQL queries, batch search, EXPLAIN plans, CRUD operations |
@@ -58,6 +68,9 @@ API keys are needed (except for the GraphRAG examples).
 ## Running
 
 ```bash
+# Local text embeddings (first run downloads all-MiniLM-L6-v2)
+python hello_velesdb_text.py
+
 # Self-contained examples (no external dependencies beyond velesdb + numpy)
 python fusion_strategies.py
 python graph_traversal.py

--- a/examples/python/hello_velesdb_text.py
+++ b/examples/python/hello_velesdb_text.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""hello_velesdb_text.py — Search your own text with a local embedding model.
+
+Run:
+    pip install "velesdb[embed-sentence-transformers]"
+    python hello_velesdb_text.py
+
+The first run downloads all-MiniLM-L6-v2 through SentenceTransformers.
+VelesDB does not bundle the model, and no API key or server is required.
+
+Expected output:
+    Query: "How do I find documents with similar meaning?"
+      Semantic search finds documents with similar meaning.
+"""
+import velesdb
+from velesdb.embed import SentenceTransformerEmbedder
+
+
+DOCUMENTS = [
+    "Semantic search finds documents with similar meaning.",
+    "VelesDB stores vectors locally on your machine.",
+    "A sourdough starter needs regular feeding.",
+]
+QUERY = "How do I find documents with similar meaning?"
+
+# 1. Load an opt-in local model and use its real output dimension.
+embedder = SentenceTransformerEmbedder("all-MiniLM-L6-v2")
+
+# 2. Dimension and metric are fixed when this collection is first created.
+db = velesdb.Database("./hello_velesdb_text_data")
+docs = db.get_or_create_collection(
+    "docs",
+    dimension=embedder.dimension,
+    metric="cosine",
+)
+
+# 3. Embed and store ordinary text. Re-running the script updates the same IDs.
+vectors = embedder.embed(DOCUMENTS)
+docs.upsert(
+    [
+        {"id": index, "vector": vector, "payload": {"text": text}}
+        for index, (text, vector) in enumerate(zip(DOCUMENTS, vectors), start=1)
+    ]
+)
+
+# 4. Embed a text query with the same model, then search its nearest neighbour.
+query_vector = embedder.embed([QUERY])[0]
+results = docs.search_request(
+    velesdb.SearchOptions(vector=query_vector, top_k=1)
+)
+
+print(f'Query: "{QUERY}"')
+for result in results:
+    print(f"  {result['payload']['text']}")


### PR DESCRIPTION
## Summary

- add a runnable `hello_velesdb_text.py` path from sentences to local SentenceTransformers embeddings and search
- link the real-text path from the root and Python quickstarts, including expected output and the dimension/metric immutability rule
- document embedding-generation support honestly in the comparison table

## Validation

- `python -m py_compile examples/python/hello_velesdb_text.py`
- `python scripts/check-promise-contract.py`
- `bash scripts/check-doc-contract.sh`
- `python scripts/check-feature-claims.py`
- `python scripts/check-todo-annotations.py`
- `git diff --check`

Closes #1888