### PR TITLE
refactor(core): extract shared dense+sparse fusion helper

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -340,31 +340,7 @@ impl Collection {
             metadata_filter.as_ref(),
         );
 
-        // Graceful degradation: if one branch is empty, return the other.
-        if dense_results.is_empty() && sparse_results.is_empty() {
-            return Ok(Vec::new());
-        }
-        if dense_results.is_empty() {
-            let scored: Vec<(u64, f32)> = sparse_results
-                .iter()
-                .map(|sd| (sd.doc_id, sd.score))
-                .collect();
-            return Ok(self.resolve_fused_results(&scored, limit));
-        }
-        if sparse_results.is_empty() {
-            return Ok(self.resolve_fused_results(&dense_results, limit));
-        }
-
-        let sparse_tuples: Vec<(u64, f32)> = sparse_results
-            .iter()
-            .map(|sd| (sd.doc_id, sd.score))
-            .collect();
-
-        let fused = strategy
-            .fuse(vec![dense_results, sparse_tuples])
-            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
-
-        Ok(self.resolve_fused_results(&fused, limit))
+        self.fuse_dense_sparse(dense_results, &sparse_results, limit, strategy)
     }
 
     /// Execute dense and sparse branches, optionally in parallel.
@@ -460,6 +436,48 @@ impl Collection {
             };
             (dense, sparse)
         }
+    }
+
+    /// Fuse dense and sparse branch results into ranked `SearchResult`s.
+    ///
+    /// Gracefully degrades when either branch is empty by resolving the
+    /// other branch directly, skipping fusion entirely. Shared by the
+    /// VelesQL hybrid path and the raw `SparseVector` SDK entry points.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the fusion strategy itself fails.
+    pub(crate) fn fuse_dense_sparse(
+        &self,
+        dense_results: Vec<(u64, f32)>,
+        sparse_results: &[crate::index::sparse::ScoredDoc],
+        limit: usize,
+        strategy: &FusionStrategy,
+    ) -> Result<Vec<SearchResult>> {
+        if dense_results.is_empty() && sparse_results.is_empty() {
+            return Ok(Vec::new());
+        }
+        if dense_results.is_empty() {
+            let scored: Vec<(u64, f32)> = sparse_results
+                .iter()
+                .map(|sd| (sd.doc_id, sd.score))
+                .collect();
+            return Ok(self.resolve_fused_results(&scored, limit));
+        }
+        if sparse_results.is_empty() {
+            return Ok(self.resolve_fused_results(&dense_results, limit));
+        }
+
+        let sparse_tuples: Vec<(u64, f32)> = sparse_results
+            .iter()
+            .map(|sd| (sd.doc_id, sd.score))
+            .collect();
+
+        let fused = strategy
+            .fuse(vec![dense_results, sparse_tuples])
+            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
+
+        Ok(self.resolve_fused_results(&fused, limit))
     }
 
     // ------------------------------------------------------------------

--- a/crates/velesdb-core/src/collection/search/sparse.rs
+++ b/crates/velesdb-core/src/collection/search/sparse.rs
@@ -7,7 +7,7 @@
 
 use super::resolve;
 use crate::collection::types::Collection;
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::fusion::FusionStrategy;
 use crate::point::SearchResult;
 use crate::sparse_index::{search::sparse_search, SparseVector, DEFAULT_SPARSE_INDEX_NAME};
@@ -168,29 +168,6 @@ impl Collection {
         let (dense_results, sparse_results) =
             self.execute_both_branches(dense_vector, sparse_query, index_name, candidate_k, filter);
 
-        if dense_results.is_empty() && sparse_results.is_empty() {
-            return Ok(Vec::new());
-        }
-        if dense_results.is_empty() {
-            let scored: Vec<(u64, f32)> = sparse_results
-                .iter()
-                .map(|sd| (sd.doc_id, sd.score))
-                .collect();
-            return Ok(self.resolve_fused_results(&scored, k));
-        }
-        if sparse_results.is_empty() {
-            return Ok(self.resolve_fused_results(&dense_results, k));
-        }
-
-        let sparse_tuples: Vec<(u64, f32)> = sparse_results
-            .iter()
-            .map(|sd| (sd.doc_id, sd.score))
-            .collect();
-
-        let fused = strategy
-            .fuse(vec![dense_results, sparse_tuples])
-            .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
-
-        Ok(self.resolve_fused_results(&fused, k))
+        self.fuse_dense_sparse(dense_results, &sparse_results, k, strategy)
     }
 }


### PR DESCRIPTION
## Description

`hybrid_sparse_search_inner` (the raw `SparseVector` SDK entry point in `collection/search/sparse.rs`) and `execute_hybrid_search_with_strategy` (the VelesQL hybrid path in `collection/search/query/hybrid_sparse.rs`) both call `execute_both_branches(...)` and then ran byte-for-byte identical logic afterward: the empty-branch graceful-degradation checks, the `sparse_tuples` remap, and the `strategy.fuse(...)` + `resolve_fused_results` call.

Extracted that shared tail into one private helper, `Collection::fuse_dense_sparse`, and call it from both sites. No behavior change — pure DRY cleanup of a duplicated block in a hot search path.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Ran the full sparse/hybrid test surface: `cargo test -p velesdb-core --features persistence sparse -- --test-threads=1` → 137 lib tests + 8 integration tests, all passing, 0 failures.

Also verified:
- `cargo clippy -p velesdb-core --lib --features persistence -- -D warnings -D clippy::pedantic` → clean
- `cargo fmt --all -- --check` → clean
- `python3 scripts/check_prod_unwraps.py` → passed

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Both call sites are private or crate-internal, so this touches no public API. No public API, no `unsafe`, and no hot-loop behavior changed.