### PR TITLE
refactor(memory): name HTTP features by role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,35 +139,34 @@ jobs:
 
       # The workspace check above unifies features across crates, so a feature
       # that only compiles because a SIBLING feature happens to be on still
-      # passes it. `--features extract` alone did not compile: it pulls
-      # `dep:ureq` but not `ollama`, while extract.rs calls a helper gated on
-      # `ollama`. Each optional feature of velesdb-memory is therefore checked
-      # in isolation.
+      # passes it. Each optional feature of velesdb-memory is therefore checked
+      # in isolation. The role-named HTTP features are canonical; `ollama` and
+      # `extract` remain compatibility aliases and must keep compiling too.
       #
       # `--all-targets` is part of the contract, not an embellishment: without
       # it this step never compiles the test and example targets, and sixteen
-      # BDD suites plus six examples sat broken under `context`/`ollama`/
-      # `extract` alone with this step green (#1765) — a target that cannot
-      # fail the build is not guarded by it.
+      # BDD suites plus six examples sat broken under isolated features with
+      # this step green (#1765) — a target that cannot fail the build is not
+      # guarded by it.
       - name: Check each velesdb-memory feature in isolation
         run: |
           set -eu
-          for feat in mcp http context persistence ollama extract; do
+          for feat in mcp http context persistence embedder-http extractor-http ollama extract; do
             echo "::group::--features $feat"
             cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
             echo "::endgroup::"
           done
 
-      # `extract` was CHECKED above but never TESTED: no `cargo test` in this
-      # workflow passes the feature, so its nineteen unit tests — the graph
-      # prompt contract and the reply parser among them — have never run on
-      # CI. A test that cannot fail the build is documentation, not a gate.
-      #
-      # Paired with `ollama` because `extract` alone does not compile (see the
-      # comment above). The tests reached this way are pure parsing and
-      # prompt-building: none opens a socket, so no service is needed.
-      - name: Test the velesdb-memory extract feature
-        run: cargo test -p velesdb-memory --features extract,ollama,persistence
+      # The extraction backend's unit tests are pure parsing and prompt
+      # building: none opens a socket. Run them under the canonical role name
+      # and its compatibility alias so neither path can silently stop enabling
+      # the implementation it promises.
+      - name: Test the velesdb-memory extraction features
+        run: |
+          cargo test -p velesdb-memory --lib --no-default-features --features extractor-http,persistence
+          cargo test -p velesdb-memory --lib --no-default-features --features extract,persistence
+          cargo test -p velesdb-memory --test default_build_carries_semantic_backends \
+            --no-default-features --features ollama,extract
 
       # Same hole as the step above, left open for the whole HTTP transport:
       # six `[[test]]` targets declare `required-features = ["http"]` and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **HTTP inference features are named by role (#1766).** `embedder-http` and
+  `extractor-http` are now the canonical build features. The former `ollama`
+  and `extract` names remain compatibility aliases, so existing dependency
+  declarations continue to compile unchanged.
+
 ### Fixed
 
 - **Python and Node bindings now read `VELESDB_MEMORY_EMBEDDER*` and gain the

--- a/crates/velesdb-memory/BENCHMARK.md
+++ b/crates/velesdb-memory/BENCHMARK.md
@@ -95,7 +95,7 @@ sentences and the title that connects them — not just an answer.
 ```sh
 ollama pull mxbai-embed-large
 # fetch HotpotQA dev (distractor) into examples/multihop/data/
-cargo run --release -p velesdb-memory --features ollama --example multihop -- \
+cargo run --release -p velesdb-memory --features embedder-http --example multihop -- \
   --questions 3000 --k 5 --idf --embed-model mxbai-embed-large
 ```
 
@@ -134,7 +134,7 @@ independently built datasets, not one.
 ```sh
 # convert 2Wiki dev (voidful/2WikiMultihopQA) into the column-oriented schema,
 # then run the SAME example used for HotpotQA — only --dataset changes:
-cargo run --release -p velesdb-memory --features ollama --example multihop -- \
+cargo run --release -p velesdb-memory --features embedder-http --example multihop -- \
   --dataset examples/multihop/data/twowiki_dev_1000.json --questions 1000 --k 5 --idf
 ```
 
@@ -350,18 +350,18 @@ ollama pull qwen3.6:35b-mlx          # any local chat model works; this is the d
 examples/locomo/fetch_dataset.sh     # fetches LoCoMo (research data, git-ignored)
 
 # 2. LLM-free retrieval recall (fast, no judge):
-cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
   --retrieval --embed-model mxbai-embed-large --k 32
 
 # 3. full answer-accuracy run (date-routed context, Claude judge):
-cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
   --embed-model mxbai-embed-large --date-context --date-route --k 32 --claude-judge
 
 # 4. does the fused ranking reproduce through the SHIPPED recall_fused API?
 #    compare these two on identical data (LLM-free, seconds each):
-cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
   --retrieval --idf-weight        # the harness's own fusion
-cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
   --retrieval --use-shipped-api   # the installed MemoryService::recall_fused
 ```
 

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Role-named HTTP inference features (#1766).** `embedder-http` enables the
+  Ollama and OpenAI-compatible embedding backends; `extractor-http` enables
+  their extraction counterparts. The former `ollama` and `extract` features
+  remain aliases for compatibility with existing consumers.
+
 - **`openai`: an OpenAI-compatible backend for BOTH roles (#1751).** Set
   `VELESDB_MEMORY_EMBEDDER=openai` or `VELESDB_MEMORY_EXTRACTOR=openai` to
   reach oMLX, llama.cpp's server, LM Studio, vLLM or a hosted provider. The

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -128,7 +128,7 @@ optional = true
 # pick only what they need. The cost of the two extra defaults is one small
 # HTTP client (`ureq`, no TLS); the least technical install paths were the
 # ones locked out of the product's own pitch without them (#1846 aftermath).
-default = ["mcp", "persistence", "context", "ollama", "extract"]
+default = ["mcp", "persistence", "context", "embedder-http", "extractor-http"]
 mcp = ["dep:rmcp", "dep:tokio", "dep:tracing", "dep:tracing-subscriber", "persistence"]
 # Streamable-HTTP transport (multi-client daemon mode, see the README's "HTTP
 # transport" section): lets several MCP clients share ONE `velesdb-memory`
@@ -170,17 +170,20 @@ persistence = [
     "dep:atomicwrites",
 ]
 # Real on-device semantic recall via a local Ollama or OpenAI-compatible
-# embeddings endpoint (the name predates the protocol split: this is the HTTP
-# dependency for the embedding ROLE, not a vendor). On by default — see the
-# `default` comment; nothing is contacted unless `VELESDB_MEMORY_EMBEDDER`
-# opts in at runtime.
-ollama = ["dep:ureq"]
+# embeddings endpoint. On by default — see the `default` comment; nothing is
+# contacted unless `VELESDB_MEMORY_EMBEDDER` opts in at runtime.
+embedder-http = ["dep:ureq"]
 # Batteries-included text → facts+entities extraction (Ollama or
 # OpenAI-compatible backends) so the fact↔entity graph self-builds. On by
 # default — same reasoning and same runtime opt-in (`VELESDB_MEMORY_EXTRACTOR`)
-# as `ollama`; the Extractor trait itself is always available feature-free for
-# bring-your-own-LLM.
-extract = ["dep:ureq"]
+# as `embedder-http`; the Extractor trait itself is always available
+# feature-free for bring-your-own-LLM.
+extractor-http = ["dep:ureq"]
+# Compatibility aliases retained for existing library consumers. New code
+# should use the role-named features above; both aliases enable exactly the
+# same implementation gates and dependencies.
+ollama = ["embedder-http"]
+extract = ["extractor-http"]
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -249,12 +252,12 @@ path = "examples/context_savings/main.rs"
 required-features = ["context"]
 
 # Real-data LoCoMo benchmark. Needs a local Ollama (all-minilm + a generative
-# model), so it only builds with the `ollama` feature.
+# model), so it only builds with the `embedder-http` feature.
 [[example]]
 name = "locomo"
 path = "examples/locomo/main.rs"
 # `persistence` too: these examples open the file-backed store (#1765).
-required-features = ["ollama", "persistence"]
+required-features = ["embedder-http", "persistence"]
 
 [lib]
 name = "velesdb_memory"
@@ -338,22 +341,22 @@ required-features = ["persistence"]
 name = "multihop"
 path = "examples/multihop/main.rs"
 # `persistence` too: these examples open the file-backed store (#1765).
-required-features = ["ollama", "persistence"]
+required-features = ["embedder-http", "persistence"]
 
 [[example]]
 name = "colfilter"
 path = "examples/colfilter/main.rs"
 # `persistence` too: these examples open the file-backed store (#1765).
-required-features = ["ollama", "persistence"]
+required-features = ["embedder-http", "persistence"]
 
 [[example]]
 name = "timeqa"
 path = "examples/timeqa/main.rs"
 # `persistence` too: these examples open the file-backed store (#1765).
-required-features = ["ollama", "persistence"]
+required-features = ["embedder-http", "persistence"]
 
 [[example]]
 name = "triengine"
 path = "examples/triengine/main.rs"
 # `persistence` too: these examples open the file-backed store (#1765).
-required-features = ["ollama", "persistence"]
+required-features = ["embedder-http", "persistence"]

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -245,9 +245,9 @@ only a third of the answers; the graph recovers all of them, **+67 pp** with a
 real model. Run that arm yourself:
 
 ```bash
-cargo build --release -p velesdb-memory --features ollama && ollama pull all-minilm
+cargo build --release -p velesdb-memory --features embedder-http && ollama pull all-minilm
 VELESDB_MEMORY_EMBEDDER=ollama \
-  cargo run --release -p velesdb-memory --features ollama --example bench_multihop
+  cargo run --release -p velesdb-memory --features embedder-http --example bench_multihop
 ```
 
 `bench_multihop` measures the *engine's* contribution on controlled data with
@@ -316,7 +316,8 @@ Other verified clients: Cursor, Cline, Zed, opencode, Devin CLI.
 - **A store is fixed to one embedder.** The embedding dimension is probed from
   the model, so do not switch embedders on an existing store.
 - **Bring-your-own-links by default.** The graph is built by `relate` and
-  `links`; automatic extraction needs `--features extract` plus a local model.
+  `links`; automatic extraction needs `--features extractor-http` plus a local
+  model. The former `extract` feature remains a compatibility alias.
 - **`path` ingestion is off unless allowlisted** via
   `VELESDB_MEMORY_INGEST_ROOTS`.
 - **Binding parity is incomplete.** `compile_transcript` is MCP-only; the Node

--- a/crates/velesdb-memory/examples/bench_multihop.rs
+++ b/crates/velesdb-memory/examples/bench_multihop.rs
@@ -5,8 +5,8 @@
 //! ```text
 //! cargo run --release -p velesdb-memory --example bench_multihop
 //! # real semantic embedder (genuine scores), still local:
-//! cargo build --release -p velesdb-memory --features ollama && ollama pull all-minilm
-//! VELESDB_MEMORY_EMBEDDER=ollama cargo run --release -p velesdb-memory --features ollama --example bench_multihop
+//! cargo build --release -p velesdb-memory --features embedder-http && ollama pull all-minilm
+//! VELESDB_MEMORY_EMBEDDER=ollama cargo run --release -p velesdb-memory --features embedder-http --example bench_multihop
 //! ```
 //!
 //! ## Method
@@ -194,11 +194,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Deterministic `HashEmbedder` by default; a real on-device model via Ollama
-/// when built `--features ollama` with `VELESDB_MEMORY_EMBEDDER=ollama`.
-// Without the `ollama` feature this can't fail; the `Result` is for the on path.
+/// when built `--features embedder-http` with `VELESDB_MEMORY_EMBEDDER=ollama`.
+// Without the `embedder-http` feature this can't fail; the `Result` is for the on path.
 #[allow(clippy::unnecessary_wraps)]
 fn embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
-    #[cfg(feature = "ollama")]
+    #[cfg(feature = "embedder-http")]
     if std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() == Ok("ollama") {
         use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
         return Ok(Box::new(OllamaEmbedder::new(
@@ -211,7 +211,7 @@ fn embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
 
 /// Human label for the active embedder, for the report header.
 fn embedder_label() -> &'static str {
-    #[cfg(feature = "ollama")]
+    #[cfg(feature = "embedder-http")]
     if std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() == Ok("ollama") {
         return "ollama / all-minilm (real semantic)";
     }

--- a/crates/velesdb-memory/examples/colfilter/main.rs
+++ b/crates/velesdb-memory/examples/colfilter/main.rs
@@ -15,7 +15,7 @@
 //! single-answer subset (where vector already suffices).
 //!
 //! ```text
-//! cargo run --release -p velesdb-memory --features ollama --example colfilter -- \
+//! cargo run --release -p velesdb-memory --features embedder-http --example colfilter -- \
 //!   --embed-model mxbai-embed-large --k 5
 //! ```
 

--- a/crates/velesdb-memory/examples/locomo/README.md
+++ b/crates/velesdb-memory/examples/locomo/README.md
@@ -20,12 +20,12 @@ ollama pull all-minilm          # embeddings (384-dim)
 ollama pull qwen3.6:35b-mlx     # extraction + answer + judge (any local chat model works)
 
 # 2. smoke on one conversation, then the full run
-cargo run --release -p velesdb-memory --features ollama --example locomo -- --conversations 1
-cargo run --release -p velesdb-memory --features ollama --example locomo
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- --conversations 1
+cargo run --release -p velesdb-memory --features embedder-http --example locomo
 
 # explanation benchmark (LLM-free, fast): does the graph connect scattered
 # evidence that pure vector recall misses?
-cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+cargo run --release -p velesdb-memory --features embedder-http --example locomo -- --explanation
 ```
 
 Flags: `--conversations N`, `--max-qa N` (cap per conversation), `--k` (fact

--- a/crates/velesdb-memory/examples/locomo/main.rs
+++ b/crates/velesdb-memory/examples/locomo/main.rs
@@ -8,21 +8,21 @@
 //! ollama pull all-minilm && ollama pull qwen3.6:35b-mlx
 //!
 //! # smoke (1 conversation), then the full run (all 10):
-//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --conversations 1
-//! cargo run --release -p velesdb-memory --features ollama --example locomo
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo -- --conversations 1
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo
 //! # LLM-free explanation benchmark (does the graph connect scattered evidence?):
-//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --explanation
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo -- --explanation
 //!
 //! # Full-context baseline (whole conversation, no retrieval) — the local
 //! # ceiling our budgeted retrieval trades tokens against:
-//! cargo run --release -p velesdb-memory --features ollama --example locomo -- --full-context
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo -- --full-context
 //!
 //! # LLM-free reproduction: does the SHIPPED recall_fused reproduce the fused
 //! # retrieval? Compare the harness fusion against the installed API on the same
 //! # data (single-seed, no BM25, idf-weighted to match recall_fused):
-//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
 //!     --retrieval --idf-weight                       # harness fusion
-//! cargo run --release -p velesdb-memory --features ollama --example locomo -- \
+//! cargo run --release -p velesdb-memory --features embedder-http --example locomo -- \
 //!     --retrieval --use-shipped-api                  # shipped recall_fused
 //! ```
 //!

--- a/crates/velesdb-memory/examples/multihop/main.rs
+++ b/crates/velesdb-memory/examples/multihop/main.rs
@@ -12,7 +12,7 @@
 //!
 //! ```text
 //! ollama pull mxbai-embed-large
-//! cargo run --release -p velesdb-memory --features ollama --example multihop -- \
+//! cargo run --release -p velesdb-memory --features embedder-http --example multihop -- \
 //!   --embed-model mxbai-embed-large --k 8 --questions 300
 //! ```
 

--- a/crates/velesdb-memory/examples/timeqa/main.rs
+++ b/crates/velesdb-memory/examples/timeqa/main.rs
@@ -12,8 +12,8 @@
 //! trusting any ablation (a parsing bug would be misattributed to the engine).
 //!
 //! ```text
-//! cargo run --release -p velesdb-memory --features ollama --example timeqa -- --validate
-//! cargo run --release -p velesdb-memory --features ollama --example timeqa -- --k 5 --embed-model mxbai-embed-large
+//! cargo run --release -p velesdb-memory --features embedder-http --example timeqa -- --validate
+//! cargo run --release -p velesdb-memory --features embedder-http --example timeqa -- --k 5 --embed-model mxbai-embed-large
 //! ```
 
 use std::error::Error;

--- a/crates/velesdb-memory/examples/triengine/main.rs
+++ b/crates/velesdb-memory/examples/triengine/main.rs
@@ -15,7 +15,7 @@
 //! compound.
 //!
 //! ```text
-//! cargo run --release -p velesdb-memory --features ollama --example triengine -- --k 5
+//! cargo run --release -p velesdb-memory --features embedder-http --example triengine -- --k 5
 //! ```
 
 use std::collections::{HashMap, HashSet};

--- a/crates/velesdb-memory/examples/wow_offline.rs
+++ b/crates/velesdb-memory/examples/wow_offline.rs
@@ -46,13 +46,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Pick the embedder: deterministic `HashEmbedder` by default (offline,
 /// reproducible); a real on-device model via Ollama when built with
-/// `--features ollama` and `VELESDB_MEMORY_EMBEDDER=ollama` is set — that gives
+/// `--features embedder-http` and `VELESDB_MEMORY_EMBEDDER=ollama` is set — that gives
 /// genuine semantic scores instead of token hashes.
-// Without the `ollama` feature this can't fail (it always returns the hash
+// Without the `embedder-http` feature this can't fail (it always returns the hash
 // embedder), but the `Result` is part of the signature for the feature-on path.
 #[allow(clippy::unnecessary_wraps)]
 fn embedder() -> Result<DynEmbedder, Box<dyn std::error::Error>> {
-    #[cfg(feature = "ollama")]
+    #[cfg(feature = "embedder-http")]
     if std::env::var("VELESDB_MEMORY_EMBEDDER").as_deref() == Ok("ollama") {
         use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
         return Ok(Box::new(OllamaEmbedder::new(

--- a/crates/velesdb-memory/media/wow.tape
+++ b/crates/velesdb-memory/media/wow.tape
@@ -28,7 +28,7 @@ Set BorderRadius 10
 # Hidden setup: build once with the real-embedder feature, point it at the local
 # model, clear the screen. The commands below are then instant and clean.
 Hide
-Type "cargo build -q --features ollama -p velesdb-memory --example wow_offline 2>/dev/null"
+Type "cargo build -q --features embedder-http -p velesdb-memory --example wow_offline 2>/dev/null"
 Enter
 Sleep 4s
 Type "export VELESDB_MEMORY_EMBEDDER=ollama"

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -6,7 +6,7 @@
 //! [`Embedder`] trait with a default on-device model and a deterministic,
 //! network-free fallback for tests and air-gapped reproducibility.
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 use serde::Deserialize;
 
 /// Failure produced by an [`Embedder`] backend (e.g. a network-backed embedder
@@ -183,22 +183,22 @@ pub fn select_embedder(backend: Option<&str>) -> Result<EmbedderSelection, Strin
 
 // --- Optional real-recall backend: a local Ollama embeddings endpoint --------
 //
-// Enabled with `--features ollama`. The default build omits this backend (and
-// its HTTP dependency) so the shipped binary stays tiny, zero-dependency, and
-// fully offline. This backend keeps the binary small too: it calls a model the
-// user already runs locally, so the memory still never leaves the machine.
+// Enabled with `--features embedder-http`. A minimal `--no-default-features`
+// build omits this backend and its HTTP dependency. This backend keeps the
+// binary small: it calls a model the user already runs locally, so the memory
+// still never leaves the machine.
 
 /// Default Ollama base URL.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 
 /// Default Ollama embedding model (384-dim; `ollama pull all-minilm`).
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub const DEFAULT_OLLAMA_MODEL: &str = "all-minilm";
 
 /// Embeds text through a local Ollama `/api/embeddings` endpoint — real
 /// semantic recall while the model stays on the user's own machine.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 #[derive(Debug, Clone)]
 pub struct OllamaEmbedder {
     base_url: String,
@@ -207,7 +207,7 @@ pub struct OllamaEmbedder {
     agent: ureq::Agent,
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 impl OllamaEmbedder {
     /// Connect to Ollama at `base_url` using `model`, probing the embedding
     /// dimension once so it adapts to whatever model is configured.
@@ -232,7 +232,7 @@ impl OllamaEmbedder {
     }
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 impl Embedder for OllamaEmbedder {
     fn dimension(&self) -> usize {
         self.dimension
@@ -250,10 +250,9 @@ impl Embedder for OllamaEmbedder {
 /// its own protocol, both over the same transport. Reaching a new server is a
 /// different base URL, never a new backend name.
 ///
-/// Gated on `feature = "ollama"` because that feature carries this crate's
-/// HTTP dependency for the embedding role. The name predates the protocol
-/// split and now under-describes what it enables.
-#[cfg(feature = "ollama")]
+/// Gated on `feature = "embedder-http"`, which carries this crate's HTTP
+/// dependency for the embedding role.
+#[cfg(feature = "embedder-http")]
 #[derive(Debug)]
 pub struct OpenAiEmbedder {
     client: crate::http_client::HttpJsonClient,
@@ -261,7 +260,7 @@ pub struct OpenAiEmbedder {
     dimension: usize,
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 impl OpenAiEmbedder {
     /// Connect to the server at `base_url` using `model`, probing the
     /// embedding dimension once so it adapts to whatever model is configured.
@@ -323,7 +322,7 @@ impl OpenAiEmbedder {
     }
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 impl Embedder for OpenAiEmbedder {
     fn dimension(&self) -> usize {
         self.dimension
@@ -347,7 +346,7 @@ impl Embedder for OpenAiEmbedder {
 /// Override with `VELESDB_MEMORY_OLLAMA_KEEP_ALIVE` (any value Ollama accepts,
 /// e.g. `30m`, or `0` to unload immediately) when pinning the weights costs
 /// more RAM than the latency is worth.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub(crate) const DEFAULT_KEEP_ALIVE: i64 = -1;
 
 /// The configured keep-alive as Ollama expects it on the wire.
@@ -361,9 +360,9 @@ pub(crate) const DEFAULT_KEEP_ALIVE: i64 = -1;
 ///
 /// So: parse as a number when it is one, pass through as a string otherwise.
 // Also reachable from `extract.rs`, whose Ollama client sends the same
-// field. Gating this on `ollama` alone broke `--features extract` on its
-// own: `extract` pulls `dep:ureq`, not `ollama`.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+// field. Gating this on the embedding role alone broke the extraction role in
+// isolation; both role features pull `dep:ureq`.
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub(crate) fn keep_alive() -> serde_json::Value {
     let raw = std::env::var("VELESDB_MEMORY_OLLAMA_KEEP_ALIVE")
         .ok()
@@ -378,7 +377,7 @@ pub(crate) fn keep_alive() -> serde_json::Value {
     }
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn build_request_body(model: &str, text: &str) -> String {
     serde_json::json!({
         "model": model,
@@ -389,14 +388,14 @@ fn build_request_body(model: &str, text: &str) -> String {
 }
 
 /// Ollama `/api/embeddings` response shape.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 #[derive(Deserialize)]
 struct EmbeddingResponse {
     embedding: Vec<f32>,
 }
 
 /// Parse an embeddings response body into a vector.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn parse_embedding_response(body: &str) -> Result<Vec<f32>, EmbedError> {
     let parsed: EmbeddingResponse = serde_json::from_str(body)
         .map_err(|err| EmbedError::Backend(format!("invalid embeddings response: {err}")))?;
@@ -418,7 +417,7 @@ fn parse_embedding_response(body: &str) -> Result<Vec<f32>, EmbedError> {
 /// Deliberately far below `extract.rs`'s 300 s: that ceiling covers text
 /// GENERATION, while an embedding that has not returned in a minute is not
 /// going to.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 const EMBED_TIMEOUT_SECS: u64 = 60;
 
 /// Ceiling on establishing the TCP connection.
@@ -428,13 +427,13 @@ const EMBED_TIMEOUT_SECS: u64 = 60;
 /// the open internet and an absurd one for a daemon on `localhost`, which either
 /// accepts immediately or is not running. Since retries multiply this wait, 30 s
 /// would turn a dead Ollama into a 90 s stall.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Ceiling on writing the request. Applied to the socket at connect time, so —
 /// unlike the read timeout below — it is in force independently of the global
 /// deadline.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Agent used for every embeddings request, with [`EMBED_TIMEOUT_SECS`]
@@ -451,7 +450,7 @@ const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// a per-read ceiling today. `.timeout_connect()` and `.timeout_write()` are the
 /// two that bite. Saying otherwise in a doc — or writing a test that claimed to
 /// prove a per-read bound — would be a reassurance with nothing behind it.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn embed_agent(timeout: std::time::Duration) -> ureq::Agent {
     ureq::AgentBuilder::new()
         .timeout_connect(CONNECT_TIMEOUT)
@@ -464,7 +463,7 @@ fn embed_agent(timeout: std::time::Duration) -> ureq::Agent {
 /// How one embeddings attempt failed, kept apart just long enough to classify
 /// it: transport and body failures may be replayed, a payload the server
 /// answered in full is the server's final word.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 enum OllamaCall {
     /// The request never completed (reset, refusal, timeout, HTTP error status).
     /// Boxed: `ureq::Error::Status` carries a whole `Response`.
@@ -476,7 +475,7 @@ enum OllamaCall {
 }
 
 /// Replay policy for one embeddings attempt.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn call_is_retryable(err: &OllamaCall) -> bool {
     match err {
         OllamaCall::Transport(inner) => crate::http_retry::is_retryable(inner),
@@ -486,7 +485,7 @@ fn call_is_retryable(err: &OllamaCall) -> bool {
 }
 
 /// The knobs that actually configure this backend, named in its failures.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 const EMBED_LEVERS: crate::http_retry::FailureLevers<'static> = crate::http_retry::FailureLevers {
     url_var: "VELESDB_MEMORY_OLLAMA_URL",
     model_var: "VELESDB_MEMORY_OLLAMA_MODEL",
@@ -507,7 +506,7 @@ const EMBED_LEVERS: crate::http_retry::FailureLevers<'static> = crate::http_retr
 /// The whole attempt — POST *and* body read — sits inside the closure, so a
 /// truncated response is classified and replayed like any other transport
 /// failure instead of surfacing later as an unexplained parse error.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn request_embedding(
     agent: &ureq::Agent,
     base_url: &str,
@@ -556,7 +555,7 @@ fn request_embedding(
     }
 }
 
-#[cfg(all(test, feature = "ollama"))]
+#[cfg(all(test, feature = "embedder-http"))]
 #[path = "embedder_tests.rs"]
 mod ollama_tests;
 

--- a/crates/velesdb-memory/src/embedder_selection_tests.rs
+++ b/crates/velesdb-memory/src/embedder_selection_tests.rs
@@ -1,10 +1,11 @@
 //! Tests for [`super::select_embedder`] — the seam that resolves an embedding
 //! backend name to what the caller must do about it.
 //!
-//! Deliberately NOT gated on `feature = "ollama"` (unlike `embedder_tests.rs`,
+//! Deliberately NOT gated on `feature = "embedder-http"` (unlike
+//! `embedder_tests.rs`,
 //! which tests the Ollama client itself): the `hash` arm must resolve in every
-//! build, including the default one that has no HTTP backend compiled in. A
-//! test that only ran under `--features ollama` would leave the shipped
+//! build, including a feature-free one that has no HTTP backend compiled in. A
+//! test that only ran under `--features embedder-http` would leave the shipped
 //! binary's own path unexercised.
 
 use super::*;

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -11,7 +11,7 @@
 //!
 //! Mirroring the [`crate::embedder`] pattern, the plug-point is dependency-free
 //! (bring your own LLM by implementing [`Extractor`]) while a batteries-included
-//! `OllamaExtractor` backend lives behind the `extract` feature.
+//! `OllamaExtractor` backend lives behind the `extractor-http` feature.
 
 /// One extracted, graph-ready fact: a self-contained sentence plus the salient
 /// topics it concerns. The topics become shared graph hubs, so two facts about
@@ -735,7 +735,7 @@ pub type DynExtractor = std::sync::Arc<dyn Extractor + Send + Sync>;
 // reason: without a dependency-free choice, every contract
 // `remember_extracted` publishes is reachable only through a network call, so
 // no binding can exercise it and no test can prove it. Deliberately NOT behind
-// `extract` — that feature exists to pull in the HTTP client, which this
+// `extractor-http` — that feature exists to pull in the HTTP client, which this
 // backend does not need.
 
 /// Deterministic, network-free extractor: it reads the structure a passage
@@ -905,7 +905,7 @@ impl std::fmt::Debug for ExtractorSelection {
 ///
 /// # Why this exists, and why it is in the library rather than the binary
 ///
-/// The selection used to live inside the daemon's `#[cfg(feature = "extract")]`
+/// The selection used to live inside the daemon's `#[cfg(feature = "extractor-http")]`
 /// block. That gate is what made [`OutlineExtractor`] unreachable from the MCP
 /// server (#1734): the extractor needs no dependency and is linked into every
 /// build, but the only code that could *choose* it was compiled away unless an
@@ -946,29 +946,29 @@ pub fn select_extractor(backend: &str) -> Result<ExtractorSelection, String> {
 
 // --- Optional batteries-included backend: a local Ollama generative model -----
 //
-// Enabled with `--features extract`. The default build omits this backend (and
-// its HTTP dependency) so the shipped binary stays tiny and fully offline. Like
-// the Ollama embedder, it calls a model the user already runs locally, so the
-// text never leaves the machine.
+// Enabled with `--features extractor-http`. A minimal `--no-default-features`
+// build omits this backend and its HTTP dependency. Like the Ollama embedder,
+// it calls a model the user already runs locally, so the text never leaves the
+// machine.
 
 /// Default Ollama base URL for the generative extraction endpoint.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 
 /// Per-request timeout. Generation is far slower and more stall-prone than an
 /// embedding call, so a wedged model fails the call instead of hanging forever.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const REQUEST_TIMEOUT_SECS: u64 = 300;
 
 /// Ceiling on establishing the TCP connection to Ollama. Short on purpose: a
 /// local daemon accepts at once or is not running, and `ureq`'s 30 s default
 /// would be paid once per replay.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// Ceiling on writing the request (prompt upload). Unlike the read bound, this
 /// one is applied to the socket at connect time and is genuinely in force.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Ceiling on how many tokens one extraction call may generate.
@@ -980,7 +980,7 @@ const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// sentence's worth of triples needs, and turns the worst case into a
 /// bounded one instead of a tuning knob callers have to discover by timing
 /// out.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const MAX_GENERATION_TOKENS: u32 = 512;
 
 /// The knobs that actually configure the extractor, named in its failures.
@@ -991,7 +991,7 @@ const MAX_GENERATION_TOKENS: u32 = 512;
 /// path never consults — an "actionable" message that is actively wrong. There
 /// is no offline fallback to offer either: extraction is opt-in, and running
 /// without it is simply not passing an extractor.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const EXTRACT_LEVERS: crate::http_retry::FailureLevers<'static> =
     crate::http_retry::FailureLevers {
         url_var: "VELESDB_MEMORY_EXTRACTOR_URL",
@@ -1001,7 +1001,7 @@ const EXTRACT_LEVERS: crate::http_retry::FailureLevers<'static> =
 
 /// How one generation attempt failed — transport and body failures may be
 /// replayed, a complete response is the server's final word.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 enum GenerateCall {
     /// The request never completed. Boxed: `ureq::Error::Status` carries a
     /// whole `Response`.
@@ -1011,7 +1011,7 @@ enum GenerateCall {
 }
 
 /// Replay policy for one generation attempt.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn generate_is_retryable(err: &GenerateCall) -> bool {
     match err {
         GenerateCall::Transport(inner) => crate::http_retry::is_retryable(inner),
@@ -1021,7 +1021,7 @@ fn generate_is_retryable(err: &GenerateCall) -> bool {
 
 /// Turn a failed generation into a message that names the endpoint, the model,
 /// how many attempts were spent, and the variables that change the outcome.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn describe_generate_failure(url: &str, model: &str, err: &GenerateCall, attempts: u32) -> String {
     let cause = match err {
         GenerateCall::Transport(inner) => inner.to_string(),
@@ -1043,7 +1043,7 @@ fn describe_generate_failure(url: &str, model: &str, err: &GenerateCall, attempt
 /// The caller picks the generative model (Ollama has no universal default for
 /// generation); `temperature` is pinned to `0` and `think` disabled for stable,
 /// reproducible output.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(Debug, Clone)]
 pub struct OllamaExtractor {
     base_url: String,
@@ -1051,7 +1051,7 @@ pub struct OllamaExtractor {
     agent: ureq::Agent,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl OllamaExtractor {
     /// Build an extractor targeting `model` on the Ollama server at `base_url`
     /// (e.g. [`DEFAULT_OLLAMA_URL`]).
@@ -1085,7 +1085,7 @@ impl OllamaExtractor {
 /// A free function because every generative backend produces the same reply
 /// and reads it the same way — only the transport differs. Leaving a copy in
 /// each `impl` would let two backends drift on what counts as a valid answer.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn facts_from_reply(reply: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
     let raw =
         json_slice::<Vec<RawFact>>(reply).ok_or_else(|| ExtractError::Parse(truncate(reply)))?;
@@ -1093,14 +1093,14 @@ fn facts_from_reply(reply: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
 }
 
 /// [`facts_from_reply`]'s counterpart for [`Extractor::extract_graph`].
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn extraction_from_reply(reply: &str) -> Result<Extraction, ExtractError> {
     let raw = json_slice_object::<RawExtraction>(reply)
         .ok_or_else(|| ExtractError::Parse(truncate(reply)))?;
     Ok(raw.into_extraction())
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl Extractor for OllamaExtractor {
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
         facts_from_reply(&self.generate(&build_prompt(text))?)
@@ -1116,14 +1116,14 @@ impl Extractor for OllamaExtractor {
 /// A sibling of [`OllamaExtractor`], not a layer over it — the same shape the
 /// embedding role takes. The prompt stays here, on the role side: it is what
 /// this crate wants said, not something the protocol knows about.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(Debug)]
 pub struct OpenAiExtractor {
     client: crate::http_client::HttpJsonClient,
     model: String,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl OpenAiExtractor {
     /// Build an extractor targeting `model` on the server at `base_url`
     /// (origin and port, no path).
@@ -1177,7 +1177,7 @@ impl OpenAiExtractor {
     }
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl Extractor for OpenAiExtractor {
     fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
         facts_from_reply(&self.generate(&build_prompt(text))?)
@@ -1188,7 +1188,7 @@ impl Extractor for OpenAiExtractor {
     }
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl OllamaExtractor {
     /// POST one prompt to Ollama's `/api/generate` and return the trimmed reply,
     /// replaying the call when the failure is transient.
@@ -1236,7 +1236,7 @@ impl OllamaExtractor {
 }
 
 /// The strict JSON contract the extraction prompt asks the model to honour.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(serde::Deserialize)]
 struct RawFact {
     fact: String,
@@ -1244,7 +1244,7 @@ struct RawFact {
     entities: Vec<String>,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl RawFact {
     /// Keep a fact only if it has text; trim and lowercase its topics, dropping
     /// blanks and duplicates so the same topic recurs as the same graph hub.
@@ -1268,13 +1268,13 @@ impl RawFact {
 /// Canonical form of an entity name: trimmed and lowercased. The one place
 /// the rule lives, so a name arriving as a topic, as a relation endpoint, or
 /// as an attribute owner always resolves to the SAME entity hub.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn canonical_entity(name: &str) -> String {
     name.trim().to_lowercase()
 }
 
 /// The strict JSON contract the *graph* extraction prompt asks for.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(serde::Deserialize)]
 struct RawExtraction {
     #[serde(default)]
@@ -1285,7 +1285,7 @@ struct RawExtraction {
     attributes: Vec<RawAttribute>,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(serde::Deserialize)]
 struct RawRelation {
     subject: String,
@@ -1293,7 +1293,7 @@ struct RawRelation {
     object: String,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 #[derive(serde::Deserialize)]
 struct RawAttribute {
     entity: String,
@@ -1301,7 +1301,7 @@ struct RawAttribute {
     value: serde_json::Value,
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl RawExtraction {
     /// Canonicalize and drop the unusable: a relation missing an endpoint or a
     /// label, an attribute missing an owner or a name. A malformed item is
@@ -1328,7 +1328,7 @@ impl RawExtraction {
     }
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl RawRelation {
     fn into_relation(self) -> Option<ExtractedRelation> {
         let subject = canonical_entity(&self.subject);
@@ -1347,7 +1347,7 @@ impl RawRelation {
     }
 }
 
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 impl RawAttribute {
     fn into_attribute(self) -> Option<ExtractedAttribute> {
         let entity = canonical_entity(&self.entity);
@@ -1372,7 +1372,7 @@ impl RawAttribute {
 /// type-strictly, so an age emitted as `"15"` would never match `age >= 15` —
 /// no error, just a silent miss, which is the worst possible failure mode for
 /// a memory system.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn build_graph_prompt(text: &str) -> String {
     format!(
         "You are building a knowledge graph from the passage below.\n\n\
@@ -1421,7 +1421,7 @@ Return ONLY this JSON object, no prose, no markdown fence:\n\
 }
 
 /// Build the extraction prompt: the passage plus a strict JSON contract.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn build_prompt(text: &str) -> String {
     format!(
         "You are building a memory graph from the passage below.\n\n\
@@ -1439,7 +1439,7 @@ Return ONLY a JSON array, no prose, each item exactly:\n\
 }
 
 /// Pull the `response` string out of Ollama's `/api/generate` JSON envelope.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn parse_generate_response(body: &str) -> Result<String, ExtractError> {
     let value: serde_json::Value = serde_json::from_str(body)
         .map_err(|err| ExtractError::Backend(format!("invalid generate response: {err}")))?;
@@ -1451,7 +1451,7 @@ fn parse_generate_response(body: &str) -> Result<String, ExtractError> {
 }
 
 /// A short, single-line preview of model output for error messages.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn truncate(text: &str) -> String {
     const LIMIT: usize = 120;
     let mut out = String::new();
@@ -1473,7 +1473,7 @@ fn truncate(text: &str) -> String {
 /// Parse `text` into `T`, first slicing out the outermost JSON array/object.
 /// Local models usually honour "return only JSON" but occasionally wrap it in
 /// fences or a sentence; slicing the first balanced span tolerates that.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn json_slice<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
     let slice = balanced_slice(text)?;
     serde_json::from_str::<T>(slice).ok()
@@ -1486,7 +1486,7 @@ fn json_slice<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
 /// preferring arrays slices out the inner facts list and then fails to read it
 /// as the whole extraction. That failure is invisible to a stub-backed test —
 /// only a real model reply goes through this path.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn json_slice_object<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
     let slice = balanced_slice_preferring(text, b'{')?;
     serde_json::from_str::<T>(slice).ok()
@@ -1498,14 +1498,14 @@ fn json_slice_object<T: serde::de::DeserializeOwned>(text: &str) -> Option<T> {
 /// Prefers an array: the fact-only reply is a JSON list, and prose before it
 /// ("Result {ok}: [...]") may carry a stray `{` that would mis-slice the
 /// object span instead of the array.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn balanced_slice(text: &str) -> Option<&str> {
     balanced_slice_preferring(text, b'[')
 }
 
 /// [`balanced_slice`] with the caller choosing which delimiter wins when both
 /// appear — the shape the caller actually expects at the top level.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn balanced_slice_preferring(text: &str, preferred: u8) -> Option<&str> {
     let bytes = text.as_bytes();
     let fallback = if preferred == b'[' { b'{' } else { b'[' };
@@ -1530,7 +1530,7 @@ fn balanced_slice_preferring(text: &str, preferred: u8) -> Option<&str> {
 
 /// Advance the structural scan for one out-of-string byte; returns `true` once
 /// the outermost bracket has just closed (`depth` back to zero).
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn scan_structural(byte: u8, open: u8, close: u8, in_string: &mut bool, depth: &mut u32) -> bool {
     if byte == b'"' {
         *in_string = true;
@@ -1545,7 +1545,7 @@ fn scan_structural(byte: u8, open: u8, close: u8, in_string: &mut bool, depth: &
 
 /// Advance the in-string escape state for one byte; returns whether the scanner
 /// is still inside the string literal afterwards.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn step_string(escaped: &mut bool, byte: u8) -> bool {
     match (*escaped, byte) {
         (true, _) => {
@@ -1565,7 +1565,7 @@ fn step_string(escaped: &mut bool, byte: u8) -> bool {
 #[path = "extractor_selection_tests.rs"]
 mod selection_tests;
 
-#[cfg(all(test, feature = "extract"))]
+#[cfg(all(test, feature = "extractor-http"))]
 mod tests {
     use super::*;
 

--- a/crates/velesdb-memory/src/extractor_selection_tests.rs
+++ b/crates/velesdb-memory/src/extractor_selection_tests.rs
@@ -1,13 +1,13 @@
 //! Tests for [`super::select_extractor`] — the seam that resolves an extraction
 //! backend name to what the caller must do about it.
 //!
-//! Deliberately NOT gated on `feature = "extract"`, and that absence is the
-//! point: `outline` and `none` must resolve in every build, including the
-//! published one that has no HTTP backend compiled in. #1734 is exactly what
+//! Deliberately NOT gated on `feature = "extractor-http"`, and that absence is
+//! the point: `outline` and `none` must resolve in every build, including a
+//! feature-free one that has no HTTP backend compiled in. #1734 is exactly what
 //! happens when the only code that can *choose* a dependency-free backend sits
 //! behind an unrelated HTTP feature — two published tools went dead by default.
-//! A test living inside `extract.rs`'s own `cfg(feature = "extract")` module
-//! would have been compiled away alongside the defect.
+//! A test living inside `extract.rs`'s own `cfg(feature = "extractor-http")`
+//! module would have been compiled away alongside the defect.
 //!
 //! Its counterpart is `embedder_selection_tests.rs`; the two roles are kept
 //! deliberately symmetric, down to the shape of the refusals.

--- a/crates/velesdb-memory/src/http_retry.rs
+++ b/crates/velesdb-memory/src/http_retry.rs
@@ -206,7 +206,10 @@ pub(crate) fn actionable_ollama_failure(
 ///
 /// `hint` is the caller's escape hatch (e.g. the fully-offline embedder), or
 /// `None` when it has none to offer.
-#[cfg_attr(not(any(feature = "ollama", feature = "extract")), allow(dead_code))]
+#[cfg_attr(
+    not(any(feature = "embedder-http", feature = "extractor-http")),
+    allow(dead_code)
+)]
 pub(crate) fn actionable_openai_failure(
     endpoint: &str,
     url: &str,

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -74,7 +74,7 @@ pub mod http;
 /// Synchronous retry + actionable failure reporting shared by the two blocking
 /// Ollama call sites ([`embedder`] and [`extract`]). Internal: it exists to make
 /// those two backends resilient, not to be a general-purpose retry API.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 mod http_retry;
 /// Content-addressed memory ids — internal; ids surface through the service API.
 pub(crate) mod id;
@@ -103,12 +103,12 @@ pub mod model;
 
 /// Authenticated JSON over HTTP: the transport under every remote inference
 /// backend, with no knowledge of role or vendor.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub mod http_client;
 
 /// The OpenAI-compatible protocol — paths, bodies, responses — over
 /// [`http_client`].
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 mod openai;
 /// Is a configured remote inference backend actually reachable? (#1751 D2)
 ///
@@ -117,12 +117,12 @@ mod openai;
 /// remote backend to be unreachable, and no transport to ask with. Declaring
 /// it unconditionally compiled here and nowhere else — the default build has
 /// neither dependency.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub mod reachability;
 /// Where a remote embedding/extraction backend's URL, model and credential
 /// come from, resolved from the environment once so the daemon and the
 /// language bindings read the same variables the same way (#1886).
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub mod remote_endpoint;
 /// Optional second-stage re-scoring of a fused recall pool (bring your own
 /// cross-encoder/LLM). Never wired in by default — see [`rerank::Reranker`].
@@ -172,16 +172,16 @@ pub use embedder::{
     select_embedder, DynEmbedder, EmbedError, Embedder, EmbedderSelection, HashEmbedder,
     HASH_EMBEDDER_NOTICE,
 };
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub use embedder::{OllamaEmbedder, OpenAiEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 pub use error::{ErrorCategory, MemoryError};
 pub use extract::{
     select_extractor, DynExtractor, ExtractError, ExtractedAttribute, ExtractedFact,
     ExtractedRelation, Extraction, Extractor, ExtractorSelection, OutlineExtractor,
 };
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 pub use extract::{OllamaExtractor, OpenAiExtractor};
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub use http_client::{Auth, HttpJsonClient};
 #[cfg(feature = "mcp")]
 pub use mcp::McpServer;
@@ -190,9 +190,9 @@ pub use model::{
     EntityRelation, Explanation, FusionOptions, Link, MemoryEdge, MemoryNode, Recollection,
     RememberedExtraction, UnrelateOutcome,
 };
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub use remote_endpoint::embedder_env_endpoint;
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub use remote_endpoint::{role_auth, RemoteEndpoint};
 pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{AutographWorkerHandle, MemoryService, Metadata};

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -8,7 +8,7 @@
 //! `VELESDB_MEMORY_EXTRACTOR` to set `remember_extracted`'s default backend
 //! (calls may override it): `outline` reads directives you write explicitly
 //! and needs no model and no extra feature, while `ollama` and `openai` infer
-//! them with a generative model and need `--features extract`.
+//! them with a generative model and need `--features extractor-http`.
 //!
 //! Each role carries its own `_URL`, `_MODEL` and `_API_TOKEN`, and the two are
 //! configured independently — embedding on a local Ollama while extracting on
@@ -894,14 +894,14 @@ fn apply_autograph(
     }
 }
 
-/// Without the `extract` feature there is no remote extraction backend in this
+/// Without the `extractor-http` feature there is no remote extraction backend in this
 /// build, so there is nothing to be unreachable and no transport to ask with.
 ///
 /// A no-op rather than a `cfg` at the call site, matching how
 /// `build_remote_extractor` is paired a few lines below: the one arm that
 /// reaches both is easier to read with the condition next to the reason than
 /// wrapped around the code that uses it.
-#[cfg(not(feature = "extract"))]
+#[cfg(not(feature = "extractor-http"))]
 fn warn_if_extraction_backend_is_unreachable(_backend: &str) {}
 
 /// How long startup may spend asking whether the extraction backend is there.
@@ -909,7 +909,7 @@ fn warn_if_extraction_backend_is_unreachable(_backend: &str) {}
 /// Short on purpose: this runs before the daemon serves anything, and the
 /// answer is worth having only if getting it costs nothing. A stalled server
 /// is itself an answer, delivered by this timeout.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 const EXTRACTION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Say once, at startup, when the configured extraction backend cannot be
@@ -926,7 +926,7 @@ const EXTRACTION_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// Never falls back to another backend. A daemon that quietly answered with a
 /// different engine than the one configured is the defect #1751's own gate
 /// comment calls a contradiction the operator cannot resolve.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn warn_if_extraction_backend_is_unreachable(backend: &str) {
     use velesdb_memory::reachability::{probe_openai, warning_line, Reachability};
 
@@ -954,7 +954,7 @@ fn warn_if_extraction_backend_is_unreachable(backend: &str) {
 /// Resolves the same way the builders do — including Ollama's canonical local
 /// default — because a probe of a different address than the one that will be
 /// used answers a question nobody asked.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn extraction_endpoint_for_probe(backend: &str) -> Option<(String, String)> {
     let endpoint = extractor_endpoint().ok()?;
     let url = match backend {
@@ -1081,7 +1081,7 @@ fn build_server(
 
 /// Attach the extraction backend named `backend` to `server`.
 ///
-/// **There is deliberately no `#[cfg(feature = "extract")]` on this function.**
+/// **There is deliberately no `#[cfg(feature = "extractor-http")]` on this function.**
 /// That gate used to sit on the whole selection, which is what made
 /// `OutlineExtractor` unreachable from the MCP server (#1734): the extractor
 /// needs no dependency and is linked into every build, but the only code that
@@ -1124,7 +1124,7 @@ fn attach_extractor(
 /// dispatch lives in the binary — so the two CAN drift. When they do, the
 /// operator gets a message naming the gap instead of an Ollama client quietly
 /// pointed at a server that speaks something else.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn build_remote_extractor(
     backend: &str,
 ) -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
@@ -1135,17 +1135,17 @@ fn build_remote_extractor(
     }
 }
 
-/// Without the `extract` feature there is no HTTP backend to build, whichever
+/// Without the `extractor-http` feature there is no HTTP backend to build, whichever
 /// one was asked for. The error names the offline alternative rather than only
 /// what is missing: since #1734, `outline` is a real answer in **every** build,
 /// so a user who only wanted a graph is one setting away instead of one
 /// rebuild away.
-#[cfg(not(feature = "extract"))]
+#[cfg(not(feature = "extractor-http"))]
 fn build_remote_extractor(
     backend: &str,
 ) -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
     Err(format!(
-        "VELESDB_MEMORY_EXTRACTOR={backend} needs a build with `--features extract`; \
+        "VELESDB_MEMORY_EXTRACTOR={backend} needs a build with `--features extractor-http`; \
          for an offline deterministic graph with no rebuild, set \
          VELESDB_MEMORY_EXTRACTOR=outline instead"
     )
@@ -1168,7 +1168,7 @@ fn build_remote_extractor(
 ///
 /// # Errors
 /// An `_API_TOKEN` that is set but empty.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn embedder_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::error::Error>> {
     let (endpoint, notice) = velesdb_memory::embedder_env_endpoint()?;
     // Once, at startup, and only when the two genuinely disagree. Called from
@@ -1187,7 +1187,7 @@ fn embedder_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::er
 ///
 /// # Errors
 /// An `_API_TOKEN` that is set but empty.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn extractor_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::error::Error>> {
     Ok(velesdb_memory::RemoteEndpoint {
         url: env_opt("VELESDB_MEMORY_EXTRACTOR_URL"),
@@ -1197,7 +1197,7 @@ fn extractor_endpoint() -> Result<velesdb_memory::RemoteEndpoint, Box<dyn std::e
 }
 
 /// A variable's value, or `None` when it is unset.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 fn env_opt(name: &str) -> Option<String> {
     std::env::var(name).ok()
 }
@@ -1206,7 +1206,7 @@ fn env_opt(name: &str) -> Option<String> {
 ///
 /// Reachable only if `select_*` gains a name and the dispatch below is not
 /// updated with it — the exact drift a wildcard arm used to hide.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 fn unwired_backend(role: &str, backend: &str) -> String {
     format!(
         "the {role} backend '{backend}' is accepted by velesdb-memory's selector but \
@@ -1217,7 +1217,7 @@ fn unwired_backend(role: &str, backend: &str) -> String {
 
 /// Build the Ollama-backed extractor from `VELESDB_MEMORY_EXTRACTOR_URL`
 /// (default local) and the required `VELESDB_MEMORY_EXTRACTOR_MODEL`.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use velesdb_memory::extract::DEFAULT_OLLAMA_URL;
@@ -1238,7 +1238,7 @@ fn build_ollama_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std:
 
 /// Build the OpenAI-compatible extractor from the extraction role's own
 /// `VELESDB_MEMORY_EXTRACTOR_URL`, `_MODEL` and optional `_API_TOKEN`.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn build_openai_extractor() -> Result<velesdb_memory::DynExtractor, Box<dyn std::error::Error>> {
     use std::sync::Arc;
     use velesdb_memory::OpenAiExtractor;
@@ -1300,7 +1300,7 @@ fn build_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
 /// lives in the library and this dispatch lives in the binary, so a name added
 /// to one and not the other must say so rather than fall back to whichever
 /// client happens to be first.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn build_remote_embedder(backend: &str) -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     match backend {
         "ollama" => build_ollama_embedder(),
@@ -1309,14 +1309,12 @@ fn build_remote_embedder(backend: &str) -> Result<ConfiguredEmbedder, Box<dyn st
     }
 }
 
-/// Without the `ollama` feature this crate has no HTTP embedding backend at
-/// all, whichever one was asked for. The feature's name predates the protocol
-/// split and now under-describes what it carries — it is this crate's HTTP
-/// dependency for the embedding role, not a vendor.
-#[cfg(not(feature = "ollama"))]
+/// Without the `embedder-http` feature this crate has no HTTP embedding backend
+/// at all, whichever one was asked for.
+#[cfg(not(feature = "embedder-http"))]
 fn build_remote_embedder(backend: &str) -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     Err(format!(
-        "the '{backend}' embedder requires building with `--features ollama` \
+        "the '{backend}' embedder requires building with `--features embedder-http` \
          (that feature carries the HTTP dependency for both remote embedding \
          backends); VELESDB_MEMORY_EMBEDDER=hash needs no rebuild"
     )
@@ -1345,7 +1343,7 @@ fn warn_hash_embedder_not_semantic() {
 /// Build the Ollama-backed embedder, defaulting both the URL and the model —
 /// unchanged behaviour, now reached through the role-named variables with the
 /// `VELESDB_MEMORY_OLLAMA_*` pair kept working as aliases.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn build_ollama_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::{OllamaEmbedder, DEFAULT_OLLAMA_MODEL, DEFAULT_OLLAMA_URL};
 
@@ -1364,7 +1362,7 @@ fn build_ollama_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Err
 
 /// Build the OpenAI-compatible embedder. Both the URL and the model are
 /// required — see [`velesdb_memory::RemoteEndpoint::require`].
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn build_openai_embedder() -> Result<ConfiguredEmbedder, Box<dyn std::error::Error>> {
     use velesdb_memory::OpenAiEmbedder;
 

--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1699,7 +1699,7 @@ fn unrelate_params_accept_string_or_number_ids_on_the_wire() {
 /// The defect was never in the library: `OutlineExtractor` always worked, and
 /// `McpServer::with_extractor` always accepted it. What was broken is that the
 /// only code able to CHOOSE `outline` sat inside the daemon's
-/// `#[cfg(feature = "extract")]` block, so on a default build two of the twenty
+/// `#[cfg(feature = "extractor-http")]` block, so on a default build two of the twenty
 /// published tools were dead — `remember_extracted` refused outright, and
 /// `entity` answered `found: false` for every name, entity hubs being born only
 /// of extraction.

--- a/crates/velesdb-memory/src/migration/tests/performance.rs
+++ b/crates/velesdb-memory/src/migration/tests/performance.rs
@@ -604,7 +604,7 @@ fn the_cursor_cost_per_fact_does_not_grow_like_the_offset_walk() {
 /// by the same amount, which is why the assertion below compares the two
 /// measurements to each other and not to any number written here.
 #[test]
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 #[ignore = "needs a live embedding backend; run deliberately, on a machine at rest"]
 fn the_embedder_dominates_only_when_the_model_changes() {
     use crate::embedder::{Embedder, OllamaEmbedder};

--- a/crates/velesdb-memory/src/openai.rs
+++ b/crates/velesdb-memory/src/openai.rs
@@ -31,7 +31,7 @@ use serde_json::{json, Value};
 ///
 /// A trailing `/v1` is stripped only when something precedes it, so a host
 /// genuinely called `v1` (`http://v1`) is left alone.
-#[cfg(any(feature = "ollama", feature = "extract"))]
+#[cfg(any(feature = "embedder-http", feature = "extractor-http"))]
 pub(crate) fn base_url(configured: &str) -> String {
     let trimmed = configured.trim().trim_end_matches('/');
     match trimmed.strip_suffix("/v1") {
@@ -41,15 +41,15 @@ pub(crate) fn base_url(configured: &str) -> String {
 }
 
 /// Embeddings endpoint, relative to the caller's base URL.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub(crate) const EMBEDDINGS_PATH: &str = "/v1/embeddings";
 
 /// Chat-completions endpoint, relative to the caller's base URL.
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 pub(crate) const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
 
 /// Body of an embeddings request.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
     json!({ "model": model, "input": input }).to_string()
 }
@@ -60,7 +60,7 @@ pub(crate) fn embeddings_body(model: &str, input: &str) -> String {
 /// that answers differently to the same text turns one stored fact into two
 /// on a re-run. `max_tokens` caps runaway generation the same way the Ollama
 /// backend's `num_predict` does — see `extract::MAX_GENERATION_TOKENS` (#1846).
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 pub(crate) fn chat_body(model: &str, prompt: &str, max_tokens: u32) -> String {
     json!({
         "model": model,
@@ -78,7 +78,7 @@ pub(crate) fn chat_body(model: &str, prompt: &str, max_tokens: u32) -> String {
 /// own `{"error":{"message":...}}` envelope when the server sent one — a
 /// server that answers `200` with an error body is common enough that reading
 /// past it would report "malformed response" for a perfectly clear refusal.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub(crate) fn parse_embeddings_response(payload: &str) -> Result<Vec<f32>, String> {
     let value = parse_json(payload)?;
     // Deserialized into a typed `Vec<f32>` rather than walked as `Value` and
@@ -104,13 +104,13 @@ pub(crate) fn parse_embeddings_response(payload: &str) -> Result<Vec<f32>, Strin
 }
 
 /// `{"data":[{"embedding":[...]}]}` — only the field this crate reads.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 #[derive(serde::Deserialize)]
 struct EmbeddingsResponse {
     data: Vec<EmbeddingDatum>,
 }
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 #[derive(serde::Deserialize)]
 struct EmbeddingDatum {
     embedding: Vec<f32>,
@@ -121,7 +121,7 @@ struct EmbeddingDatum {
 ///
 /// # Errors
 /// As [`parse_embeddings_response`].
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 pub(crate) fn parse_chat_response(payload: &str) -> Result<String, String> {
     let value = parse_json(payload)?;
     value

--- a/crates/velesdb-memory/src/openai_tests.rs
+++ b/crates/velesdb-memory/src/openai_tests.rs
@@ -11,7 +11,7 @@
 use super::*;
 
 #[test]
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn an_embeddings_body_carries_the_model_and_the_input() {
     let body = embeddings_body("text-embedding-3-small", "hello world");
     let json: Value = serde_json::from_str(&body).expect("valid json");
@@ -20,7 +20,7 @@ fn an_embeddings_body_carries_the_model_and_the_input() {
 }
 
 #[test]
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn a_chat_body_pins_temperature_to_zero() {
     // Same reason the Ollama backend pins it: a backend that answers
     // differently to the same text turns one stored fact into two on a re-run.
@@ -33,7 +33,7 @@ fn a_chat_body_pins_temperature_to_zero() {
 }
 
 #[test]
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn a_chat_body_caps_completion_tokens() {
     // Unbounded, the real extraction prompt measured 3 933 completion tokens
     // for a twelve-word sentence — 1 min 59 s to store one fact (#1846).
@@ -43,7 +43,7 @@ fn a_chat_body_caps_completion_tokens() {
 }
 
 #[test]
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn an_embeddings_response_yields_its_vector() {
     let vector =
         parse_embeddings_response(r#"{"data":[{"embedding":[0.25,-0.5]}]}"#).expect("parsed");
@@ -51,7 +51,7 @@ fn an_embeddings_response_yields_its_vector() {
 }
 
 #[test]
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn a_chat_response_yields_the_assistant_message() {
     let content =
         parse_chat_response(r#"{"choices":[{"message":{"content":"[]"}}]}"#).expect("parsed");
@@ -61,7 +61,7 @@ fn a_chat_response_yields_the_assistant_message() {
 // --- Negative ----------------------------------------------------------------
 
 #[test]
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn an_error_envelope_is_reported_as_a_refusal_not_a_malformed_response() {
     // A server that answers 200 with `{"error":{...}}` is common enough that
     // reading past the envelope would report "no data[0].embedding" for a
@@ -79,7 +79,7 @@ fn an_error_envelope_is_reported_as_a_refusal_not_a_malformed_response() {
 }
 
 #[test]
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn a_non_json_response_names_what_came_back() {
     let err = parse_chat_response("<html>502 Bad Gateway</html>")
         .expect_err("HTML is not a chat completion");
@@ -90,7 +90,7 @@ fn a_non_json_response_names_what_came_back() {
 }
 
 #[test]
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 fn a_missing_field_is_reported_rather_than_silently_empty() {
     let err = parse_embeddings_response(r#"{"data":[]}"#)
         .expect_err("an empty data array carries no vector");
@@ -101,7 +101,7 @@ fn a_missing_field_is_reported_rather_than_silently_empty() {
 }
 
 #[test]
-#[cfg(feature = "extract")]
+#[cfg(feature = "extractor-http")]
 fn a_long_payload_is_previewed_not_pasted_whole() {
     let payload = format!(r#"{{"junk":"{}"}}"#, "x".repeat(5_000));
     let err = parse_chat_response(&payload).expect_err("no content field");

--- a/crates/velesdb-memory/src/remote_endpoint.rs
+++ b/crates/velesdb-memory/src/remote_endpoint.rs
@@ -11,7 +11,7 @@
 //! it was until #1886, simply never reading) the resolution the daemon
 //! already had.
 
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 use crate::config::{alias_conflict_notice, resolve_alias};
 use crate::http_client::Auth;
 
@@ -96,7 +96,7 @@ pub fn role_auth(name: &str) -> Result<Auth, String> {
 ///
 /// # Errors
 /// An `_API_TOKEN` that is set but empty.
-#[cfg(feature = "ollama")]
+#[cfg(feature = "embedder-http")]
 pub fn embedder_env_endpoint() -> Result<(RemoteEndpoint, Option<String>), String> {
     let url = resolve_alias(
         env_opt("VELESDB_MEMORY_EMBEDDER_URL").as_deref(),
@@ -124,6 +124,6 @@ pub fn embedder_env_endpoint() -> Result<(RemoteEndpoint, Option<String>), Strin
     Ok((endpoint, alias_conflict_notice(&conflicts)))
 }
 
-#[cfg(all(test, feature = "ollama"))]
+#[cfg(all(test, feature = "embedder-http"))]
 #[path = "remote_endpoint_tests.rs"]
 mod tests;

--- a/crates/velesdb-memory/tests/backend_dispatch_bdd.rs
+++ b/crates/velesdb-memory/tests/backend_dispatch_bdd.rs
@@ -23,7 +23,7 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
-#![cfg(all(feature = "extract", feature = "ollama"))]
+#![cfg(all(feature = "extractor-http", feature = "embedder-http"))]
 
 use std::process::{Command, Output};
 

--- a/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
+++ b/crates/velesdb-memory/tests/default_build_carries_semantic_backends.rs
@@ -13,8 +13,8 @@
 //!
 //! * The pin itself is the UNGATED runtime assertion below. Plain
 //!   `cargo test` builds test targets with the crate's default features, so
-//!   if `ollama` or `extract` ever leave the default set again, that test
-//!   goes red in every default-features suite run.
+//!   if `embedder-http` or `extractor-http` ever leave the default set again,
+//!   that test goes red in every default-features suite run.
 //! * The constructive proof (types reachable, selectors routing) sits in a
 //!   module gated on both features. It cannot live ungated: the CI feature
 //!   matrix `cargo check`s every optional feature IN ISOLATION with
@@ -26,8 +26,8 @@
 #[test]
 fn the_default_test_build_carries_the_semantic_backends() {
     assert!(
-        cfg!(feature = "ollama") && cfg!(feature = "extract"),
-        "`ollama` and `extract` must be default features: the default build \
+        cfg!(feature = "embedder-http") && cfg!(feature = "extractor-http"),
+        "`embedder-http` and `extractor-http` must be default features: the default build \
          is what `cargo install` and the .mcpb registry bundle ship, and \
          those users cannot rebuild — semantic recall and extraction must be \
          an env-var switch, never a compile-time privilege"
@@ -35,6 +35,16 @@ fn the_default_test_build_carries_the_semantic_backends() {
 }
 
 #[cfg(all(feature = "ollama", feature = "extract"))]
+#[test]
+fn compatibility_aliases_enable_the_role_features() {
+    assert!(
+        cfg!(feature = "embedder-http") && cfg!(feature = "extractor-http"),
+        "`ollama` and `extract` must remain aliases for `embedder-http` and \
+         `extractor-http`"
+    );
+}
+
+#[cfg(all(feature = "embedder-http", feature = "extractor-http"))]
 mod with_the_backends_present {
     use velesdb_memory::{
         select_embedder, select_extractor, Auth, EmbedderSelection, ExtractorSelection,

--- a/crates/velesdb-memory/tests/mcp_tools_drift.rs
+++ b/crates/velesdb-memory/tests/mcp_tools_drift.rs
@@ -35,14 +35,14 @@
 //! The `cfg` below is a CONJUNCTION, not an equality: every SUPERSET of
 //! `mcp` + `context` + `persistence` satisfies it too — so "under any other
 //! feature set this file compiles to nothing" would be false. One such
-//! superset already runs in CI: the `lint` job's "Test the velesdb-memory
-//! extract feature" step (`.github/workflows/ci.yml`) invokes
-//! `cargo test -p velesdb-memory --features extract,ollama,persistence`
-//! WITHOUT `--no-default-features`, so this file compiles and executes there
-//! as well. Verified by running it, not assumed: it passes, because the
-//! twenty-three tools are registered unconditionally — `remember_extracted` is
-//! always advertised and merely answers "no extractor configured" until one
-//! is attached, so neither `extract` nor `ollama` adds or removes a tool.
+//! superset already runs in CI: the `lint` job's "Test the velesdb-memory http
+//! transport" step (`.github/workflows/ci.yml`) invokes
+//! `cargo test -p velesdb-memory --features http` WITHOUT
+//! `--no-default-features`, so this file compiles and executes there as well.
+//! Verified by running it, not assumed: it passes, because the twenty-three
+//! tools are registered unconditionally — `remember_extracted` is always
+//! advertised and merely answers "no extractor configured" until one is
+//! attached, so neither role-named HTTP feature adds or removes a tool.
 //!
 //! The trap is therefore conditional, not present: the day a tool (or a DTO
 //! field reachable from a schema) sits behind a non-default feature, this

--- a/crates/velesdb-memory/tests/openai_auth_bdd.rs
+++ b/crates/velesdb-memory/tests/openai_auth_bdd.rs
@@ -15,7 +15,7 @@
 //!
 //! Categories: Nominal (≥60%), Edge (~20%), Negative (≥20%).
 
-#![cfg(all(feature = "ollama", feature = "extract"))]
+#![cfg(all(feature = "embedder-http", feature = "extractor-http"))]
 
 use std::io::{Read as _, Write as _};
 use std::net::{SocketAddr, TcpListener};

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -26,9 +26,10 @@ crate-type = ["cdylib"]
 [dependencies]
 # The high-level memory wedge ONLY. `default-features = false` drops the MCP
 # server stack (rmcp/tokio-server) — the license boundary AND the lean prebuild.
-# `ollama`+`extract` compile the real embedder + auto-extraction into the default
-# prebuild (full PyO3 parity). We MUST NOT depend on velesdb-core directly.
-velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract", "context"] }
+# `embedder-http`+`extractor-http` compile the real embedder + auto-extraction
+# into the default prebuild (full PyO3 parity). We MUST NOT depend on
+# velesdb-core directly.
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "embedder-http", "extractor-http", "context"] }
 napi = { version = "3", default-features = false, features = ["napi9", "serde-json"] }
 napi-derive = "3"
 serde = { workspace = true }

--- a/crates/velesdb-python/Cargo.toml
+++ b/crates/velesdb-python/Cargo.toml
@@ -24,11 +24,11 @@ crate-type = ["cdylib", "rlib"]
 velesdb-core = { workspace = true }
 # The high-level memory wedge (MemoryService: remember/recall/relate/forget/why
 # + remember_extracted). `default-features = false` drops the MCP server stack
-# (rmcp/tokio-server); `ollama`+`extract` enable real embeddings and extraction;
-# `context` enables the deterministic context compiler (EPIC-P-071/US-001) —
-# zero new dependencies (`context = []` in velesdb-memory), same feature set
-# velesdb-node already builds with.
-velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "ollama", "extract", "context"] }
+# (rmcp/tokio-server); `embedder-http`+`extractor-http` enable real embeddings
+# and extraction; `context` enables the deterministic context compiler
+# (EPIC-P-071/US-001) — zero new dependencies (`context = []` in
+# velesdb-memory), same feature set velesdb-node already builds with.
+velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "embedder-http", "extractor-http", "context"] }
 # `extension-module` is deliberately NOT hard-coded here: it tells PyO3 to leave
 # libpython unresolved, which is right for the wheel but makes any test binary
 # unlinkable. It moves to the `extension-module` feature below, which `default`

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -249,8 +249,8 @@ any URL that is not `https://`, even for `127.0.0.1`, so plain HTTP is no
 longer viable as the default.
 
 ```bash
-cargo install velesdb-memory --features http,ollama
-# → opt into `ollama` at BUILD time only if you want that embedder available;
+cargo install velesdb-memory --features http,embedder-http
+# → opt into HTTP embedders at BUILD time only if you want them available;
 #   VELESDB_MEMORY_EMBEDDER stays a runtime choice regardless.
 velesdb-memory --http
 # [velesdb-memory] HTTPS server listening on https://127.0.0.1:18090/mcp
@@ -613,8 +613,9 @@ places:
 
 ## Installing the daemon without a Rust toolchain
 
-Both installers default to `cargo install --features ollama,http`, which needs
-a Rust toolchain on the machine. Pass `--from-release[=TAG]` (`.sh`) or
+Both installers default to
+`cargo install --features embedder-http,extractor-http,http`, which needs a
+Rust toolchain on the machine. Pass `--from-release[=TAG]` (`.sh`) or
 `-FromRelease` / `-FromReleaseTag <TAG>` (`.ps1`, which has no PowerShell
 equivalent of the shell flag's optional inline value) to instead download a
 prebuilt `velesdb-memory-daemon-<target>.{tar.gz,zip}` archive from a

--- a/docs/guides/MIGRATION_v5.0.0.md
+++ b/docs/guides/MIGRATION_v5.0.0.md
@@ -67,7 +67,8 @@ intact behind the visibility change.
 ## 3. Behavior notes that are NOT breaks
 
 - **`velesdb-memory`'s default build now carries both semantic backends**
-  (`ollama` + `extract` features). Nothing changes at runtime until
+  (`embedder-http` + `extractor-http` features; `ollama` + `extract` remain
+  compatibility aliases). Nothing changes at runtime until
   `VELESDB_MEMORY_EMBEDDER` / `VELESDB_MEMORY_EXTRACTOR` opt in — the
   default embedder is still the offline `hash`. A packager who wants the
   previous minimal binary builds with

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -23,11 +23,15 @@ The tool surface is feature-gated at build time:
 |---|---|---|
 | `mcp` | yes | `remember`, `recall`, `recall_where`, `recall_fused`, `feedback`, `relate`, `unrelate`, `forget`, `entity`, `why`, `remember_extracted`, `memory_status`, `list_memories` |
 | `context` | yes | `compile_context`, `compile_transcript`, `explain_compilation`, `retrieve_context_source`, `context_savings`, `save_working_context`, `load_working_context`, `list_working_contexts`, `suggest_budget` |
-| `extract` | no | none — it enables the *backend* `remember_extracted` needs (see that tool) |
+| `embedder-http` | yes | none — it enables the Ollama and OpenAI-compatible embedding backends |
+| `extractor-http` | yes | none — it enables the HTTP backends `remember_extracted` needs (see that tool) |
+| `ollama` | no | compatibility alias for `embedder-http` |
+| `extract` | no | compatibility alias for `extractor-http` |
 
-`default = ["mcp", "persistence", "context", "ollama", "extract"]` (the last
-two carry the HTTP backends for embedding and extraction — runtime-switched,
-off until their env vars opt in), so a plain `cargo install velesdb-memory`
+`default = ["mcp", "persistence", "context", "embedder-http",
+"extractor-http"]` (the last two carry the HTTP backends for embedding and
+extraction — runtime-switched, off until their env vars opt in), so a plain
+`cargo install velesdb-memory`
 advertises all **22** tools. They are served by
 one MCP server: the context router is combined into the memory router in
 `McpServer::new`, never a second server.

--- a/examples/agent_memory/memory_builds_its_own_graph.py
+++ b/examples/agent_memory/memory_builds_its_own_graph.py
@@ -2,7 +2,7 @@
 
 Local model, runs on your machine, nothing leaves it:
 
-    cd crates/velesdb-python && maturin develop --features extract   # build with extract
+    cd crates/velesdb-python && maturin develop --features extractor-http   # HTTP extractor
     ollama pull qwen3.6:27b-mlx && ollama pull all-minilm
     python examples/agent_memory/memory_builds_its_own_graph.py
 

--- a/integrations/agent-hooks/claude-code/hooks/update-daemon.sh
+++ b/integrations/agent-hooks/claude-code/hooks/update-daemon.sh
@@ -47,7 +47,7 @@ echo "daemon: ${before:-unreachable} → building ${target} from ${REPO}"
 # does less.
 cargo install --path "$REPO/crates/velesdb-memory" \
   --bin velesdb-memory \
-  --features http,ollama,extract \
+  --features http,embedder-http,extractor-http \
   --force
 
 if command -v launchctl >/dev/null 2>&1; then

--- a/scripts/install-memory-daemon.ps1
+++ b/scripts/install-memory-daemon.ps1
@@ -308,12 +308,12 @@ function Initialize-Ollama {
 
 # ---- 4. Build (cargo) or install a prebuilt release archive -----------------
 function Build-Daemon {
-    Write-Warn 'Building velesdb-memory (--features ollama,http,extract)...'
+    Write-Warn 'Building velesdb-memory (--features embedder-http,http,extractor-http)...'
     # Always both features regardless of the runtime embedder choice above:
     # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
     # choice, so flipping it later is a restart, never a rebuild.
     cargo install --path "$script:RepoRoot/crates/velesdb-memory" --bin velesdb-memory `
-        --features ollama,http,extract --force
+        --features embedder-http,http,extractor-http --force
     if ($LASTEXITCODE -ne 0) {
         Write-ErrorMsg 'cargo install failed.'
         exit 1

--- a/scripts/install-memory-daemon.sh
+++ b/scripts/install-memory-daemon.sh
@@ -47,7 +47,7 @@
 #   --wire-only              Skip build/daemon setup: only (re-)verify CA trust and re-wire the
 #                            clients against an already-installed daemon (no prompts, fast)
 #   --force-restart          Reload the daemon even if already running
-#   --from-release[=TAG]     Install the prebuilt daemon binary (--features ollama,http,extract) from a
+#   --from-release[=TAG]     Install the prebuilt daemon binary (--features embedder-http,http,extractor-http) from a
 #                            GitHub Release archive instead of `cargo install` (default TAG: the
 #                            latest published velesdb-memory-vX.Y.Z release). Needs no Rust
 #                            toolchain. Only active from the first release that publishes the
@@ -387,16 +387,16 @@ setup_ollama() {
 
 # ---- 4. Build --------------------------------------------------------------
 build_daemon() {
-  echo -e "${YELLOW}🔨 Building velesdb-memory (--features ollama,http,extract)...${NC}"
+  echo -e "${YELLOW}🔨 Building velesdb-memory (--features embedder-http,http,extractor-http)...${NC}"
   # Always both features regardless of the runtime embedder choice above:
   # the hash/ollama switch stays a pure VELESDB_MEMORY_EMBEDDER runtime
   # choice, so flipping it later is a restart, never a rebuild.
   cargo install --path "$REPO_ROOT/crates/velesdb-memory" --bin velesdb-memory \
-    --features ollama,http,extract --force
+    --features embedder-http,http,extractor-http --force
 }
 
 # ---- 4b. --from-release: install a prebuilt daemon binary, no cargo needed --
-# Mirrors build_daemon()'s guarantee (--features ollama,http,extract) without a Rust
+# Mirrors build_daemon()'s guarantee (--features embedder-http,http,extractor-http) without a Rust
 # toolchain, by downloading the same binary release-memory.yml's
 # build-daemon-archive job produces. Only active from the first release that
 # ships the archive onward (added after 0.11.0) — an older/pinned tag simply

--- a/server.json
+++ b/server.json
@@ -26,7 +26,7 @@
         },
         {
           "name": "VELESDB_MEMORY_EMBEDDER",
-          "description": "Embedding backend: 'hash' (default, offline, zero-dep), 'ollama' (real semantic recall via a local model), or 'openai' (any OpenAI-compatible server — oMLX, llama.cpp, LM Studio, vLLM, a hosted provider — set VELESDB_MEMORY_EMBEDDER_URL and _MODEL). Both remote backends need a binary built --features ollama.",
+          "description": "Embedding backend: 'hash' (default, offline, zero-dep), 'ollama' (real semantic recall via a local model), or 'openai' (any OpenAI-compatible server — oMLX, llama.cpp, LM Studio, vLLM, a hosted provider — set VELESDB_MEMORY_EMBEDDER_URL and _MODEL). Both remote backends need a binary built --features embedder-http.",
           "isRequired": false,
           "default": "hash"
         }

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -20,7 +20,7 @@ startCommand:
         description: >-
           Embedding backend. 'hash' is offline and zero-dependency (default).
           'ollama' gives real semantic recall via a local model and requires a
-          binary built with --features ollama plus a running Ollama.
+          binary built with --features embedder-http plus a running Ollama.
       ollamaModel:
         type: string
         default: all-minilm


### PR DESCRIPTION
## Summary

- introduce role-named `embedder-http` and `extractor-http` features
- retain `ollama` and `extract` as backward-compatible aliases
- migrate internal consumers, packaging, CI, examples, and current documentation to the canonical names
- test canonical features and compatibility aliases independently

## Validation

- strict workspace, Node, Python, and unsafe clippy gates
- full core and memory test suites, doctests, feature-isolation checks, and WASM tests
- 485 policy/contract tests
- complexity and duplication thresholds
- `cargo deny check advisories licenses bans sources`
- `cargo publish -p velesdb-memory --dry-run --allow-dirty`

Closes #1766