### PR TITLE
test: execute refusal vectors for every required guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
       - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
         with:
           toolchain: ${{ env.RUST_VERSION }}
@@ -543,7 +547,7 @@ jobs:
           tool: wasm-pack
 
       - name: Run wasm-bindgen tests (Node)
-        run: wasm-pack test --node crates/velesdb-wasm
+        run: python3 scripts/run-wasm-bindgen-tests.py --root .
 
   # ===========================================================================
   # OpenAPI Drift Check
@@ -846,6 +850,10 @@ jobs:
         with:
           node-version: '20'
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -877,11 +885,7 @@ jobs:
       # including new ones like skills-sync.spec.mjs — is picked up automatically;
       # see package.json's "test" script for the single source of truth on the glob.
       - name: Build napi addon + run Node tests
-        working-directory: crates/velesdb-node
-        run: |
-          npm install --no-audit --no-fund
-          npx napi build --platform
-          npm test
+        run: python3 scripts/run-node-binding-tests.py --root .
 
       # Mirror the release assembly before any tag exists: test the root
       # tarball plus its native package from a clean npm install, never the
@@ -995,6 +999,11 @@ jobs:
         with:
           node-version: '20'
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        if: needs.node-windows-changed.outputs.relevant == 'true'
+        with:
+          python-version: '3.12'
+
       - name: Install stable Rust toolchain
         if: needs.node-windows-changed.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@stable
@@ -1011,12 +1020,7 @@ jobs:
       # file (not `npm test`) — see the job-level comment for why (#1509).
       - name: Build napi addon + run Node tests (Windows)
         if: needs.node-windows-changed.outputs.relevant == 'true'
-        working-directory: crates/velesdb-node
-        shell: bash
-        run: |
-          npm install --no-audit --no-fund
-          npx napi build --platform
-          node --test __test__/index.spec.mjs
+        run: python scripts/run-node-binding-tests-windows.py --root .
 
       - name: Skipped — crates/velesdb-node/** unchanged
         if: needs.node-windows-changed.outputs.relevant != 'true'

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -39,74 +39,8 @@ jobs:
           echo "event '${{ github.event_name }}' carries no pull_request payload:"
           echo "Git Flow, branch freshness and attribution have nothing to assert."
 
-      - name: Block archive branches as PR source
-        if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.head.ref, 'archive/') }}
-        env:
-          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
-        run: |
-          echo "::error::PR source branch '${BRANCH_NAME}' is archived and cannot be merged."
-          exit 1
-
-      - name: Enforce Git Flow branch rules
-        if: ${{ github.event_name == 'pull_request' }}
-        env:
-          SOURCE_REF: ${{ github.event.pull_request.head.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          # Git Flow enforcement rules:
-          #
-          # → develop : feature/*, feat/*, fix/*, bugfix/*,
-          #             refactor/*, chore/*, docs/*, style/*,
-          #             perf/*, test/*, build/*, ci/*, dependabot/*
-          # → main    : develop, release/*, hotfix/*, support/*
-          #
-          # bugfix/* is the standard Git Flow alias for fix/* (bug fixes in develop).
-          # dependabot/* is created by GitHub's Dependabot bot and always targets
-          # develop per .github/dependabot.yml configuration — the prefix is
-          # controlled by Dependabot itself and is not renameable.
-          # support/* maintains older release lines and merges directly to main.
-          # Any other target branch is rejected.
-
-          allowed_to_develop() {
-            local src="$1"
-            case "$src" in
-              feature/*|feat/*|fix/*|bugfix/*|refactor/*|chore/*) return 0 ;;
-              docs/*|style/*|perf/*|test/*|build/*|ci/*) return 0 ;;
-              dependabot/*) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          allowed_to_main() {
-            local src="$1"
-            case "$src" in
-              develop|release/*|hotfix/*|support/*) return 0 ;;
-              *) return 1 ;;
-            esac
-          }
-
-          if [ "$BASE_REF" = "develop" ]; then
-            if allowed_to_develop "$SOURCE_REF"; then
-              echo "OK: '${SOURCE_REF}' → develop (Git Flow valid)"
-            else
-              echo "::error::Git Flow violation: '${SOURCE_REF}' cannot target 'develop'."
-              echo "::error::Branches allowed to target 'develop': feature/*, feat/*, fix/*, bugfix/*, refactor/*, chore/*, docs/*, style/*, perf/*, test/*, build/*, ci/*, dependabot/*"
-              exit 1
-            fi
-          elif [ "$BASE_REF" = "main" ]; then
-            if allowed_to_main "$SOURCE_REF"; then
-              echo "OK: '${SOURCE_REF}' → main (Git Flow valid)"
-            else
-              echo "::error::Git Flow violation: '${SOURCE_REF}' cannot target 'main'."
-              echo "::error::Branches allowed to target 'main': develop, release/*, hotfix/*, support/*"
-              exit 1
-            fi
-          else
-            echo "::error::PR targets '${BASE_REF}', which is not a valid Git Flow integration branch."
-            echo "::error::Valid targets are 'main' and 'develop'."
-            exit 1
-          fi
-
+      # The policy is executable repository code now, so the checkout must
+      # precede even the source/target-only half of the guard.
       - name: Checkout head branch
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -114,18 +48,33 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Enforce PR source and Git Flow rules
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          SOURCE_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          python3 scripts/check-pr-governance.py \
+            --guard git-flow \
+            --source-ref "$SOURCE_REF" \
+            --base-ref "$BASE_REF"
+
+      - name: Fetch latest base branch
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "${BASE_REF}" --depth=1
+
       - name: Verify branch includes latest base branch
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin "${BASE_REF}" --depth=1
-          if git merge-base --is-ancestor "origin/${BASE_REF}" HEAD; then
-            echo "OK: HEAD contains latest origin/${BASE_REF}."
-          else
-            echo "::error::Branch is behind origin/${BASE_REF}. Rebase/merge ${BASE_REF} before opening this PR."
-            exit 1
-          fi
+          python3 scripts/check-pr-governance.py \
+            --guard freshness \
+            --root . \
+            --base-ref "$BASE_REF" \
+            --base-commit "origin/${BASE_REF}"
 
       - name: Reject AI-attributed commits
         if: ${{ github.event_name == 'pull_request' }}

--- a/scripts/check-pr-governance.py
+++ b/scripts/check-pr-governance.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Executable Git Flow and branch-freshness policy for pull requests.
+
+The policy used to live in conditional shell blocks in pr-governance.yml.
+That made it impossible to hand the guard a refused and an accepted case.
+This CLI keeps the GitHub event adaptation in YAML and puts the policy and
+its process exit in one locally executable, unit-tested place.
+
+Exit codes: 0 = accepted, 1 = policy refusal, 2 = usage/git error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEVELOP_PREFIXES = (
+    "feature/",
+    "feat/",
+    "fix/",
+    "bugfix/",
+    "refactor/",
+    "chore/",
+    "docs/",
+    "style/",
+    "perf/",
+    "test/",
+    "build/",
+    "ci/",
+    "dependabot/",
+)
+MAIN_PREFIXES = ("release/", "hotfix/", "support/")
+
+
+def git_flow_violation(source_ref: str, base_ref: str) -> str | None:
+    """Return the policy violation, or ``None`` for an admitted PR route."""
+    if source_ref.startswith("archive/"):
+        return f"PR source branch '{source_ref}' is archived and cannot be merged."
+
+    if base_ref == "develop":
+        if source_ref.startswith(DEVELOP_PREFIXES):
+            return None
+        return (
+            f"Git Flow violation: '{source_ref}' cannot target 'develop'. "
+            "Allowed prefixes: feature/, feat/, fix/, bugfix/, refactor/, "
+            "chore/, docs/, style/, perf/, test/, build/, ci/, dependabot/."
+        )
+
+    if base_ref == "main":
+        if source_ref == "develop" or source_ref.startswith(MAIN_PREFIXES):
+            return None
+        return (
+            f"Git Flow violation: '{source_ref}' cannot target 'main'. "
+            "Allowed sources: develop, release/*, hotfix/*, support/*."
+        )
+
+    return (
+        f"PR targets '{base_ref}', which is not a valid Git Flow integration "
+        "branch. Valid targets are 'main' and 'develop'."
+    )
+
+
+def check_git_flow(source_ref: str, base_ref: str) -> int:
+    """Print the Git Flow verdict in GitHub annotation form."""
+    violation = git_flow_violation(source_ref, base_ref)
+    if violation is not None:
+        print(f"::error::{violation}", file=sys.stderr)
+        return 1
+    print(f"OK: '{source_ref}' -> {base_ref} (Git Flow valid)")
+    return 0
+
+
+def check_freshness(root: Path, base_commit: str, base_ref: str) -> int:
+    """Require ``base_commit`` to be an ancestor of the checkout's HEAD."""
+    if not root.is_dir():
+        print(f"ERROR: repository root does not exist: {root}", file=sys.stderr)
+        return 2
+    try:
+        result = subprocess.run(  # noqa: S603 - arguments are not shell-evaluated
+            [
+                "git",
+                "-C",
+                str(root),
+                "merge-base",
+                "--is-ancestor",
+                base_commit,
+                "HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        print(f"ERROR: could not start git: {error}", file=sys.stderr)
+        return 2
+
+    if result.returncode == 0:
+        print(f"OK: HEAD contains latest {base_commit}.")
+        return 0
+    if result.returncode == 1:
+        print(
+            f"::error::Branch is behind {base_commit}. Rebase/merge {base_ref} "
+            "before opening this PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    detail = (result.stderr or result.stdout).strip()
+    print(
+        f"ERROR: git could not compare HEAD with {base_commit} "
+        f"(exit {result.returncode}): {detail}",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--guard",
+        choices=("all", "git-flow", "freshness"),
+        default="all",
+        help="policy member to run (default: all)",
+    )
+    parser.add_argument("--source-ref", help="pull request source branch")
+    parser.add_argument("--base-ref", help="pull request target branch")
+    parser.add_argument("--base-commit", help="fetched base commit/ref for freshness")
+    parser.add_argument("--root", type=Path, default=REPO_ROOT, help="git work tree")
+    args = parser.parse_args(argv)
+
+    if args.guard in {"all", "git-flow"}:
+        if not args.source_ref or not args.base_ref:
+            parser.error("--source-ref and --base-ref are required for git-flow")
+        verdict = check_git_flow(args.source_ref, args.base_ref)
+        if verdict != 0:
+            return verdict
+
+    if args.guard in {"all", "freshness"}:
+        if not args.base_commit or not args.base_ref:
+            parser.error("--base-commit and --base-ref are required for freshness")
+        return check_freshness(args.root.resolve(), args.base_commit, args.base_ref)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_test_runner.py
+++ b/scripts/ci_test_runner.py
@@ -1,0 +1,150 @@
+"""Shared process runner for CI-only Node and WASM functional gates.
+
+The binding crates are outside ``cargo test --workspace`` or contain tests
+that only exist on wasm32.  Their workflow steps therefore are guards in
+their own right.  Keeping the command construction here gives those guards a
+real CLI surface: the workflow and the refusal-vector harness execute the
+same sequencing and exit-code propagation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass(frozen=True)
+class Stage:
+    """One named subprocess in a blocking CI gate."""
+
+    label: str
+    command: tuple[str, ...]
+
+
+def run_stages(stages: Sequence[Stage], cwd: Path) -> int:
+    """Run stages in order, normalising a tool refusal to exit code 1.
+
+    A child that ran and returned non-zero is a gate refusal.  Failure to
+    start the child is operational breakage and remains distinguishable as
+    exit 2, matching the repository refusal-vector contract.
+    """
+    for stage in stages:
+        print(f"[{stage.label}] {shlex.join(stage.command)}", flush=True)
+        try:
+            result = subprocess.run(  # noqa: S603 - fixed, CLI-visible tool path
+                list(stage.command), cwd=cwd, check=False
+            )
+        except OSError as error:
+            print(
+                f"ERROR: could not start {stage.command[0]!r}: {error}",
+                file=sys.stderr,
+            )
+            return 2
+        if result.returncode != 0:
+            print(
+                f"ERROR: {stage.label} failed with exit code {result.returncode}.",
+                file=sys.stderr,
+            )
+            return 1
+    return 0
+
+
+def node_stages(npm: str, npx: str) -> tuple[Stage, ...]:
+    """The Linux N-API sequence formerly written inline in ci.yml."""
+    return (
+        Stage("Install Node dependencies", (npm, "install", "--no-audit", "--no-fund")),
+        Stage("Build the napi addon", (npx, "napi", "build", "--platform")),
+        Stage("Run the Node suites", (npm, "test")),
+    )
+
+
+def windows_node_stages(npm: str, npx: str, node: str) -> tuple[Stage, ...]:
+    """The Windows N-API sequence, including its deliberately explicit spec."""
+    return (
+        Stage("Install Node dependencies", (npm, "install", "--no-audit", "--no-fund")),
+        Stage("Build the napi addon", (npx, "napi", "build", "--platform")),
+        Stage(
+            "Run the Windows Node suite",
+            (node, "--test", "__test__/index.spec.mjs"),
+        ),
+    )
+
+
+def wasm_stages(wasm_pack: str) -> tuple[Stage, ...]:
+    """The wasm-bindgen suite and the Node runner it requires."""
+    return (
+        Stage(
+            "Run wasm-bindgen tests under Node",
+            (wasm_pack, "test", "--node", "crates/velesdb-wasm"),
+        ),
+    )
+
+
+def _tool_default(name: str) -> str:
+    """Use the command shim suffix CreateProcess requires on Windows."""
+    if os.name == "nt" and name in {"npm", "npx"}:
+        return f"{name}.cmd"
+    return name
+
+
+def _parser(description: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repository root (defaults to the checkout containing this script)",
+    )
+    return parser
+
+
+def _require_directory(parser: argparse.ArgumentParser, path: Path, label: str) -> Path:
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        parser.error(f"{label} does not exist: {resolved}")
+    return resolved
+
+
+def run_node_binding(argv: Sequence[str] | None = None) -> int:
+    """Run the Linux N-API build and complete Node suite."""
+    parser = _parser("Build the N-API addon and run its Linux Node suites.")
+    parser.add_argument("--npm", default=_tool_default("npm"), help="npm executable")
+    parser.add_argument("--npx", default=_tool_default("npx"), help="npx executable")
+    args = parser.parse_args(argv)
+    package = _require_directory(
+        parser, args.root / "crates" / "velesdb-node", "Node package directory"
+    )
+    return run_stages(node_stages(args.npm, args.npx), package)
+
+
+def run_windows_node_binding(argv: Sequence[str] | None = None) -> int:
+    """Run the Windows N-API build and its portable regression spec."""
+    parser = _parser("Build the N-API addon and run its Windows Node suite.")
+    parser.add_argument("--npm", default=_tool_default("npm"), help="npm executable")
+    parser.add_argument("--npx", default=_tool_default("npx"), help="npx executable")
+    parser.add_argument("--node", default="node", help="Node executable")
+    args = parser.parse_args(argv)
+    package = _require_directory(
+        parser, args.root / "crates" / "velesdb-node", "Node package directory"
+    )
+    return run_stages(
+        windows_node_stages(args.npm, args.npx, args.node), package
+    )
+
+
+def run_wasm_bindgen(argv: Sequence[str] | None = None) -> int:
+    """Run the wasm32-only wasm-bindgen suites under Node."""
+    parser = _parser("Run the wasm-bindgen functional suites under Node.")
+    parser.add_argument("--wasm-pack", default="wasm-pack", help="wasm-pack executable")
+    args = parser.parse_args(argv)
+    root = _require_directory(parser, args.root, "repository root")
+    _require_directory(parser, root / "crates" / "velesdb-wasm", "WASM crate directory")
+    return run_stages(wasm_stages(args.wasm_pack), root)

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -14,8 +14,8 @@
     "is still on disk, so the suite demands an accounting for it."
   ],
   "_schema": {
-    "script": "repo-relative path, the identity of the guard — the workflow itself when the guard is inline steps (see `inline_steps`)",
-    "inline_steps": "present when the guard is written as steps inside `workflow` rather than as a script under scripts/: the exact `- name:` of each step that must exist in `job`. The wiring test then reads those steps instead of hunting for a `run:` line naming a script. Without it, the three checks of pr-governance.yml — Git Flow, branch freshness, AI attribution — were real guards that the declared set simply did not mention.",
+    "script": "repo-relative path and identity of the executable guard — or the workflow itself for a legacy inline guard (see `inline_steps`)",
+    "inline_steps": "legacy support when a guard is written as steps inside `workflow` rather than as a script under scripts/: the exact `- name:` of each step that must exist in `job`. The wiring test reads those steps instead of hunting for a script invocation. #1715 extracted the last such guards, but the parser and mutation contracts remain so a future inline guard cannot be invisible.",
     "workflow": "the workflow file whose job invokes it",
     "job": "the job key inside that workflow",
     "required": "true when a failure of `job` must fail the single required check (CI Success)",
@@ -25,9 +25,12 @@
     "self_test_required": "true when that module runs inside a required job",
     "blind_spot": "known limit of the guard's reach, with the issue tracking it",
     "required_via": "when the guard lives outside ci.yml: the ci.yml job that calls its workflow, and through which it becomes required",
-    "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the same tree repaired. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
+    "must_refuse": "executable refusal vectors, run by scripts/tests/test_guard_refusal_vectors.py: each materialises `files` under a temp dir, invokes the guard with `argv` (`{root}` is substituted), and demands exit 1 — then demands exit 0 on `accepts`, the repaired state. `argv` may itself be keyed by those two states when arguments are the policy input. Exit 1 and not merely non-zero: a guard that crashes exits 2, and a crash is not a refusal.",
+    "base": "optional `repository` inside a vector: copy every tracked path from the current checkout before applying the state overlay. This is the scalable accepted control for a guard whose shipped registry structurally requires many real surfaces; the vector records only its deliberate drift instead of duplicating the tree.",
+    "replace": "optional exact text replacements keyed by `files` and `accepts`, applied after the base and file overlay. Each `old` string must occur exactly once, so a stale mutation is an error rather than a vacuous green vector.",
+    "executable": "optional fixture paths keyed by `files` and `accepts` that receive executable bits. This lets process gates receive deterministic tool doubles while exercising their real sequencing and exit propagation.",
     "refusal_untested": "mandatory when a strict, required guard declares no `must_refuse`: why no vector exists yet, and the issue tracking it. A guard nobody has seen refuse is the defect of this campaign; this field keeps that visible instead of absent.",
-    "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make. Two further keys, both optional and both keyed like the trees: `author` (`Name <email>`) and `message`. Without them a guard that reads WHO authored a commit could not be handed two trees differing in the only field it looks at; they default to the harness identity, so vectors written before they existed are unchanged.",
+    "repo": "optional inside a must_refuse vector: turns the materialised tree into a git work tree and tracks the paths it names, keyed like the trees (`files`, `accepts`). For guards that ask git rather than the filesystem — is this path tracked, who authored this commit — where a plain temp directory erases the very distinction they exist to make. Optional state-keyed `author` (`Name <email>`), `message`, and `relation` are also part of the state. `relation` is `ancestor` or `diverged` and creates refs/heads/vector-base so freshness policy can receive both histories.",
     "subguards": "for a guard exposing a `--guard <name>` selector: every selector that must actually be invoked in `job`. Without it, a script cited once for another selector satisfies the wiring test, and a sub-guard can be dropped from CI while the registry keeps announcing it — measured, that disarm stayed green.",
     "not_a_gate": "scripts a workflow runs that CANNOT refuse — no non-zero exit path. Surfaced by the reverse sweep (workflows -> registry) and kept out of `guards` so the registry never overstates what it covers. The `reason` is mandatory and the no-failure-path claim is verified against the source."
   },
@@ -258,7 +261,28 @@
         "issue": 1695,
         "summary": "POLICED_TOOLS holds 14 of the 20 published tools, and SURFACE_GLOBS still misses the Python and WASM binding sources. The six left out — compile_context, entity, recall, remember, remember_extracted, why — are named in the module header with what blocks them: each is waiting on the nested-shape treatment (#1695 lots 2-3), because they carry literals the guard would report as drift that are really a sibling's shape, an input schema, an MCP client config file or another API's dict — entity alone has twelve, six of them LangChain dictionaries. They go in by batches, each batch verified by a mutation that must make the guard refuse."
       },
-      "refusal_untested": "Takes --root, and the REFUSED half is cheap. The blocker is the ACCEPTED control, and it is structural: _structural_failures short-circuits before any drift check unless every pinned surface of every policed tool is present AND carries a declaration the attribution rule credits to that tool. With the registry at fourteen tools that is 17 distinct files, one of which (docs/reference/MCP_TOOLS.md) must carry fourteen correct declarations at once. The cost scales with the registry, so a fixture written for this batch has to be rewritten at the next one — the same argument that deferred it from the attribution rule, now transposed to the registry. Refusal IS proven meanwhile, three ways: ModeTests drives main(['--root', ...]) to exit 1 and back to 0; the synthetic suite pins every rule RED-first; and RealRepositoryTests runs the shipped registry against this tree. What is missing is only the subprocess vector over the SHIPPED registry. Tracked by #1715.",
+      "must_refuse": [
+        {
+          "vector": "the shipped MCP registry with feedback's documented confidence key renamed, against the untouched tracked repository",
+          "base": "repository",
+          "files": {},
+          "accepts": {},
+          "replace": {
+            "files": [
+              {
+                "path": "docs/reference/MCP_TOOLS.md",
+                "old": "Returns `{ id, id_str, confidence }`",
+                "new": "Returns `{ id, id_str, certainty }`"
+              }
+            ],
+            "accepts": []
+          },
+          "argv": [
+            "--root",
+            "{root}"
+          ]
+        }
+      ],
       "subguards": [
         "return-shape"
       ]
@@ -573,35 +597,118 @@
       "job": "gates",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_run_production_gates",
+      "self_test_required": true,
       "blind_spot": {
         "issue": null,
         "summary": "None known. Folded into CI Success's needs and chain via the `production-gates` caller job, so a failure now blocks the merge."
       },
       "required_via": "production-gates",
-      "refusal_untested": "Measured, and NOT for the reason previously written here. Under the harness (cwd = a temp tree) its first line, `bash scripts/check-doc-contract.sh`, cannot be found and the runner exits 127 — not 1, so it would fail the vector contract even though it did stop. And the positive control is out of reach in principle: gates 3 to 5 are `cargo test` invocations against velesdb-core (velesql_planner_golden, crash_recovery_tests, wal_recovery_tests), so exit 0 requires a real crate and a full build, not a materialised tree. Its refusal is genuinely its members'; each of those now carries its own vector. Tracked by #1715."
+      "subguards": [
+        "doc-contract",
+        "promise-contract",
+        "planner",
+        "crash-recovery",
+        "wal-recovery"
+      ],
+      "must_refuse": [
+        {
+          "vector": "the production meta-runner's doc-contract member sees a runtime route missing from README, then accepts the documented route",
+          "files": {
+            "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
+            "README.md": "`/query/explain`\n"
+          },
+          "accepts": {
+            "crates/velesdb-server/src/routes.rs": ".route(\"/query/explain\", get(explain))\n.route(\"/aggregate\", post(aggregate))\n",
+            "README.md": "`/query/explain`\n`/aggregate`\n"
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--guard",
+            "doc-contract"
+          ]
+        }
+      ]
     },
     {
-      "script": ".github/workflows/pr-governance.yml",
-      "inline_steps": [
-        "Block archive branches as PR source",
-        "Enforce Git Flow branch rules",
-        "Verify branch includes latest base branch"
-      ],
-      "purpose": "Git Flow branch rules, freshness of the branch against its base, and no AI-attributed commit.",
+      "script": "scripts/check-pr-governance.py",
+      "purpose": "Git Flow source/target rules and freshness of the branch against its fetched base.",
       "workflow": ".github/workflows/pr-governance.yml",
       "job": "governance",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_check_pr_governance",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "an archived PR source is refused while an admitted feature source targeting develop passes",
+          "files": {
+            "EVENT.txt": "pull request policy fixture\n"
+          },
+          "accepts": {
+            "EVENT.txt": "pull request policy fixture\n"
+          },
+          "argv": {
+            "files": [
+              "--guard",
+              "git-flow",
+              "--source-ref",
+              "archive/old-work",
+              "--base-ref",
+              "develop"
+            ],
+            "accepts": [
+              "--guard",
+              "git-flow",
+              "--source-ref",
+              "feat/current-work",
+              "--base-ref",
+              "develop"
+            ]
+          }
+        },
+        {
+          "vector": "a fetched base on a sibling commit is refused while the same base as an ancestor of HEAD passes",
+          "files": {
+            "TRACKED.txt": "branch topology fixture\n"
+          },
+          "accepts": {
+            "TRACKED.txt": "branch topology fixture\n"
+          },
+          "repo": {
+            "files": [
+              "TRACKED.txt"
+            ],
+            "accepts": [
+              "TRACKED.txt"
+            ],
+            "relation": {
+              "files": "diverged",
+              "accepts": "ancestor"
+            }
+          },
+          "argv": [
+            "--guard",
+            "freshness",
+            "--root",
+            "{root}",
+            "--base-ref",
+            "develop",
+            "--base-commit",
+            "refs/heads/vector-base"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
-        "summary": "No self-test materialises a PR these steps must reject: Git Flow and branch freshness read a pull_request payload no local tree reproduces. The attribution check is no longer inline — it moved to scripts/check-ai-attribution.py, which is tested (#1699 closed)."
+        "summary": "The GitHub event-to-CLI mapping remains YAML's responsibility. The wiring contract pins both explicit --guard selectors; unit tests and vectors cover the policy and real git topology after that boundary. AI attribution is a separate executable guard in the same job."
       },
       "required_via": "pr-governance",
-      "refusal_untested": "Not a script but three inline steps, and the two that remain here read a `pull_request` payload — the source branch name and its merge-base with the base branch — that no materialised tree reproduces: there is no pull request to describe. The third check, AI attribution, is no longer inline (it moved to scripts/check-ai-attribution.py) and now carries an executable vector of its own. Tracked by #1715."
+      "subguards": [
+        "git-flow",
+        "freshness"
+      ]
     },
     {
       "script": "scripts/check-ai-attribution.py",
@@ -647,58 +754,133 @@
       "required_via": "pr-governance"
     },
     {
-      "script": ".github/workflows/ci.yml",
-      "inline_steps": [
-        "Build napi addon + run Node tests"
-      ],
+      "script": "scripts/run-node-binding-tests.py",
       "purpose": "The Node binding's functional gate: build the napi addon (debug profile) and run every __test__/*.spec.mjs suite via `npm test`.",
       "workflow": ".github/workflows/ci.yml",
       "job": "node-binding-tests",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the Linux N-API pipeline reaches a failing npm test after install and build, then propagates a repaired tool's success",
+          "files": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:] == ['test'] else 0)\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-ci-tool"
+            ],
+            "accepts": [
+              "tools/fake-ci-tool"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--npm",
+            "{root}/tools/fake-ci-tool",
+            "--npx",
+            "{root}/tools/fake-ci-tool"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
-        "summary": "The pin holds the step by its `- name:`, so the wiring test proves the step exists in the job and is not disarmed — it cannot prove the step's shell body still runs `npm test`. A body rewritten to a no-op under the same name stays green. Same limit as every inline guard, pr-governance's included."
-      },
-      "refusal_untested": "Not a script but a workflow step whose body is `npm install` + `npx napi build --platform` + `npm test` against the real crate: exit 1 needs a failing Node test and exit 0 a full addon build, neither reachable from a materialised temp tree. Its refusal is its test suite's. Measured before this entry existed: deleting the step's one `run:` block turned nothing red — the audit finding this entry closes. Tracked by #1715."
+        "summary": "The vector dependency-injects npm/npx to prove the exact three-stage sequence and exit propagation without compiling the addon twice. The required CI job still supplies the real tools and crate; the Node suites own addon semantics."
+      }
     },
     {
-      "script": ".github/workflows/ci.yml",
-      "inline_steps": [
-        "Build napi addon + run Node tests (Windows)"
-      ],
+      "script": "scripts/run-node-binding-tests-windows.py",
       "purpose": "The Windows leg of the Node binding gate (#1515): the same napi build, then `node --test __test__/index.spec.mjs` — the file that carries the three Windows-only regressions (#1509, #1510, #1511).",
       "workflow": ".github/workflows/ci.yml",
       "job": "node-binding-tests-windows",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the Windows N-API pipeline reaches a failing explicit Node spec after install and build, then propagates success",
+          "files": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nimport sys\nraise SystemExit(1 if sys.argv[1:2] == ['--test'] else 0)\n"
+          },
+          "accepts": {
+            "crates/velesdb-node/.fixture": "package root\n",
+            "tools/fake-ci-tool": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-ci-tool"
+            ],
+            "accepts": [
+              "tools/fake-ci-tool"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--npm",
+            "{root}/tools/fake-ci-tool",
+            "--npx",
+            "{root}/tools/fake-ci-tool",
+            "--node",
+            "{root}/tools/fake-ci-tool"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
-        "summary": "The step is `if:`-guarded by the node-windows-changed path filter, so on a PR that leaves crates/velesdb-node/** untouched it no-ops by design (the cost tradeoff is written above the job). The wiring test proves the step exists and is not disarmed, not that any given PR executed it — and not that its shell body still runs the spec file."
-      },
-      "refusal_untested": "Same shape as the Linux leg: a workflow step whose body builds the addon on windows-latest and runs one spec file — no materialised tree can reach either exit. It runs only when the path filter says the addon changed, which is the documented tradeoff, not a disarm. Deleting the step was measured green before this entry pinned it. Tracked by #1715."
+        "summary": "The job remains path-filtered by node-windows-changed, so PRs outside crates/velesdb-node intentionally no-op. The command contract pins the Windows-specific explicit spec; the vector substitutes tools only to make its refusal hermetic."
+      }
     },
     {
-      "script": ".github/workflows/ci.yml",
-      "inline_steps": [
-        "Run wasm-bindgen tests (Node)"
-      ],
+      "script": "scripts/run-wasm-bindgen-tests.py",
       "purpose": "The WASM functional gate: `wasm-pack test --node crates/velesdb-wasm` runs the wasm-bindgen suites (tests/*.rs gated on target_arch = \"wasm32\") that compile to empty binaries under the native test job and are invisible to `cargo check`.",
       "workflow": ".github/workflows/ci.yml",
       "job": "wasm-check",
       "required": true,
       "mode": "strict",
-      "self_test": null,
-      "self_test_required": false,
+      "self_test": "scripts.tests.test_ci_test_gate",
+      "self_test_required": true,
+      "must_refuse": [
+        {
+          "vector": "the wasm-bindgen Node runner propagates wasm-pack's refusal and accepts the repaired tool",
+          "files": {
+            "crates/velesdb-wasm/.fixture": "crate root\n",
+            "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(1)\n"
+          },
+          "accepts": {
+            "crates/velesdb-wasm/.fixture": "crate root\n",
+            "tools/fake-wasm-pack": "#!/usr/bin/env python3\nraise SystemExit(0)\n"
+          },
+          "executable": {
+            "files": [
+              "tools/fake-wasm-pack"
+            ],
+            "accepts": [
+              "tools/fake-wasm-pack"
+            ]
+          },
+          "argv": [
+            "--root",
+            "{root}",
+            "--wasm-pack",
+            "{root}/tools/fake-wasm-pack"
+          ]
+        }
+      ],
       "blind_spot": {
         "issue": null,
-        "summary": "The pin holds the step by its `- name:`; a body rewritten away from `wasm-pack test` under the same name stays green. And the step covers only the wasm32-gated suites — the host-run quantization parity step in the same job is not pinned here, though it is also named coverage the `test` job already runs transitively."
-      },
-      "refusal_untested": "A workflow step whose body is a wasm-pack build-and-test of the real crate under a Node runner: exit 1 needs a failing wasm-bindgen test, exit 0 a full wasm32 build — neither reachable from a materialised temp tree. Its refusal is the suite's own (memory_wedge_web.rs and siblings). This step was the one-line deletion that turned nothing red until this entry pinned it. Tracked by #1715."
+        "summary": "The vector substitutes wasm-pack to prove command shape and refusal propagation without installing the wasm toolchain in gate-contracts. The required wasm-check job supplies real wasm-pack and owns wasm32 suite semantics."
+      }
     },
     {
       "script": "scripts/compare_perf.py",

--- a/scripts/run-node-binding-tests-windows.py
+++ b/scripts/run-node-binding-tests-windows.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the Windows N-API functional gate."""
+
+from ci_test_runner import run_windows_node_binding
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_windows_node_binding())

--- a/scripts/run-node-binding-tests.py
+++ b/scripts/run-node-binding-tests.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the Linux N-API functional gate."""
+
+from ci_test_runner import run_node_binding
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_node_binding())

--- a/scripts/run-production-gates.sh
+++ b/scripts/run-production-gates.sh
@@ -1,21 +1,99 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+GUARD="all"
+
+usage() {
+  cat <<'EOF'
+Usage: run-production-gates.sh [--root PATH] [--guard NAME]
+
+Run all production gates, or one member for local diagnosis/refusal vectors.
+NAME is one of: all, doc-contract, promise-contract, planner,
+                crash-recovery, wal-recovery.
+EOF
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    --root)
+      if (( $# < 2 )); then
+        echo "ERROR: --root requires a path" >&2
+        exit 2
+      fi
+      ROOT="$2"
+      shift 2
+      ;;
+    --guard)
+      if (( $# < 2 )); then
+        echo "ERROR: --guard requires a name" >&2
+        exit 2
+      fi
+      GUARD="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$GUARD" in
+  all|doc-contract|promise-contract|planner|crash-recovery|wal-recovery) ;;
+  *)
+    echo "ERROR: unknown guard: $GUARD" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "ERROR: repository root does not exist: $ROOT" >&2
+  exit 2
+fi
+ROOT="$(cd -- "$ROOT" && pwd -P)"
+cd -- "$ROOT"
+
+selected() {
+  [[ "$GUARD" == "all" || "$GUARD" == "$1" ]]
+}
+
 # Production release gates for velesdb-core promise protection.
 
-echo "[Gate 1/5] README/runtime doc contract"
-bash scripts/check-doc-contract.sh
+if selected doc-contract; then
+  echo "[Gate 1/5] README/runtime doc contract"
+  bash "$SCRIPT_DIR/check-doc-contract.sh"
+fi
 
-echo "[Gate 2/5] Promise contract registry"
-python3 scripts/check-promise-contract.py
+if selected promise-contract; then
+  echo "[Gate 2/5] Promise contract registry"
+  python3 "$SCRIPT_DIR/check-promise-contract.py" --root "$ROOT"
+fi
 
-echo "[Gate 3/5] Deterministic VelesQL planner golden tests"
-cargo test -p velesdb-core --test velesql_planner_golden -- --nocapture
+if selected planner; then
+  echo "[Gate 3/5] Deterministic VelesQL planner golden tests"
+  cargo test -p velesdb-core --test velesql_planner_golden -- --nocapture
+fi
 
-echo "[Gate 4/5] Crash recovery corruption scenarios"
-cargo test -p velesdb-core --test crash_recovery_tests -- --nocapture
+if selected crash-recovery; then
+  echo "[Gate 4/5] Crash recovery corruption scenarios"
+  cargo test -p velesdb-core --test crash_recovery_tests -- --nocapture
+fi
 
-echo "[Gate 5/5] WAL recovery regression tests"
-cargo test -p velesdb-core storage::wal_recovery_tests -- --nocapture
+if selected wal-recovery; then
+  echo "[Gate 5/5] WAL recovery regression tests"
+  cargo test -p velesdb-core storage::wal_recovery_tests -- --nocapture
+fi
 
-echo "All production gates passed."
+if [[ "$GUARD" == "all" ]]; then
+  echo "All production gates passed."
+else
+  echo "Production gate '$GUARD' passed."
+fi

--- a/scripts/run-wasm-bindgen-tests.py
+++ b/scripts/run-wasm-bindgen-tests.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entry point for the wasm32-only wasm-bindgen functional gate."""
+
+from ci_test_runner import run_wasm_bindgen
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_wasm_bindgen())

--- a/scripts/tests/test_check_pr_governance.py
+++ b/scripts/tests/test_check_pr_governance.py
@@ -1,0 +1,98 @@
+"""Unit contracts for the executable PR Git Flow and freshness guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import contextlib
+import io
+import subprocess
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-pr-governance.py"
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_pr_governance", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+cpg = _load_script()
+
+
+class GitFlowTests(unittest.TestCase):
+    def test_every_development_prefix_is_admitted(self) -> None:
+        prefixes = (
+            "feature",
+            "feat",
+            "fix",
+            "bugfix",
+            "refactor",
+            "chore",
+            "docs",
+            "style",
+            "perf",
+            "test",
+            "build",
+            "ci",
+            "dependabot",
+        )
+        for prefix in prefixes:
+            with self.subTest(prefix=prefix):
+                self.assertIsNone(cpg.git_flow_violation(f"{prefix}/change", "develop"))
+
+    def test_only_release_lines_are_admitted_to_main(self) -> None:
+        for source in ("develop", "release/1.0", "hotfix/cve", "support/0.9"):
+            with self.subTest(source=source):
+                self.assertIsNone(cpg.git_flow_violation(source, "main"))
+
+    def test_archive_sources_are_refused_before_other_rules(self) -> None:
+        violation = cpg.git_flow_violation("archive/old-work", "develop")
+        self.assertIsNotNone(violation)
+        self.assertIn("archived", violation)
+
+    def test_wrong_source_and_unknown_target_are_refused(self) -> None:
+        self.assertIsNotNone(cpg.git_flow_violation("main", "develop"))
+        self.assertIsNotNone(cpg.git_flow_violation("feat/x", "staging"))
+
+
+class FreshnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="governance-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+
+    def test_an_ancestor_base_is_accepted(self) -> None:
+        with mock.patch.object(
+            cpg.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0),
+        ), contextlib.redirect_stdout(io.StringIO()):
+            self.assertEqual(cpg.check_freshness(self.root, "base", "develop"), 0)
+
+    def test_a_diverged_base_is_refused(self) -> None:
+        with mock.patch.object(
+            cpg.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 1),
+        ), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(cpg.check_freshness(self.root, "base", "develop"), 1)
+
+    def test_a_git_failure_is_not_misreported_as_policy_refusal(self) -> None:
+        with mock.patch.object(
+            cpg.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 128, stderr="bad ref"),
+        ), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(cpg.check_freshness(self.root, "missing", "develop"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -940,7 +940,16 @@ class GuardRegistryDisarmTests(unittest.TestCase):
         for entry in self.registry["guards"]:
             if entry.get("inline_steps"):
                 return entry
-        raise AssertionError("no inline guard in the registry to mutate")
+        # #1715 extracted the final inline guards into executable scripts. Keep
+        # the parser/disarm contract alive against a real remaining workflow
+        # step so reintroducing an inline entry cannot make this capability
+        # silently rot merely because the registry currently needs none.
+        return {
+            "script": ".github/workflows/ci.yml",
+            "workflow": ".github/workflows/ci.yml",
+            "job": "wasm-check",
+            "inline_steps": ["Run wasm-bindgen tests (Node)"],
+        }
 
     def test_deleting_an_inline_step_from_its_workflow_is_detected(self) -> None:
         entry = self._inline_entry()

--- a/scripts/tests/test_ci_test_gate.py
+++ b/scripts/tests/test_ci_test_gate.py
@@ -1,0 +1,106 @@
+"""Contract tests for the process wrappers used by the Node and WASM jobs."""
+
+from __future__ import annotations
+
+import subprocess
+import contextlib
+import io
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import ci_test_runner
+
+
+class RunStagesTests(unittest.TestCase):
+    def test_every_stage_runs_in_order(self) -> None:
+        stages = (
+            ci_test_runner.Stage("install", ("npm", "install")),
+            ci_test_runner.Stage("build", ("npx", "napi", "build")),
+            ci_test_runner.Stage("test", ("npm", "test")),
+        )
+        completed = subprocess.CompletedProcess([], 0)
+
+        with mock.patch.object(
+            ci_test_runner.subprocess, "run", return_value=completed
+        ) as run, contextlib.redirect_stdout(io.StringIO()):
+            result = ci_test_runner.run_stages(stages, Path("/fixture"))
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[0] for call in run.call_args_list],
+            [list(stage.command) for stage in stages],
+        )
+        self.assertTrue(all(call.kwargs["cwd"] == Path("/fixture") for call in run.call_args_list))
+
+    def test_a_failed_stage_refuses_and_stops_the_pipeline(self) -> None:
+        stages = (
+            ci_test_runner.Stage("install", ("npm", "install")),
+            ci_test_runner.Stage("build", ("npx", "napi", "build")),
+            ci_test_runner.Stage("test", ("npm", "test")),
+        )
+        results = (
+            subprocess.CompletedProcess([], 0),
+            subprocess.CompletedProcess([], 9),
+        )
+
+        with mock.patch.object(
+            ci_test_runner.subprocess, "run", side_effect=results
+        ) as run, contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            result = ci_test_runner.run_stages(stages, Path("/fixture"))
+
+        self.assertEqual(result, 1)
+        self.assertEqual(run.call_count, 2, "nothing may run after the refusing stage")
+
+    def test_an_unstartable_tool_is_an_operational_error(self) -> None:
+        stages = (ci_test_runner.Stage("test", ("missing-tool", "test")),)
+        with mock.patch.object(
+            ci_test_runner.subprocess, "run", side_effect=FileNotFoundError("missing")
+        ), contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(
+            io.StringIO()
+        ):
+            self.assertEqual(ci_test_runner.run_stages(stages, Path("/fixture")), 2)
+
+
+class CommandContractTests(unittest.TestCase):
+    def test_linux_node_gate_keeps_the_workflow_sequence(self) -> None:
+        self.assertEqual(
+            ci_test_runner.node_stages("npm-x", "npx-x"),
+            (
+                ci_test_runner.Stage(
+                    "Install Node dependencies",
+                    ("npm-x", "install", "--no-audit", "--no-fund"),
+                ),
+                ci_test_runner.Stage(
+                    "Build the napi addon",
+                    ("npx-x", "napi", "build", "--platform"),
+                ),
+                ci_test_runner.Stage("Run the Node suites", ("npm-x", "test")),
+            ),
+        )
+
+    def test_windows_node_gate_keeps_the_single_portable_spec(self) -> None:
+        self.assertEqual(
+            ci_test_runner.windows_node_stages("npm-x", "npx-x", "node-x")[-1],
+            ci_test_runner.Stage(
+                "Run the Windows Node suite",
+                ("node-x", "--test", "__test__/index.spec.mjs"),
+            ),
+        )
+
+    def test_wasm_gate_keeps_the_node_runner(self) -> None:
+        self.assertEqual(
+            ci_test_runner.wasm_stages("wasm-pack-x"),
+            (
+                ci_test_runner.Stage(
+                    "Run wasm-bindgen tests under Node",
+                    ("wasm-pack-x", "test", "--node", "crates/velesdb-wasm"),
+                ),
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_guard_refusal_vectors.py
+++ b/scripts/tests/test_guard_refusal_vectors.py
@@ -41,6 +41,7 @@ declaring what it refuses are one act, in one file, confronted by
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -71,6 +72,63 @@ def materialise(tree: "dict[str, str]", root: Path) -> None:
         path.write_text(content, encoding="utf-8")
 
 
+def copy_repository_snapshot(root: Path) -> None:
+    """Copy the current contents of every tracked path, excluding ``.git``.
+
+    A shipped-registry vector needs all currently pinned surfaces as its
+    accepted control. Encoding thousands of lines into guards.json would
+    duplicate the repository and go stale whenever a new surface is pinned.
+    The tracked snapshot is the scalable fixture; a vector then declares only
+    its deliberate overlay mutation.
+    """
+    listed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        capture_output=True,
+        check=True,
+    ).stdout
+    for encoded in listed.split(b"\0"):
+        if not encoded:
+            continue
+        relative = encoded.decode("utf-8", errors="surrogateescape")
+        source = REPO_ROOT / relative
+        destination = root / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            destination.symlink_to(os.readlink(source))
+        else:
+            shutil.copy2(source, destination)
+
+
+def apply_replacements(replacements: "list[dict[str, str]]", root: Path) -> None:
+    """Apply exact, anti-vacuous text replacements to a fixture tree."""
+    for replacement in replacements:
+        path = root / replacement["path"]
+        text = path.read_text(encoding="utf-8")
+        old = replacement["old"]
+        occurrences = text.count(old)
+        if occurrences != 1:
+            raise ValueError(
+                f"{replacement['path']}: replacement source must occur exactly once "
+                f"(found {occurrences})"
+            )
+        path.write_text(text.replace(old, replacement["new"], 1), encoding="utf-8")
+
+
+def mark_executable(paths: "list[str]", root: Path) -> None:
+    """Give declared fixture tools executable bits on every Unix platform."""
+    for relative in paths:
+        path = root / relative
+        if not path.is_file():
+            raise ValueError(f"executable fixture path does not exist: {relative}")
+        path.chmod(path.stat().st_mode | 0o111)
+
+
+def argv_for_state(vector: dict, key: str) -> "list[str]":
+    """Return common argv, or the argv specific to one vector state."""
+    argv = vector["argv"]
+    return argv[key] if isinstance(argv, dict) else argv
+
+
 #: Identity and message a `repo` vector gets unless it names its own. Local to
 #: the tree, so the harness never depends on the machine's git configuration.
 DEFAULT_IDENTITY = "refusal-vector-harness <harness@velesdb.invalid>"
@@ -88,6 +146,7 @@ def make_repository(
     tracked: "list[str]",
     identity: str = DEFAULT_IDENTITY,
     message: str = DEFAULT_MESSAGE,
+    relation: "str | None" = None,
 ) -> None:
     """Turn the materialised tree into a git work tree, tracking `tracked`.
 
@@ -116,6 +175,24 @@ def make_repository(
         run("add", "--", relative)
     run("commit", "-q", "-m", message)
 
+    if relation is None:
+        return
+    if relation not in {"ancestor", "diverged"}:
+        raise ValueError(f"unknown repository relation: {relation}")
+
+    head_branch = run("symbolic-ref", "--short", "HEAD").stdout.strip()
+    run("branch", "vector-base", "HEAD")
+    if relation == "ancestor":
+        run("commit", "-q", "--allow-empty", "-m", "vector head")
+        return
+
+    # The base and HEAD each advance from the fixture commit, making them
+    # siblings. `vector-base` therefore is not an ancestor of HEAD.
+    run("checkout", "-q", "vector-base")
+    run("commit", "-q", "--allow-empty", "-m", "vector base")
+    run("checkout", "-q", head_branch)
+    run("commit", "-q", "--allow-empty", "-m", "vector head")
+
 
 def run_guard(script: str, argv: "list[str]", root: Path) -> "subprocess.CompletedProcess[str]":
     """Invoke ``script`` on the materialised tree.
@@ -140,7 +217,11 @@ class RefusalVectorTests(unittest.TestCase):
     def _run_tree(self, entry: dict, vector: dict, key: str) -> "subprocess.CompletedProcess[str]":
         tmp = Path(tempfile.mkdtemp(prefix="guard-vector-"))
         self.addCleanup(shutil.rmtree, tmp, True)
+        if vector.get("base") == "repository":
+            copy_repository_snapshot(tmp)
         materialise(vector[key], tmp)
+        apply_replacements((vector.get("replace") or {}).get(key, []), tmp)
+        mark_executable((vector.get("executable") or {}).get(key, []), tmp)
         # `repo` names the paths git must TRACK; everything else stays
         # untracked, which is the whole point for a guard that asks git.
         repo = vector.get("repo")
@@ -150,8 +231,9 @@ class RefusalVectorTests(unittest.TestCase):
                 repo.get(key, []),
                 repo.get("author", {}).get(key, DEFAULT_IDENTITY),
                 repo.get("message", {}).get(key, DEFAULT_MESSAGE),
+                repo.get("relation", {}).get(key),
             )
-        return run_guard(entry["script"], vector["argv"], tmp)
+        return run_guard(entry["script"], argv_for_state(vector, key), tmp)
 
     def test_every_declared_vector_is_refused(self) -> None:
         for entry in guards_with_vectors():
@@ -217,12 +299,22 @@ class RefusalVectorTests(unittest.TestCase):
                         sorted(repo.get("files", [])),
                         author.get("files"),
                         message.get("files"),
+                        (repo.get("relation") or {}).get("files"),
+                        vector.get("base"),
+                        (vector.get("replace") or {}).get("files", []),
+                        sorted((vector.get("executable") or {}).get("files", [])),
+                        argv_for_state(vector, "files"),
                     )
                     accepted = (
                         vector["accepts"],
                         sorted(repo.get("accepts", [])),
                         author.get("accepts"),
                         message.get("accepts"),
+                        (repo.get("relation") or {}).get("accepts"),
+                        vector.get("base"),
+                        (vector.get("replace") or {}).get("accepts", []),
+                        sorted((vector.get("executable") or {}).get("accepts", [])),
+                        argv_for_state(vector, "accepts"),
                     )
                     self.assertNotEqual(
                         refused,
@@ -241,8 +333,29 @@ class VectorShapeTests(unittest.TestCase):
                 with self.subTest(script=entry["script"]):
                     for field in ("vector", "files", "argv", "accepts"):
                         self.assertIn(field, vector, f"missing `{field}`")
-                    self.assertTrue(vector["files"], "an empty tree exercises nothing")
-                    self.assertTrue(vector["accepts"], "an empty control proves nothing")
+                    self.assertIn(vector.get("base"), (None, "repository"))
+                    if vector.get("base") != "repository":
+                        self.assertTrue(vector["files"], "an empty tree exercises nothing")
+                        self.assertTrue(vector["accepts"], "an empty control proves nothing")
+                    argv = vector["argv"]
+                    if isinstance(argv, dict):
+                        self.assertEqual(set(argv), {"files", "accepts"})
+                        self.assertTrue(all(isinstance(value, list) for value in argv.values()))
+                    else:
+                        self.assertIsInstance(argv, list)
+                    for state in ("files", "accepts"):
+                        replacements = (vector.get("replace") or {}).get(state, [])
+                        for replacement in replacements:
+                            self.assertEqual(
+                                set(replacement),
+                                {"path", "old", "new"},
+                                "a replacement declares path, old and new exactly",
+                            )
+                            self.assertNotEqual(replacement["old"], replacement["new"])
+                    relation = (vector.get("repo") or {}).get("relation", {})
+                    self.assertTrue(
+                        all(value in {"ancestor", "diverged"} for value in relation.values())
+                    )
                     self.assertTrue(
                         (vector["vector"] or "").strip(),
                         "a vector must say in words what it materialises",
@@ -256,6 +369,61 @@ class VectorShapeTests(unittest.TestCase):
             guards_with_vectors(),
             "no guard declares a refusal vector: this suite proves nothing",
         )
+
+
+class HarnessExtensionTests(unittest.TestCase):
+    """The scalable fixture features #1715 needs are contracts themselves."""
+
+    def test_argv_can_differ_between_the_refused_and_accepted_state(self) -> None:
+        vector = {
+            "argv": {
+                "files": ["--source-ref", "archive/old"],
+                "accepts": ["--source-ref", "feat/current"],
+            }
+        }
+        self.assertEqual(argv_for_state(vector, "files"), ["--source-ref", "archive/old"])
+        self.assertEqual(
+            argv_for_state(vector, "accepts"), ["--source-ref", "feat/current"]
+        )
+
+    def test_a_repository_overlay_replacement_must_match_exactly_once(self) -> None:
+        root = Path(tempfile.mkdtemp(prefix="guard-replacement-test-"))
+        self.addCleanup(shutil.rmtree, root, True)
+        (root / "surface.md").write_text("Returns {good}.\n", encoding="utf-8")
+
+        apply_replacements(
+            [{"path": "surface.md", "old": "{good}", "new": "{drift}"}], root
+        )
+        self.assertEqual(
+            (root / "surface.md").read_text(encoding="utf-8"),
+            "Returns {drift}.\n",
+        )
+        with self.assertRaisesRegex(ValueError, "exactly once"):
+            apply_replacements(
+                [{"path": "surface.md", "old": "{missing}", "new": "{drift}"}],
+                root,
+            )
+
+    def test_repository_relation_can_model_a_stale_and_fresh_branch(self) -> None:
+        for relation, expected in (("diverged", 1), ("ancestor", 0)):
+            with self.subTest(relation=relation):
+                root = Path(tempfile.mkdtemp(prefix="guard-history-test-"))
+                self.addCleanup(shutil.rmtree, root, True)
+                (root / "tracked.txt").write_text("fixture\n", encoding="utf-8")
+                make_repository(root, ["tracked.txt"], relation=relation)
+                result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(root),
+                        "merge-base",
+                        "--is-ancestor",
+                        "refs/heads/vector-base",
+                        "HEAD",
+                    ],
+                    check=False,
+                )
+                self.assertEqual(result.returncode, expected)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_run_production_gates.py
+++ b/scripts/tests/test_run_production_gates.py
@@ -1,0 +1,47 @@
+"""CLI contracts for scripts/run-production-gates.sh."""
+
+from __future__ import annotations
+
+import subprocess
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "run-production-gates.sh"
+
+
+class ProductionGateCliTests(unittest.TestCase):
+    def _fixture(self, documented: bool) -> Path:
+        root = Path(tempfile.mkdtemp(prefix="production-gates-test-"))
+        self.addCleanup(shutil.rmtree, root, True)
+        source = root / "crates" / "velesdb-server" / "src"
+        source.mkdir(parents=True)
+        (source / "routes.rs").write_text(
+            '.route("/query/explain", get(explain))\n.route("/aggregate", post(aggregate))\n',
+            encoding="utf-8",
+        )
+        readme = "`/query/explain`\n"
+        if documented:
+            readme += "`/aggregate`\n"
+        (root / "README.md").write_text(readme, encoding="utf-8")
+        return root
+
+    def _run(self, root: Path, guard: str = "doc-contract") -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(SCRIPT), "--root", str(root), "--guard", guard],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_selected_member_refuses_and_accepts(self) -> None:
+        self.assertEqual(self._run(self._fixture(False)).returncode, 1)
+        self.assertEqual(self._run(self._fixture(True)).returncode, 0)
+
+    def test_unknown_selector_is_a_usage_error(self) -> None:
+        self.assertEqual(self._run(self._fixture(True), "unknown").returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1715

## Summary

- extend the refusal-vector harness with tracked-repository overlays, exact mutations, per-state argv, executable tool doubles, and real git topology
- extract PR governance, Linux/Windows N-API, and wasm-bindgen workflow gates into executable CLI guards
- add `--root` and member selection to the production meta-runner while preserving its default five-gate path
- replace every current `refusal_untested` entry with a subprocess-level refusal and accepted control

## Validation

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t . -v` — 458 passed, 9 skipped
- `python3 -m unittest scripts.tests.test_guard_refusal_vectors -v` — 8 passed
- `bash scripts/run-production-gates.sh` — all 5 gates passed (planner 2, crash recovery 15, WAL recovery 38)
- all six `velesdb-memory` features compile in isolation with `RUSTFLAGS=-D warnings`
- `cargo check -p velesdb-core -p velesdb-wasm --target wasm32-unknown-unknown --no-default-features` with `RUSTFLAGS=-D warnings`
- `cargo fmt --all -- --check`, YAML/JSON/Python/shell syntax, and diff checks

The local sandbox forbids Unix-domain socket creation and lacks the GTK `pkg-config` packages installed by CI; the affected platform-only checks remain covered by the required CI matrix.