### PR TITLE
fix(api): standardize result count on k

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -142,7 +142,7 @@ remember { "fact": "we chose parking_lot to avoid lock poisoning",
            "metadata": { "project": "checkout" } }
 → { "id": 9876543210, "id_str": "9876543210" }
 
-recall { "query": "locking strategy", "limit": 5 }
+recall { "query": "locking strategy", "k": 5 }
 → { "memories": [ { "id": 9876543210, "id_str": "9876543210",
                     "score": 0.59,
                     "content": "we chose parking_lot to avoid lock poisoning",

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -65,8 +65,14 @@ pub(super) struct RememberResult {
 pub(super) struct RecallParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
-    /// Maximum number of memories to return (default 10).
-    #[serde(default, deserialize_with = "super::wire::lenient")]
+    /// Maximum number of memories to return (default 10). `k` is canonical;
+    /// the deprecated `limit` spelling remains a wire alias for one version.
+    #[serde(
+        default,
+        rename = "k",
+        alias = "limit",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
@@ -136,8 +142,14 @@ impl RecallResult {
 pub(super) struct RecallWhereParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
-    /// Maximum number of memories to return (default 10).
-    #[serde(default, deserialize_with = "super::wire::lenient")]
+    /// Maximum number of memories to return (default 10). `k` is canonical;
+    /// the deprecated `limit` spelling remains a wire alias for one version.
+    #[serde(
+        default,
+        rename = "k",
+        alias = "limit",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub(super) limit: Option<usize>,
     /// Structured `ColumnStore` predicates (ranges/comparisons) combined with AND,
     /// e.g. a date window `[{"field":"ts","op":"ge","value":20230101},
@@ -157,10 +169,16 @@ pub(super) struct RecallWhereParams {
 pub(super) struct RecallFusedParams {
     /// Natural-language query to match semantically.
     pub(super) query: String,
-    /// Maximum number of memories to return (default 10). Multi-hop reasoning
-    /// benefits from a larger budget (~32-64); simple and temporal recall
-    /// saturate early, where a larger budget only adds tokens.
-    #[serde(default, deserialize_with = "super::wire::lenient")]
+    /// Maximum number of memories to return (default 10). `k` is canonical;
+    /// the deprecated `limit` spelling remains a wire alias for one version.
+    /// Multi-hop reasoning benefits from a larger budget (~32-64); simple and
+    /// temporal recall saturate early, where a larger budget only adds tokens.
+    #[serde(
+        default,
+        rename = "k",
+        alias = "limit",
+        deserialize_with = "super::wire::lenient"
+    )]
     pub(super) limit: Option<usize>,
     /// Optional exact-match metadata filter (e.g.
     /// `{"project": "veles", "status": "resolved"}`).
@@ -176,11 +194,11 @@ pub(super) struct RecallFusedParams {
     #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) graph_boost: Option<f64>,
     /// Depth of the oversampled vector candidate pool fusion re-ranks before
-    /// the `limit` cutoff (default: `limit` scaled up, floored at 64). That
+    /// the `k` cutoff (default: `k` scaled up, floored at 64). That
     /// default is already deep enough for a graph-reached fact to surface;
     /// widen it to give a reranker more to work with, narrow it to confine
     /// fusion to the strongest vector hits. Capped at 1000, the same ceiling
-    /// `limit` carries — NOT the one `hops` carries, which is 10.
+    /// `k` carries — NOT the one `hops` carries, which is 10.
     #[serde(default, deserialize_with = "super::wire::lenient")]
     pub(super) pool: Option<usize>,
     /// Name of the metadata field holding each fact's date as a `YYYYMMDD`

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1477,7 +1477,7 @@ fn test_remember_extracted_description_names_every_published_output_field() {
 /// degrade a parameter whose advertised schema carries no DIRECT `type`
 /// keyword — `anyOf`-wrapped optionals and `$ref`-only structs both come out
 /// untyped on the client side, and the harness then serializes the argument
-/// as a JSON-encoded STRING (`limit: "6"`, `filter: "{\"project\":...}"`),
+/// as a JSON-encoded STRING (`k: "6"`, `filter: "{\"project\":...}"`),
 /// which the server rejects. Same wire-contract class as issue #1468
 /// (u64 ids vs float-lossy clients): the schema must be harness-proof, not
 /// merely spec-correct.
@@ -1502,6 +1502,31 @@ fn test_recall_fused_input_schema_types_every_parameter_directly() {
     }
 }
 
+#[test]
+fn recall_family_advertises_k_as_the_canonical_count_parameter() {
+    let tools = [
+        McpServer::recall_tool_attr(),
+        McpServer::recall_where_tool_attr(),
+        McpServer::recall_fused_tool_attr(),
+    ];
+    for tool in tools {
+        let schema = serde_json::to_value(&tool.input_schema).expect("schema serializes");
+        let properties = schema["properties"]
+            .as_object()
+            .expect("recall input schema must have properties");
+        assert!(
+            properties.contains_key("k"),
+            "{} must advertise `k`",
+            tool.name
+        );
+        assert!(
+            !properties.contains_key("limit"),
+            "{} must keep `limit` as a wire alias, not the canonical schema field",
+            tool.name
+        );
+    }
+}
+
 /// Server-side tolerance half of the harness-proof contract: a client that
 /// DID stringify a scalar or object argument (today's Claude Code harness
 /// does exactly that for schema-degraded parameters) must still be served.
@@ -1510,7 +1535,7 @@ fn test_recall_fused_input_schema_types_every_parameter_directly() {
 fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
     let params: RecallFusedParams = serde_json::from_value(serde_json::json!({
         "query": "q",
-        "limit": "6",
+        "k": "6",
         "hops": "2",
         "graph_boost": "0.15",
         "pool": "128",
@@ -1526,6 +1551,49 @@ fn test_recall_fused_params_accept_stringified_scalars_and_objects() {
         filter.get("project").and_then(|v| v.as_str()),
         Some("velesdb")
     );
+}
+
+#[test]
+fn recall_fused_accepts_k_and_the_deprecated_limit_alias() {
+    for (input, value) in [
+        (serde_json::json!({"query": "q", "k": 7}), 7),
+        (serde_json::json!({"query": "q", "limit": 8}), 8),
+    ] {
+        let params: RecallFusedParams = serde_json::from_value(input)
+            .expect("canonical and deprecated spellings must deserialize");
+        assert_eq!(params.limit, Some(value));
+    }
+}
+
+#[test]
+fn recall_and_recall_where_accept_the_deprecated_limit_alias() {
+    let recall: RecallParams = serde_json::from_value(serde_json::json!({
+        "query": "q",
+        "limit": 7
+    }))
+    .expect("recall must accept deprecated `limit`");
+    assert_eq!(recall.limit, Some(7));
+
+    let recall_where: RecallWhereParams = serde_json::from_value(serde_json::json!({
+        "query": "q",
+        "limit": 8,
+        "filters": []
+    }))
+    .expect("recall_where must accept deprecated `limit`");
+    assert_eq!(recall_where.limit, Some(8));
+}
+
+#[test]
+fn recall_fused_rejects_k_and_limit_together() {
+    let result = serde_json::from_value::<RecallFusedParams>(serde_json::json!({
+        "query": "q",
+        "k": 7,
+        "limit": 8
+    }));
+    let Err(error) = result else {
+        panic!("two spellings for one parameter must be ambiguous");
+    };
+    assert!(error.to_string().contains("duplicate field"), "{error}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/velesdb-memory/tests/binding_parity_bdd.rs
+++ b/crates/velesdb-memory/tests/binding_parity_bdd.rs
@@ -1146,6 +1146,68 @@ fn output_root_fields(tool: &rmcp::model::Tool) -> BTreeSet<String> {
         .unwrap_or_default()
 }
 
+/// Root input property names from the live MCP schema.
+fn input_root_fields(tool: &rmcp::model::Tool) -> BTreeSet<String> {
+    tool.input_schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .map(|props| props.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// The parameter list of `method`'s Rust declaration inside its source region.
+fn input_window(region: &str, method: &str) -> String {
+    let Some(header) = region
+        .lines()
+        .position(|line| method_name(line.trim()).as_deref() == Some(method))
+    else {
+        return String::new();
+    };
+    let declaration = region.lines().skip(header).collect::<Vec<_>>().join("\n");
+    let Some(open) = declaration.find('(') else {
+        return String::new();
+    };
+    let Some(close) = matching_paren(&declaration[open..]).map(|offset| open + offset) else {
+        return String::new();
+    };
+    declaration[open + 1..close].to_owned()
+}
+
+#[tokio::test]
+async fn recall_count_input_is_k_on_the_server_and_every_binding() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let recall_tools = ["recall", "recall_where", "recall_fused"];
+    let mut gaps = Vec::new();
+    for name in recall_tools {
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name.as_ref() == name)
+            .unwrap_or_else(|| panic!("live server no longer advertises `{name}`"));
+        let fields = input_root_fields(tool);
+        if !fields.contains("k") || fields.contains("limit") {
+            gaps.push(format!(
+                "  {name} advertises {fields:?}, expected canonical `k`"
+            ));
+        }
+        for binding in BINDINGS {
+            let regions = method_regions(binding);
+            let params = regions
+                .get(name)
+                .map_or_else(String::new, |region| input_window(region, name));
+            if !names_identifier(&params, "k") {
+                gaps.push(format!("  {}.{name} does not accept `k`", binding.name));
+            }
+        }
+    }
+    assert!(
+        gaps.is_empty(),
+        "shared recall count input drifted across surfaces:\n{}",
+        gaps.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
 /// The server source files declaring the tools, scanned for the Rust type
 /// each tool's `output_schema` is derived from.
 const SERVER_TOOL_SOURCES: &[&str] = &[

--- a/crates/velesdb-memory/tests/mcp_recall_fused_pool_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_recall_fused_pool_bdd.rs
@@ -11,7 +11,7 @@
 //! So this suite asserts on the EFFECT, not on acceptance. `pool` is the
 //! depth of the vector candidate pool fusion re-ranks: at `1` only the top
 //! vector hit may enter, so a store holding several facts must come back
-//! with a single memory even though `limit` allows ten. A tool that merely
+//! with a single memory even though `k` allows ten. A tool that merely
 //! swallowed the argument returns all of them, and the assertion names the
 //! count.
 //!
@@ -30,7 +30,7 @@ use velesdb_memory::mcp::McpServer;
 use velesdb_memory::{DynEmbedder, HashEmbedder, MemoryService, DEFAULT_DIMENSION};
 
 /// Facts with no `relate` edge between them, so nothing is graph-reached and
-/// the returned count is exactly the vector pool's depth capped by `limit` —
+/// the returned count is exactly the vector pool's depth capped by `k` —
 /// the property under test, with no fusion promotion blurring it.
 const FACTS: [&str; 6] = [
     "we chose parking_lot to avoid lock poisoning",
@@ -145,7 +145,7 @@ async fn a_narrowed_pool_admits_fewer_candidates_than_the_default() {
     assert_eq!(
         default_depth,
         FACTS.len(),
-        "with the proven default pool, `limit: 10` returns every stored fact"
+        "with the proven default pool, `k: 10` returns every stored fact"
     );
 
     let narrowed = fused_count(

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -1023,7 +1023,7 @@ async fn every_scalar_input_slot_accepts_the_form_it_announces() {
 ///
 /// The complement below cannot simply be "a slot announced `integer` refuses
 /// a string": measured on 2026-07-29, ten integer slots accept `"6"` —
-/// `recall.limit`, `why.max_hops`, `compile_transcript.token_budget`… — and
+/// `recall.k`, `why.max_hops`, `compile_transcript.token_budget`… — and
 /// that is not drift. It is `mcp::wire::lenient`, a deliberate, documented
 /// server-side fallback for the harness that stringifies an argument BECAUSE
 /// its view of the schema degraded. Removing it would break exactly the

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -79,7 +79,7 @@ docs.upsert([
     {"id": 3, "vector": [0.6, 0.0, 0.8, 0.0], "payload": {"title": "AI-generated jazz"}},
 ])
 
-results = docs.search_request(velesdb.SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], top_k=2))
+results = docs.search_request(velesdb.SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], k=2))
 for r in results:
     print(f"score={r['score']:.3f}  {r['payload']['title']}")
 ```

--- a/crates/velesdb-python/python/velesdb/__init__.pyi
+++ b/crates/velesdb-python/python/velesdb/__init__.pyi
@@ -170,18 +170,19 @@ class SearchOptions:
 
         opts = SearchOptions(
             vector=my_embedding,
-            top_k=20,
+            k=20,
             filter={"condition": {"type": "eq", "field": "lang", "value": "en"}},
         )
 
     Fluent builder style (each ``with_*`` method returns ``self``)::
 
-        opts = SearchOptions().with_vector(my_embedding).with_top_k(20)
+        opts = SearchOptions().with_vector(my_embedding).with_k(20)
 
     Attributes:
         vector: Dense query vector (list or numpy array).
         sparse_vector: Sparse query as dict[int, float] or scipy sparse.
-        top_k: Max results to return (default: 10).
+        k: Max results to return (default: 10).
+        top_k: Deprecated alias for ``k``.
         filter: Metadata pre-filter dict. Shape: ``{"condition": <cond>}`` where
             ``<cond>`` is ``{"type": <op>, "field": ..., ...}``. Operators:
             ``eq``/``neq``/``gt``/``gte``/``lt``/``lte`` (``field``+``value``),
@@ -200,12 +201,13 @@ class SearchOptions:
 
     Example:
         >>> cond = {"type": "eq", "field": "lang", "value": "en"}
-        >>> opts = SearchOptions(vector=my_embedding, top_k=20, filter={"condition": cond})
+        >>> opts = SearchOptions(vector=my_embedding, k=20, filter={"condition": cond})
         >>> results = collection.search_request(opts)
     """
 
     vector: Optional[Union[List[float], "np.ndarray"]]
     sparse_vector: Optional[Dict[int, float]]
+    k: int
     top_k: int
     filter: Optional[Dict[str, Any]]
     sparse_index_name: Optional[str]
@@ -219,7 +221,8 @@ class SearchOptions:
         vector: Optional[Union[List[float], "np.ndarray"]] = None,
         *,
         sparse_vector: Optional[Dict[int, float]] = None,
-        top_k: int = 10,
+        k: Optional[int] = None,
+        top_k: Optional[int] = None,
         filter: Optional[Dict[str, Any]] = None,
         sparse_index_name: Optional[str] = None,
         include_vectors: bool = False,
@@ -233,6 +236,7 @@ class SearchOptions:
     def with_sparse_vector(
         self, sparse_vector: Optional[Dict[int, float]]
     ) -> "SearchOptions": ...
+    def with_k(self, k: int) -> "SearchOptions": ...
     def with_top_k(self, top_k: int) -> "SearchOptions": ...
     def with_filter(self, filter: Optional[Dict[str, Any]]) -> "SearchOptions": ...
     def with_sparse_index_name(self, name: Optional[str]) -> "SearchOptions": ...
@@ -509,7 +513,7 @@ class Collection:
             List of dicts with ``id``, ``score``, and ``payload`` keys.
 
         Example:
-            >>> opts = SearchOptions(vector=my_embedding, top_k=20)
+            >>> opts = SearchOptions(vector=my_embedding, k=20)
             >>> results = collection.search_request(opts)
         """
         ...

--- a/crates/velesdb-python/src/collection/search.rs
+++ b/crates/velesdb-python/src/collection/search.rs
@@ -80,17 +80,17 @@ impl Collection {
             2,
         )?;
 
-        let opts = SearchOptions::new(
+        let opts = SearchOptions {
             vector,
             sparse_vector,
-            top_k,
+            k: top_k,
             filter,
             sparse_index_name,
             include_vectors,
-            None,
+            fusion: None,
             principal,
             tenant,
-        );
+        };
         self.search_request(py, &opts)
     }
 
@@ -108,7 +108,7 @@ impl Collection {
     ///     List of dicts with ``id``, ``score``, and ``payload`` keys.
     ///
     /// Example:
-    ///     >>> opts = SearchOptions(vector=my_emb, top_k=20, filter={"lang": "en"})
+    ///     >>> opts = SearchOptions(vector=my_emb, k=20, filter={"lang": "en"})
     ///     >>> results = collection.search_request(opts)
     #[pyo3(signature = (opts))]
     fn search_request(&self, py: Python<'_>, opts: &SearchOptions) -> PyResult<Vec<Py<PyAny>>> {
@@ -125,7 +125,7 @@ impl Collection {
             .transpose()?;
         let filter_obj = parse_optional_filter(py, opts.filter.as_ref().map(|f| f.clone_ref(py)))?;
 
-        let top_k = opts.top_k;
+        let top_k = opts.k;
         let sparse_index_name = opts.sparse_index_name.clone();
         let include_vectors = opts.include_vectors;
         let fusion = opts.fusion.as_ref().map(FusionStrategy::inner);

--- a/crates/velesdb-python/src/collection/search_options.rs
+++ b/crates/velesdb-python/src/collection/search_options.rs
@@ -13,20 +13,21 @@
 //!
 //!   Keyword-constructor style:
 //!   ```python
-//!   opts = SearchOptions(vector=embedding, top_k=10, filter={"k": "v"})
+//!   opts = SearchOptions(vector=embedding, k=10, filter={"k": "v"})
 //!   results = collection.search_request(opts)
 //!   ```
 //!
 //!   Fluent builder style (chains return the same object):
 //!   ```python
 //!   results = collection.search_request(
-//!       SearchOptions().with_vector(embedding).with_top_k(10)
+//!       SearchOptions().with_vector(embedding).with_k(10)
 //!   )
 //!   ```
 //!
 //! v2.0 (breaking): `search()` kwargs path removed, `search_request()` is the
 //! single canonical entry point.
 
+use pyo3::exceptions::{PyDeprecationWarning, PyTypeError};
 use pyo3::prelude::*;
 
 use crate::FusionStrategy;
@@ -41,7 +42,7 @@ use crate::FusionStrategy;
 ///     >>> from velesdb import SearchOptions
 ///     >>> opts = SearchOptions(
 ///     ...     vector=my_embedding,
-///     ...     top_k=20,
+///     ...     k=20,
 ///     ...     filter={"category": "news"},
 ///     ... )
 ///     >>> results = collection.search_request(opts)
@@ -57,7 +58,7 @@ pub struct SearchOptions {
     pub sparse_vector: Option<Py<PyAny>>,
     /// Number of results to return (default: 10).
     #[pyo3(get, set)]
-    pub top_k: usize,
+    pub k: usize,
     /// Optional metadata filter dict.
     #[pyo3(get, set)]
     pub filter: Option<Py<PyAny>>,
@@ -99,7 +100,8 @@ impl SearchOptions {
     /// Args:
     ///     vector: Dense query vector.
     ///     sparse_vector: Sparse query (dict[int, float] or scipy sparse).
-    ///     top_k: Max results to return (default: 10).
+    ///     k: Max results to return (default: 10).
+    ///     top_k: Deprecated alias for ``k``.
     ///     filter: Metadata pre-filter dict.
     ///     sparse_index_name: Named sparse index to query.
     ///     include_vectors: Include raw vectors in results (default: False).
@@ -113,7 +115,8 @@ impl SearchOptions {
         vector = None,
         *,
         sparse_vector = None,
-        top_k = 10,
+        k = None,
+        top_k = None,
         filter = None,
         sparse_index_name = None,
         include_vectors = false,
@@ -122,33 +125,35 @@ impl SearchOptions {
         tenant = None,
     ))]
     pub fn new(
+        py: Python<'_>,
         vector: Option<Py<PyAny>>,
         sparse_vector: Option<Py<PyAny>>,
-        top_k: usize,
+        k: Option<usize>,
+        top_k: Option<usize>,
         filter: Option<Py<PyAny>>,
         sparse_index_name: Option<String>,
         include_vectors: bool,
         fusion: Option<FusionStrategy>,
         principal: Option<String>,
         tenant: Option<String>,
-    ) -> Self {
-        Self {
+    ) -> PyResult<Self> {
+        resolve_k(py, k, top_k).map(|k| Self {
             vector,
             sparse_vector,
-            top_k,
+            k,
             filter,
             sparse_index_name,
             include_vectors,
             fusion,
             principal,
             tenant,
-        }
+        })
     }
 
     fn __repr__(&self) -> String {
         format!(
-            "SearchOptions(top_k={}, include_vectors={}, sparse_index_name={:?})",
-            self.top_k, self.include_vectors, self.sparse_index_name,
+            "SearchOptions(k={}, include_vectors={}, sparse_index_name={:?})",
+            self.k, self.include_vectors, self.sparse_index_name,
         )
     }
 }
@@ -157,7 +162,7 @@ impl SearchOptions {
 /// Python object so calls can be chained:
 ///
 /// ```python
-/// opts = SearchOptions().with_vector(emb).with_top_k(20).with_filter({"lang": "en"})
+/// opts = SearchOptions().with_vector(emb).with_k(20).with_filter({"lang": "en"})
 /// ```
 ///
 /// The `Py<Self>` receiver pattern is the idiomatic PyO3 way to implement
@@ -182,9 +187,31 @@ impl SearchOptions {
     }
 
     /// Sets the number of results to return and returns `self`.
-    pub fn with_top_k(slf: Py<Self>, py: Python<'_>, top_k: usize) -> Py<Self> {
-        slf.bind(py).borrow_mut().top_k = top_k;
+    pub fn with_k(slf: Py<Self>, py: Python<'_>, k: usize) -> Py<Self> {
+        slf.bind(py).borrow_mut().k = k;
         slf
+    }
+
+    /// Deprecated alias for :py:meth:`with_k`.
+    pub fn with_top_k(slf: Py<Self>, py: Python<'_>, top_k: usize) -> PyResult<Py<Self>> {
+        warn_top_k(py)?;
+        slf.bind(py).borrow_mut().k = top_k;
+        Ok(slf)
+    }
+
+    /// Deprecated alias for the canonical ``k`` attribute.
+    #[getter(top_k)]
+    fn top_k(&self, py: Python<'_>) -> PyResult<usize> {
+        warn_top_k(py)?;
+        Ok(self.k)
+    }
+
+    /// Deprecated alias for the canonical ``k`` attribute.
+    #[setter(top_k)]
+    fn set_top_k(&mut self, py: Python<'_>, top_k: usize) -> PyResult<()> {
+        warn_top_k(py)?;
+        self.k = top_k;
+        Ok(())
     }
 
     /// Sets the metadata filter and returns `self`.
@@ -224,4 +251,27 @@ impl SearchOptions {
         slf.bind(py).borrow_mut().tenant = tenant;
         slf
     }
+}
+
+fn resolve_k(py: Python<'_>, k: Option<usize>, top_k: Option<usize>) -> PyResult<usize> {
+    match (k, top_k) {
+        (Some(_), Some(_)) => Err(PyTypeError::new_err(
+            "pass `k` or deprecated `top_k`, not both",
+        )),
+        (Some(value), None) => Ok(value),
+        (None, Some(value)) => {
+            warn_top_k(py)?;
+            Ok(value)
+        }
+        (None, None) => Ok(10),
+    }
+}
+
+fn warn_top_k(py: Python<'_>) -> PyResult<()> {
+    PyErr::warn(
+        py,
+        &py.get_type::<PyDeprecationWarning>(),
+        c"`top_k` is deprecated; use `k` instead. It will be removed after one compatibility version.",
+        2,
+    )
 }

--- a/crates/velesdb-python/src/lib.rs
+++ b/crates/velesdb-python/src/lib.rs
@@ -23,7 +23,7 @@
 //! ])
 //!
 //! # Search (canonical API; collection.search(...) is deprecated since v1.15)
-//! results = collection.search_request(SearchOptions(vector=[0.1, 0.2, ...], top_k=10))
+//! results = collection.search_request(SearchOptions(vector=[0.1, 0.2, ...], k=10))
 //! ```
 
 mod agent;
@@ -80,7 +80,7 @@ pub struct SearchResult {
 ///     >>> db = velesdb.Database("./my_data")
 ///     >>> collection = db.create_collection("docs", dimension=768)
 ///     >>> collection.upsert([{"id": 1, "vector": [...], "payload": {"title": "Doc"}}])
-///     >>> results = collection.search_request(SearchOptions(vector=[...], top_k=10))
+///     >>> results = collection.search_request(SearchOptions(vector=[...], k=10))
 #[pymodule]
 fn velesdb(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Database>()?;

--- a/crates/velesdb-python/tests/test_search_gate.py
+++ b/crates/velesdb-python/tests/test_search_gate.py
@@ -134,7 +134,7 @@ def test_search_request_deny_fails_closed():
     with _Db(observer=_deny_reads) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+            collection.search_request(SearchOptions(vector=QUERY, k=2))
 
 
 def test_text_search_deny_fails_closed():
@@ -176,7 +176,7 @@ def test_policy_exception_fails_open_by_default():
     """A raising policy must NOT break the read in the default (fail-open) mode."""
     with _Db(observer=_raise_on_read) as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=2))
         assert _ids(results) == {1, 2}
 
 
@@ -185,14 +185,14 @@ def test_policy_exception_fails_closed_under_strict():
     with _Db(observer=_raise_on_read, observer_strict=True) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+            collection.search_request(SearchOptions(vector=QUERY, k=2))
 
 
 def test_bad_return_type_fails_open_by_default():
     """An uninterpretable return value is treated as allow by default."""
     with _Db(observer=_return_bad_type) as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=2))
         assert _ids(results) == {1, 2}
 
 
@@ -201,14 +201,14 @@ def test_bad_return_type_fails_closed_under_strict():
     with _Db(observer=_return_bad_type, observer_strict=True) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+            collection.search_request(SearchOptions(vector=QUERY, k=2))
 
 
 def test_explicit_allow_unaffected_by_strict():
     """None/allow from the policy still allows even under strict mode."""
     with _Db(observer=_scope_to_acme, observer_strict=True) as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=10))
         # Scope still narrows to tenant 'acme' (id 1), proving strict didn't
         # turn an explicit allow-with-scope into a denial.
         assert _ids(results) == {1}
@@ -223,13 +223,13 @@ def test_search_scope_narrows_results():
     # Ungated: both points are returned.
     with _Db() as db:
         collection = _seed(db)
-        ungated = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        ungated = collection.search_request(SearchOptions(vector=QUERY, k=10))
     assert _ids(ungated) == {1, 2}
 
     # Scoped to tenant == 'acme': only point 1 survives.
     with _Db(observer=_scope_to_acme) as db:
         collection = _seed(db)
-        scoped = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        scoped = collection.search_request(SearchOptions(vector=QUERY, k=10))
     assert _ids(scoped) == {1}
 
 
@@ -285,7 +285,7 @@ def test_malformed_scope_filter_denies():
     with _Db(observer=bad_scope) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+            collection.search_request(SearchOptions(vector=QUERY, k=10))
 
 
 # ---------------------------------------------------------------------------
@@ -306,7 +306,7 @@ def test_empty_scope_dict_denies():
     with _Db(observer=empty_scope) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+            collection.search_request(SearchOptions(vector=QUERY, k=10))
 
 
 def test_tenant_only_scope_dict_denies():
@@ -320,7 +320,7 @@ def test_tenant_only_scope_dict_denies():
     with _Db(observer=tenant_only) as db:
         collection = _seed(db)
         with pytest.raises(Exception):
-            collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+            collection.search_request(SearchOptions(vector=QUERY, k=10))
 
 
 def test_tenant_plus_filter_scope_narrows():
@@ -333,7 +333,7 @@ def test_tenant_plus_filter_scope_narrows():
 
     with _Db(observer=scoped) as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=10))
     assert _ids(results) == {1}
 
 
@@ -348,7 +348,7 @@ def test_sparse_search_deny_fails_closed():
         collection = _seed(db)
         with pytest.raises(Exception):
             collection.search_request(
-                SearchOptions(sparse_vector={0: 1.0}, top_k=2)
+                SearchOptions(sparse_vector={0: 1.0}, k=2)
             )
 
 
@@ -437,7 +437,7 @@ def test_graph_search_by_embedding_scope_narrows():
 def test_no_observer_returns_all_results():
     with _Db() as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=10))
     assert _ids(results) == {1, 2}
     # Nearest neighbour to QUERY is point 1 (exact match).
     assert results[0]["id"] == 1
@@ -457,7 +457,7 @@ def test_allow_observer_permits_read():
 
     with _Db(observer=notify_only) as db:
         collection = _seed(db)
-        results = collection.search_request(SearchOptions(vector=QUERY, top_k=10))
+        results = collection.search_request(SearchOptions(vector=QUERY, k=10))
     assert _ids(results) == {1, 2}
 
 
@@ -472,7 +472,7 @@ def test_query_request_fields_carry_search_operation():
 
     with _Db(observer=observe) as db:
         collection = _seed(db)
-        collection.search_request(SearchOptions(vector=QUERY, top_k=2))
+        collection.search_request(SearchOptions(vector=QUERY, k=2))
         collection.text_search("learning", top_k=2)
         collection.hybrid_search(QUERY, "learning", top_k=2)
 

--- a/crates/velesdb-python/tests/test_search_options.py
+++ b/crates/velesdb-python/tests/test_search_options.py
@@ -50,7 +50,7 @@ def collection(temp_db):
 
 def test_search_options_defaults():
     opts = SearchOptions()
-    assert opts.top_k == 10
+    assert opts.k == 10
     assert opts.vector is None
     assert opts.sparse_vector is None
     assert opts.filter is None
@@ -60,18 +60,40 @@ def test_search_options_defaults():
 
 def test_search_options_fields_set():
     vec = [0.1, 0.2, 0.3, 0.4]
-    opts = SearchOptions(vector=vec, top_k=5, include_vectors=True)
-    assert opts.top_k == 5
+    opts = SearchOptions(vector=vec, k=5, include_vectors=True)
+    assert opts.k == 5
     assert opts.include_vectors is True
     assert list(opts.vector) == vec
 
 
 def test_search_options_repr():
-    opts = SearchOptions(top_k=20, include_vectors=True, sparse_index_name="my_idx")
+    opts = SearchOptions(k=20, include_vectors=True, sparse_index_name="my_idx")
     r = repr(opts)
     assert "SearchOptions" in r
     assert "20" in r
     assert "my_idx" in r
+
+
+def test_search_options_top_k_alias_warns_and_sets_k():
+    with pytest.warns(DeprecationWarning, match="top_k.*deprecated.*k"):
+        opts = SearchOptions(top_k=7)
+
+    assert opts.k == 7
+
+    with pytest.warns(DeprecationWarning, match="top_k.*deprecated.*k"):
+        assert opts.top_k == 7
+    with pytest.warns(DeprecationWarning, match="top_k.*deprecated.*k"):
+        opts.top_k = 8
+    assert opts.k == 8
+    with pytest.warns(DeprecationWarning, match="top_k.*deprecated.*k"):
+        returned = opts.with_top_k(9)
+    assert returned is opts
+    assert opts.k == 9
+
+
+def test_search_options_rejects_k_and_top_k_together():
+    with pytest.raises(TypeError, match="k.*top_k"):
+        SearchOptions(k=3, top_k=4)
 
 
 # ---------------------------------------------------------------------------
@@ -86,7 +108,7 @@ def test_search_request_matches_search(collection):
         warnings.simplefilter("ignore", DeprecationWarning)
         legacy = collection.search(vector=query, top_k=3)
 
-    opts = SearchOptions(vector=query, top_k=3)
+    opts = SearchOptions(vector=query, k=3)
     modern = collection.search_request(opts)
 
     assert len(legacy) == len(modern)
@@ -99,7 +121,7 @@ def test_search_request_with_filter(collection):
     query = [0.5, 0.5, 0.5, 0.1]
     opts = SearchOptions(
         vector=query,
-        top_k=5,
+        k=5,
         filter={"condition": {"type": "eq", "field": "idx", "value": 2}},
     )
     results = collection.search_request(opts)
@@ -108,11 +130,11 @@ def test_search_request_with_filter(collection):
         assert r["payload"]["idx"] == 2
 
 
-def test_search_request_top_k_respected(collection):
+def test_search_request_k_respected(collection):
     query = [0.5, 0.5, 0.5, 0.1]
-    opts = SearchOptions(vector=query, top_k=2)
+    opts = SearchOptions(vector=query, k=2)
     results = collection.search_request(opts)
-    assert len(results) == 2, f"top_k=2 over 5 points must return exactly 2 results, got {len(results)}"
+    assert len(results) == 2, f"k=2 over 5 points must return exactly 2 results, got {len(results)}"
 
 
 # ---------------------------------------------------------------------------

--- a/crates/velesdb-python/tests/test_streaming_ingest.py
+++ b/crates/velesdb-python/tests/test_streaming_ingest.py
@@ -52,7 +52,7 @@ def test_enable_streaming_then_stream_insert_lands_points(temp_db):
 
     # The drain task flushes asynchronously; wait until the points land.
     assert _wait_until(lambda: not collection.is_empty()), "streamed points never drained"
-    results = collection.search_request(SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], top_k=1))
+    results = collection.search_request(SearchOptions(vector=[1.0, 0.0, 0.0, 0.0], k=1))
     assert results[0]["id"] == 1
 
 

--- a/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
+++ b/crates/velesdb-python/tests/test_velesql_sdk_backlog.py
@@ -181,13 +181,13 @@ def test_hybrid_fusion_changes_ordering(temp_db_path):
 
     # All-dense RSF: dense-dominant node 1 ranks first.
     dense_opts = velesdb.SearchOptions(
-        vector=dense, sparse_vector=sparse, top_k=3
+        vector=dense, sparse_vector=sparse, k=3
     ).with_fusion(velesdb.FusionStrategy.relative_score(1.0, 0.0))
     dense_first = [r["id"] for r in collection.search_request(dense_opts)][0]
 
     # All-sparse RSF: sparse-dominant node 2 ranks first.
     sparse_opts = velesdb.SearchOptions(
-        vector=dense, sparse_vector=sparse, top_k=3
+        vector=dense, sparse_vector=sparse, k=3
     ).with_fusion(velesdb.FusionStrategy.relative_score(0.0, 1.0))
     sparse_first = [r["id"] for r in collection.search_request(sparse_opts)][0]
 
@@ -213,13 +213,13 @@ def test_hybrid_fusion_default_unchanged(temp_db_path):
     omitted = sorted(
         r["id"]
         for r in collection.search_request(
-            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, top_k=3)
+            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, k=3)
         )
     )
     explicit_none = sorted(
         r["id"]
         for r in collection.search_request(
-            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, top_k=3).with_fusion(None)
+            velesdb.SearchOptions(vector=dense, sparse_vector=sparse, k=3).with_fusion(None)
         )
     )
     # Same candidate set under the default fusion (RRF), regardless of tie order.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -72,7 +72,7 @@ coll.search(&query, 10)?;
 ```python
 # Before (legacy untyped collection)
 coll = db.get_collection("docs")
-results = coll.search_request(velesdb.SearchOptions(vector=query_vec, top_k=10))
+results = coll.search_request(velesdb.SearchOptions(vector=query_vec, k=10))
 
 # After (preferred for graph collections)
 graph = db.create_graph_collection("knowledge", dimension=768)
@@ -344,7 +344,7 @@ Yes. All methods that accept vectors (`search`, `upsert`, etc.) accept both Pyth
 import numpy as np
 
 vec = np.random.randn(384).astype(np.float32)
-results = coll.search_request(velesdb.SearchOptions(vector=vec, top_k=10))
+results = coll.search_request(velesdb.SearchOptions(vector=vec, k=10))
 ```
 
 ### Where are the Python examples?

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Each binding has its own reference guide; the
 
 | Binding | Reference |
 |---------|-----------|
+| Cross-surface | [API correspondence](./guides/API_CORRESPONDENCE.md) |
 | Rust (`velesdb-core`) | [Public API map](./guides/CORE_API_MAP.md) · [VelesQL](./guides/CORE_VELESQL_REFERENCE.md) |
 | Python | [API reference](./guides/PYTHON_API_REFERENCE.md) |
 | WASM (browser) | [JavaScript API](./guides/WASM_API.md) |

--- a/docs/guides/API_CORRESPONDENCE.md
+++ b/docs/guides/API_CORRESPONDENCE.md
@@ -1,0 +1,50 @@
+# API correspondence: Rust, Python, TypeScript, and MCP
+
+The same intent is exposed through different API shapes. This page maps the
+five common gestures without pretending that raw vector collections and agent
+memory are interchangeable.
+
+## Quick mapping
+
+| Gesture | Rust (`velesdb-core`) | Python | TypeScript SDK | MCP (`velesdb-memory`) |
+|---|---|---|---|---|
+| Open | `Database::open("./data")?` | `velesdb.Database("./data")` | `new VelesDB({ backend: "wasm" })`, then `await db.init()` | The daemon opens its configured memory store; tools do not open paths. |
+| Create | `db.create_collection("docs", 384, DistanceMetric::Cosine)?`, then `db.get_vector_collection("docs")` | `db.create_collection("docs", dimension=384)` | `await db.createCollection("docs", { dimension: 384, metric: "cosine" })` | No raw collection-creation tool; the memory store is managed by the daemon. |
+| Insert | `collection.upsert(points)?`, then `collection.flush()?` | `collection.upsert(points)` | `await db.upsert("docs", document)` | `remember({ fact, links, metadata })` stores an agent-memory fact, not a raw vector. |
+| Search | `collection.search(&query, k)?` | `collection.search_request(SearchOptions(vector=query, k=10))` | `await db.search("docs", query, { k: 10 })` | `recall({ query, k: 10 })` performs semantic memory recall, not collection search. |
+| Recall | `velesdb_memory::MemoryService::recall(query, k, filter)` | `MemoryService(...).recall(query, k=10)` | `memory.recall(query, 10)` | `recall({ query, k: 10 })` |
+
+`k` is the canonical result-count name for the modern search and recall
+surfaces. Python `SearchOptions.top_k` and the MCP recall-family `limit` field
+remain accepted as deprecated aliases for one compatibility version. The
+legacy Python `Collection.search(..., top_k=...)` method also remains available,
+but that whole method has been deprecated since v1.15; new code should use
+`search_request(SearchOptions(...))`.
+
+## Deliberate differences
+
+### Dimension inference
+
+Rust and TypeScript collection creation require a dimension. Python may omit
+it: `db.create_collection("docs", dimension=None)` returns a deferred collection
+and infers the dimension from the first `upsert()`. Supplying the dimension
+explicitly remains useful when an empty collection must reject incompatible
+vectors immediately.
+
+### Durability boundary
+
+Rust makes the routine durability barrier explicit: call `flush()` after
+`upsert()` at the commit point. Python `upsert()` flushes its batch, while
+`upsert_bulk()` performs one flush for the whole batch; `collection.flush()` is
+also available when an explicit boundary makes the application flow clearer.
+The TypeScript backend owns its persistence behavior: REST delegates durability
+to the server and WASM uses the browser backend. MCP `remember` persists through
+the memory service and does not expose a separate flush gesture.
+
+### Collection handles versus memory tools
+
+Rust and Python return collection handles; the TypeScript client keeps the
+collection name in each call. MCP intentionally exposes higher-level memory
+operations instead of raw collection lifecycle methods. Use the SDK surfaces
+for vector CRUD and the MCP surface for durable agent facts, relationships,
+feedback, and explainable recall.

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -124,7 +124,7 @@ collection.upsert([
 ])
 
 # Search
-results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, k=10))
 ```
 
 ---

--- a/docs/guides/PYTHON_API_REFERENCE.md
+++ b/docs/guides/PYTHON_API_REFERENCE.md
@@ -28,9 +28,10 @@ which your IDE reads directly (`py.typed` is included in the wheel).
 used throughout the VelesDB Python documentation. The older multi-keyword
 `collection.search(vector=..., top_k=..., filter=...)` still works but is
 **deprecated since v1.15** — it emits a `DeprecationWarning`.
-`SearchOptions` accepts `vector`, `sparse_vector`, `top_k`, `filter`,
+`SearchOptions` accepts canonical `k`, plus `vector`, `sparse_vector`, `filter`,
 `sparse_index_name` and `include_vectors`, plus a fluent builder
-(`SearchOptions().with_vector(v).with_top_k(10)`). The `vector` argument
+(`SearchOptions().with_vector(v).with_k(10)`). The deprecated `top_k` spelling
+remains accepted as an alias for one compatibility version. The `vector` argument
 accepts numpy arrays (`dtype=np.float32`) as well as Python lists.
 
 ## Database
@@ -113,7 +114,7 @@ collection.upsert_bulk([
 ])
 
 # Vector search
-results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, k=10))
 
 # Search with custom HNSW ef_search (trade speed for recall)
 results = collection.search_with_ef(vector=query_vector, top_k=10, ef_search=256)
@@ -133,14 +134,14 @@ from velesdb import FusionStrategy
 
 results = collection.multi_query_search(
     vectors=[query1, query2, query3],  # Multiple reformulations
-    top_k=10,
+    k=10,
     fusion=FusionStrategy.rrf(k=60)  # RRF, average, maximum, or weighted
 )
 
 # Weighted fusion (like SearchXP scoring)
 results = collection.multi_query_search(
     vectors=[v1, v2, v3],
-    top_k=10,
+    k=10,
     fusion=FusionStrategy.weighted(
         avg_weight=0.6,
         max_weight=0.3,
@@ -298,14 +299,14 @@ collection.upsert([
 # Sparse-only search (no dense vector needed)
 results = collection.search_request(velesdb.SearchOptions(
     sparse_vector={0: 1.0, 42: 2.0},
-    top_k=5,
+    k=5,
 ))
 
 # Hybrid dense + sparse search (fused with RRF k=60 by default)
 results = collection.search_request(velesdb.SearchOptions(
     vector=[0.15, 0.25, 0.35, 0.45],
     sparse_vector={0: 1.0, 42: 2.0},
-    top_k=10,
+    k=10,
 ))
 
 # Named sparse indexes (e.g., separate SPLADE and BM25 sparse models)
@@ -324,7 +325,7 @@ collection.upsert([
 results = collection.search_request(velesdb.SearchOptions(
     vector=[0.2, 0.3, 0.4, 0.5],
     sparse_vector={10: 1.5, 20: 0.8},
-    top_k=10,
+    k=10,
     sparse_index_name="splade",  # query a specific named sparse index
 ))
 ```
@@ -336,7 +337,7 @@ from scipy.sparse import csr_matrix
 import numpy as np
 
 sparse_query = csr_matrix(np.array([[0.0, 1.5, 0.0, 0.8]]))
-results = collection.search_request(velesdb.SearchOptions(sparse_vector=sparse_query, top_k=5))
+results = collection.search_request(velesdb.SearchOptions(sparse_vector=sparse_query, k=5))
 ```
 
 ## Fusion strategies

--- a/docs/guides/PYTHON_PERFORMANCE.md
+++ b/docs/guides/PYTHON_PERFORMANCE.md
@@ -172,7 +172,7 @@ GIL is released for the entire batch.
 # Slow: one GIL release + one HNSW traversal per query
 results = []
 for query in query_vectors:
-    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10)))
+    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10)))
 
 # Fast: one GIL release, queries dispatched together
 searches = [{"vector": q.tolist(), "top_k": 10} for q in query_vectors]
@@ -238,7 +238,7 @@ import numpy as np
 collection = db.get_collection("docs")
 
 def search_one(query_vector: np.ndarray) -> list:
-    return collection.search_request(velesdb.SearchOptions(vector=query_vector.tolist(), top_k=10))
+    return collection.search_request(velesdb.SearchOptions(vector=query_vector.tolist(), k=10))
 
 query_vectors = np.random.randn(100, 384).astype(np.float32)
 
@@ -272,13 +272,13 @@ import time
 
 # Warm up — results discarded
 for _ in range(5):
-    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 
 # Measure
 times = []
 for _ in range(100):
     t0 = time.perf_counter_ns()
-    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
     times.append(time.perf_counter_ns() - t0)
 
 median_us = sorted(times)[len(times) // 2] / 1_000
@@ -318,7 +318,7 @@ returns nanoseconds and has the highest resolution available on the OS:
 import time
 
 t0 = time.perf_counter_ns()
-results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 elapsed_ns = time.perf_counter_ns() - t0
 elapsed_us = elapsed_ns / 1_000
 
@@ -340,7 +340,7 @@ import numpy as np
 latencies_ns = []
 for _ in range(200):
     t0 = time.perf_counter_ns()
-    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
     latencies_ns.append(time.perf_counter_ns() - t0)
 
 arr = np.array(latencies_ns) / 1_000  # convert to µs
@@ -358,11 +358,11 @@ print(f"p99: {np.percentile(arr, 99):.1f} µs")
 ```python
 # Slow: per-element Python float -> f32 conversion at the FFI boundary
 query = [0.1, 0.2, 0.3, ...]  # list of Python floats
-results = collection.search_request(velesdb.SearchOptions(vector=query, top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=query, k=10))
 
 # Fast: float32 array, no per-element conversion
 query = np.array([0.1, 0.2, 0.3, ...], dtype=np.float32)
-results = collection.search_request(velesdb.SearchOptions(vector=query, top_k=10))  # accepts numpy arrays directly
+results = collection.search_request(velesdb.SearchOptions(vector=query, k=10))  # accepts numpy arrays directly
 ```
 
 ### Antipattern 2 — `upsert()` or `upsert_bulk()` loop instead of `upsert_bulk_numpy()`
@@ -392,7 +392,7 @@ collection.upsert_bulk_numpy(vectors, ids)
 # Slow: N separate GIL release/acquire cycles, N separate Python calls
 results = []
 for query in query_batch:
-    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10)))
+    results.append(collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10)))
 
 # Fast: one GIL release, all traversals dispatched together
 searches = [{"vector": q.tolist(), "top_k": 10} for q in query_batch]
@@ -408,12 +408,12 @@ eliminates 31 redundant GIL release/acquire and argument-parsing cycles.
 # Unreliable: time.time() may have only millisecond resolution
 import time
 t0 = time.time()
-collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 print(f"Latency: {(time.time() - t0) * 1e6:.1f} µs")  # may read 0 µs
 
 # Correct: perf_counter_ns() has nanosecond resolution
 t0 = time.perf_counter_ns()
-collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 print(f"Latency: {(time.perf_counter_ns() - t0) / 1_000:.1f} µs")
 ```
 
@@ -422,7 +422,7 @@ print(f"Latency: {(time.perf_counter_ns() - t0) / 1_000:.1f} µs")
 ```python
 # Unreliable: first call includes cold-start overhead (page faults, branch predictor)
 t0 = time.perf_counter_ns()
-results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+results = collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 print(f"{(time.perf_counter_ns() - t0) / 1_000:.1f} µs")  # 3-10x the steady-state
 ```
 
@@ -430,12 +430,12 @@ Correct: warm up, then measure over many iterations:
 
 ```python
 for _ in range(5):  # warm up
-    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
 
 times = []
 for _ in range(100):  # measure
     t0 = time.perf_counter_ns()
-    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), top_k=10))
+    collection.search_request(velesdb.SearchOptions(vector=query.tolist(), k=10))
     times.append(time.perf_counter_ns() - t0)
 ```
 

--- a/docs/guides/PYTHON_RAG_PIPELINE.md
+++ b/docs/guides/PYTHON_RAG_PIPELINE.md
@@ -35,7 +35,7 @@ collection.upsert([
 
 # 4. Search with a natural language query
 query_vector = model.encode("How does vector search work?").tolist()
-results = collection.search_request(velesdb.SearchOptions(vector=query_vector, top_k=2))
+results = collection.search_request(velesdb.SearchOptions(vector=query_vector, k=2))
 
 for r in results:
     print(f"Score: {r['score']:.4f} | {r['payload']['text']}")
@@ -69,7 +69,7 @@ collection.upsert([{"id": i, "vector": v, "payload": {"text": t}}
                    for i, (v, t) in enumerate(zip(vectors, texts))])
 
 results = collection.search_request(
-    velesdb.SearchOptions(vector=embedder.embed(["fast search"])[0], top_k=2)
+    velesdb.SearchOptions(vector=embedder.embed(["fast search"])[0], k=2)
 )
 ```
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -16,6 +16,7 @@ each guide links back.
 | [Configuration](./CONFIGURATION.md) | `velesdb.toml` configuration reference |
 | [Use Cases](./USE_CASES.md) | Common use cases and recommended configurations |
 | [Business Scenarios](./BUSINESS_SCENARIOS.md) | End-to-end business problems solved with single queries |
+| [API correspondence](./API_CORRESPONDENCE.md) | Rust, Python, TypeScript and MCP names for open, create, insert, search and recall |
 
 ## Core engine (Rust)
 

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -309,7 +309,7 @@ coll = db.get_collection("docs")
 
 results = coll.search_request(velesdb.SearchOptions(
     sparse_vector={42: 0.8, 156: 0.3, 891: 0.5},
-    top_k=10
+    k=10
 ))
 ```
 
@@ -367,7 +367,7 @@ When both the `vector` and `sparse_vector` fields are provided, VelesDB automati
 results = coll.search_request(velesdb.SearchOptions(
     vector=[0.1, 0.2, 0.3, ...],
     sparse_vector={42: 0.8, 156: 0.3},
-    top_k=10
+    k=10
 ))
 ```
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -131,7 +131,7 @@ served by the ColumnStore.
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `query` | string | yes | Natural-language query. |
-| `limit` | integer | no | Default 10, capped at 1000 (`MAX_RECALL_LIMIT`). |
+| `k` | integer | no | Default 10, capped at 1000 (`MAX_RECALL_LIMIT`). |
 | `filter` | object | no | Exact-match metadata, e.g. `{"project":"veles","status":"resolved"}`. |
 
 Returns `{ memories: [ { id, id_str, score, content, metadata } ] }`. Ranking
@@ -140,7 +140,7 @@ future `recall` order; the returned `score` stays the raw similarity, never
 the blended value.
 
 ```jsonc
-recall { "query": "billing retries", "limit": 5, "filter": { "project": "checkout" } }
+recall { "query": "billing retries", "k": 5, "filter": { "project": "checkout" } }
 → { "memories": [ { "id": 9876543210, "id_str": "9876543210", "score": 0.59, "content": "…" } ] }
 ```
 
@@ -152,7 +152,7 @@ comparisons, not just equality.
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `query` | string | yes | Natural-language query. |
-| `limit` | integer | no | Default 10, capped at 1000. |
+| `k` | integer | no | Default 10, capped at 1000. |
 | `filters` | array of `{field, op, value}` | yes | `op` ∈ `eq`, `ne`, `lt`, `le`, `gt`, `ge`. All predicates are ANDed. |
 
 `recall_where` returns `{ memories }`, most similar first — the same envelope
@@ -188,17 +188,22 @@ filter + graph reach).
 | Parameter | Type | Required | Notes |
 |---|---|---|---|
 | `query` | string | yes | Natural-language query. |
-| `limit` | integer | no | Default 10, capped at 1000. Multi-hop questions benefit from ~32–64; simple and temporal recall saturate early. |
+| `k` | integer | no | Default 10, capped at 1000. Multi-hop questions benefit from ~32–64; simple and temporal recall saturate early. |
 | `filter` | object | no | Exact-match metadata filter. |
 | `hops` | integer | no | Graph hops walked from the top vector hit (default 2, capped at 10). |
 | `graph_boost` | number | no | Weight added to a graph-reached fact's normalised vector score (default 0.15). |
-| `pool` | integer | no | Depth of the oversampled vector candidate pool fusion re-ranks before the `limit` cutoff (default `max(limit × 8, 64)`, floored at 1, capped at 1000). Same knob as the Node/WASM `pool` and the Python `options={"pool": …}`. |
+| `pool` | integer | no | Depth of the oversampled vector candidate pool fusion re-ranks before the `k` cutoff (default `max(k × 8, 64)`, floored at 1, capped at 1000). Same knob as the Node/WASM `pool` and the Python `options={"pool": …}`. |
 | `date_field` | string | no | Metadata key holding each fact's `YYYYMMDD` date (e.g. the automatic `_veles_date`). |
 
 Returns `{ memories, dated_context?, now? }`. `dated_context` (a
 chronological `- [YYYY-MM-DD] content` rendering, oldest first, undated facts
 last) and the `now` anchor appear only when `date_field` was set and at least
 one fact carries a date.
+
+For `recall`, `recall_where`, and `recall_fused`, `k` is the advertised
+result-count parameter. The former `limit` spelling remains accepted as a
+deprecated wire alias for one compatibility version, but it is absent from
+the generated tool schemas. Sending both names is rejected.
 
 ## `relate`
 

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -2701,8 +2701,8 @@
             "description": "Optional exact-match metadata filter (e.g.\n`{\"project\": \"veles\", \"status\": \"resolved\"}`).",
             "type": "object"
           },
-          "limit": {
-            "description": "Maximum number of memories to return (default 10).",
+          "k": {
+            "description": "Maximum number of memories to return (default 10). `k` is canonical;\nthe deprecated `limit` spelling remains a wire alias for one version.",
             "minimum": 0,
             "type": "integer"
           },
@@ -2793,13 +2793,13 @@
             "minimum": 0,
             "type": "integer"
           },
-          "limit": {
-            "description": "Maximum number of memories to return (default 10). Multi-hop reasoning\nbenefits from a larger budget (~32-64); simple and temporal recall\nsaturate early, where a larger budget only adds tokens.",
+          "k": {
+            "description": "Maximum number of memories to return (default 10). `k` is canonical;\nthe deprecated `limit` spelling remains a wire alias for one version.\nMulti-hop reasoning benefits from a larger budget (~32-64); simple and\ntemporal recall saturate early, where a larger budget only adds tokens.",
             "minimum": 0,
             "type": "integer"
           },
           "pool": {
-            "description": "Depth of the oversampled vector candidate pool fusion re-ranks before\nthe `limit` cutoff (default: `limit` scaled up, floored at 64). That\ndefault is already deep enough for a graph-reached fact to surface;\nwiden it to give a reranker more to work with, narrow it to confine\nfusion to the strongest vector hits. Capped at 1000, the same ceiling\n`limit` carries — NOT the one `hops` carries, which is 10.",
+            "description": "Depth of the oversampled vector candidate pool fusion re-ranks before\nthe `k` cutoff (default: `k` scaled up, floored at 64). That\ndefault is already deep enough for a graph-reached fact to surface;\nwiden it to give a reranker more to work with, narrow it to confine\nfusion to the strongest vector hits. Capped at 1000, the same ceiling\n`k` carries — NOT the one `hops` carries, which is 10.",
             "minimum": 0,
             "type": "integer"
           },
@@ -2924,8 +2924,8 @@
             },
             "type": "array"
           },
-          "limit": {
-            "description": "Maximum number of memories to return (default 10).",
+          "k": {
+            "description": "Maximum number of memories to return (default 10). `k` is canonical;\nthe deprecated `limit` spelling remains a wire alias for one version.",
             "minimum": 0,
             "type": "integer"
           },


### PR DESCRIPTION
## Summary

- make `k` the canonical result-count input for the MCP recall family and Python `SearchOptions`
- preserve `limit` / `top_k` as deprecated one-version compatibility aliases and reject ambiguous dual spelling
- add live input-parity coverage across bindings and a Rust/Python/TypeScript/MCP correspondence guide

## Validation

- full workspace clippy and dedicated Python/Node clippy: pass
- core, memory, Python, WASM and doctest suites: pass
- 485 script guard tests: pass
- duplication: 1.66%, unchanged from `develop`
- added functions: CC <= 7 and NLOC <= 33
- unsafe/TODO/doc/MCP/feature/performance/attribution guards: pass

Closes #1889