### PR TITLE
feat(memory): capture online migration mutations

### DIFF
--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -244,6 +244,13 @@ name = "autograph_write_benchmark"
 harness = false
 required-features = ["persistence"]
 
+# Comparative steady-state cost of the service-generation read guard with
+# mutation capture disabled (issue #1925).
+[[bench]]
+name = "generation_gate_benchmark"
+harness = false
+required-features = ["persistence"]
+
 # Reproducible before/after benchmark of the deterministic context compiler.
 # Offline and dependency-free — needs only the `context` feature.
 [[example]]

--- a/crates/velesdb-memory/benches/generation_gate_benchmark.rs
+++ b/crates/velesdb-memory/benches/generation_gate_benchmark.rs
@@ -1,0 +1,26 @@
+//! Steady-state cost of the no-capture service-generation guard.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use velesdb_memory::{HashEmbedder, MemoryService, MemoryStore, NativeStore};
+
+const DIMENSION: usize = 4;
+
+fn generation_gate(c: &mut Criterion) {
+    let direct_dir = tempfile::tempdir().expect("direct tempdir");
+    let direct = NativeStore::open(direct_dir.path(), DIMENSION).expect("direct store");
+    let service_dir = tempfile::tempdir().expect("service tempdir");
+    let service = MemoryService::open(service_dir.path(), HashEmbedder::new(DIMENSION))
+        .expect("guarded service");
+    let mut group = c.benchmark_group("generation_gate_no_capture");
+
+    group.bench_function("native_count_direct", |b| {
+        b.iter(|| black_box(direct.count()));
+    });
+    group.bench_function("service_count_guarded", |b| {
+        b.iter(|| black_box(service.fact_count()));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, generation_gate);
+criterion_main!(benches);

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -178,6 +178,15 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         compiler: &ContextCompiler,
         request: &CompileRequest,
     ) -> Result<CompiledContext, MemoryError> {
+        let _generation = self.enter_generation();
+        self.compile_context_inner(compiler, request)
+    }
+
+    fn compile_context_inner(
+        &self,
+        compiler: &ContextCompiler,
+        request: &CompileRequest,
+    ) -> Result<CompiledContext, MemoryError> {
         let importance = compiler.effective_policy(request).importance.clone();
         let memories = self.context_memories(request, &importance)?;
         self.compile_with_memories(compiler, request, memories)
@@ -203,6 +212,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         request: &CompileRequest,
         reranker: &R,
     ) -> Result<CompiledContext, MemoryError> {
+        let _generation = self.enter_generation();
         let importance = compiler.effective_policy(request).importance.clone();
         let memories = self.context_memories_reranked(request, reranker, &importance)?;
         self.compile_with_memories(compiler, request, memories)
@@ -307,7 +317,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         let filter = scope_filter(scope);
         let opts = FusionOptions::from_knobs(scope.hops, scope.graph_boost, None);
         let ranked =
-            self.recall_fused_reranked(&request.query, k, filter.as_ref(), opts, reranker)?;
+            self.recall_fused_reranked_inner(&request.query, k, filter.as_ref(), opts, reranker)?;
         let count = ranked.len().max(1);
         let candidates = ranked
             .into_iter()
@@ -606,6 +616,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Returns [`MemoryError::UnknownHandle`] when the handle is malformed
     /// or nothing is stored under it (never stored, expired, or forgotten).
     pub fn retrieve_context_source(&self, handle: &str) -> Result<ContextSource, MemoryError> {
+        let _generation = self.enter_generation();
         let unknown = || MemoryError::UnknownHandle(handle.to_owned());
         let hash = provenance::parse_handle(handle).ok_or_else(unknown)?;
         let slot = source_id(hash);
@@ -659,6 +670,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         fragment_id: u64,
         fragment_index: Option<usize>,
     ) -> Result<ContextDecision, MemoryError> {
+        let _generation = self.enter_generation();
         if let Some(index) = fragment_index {
             let len = request.fragments.len();
             if index >= len {
@@ -685,7 +697,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         policy.slim_response = false;
         request.policy = Some(policy);
         let compiled =
-            self.compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)?;
+            self.compile_context_inner(&ContextCompiler::new(CompilePolicy::default()), &request)?;
         let decision = if let Some(index) = fragment_index {
             compiled.decisions.into_iter().nth(index)
         } else {
@@ -733,6 +745,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// # Errors
     /// Returns [`MemoryError`] if the underlying filtered recall fails.
     pub fn context_savings(&self, project: Option<&str>) -> Result<ContextSavings, MemoryError> {
+        let _generation = self.enter_generation();
         // Filter at the STORAGE layer on the reserved event marker: callers
         // can neither set nor query `_veles_*` keys, so only genuine bridge
         // events can ever match — a caller fact posing as an event counts
@@ -779,6 +792,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         session: &str,
         working: &WorkingContext,
     ) -> Result<u64, MemoryError> {
+        let _generation = self.enter_generation();
         if working.is_empty() {
             return Err(MemoryError::EmptyWorkingContext);
         }
@@ -830,6 +844,15 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// fact is corruption — reporting it as "nothing saved" would tell the
     /// caller the one thing that is certainly false), or a storage error.
     pub fn load_working_context(
+        &self,
+        project: &str,
+        session: &str,
+    ) -> Result<Option<WorkingContext>, MemoryError> {
+        let _generation = self.enter_generation();
+        self.load_working_context_inner(project, session)
+    }
+
+    fn load_working_context_inner(
         &self,
         project: &str,
         session: &str,
@@ -891,7 +914,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         project: &str,
         session: &str,
     ) -> Result<LoadedWorkingContext, MemoryError> {
-        let working = self.load_working_context(project, session)?;
+        let _generation = self.enter_generation();
+        let working = self.load_working_context_inner(project, session)?;
         let other_sessions = self.other_sessions_for(project, session, working.is_some())?;
         Ok(LoadedWorkingContext {
             found: working.is_some(),
@@ -931,7 +955,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         session: &str,
         found: bool,
     ) -> Result<Vec<String>, MemoryError> {
-        let listed = match self.list_working_contexts(project) {
+        let listed = match self.list_working_contexts_inner(project) {
             Ok(listed) => listed,
             Err(_) if found => return Ok(Vec::new()),
             Err(err) => return Err(err),
@@ -999,6 +1023,14 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// [`MemoryError::WorkingContextCodec`] if it does not parse or is
     /// corrupt (marked, but with no body).
     pub fn list_working_contexts(
+        &self,
+        project: &str,
+    ) -> Result<Vec<WorkingContextSession>, MemoryError> {
+        let _generation = self.enter_generation();
+        self.list_working_contexts_inner(project)
+    }
+
+    fn list_working_contexts_inner(
         &self,
         project: &str,
     ) -> Result<Vec<WorkingContextSession>, MemoryError> {

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -116,6 +116,12 @@ pub enum MemoryError {
     #[error("rerank error: {0}")]
     Rerank(#[from] RerankError),
 
+    /// The online-migration observer could not durably classify a mutation.
+    /// The source write has not run when this error is returned.
+    #[cfg(feature = "persistence")]
+    #[error("migration capture error: {0}")]
+    MigrationCapture(String),
+
     /// A fused-recall filter referenced a field name that is not a plain
     /// identifier, named a reserved key, or carried a non-scalar value.
     #[error("invalid filter field: {0}")]
@@ -298,7 +304,7 @@ impl MemoryError {
             Self::WorkingContextCodec(_) => ErrorCategory::Internal,
             Self::UnknownMemory(_) => ErrorCategory::NotFound,
             #[cfg(feature = "persistence")]
-            Self::Memory(_) => ErrorCategory::Internal,
+            Self::Memory(_) | Self::MigrationCapture(_) => ErrorCategory::Internal,
             Self::Storage(_) | Self::Embed(_) | Self::Extract(_) | Self::Rerank(_) => {
                 ErrorCategory::Internal
             }

--- a/crates/velesdb-memory/src/fused_recall.rs
+++ b/crates/velesdb-memory/src/fused_recall.rs
@@ -46,6 +46,17 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         filter: Option<&Metadata>,
         opts: FusionOptions,
     ) -> Result<Vec<Recollection>, MemoryError> {
+        let _generation = self.enter_generation();
+        self.recall_fused_inner(query, k, filter, opts)
+    }
+
+    fn recall_fused_inner(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+    ) -> Result<Vec<Recollection>, MemoryError> {
         let query = query.trim();
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
@@ -112,7 +123,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         opts: FusionOptions,
         date_field: &str,
     ) -> Result<(Vec<Recollection>, crate::DatedContext), MemoryError> {
-        let hits = self.recall_fused(query, k, filter, opts)?;
+        let _generation = self.enter_generation();
+        let hits = self.recall_fused_inner(query, k, filter, opts)?;
         let ctx = crate::format_dated_context(&hits, date_field);
         Ok((hits, ctx))
     }
@@ -133,6 +145,18 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Returns [`MemoryError`] if embedding, vector search, graph traversal,
     /// or `reranker` itself fails.
     pub fn recall_fused_reranked<R: Reranker>(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+        opts: FusionOptions,
+        reranker: &R,
+    ) -> Result<Vec<Recollection>, MemoryError> {
+        let _generation = self.enter_generation();
+        self.recall_fused_reranked_inner(query, k, filter, opts, reranker)
+    }
+
+    pub(super) fn recall_fused_reranked_inner<R: Reranker>(
         &self,
         query: &str,
         k: usize,

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -100,6 +100,8 @@ pub mod migration;
 /// (`Link`, `Recollection`, `ColumnFilter`, `Explanation`, …), separate from the
 /// service that computes them.
 pub mod model;
+#[cfg(feature = "persistence")]
+mod mutation;
 
 /// Authenticated JSON over HTTP: the transport under every remote inference
 /// backend, with no knowledge of role or vendor.

--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -1,0 +1,171 @@
+//! Pre-mutation classification for the native online-migration coordinator.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::MemoryError;
+
+/// Idempotent source state that a migration must re-read after a mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DirtyKey {
+    Fact(u64),
+    OutgoingEdges(u64),
+}
+
+/// Sink invoked before a native source mutation is allowed to run.
+pub(crate) trait MutationObserver: Send + Sync {
+    fn before_mutation(&self, key: DirtyKey) -> Result<(), MemoryError>;
+}
+
+/// Replaceable observer slot. `None` is the steady-state no-capture path.
+#[derive(Default)]
+pub(crate) struct MutationCapture {
+    observer: RwLock<Option<Arc<dyn MutationObserver>>>,
+}
+
+impl MutationCapture {
+    pub(crate) fn observe(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        let observer = self.observer.read();
+        match observer.as_ref() {
+            Some(observer) => observer.before_mutation(key),
+            None => Ok(()),
+        }
+    }
+
+    #[allow(dead_code)] // The durable-journal slice supplies the first production observer.
+    pub(crate) fn replace(&self, observer: Option<Arc<dyn MutationObserver>>) {
+        *self.observer.write() = observer;
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.observer.read().is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use parking_lot::{Condvar, Mutex};
+
+    use super::{DirtyKey, MutationObserver};
+    use crate::{EmbedError, Embedder, MemoryError, MemoryService};
+
+    struct BlockingEmbedder {
+        entered: mpsc::Sender<()>,
+        released: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Embedder for BlockingEmbedder {
+        fn dimension(&self) -> usize {
+            4
+        }
+
+        fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
+            let _ = self.entered.send(());
+            let (released, wake) = &*self.released;
+            let mut released = released.lock();
+            while !*released {
+                wake.wait(&mut released);
+            }
+            Ok(vec![0.0; 4])
+        }
+    }
+
+    struct NoopObserver;
+
+    impl MutationObserver for NoopObserver {
+        fn before_mutation(&self, _key: DirtyKey) -> Result<(), MemoryError> {
+            Ok(())
+        }
+    }
+
+    const MUTATING: &[&str] = &[
+        "delete",
+        "relate",
+        "store",
+        "store_with_metadata",
+        "store_with_metadata_and_ttl",
+        "store_with_ttl",
+        "unrelate",
+        "unrelate_from",
+        "update_metadata",
+    ];
+    const READ_ONLY: &[&str] = &[
+        "count",
+        "edge_count",
+        "get",
+        "get_metadata",
+        "get_metadata_batch",
+        "incoming_relations",
+        "incoming_relations_bounded",
+        "list",
+        "query_columnar",
+        "query_excluding",
+        "query_filtered",
+        "relations",
+        "relations_bounded",
+    ];
+
+    #[test]
+    fn memory_store_registry_classifies_every_primitive() {
+        let source = include_str!("storage.rs");
+        let body = source
+            .split_once("pub trait MemoryStore")
+            .expect("MemoryStore trait")
+            .1
+            .split_once("\n}\n")
+            .expect("MemoryStore trait body")
+            .0;
+        let actual: BTreeSet<&str> = body.lines().filter_map(method_name).collect();
+        let classified: BTreeSet<&str> = MUTATING.iter().chain(READ_ONLY).copied().collect();
+
+        assert_eq!(actual, classified);
+        assert!(MUTATING.iter().all(|name| !READ_ONLY.contains(name)));
+    }
+
+    #[test]
+    fn exclusive_activation_waits_for_an_in_flight_read_request() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let released = Arc::new((Mutex::new(false), Condvar::new()));
+        let service = Arc::new(
+            MemoryService::open(
+                dir.path(),
+                BlockingEmbedder {
+                    entered: entered_tx,
+                    released: Arc::clone(&released),
+                },
+            )
+            .expect("open service"),
+        );
+        let reader_service = Arc::clone(&service);
+        let reader = std::thread::spawn(move || reader_service.recall("query", 1, None));
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("read reached embedder");
+        let activation_service = Arc::clone(&service);
+        let (activated_tx, activated_rx) = mpsc::channel();
+        let activation = std::thread::spawn(move || {
+            activation_service.install_mutation_observer(Some(Arc::new(NoopObserver)));
+            let _ = activated_tx.send(());
+        });
+
+        assert!(activated_rx
+            .recv_timeout(Duration::from_millis(50))
+            .is_err());
+        *released.0.lock() = true;
+        released.1.notify_all();
+        reader.join().expect("reader thread").expect("recall");
+        activation.join().expect("activation thread");
+    }
+
+    fn method_name(line: &str) -> Option<&str> {
+        line.strip_prefix("    fn ")?
+            .split_once('(')
+            .map(|(name, _)| name)
+    }
+}

--- a/crates/velesdb-memory/src/reinforce.rs
+++ b/crates/velesdb-memory/src/reinforce.rs
@@ -69,6 +69,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// Returns [`MemoryError::UnknownMemory`] if `id` is not a live fact, or a
     /// storage error if the read-back or persist fails.
     pub fn feedback(&self, id: u64, success: bool) -> Result<f32, MemoryError> {
+        let _generation = self.enter_generation();
         // Raw payload (reserved keys included) so we can read the current RL
         // state the caller-facing metadata hides.
         let payload = self

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -3,6 +3,8 @@
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "persistence")]
 use std::path::Path;
+#[cfg(feature = "persistence")]
+use std::sync::Arc;
 
 use serde_json::{Map, Value};
 
@@ -22,6 +24,8 @@ use crate::model::{
     ColumnFilter, EntityProfile, EntityRelation, Explanation, Link, MemoryEdge, MemoryNode,
     Recollection, RememberedExtraction, UnrelateOutcome,
 };
+#[cfg(feature = "persistence")]
+use crate::mutation::MutationObserver;
 #[cfg(feature = "persistence")]
 use crate::storage::NativeStore;
 use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore, AUTO_DATE_FIELD};
@@ -97,6 +101,7 @@ pub struct MemoryService<E: Embedder, S: MemoryStore = NativeStore> {
     embedder: E,
     autograph: Option<crate::extract::DynExtractor>,
     autograph_queue: AutographQueue,
+    generation_gate: parking_lot::RwLock<()>,
 }
 #[cfg(not(feature = "persistence"))]
 pub struct MemoryService<E: Embedder, S: MemoryStore> {
@@ -104,6 +109,13 @@ pub struct MemoryService<E: Embedder, S: MemoryStore> {
     embedder: E,
     autograph: Option<crate::extract::DynExtractor>,
     autograph_queue: AutographQueue,
+}
+
+struct GenerationGuard<'a> {
+    #[cfg(feature = "persistence")]
+    _guard: parking_lot::RwLockReadGuard<'a, ()>,
+    #[cfg(not(feature = "persistence"))]
+    _lifetime: std::marker::PhantomData<&'a ()>,
 }
 
 /// One deferred autograph: the stored fact a background worker will read for
@@ -186,7 +198,14 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
             embedder,
             autograph: None,
             autograph_queue: AutographQueue::default(),
+            generation_gate: parking_lot::RwLock::new(()),
         })
+    }
+
+    #[allow(dead_code)] // The durable-journal slice supplies the first production observer.
+    pub(crate) fn install_mutation_observer(&self, observer: Option<Arc<dyn MutationObserver>>) {
+        let _generation = self.generation_gate.write();
+        self.store.set_mutation_observer(observer);
     }
 }
 
@@ -200,6 +219,23 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             embedder,
             autograph: None,
             autograph_queue: AutographQueue::default(),
+            #[cfg(feature = "persistence")]
+            generation_gate: parking_lot::RwLock::new(()),
+        }
+    }
+
+    #[cfg(feature = "persistence")]
+    fn enter_generation(&self) -> GenerationGuard<'_> {
+        GenerationGuard {
+            _guard: self.generation_gate.read(),
+        }
+    }
+
+    #[cfg(not(feature = "persistence"))]
+    fn enter_generation(&self) -> GenerationGuard<'_> {
+        let _ = self;
+        GenerationGuard {
+            _lifetime: std::marker::PhantomData,
         }
     }
 
@@ -267,7 +303,8 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         links: &[Link],
         metadata: Option<&Metadata>,
     ) -> Result<u64, MemoryError> {
-        self.remember_with_ttl(fact, links, metadata, None)
+        let _generation = self.enter_generation();
+        self.remember_inner(fact, links, metadata, None, true)
     }
 
     /// Like [`Self::remember`], but the fact **expires after `ttl_seconds`**.
@@ -309,6 +346,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         metadata: Option<&Metadata>,
         ttl_seconds: Option<u64>,
     ) -> Result<u64, MemoryError> {
+        let _generation = self.enter_generation();
         self.remember_inner(fact, links, metadata, ttl_seconds, true)
     }
 
@@ -481,6 +519,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// — the store's [`MemoryStore::count`], relayed for `memory_status`.
     #[must_use]
     pub fn fact_count(&self) -> usize {
+        let _generation = self.enter_generation();
         self.store.count()
     }
 
@@ -490,6 +529,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// different things about `why()`.
     #[must_use]
     pub fn edge_count(&self) -> Option<usize> {
+        let _generation = self.enter_generation();
         self.store.edge_count()
     }
 
@@ -518,6 +558,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         filter: Option<&Metadata>,
         include_internal: bool,
     ) -> Result<(Vec<crate::model::ListedMemory>, Option<u64>), MemoryError> {
+        let _generation = self.enter_generation();
         let limit = crate::limits::clamp_recall_limit(limit.max(1));
         let (page, next) = self.store.list(cursor, limit)?;
         let memories = page
@@ -550,6 +591,7 @@ where
                 skipped_on_close += 1;
                 continue;
             }
+            let _generation = self.enter_generation();
             self.autograph(job.fact_id, &job.fact);
         }
         if skipped_on_close > 0 {
@@ -750,8 +792,9 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         extractor: &X,
         metadata: Option<&Metadata>,
     ) -> Result<RememberedExtraction, MemoryError> {
+        let _generation = self.enter_generation();
         let extraction = Self::extract_passage(text, extractor)?;
-        self.store_extraction(&extraction, metadata)
+        self.store_extraction_inner(&extraction, metadata)
     }
 
     /// Extract and orient one passage without writing any memory state.
@@ -775,7 +818,17 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
 
     /// Store a previously generated extraction through the same idempotent
     /// fact, hub, edge, and attribute primitives as [`Self::remember_extracted`].
+    #[cfg(feature = "mcp")]
     pub(crate) fn store_extraction(
+        &self,
+        extraction: &crate::extract::Extraction,
+        metadata: Option<&Metadata>,
+    ) -> Result<RememberedExtraction, MemoryError> {
+        let _generation = self.enter_generation();
+        self.store_extraction_inner(extraction, metadata)
+    }
+
+    fn store_extraction_inner(
         &self,
         extraction: &crate::extract::Extraction,
         metadata: Option<&Metadata>,
@@ -808,6 +861,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// # Errors
     /// Returns [`MemoryError`] if the store lookup fails.
     pub fn entity_profile(&self, name: &str) -> Result<Option<EntityProfile>, MemoryError> {
+        let _generation = self.enter_generation();
         let key = canonical_entity_name(name);
         if key.is_empty() {
             return Ok(None);
@@ -1082,7 +1136,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         edges: &mut HashSet<(u64, u64, String)>,
     ) -> Result<(), MemoryError> {
         if edges.insert((from, to, label.to_string())) {
-            self.relate(from, to, label)?;
+            self.relate_inner(from, to, label)?;
         }
         Ok(())
     }
@@ -1199,6 +1253,16 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         k: usize,
         filter: Option<&Metadata>,
     ) -> Result<Vec<Recollection>, MemoryError> {
+        let _generation = self.enter_generation();
+        self.recall_inner(query, k, filter)
+    }
+
+    fn recall_inner(
+        &self,
+        query: &str,
+        k: usize,
+        filter: Option<&Metadata>,
+    ) -> Result<Vec<Recollection>, MemoryError> {
         let query = query.trim();
         if query.is_empty() {
             return Ok(Vec::new());
@@ -1287,6 +1351,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         k: usize,
         filters: &[ColumnFilter],
     ) -> Result<Vec<Recollection>, MemoryError> {
+        let _generation = self.enter_generation();
         let query = query.trim();
         if query.is_empty() || k == 0 {
             return Ok(Vec::new());
@@ -1297,7 +1362,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // scaffolding as results (same `[]` ≡ unfiltered convention as
         // `search`'s empty-map handling).
         if filters.is_empty() {
-            return self.recall(query, k, None);
+            return self.recall_inner(query, k, None);
         }
         let embedding = self.embedder.embed(query)?;
         self.store.query_columnar(&embedding, k, filters)
@@ -1320,6 +1385,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// [`MemoryError::UnknownMemory`] if either endpoint is missing, or
     /// a storage error if the edge cannot be created.
     pub fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        let _generation = self.enter_generation();
+        self.relate_inner(from, to, relation)
+    }
+
+    fn relate_inner(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
         validate_relation(relation)?;
         if from == to {
             return Err(MemoryError::SelfRelation(from));
@@ -1356,6 +1426,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         to: u64,
         relation: &str,
     ) -> Result<UnrelateOutcome, MemoryError> {
+        let _generation = self.enter_generation();
         validate_relation(relation)?;
         if from == to {
             return Err(MemoryError::SelfRelation(from));
@@ -1377,7 +1448,10 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     ) -> Result<usize, MemoryError> {
         let mut removed = 0usize;
         for edge in self.store.relations(from)? {
-            if edge.to == to && edge.relation == relation && self.store.unrelate(edge.id)? {
+            if edge.to == to
+                && edge.relation == relation
+                && self.store.unrelate_from(from, edge.id)?
+            {
                 removed += 1;
             }
         }
@@ -1402,6 +1476,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
     /// # Errors
     /// Returns [`MemoryError`] if the existence check or the deletion fails.
     pub fn forget(&self, fact_id: u64) -> Result<bool, MemoryError> {
+        let _generation = self.enter_generation();
         let found = self.store.get(fact_id)?.is_some();
         // Read the fact's hubs BEFORE the delete: afterwards its edges are gone
         // and there is no way back to the entities it created.
@@ -1500,6 +1575,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         max_hops: usize,
         filter: Option<&Metadata>,
     ) -> Result<Explanation, MemoryError> {
+        let _generation = self.enter_generation();
         let decision = decision.trim();
         if decision.is_empty() {
             return Ok(Explanation::default());

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -24,6 +24,8 @@ use velesdb_core::{Database, SearchResult};
 
 use crate::error::MemoryError;
 use crate::model::{BoundedMemoryEdges, ColumnFilter, MemoryEdge, Recollection};
+#[cfg(feature = "persistence")]
+use crate::mutation::{DirtyKey, MutationCapture, MutationObserver};
 use crate::service::Metadata;
 
 /// The storage primitives [`crate::service::MemoryService`] needs: write,
@@ -238,6 +240,19 @@ pub trait MemoryStore {
     /// Returns [`MemoryError`] if storage access fails.
     fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError>;
 
+    /// Remove an edge while preserving its known source for mutation capture.
+    ///
+    /// The default keeps third-party backends source-compatible. Native
+    /// online migration overrides it so `OutgoingEdges(from)` is recorded
+    /// before the edge is removed.
+    ///
+    /// # Errors
+    /// Returns [`MemoryError`] if storage access fails.
+    fn unrelate_from(&self, from: u64, edge_id: u64) -> Result<bool, MemoryError> {
+        let _ = from;
+        self.unrelate(edge_id)
+    }
+
     /// The total number of live (non-expired) tracked facts, including
     /// internal entity hubs — used as a corpus-size proxy for idf weighting.
     fn count(&self) -> usize;
@@ -329,6 +344,7 @@ pub struct NativeStore {
     /// that speak to the engine directly — [`MemoryStore::list`] walks the
     /// collection cursor, which `AgentMemory` does not re-expose.
     db: Arc<Database>,
+    capture: MutationCapture,
 }
 
 #[cfg(feature = "persistence")]
@@ -340,13 +356,30 @@ impl NativeStore {
     pub fn open<P: AsRef<Path>>(path: P, dimension: usize) -> Result<Self, MemoryError> {
         let db = Arc::new(Database::open(path)?);
         let memory = AgentMemory::with_dimension(Arc::clone(&db), dimension)?;
-        Ok(Self { memory, db })
+        Ok(Self {
+            memory,
+            db,
+            capture: MutationCapture::default(),
+        })
+    }
+
+    #[allow(dead_code)] // Reached by the coordinator seam introduced in the same slice.
+    pub(crate) fn set_mutation_observer(&self, observer: Option<Arc<dyn MutationObserver>>) {
+        self.capture.replace(observer);
+    }
+
+    fn unrelate_unobserved(&self, edge_id: u64) -> Result<bool, MemoryError> {
+        self.memory
+            .semantic()
+            .unrelate(edge_id)
+            .map_err(MemoryError::from)
     }
 }
 
 #[cfg(feature = "persistence")]
 impl MemoryStore for NativeStore {
     fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         self.memory
             .semantic()
             .store(id, content, embedding)
@@ -360,6 +393,7 @@ impl MemoryStore for NativeStore {
         embedding: &[f32],
         metadata: &Metadata,
     ) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         self.memory
             .semantic()
             .store_with_metadata(id, content, embedding, metadata)
@@ -373,6 +407,7 @@ impl MemoryStore for NativeStore {
         embedding: &[f32],
         ttl_seconds: u64,
     ) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         self.memory
             .semantic()
             .store_with_ttl(id, content, embedding, ttl_seconds)
@@ -380,6 +415,7 @@ impl MemoryStore for NativeStore {
     }
 
     fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         self.memory
             .semantic()
             .update_metadata(id, metadata)
@@ -394,6 +430,7 @@ impl MemoryStore for NativeStore {
         metadata: &Metadata,
         ttl_seconds: u64,
     ) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         // Ordre delibere : le fait est ecrit avec sa metadata et SANS
         // expiration, donc il ne peut pas expirer entre les deux appels.
         // L'expiration est posee ensuite. C'est l'inverse de la sequence
@@ -428,6 +465,7 @@ impl MemoryStore for NativeStore {
     }
 
     fn delete(&self, id: u64) -> Result<(), MemoryError> {
+        self.capture.observe(DirtyKey::Fact(id))?;
         self.memory.semantic().delete(id).map_err(MemoryError::from)
     }
 
@@ -484,6 +522,7 @@ impl MemoryStore for NativeStore {
     }
 
     fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.capture.observe(DirtyKey::OutgoingEdges(from))?;
         self.memory
             .semantic()
             .relate(from, to, relation, None)
@@ -521,10 +560,17 @@ impl MemoryStore for NativeStore {
     }
 
     fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
-        self.memory
-            .semantic()
-            .unrelate(edge_id)
-            .map_err(MemoryError::from)
+        if self.capture.is_active() {
+            return Err(MemoryError::MigrationCapture(format!(
+                "cannot remove edge {edge_id} without its source id"
+            )));
+        }
+        self.unrelate_unobserved(edge_id)
+    }
+
+    fn unrelate_from(&self, from: u64, edge_id: u64) -> Result<bool, MemoryError> {
+        self.capture.observe(DirtyKey::OutgoingEdges(from))?;
+        self.unrelate_unobserved(edge_id)
     }
 
     fn count(&self) -> usize {

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -2,11 +2,306 @@
 
 use super::*;
 use crate::model::ColumnOp;
+use crate::{ExtractError, ExtractedFact, Extractor, Link};
+use crate::{HashEmbedder, MemoryService};
+use parking_lot::{Condvar, Mutex};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+#[derive(Default)]
+struct RecordingObserver {
+    keys: Mutex<Vec<DirtyKey>>,
+    failure: Mutex<Option<String>>,
+}
+
+impl MutationObserver for RecordingObserver {
+    fn before_mutation(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        if let Some(message) = self.failure.lock().clone() {
+            return Err(MemoryError::MigrationCapture(message));
+        }
+        self.keys.lock().push(key);
+        Ok(())
+    }
+}
+
+struct BlockingObserver {
+    entered: mpsc::Sender<()>,
+    released: Mutex<bool>,
+    wake: Condvar,
+}
+
+struct FailOnObserver {
+    key: DirtyKey,
+    seen: Mutex<Vec<DirtyKey>>,
+}
+
+impl MutationObserver for FailOnObserver {
+    fn before_mutation(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        self.seen.lock().push(key);
+        if key == self.key {
+            return Err(MemoryError::MigrationCapture("injected refusal".to_owned()));
+        }
+        Ok(())
+    }
+}
+
+struct OneEntityExtractor;
+
+impl Extractor for OneEntityExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![ExtractedFact {
+            text: text.to_owned(),
+            entities: vec!["migration".to_owned()],
+        }])
+    }
+}
+
+impl MutationObserver for BlockingObserver {
+    fn before_mutation(&self, _key: DirtyKey) -> Result<(), MemoryError> {
+        let _ = self.entered.send(());
+        let mut released = self.released.lock();
+        while !*released {
+            self.wake.wait(&mut released);
+        }
+        Ok(())
+    }
+}
 
 fn store() -> (tempfile::TempDir, NativeStore) {
     let dir = tempfile::tempdir().expect("tempdir");
     let store = NativeStore::open(dir.path(), 4).expect("open store");
     (dir, store)
+}
+
+#[test]
+fn every_native_mutation_is_classified_before_the_source_write() {
+    let (_dir, store) = store();
+    let observer = Arc::new(RecordingObserver::default());
+    store.set_mutation_observer(Some(observer.clone()));
+    let mut metadata = Metadata::new();
+    metadata.insert("tag".to_owned(), Value::from("test"));
+
+    store.store(1, "one", &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store
+        .store_with_metadata(2, "two", &[0.0, 1.0, 0.0, 0.0], &metadata)
+        .unwrap();
+    store
+        .store_with_ttl(3, "three", &[0.0, 0.0, 1.0, 0.0], 60)
+        .unwrap();
+    store
+        .store_with_metadata_and_ttl(4, "four", &[0.0, 0.0, 0.0, 1.0], &metadata, 60)
+        .unwrap();
+    store.update_metadata(1, &metadata).unwrap();
+    let edge_id = store.relate(1, 2, "supports").unwrap();
+    assert!(store.unrelate_from(1, edge_id).unwrap());
+    store.delete(1).unwrap();
+
+    assert_eq!(
+        *observer.keys.lock(),
+        vec![
+            DirtyKey::Fact(1),
+            DirtyKey::Fact(2),
+            DirtyKey::Fact(3),
+            DirtyKey::Fact(4),
+            DirtyKey::Fact(1),
+            DirtyKey::OutgoingEdges(1),
+            DirtyKey::OutgoingEdges(1),
+            DirtyKey::Fact(1),
+        ]
+    );
+}
+
+#[test]
+fn observer_failure_prevents_the_source_mutation() {
+    let (_dir, store) = store();
+    let observer = Arc::new(RecordingObserver::default());
+    *observer.failure.lock() = Some("journal unavailable".to_owned());
+    store.set_mutation_observer(Some(observer));
+
+    let error = store
+        .store(7, "must not persist", &[1.0, 0.0, 0.0, 0.0])
+        .expect_err("capture refusal must be returned");
+
+    assert!(matches!(error, MemoryError::MigrationCapture(_)));
+    assert!(store.get(7).unwrap().is_none());
+}
+
+#[test]
+fn exclusive_capture_activation_waits_for_the_in_flight_request() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let service =
+        Arc::new(MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service"));
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let blocking = Arc::new(BlockingObserver {
+        entered: entered_tx,
+        released: Mutex::new(false),
+        wake: Condvar::new(),
+    });
+    service.install_mutation_observer(Some(blocking.clone()));
+
+    let writer_service = Arc::clone(&service);
+    let writer = std::thread::spawn(move || writer_service.remember("first", &[], None));
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("mutation reached observer");
+
+    let next = Arc::new(RecordingObserver::default());
+    let activation_service = Arc::clone(&service);
+    let activation_observer = Arc::clone(&next);
+    let (activated_tx, activated_rx) = mpsc::channel();
+    let activation = std::thread::spawn(move || {
+        activation_service.install_mutation_observer(Some(activation_observer));
+        let _ = activated_tx.send(());
+    });
+    assert!(activated_rx
+        .recv_timeout(Duration::from_millis(50))
+        .is_err());
+
+    *blocking.released.lock() = true;
+    blocking.wake.notify_all();
+    writer.join().expect("writer thread").expect("remember");
+    activation.join().expect("activation thread");
+
+    let second = service.remember("second", &[], None).expect("remember");
+    assert_eq!(*next.keys.lock(), vec![DirtyKey::Fact(second)]);
+}
+
+#[test]
+fn service_mutation_surfaces_reach_the_native_observer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let service = MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service");
+    let observer = Arc::new(RecordingObserver::default());
+    service.install_mutation_observer(Some(observer.clone()));
+    let mut metadata = Metadata::new();
+    metadata.insert("kind".to_owned(), Value::from("contract"));
+
+    let first = service
+        .remember_with_ttl("first", &[], Some(&metadata), Some(60))
+        .expect("remember ttl");
+    service.feedback(first, true).expect("feedback");
+    let second = service.remember("second", &[], None).expect("remember");
+    service.relate(first, second, "supports").expect("relate");
+    service
+        .unrelate(first, second, "supports")
+        .expect("unrelate");
+    service.forget(second).expect("forget");
+
+    assert_eq!(
+        *observer.keys.lock(),
+        vec![
+            DirtyKey::Fact(first),
+            DirtyKey::Fact(first),
+            DirtyKey::Fact(second),
+            DirtyKey::OutgoingEdges(first),
+            DirtyKey::OutgoingEdges(first),
+            DirtyKey::Fact(second),
+        ]
+    );
+}
+
+#[test]
+fn autograph_and_extraction_writes_are_captured() {
+    let extraction_dir = tempfile::tempdir().expect("tempdir");
+    let extraction_service =
+        MemoryService::open(extraction_dir.path(), HashEmbedder::new(4)).expect("open service");
+    let extraction_observer = Arc::new(RecordingObserver::default());
+    extraction_service.install_mutation_observer(Some(extraction_observer.clone()));
+    extraction_service
+        .remember_extracted("extracted fact", &OneEntityExtractor, None)
+        .expect("remember extracted");
+    assert!(extraction_observer
+        .keys
+        .lock()
+        .iter()
+        .any(|key| matches!(key, DirtyKey::OutgoingEdges(_))));
+
+    let autograph_dir = tempfile::tempdir().expect("tempdir");
+    let autograph_service = MemoryService::open(autograph_dir.path(), HashEmbedder::new(4))
+        .expect("open service")
+        .with_autograph(Arc::new(OneEntityExtractor));
+    let autograph_observer = Arc::new(RecordingObserver::default());
+    autograph_service.install_mutation_observer(Some(autograph_observer.clone()));
+    autograph_service
+        .remember("autograph fact", &[], None)
+        .expect("remember autograph");
+    assert!(autograph_observer
+        .keys
+        .lock()
+        .iter()
+        .any(|key| matches!(key, DirtyKey::OutgoingEdges(_))));
+}
+
+#[test]
+fn captured_link_failure_also_captures_the_rollback_delete() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let service = MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service");
+    let target = service
+        .remember("target", &[], None)
+        .expect("remember target");
+    let source = crate::id::stable_id("source");
+    let observer = Arc::new(FailOnObserver {
+        key: DirtyKey::OutgoingEdges(source),
+        seen: Mutex::new(Vec::new()),
+    });
+    service.install_mutation_observer(Some(observer.clone()));
+
+    let error = service
+        .remember(
+            "source",
+            &[Link {
+                target,
+                relation: "supports".to_owned(),
+            }],
+            None,
+        )
+        .expect_err("edge capture refusal must fail remember");
+
+    assert!(matches!(error, MemoryError::MigrationCapture(_)));
+    assert_eq!(
+        *observer.seen.lock(),
+        vec![
+            DirtyKey::Fact(source),
+            DirtyKey::OutgoingEdges(source),
+            DirtyKey::Fact(source),
+        ]
+    );
+    assert_eq!(service.fact_count(), 1, "rollback removed the source fact");
+}
+
+#[cfg(feature = "context")]
+#[test]
+fn context_source_and_event_writes_are_captured() {
+    use crate::context::{CompilePolicy, CompileRequest, ContextCompiler, ContextFragment};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let service = MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service");
+    let observer = Arc::new(RecordingObserver::default());
+    service.install_mutation_observer(Some(observer.clone()));
+    let request = CompileRequest {
+        query: "migration".to_owned(),
+        fragments: vec![ContextFragment {
+            path: None,
+            id: None,
+            content: "source body".to_owned(),
+            kind: None,
+            priority: None,
+            metadata: None,
+            media: None,
+        }],
+        project: Some("velesdb".to_owned()),
+        target_model: None,
+        token_budget: 1_000,
+        memory_scope: None,
+        policy: None,
+    };
+
+    service
+        .compile_context(&ContextCompiler::new(CompilePolicy::default()), &request)
+        .expect("compile context");
+
+    let keys = observer.keys.lock();
+    assert_eq!(keys.len(), 2, "one source fact and one event fact");
+    assert!(keys.iter().all(|key| matches!(key, DirtyKey::Fact(_))));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add a persistence-only generation gate around every `MemoryService` request that can observe or mutate native state
- classify every native mutation before the source write as `Fact(id)` or `OutgoingEdges(from)`
- fail closed when an edge removal cannot identify its source while capture is active
- keep third-party `MemoryStore` implementations source-compatible through the default `unrelate_from` method
- add structural exhaustiveness, concurrency, failure, rollback, extraction, autograph, context, and service-surface tests

This is only the first implementation slice of the online migration contract. It does not complete or close #1796.

## Correctness and risk review

- OOM: no volume-proportional allocation; capture state is one optional observer and copy-sized dirty keys
- performance: no-capture benchmark measured direct count at 5.3043–5.3062 ns and guarded service count at 5.4960–5.5139 ns (~0.20 ns absolute overhead)
- data loss: observation happens before each source mutation; observer failure prevents the write; exclusive activation waits for in-flight requests; unknown-source removal fails closed
- security: private coordinator seam, no new public control surface, no unsafe code, no credential or journal payload added

## Validation

- full `velesdb-memory --all-features` suite: 716 unit tests plus all integration suites and doctest, 0 failed
- `velesdb-core --features persistence`: 5,367 tests plus integration/doctests, 0 failed
- strict workspace, Node, Python, and unsafe Clippy gates
- no-default workspace and wasm32 target checks
- functional WASM gate: 76 executed, 0 failed
- 485 policy tests, docs/contracts/freshness/hooks, cargo-deny, publish dry-run
- production unwrap/TODO/unsafe guards: 0 findings
- jscpd unchanged from `develop`: 360 clones, 3,566 duplicated lines, 1.66%
- changed functions: cyclomatic complexity <= 8 and NLOC <= 50; changed files <= 500 NLOC

Closes #1925
Refs #1796