### PR TITLE
refactor(core): bound Collection::assemble with focused builders

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -6,7 +6,6 @@ use crate::collection::graph::property_index::{
 use crate::collection::graph::{ConcurrentEdgeStore, LabelIndex, PropertyIndex, RangeIndex};
 use crate::collection::types::{Collection, CollectionConfig};
 use crate::error::Result;
-use crate::guardrails::GuardRails;
 use crate::index::sparse::SparseInvertedIndex;
 use crate::index::{Bm25Index, HnswIndex};
 use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage};
@@ -70,7 +69,8 @@ impl Collection {
     /// Assembles a `Collection` from pre-built components and default caches.
     ///
     /// This is the single point of truth for the `Self { .. }` struct literal,
-    /// eliminating duplication across the five public constructors.
+    /// eliminating duplication across the five public constructors. Focused
+    /// builders keep this orchestration within the function-size budget.
     pub(super) fn assemble(parts: CollectionParts) -> Self {
         #[cfg(feature = "persistence")]
         let deferred_indexer = Self::build_deferred_indexer(&parts.config);
@@ -78,34 +78,20 @@ impl Collection {
         let async_index_builder = Self::build_async_index_builder(&parts.config);
 
         Self {
-            storage: crate::collection::types::StorageState {
-                path: parts.path,
-                config: Arc::new(RwLock::new(parts.config)),
-                vector_storage: parts.vector_storage,
-                payload_storage: parts.payload_storage,
-                index: parts.index,
-                text_index: parts.text_index,
-                sq8_cache: Arc::new(RwLock::new(HashMap::new())),
-                binary_cache: Arc::new(RwLock::new(HashMap::new())),
-                pq_cache: Arc::new(RwLock::new(HashMap::new())),
-                pq_quantizer: Arc::new(RwLock::new(None)),
-                pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
-                payload_mirror: Arc::new(
-                    crate::collection::payload_mirror::PayloadMirror::default(),
-                ),
-            },
-            graph: Arc::new(crate::collection::types::GraphStore {
-                property_index: Arc::new(RwLock::new(parts.property_index)),
-                label_index: Arc::new(RwLock::new(parts.label_index)),
-                range_index: Arc::new(RwLock::new(parts.range_index)),
-                graph_range_indexes: Arc::new(RwLock::new(HashMap::new())),
-                edge_range_indexes: Arc::new(RwLock::new(HashMap::new())),
-                composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
-                query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
-                index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
-                edge_store: Arc::new(parts.edge_store),
-                edge_wal_lock: Arc::new(Mutex::new(())),
-            }),
+            storage: Self::build_storage_state(
+                parts.path,
+                parts.config,
+                parts.vector_storage,
+                parts.payload_storage,
+                parts.index,
+                parts.text_index,
+            ),
+            graph: Self::build_graph_store(
+                parts.property_index,
+                parts.label_index,
+                parts.range_index,
+                parts.edge_store,
+            ),
             query: crate::collection::types::QueryState {
                 sparse_indexes: Arc::new(RwLock::new(parts.sparse_indexes)),
                 secondary_indexes: Arc::new(RwLock::new(HashMap::new())),
@@ -132,13 +118,56 @@ impl Collection {
                 async_index_builder,
                 auto_reindex: Arc::new(RwLock::new(None)),
             },
-            runtime: crate::collection::types::RuntimeGuards {
-                guard_rails: Arc::new(GuardRails::default()),
-                runtime_limits: Arc::new(RwLock::new(
-                    crate::collection::types::RuntimeLimits::default(),
-                )),
-            },
+            runtime: crate::collection::types::RuntimeGuards::default(),
         }
+    }
+
+    /// Builds the storage/cache half of a `Collection` from its persisted
+    /// components; caches always start empty.
+    fn build_storage_state(
+        path: PathBuf,
+        config: CollectionConfig,
+        vector_storage: Arc<RwLock<MmapStorage>>,
+        payload_storage: Arc<RwLock<LogPayloadStorage>>,
+        index: Arc<HnswIndex>,
+        text_index: Arc<Bm25Index>,
+    ) -> crate::collection::types::StorageState {
+        crate::collection::types::StorageState {
+            path,
+            config: Arc::new(RwLock::new(config)),
+            vector_storage,
+            payload_storage,
+            index,
+            text_index,
+            sq8_cache: Arc::new(RwLock::new(HashMap::new())),
+            binary_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_cache: Arc::new(RwLock::new(HashMap::new())),
+            pq_quantizer: Arc::new(RwLock::new(None)),
+            pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),
+            payload_mirror: Arc::new(crate::collection::payload_mirror::PayloadMirror::default()),
+        }
+    }
+
+    /// Builds the graph half of a `Collection` from its persisted indexes;
+    /// derived/query-tracking indexes always start empty.
+    fn build_graph_store(
+        property_index: PropertyIndex,
+        label_index: LabelIndex,
+        range_index: RangeIndex,
+        edge_store: ConcurrentEdgeStore,
+    ) -> Arc<crate::collection::types::GraphStore> {
+        Arc::new(crate::collection::types::GraphStore {
+            property_index: Arc::new(RwLock::new(property_index)),
+            label_index: Arc::new(RwLock::new(label_index)),
+            range_index: Arc::new(RwLock::new(range_index)),
+            graph_range_indexes: Arc::new(RwLock::new(HashMap::new())),
+            edge_range_indexes: Arc::new(RwLock::new(HashMap::new())),
+            composite_index_manager: Arc::new(RwLock::new(CompositeIndexManager::new())),
+            query_pattern_tracker: Arc::new(RwLock::new(QueryPatternTracker::new())),
+            index_advisor: Arc::new(RwLock::new(IndexAdvisor::new())),
+            edge_store: Arc::new(edge_store),
+            edge_wal_lock: Arc::new(Mutex::new(())),
+        })
     }
 
     /// Builds the optional `DeferredIndexer` from config.

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -523,7 +523,7 @@ pub(crate) struct StreamingState {
 /// planner, caches, stats) — state the engine builds and consults itself to
 /// decide *how* to execute. Limits change via configuration; engine state
 /// changes via execution.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) struct RuntimeGuards {
     /// Guard-rails for query execution (EPIC-048).
     pub(crate) guard_rails: Arc<GuardRails>,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

`Collection::assemble` was 67 NLOC, above the 50-NLOC function budget. This PR applies the smallest behavior-preserving split:

- extracts the two largest coherent constructors: `build_storage_state` and `build_graph_store`;
- derives the natural `Default` implementation for `RuntimeGuards`;
- keeps query, generation, and streaming construction inline to avoid single-use abstractions that do not help the hard limit.

`assemble` is now 48 NLOC with cyclomatic complexity 1. Both extracted builders also have complexity 1 (23 and 19 NLOC). No decision branch was added, and construction values, order, visibility, and public API are unchanged.

The final patch is +29 net lines, reduced from the original six-helper proposal (+72 net lines).

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## Validation

- [x] `cargo fmt --all`
- [x] Pedantic `velesdb-core` clippy with `persistence,gpu,update-check`
- [x] Undocumented-unsafe-blocks clippy gate
- [x] Targeted collection tests: 242 passed, 2 ignored, 0 failed
- [x] Workspace pre-commit suite: `velesdb-core` 5367 passed, 16 ignored, 0 failed; remaining workspace libraries passed
- [x] `cargo check --no-default-features`
- [x] Production unwrap/expect guard: 0
- [x] TODO governance: 0
- [x] Unsafe audit on changed files: 0
- [x] Attribution guard: 0
- [x] Rust duplication: 1.64%
- [x] Changed-file limits: `lifecycle.rs` 463 code NLOC; `types.rs` 328 code NLOC
- [x] Function limits: no NLOC or complexity threshold finding

## Risk assessment

This refactor does not touch search, persistence behavior, `Drop`, unsafe code, SIMD dispatch, public APIs, or construction order. It only moves two existing struct literals into private focused builders and uses the existing zero-value defaults for runtime guards.