### PR TITLE
feat(memory): persist durable extraction jobs

### DIFF
--- a/crates/velesdb-memory/ARCHITECTURE.md
+++ b/crates/velesdb-memory/ARCHITECTURE.md
@@ -21,7 +21,7 @@ invariants that hold the design together.
 │                                                                            │
 │   src/main.rs ── env config (store path, embedder, extractor) ──┐          │
 │                                                                 ▼          │
-│   src/mcp.rs ── McpServer: 22 tools (memory + graph + context compiler)    │
+│   src/mcp.rs ── McpServer: 23 tools (memory + graph + context compiler)    │
 │     remember · recall · relate · forget · why · remember_extracted · …    │
 │        │                                                                   │
 │        ▼                                                                   │
@@ -66,7 +66,7 @@ Mermaid view (renders on GitHub):
 flowchart TD
   C["MCP clients (Claude Code, Cursor, Zed…)"] -- "stdio JSON-RPC" --> M
   subgraph VM["velesdb-memory (this crate)"]
-    M["mcp.rs · McpServer — 22 tools"] --> S["service.rs · MemoryService&lt;E&gt;"]
+    M["mcp.rs · McpServer — 23 tools"] --> S["service.rs · MemoryService&lt;E&gt;"]
     EMB["embedder.rs · Embedder (Hash | Ollama)"] --> S
     EXT["extract.rs · Extractor (Ollama | BYO)"] --> S
     S --> LB{{"License boundary: memory semantics only"}}
@@ -136,17 +136,27 @@ it. `remember_extracted` adds the missing commodity — it makes the graph
 *self-build* from raw text:
 
 ```
-remember_extracted(text, extractor, metadata?)
+remember_extracted(text, extractor, metadata?, idempotency_key?)
   │
-  1. extractor.extract(text) → [ {fact, topics[]} … ]      [Extractor: LLM or BYO]
-  2. for each fact:
+  1. validate + fingerprint request
+  2. atomically persist ACCEPTED snapshot
+  ├──────────────────────────────► {request_id, state, reused}  [immediate receipt]
+  │
+  │  serial durable worker
+  3. persist RUNNING
+  4. extractor.extract(text) → [ {fact, topics[]} … ]      [Extractor: LLM or BYO]
+  5. persist generated extraction before any graph write
+  6. for each fact:
        fact_id = remember(fact, metadata)                  [Vector + Column]
        for each topic:
          hub_id = hub(topic)   // salted id, reserved _veles_hub marker
          relate(fact_id, hub_id, "about")     ─┐ bidirectional,
          relate(hub_id, fact_id, "mentions")  ─┘ deduped vs persisted edges
+  7. atomically persist COMMITTED result and discard source/extraction
   ▼
-[fact_id …]   ·   facts sharing a topic are now reachable through its hub
+extraction_status(request_id) → [fact_id …]
+  · facts sharing a topic are now reachable through its hub
+  · FAILED is terminal and queryable with its error
 ```
 
 **Topic hubs** are the mechanism that connects facts across passages
@@ -172,6 +182,13 @@ scaffolding: marked with the reserved `_veles_hub` key and **excluded from
   can't push real facts out of `recall`/`why`.
 - **Idempotent ingestion** — `remember_extracted` folds already-persisted edges
   into its dedup set, so re-ingesting the same text doesn't duplicate edges.
+- **Durable acceptance** — an extraction receipt is returned only after its
+  `accepted` snapshot is atomically replaced and synced. A stable
+  `idempotency_key` cannot alias a changed payload.
+- **Deterministic recovery boundary** — generated model output is persisted
+  before graph writes. A restart replays that same output through
+  content-addressed facts and deduplicated edges; it regenerates only when no
+  model output was durably recorded.
 - **Local-first** — embeddings/extraction call a model the user already runs
   (Ollama); memory and text never leave the machine.
 

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -155,6 +155,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING (MCP) — `remember_extracted` is now a durable asynchronous job
+  (#1839).** It returns `{request_id, state, reused}` immediately after an
+  `accepted` record is synced, rather than holding the transport open across
+  model generation and graph writes. Callers should supply one
+  `idempotency_key` per logical operation and poll the new
+  `extraction_status` tool for `{state, ids, ids_str, skipped_over_cap,
+  error}`. Identical retries reuse the persisted receipt; a changed payload
+  under the same key is rejected. Accepted/running jobs recover after restart,
+  and the generated extraction is persisted before writes so an interrupted
+  commit replays stable output. The Rust `MemoryService` and language-binding
+  methods remain synchronous and keep their existing return envelopes.
+
 - **BREAKING — `remember_extracted` returns an envelope**, `{ids,
   skipped_over_cap}` (`{ids, skippedOverCap}` on the JS surfaces), where Node
   returned `Array<string>` and Python `List[int]`. **Migration**: read

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -36,6 +36,10 @@ toml = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { version = "0.11", optional = true }
 fs2 = { version = "0.4", optional = true }
+# Secure sibling temporary files for durable extraction-job snapshots. The
+# dependency follows `persistence`, so wasm/no-default consumers do not carry
+# filesystem code.
+tempfile = { version = "3", optional = true }
 # Pinned to rmcp's schemars (1.2.x) so domain types and MCP DTOs share one
 # JsonSchema derive — no duplicate wire/domain structs.
 schemars = "1"
@@ -162,6 +166,7 @@ persistence = [
     "velesdb-core/persistence",
     "dep:sha2",
     "dep:fs2",
+    "dep:tempfile",
     "dep:atomicwrites",
 ]
 # Real on-device semantic recall via a local Ollama or OpenAI-compatible
@@ -178,10 +183,13 @@ ollama = ["dep:ureq"]
 extract = ["dep:ureq"]
 
 [dev-dependencies]
-tempfile = "3"
 serde_json = { workspace = true }
 tokio = { workspace = true }
 criterion = { workspace = true }
+# Integration tests use scratch stores even when `persistence` is not one of
+# the features under test. Keep the production dependency optional while
+# making the test harness feature-independent.
+tempfile = { workspace = true }
 # tests/daemon_logging.rs (#1780) installs a capturing global subscriber to
 # assert the per-request events exist, carry the promised fields, and never
 # leak a payload. Dev-only copies of the optional prod deps above, so the

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -258,11 +258,11 @@ end-to-end *extraction* comparison on the real
 
 ## What the server exposes
 
-22 MCP tools in the default build, in three families:
+23 MCP tools in the default build, in three families:
 
 | Family | Tools |
 |---|---|
-| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `unrelate`, `forget`, `entity`, `why`, `feedback`, `remember_extracted`, `memory_status`, `list_memories` |
+| Durable memory | `remember`, `recall`, `recall_where`, `recall_fused`, `relate`, `unrelate`, `forget`, `entity`, `why`, `feedback`, `remember_extracted`, `extraction_status`, `memory_status`, `list_memories` |
 | Context compiler | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `suggest_budget` |
 | Session resumption | `save_working_context`, `load_working_context`, `list_working_contexts` |
 
@@ -333,6 +333,7 @@ Other verified clients: Cursor, Cline, Zed, opencode, Devin CLI.
 | `Storage(DatabaseLocked)` | Two processes opened the same store — usually a second client, or a stray stdio process next to the daemon. | Run one `--http` daemon and point every client at it, or give the second client its own `VELESDB_MEMORY_PATH`. |
 | The server never starts from a JSON/TOML config | `~` is not expanded: those configs spawn the binary without a shell. | Use an absolute path, e.g. `/home/you/.cargo/bin/velesdb-memory`. |
 | `extraction backend not configured` from `remember_extracted` | The call omitted `extractor` and `VELESDB_MEMORY_EXTRACTOR` is unset. | Pass `extractor: "outline"`, or configure the daemon default; see [auto-extraction](../../docs/guides/MCP_SERVER_SETUP.md#auto-extraction-backend-opt-in). |
+| A `remember_extracted` client timed out | The durable job may still be running or committed; a transport timeout is not an outcome. | Retry with the same `idempotency_key`, then poll `extraction_status` using the returned `request_id`. |
 | `IngestDisabled` on a `path` fragment | `VELESDB_MEMORY_INGEST_ROOTS` is unset or empty — path ingestion is off by default. | Start the server with an allowlist of absolute directories. |
 | `relate` / `forget` reports a missing id from a JS client | Ids exceed 2^53 and lose precision as JSON numbers. | Relay the `id_str` field, or set `"policy": {"ids_as_strings": true}` on compiler calls. |
 

--- a/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
+++ b/crates/velesdb-memory/skill/velesdb-memory/SKILL.md
@@ -3,7 +3,7 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity/memory_status)
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/extraction_status/entity/memory_status)
   are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
@@ -51,7 +51,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    the USER should be told if recall quality matters, since fixing it is one
    env var); `memory.edges` (`0` = the graph is flat, so `why` degrades to
    plain search until something wires links); `extraction.configured`
-   (whether `remember_extracted` will work at all). Do not re-poll it every
+   (whether `remember_extracted` may omit its backend; explicit `outline`
+   still works when false). Do not re-poll it every
    turn — it answers configuration questions, not content ones.
 
 1. **Recall before you act.** At the start of a task, retrieve what's already
@@ -220,9 +221,11 @@ tool for a *decision* graph, where you choose the edges deliberately. It is the
 wrong tool for facts about **people, places, organisations and things**, where
 the edges are simply what the sentence already says.
 
-`remember_extracted(text)` reads a passage and stores three things at once: the
-atomic facts, the typed edges **between named entities**, and the **attributes**
-those entities carry. Say it in plain language and the graph assembles itself:
+`remember_extracted(text)` durably accepts a passage for background work and
+returns `{request_id, state, reused}` before model generation. The job stores
+three things: atomic facts, typed edges **between named entities**, and the
+**attributes** those entities carry. Say it in plain language and the graph
+assembles itself:
 
 > "Bruno Durand est le père d'Theo Durand. Theo Durand a 15 ans.
 >  Theo Durand a une sœur, Camille Durand."
@@ -276,6 +279,16 @@ are **not** interchangeable:
 Pick `"outline"` when you control the input format, or to get a graph at all
 without running a model. Pick `"ollama"` when the input is prose nobody is
 going to reformat.
+
+**Always close the asynchronous loop.** Give one logical write a stable
+`idempotency_key`; if the client times out, retry that same key and unchanged
+payload rather than guessing whether the write happened. Keep the returned
+`request_id` and poll `extraction_status(request_id)` until `committed` or
+`failed`. Only a committed status carries final `ids` / u64-safe `ids_str` and
+`skipped_over_cap`; read the latter because non-zero means the passage was only
+partly stored. `accepted` and `running` survive daemon restarts. A `failed`
+status is terminal: surface its `error`, correct the cause, then submit a new
+logical operation with a new key.
 
 ## Concrete scenarios
 

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -16,7 +16,7 @@
 /// One extracted, graph-ready fact: a self-contained sentence plus the salient
 /// topics it concerns. The topics become shared graph hubs, so two facts about
 /// the same topic are reachable from one another even with no textual overlap.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExtractedFact {
     /// The atomic, standalone fact (pronouns resolved, dates absolute).
     pub text: String,
@@ -38,7 +38,7 @@ pub struct ExtractedFact {
 /// [`ExtractedFact::entities`] (trimmed, lowercased), so they resolve to the
 /// SAME entity hub as the topics — the hub id is content-addressed, so this
 /// holds across separate calls and across sessions.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExtractedRelation {
     /// Canonical lowercase entity the edge points *from*.
     pub subject: String,
@@ -58,7 +58,7 @@ pub struct ExtractedRelation {
 /// TYPE-STRICT with no coercion, so an age extracted as the string `"15"`
 /// would silently never match a numeric filter — the extraction contract
 /// therefore demands numbers stay numbers.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ExtractedAttribute {
     /// Canonical lowercase entity the attribute belongs to.
     pub entity: String,
@@ -73,7 +73,7 @@ pub struct ExtractedAttribute {
 ///
 /// [`Extractor::extract`] returns only the `facts` half; a backend that can
 /// also read relations and attributes overrides [`Extractor::extract_graph`].
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Extraction {
     /// The atomic, standalone facts, each with the topics it concerns.
     pub facts: Vec<ExtractedFact>,

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -107,6 +107,19 @@ pub const MAX_WHY_EDGES: usize = MAX_WHY_NODES * 4;
 /// is rebuilt by re-remembering.
 pub const MAX_AUTOGRAPH_QUEUE: usize = 64;
 
+/// Maximum extraction jobs that may be accepted but not yet terminal.
+///
+/// Unlike autograph enrichments, these jobs are durable and therefore never
+/// dropped when the worker falls behind. Admission stops at the same bounded
+/// depth instead: the accepted receipt remains an honest promise that the job
+/// will either commit or expose a persisted failure.
+pub const MAX_EXTRACTION_JOBS: usize = 64;
+
+/// Maximum caller-supplied idempotency-key size for `remember_extracted`.
+/// Keys are hashed before they reach a filename, but bounding the input still
+/// prevents an otherwise tiny receipt call from carrying an arbitrary payload.
+pub const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
+
 /// Maximum typed edges an `entity` profile resolves and returns PER
 /// DIRECTION (`relations` and `relations_in` each) — the same width grammar
 /// as [`MAX_WHY_NODE_DEGREE`], on the surface #1743 never covered: resolving

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -133,10 +133,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         embedder_model,
         embedder_dimension,
     } = configured;
+    let store_path = std::path::PathBuf::from(store_path);
     let server = apply_ingest_roots(apply_default_ttl(
         build_server(service)?
             .with_embedder_identity(embedder_model, embedder_dimension)
-            .with_store_dir(store_path),
+            .with_store_dir(&store_path)
+            .with_extraction_jobs(&store_path)
+            .map_err(std::io::Error::other)?,
     )?)?;
 
     tokio::runtime::Runtime::new()?.block_on(async move {

--- a/crates/velesdb-memory/src/mcp.rs
+++ b/crates/velesdb-memory/src/mcp.rs
@@ -40,19 +40,24 @@ use crate::extract::DynExtractor;
 mod context_tools;
 
 mod dto;
+mod extraction_job_model;
+mod extraction_job_store;
+mod extraction_jobs;
 mod extractor_resolver;
 mod wire;
 use dto::{
-    EmbedderStatus, EntityParams, EntityProfileDto, ExplanationDto, ExtractionStatus,
-    FeedbackParams, FeedbackResult, ForgetParams, ForgetResult, ListMemoriesParams,
-    ListMemoriesResult, ListedMemoryDto, MemoryCounts, MemoryStatusResult, ProvenanceStatus,
-    RecallFusedParams, RecallFusedResult, RecallParams, RecallResult, RecallWhereParams,
-    RelateParams, RelateResult, RememberExtractedParams, RememberExtractedResult, RememberParams,
-    RememberResult, UnrelateParams, UnrelateResult, WhyParams,
+    EmbedderStatus, EntityParams, EntityProfileDto, ExplanationDto, ExtractionJobStatusParams,
+    ExtractionJobStatusResult, ExtractionStatus, FeedbackParams, FeedbackResult, ForgetParams,
+    ForgetResult, ListMemoriesParams, ListMemoriesResult, ListedMemoryDto, MemoryCounts,
+    MemoryStatusResult, ProvenanceStatus, RecallFusedParams, RecallFusedResult, RecallParams,
+    RecallResult, RecallWhereParams, RelateParams, RelateResult, RememberExtractedParams,
+    RememberExtractedResult, RememberParams, RememberResult, UnrelateParams, UnrelateResult,
+    WhyParams,
 };
-use extractor_resolver::{ExtractorResolveError, ExtractorResolver};
+use extraction_jobs::{ExtractionJobs, JobError};
+use extractor_resolver::ExtractorResolver;
 
-/// Le constructeur de schema d'ENTREE, unique pour les vingt-deux outils :
+/// Le constructeur de schema d'ENTREE, unique pour les vingt-trois outils :
 /// [`crate::schema::wire_safe_input_schema`].
 ///
 /// `keys` nomme les proprietes que CET outil accepte en chaine decimale
@@ -80,7 +85,10 @@ pub struct McpServer {
     /// waits for at most ONE generation.
     _autograph_worker: Option<Arc<crate::service::AutographWorkerHandle>>,
     /// Daemon-level default and per-call selection for `remember_extracted`.
-    extractors: ExtractorResolver,
+    extractors: Arc<parking_lot::RwLock<ExtractorResolver>>,
+    /// Durable receipt/status state machine for `remember_extracted`.
+    /// Configured by the native daemon once its store path is known.
+    extraction_jobs: Option<ExtractionJobs>,
     /// Default time-to-live (seconds) applied to `remember`d facts that don't
     /// specify their own `ttl_seconds`. `None` (the default) stores permanently.
     /// Set from `VELESDB_MEMORY_DEFAULT_TTL` by the binary.
@@ -131,7 +139,8 @@ impl McpServer {
         Self {
             service,
             _autograph_worker: autograph_worker,
-            extractors: ExtractorResolver::default(),
+            extractors: Arc::new(parking_lot::RwLock::new(ExtractorResolver::default())),
+            extraction_jobs: None,
             default_ttl: None,
             embedder_identity: None,
             store_dir: None,
@@ -195,8 +204,8 @@ impl McpServer {
     /// Attach an extraction backend, enabling the `remember_extracted` tool.
     /// Without it the tool reports that extraction is not configured.
     #[must_use]
-    pub fn with_extractor(mut self, extractor: DynExtractor) -> Self {
-        self.extractors = ExtractorResolver::unnamed(extractor);
+    pub fn with_extractor(self, extractor: DynExtractor) -> Self {
+        *self.extractors.write() = ExtractorResolver::unnamed(extractor);
         self
     }
 
@@ -206,11 +215,35 @@ impl McpServer {
     /// # Errors
     /// Returns an error when `backend` is unknown or disables extraction.
     pub fn with_named_extractor(
-        mut self,
+        self,
         backend: impl Into<String>,
         extractor: DynExtractor,
     ) -> Result<Self, String> {
-        self.extractors = ExtractorResolver::named(backend.into(), extractor)?;
+        *self.extractors.write() = ExtractorResolver::named(backend.into(), extractor)?;
+        Ok(self)
+    }
+
+    /// Enable the durable extraction-job worker under the native store root.
+    ///
+    /// Call this after opening the store and before serving requests. Accepted
+    /// and in-flight records are recovered immediately; corrupt durable state
+    /// fails startup instead of silently losing a receipt.
+    ///
+    /// # Errors
+    /// Returns a descriptive error if the job directory cannot be created,
+    /// validated, read, or if the recovery worker cannot start.
+    pub fn with_extraction_jobs(
+        mut self,
+        store_root: impl AsRef<std::path::Path>,
+    ) -> Result<Self, String> {
+        self.extraction_jobs = Some(
+            ExtractionJobs::open(
+                store_root.as_ref(),
+                Arc::clone(&self.service),
+                Arc::clone(&self.extractors),
+            )
+            .map_err(|error| error.to_string())?,
+        );
         Ok(self)
     }
 
@@ -529,7 +562,7 @@ impl McpServer {
         // conserve des $ref qu'un client aveugle aux $defs ne resout pas —
         // or les SDK MCP valident structuredContent contre ce schema.
         output_schema = crate::schema::wire_safe_output_schema::<RememberExtractedResult>(),
-        description = "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Set `extractor` per call (`outline`, `ollama`, or `openai`), or omit it to use the daemon default from VELESDB_MEMORY_EXTRACTOR. `outline` is always available; a remote backend must be the one configured when the daemon started. Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts."
+        description = "Accept a passage for durable background extraction and return before model generation. Set `extractor` per call (`outline`, `ollama`, or `openai`), or omit it to use VELESDB_MEMORY_EXTRACTOR. Supply `idempotency_key` when retrying across a client timeout: the same key and payload reuse one job, while a changed payload is rejected. The receipt returns `request_id`, its initial `state` (`accepted`, or the persisted state of a reused request), and `reused`. Poll `extraction_status(request_id)` until `committed` or `failed`; accepted/running jobs survive process restart."
     )]
     async fn remember_extracted(
         &self,
@@ -539,6 +572,7 @@ impl McpServer {
             text,
             metadata,
             extractor,
+            idempotency_key,
         } = params;
         if text.len() > MAX_FACT_BYTES {
             return Err(ErrorData::new(
@@ -547,25 +581,63 @@ impl McpServer {
                 None,
             ));
         }
-        let extractor = self
-            .extractors
-            .resolve(extractor.as_deref())
-            .map_err(extractor_error)?;
-        // Extraction makes a blocking network call (up to the extractor's
-        // timeout), so run it off the async worker pool to keep the stdio loop
-        // responsive to other tool calls and cancellations.
-        let service = Arc::clone(&self.service);
-        let outcome = tokio::task::spawn_blocking(move || {
-            service.remember_extracted(&text, &extractor, metadata.as_ref())
+        let jobs = self.extraction_jobs.clone().ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "durable extraction jobs are not configured for this server",
+                None,
+            )
+        })?;
+        let receipt = tokio::task::spawn_blocking(move || {
+            jobs.submit(
+                &text,
+                metadata,
+                extractor.as_deref(),
+                idempotency_key.as_deref(),
+            )
         })
         .await
         .map_err(join_error)?
-        .map_err(to_error)?;
-        let ids_str = outcome.ids.iter().map(u64::to_string).collect();
+        .map_err(job_error)?;
         Ok(Json(RememberExtractedResult {
-            ids: outcome.ids,
+            request_id: receipt.request_id,
+            state: receipt.state,
+            reused: receipt.reused,
+        }))
+    }
+
+    #[tool(
+        name = "extraction_status",
+        output_schema = crate::schema::wire_safe_output_schema::<ExtractionJobStatusResult>(),
+        description = "Read one durable extraction job by the `request_id` returned from `remember_extracted`. Returns that `request_id`, its persisted `state` (`accepted`, `running`, `committed`, or `failed`), committed fact `ids` and their u64-safe decimal `ids_str` twins, `skipped_over_cap` after commit, and `error` after failure. While accepted/running, `ids` and `ids_str` are empty and both optional terminal fields are null."
+    )]
+    async fn extraction_status(
+        &self,
+        Parameters(params): Parameters<ExtractionJobStatusParams>,
+    ) -> Result<Json<ExtractionJobStatusResult>, ErrorData> {
+        let jobs = self.extraction_jobs.clone().ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "durable extraction jobs are not configured for this server",
+                None,
+            )
+        })?;
+        let view = tokio::task::spawn_blocking(move || jobs.status(&params.request_id))
+            .await
+            .map_err(join_error)?
+            .map_err(job_error)?;
+        let (ids, skipped_over_cap) = view.outcome.map_or_else(
+            || (Vec::new(), None),
+            |outcome| (outcome.ids, Some(outcome.skipped_over_cap)),
+        );
+        let ids_str = ids.iter().map(u64::to_string).collect();
+        Ok(Json(ExtractionJobStatusResult {
+            request_id: view.request_id,
+            state: view.state,
+            ids,
             ids_str,
-            skipped_over_cap: outcome.skipped_over_cap,
+            skipped_over_cap,
+            error: view.error,
         }))
     }
 
@@ -622,7 +694,7 @@ impl McpServer {
                 // extractor is attached separately and reports through the
                 // two autograph fields, so an autograph-only configuration
                 // never claims a tool that would refuse.
-                configured: self.extractors.default_is_configured(),
+                configured: self.extractors.read().default_is_configured(),
                 autograph_active: self.service.autograph_queue_open(),
                 autograph_dropped: self.service.autograph_dropped(),
             },
@@ -686,11 +758,12 @@ impl McpServer {
 /// "context")]` variant since the context-compiler tools only exist in that
 /// build.
 #[cfg(feature = "context")]
-const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, remember_extracted, recall, recall_fused, recall_where, relate, unrelate, forget, feedback, entity, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); remember_extracted reads the entities, typed edges and attributes a passage STATES and wires them into the graph, and entity(name) answers a question ABOUT a named thing rather than about the sentences mentioning it; memory_status reports the server's health — which embedder runs and whether recall is semantic, extraction wiring, and graph size; list_memories audits the store page by page — what recall cannot answer, because what resembles no query stays invisible; (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
+const SERVER_INSTRUCTIONS: &str = "Local-first memory and context engineering for AI agents, three tool families: (1) durable memory — remember, remember_extracted, extraction_status, recall, recall_fused, recall_where, relate, unrelate, forget, feedback, entity, and why — explainable (why returns the evidence trail) and self-improving (feedback re-ranks future recall); remember_extracted durably accepts a passage, then reads the entities, typed edges and attributes it STATES and wires them into the graph in the background: keep its request_id and poll extraction_status until committed or failed, reusing one idempotency_key across transport retries; entity(name) answers a question ABOUT a named thing rather than about the sentences mentioning it; memory_status reports the server's health — which embedder runs and whether recall is semantic, extraction wiring, and graph size; list_memories audits the store page by page — what recall cannot answer, because what resembles no query stays invisible; (2) the deterministic context compiler — compile_context, compile_transcript, explain_compilation, retrieve_context_source, context_savings, and suggest_budget — token-budgets and audits prompt context with no LLM call, ever; (3) cross-session working-context resumption — save_working_context, load_working_context, and list_working_contexts. compile_context/explain_compilation fragments accept a `path` instead of inline `content` to ingest a file by reference — disabled unless the server is started with VELESDB_MEMORY_INGEST_ROOTS set to an allowlist of directories (compile_transcript's own `path` field uses the same allowlist). compile_transcript is a one-call shortcut over compile_context for a raw agent-session transcript: it segments plain or JSONL text into turns before compiling, so an agent no longer needs to segment a transcript by hand. Nothing ever leaves the machine.";
 
 #[cfg(not(feature = "context"))]
 const SERVER_INSTRUCTIONS: &str = "Local-first memory for AI agents: remember facts, recall them \
      semantically, relate them, forget them, ask why a decision was made (connected subgraph), \
+     submit durable remember_extracted jobs and poll extraction_status to completion, \
      read memory_status for the server's health — embedder semantics, extraction wiring, \
      graph size — and audit the store page by page with list_memories.";
 
@@ -828,20 +901,17 @@ fn assert_every_input_slot_is_typed(router: &ToolRouter<McpServer>) {
     );
 }
 
-/// Preserve the existing server-fault code for a missing default while
-/// classifying an explicit, unusable backend name as caller input.
-fn extractor_error(error: ExtractorResolveError) -> ErrorData {
-    match error {
-        ExtractorResolveError::DefaultNotConfigured => ErrorData::new(
-            ErrorCode::INTERNAL_ERROR,
-            "extraction backend not configured: set VELESDB_MEMORY_EXTRACTOR, \
-             or pass extractor='outline' for the offline deterministic reader",
-            None,
-        ),
-        ExtractorResolveError::InvalidRequest(message) => {
-            ErrorData::new(ErrorCode::INVALID_PARAMS, message, None)
+#[allow(clippy::needless_pass_by_value)]
+fn job_error(error: JobError) -> ErrorData {
+    let code = match error {
+        JobError::Invalid(_) | JobError::Conflict | JobError::NotFound(_) => {
+            ErrorCode::INVALID_PARAMS
         }
-    }
+        JobError::AtCapacity | JobError::BackendNotConfigured | JobError::Storage(_) => {
+            ErrorCode::INTERNAL_ERROR
+        }
+    };
+    ErrorData::new(code, error.to_string(), None)
 }
 
 /// Map a `spawn_blocking` join failure (a panicked or cancelled tool task) to an

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -18,6 +18,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+use super::extraction_jobs::ExtractionJobState;
 use crate::model::{
     deserialize_id, ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryEdge,
     MemoryNode, Recollection,
@@ -572,23 +573,48 @@ pub(super) struct RememberExtractedParams {
     /// backend configured when the daemon started.
     #[serde(default)]
     pub(super) extractor: Option<String>,
+    /// Optional retry key. Reusing it with the same payload returns the same
+    /// durable job; reusing it with a different payload is rejected.
+    #[serde(default)]
+    pub(super) idempotency_key: Option<String>,
 }
 
-/// Result of the `remember_extracted` tool.
+/// Immediate durable receipt from the `remember_extracted` tool.
 #[derive(Serialize, JsonSchema)]
 #[schemars(transform = crate::schema::strip_int_formats)]
 pub(super) struct RememberExtractedResult {
-    /// Stable ids of the stored facts, in extraction order.
+    /// Stable 64-hex identifier used to query the durable job.
+    pub(super) request_id: String,
+    /// State observed when the receipt was produced.
+    pub(super) state: ExtractionJobState,
+    /// Whether an identical prior request was reused instead of enqueued.
+    pub(super) reused: bool,
+}
+
+/// Parameters for the `extraction_status` tool.
+#[derive(Deserialize, JsonSchema)]
+pub(super) struct ExtractionJobStatusParams {
+    /// The `request_id` returned by `remember_extracted`.
+    pub(super) request_id: String,
+}
+
+/// Durable status and terminal result of one extraction job.
+#[derive(Serialize, JsonSchema)]
+#[schemars(transform = crate::schema::strip_int_formats)]
+pub(super) struct ExtractionJobStatusResult {
+    /// Stable job identifier.
+    pub(super) request_id: String,
+    /// One of `accepted`, `running`, `committed`, or `failed`.
+    pub(super) state: ExtractionJobState,
+    /// Stored fact ids after commit; empty while pending or failed.
     pub(super) ids: Vec<u64>,
-    /// Decimal-string twins of `ids`, same order (issue #1468) — see
-    /// [`RememberResult::id_str`].
+    /// Decimal-string twins of `ids` for float-lossy JSON clients.
     pub(super) ids_str: Vec<String>,
-    /// Extracted facts DROPPED for exceeding the embeddable text cap
-    /// (2048 bytes). Additive and always present: a skip the caller cannot
-    /// see is indistinguishable from the model extracting fewer facts, and
-    /// this tool exists precisely so the caller does not have to verify what
-    /// it stored.
-    pub(super) skipped_over_cap: usize,
+    /// Extracted facts dropped for exceeding the embeddable cap, present only
+    /// after commit.
+    pub(super) skipped_over_cap: Option<usize>,
+    /// Terminal failure detail, present only in the `failed` state.
+    pub(super) error: Option<String>,
 }
 
 /// The `embedder` block of [`MemoryStatusResult`].

--- a/crates/velesdb-memory/src/mcp/extraction_job_model.rs
+++ b/crates/velesdb-memory/src/mcp/extraction_job_model.rs
@@ -1,0 +1,181 @@
+//! Persisted types and invariants for durable extraction jobs.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::extract::Extraction;
+use crate::model::RememberedExtraction;
+use crate::service::Metadata;
+
+pub(super) const RECORD_VERSION: u8 = 1;
+
+/// Persisted lifecycle exposed by both extraction tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ExtractionJobState {
+    Accepted,
+    Running,
+    Committed,
+    Failed,
+}
+
+impl ExtractionJobState {
+    pub(super) fn is_terminal(self) -> bool {
+        matches!(self, Self::Committed | Self::Failed)
+    }
+}
+
+/// Lightweight receipt returned before model generation begins.
+pub(super) struct JobReceipt {
+    pub(super) request_id: String,
+    pub(super) state: ExtractionJobState,
+    pub(super) reused: bool,
+}
+
+/// Query view of one durable job.
+pub(super) struct JobView {
+    pub(super) request_id: String,
+    pub(super) state: ExtractionJobState,
+    pub(super) outcome: Option<JobOutcome>,
+    pub(super) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct JobOutcome {
+    pub(super) ids: Vec<u64>,
+    pub(super) skipped_over_cap: usize,
+}
+
+impl From<RememberedExtraction> for JobOutcome {
+    fn from(value: RememberedExtraction) -> Self {
+        Self {
+            ids: value.ids,
+            skipped_over_cap: value.skipped_over_cap,
+        }
+    }
+}
+
+/// Submission/status failures mapped to JSON-RPC by the MCP layer.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum JobError {
+    #[error("{0}")]
+    Invalid(String),
+    #[error("idempotency key already belongs to a different extraction request")]
+    Conflict,
+    #[error("too many extraction jobs are pending; retry after one reaches a terminal state")]
+    AtCapacity,
+    #[error(
+        "extraction backend not configured: set VELESDB_MEMORY_EXTRACTOR, or pass \
+         extractor='outline' for the offline deterministic reader"
+    )]
+    BackendNotConfigured,
+    #[error("extraction request '{0}' does not exist")]
+    NotFound(String),
+    #[error("durable extraction job storage failed: {0}")]
+    Storage(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct PersistedRequest {
+    pub(super) text: String,
+    pub(super) metadata: Option<Metadata>,
+    pub(super) backend: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct JobRecord {
+    pub(super) version: u8,
+    pub(super) request_id: String,
+    pub(super) input_digest: String,
+    pub(super) state: ExtractionJobState,
+    pub(super) request: Option<PersistedRequest>,
+    pub(super) extraction: Option<Extraction>,
+    pub(super) outcome: Option<JobOutcome>,
+    pub(super) error: Option<String>,
+}
+
+impl JobRecord {
+    pub(super) fn accepted(
+        request_id: String,
+        input_digest: String,
+        request: PersistedRequest,
+    ) -> Self {
+        Self {
+            version: RECORD_VERSION,
+            request_id,
+            input_digest,
+            state: ExtractionJobState::Accepted,
+            request: Some(request),
+            extraction: None,
+            outcome: None,
+            error: None,
+        }
+    }
+
+    pub(super) fn validate(&self) -> Result<(), JobError> {
+        self.validate_identity()?;
+        if self.has_valid_shape() {
+            return Ok(());
+        }
+        Err(JobError::Storage(format!(
+            "inconsistent extraction job '{}'",
+            self.request_id
+        )))
+    }
+
+    fn validate_identity(&self) -> Result<(), JobError> {
+        if self.version != RECORD_VERSION || !valid_digest(&self.request_id) {
+            return Err(JobError::Storage(
+                "invalid extraction job identity".to_owned(),
+            ));
+        }
+        if !valid_digest(&self.input_digest) {
+            return Err(JobError::Storage(
+                "invalid extraction input digest".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn has_valid_shape(&self) -> bool {
+        match self.state {
+            ExtractionJobState::Accepted => self.has_accepted_shape(),
+            ExtractionJobState::Running => self.has_running_shape(),
+            ExtractionJobState::Committed => self.has_committed_shape(),
+            ExtractionJobState::Failed => self.has_failed_shape(),
+        }
+    }
+
+    fn has_accepted_shape(&self) -> bool {
+        self.request.is_some()
+            && self.extraction.is_none()
+            && self.outcome.is_none()
+            && self.error.is_none()
+    }
+
+    fn has_running_shape(&self) -> bool {
+        self.request.is_some() && self.outcome.is_none() && self.error.is_none()
+    }
+
+    fn has_committed_shape(&self) -> bool {
+        self.request.is_none()
+            && self.extraction.is_none()
+            && self.outcome.is_some()
+            && self.error.is_none()
+    }
+
+    fn has_failed_shape(&self) -> bool {
+        self.request.is_none()
+            && self.extraction.is_none()
+            && self.outcome.is_none()
+            && self.error.is_some()
+    }
+}
+
+pub(super) fn valid_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}

--- a/crates/velesdb-memory/src/mcp/extraction_job_store.rs
+++ b/crates/velesdb-memory/src/mcp/extraction_job_store.rs
@@ -1,0 +1,209 @@
+//! Atomic per-job snapshots for the durable extraction state machine.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::extraction_jobs::{JobError, JobRecord};
+
+const JOB_DIRECTORY: &str = "extraction-jobs";
+const MAX_RECORD_BYTES: u64 = 16 * 1024 * 1024;
+const TEMP_PREFIX: &str = ".extraction-job-";
+
+pub(super) struct JobStore {
+    directory: PathBuf,
+}
+
+impl JobStore {
+    pub(super) fn open(root: &Path) -> Result<Self, JobError> {
+        let directory = root.join(JOB_DIRECTORY);
+        ensure_job_directory(root, &directory)?;
+        let metadata = std::fs::symlink_metadata(&directory).map_err(storage_error)?;
+        if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+            return Err(JobError::Storage(format!(
+                "{} must be a real directory, not a symlink",
+                directory.display()
+            )));
+        }
+        Ok(Self { directory })
+    }
+
+    pub(super) fn pending(&self) -> Result<Vec<String>, JobError> {
+        let mut pending = Vec::new();
+        for entry in self.entries()? {
+            if remove_if_temporary(&entry)? {
+                continue;
+            }
+            let record = self.load_entry(&entry)?;
+            if !record.state.is_terminal() {
+                pending.push(record.request_id);
+            }
+        }
+        pending.sort();
+        Ok(pending)
+    }
+
+    pub(super) fn load(&self, request_id: &str) -> Result<Option<JobRecord>, JobError> {
+        let path = self.path(request_id);
+        let Some(bytes) = read_record_bytes(&path)? else {
+            return Ok(None);
+        };
+        let record: JobRecord = serde_json::from_slice(&bytes).map_err(storage_error)?;
+        record.validate()?;
+        validate_filename(&record, request_id, &path)?;
+        Ok(Some(record))
+    }
+
+    pub(super) fn save(&self, record: &JobRecord) -> Result<(), JobError> {
+        let bytes = serialize_record(record)?;
+        let temporary_path = write_temporary(&self.directory, &bytes)?;
+        promote(&temporary_path, &self.path(&record.request_id)).map_err(storage_error)?;
+        sync_directory(&self.directory).map_err(storage_error)
+    }
+
+    fn entries(&self) -> Result<Vec<std::fs::DirEntry>, JobError> {
+        let entries = std::fs::read_dir(&self.directory).map_err(storage_error)?;
+        entries.map(|entry| entry.map_err(storage_error)).collect()
+    }
+
+    fn load_entry(&self, entry: &std::fs::DirEntry) -> Result<JobRecord, JobError> {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let request_id = name.strip_suffix(".json").ok_or_else(|| {
+            JobError::Storage(format!(
+                "unexpected entry in {}: {name}",
+                self.directory.display()
+            ))
+        })?;
+        self.load(request_id)?
+            .ok_or_else(|| JobError::Storage(format!("job record vanished: {name}")))
+    }
+
+    fn path(&self, request_id: &str) -> PathBuf {
+        self.directory.join(format!("{request_id}.json"))
+    }
+}
+
+fn ensure_job_directory(root: &Path, directory: &Path) -> Result<(), JobError> {
+    match std::fs::create_dir(directory) {
+        Ok(()) => sync_directory(root).map_err(storage_error),
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(error) => Err(storage_error(error)),
+    }
+}
+
+fn remove_if_temporary(entry: &std::fs::DirEntry) -> Result<bool, JobError> {
+    let name = entry.file_name().to_string_lossy().into_owned();
+    let is_temporary = name.starts_with(TEMP_PREFIX)
+        && entry
+            .path()
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("tmp"));
+    if !is_temporary {
+        return Ok(false);
+    }
+    std::fs::remove_file(entry.path()).map_err(storage_error)?;
+    Ok(true)
+}
+
+fn read_record_bytes(path: &Path) -> Result<Option<Vec<u8>>, JobError> {
+    let Some(metadata) = record_metadata(path)? else {
+        return Ok(None);
+    };
+    validate_record_metadata(path, &metadata)?;
+    std::fs::read(path).map(Some).map_err(storage_error)
+}
+
+fn record_metadata(path: &Path) -> Result<Option<std::fs::Metadata>, JobError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(storage_error(error)),
+    }
+}
+
+fn validate_record_metadata(path: &Path, metadata: &std::fs::Metadata) -> Result<(), JobError> {
+    if !metadata.file_type().is_file() || metadata.len() > MAX_RECORD_BYTES {
+        return Err(JobError::Storage(format!(
+            "invalid extraction job record {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_filename(record: &JobRecord, request_id: &str, path: &Path) -> Result<(), JobError> {
+    if record.request_id != request_id {
+        return Err(JobError::Storage(format!(
+            "job filename does not match its request_id: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn serialize_record(record: &JobRecord) -> Result<Vec<u8>, JobError> {
+    record.validate()?;
+    let bytes = serde_json::to_vec(record).map_err(storage_error)?;
+    if bytes.len() as u64 > MAX_RECORD_BYTES {
+        return Err(JobError::Storage(format!(
+            "job '{}' exceeds the {} byte snapshot limit",
+            record.request_id, MAX_RECORD_BYTES
+        )));
+    }
+    Ok(bytes)
+}
+
+fn write_temporary(directory: &Path, bytes: &[u8]) -> Result<PathBuf, JobError> {
+    let mut temporary = tempfile::Builder::new()
+        .prefix(TEMP_PREFIX)
+        .suffix(".tmp")
+        .tempfile_in(directory)
+        .map_err(storage_error)?;
+    temporary.write_all(bytes).map_err(storage_error)?;
+    temporary.flush().map_err(storage_error)?;
+    temporary.as_file().sync_all().map_err(storage_error)?;
+    let (file, temporary_path) = temporary
+        .keep()
+        .map_err(|error| storage_error(error.error))?;
+    drop(file);
+    Ok(temporary_path)
+}
+
+pub(super) fn storage_error(error: impl std::fmt::Display) -> JobError {
+    JobError::Storage(error.to_string())
+}
+
+#[cfg(unix)]
+fn promote(temporary: &Path, final_path: &Path) -> std::io::Result<()> {
+    std::fs::rename(temporary, final_path)
+}
+
+#[cfg(windows)]
+fn promote(temporary: &Path, final_path: &Path) -> std::io::Result<()> {
+    atomicwrites::replace_atomic(temporary, final_path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn promote(_temporary: &Path, _final_path: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "durable extraction jobs require Unix or Windows atomic replacement",
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(directory: &Path) -> std::io::Result<()> {
+    std::fs::File::open(directory)?.sync_all()
+}
+
+#[cfg(windows)]
+fn sync_directory(_directory: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn sync_directory(_directory: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "no durable directory barrier is available on this platform",
+    ))
+}

--- a/crates/velesdb-memory/src/mcp/extraction_jobs.rs
+++ b/crates/velesdb-memory/src/mcp/extraction_jobs.rs
@@ -1,0 +1,504 @@
+//! Durable state machine behind the asynchronous `remember_extracted` tool.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+
+use parking_lot::{Mutex, RwLock};
+use sha2::{Digest, Sha256};
+
+#[cfg(test)]
+use super::extraction_job_model::RECORD_VERSION;
+pub(super) use super::extraction_job_model::{
+    valid_digest, ExtractionJobState, JobError, JobReceipt, JobRecord, JobView, PersistedRequest,
+};
+use super::extraction_job_store::{storage_error, JobStore};
+use super::extractor_resolver::ExtractorResolver;
+use crate::embedder::DynEmbedder;
+use crate::extract::Extraction;
+use crate::model::RememberedExtraction;
+use crate::service::{MemoryService, Metadata};
+
+#[derive(Default)]
+struct RuntimeState {
+    pending: usize,
+    queued: HashSet<String>,
+}
+
+struct PreparedSubmission {
+    request: PersistedRequest,
+    input_digest: String,
+    request_id: String,
+}
+
+struct Shared {
+    service: Arc<MemoryService<DynEmbedder>>,
+    extractors: Arc<RwLock<ExtractorResolver>>,
+    store: JobStore,
+    runtime: Mutex<RuntimeState>,
+    closing: Arc<AtomicBool>,
+}
+
+enum Command {
+    Run(String),
+    Stop,
+}
+
+struct WorkerGuard {
+    closing: Arc<AtomicBool>,
+    tx: mpsc::Sender<Command>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for WorkerGuard {
+    fn drop(&mut self) {
+        self.closing.store(true, Ordering::Release);
+        let _ = self.tx.send(Command::Stop);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+/// Cloneable front-end to one serial, durable extraction worker.
+#[derive(Clone)]
+pub(super) struct ExtractionJobs {
+    shared: Arc<Shared>,
+    tx: mpsc::Sender<Command>,
+    _guard: Arc<WorkerGuard>,
+}
+
+impl ExtractionJobs {
+    pub(super) fn open(
+        root: &Path,
+        service: Arc<MemoryService<DynEmbedder>>,
+        extractors: Arc<RwLock<ExtractorResolver>>,
+    ) -> Result<Self, JobError> {
+        let store = JobStore::open(root)?;
+        let pending = store.pending()?;
+        if pending.len() > crate::limits::MAX_EXTRACTION_JOBS {
+            return Err(JobError::Storage(format!(
+                "{} non-terminal extraction jobs exceed the limit of {}",
+                pending.len(),
+                crate::limits::MAX_EXTRACTION_JOBS
+            )));
+        }
+        let closing = Arc::new(AtomicBool::new(false));
+        let runtime = RuntimeState {
+            pending: pending.len(),
+            queued: pending.iter().cloned().collect(),
+        };
+        let shared = Arc::new(Shared {
+            service,
+            extractors,
+            store,
+            runtime: Mutex::new(runtime),
+            closing: Arc::clone(&closing),
+        });
+        let (tx, rx) = mpsc::channel();
+        let worker_shared = Arc::clone(&shared);
+        let join = std::thread::Builder::new()
+            .name("velesdb-extraction-jobs".to_owned())
+            .spawn(move || worker_loop(&worker_shared, &rx))
+            .map_err(|error| JobError::Storage(format!("cannot spawn worker: {error}")))?;
+        for request_id in pending {
+            tx.send(Command::Run(request_id))
+                .map_err(|_| JobError::Storage("worker stopped during recovery".to_owned()))?;
+        }
+        let guard = Arc::new(WorkerGuard {
+            closing,
+            tx: tx.clone(),
+            join: Some(join),
+        });
+        Ok(Self {
+            shared,
+            tx,
+            _guard: guard,
+        })
+    }
+
+    pub(super) fn submit(
+        &self,
+        text: &str,
+        metadata: Option<Metadata>,
+        requested_backend: Option<&str>,
+        idempotency_key: Option<&str>,
+    ) -> Result<JobReceipt, JobError> {
+        let prepared = prepare_submission(text, metadata, requested_backend, idempotency_key)?;
+        let mut runtime = self.shared.runtime.lock();
+        if let Some(receipt) = self.reused_receipt(&prepared, &mut runtime)? {
+            return Ok(receipt);
+        }
+        self.accept_new(prepared, requested_backend, &mut runtime)
+    }
+
+    fn reused_receipt(
+        &self,
+        prepared: &PreparedSubmission,
+        runtime: &mut RuntimeState,
+    ) -> Result<Option<JobReceipt>, JobError> {
+        let Some(existing) = self.shared.store.load(&prepared.request_id)? else {
+            return Ok(None);
+        };
+        if existing.input_digest != prepared.input_digest {
+            return Err(JobError::Conflict);
+        }
+        enqueue_if_needed(&self.tx, runtime, &prepared.request_id, existing.state)?;
+        Ok(Some(JobReceipt {
+            request_id: prepared.request_id.clone(),
+            state: existing.state,
+            reused: true,
+        }))
+    }
+
+    fn accept_new(
+        &self,
+        mut prepared: PreparedSubmission,
+        requested_backend: Option<&str>,
+        runtime: &mut RuntimeState,
+    ) -> Result<JobReceipt, JobError> {
+        prepared.request.backend = self.resolve_backend(requested_backend)?;
+        if runtime.pending >= crate::limits::MAX_EXTRACTION_JOBS {
+            return Err(JobError::AtCapacity);
+        }
+        stamp_acceptance_date(&mut prepared.request.metadata);
+        let record = JobRecord::accepted(
+            prepared.request_id.clone(),
+            prepared.input_digest,
+            prepared.request,
+        );
+        self.shared.store.save(&record)?;
+        runtime.pending += 1;
+        enqueue_if_needed(
+            &self.tx,
+            runtime,
+            &prepared.request_id,
+            ExtractionJobState::Accepted,
+        )?;
+        Ok(JobReceipt {
+            request_id: prepared.request_id,
+            state: ExtractionJobState::Accepted,
+            reused: false,
+        })
+    }
+
+    fn resolve_backend(&self, requested: Option<&str>) -> Result<Option<String>, JobError> {
+        self.shared
+            .extractors
+            .read()
+            .resolve_for_job(requested)
+            .map(|resolved| resolved.backend)
+            .map_err(|error| match error {
+                super::extractor_resolver::ExtractorResolveError::DefaultNotConfigured => {
+                    JobError::BackendNotConfigured
+                }
+                super::extractor_resolver::ExtractorResolveError::InvalidRequest(message) => {
+                    JobError::Invalid(message)
+                }
+            })
+    }
+
+    pub(super) fn status(&self, request_id: &str) -> Result<JobView, JobError> {
+        if !valid_digest(request_id) {
+            return Err(JobError::Invalid(
+                "request_id must be 64 lowercase hexadecimal characters".to_owned(),
+            ));
+        }
+        let mut runtime = self.shared.runtime.lock();
+        let record = self
+            .shared
+            .store
+            .load(request_id)?
+            .ok_or_else(|| JobError::NotFound(request_id.to_owned()))?;
+        enqueue_if_needed(&self.tx, &mut runtime, request_id, record.state)?;
+        Ok(JobView {
+            request_id: record.request_id,
+            state: record.state,
+            outcome: record.outcome,
+            error: record.error,
+        })
+    }
+}
+
+#[derive(serde::Serialize)]
+struct InputFingerprint<'a> {
+    text: &'a str,
+    metadata: &'a Option<Metadata>,
+    extractor: Option<&'a str>,
+}
+
+fn prepare_submission(
+    text: &str,
+    metadata: Option<Metadata>,
+    requested_backend: Option<&str>,
+    idempotency_key: Option<&str>,
+) -> Result<PreparedSubmission, JobError> {
+    let request = normalized_request(text, metadata)?;
+    let fingerprint = InputFingerprint {
+        text: &request.text,
+        metadata: &request.metadata,
+        extractor: requested_backend,
+    };
+    let encoded = serde_json::to_vec(&fingerprint).map_err(storage_error)?;
+    Ok(PreparedSubmission {
+        input_digest: hex_digest(b"velesdb extraction input v1\0", &encoded),
+        request_id: request_id(idempotency_key, &encoded)?,
+        request,
+    })
+}
+
+fn normalized_request(
+    text: &str,
+    metadata: Option<Metadata>,
+) -> Result<PersistedRequest, JobError> {
+    let text = text.trim().to_owned();
+    if text.is_empty() {
+        return Err(JobError::Invalid("text must not be empty".to_owned()));
+    }
+    validate_metadata(metadata.as_ref())?;
+    Ok(PersistedRequest {
+        text,
+        metadata,
+        backend: None,
+    })
+}
+
+fn validate_metadata(metadata: Option<&Metadata>) -> Result<(), JobError> {
+    let Some(metadata) = metadata else {
+        return Ok(());
+    };
+    if let Some(key) = metadata
+        .keys()
+        .find(|key| crate::storage::is_reserved_key(key))
+    {
+        return Err(JobError::Invalid(format!(
+            "metadata key '{key}' is reserved"
+        )));
+    }
+    let bytes = crate::limits::metadata_bytes(metadata);
+    if bytes > crate::limits::MAX_METADATA_BYTES {
+        return Err(JobError::Invalid(format!(
+            "metadata of {bytes} bytes exceeds the cap of {} bytes",
+            crate::limits::MAX_METADATA_BYTES
+        )));
+    }
+    Ok(())
+}
+
+fn stamp_acceptance_date(metadata: &mut Option<Metadata>) {
+    if metadata
+        .as_ref()
+        .is_some_and(|value| value.contains_key(crate::storage::AUTO_DATE_FIELD))
+    {
+        return;
+    }
+    let Some(today) = crate::clock::today_ymd() else {
+        return;
+    };
+    metadata
+        .get_or_insert_with(Metadata::new)
+        .insert(crate::storage::AUTO_DATE_FIELD.to_owned(), today.into());
+}
+
+fn request_id(key: Option<&str>, encoded: &[u8]) -> Result<String, JobError> {
+    let Some(key) = key else {
+        return Ok(hex_digest(b"velesdb extraction request v1\0", encoded));
+    };
+    if key.trim().is_empty() {
+        return Err(JobError::Invalid(
+            "idempotency_key must not be empty".to_owned(),
+        ));
+    }
+    if key.len() > crate::limits::MAX_IDEMPOTENCY_KEY_BYTES {
+        return Err(JobError::Invalid(format!(
+            "idempotency_key exceeds {} bytes",
+            crate::limits::MAX_IDEMPOTENCY_KEY_BYTES
+        )));
+    }
+    Ok(hex_digest(
+        b"velesdb extraction idempotency key v1\0",
+        key.as_bytes(),
+    ))
+}
+
+fn hex_digest(domain: &[u8], body: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(body);
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn enqueue_if_needed(
+    tx: &mpsc::Sender<Command>,
+    runtime: &mut RuntimeState,
+    request_id: &str,
+    state: ExtractionJobState,
+) -> Result<(), JobError> {
+    if state.is_terminal() || !runtime.queued.insert(request_id.to_owned()) {
+        return Ok(());
+    }
+    if tx.send(Command::Run(request_id.to_owned())).is_err() {
+        runtime.queued.remove(request_id);
+        return Err(JobError::Storage(
+            "extraction worker is unavailable".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn worker_loop(shared: &Arc<Shared>, rx: &mpsc::Receiver<Command>) {
+    while let Ok(command) = rx.recv() {
+        if shared.closing.load(Ordering::Acquire) {
+            break;
+        }
+        let Command::Run(request_id) = command else {
+            break;
+        };
+        let terminal = process_job(shared, &request_id);
+        let mut runtime = shared.runtime.lock();
+        runtime.queued.remove(&request_id);
+        if terminal {
+            runtime.pending = runtime.pending.saturating_sub(1);
+        }
+    }
+}
+
+fn process_job(shared: &Shared, request_id: &str) -> bool {
+    let Ok(Some(mut record)) = shared.store.load(request_id) else {
+        return false;
+    };
+    if record.state.is_terminal() {
+        return true;
+    }
+    record.state = ExtractionJobState::Running;
+    if let Err(error) = shared.store.save(&record) {
+        tracing::error!(%request_id, %error, "cannot persist extraction job transition");
+        return false;
+    }
+    match execute_job(shared, &mut record) {
+        Ok(outcome) => finish_committed(shared, record, outcome),
+        Err(error) => finish_failed(shared, record, error),
+    }
+}
+
+fn execute_job(shared: &Shared, record: &mut JobRecord) -> Result<RememberedExtraction, String> {
+    ensure_extraction(shared, record)?;
+    let Some(extraction) = record.extraction.as_ref() else {
+        return Err("job extraction is missing".to_owned());
+    };
+    let Some(request) = record.request.as_ref() else {
+        return Err("job request is missing".to_owned());
+    };
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        shared
+            .service
+            .store_extraction(extraction, request.metadata.as_ref())
+    }));
+    match result {
+        Ok(Ok(outcome)) => Ok(outcome),
+        Ok(Err(error)) => Err(error.to_string()),
+        Err(payload) => Err(panic_text(payload.as_ref())),
+    }
+}
+
+fn ensure_extraction(shared: &Shared, record: &mut JobRecord) -> Result<(), String> {
+    if record.extraction.is_some() {
+        return Ok(());
+    }
+    record.extraction = Some(generate(shared, record)?);
+    shared.store.save(record).map_err(|error| error.to_string())
+}
+
+fn generate(shared: &Shared, record: &JobRecord) -> Result<Extraction, String> {
+    let request = record
+        .request
+        .as_ref()
+        .ok_or_else(|| "job request is missing".to_owned())?;
+    let resolved = shared
+        .extractors
+        .read()
+        .resolve_for_job(request.backend.as_deref())
+        .map_err(extractor_error_text)?;
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        MemoryService::<DynEmbedder>::extract_passage(&request.text, &resolved.extractor)
+    }));
+    match result {
+        Ok(Ok(extraction)) => Ok(extraction),
+        Ok(Err(error)) => Err(error.to_string()),
+        Err(payload) => Err(panic_text(payload.as_ref())),
+    }
+}
+
+fn extractor_error_text(error: super::extractor_resolver::ExtractorResolveError) -> String {
+    match error {
+        super::extractor_resolver::ExtractorResolveError::DefaultNotConfigured => {
+            "extraction backend is no longer configured".to_owned()
+        }
+        super::extractor_resolver::ExtractorResolveError::InvalidRequest(message) => message,
+    }
+}
+
+fn finish_committed(shared: &Shared, mut record: JobRecord, outcome: RememberedExtraction) -> bool {
+    record.state = ExtractionJobState::Committed;
+    record.request = None;
+    record.extraction = None;
+    record.outcome = Some(outcome.into());
+    record.error = None;
+    persist_terminal(shared, &record)
+}
+
+fn finish_failed(shared: &Shared, mut record: JobRecord, error: String) -> bool {
+    record.state = ExtractionJobState::Failed;
+    record.request = None;
+    record.extraction = None;
+    record.outcome = None;
+    record.error = Some(truncate_error(error));
+    persist_terminal(shared, &record)
+}
+
+fn persist_terminal(shared: &Shared, record: &JobRecord) -> bool {
+    match shared.store.save(record) {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::error!(request_id = %record.request_id, %error, "cannot persist terminal extraction job");
+            false
+        }
+    }
+}
+
+fn truncate_error(mut error: String) -> String {
+    const MAX_ERROR_BYTES: usize = 4_096;
+    const ELLIPSIS: &str = "…";
+    if error.len() <= MAX_ERROR_BYTES {
+        return error;
+    }
+    let mut end = MAX_ERROR_BYTES - ELLIPSIS.len();
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    error.truncate(end);
+    error.push_str(ELLIPSIS);
+    error
+}
+
+fn panic_text(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return format!("extraction worker panicked: {message}");
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return format!("extraction worker panicked: {message}");
+    }
+    "extraction worker panicked".to_owned()
+}
+
+#[cfg(test)]
+#[path = "extraction_jobs_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/mcp/extraction_jobs_tests.rs
+++ b/crates/velesdb-memory/src/mcp/extraction_jobs_tests.rs
@@ -1,0 +1,151 @@
+//! Recovery proofs for the durable extraction state machine.
+
+use super::*;
+use crate::embedder::HashEmbedder;
+use crate::extract::{ExtractError, ExtractedFact, Extractor};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+struct GenerationMustNotRun {
+    calls: AtomicUsize,
+}
+
+impl Extractor for GenerationMustNotRun {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        panic!("a persisted extraction must not be generated again")
+    }
+}
+
+fn accepted_record() -> JobRecord {
+    JobRecord::accepted(
+        "a".repeat(64),
+        "b".repeat(64),
+        PersistedRequest {
+            text: "source passage".to_owned(),
+            metadata: None,
+            backend: Some("outline".to_owned()),
+        },
+    )
+}
+
+#[test]
+fn persisted_states_reject_fields_owned_by_another_phase() {
+    let mut accepted_with_outcome = accepted_record();
+    accepted_with_outcome.outcome = Some(super::super::extraction_job_model::JobOutcome {
+        ids: vec![1],
+        skipped_over_cap: 0,
+    });
+    assert!(accepted_with_outcome.validate().is_err());
+
+    let mut committed_with_request = accepted_record();
+    committed_with_request.state = ExtractionJobState::Committed;
+    committed_with_request.outcome = accepted_with_outcome.outcome;
+    assert!(committed_with_request.validate().is_err());
+}
+
+#[test]
+fn persisted_failure_text_respects_its_utf8_byte_limit() {
+    let truncated = truncate_error("é".repeat(4_096));
+
+    assert!(truncated.len() <= 4_096);
+    assert!(truncated.ends_with('…'));
+    assert!(truncated.is_char_boundary(truncated.len()));
+}
+
+fn persist_interrupted_job(
+    directory: &Path,
+    service: &MemoryService<DynEmbedder>,
+) -> (String, usize, Option<usize>) {
+    let request = PersistedRequest {
+        text: "source passage".to_owned(),
+        metadata: None,
+        backend: None,
+    };
+    let encoded = serde_json::to_vec(&request).expect("serialize request");
+    let input_digest = hex_digest(b"velesdb extraction input v1\0", &encoded);
+    let request_id = request_id(None, &encoded).expect("derive request id");
+    let extraction = Extraction {
+        facts: vec![ExtractedFact {
+            text: "Recovered fact is written exactly once.".to_owned(),
+            entities: vec!["recovery".to_owned()],
+        }],
+        ..Extraction::default()
+    };
+    service
+        .store_extraction(&extraction, None)
+        .expect("simulate writes completed before the process stopped");
+    let facts_before_replay = service.fact_count();
+    let edges_before_replay = service.edge_count();
+    let record = JobRecord {
+        version: RECORD_VERSION,
+        request_id: request_id.clone(),
+        input_digest,
+        state: ExtractionJobState::Running,
+        request: Some(request),
+        extraction: Some(extraction),
+        outcome: None,
+        error: None,
+    };
+    JobStore::open(directory)
+        .expect("open job snapshots")
+        .save(&record)
+        .expect("persist interrupted running job");
+    (request_id, facts_before_replay, edges_before_replay)
+}
+
+fn wait_for_terminal(jobs: &ExtractionJobs, request_id: &str) -> JobView {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = jobs.status(request_id).expect("read recovered status");
+        if status.state.is_terminal() {
+            return status;
+        }
+        assert!(Instant::now() < deadline, "recovered job must finish");
+        std::thread::yield_now();
+    }
+}
+
+fn assert_write_remains_exactly_once(
+    service: &MemoryService<DynEmbedder>,
+    facts_before_replay: usize,
+    edges_before_replay: Option<usize>,
+) {
+    assert_eq!(service.fact_count(), facts_before_replay);
+    assert_eq!(service.edge_count(), edges_before_replay);
+    let recalled = service
+        .recall("recovered written", 10, None)
+        .expect("recall recovered write");
+    assert_eq!(
+        recalled
+            .iter()
+            .filter(|memory| memory.content == "Recovered fact is written exactly once.")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn recovery_commits_persisted_extraction_without_second_generation() {
+    let directory = tempfile::tempdir().expect("create durable job store");
+    let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
+    let service = Arc::new(
+        MemoryService::open(directory.path(), embedder).expect("open native memory service"),
+    );
+    let (request_id, facts_before_replay, edges_before_replay) =
+        persist_interrupted_job(directory.path(), &service);
+
+    let extractor = Arc::new(GenerationMustNotRun {
+        calls: AtomicUsize::new(0),
+    });
+    let resolver = Arc::new(RwLock::new(ExtractorResolver::unnamed(extractor.clone())));
+    let jobs = ExtractionJobs::open(directory.path(), Arc::clone(&service), resolver)
+        .expect("recover durable worker");
+    let status = wait_for_terminal(&jobs, &request_id);
+
+    assert_eq!(status.state, ExtractionJobState::Committed);
+    assert_eq!(status.outcome.expect("committed outcome").ids.len(), 1);
+    assert_eq!(extractor.calls.load(Ordering::SeqCst), 0);
+    assert_write_remains_exactly_once(&service, facts_before_replay, edges_before_replay);
+}

--- a/crates/velesdb-memory/src/mcp/extractor_resolver.rs
+++ b/crates/velesdb-memory/src/mcp/extractor_resolver.rs
@@ -16,6 +16,12 @@ struct NamedExtractor {
     extractor: DynExtractor,
 }
 
+/// One resolved backend plus the stable name persisted with a durable job.
+pub(super) struct ResolvedExtractor {
+    pub(super) backend: Option<String>,
+    pub(super) extractor: DynExtractor,
+}
+
 /// The daemon-level default plus the rules for a per-call override.
 #[derive(Clone, Default)]
 pub(super) struct ExtractorResolver {
@@ -48,17 +54,21 @@ impl ExtractorResolver {
         }
     }
 
-    /// Resolve an optional per-call name, falling back to the daemon default.
-    pub(super) fn resolve(
+    /// Resolve a backend while retaining the canonical choice needed to
+    /// recover a durable extraction job after process restart.
+    pub(super) fn resolve_for_job(
         &self,
         requested: Option<&str>,
-    ) -> Result<DynExtractor, ExtractorResolveError> {
+    ) -> Result<ResolvedExtractor, ExtractorResolveError> {
         match requested {
             Some(backend) => self.resolve_requested(backend),
             None => self
                 .default
                 .as_ref()
-                .map(|configured| configured.extractor.clone())
+                .map(|configured| ResolvedExtractor {
+                    backend: configured.backend.clone(),
+                    extractor: configured.extractor.clone(),
+                })
                 .ok_or(ExtractorResolveError::DefaultNotConfigured),
         }
     }
@@ -68,9 +78,12 @@ impl ExtractorResolver {
         self.default.is_some()
     }
 
-    fn resolve_requested(&self, backend: &str) -> Result<DynExtractor, ExtractorResolveError> {
+    fn resolve_requested(&self, backend: &str) -> Result<ResolvedExtractor, ExtractorResolveError> {
         match select_extractor(backend).map_err(ExtractorResolveError::InvalidRequest)? {
-            ExtractorSelection::Ready(extractor) => Ok(extractor),
+            ExtractorSelection::Ready(extractor) => Ok(ResolvedExtractor {
+                backend: Some(backend.to_owned()),
+                extractor,
+            }),
             ExtractorSelection::NeedsRemoteConfig(name) => self.resolve_remote(name),
             ExtractorSelection::Disabled => Err(ExtractorResolveError::InvalidRequest(
                 "extractor 'none' cannot extract a passage; omit the field to use the daemon default"
@@ -79,7 +92,7 @@ impl ExtractorResolver {
         }
     }
 
-    fn resolve_remote(&self, backend: &str) -> Result<DynExtractor, ExtractorResolveError> {
+    fn resolve_remote(&self, backend: &str) -> Result<ResolvedExtractor, ExtractorResolveError> {
         let Some(configured) = &self.default else {
             return Err(ExtractorResolveError::InvalidRequest(format!(
                 "extractor '{backend}' is not configured for this server; start it with \
@@ -87,7 +100,10 @@ impl ExtractorResolver {
             )));
         };
         if configured.backend.as_deref() == Some(backend) {
-            return Ok(configured.extractor.clone());
+            return Ok(ResolvedExtractor {
+                backend: Some(backend.to_owned()),
+                extractor: configured.extractor.clone(),
+            });
         }
         let current = configured
             .backend

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -13,7 +13,36 @@ fn server() -> (TempDir, McpServer) {
     let dir = TempDir::new().expect("create tempdir");
     let embedder: DynEmbedder = Box::new(HashEmbedder::new(crate::DEFAULT_DIMENSION));
     let service = MemoryService::open(dir.path(), embedder).expect("open memory store");
-    (dir, McpServer::new(service))
+    let server = McpServer::new(service)
+        .with_extraction_jobs(dir.path())
+        .expect("start durable extraction jobs");
+    (dir, server)
+}
+
+async fn committed_extraction(
+    server: &McpServer,
+    receipt: RememberExtractedResult,
+) -> ExtractionJobStatusResult {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let Json(status) = server
+                .extraction_status(Parameters(ExtractionJobStatusParams {
+                    request_id: receipt.request_id.clone(),
+                }))
+                .await
+                .expect("query extraction status");
+            match status.state {
+                extraction_jobs::ExtractionJobState::Committed => return status,
+                extraction_jobs::ExtractionJobState::Failed => {
+                    panic!("extraction failed: {:?}", status.error)
+                }
+                extraction_jobs::ExtractionJobState::Accepted
+                | extraction_jobs::ExtractionJobState::Running => tokio::task::yield_now().await,
+            }
+        }
+    })
+    .await
+    .expect("extraction job reaches a terminal state")
 }
 
 /// Run a one-hop `why(DECISION)` through the server, returning the seed
@@ -748,6 +777,31 @@ impl Extractor for GenerativeStub {
     }
 }
 
+struct CountingExtractionStub {
+    calls: AtomicUsize,
+}
+
+struct FailingExtractionStub {
+    calls: AtomicUsize,
+}
+
+impl Extractor for FailingExtractionStub {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(ExtractError::Backend("model unavailable".to_owned()))
+    }
+}
+
+impl Extractor for CountingExtractionStub {
+    fn extract(&self, _text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![ExtractedFact {
+            text: "One idempotent extraction result.".to_owned(),
+            entities: Vec::new(),
+        }])
+    }
+}
+
 #[tokio::test]
 async fn remember_extracted_builds_a_graph_through_the_server() {
     let (_dir, srv) = server();
@@ -755,14 +809,16 @@ async fn remember_extracted_builds_a_graph_through_the_server() {
         .with_named_extractor("ollama", Arc::new(GraphStub) as DynExtractor)
         .expect("ollama is a supported extractor name");
 
-    let Json(res) = srv
+    let Json(receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: "Alice and Bob work in Rust.".to_owned(),
             metadata: None,
             extractor: None,
+            idempotency_key: None,
         }))
         .await
         .expect("remember_extracted");
+    let res = committed_extraction(&srv, receipt).await;
     assert_eq!(res.ids.len(), 2, "both facts stored");
 
     // why reaches the sibling fact via the shared topic, seed is a real fact.
@@ -789,22 +845,26 @@ async fn two_successive_calls_can_select_different_extractors() {
         .expect("ollama is a supported extractor name");
     let source = "fact: Deterministic directive | outline";
 
-    let Json(outlined) = srv
+    let Json(outlined_receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: source.to_owned(),
             metadata: None,
             extractor: Some("outline".to_owned()),
+            idempotency_key: None,
         }))
         .await
         .expect("the per-call outline backend must work");
-    let Json(generative) = srv
+    let Json(generative_receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: source.to_owned(),
             metadata: None,
             extractor: Some("ollama".to_owned()),
+            idempotency_key: None,
         }))
         .await
         .expect("the configured remote backend must remain selectable");
+    let outlined = committed_extraction(&srv, outlined_receipt).await;
+    let generative = committed_extraction(&srv, generative_receipt).await;
 
     assert_ne!(outlined.ids, generative.ids, "the extractions must differ");
     let Json(listed) = srv
@@ -823,6 +883,92 @@ async fn two_successive_calls_can_select_different_extractors() {
         .collect();
     assert!(contents.contains(&"Deterministic directive"));
     assert!(contents.contains(&"Generative interpretation"));
+}
+
+#[tokio::test]
+async fn retry_key_runs_one_extraction_and_rejects_a_changed_payload() {
+    let (_dir, srv) = server();
+    let extractor = Arc::new(CountingExtractionStub {
+        calls: AtomicUsize::new(0),
+    });
+    let srv = srv.with_extractor(extractor.clone());
+    let submit = |text: &str| RememberExtractedParams {
+        text: text.to_owned(),
+        metadata: None,
+        extractor: None,
+        idempotency_key: Some("client-operation-42".to_owned()),
+    };
+
+    let Json(first) = srv
+        .remember_extracted(Parameters(submit("same passage")))
+        .await
+        .expect("first durable receipt");
+    let Json(retry) = srv
+        .remember_extracted(Parameters(submit("same passage")))
+        .await
+        .expect("retry must reuse the receipt");
+    assert_eq!(retry.request_id, first.request_id);
+    assert!(retry.reused);
+    let result = committed_extraction(&srv, first).await;
+    assert_eq!(result.ids.len(), 1);
+    assert_eq!(extractor.calls.load(Ordering::SeqCst), 1);
+
+    let error = srv
+        .remember_extracted(Parameters(submit("changed passage")))
+        .await
+        .map(|_| ())
+        .expect_err("one retry key cannot alias a changed payload");
+    assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn failed_extraction_is_terminal_queryable_and_not_retried() {
+    let (_dir, srv) = server();
+    let extractor = Arc::new(FailingExtractionStub {
+        calls: AtomicUsize::new(0),
+    });
+    let srv = srv.with_extractor(extractor.clone());
+    let params = || RememberExtractedParams {
+        text: "passage whose model call fails".to_owned(),
+        metadata: None,
+        extractor: None,
+        idempotency_key: Some("terminal-failure-proof".to_owned()),
+    };
+    let Json(receipt) = srv
+        .remember_extracted(Parameters(params()))
+        .await
+        .expect("the durable request is accepted before generation fails");
+    let status = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let Json(status) = srv
+                .extraction_status(Parameters(ExtractionJobStatusParams {
+                    request_id: receipt.request_id.clone(),
+                }))
+                .await
+                .expect("query failed extraction");
+            if status.state.is_terminal() {
+                return status;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("failed extraction reaches its terminal record");
+    assert_eq!(status.state, extraction_jobs::ExtractionJobState::Failed);
+    assert!(status.ids.is_empty());
+    assert!(status.skipped_over_cap.is_none());
+    assert!(status
+        .error
+        .as_deref()
+        .is_some_and(|error| error.contains("model unavailable")));
+
+    let Json(retry) = srv
+        .remember_extracted(Parameters(params()))
+        .await
+        .expect("same key and payload reuses terminal failure");
+    assert!(retry.reused);
+    assert_eq!(retry.state, extraction_jobs::ExtractionJobState::Failed);
+    assert_eq!(extractor.calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]
@@ -915,6 +1061,7 @@ async fn remember_extracted_without_backend_returns_internal_error() {
             text: "anything".to_owned(),
             metadata: None,
             extractor: None,
+            idempotency_key: None,
         }))
         .await
         .map(|_| ())
@@ -925,14 +1072,16 @@ async fn remember_extracted_without_backend_returns_internal_error() {
 #[tokio::test]
 async fn explicit_outline_works_without_a_daemon_default() {
     let (_dir, srv) = server();
-    let Json(stored) = srv
+    let Json(receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: "fact: A deterministic fact | outline".to_owned(),
             metadata: None,
             extractor: Some("outline".to_owned()),
+            idempotency_key: None,
         }))
         .await
         .expect("explicit outline must not need a daemon default");
+    let stored = committed_extraction(&srv, receipt).await;
     assert_eq!(stored.ids.len(), 1);
 }
 
@@ -944,6 +1093,7 @@ async fn unknown_per_call_extractor_returns_invalid_params() {
             text: "anything".to_owned(),
             metadata: None,
             extractor: Some("lmstudio".to_owned()),
+            idempotency_key: None,
         }))
         .await
         .map(|_| ())
@@ -1121,14 +1271,16 @@ async fn remember_extracted_response_echoes_ids_str() {
     }
     let (_dir, srv) = server();
     let srv = srv.with_extractor(Arc::new(Stub) as DynExtractor);
-    let Json(res) = srv
+    let Json(receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: "Alice works in Rust.".to_owned(),
             metadata: None,
             extractor: None,
+            idempotency_key: None,
         }))
         .await
         .expect("remember_extracted");
+    let res = committed_extraction(&srv, receipt).await;
     assert_eq!(res.ids_str.len(), res.ids.len());
     for (id, id_str) in res.ids.iter().zip(res.ids_str.iter()) {
         assert_eq!(*id_str, id.to_string());
@@ -1249,7 +1401,7 @@ fn test_recall_where_description_documents_type_strict_comparisons() {
 /// Whether `haystack` names `field` as a WORD, not as an accidental substring.
 ///
 /// A plain `contains` is not enough, and the measurement says so: across the
-/// twenty published tools it lets `feedback`'s `id` pass on the strength of
+/// the published tools it lets `feedback`'s `id` pass on the strength of
 /// "con-f-**id**-ence", and `entity`'s `relations` on "relation-ships". A
 /// guard weaker than its own statement is worse than none, because it reads
 /// as coverage.
@@ -1268,25 +1420,21 @@ fn description_names_field(haystack: &str, field: &str) -> bool {
     })
 }
 
-/// #1747. `remember_extracted`'s published `outputSchema` carries three root
-/// fields, and one of them — `skipped_over_cap` — exists PRECISELY to make a
-/// silent loss visible: facts the extractor produced and this tool dropped for
-/// exceeding the per-fact text cap. Its own doc-comment argues the point: "a
-/// skip the caller cannot see is indistinguishable from the model extracting
-/// fewer facts".
+/// #1747/#1839. `remember_extracted`'s published `outputSchema` carries the
+/// durable receipt fields (`request_id`, `state`, `reused`). Each changes what
+/// a caller must do next: save the id, poll the state, and distinguish an
+/// accepted operation from an idempotent retry.
 ///
-/// The description used to say only "Returns the stored facts' ids". So the
-/// one surface a model reads BEFORE deciding to call never mentioned the field
-/// whose whole purpose is to be read — the omission defeated the reason the
-/// field was added (#1692).
+/// The older synchronous contract once omitted its loss counter from the
+/// description, proving that a field present only in a schema is not enough:
+/// the model reads the description before deciding how to close the loop.
 ///
 /// The field names are DERIVED from the published schema rather than kept as a
 /// second hard-coded list here: a root field added tomorrow is caught without
 /// anyone remembering this test exists.
 ///
-/// Scope, stated so it is not overclaimed: this pins ONE tool. Fourteen of the
-/// twenty published tools would fail the same check today, and closing that
-/// class is its own piece of work (#1695).
+/// Scope, stated so it is not overclaimed: this pins ONE tool. Closing the
+/// same class across the complete published surface is tracked by #1695.
 #[test]
 fn test_remember_extracted_description_names_every_published_output_field() {
     let tool = McpServer::remember_extracted_tool_attr();
@@ -1507,11 +1655,14 @@ async fn an_outline_configured_server_builds_a_hub_that_entity_finds() {
     else {
         panic!("`outline` must be usable as-is, with no remote configuration");
     };
-    let srv = McpServer::new(service).with_extractor(extractor);
+    let srv = McpServer::new(service)
+        .with_extractor(extractor)
+        .with_extraction_jobs(dir.path())
+        .expect("start durable extraction jobs");
 
     // Tool 1 of the two that were dead: it used to answer "extraction backend
     // not configured" no matter what the operator set.
-    let Json(stored) = srv
+    let Json(receipt) = srv
         .remember_extracted(Parameters(RememberExtractedParams {
             text: "fact: Theo has a sister called Camille | Theo, Camille\n\
                    edge: Camille | soeur de | Theo\n\
@@ -1519,9 +1670,11 @@ async fn an_outline_configured_server_builds_a_hub_that_entity_finds() {
                 .to_owned(),
             metadata: None,
             extractor: None,
+            idempotency_key: None,
         }))
         .await
         .expect("remember_extracted must work on an outline-configured server");
+    let stored = committed_extraction(&srv, receipt).await;
     assert_eq!(
         stored.ids.len(),
         1,
@@ -1657,6 +1810,48 @@ fn gated_server() -> (
         .expect("open memory store")
         .with_autograph(extractor.clone());
     (dir, McpServer::new(service), extractor, release)
+}
+
+#[tokio::test]
+async fn remember_extracted_receipt_does_not_wait_for_generation() {
+    let (_dir, srv) = server();
+    let (extractor, release) = GatedServerExtractor::new();
+    let srv = srv.with_extractor(extractor.clone());
+
+    let Json(receipt) = srv
+        .remember_extracted(Parameters(RememberExtractedParams {
+            text: "Alice works at Wiscale.".to_owned(),
+            metadata: None,
+            extractor: None,
+            idempotency_key: Some("immediate-receipt-proof".to_owned()),
+        }))
+        .await
+        .expect("durable acceptance must not wait for the extractor");
+    assert_eq!(receipt.state, extraction_jobs::ExtractionJobState::Accepted);
+    assert_eq!(
+        extractor.completed.load(Ordering::SeqCst),
+        0,
+        "the receipt must arrive while generation is still blocked"
+    );
+    assert!(
+        wait_for(Duration::from_secs(5), || extractor
+            .entered
+            .load(Ordering::SeqCst)
+            == 1),
+        "the background worker must start the accepted job"
+    );
+    let Json(running) = srv
+        .extraction_status(Parameters(ExtractionJobStatusParams {
+            request_id: receipt.request_id.clone(),
+        }))
+        .await
+        .expect("read the in-flight job");
+    assert_eq!(running.state, extraction_jobs::ExtractionJobState::Running);
+
+    release.send(()).expect("release extraction");
+    let status = committed_extraction(&srv, receipt).await;
+    assert_eq!(status.state, extraction_jobs::ExtractionJobState::Committed);
+    assert_eq!(extractor.completed.load(Ordering::SeqCst), 1);
 }
 
 /// Poll until `probe` answers true — the event, not the clock (#1793).

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -750,12 +750,36 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         extractor: &X,
         metadata: Option<&Metadata>,
     ) -> Result<RememberedExtraction, MemoryError> {
+        let extraction = Self::extract_passage(text, extractor)?;
+        self.store_extraction(&extraction, metadata)
+    }
+
+    /// Extract and orient one passage without writing any memory state.
+    ///
+    /// Kept separate from [`Self::store_extraction`] so the MCP durable-job
+    /// worker can persist the model output before the first graph write. A
+    /// restart after that boundary replays stable data instead of generating a
+    /// second, potentially different extraction.
+    pub(crate) fn extract_passage<X: Extractor>(
+        text: &str,
+        extractor: &X,
+    ) -> Result<crate::extract::Extraction, MemoryError> {
         let text = text.trim();
         if text.is_empty() {
             return Err(MemoryError::EmptyFact);
         }
         let mut extraction = extractor.extract_graph(text)?;
         crate::extract::orient_kinship(text, &mut extraction.relations);
+        Ok(extraction)
+    }
+
+    /// Store a previously generated extraction through the same idempotent
+    /// fact, hub, edge, and attribute primitives as [`Self::remember_extracted`].
+    pub(crate) fn store_extraction(
+        &self,
+        extraction: &crate::extract::Extraction,
+        metadata: Option<&Metadata>,
+    ) -> Result<RememberedExtraction, MemoryError> {
         let mut entity_ids: HashMap<String, u64> = HashMap::new();
         let mut edges: HashSet<(u64, u64, String)> = HashSet::new();
         let outcome =

--- a/crates/velesdb-memory/tests/binding_parity_bdd.rs
+++ b/crates/velesdb-memory/tests/binding_parity_bdd.rs
@@ -93,17 +93,19 @@
 //! binding and read the real result. What this file adds is the thing none
 //! of those can do: notice that the SERVER grew a field nobody relayed.
 //!
-//! ### `SHAPE_DIVERGENCES` holds two different things, on purpose
+//! ### `SHAPE_DIVERGENCES` holds explicit differences, on purpose
 //!
 //! Most entries are deliberate unwraps (`recall` → a bare array, `forget` →
-//! a bare bool, an id twin collapsing to one form). A few carried
+//! a bare bool, an id twin collapsing to one form). #1839 adds a deliberate
+//! transport split: MCP extraction is a durable background receipt, while the
+//! in-process bindings keep the synchronous domain call. A few entries carried
 //! [`KNOWN_GAP`]: fields a binding really does lose. Writing a real gap down
 //! is not blessing it — it is the only way the guard can be green on the 19
 //! other tools while the gap stays visible in one place instead of being
 //! rediscovered by a user. An entry is deleted by the fix, never renewed.
 //!
-//! As of issues #1690/#1691/#1692 the second kind is EMPTY: every entry left
-//! is a deliberate unwrap. That is the state this list is meant to reach, so
+//! As of issues #1690/#1691/#1692 the known-gap kind is EMPTY: every entry left
+//! is a deliberate unwrap or contract split. That is the state this list is meant to reach, so
 //! [`KNOWN_GAP`] now sits unused on purpose — see its own doc comment. Note
 //! what it does NOT mean: nothing here caps how many gaps may be declared,
 //! and adding a seventh would have been exactly as green as fixing six. The
@@ -164,6 +166,26 @@ struct Exemption {
 
 const EXEMPTIONS: &[Exemption] = &[
     Exemption {
+        binding: "velesdb-node",
+        tool: "extraction_status",
+        reason: "this status surface exists for the MCP transport's durable background receipt; \
+                 the Node binding keeps MemoryService::remember_extracted synchronous and returns \
+                 its final ids directly, so it has no background request_id to query",
+    },
+    Exemption {
+        binding: "velesdb-python",
+        tool: "extraction_status",
+        reason: "this status surface exists for the MCP transport's durable background receipt; \
+                 the Python binding keeps MemoryService::remember_extracted synchronous and \
+                 returns its final ids directly, so it has no background request_id to query",
+    },
+    Exemption {
+        binding: "velesdb-wasm",
+        tool: "extraction_status",
+        reason: "WASM rememberExtracted is synchronous and in-memory, while durable extraction \
+                 receipts require the native persistence directory that wasm32 deliberately omits",
+    },
+    Exemption {
         binding: "velesdb-wasm",
         tool: "feedback",
         reason: "a durable learned confidence is meaningless on the in-memory WASM backend: \
@@ -223,6 +245,14 @@ const DATED_SPLIT: &str = "deliberate split, not a drop: the dated half of fused
      SECOND binding method (`recallFusedDated`), which returns the timeline and the clock. \
      This method is the undated one, and returns the bare memories array";
 
+/// MCP accepts a durable background job; in-process bindings finish inline.
+const MCP_ASYNC_SPLIT: &str = "deliberate transport split, not an omitted implementation: the \
+     MCP tool returns a durable background receipt because a model call can outlive its client \
+     transport, while this in-process binding calls the transport-neutral MemoryService \
+     synchronously and returns the committed ids plus skipped count directly. It therefore has \
+     no MCP request_id/state/reused receipt; extraction_status is separately exempted for the \
+     same reason (#1839)";
+
 /// A field the server publishes and this binding really does lose. NOT a
 /// deliberate unwrap — an entry here is an admission, kept honest by
 /// [`no_shape_divergence_is_stale`], and it must be deleted by the fix, not
@@ -231,7 +261,7 @@ const DATED_SPLIT: &str = "deliberate split, not a drop: the dated half of fused
 /// **Currently unused, and that is the point.** The six entries that carried
 /// it were deleted by their fixes (issues #1690, #1691, #1692): every field
 /// the server publishes now reaches every binding, or is a declared,
-/// motivated unwrap. The constant stays so the next honest admission has this
+/// motivated unwrap/contract split. The constant stays so the next honest admission has this
 /// exact wording to reach for — deleting it would leave the next author to
 /// invent a looser reason of their own, which is how a gap stops being
 /// visible.
@@ -308,8 +338,20 @@ const SHAPE_DIVERGENCES: &[ShapeDivergence] = &[
     ShapeDivergence {
         binding: "velesdb-node",
         tool: "remember_extracted",
-        field: "ids_str",
-        reason: ID_TWIN,
+        field: "request_id",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-node",
+        tool: "remember_extracted",
+        field: "state",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-node",
+        tool: "remember_extracted",
+        field: "reused",
+        reason: MCP_ASYNC_SPLIT,
     },
     ShapeDivergence {
         binding: "velesdb-node",
@@ -368,8 +410,20 @@ const SHAPE_DIVERGENCES: &[ShapeDivergence] = &[
     ShapeDivergence {
         binding: "velesdb-python",
         tool: "remember_extracted",
-        field: "ids_str",
-        reason: ID_TWIN,
+        field: "request_id",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-python",
+        tool: "remember_extracted",
+        field: "state",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-python",
+        tool: "remember_extracted",
+        field: "reused",
+        reason: MCP_ASYNC_SPLIT,
     },
     ShapeDivergence {
         binding: "velesdb-python",
@@ -386,8 +440,20 @@ const SHAPE_DIVERGENCES: &[ShapeDivergence] = &[
     ShapeDivergence {
         binding: "velesdb-wasm",
         tool: "remember_extracted",
-        field: "ids_str",
-        reason: ID_TWIN,
+        field: "request_id",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-wasm",
+        tool: "remember_extracted",
+        field: "state",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: "velesdb-wasm",
+        tool: "remember_extracted",
+        field: "reused",
+        reason: MCP_ASYNC_SPLIT,
     },
     ShapeDivergence {
         binding: "velesdb-wasm",
@@ -458,8 +524,20 @@ const SHAPE_DIVERGENCES: &[ShapeDivergence] = &[
     ShapeDivergence {
         binding: TYPESCRIPT_SDK,
         tool: "remember_extracted",
-        field: "ids_str",
-        reason: ID_TWIN,
+        field: "request_id",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: TYPESCRIPT_SDK,
+        tool: "remember_extracted",
+        field: "state",
+        reason: MCP_ASYNC_SPLIT,
+    },
+    ShapeDivergence {
+        binding: TYPESCRIPT_SDK,
+        tool: "remember_extracted",
+        field: "reused",
+        reason: MCP_ASYNC_SPLIT,
     },
 ];
 
@@ -1095,7 +1173,7 @@ fn server_output_types() -> BTreeMap<String, String> {
     assert!(
         types.len() >= 20,
         "only {} tool output type(s) parsed out of the server source — the scan is broken, \
-         not the server (it publishes 22 tools)",
+         not the server (it publishes 23 tools)",
         types.len(),
     );
     types

--- a/crates/velesdb-memory/tests/mcp_tools_drift.rs
+++ b/crates/velesdb-memory/tests/mcp_tools_drift.rs
@@ -40,7 +40,7 @@
 //! `cargo test -p velesdb-memory --features extract,ollama,persistence`
 //! WITHOUT `--no-default-features`, so this file compiles and executes there
 //! as well. Verified by running it, not assumed: it passes, because the
-//! twenty tools are registered unconditionally — `remember_extracted` is
+//! twenty-three tools are registered unconditionally — `remember_extracted` is
 //! always advertised and merely answers "no extractor configured" until one
 //! is attached, so neither `extract` nor `ollama` adds or removes a tool.
 //!

--- a/crates/velesdb-node/skills/velesdb-memory/SKILL.md
+++ b/crates/velesdb-node/skills/velesdb-memory/SKILL.md
@@ -3,7 +3,7 @@ name: velesdb-memory
 description: >
   Use durable, explainable, self-improving memory across a coding session via the
   velesdb-memory MCP server. Trigger whenever the velesdb-memory MCP tools
-  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/entity/memory_status)
+  (remember/recall/recall_fused/relate/why/feedback/forget/remember_extracted/extraction_status/entity/memory_status)
   are available and the
   work would benefit from remembering decisions, recalling prior context, or
   answering "why did we do X". Use it at the START of a task (recall what's known),
@@ -51,7 +51,8 @@ Server setup: [velesdb-memory README](https://github.com/cyberlife-coder/VelesDB
    the USER should be told if recall quality matters, since fixing it is one
    env var); `memory.edges` (`0` = the graph is flat, so `why` degrades to
    plain search until something wires links); `extraction.configured`
-   (whether `remember_extracted` will work at all). Do not re-poll it every
+   (whether `remember_extracted` may omit its backend; explicit `outline`
+   still works when false). Do not re-poll it every
    turn — it answers configuration questions, not content ones.
 
 1. **Recall before you act.** At the start of a task, retrieve what's already
@@ -220,9 +221,11 @@ tool for a *decision* graph, where you choose the edges deliberately. It is the
 wrong tool for facts about **people, places, organisations and things**, where
 the edges are simply what the sentence already says.
 
-`remember_extracted(text)` reads a passage and stores three things at once: the
-atomic facts, the typed edges **between named entities**, and the **attributes**
-those entities carry. Say it in plain language and the graph assembles itself:
+`remember_extracted(text)` durably accepts a passage for background work and
+returns `{request_id, state, reused}` before model generation. The job stores
+three things: atomic facts, typed edges **between named entities**, and the
+**attributes** those entities carry. Say it in plain language and the graph
+assembles itself:
 
 > "Bruno Durand est le père d'Theo Durand. Theo Durand a 15 ans.
 >  Theo Durand a une sœur, Camille Durand."
@@ -276,6 +279,16 @@ are **not** interchangeable:
 Pick `"outline"` when you control the input format, or to get a graph at all
 without running a model. Pick `"ollama"` when the input is prose nobody is
 going to reformat.
+
+**Always close the asynchronous loop.** Give one logical write a stable
+`idempotency_key`; if the client times out, retry that same key and unchanged
+payload rather than guessing whether the write happened. Keep the returned
+`request_id` and poll `extraction_status(request_id)` until `committed` or
+`failed`. Only a committed status carries final `ids` / u64-safe `ids_str` and
+`skipped_over_cap`; read the latter because non-zero means the passage was only
+partly stored. `accepted` and `running` survive daemon restarts. A `failed`
+status is terminal: surface its `error`, correct the cause, then submit a new
+logical operation with a new key.
 
 ## Concrete scenarios
 

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -714,7 +714,7 @@ impl PyMemoryService {
     }
 
     /// Extract atomic facts from raw `text` and store them, auto-building the
-    /// entity graph they state.
+    /// entity graph the passage describes.
     ///
     /// Args:
     ///     text: the passage to extract from.

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -746,7 +746,7 @@ impl WasmMemoryService {
         to_js(&EntityProfileOut::from_lookup(name, profile))
     }
 
-    /// Extract atomic facts from `text` and wire the entity graph they state,
+    /// Extract atomic facts from `text` and wire the described entity graph,
     /// with no manual `relate()`. Resolves to
     /// `{ids, skippedOverCap}` — the stored ids as decimal strings, and how
     /// many facts were dropped for exceeding the embeddable cap.

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -748,6 +748,17 @@ a requested remote backend must match the one configured at startup so it can
 reuse that backend's URL, model, and credential safely. This lets one daemon
 handle structured directives and free prose without a restart.
 
+The MCP call is a durable asynchronous contract. It returns
+`{request_id, state, reused}` after the request is persisted, before the model
+runs. Give each logical client operation an `idempotency_key`, then poll
+`extraction_status({request_id})` until `committed` or `failed`. Retrying the
+same key and payload never launches a second extraction; changing the payload
+under that key is rejected. Accepted/running jobs resume after a daemon
+restart, and model output is persisted before graph writes so an interrupted
+commit replays the same extraction. The job snapshots live under
+`<VELESDB_MEMORY_PATH>/extraction-jobs/`; terminal snapshots drop the passage
+and retain only its digest and result.
+
 `openai` is the same OpenAI-compatible protocol described under
 [Embedding backend](#embedding-backend), reached over
 `/v1/chat/completions`:

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -349,20 +349,48 @@ useful facts up and noise down with no retraining. The compiler's
 
 ## `remember_extracted`
 
-Store a passage of raw text by extracting its atomic facts and auto-building
-the fact↔topic graph, so `why` can connect them with no manual `relate`.
+Durably accept a passage for background extraction and return before model
+generation. The worker extracts atomic facts and auto-builds the fact↔topic
+graph, so `why` can connect them with no manual `relate`.
 
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `text` | string | yes | Raw text. Capped at 1 MiB (`MAX_FACT_BYTES`). |
 | `metadata` | object | no | Applied to every extracted fact. |
 | `extractor` | string | no | Per-call backend: `outline`, `ollama`, or `openai`. Omit to use the daemon default from `VELESDB_MEMORY_EXTRACTOR`. `outline` is always available; a remote name must match the backend configured when the daemon started. |
+| `idempotency_key` | string | no | Retry key, at most 256 bytes. The same key and payload reuse one durable job; the same key with a changed payload is rejected. |
 
-Returns `{ ids, ids_str, skipped_over_cap }`, the ids in extraction order.
-`skipped_over_cap` counts facts the extractor produced and this tool DROPPED
-for exceeding the 2048-byte embeddable-text cap. It is always present, and it
-is the only way to tell a drop from the model simply extracting fewer facts —
-read it, or you will believe you stored a passage you stored only part of.
+Returns an immediate `{ request_id, state, reused }` receipt. A newly accepted
+job reports `state: "accepted"`; an identical retry may report the later
+persisted state and sets `reused: true`. Without an explicit key, an exact
+normalized request is still content-addressed and deduplicated.
+
+Acceptance is durable: `accepted` and `running` records are recovered after a
+restart. The generated extraction is itself persisted before the first memory
+write, so a restart during graph storage replays stable facts and edges rather
+than asking the model for a second interpretation. If the process dies while
+the model is still generating—before an output exists to persist—that
+generation is retried on restart. At most 64 non-terminal jobs are admitted.
+
+## `extraction_status`
+
+Read the durable result of `remember_extracted`.
+
+| Parameter | Type | Required | Notes |
+|---|---|---|---|
+| `request_id` | string | yes | The 64-character lowercase hexadecimal id from the receipt. |
+
+Returns `{ request_id, state, ids, ids_str, skipped_over_cap, error }`.
+`state` is one of `accepted`, `running`, `committed`, or `failed`. While work is
+pending, both id arrays are empty and the terminal fields are `null`. On
+`committed`, `ids` are in extraction order, `ids_str` are their u64-safe
+decimal twins, and `skipped_over_cap` counts facts the extractor produced but
+the store dropped for exceeding the 2048-byte embeddable-text cap. On `failed`,
+`error` explains the terminal failure.
+
+Terminal snapshots retain the request fingerprint and result, but discard the
+source text, metadata, and generated extraction. This preserves retry
+idempotence without retaining an extra copy of the passage indefinitely.
 
 ## `memory_status`
 

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -1972,6 +1972,79 @@
       }
     },
     {
+      "description": "Read one durable extraction job by the `request_id` returned from `remember_extracted`. Returns that `request_id`, its persisted `state` (`accepted`, `running`, `committed`, or `failed`), committed fact `ids` and their u64-safe decimal `ids_str` twins, `skipped_over_cap` after commit, and `error` after failure. While accepted/running, `ids` and `ids_str` are empty and both optional terminal fields are null.",
+      "inputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "request_id": {
+            "description": "The `request_id` returned by `remember_extracted`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "request_id"
+        ],
+        "type": "object"
+      },
+      "name": "extraction_status",
+      "outputSchema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "error": {
+            "description": "Terminal failure detail, present only in the `failed` state.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ids": {
+            "description": "Stored fact ids after commit; empty while pending or failed.",
+            "items": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "ids_str": {
+            "description": "Decimal-string twins of `ids` for float-lossy JSON clients.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "request_id": {
+            "description": "Stable job identifier.",
+            "type": "string"
+          },
+          "skipped_over_cap": {
+            "description": "Extracted facts dropped for exceeding the embeddable cap, present only\nafter commit.",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "state": {
+            "description": "One of `accepted`, `running`, `committed`, or `failed`.",
+            "enum": [
+              "accepted",
+              "running",
+              "committed",
+              "failed"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "request_id",
+          "state",
+          "ids",
+          "ids_str"
+        ],
+        "type": "object"
+      }
+    },
+    {
       "description": "Reinforce a recalled memory with an outcome: `success=true` if the fact was useful, `false` if it was noise. This durably updates the fact's learned confidence, which `recall` uses to re-rank future results — over repeated feedback, useful facts drift up and noise drifts down, so the memory improves with use without retraining the model. Returns the fact's new confidence in [0,1].",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -3034,12 +3107,16 @@
       }
     },
     {
-      "description": "Store a passage of raw text by extracting its atomic facts and auto-building the fact↔topic graph, so `why` can later connect them with no manual links. Set `extractor` per call (`outline`, `ollama`, or `openai`), or omit it to use the daemon default from VELESDB_MEMORY_EXTRACTOR. `outline` is always available; a remote backend must be the one configured when the daemon started. Returns `ids` — the stored facts' ids, in extraction order — plus `ids_str`, their decimal-string twins: ids exceed 2^53, so always relay those on clients without u64-safe JSON number parsing. It also returns `skipped_over_cap`, and you should read it: that is how many facts the extractor DID produce out of your text and this tool did NOT store, because each was longer than the per-fact text limit. A non-zero `skipped_over_cap` means part of what you sent was extracted and then dropped — without that number, a short `ids` list is indistinguishable from a passage that simply held fewer facts.",
+      "description": "Accept a passage for durable background extraction and return before model generation. Set `extractor` per call (`outline`, `ollama`, or `openai`), or omit it to use VELESDB_MEMORY_EXTRACTOR. Supply `idempotency_key` when retrying across a client timeout: the same key and payload reuse one job, while a changed payload is rejected. The receipt returns `request_id`, its initial `state` (`accepted`, or the persisted state of a reused request), and `reused`. Poll `extraction_status(request_id)` until `committed` or `failed`; accepted/running jobs survive process restart.",
       "inputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "extractor": {
             "description": "Per-call backend (`outline`, `ollama`, or `openai`). Omit it to use the\nbackend configured when the daemon started.",
+            "type": "string"
+          },
+          "idempotency_key": {
+            "description": "Optional retry key. Reusing it with the same payload returns the same\ndurable job; reusing it with a different payload is rejected.",
             "type": "string"
           },
           "metadata": {
@@ -3061,31 +3138,29 @@
       "outputSchema": {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
-          "ids": {
-            "description": "Stable ids of the stored facts, in extraction order.",
-            "items": {
-              "minimum": 0,
-              "type": "integer"
-            },
-            "type": "array"
+          "request_id": {
+            "description": "Stable 64-hex identifier used to query the durable job.",
+            "type": "string"
           },
-          "ids_str": {
-            "description": "Decimal-string twins of `ids`, same order (issue #1468) — see\n[`RememberResult::id_str`].",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
+          "reused": {
+            "description": "Whether an identical prior request was reused instead of enqueued.",
+            "type": "boolean"
           },
-          "skipped_over_cap": {
-            "description": "Extracted facts DROPPED for exceeding the embeddable text cap\n(2048 bytes). Additive and always present: a skip the caller cannot\nsee is indistinguishable from the model extracting fewer facts, and\nthis tool exists precisely so the caller does not have to verify what\nit stored.",
-            "minimum": 0,
-            "type": "integer"
+          "state": {
+            "description": "State observed when the receipt was produced.",
+            "enum": [
+              "accepted",
+              "running",
+              "committed",
+              "failed"
+            ],
+            "type": "string"
           }
         },
         "required": [
-          "ids",
-          "ids_str",
-          "skipped_over_cap"
+          "request_id",
+          "state",
+          "reused"
         ],
         "type": "object"
       }


### PR DESCRIPTION
## Description

Make the MCP `remember_extracted` contract durable and asynchronous.

A submission now persists an `accepted` record before returning `{request_id, state, reused}`. Clients can retry with one `idempotency_key` and poll the new `extraction_status` tool through `accepted`, `running`, `committed`, or `failed`.

Recovery preserves the generated extraction before graph writes. After a restart, the worker replays that stable output through the existing content-addressed and edge-deduplicated storage path; it regenerates only when no model output was durably recorded. Terminal snapshots discard source text, metadata, and generated output while retaining the request digest and terminal result.

The persisted state machine validates canonical per-state shapes, uses sibling temporary files plus file/directory durability barriers, rejects symlinks and oversized/corrupt records, bounds non-terminal admission at 64 jobs, and hashes retry keys before using them in filenames.

Documentation, MCP schemas/snapshots, binding-parity declarations, changelog, architecture notes, and both distributed memory skills are updated for the transport contract. In-process Rust, Node, Python, WASM, and TypeScript binding behavior remains synchronous and is explicitly documented as a deliberate split.

Fixes #1839

## Type of Change

- [x] 💥 Breaking change (MCP response contract)
- [x] ✨ New feature
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual contract/mutation testing

Key proofs:

- receipt returns while extraction generation is deliberately blocked;
- identical retry keys generate once and changed payloads are rejected;
- failures are persisted, queryable, terminal, and not retried;
- restart recovery commits a persisted extraction without a second generation or duplicate fact/edge;
- a temporary mutation disabling the idempotency conflict guard made the dedicated test fail, then the restored guard passed;
- MCP output schema, committed tool snapshot, documentation contract, and binding parity pass together.

Validation run locally:

- `cargo fmt --all -- --check`;
- strict `velesdb-memory` Clippy on all features/targets with `-D warnings -D clippy::pedantic`;
- workspace Clippy on all applicable crates/targets with `-D warnings`; Node and Python checked separately; Tauri requires GLib/GTK/WebKit packages supplied by CI;
- workspace tests: core 5,467 unit tests + 635 BDD tests, memory 684 tests, integration suites and doctests; the sandbox-only Unix socket-bind case was the sole environment skip;
- feature-isolation builds for `mcp`, `http`, `context`, `persistence`, `ollama`, and `extract`;
- seven HTTP integration targets (25 tests);
- WASM no-default strict check, 5 host parity tests, and `wasm-pack test --node` (22 graph + 25 memory bridge + 29 web tests);
- Python Rust binding tests (97);
- repository guard suite (440 tests, 9 PowerShell-only skips);
- cargo-deny licenses/bans/sources/advisories;
- complexity threshold: no warning at CC 8 / NLOC 50 in the four new modules;
- `cargo publish -p velesdb-memory --dry-run --locked`.

**Test Configuration:**

- OS: Linux x86_64
- Rust version: 1.90.0
- Node: 26.7.0
- wasm-pack: 0.14.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand durability and recovery paths
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing tests pass locally with the documented environment exception
- [x] No dependent unpublished change is required

## Unsafe Code Checklist

No unsafe code was added or modified. The strict changed-file safety guard reports zero violations.

## High-Risk Change Checklist

- [x] Impacted invariants are documented in `crates/velesdb-memory/ARCHITECTURE.md`.
- [x] Crash/durability semantics and barriers are documented.
- [x] Restart, lifecycle, idempotency, failure, and blocked-worker tests were added.
- [ ] Maintainer reviewers to be assigned through repository ownership rules.

## Additional Notes

The language bindings intentionally keep their existing synchronous envelopes. Only the native MCP transport gains the durable receipt/status lifecycle.