### PR TITLE
feat(memory): add durable online migration journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6984,6 +6984,7 @@ dependencies = [
  "criterion",
  "fs2",
  "futures",
+ "getrandom 0.4.2",
  "hyper",
  "hyper-util",
  "parking_lot",

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true }
 toml = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { version = "0.11", optional = true }
+getrandom = { version = "0.4", optional = true }
 fs2 = { version = "0.4", optional = true }
 # Secure sibling temporary files for durable extraction-job snapshots. The
 # dependency follows `persistence`, so wasm/no-default consumers do not carry
@@ -165,6 +166,7 @@ context = []
 persistence = [
     "velesdb-core/persistence",
     "dep:sha2",
+    "dep:getrandom",
     "dep:fs2",
     "dep:tempfile",
     "dep:atomicwrites",

--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -6,6 +6,9 @@ use parking_lot::RwLock;
 
 use crate::MemoryError;
 
+#[allow(dead_code)] // The catch-up slice consumes the journal before the control surface ships.
+mod journal;
+
 /// Idempotent source state that a migration must re-read after a mutation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DirtyKey {
@@ -33,9 +36,19 @@ impl MutationCapture {
         }
     }
 
-    #[allow(dead_code)] // The durable-journal slice supplies the first production observer.
-    pub(crate) fn replace(&self, observer: Option<Arc<dyn MutationObserver>>) {
-        *self.observer.write() = observer;
+    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
+    pub(crate) fn replace(
+        &self,
+        observer: Option<Arc<dyn MutationObserver>>,
+    ) -> Result<(), MemoryError> {
+        let mut installed = self.observer.write();
+        if installed.is_some() && observer.is_some() {
+            return Err(MemoryError::MigrationCapture(
+                "a mutation observer is already active".to_owned(),
+            ));
+        }
+        *installed = observer;
+        Ok(())
     }
 
     pub(crate) fn is_active(&self) -> bool {
@@ -150,7 +163,9 @@ mod tests {
         let activation_service = Arc::clone(&service);
         let (activated_tx, activated_rx) = mpsc::channel();
         let activation = std::thread::spawn(move || {
-            activation_service.install_mutation_observer(Some(Arc::new(NoopObserver)));
+            activation_service
+                .install_mutation_observer(Some(Arc::new(NoopObserver)))
+                .expect("activate observer");
             let _ = activated_tx.send(());
         });
 
@@ -163,9 +178,28 @@ mod tests {
         activation.join().expect("activation thread");
     }
 
+    #[test]
+    fn a_second_capture_epoch_is_refused() {
+        let capture = super::MutationCapture::default();
+        capture
+            .replace(Some(Arc::new(NoopObserver)))
+            .expect("first epoch");
+        let error = capture
+            .replace(Some(Arc::new(NoopObserver)))
+            .expect_err("second epoch");
+        assert!(error.to_string().contains("already active"), "{error}");
+        capture.replace(None).expect("remove observer");
+        capture
+            .replace(Some(Arc::new(NoopObserver)))
+            .expect("replacement after removal");
+    }
+
     fn method_name(line: &str) -> Option<&str> {
         line.strip_prefix("    fn ")?
             .split_once('(')
             .map(|(name, _)| name)
     }
 }
+
+#[cfg(test)]
+mod journal_tests;

--- a/crates/velesdb-memory/src/mutation/journal.rs
+++ b/crates/velesdb-memory/src/mutation/journal.rs
@@ -1,0 +1,486 @@
+use std::fmt::Write as _;
+use std::fs::{File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use parking_lot::Mutex;
+
+use super::{DirtyKey, MutationObserver};
+use crate::MemoryError;
+
+mod format;
+mod io;
+mod platform;
+
+use format::{
+    encode_record, read_header, read_records, recover_torn_tail, scan_records, write_header,
+    EncodedRecord, JournalHeader, FORMAT_VERSION,
+};
+pub(super) use format::{JournalRecord, RECORD_BYTES};
+use io::{append_synced, write_compacted};
+use platform::{durability_barrier, promote};
+
+pub(super) const JOURNAL_FILE: &str = "online-migration-dirty.journal";
+const STAGING_FILE: &str = "online-migration-dirty.journal.tmp";
+const MAX_READ_BATCH: usize = 4_096;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct EpochIdentity {
+    source_path: PathBuf,
+    source_provenance: String,
+    target_model: String,
+    target_dimension: usize,
+    destination_path: PathBuf,
+    epoch_id: String,
+}
+
+impl EpochIdentity {
+    pub(crate) fn new(
+        source_path: PathBuf,
+        source_provenance: String,
+        target_model: String,
+        target_dimension: usize,
+        destination_path: PathBuf,
+    ) -> Result<Self, MemoryError> {
+        let mut random = [0_u8; 16];
+        getrandom::fill(&mut random)
+            .map_err(|err| capture(format!("cannot mint epoch id: {err}")))?;
+        let epoch_id = random
+            .iter()
+            .fold(String::with_capacity(32), |mut id, byte| {
+                let _ = write!(id, "{byte:02x}");
+                id
+            });
+        Self::validated(
+            source_path,
+            source_provenance,
+            target_model,
+            target_dimension,
+            destination_path,
+            epoch_id,
+        )
+    }
+
+    fn validated(
+        source_path: PathBuf,
+        source_provenance: String,
+        target_model: String,
+        target_dimension: usize,
+        destination_path: PathBuf,
+        epoch_id: String,
+    ) -> Result<Self, MemoryError> {
+        if source_provenance.trim().is_empty() || target_model.trim().is_empty() {
+            return Err(capture(
+                "epoch provenance and target model must not be empty",
+            ));
+        }
+        if target_dimension == 0 || source_path == destination_path {
+            return Err(capture(
+                "epoch paths must differ and target dimension must be positive",
+            ));
+        }
+        validate_epoch_id(&epoch_id)?;
+        Ok(Self {
+            source_path,
+            source_provenance,
+            target_model,
+            target_dimension,
+            destination_path,
+            epoch_id,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(
+        source_path: PathBuf,
+        source_provenance: &str,
+        target_model: &str,
+        target_dimension: usize,
+        destination_path: PathBuf,
+        epoch_id: &str,
+    ) -> Self {
+        Self::validated(
+            source_path,
+            source_provenance.to_owned(),
+            target_model.to_owned(),
+            target_dimension,
+            destination_path,
+            epoch_id.to_owned(),
+        )
+        .expect("valid test epoch")
+    }
+}
+
+struct JournalInner {
+    file: Option<File>,
+    header: JournalHeader,
+    header_bytes: u64,
+    last_sequence: u64,
+    poisoned: bool,
+}
+
+struct LoadedJournal {
+    file: File,
+    header: JournalHeader,
+    header_bytes: u64,
+    last_sequence: u64,
+}
+
+pub(crate) struct DirtyJournal {
+    workspace: PathBuf,
+    path: PathBuf,
+    max_bytes: u64,
+    inner: Mutex<JournalInner>,
+    #[cfg(test)]
+    fault: std::sync::atomic::AtomicU8,
+}
+
+impl DirtyJournal {
+    pub(crate) fn open(
+        workspace: &Path,
+        identity: &EpochIdentity,
+        max_bytes: u64,
+    ) -> Result<Self, MemoryError> {
+        let path = prepare_journal(workspace, identity)?;
+        let loaded = load_journal(&path)?;
+        verify_identity(&loaded.header, identity)?;
+        validate_capacity(loaded.header_bytes, max_bytes)?;
+        Ok(Self {
+            workspace: workspace.to_owned(),
+            path,
+            max_bytes,
+            inner: Mutex::new(JournalInner {
+                file: Some(loaded.file),
+                header: loaded.header,
+                header_bytes: loaded.header_bytes,
+                last_sequence: loaded.last_sequence,
+                poisoned: false,
+            }),
+            #[cfg(test)]
+            fault: std::sync::atomic::AtomicU8::new(0),
+        })
+    }
+
+    pub(crate) fn last_sequence(&self) -> u64 {
+        self.inner.lock().last_sequence
+    }
+
+    pub(crate) fn compacted_through(&self) -> u64 {
+        self.inner.lock().header.compacted_through
+    }
+
+    pub(crate) fn records_after(
+        &self,
+        sequence: u64,
+        limit: usize,
+    ) -> Result<Vec<JournalRecord>, MemoryError> {
+        let inner = self.inner.lock();
+        ensure_healthy(&inner)?;
+        let mut file =
+            File::open(&self.path).map_err(|err| capture(format!("cannot read journal: {err}")))?;
+        file.seek(SeekFrom::Start(inner.header_bytes))
+            .map_err(|err| capture(format!("cannot seek journal: {err}")))?;
+        read_records(&mut file, sequence, limit.min(MAX_READ_BATCH))
+    }
+
+    pub(crate) fn compact_through(&self, watermark: u64) -> Result<(), MemoryError> {
+        let mut inner = self.inner.lock();
+        ensure_healthy(&inner)?;
+        if watermark < inner.header.compacted_through || watermark > inner.last_sequence {
+            return Err(capture(format!("invalid compaction watermark {watermark}")));
+        }
+        if watermark == inner.header.compacted_through {
+            return Ok(());
+        }
+        let result = self.compact_locked(&mut inner, watermark);
+        if result.is_err() {
+            inner.poisoned = true;
+        }
+        result
+    }
+
+    fn compact_locked(&self, inner: &mut JournalInner, watermark: u64) -> Result<(), MemoryError> {
+        let next_header = next_header(&inner.header, watermark)?;
+        let staging = self.workspace.join(STAGING_FILE);
+        let header_bytes =
+            write_compacted(&self.path, &staging, &next_header, watermark, |point| {
+                self.maybe_fail(point)
+            })?;
+        self.publish_compaction(inner, &staging, next_header, header_bytes)
+    }
+
+    fn publish_compaction(
+        &self,
+        inner: &mut JournalInner,
+        staging: &Path,
+        next_header: JournalHeader,
+        header_bytes: u64,
+    ) -> Result<(), MemoryError> {
+        self.maybe_fail(FaultPoint::BeforeCompactionReplace)?;
+        inner.file.take();
+        promote(staging, &self.path)
+            .map_err(|err| capture(format!("cannot replace journal generation: {err}")))?;
+        self.maybe_fail(FaultPoint::AfterCompactionReplace)?;
+        self.maybe_fail(FaultPoint::BeforeDirectorySync)?;
+        durability_barrier(&self.workspace)
+            .map_err(|err| capture(format!("cannot sync journal directory: {err}")))?;
+        self.maybe_fail(FaultPoint::AfterDirectorySync)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.path)
+            .map_err(|err| capture(format!("cannot reopen compacted journal: {err}")))?;
+        inner.file = Some(file);
+        inner.header = next_header;
+        inner.header_bytes = header_bytes;
+        Ok(())
+    }
+
+    fn append(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        let mut inner = self.inner.lock();
+        ensure_healthy(&inner)?;
+        let (sequence, record) = prepare_append(&inner, self.max_bytes, key)?;
+        let result = self.append_locked(&mut inner, &record);
+        if let Err(error) = result {
+            inner.poisoned = true;
+            return Err(error);
+        }
+        inner.last_sequence = sequence;
+        Ok(())
+    }
+
+    fn append_locked(&self, inner: &mut JournalInner, record: &[u8]) -> Result<(), MemoryError> {
+        let file = inner
+            .file
+            .as_mut()
+            .ok_or_else(|| capture("journal handle is closed"))?;
+        append_synced(file, record, |point| self.maybe_fail(point))
+    }
+
+    #[cfg(test)]
+    pub(super) fn header_bytes(&self) -> u64 {
+        self.inner.lock().header_bytes
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_once_at(&self, point: FaultPoint) {
+        use std::sync::atomic::Ordering;
+        self.fault.store(point as u8, Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn maybe_fail(&self, point: FaultPoint) -> Result<(), MemoryError> {
+        use std::sync::atomic::Ordering;
+        if self
+            .fault
+            .compare_exchange(point as u8, 0, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            return Err(capture(format!("injected journal fault at {point:?}")));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    #[allow(clippy::unnecessary_wraps, clippy::unused_self)] // Mirrors the test fault seam exactly.
+    fn maybe_fail(&self, _point: FaultPoint) -> Result<(), MemoryError> {
+        Ok(())
+    }
+}
+
+impl MutationObserver for DirtyJournal {
+    fn before_mutation(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        self.append(key)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub(super) enum FaultPoint {
+    BeforeAppend = 1,
+    AfterAppend = 2,
+    BeforeAppendSync = 3,
+    AfterAppendSync = 4,
+    BeforeCompactionSync = 5,
+    AfterCompactionSync = 6,
+    BeforeCompactionReplace = 7,
+    AfterCompactionReplace = 8,
+    BeforeDirectorySync = 9,
+    AfterDirectorySync = 10,
+}
+
+fn prepare_journal(workspace: &Path, identity: &EpochIdentity) -> Result<PathBuf, MemoryError> {
+    validate_workspace(workspace)?;
+    let path = workspace.join(JOURNAL_FILE);
+    recover_staging(workspace, &path)?;
+    if !path_entry_exists(&path)? {
+        create_journal(workspace, identity)?;
+    }
+    validate_regular_file(&path)?;
+    Ok(path)
+}
+
+fn load_journal(path: &Path) -> Result<LoadedJournal, MemoryError> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|err| capture(format!("cannot open {}: {err}", path.display())))?;
+    let (header, header_bytes) = read_header(&mut file)?;
+    let (last_sequence, valid_len) = scan_records(&mut file, &header, header_bytes)?;
+    recover_torn_tail(&mut file, valid_len)?;
+    Ok(LoadedJournal {
+        file,
+        header,
+        header_bytes,
+        last_sequence,
+    })
+}
+
+fn verify_identity(header: &JournalHeader, identity: &EpochIdentity) -> Result<(), MemoryError> {
+    if header.identity != *identity {
+        return Err(capture("journal epoch identity mismatch"));
+    }
+    Ok(())
+}
+
+fn validate_capacity(header_bytes: u64, max_bytes: u64) -> Result<(), MemoryError> {
+    if max_bytes < header_bytes + RECORD_BYTES {
+        return Err(capture("journal byte cap cannot hold one record"));
+    }
+    Ok(())
+}
+
+fn next_header(header: &JournalHeader, watermark: u64) -> Result<JournalHeader, MemoryError> {
+    let generation = header
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| capture("journal generation overflow"))?;
+    Ok(JournalHeader {
+        format_version: FORMAT_VERSION,
+        generation,
+        compacted_through: watermark,
+        identity: header.identity.clone(),
+    })
+}
+
+fn next_sequence(last: u64) -> Result<u64, MemoryError> {
+    last.checked_add(1)
+        .ok_or_else(|| capture("journal sequence overflow"))
+}
+
+fn prepare_append(
+    inner: &JournalInner,
+    max_bytes: u64,
+    key: DirtyKey,
+) -> Result<(u64, EncodedRecord), MemoryError> {
+    let sequence = next_sequence(inner.last_sequence)?;
+    let file = inner
+        .file
+        .as_ref()
+        .ok_or_else(|| capture("journal handle is closed"))?;
+    ensure_append_fits(file, max_bytes)?;
+    Ok((sequence, encode_record(JournalRecord::new(sequence, key))))
+}
+
+fn ensure_append_fits(file: &File, max_bytes: u64) -> Result<(), MemoryError> {
+    let length = file
+        .metadata()
+        .map_err(|err| capture(format!("cannot size journal: {err}")))?
+        .len();
+    if length.saturating_add(RECORD_BYTES) > max_bytes {
+        return Err(capture(format!("journal byte cap {max_bytes} reached")));
+    }
+    Ok(())
+}
+
+fn create_journal(workspace: &Path, identity: &EpochIdentity) -> Result<(), MemoryError> {
+    let staging = workspace.join(STAGING_FILE);
+    let final_path = workspace.join(JOURNAL_FILE);
+    let header = JournalHeader {
+        format_version: FORMAT_VERSION,
+        generation: 0,
+        compacted_through: 0,
+        identity: identity.clone(),
+    };
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&staging)
+        .map_err(|err| capture(format!("cannot create journal staging file: {err}")))?;
+    write_header(&mut file, &header)?;
+    file.flush()
+        .map_err(|err| capture(format!("cannot flush journal header: {err}")))?;
+    file.sync_all()
+        .map_err(|err| capture(format!("cannot sync journal header: {err}")))?;
+    drop(file);
+    promote(&staging, &final_path)
+        .map_err(|err| capture(format!("cannot publish journal: {err}")))?;
+    durability_barrier(workspace)
+        .map_err(|err| capture(format!("cannot sync journal directory: {err}")))
+}
+
+fn validate_epoch_id(epoch_id: &str) -> Result<(), MemoryError> {
+    if epoch_id.len() != 32 || !epoch_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(capture("epoch id must be 32 hexadecimal characters"));
+    }
+    Ok(())
+}
+
+fn validate_workspace(workspace: &Path) -> Result<(), MemoryError> {
+    let metadata = std::fs::symlink_metadata(workspace)
+        .map_err(|err| capture(format!("cannot inspect journal workspace: {err}")))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(capture("journal workspace must be a real directory"));
+    }
+    Ok(())
+}
+
+fn validate_regular_file(path: &Path) -> Result<(), MemoryError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|err| capture(format!("cannot inspect journal file: {err}")))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(capture("journal path must be a regular file"));
+    }
+    Ok(())
+}
+
+fn recover_staging(workspace: &Path, final_path: &Path) -> Result<(), MemoryError> {
+    let staging = workspace.join(STAGING_FILE);
+    if !path_entry_exists(&staging)? {
+        return Ok(());
+    }
+    if path_entry_exists(final_path)? {
+        validate_regular_file(final_path)?;
+    }
+    validate_regular_file(&staging)?;
+    std::fs::remove_file(&staging).map_err(|err| {
+        capture(format!(
+            "cannot remove interrupted compaction staging file: {err}"
+        ))
+    })
+}
+
+fn path_entry_exists(path: &Path) -> Result<bool, MemoryError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(capture(format!(
+            "cannot inspect {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+fn ensure_healthy(inner: &JournalInner) -> Result<(), MemoryError> {
+    if inner.poisoned {
+        return Err(capture(
+            "journal is poisoned after a durability failure; reopen it",
+        ));
+    }
+    Ok(())
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}

--- a/crates/velesdb-memory/src/mutation/journal/format.rs
+++ b/crates/velesdb-memory/src/mutation/journal/format.rs
@@ -1,0 +1,260 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use sha2::{Digest, Sha256};
+
+use super::{capture, validate_epoch_id, EpochIdentity};
+use crate::mutation::DirtyKey;
+use crate::MemoryError;
+
+const MAGIC: &[u8; 8] = b"VDBDMJ01";
+pub(super) const FORMAT_VERSION: u32 = 1;
+pub(super) const DIGEST_BYTES: usize = 32;
+pub(super) const RECORD_BODY_BYTES: usize = 17;
+pub(crate) const RECORD_BYTES: u64 = (RECORD_BODY_BYTES + DIGEST_BYTES) as u64;
+const MAX_HEADER_BYTES: usize = 64 * 1024;
+pub(super) type EncodedRecord = [u8; RECORD_BODY_BYTES + DIGEST_BYTES];
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(super) struct JournalHeader {
+    pub(super) format_version: u32,
+    pub(super) generation: u64,
+    pub(super) compacted_through: u64,
+    pub(super) identity: EpochIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct JournalRecord {
+    pub(crate) sequence: u64,
+    pub(crate) key: DirtyKey,
+}
+
+impl JournalRecord {
+    pub(crate) fn new(sequence: u64, key: DirtyKey) -> Self {
+        Self { sequence, key }
+    }
+}
+
+pub(super) fn write_header(file: &mut File, header: &JournalHeader) -> Result<u64, MemoryError> {
+    let body = serde_json::to_vec(header)
+        .map_err(|err| capture(format!("cannot encode journal header: {err}")))?;
+    let length = u32::try_from(body.len()).map_err(|_| capture("journal header is too large"))?;
+    file.write_all(MAGIC)
+        .and_then(|()| file.write_all(&length.to_le_bytes()))
+        .and_then(|()| file.write_all(&body))
+        .and_then(|()| file.write_all(&digest(&body)))
+        .map_err(|err| capture(format!("cannot write journal header: {err}")))?;
+    Ok(12 + u64::from(length) + DIGEST_BYTES as u64)
+}
+
+pub(super) fn read_header(file: &mut File) -> Result<(JournalHeader, u64), MemoryError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|err| capture(format!("cannot seek journal header: {err}")))?;
+    let mut prefix = [0_u8; 12];
+    file.read_exact(&mut prefix)
+        .map_err(|err| capture(format!("incomplete journal header: {err}")))?;
+    if &prefix[..8] != MAGIC {
+        return Err(capture("unknown journal magic or version"));
+    }
+    let length = header_length(&prefix)?;
+    let (body, checksum) = read_header_body(file, length)?;
+    let header = decode_header(&body, &checksum)?;
+    Ok((header, 12 + length as u64 + DIGEST_BYTES as u64))
+}
+
+fn read_header_body(
+    file: &mut File,
+    length: usize,
+) -> Result<(Vec<u8>, [u8; DIGEST_BYTES]), MemoryError> {
+    let mut body = vec![0_u8; length];
+    let mut checksum = [0_u8; DIGEST_BYTES];
+    file.read_exact(&mut body)
+        .and_then(|()| file.read_exact(&mut checksum))
+        .map_err(|err| capture(format!("incomplete journal header: {err}")))?;
+    Ok((body, checksum))
+}
+
+fn decode_header(body: &[u8], checksum: &[u8; DIGEST_BYTES]) -> Result<JournalHeader, MemoryError> {
+    if digest(body) != *checksum {
+        return Err(capture("journal header checksum mismatch"));
+    }
+    let header: JournalHeader = serde_json::from_slice(body)
+        .map_err(|err| capture(format!("invalid journal header: {err}")))?;
+    validate_header(&header)?;
+    Ok(header)
+}
+
+fn header_length(prefix: &[u8; 12]) -> Result<usize, MemoryError> {
+    let length = u32::from_le_bytes(
+        prefix[8..12]
+            .try_into()
+            .map_err(|_| capture("invalid header length"))?,
+    ) as usize;
+    if length > MAX_HEADER_BYTES {
+        return Err(capture("journal header exceeds safety limit"));
+    }
+    Ok(length)
+}
+
+fn validate_header(header: &JournalHeader) -> Result<(), MemoryError> {
+    if header.format_version != FORMAT_VERSION {
+        return Err(capture(format!(
+            "unsupported journal version {}",
+            header.format_version
+        )));
+    }
+    validate_epoch_id(&header.identity.epoch_id)
+}
+
+pub(super) fn scan_records(
+    file: &mut File,
+    header: &JournalHeader,
+    start: u64,
+) -> Result<(u64, u64), MemoryError> {
+    let length = file
+        .metadata()
+        .map_err(|err| capture(format!("cannot size journal: {err}")))?
+        .len();
+    let payload = length.saturating_sub(start);
+    let complete = payload / RECORD_BYTES;
+    let tail = payload % RECORD_BYTES;
+    file.seek(SeekFrom::Start(start))
+        .map_err(|err| capture(format!("cannot seek records: {err}")))?;
+    scan_complete_records(file, header.compacted_through, start, complete, tail)
+}
+
+fn scan_complete_records(
+    file: &mut File,
+    compacted: u64,
+    start: u64,
+    complete: u64,
+    tail: u64,
+) -> Result<(u64, u64), MemoryError> {
+    let mut expected = compacted.saturating_add(1);
+    let mut bytes = [0_u8; RECORD_BODY_BYTES + DIGEST_BYTES];
+    for index in 0..complete {
+        file.read_exact(&mut bytes)
+            .map_err(|err| capture(format!("cannot read journal record: {err}")))?;
+        match decode_record(&bytes) {
+            Ok(record) if record.sequence == expected => expected = expected.saturating_add(1),
+            Ok(_) | Err(_) if index + 1 == complete && tail == 0 => {
+                return Ok((expected.saturating_sub(1), start + index * RECORD_BYTES));
+            }
+            Ok(_) | Err(_) => {
+                return Err(capture(format!(
+                    "interior corruption at journal record {}",
+                    index + 1
+                )))
+            }
+        }
+    }
+    Ok((expected.saturating_sub(1), start + complete * RECORD_BYTES))
+}
+
+pub(super) fn recover_torn_tail(file: &mut File, valid_len: u64) -> Result<(), MemoryError> {
+    let length = file
+        .metadata()
+        .map_err(|err| capture(format!("cannot size journal: {err}")))?
+        .len();
+    if length != valid_len {
+        file.set_len(valid_len)
+            .map_err(|err| capture(format!("cannot truncate torn journal tail: {err}")))?;
+        file.sync_all()
+            .map_err(|err| capture(format!("cannot sync recovered journal: {err}")))?;
+    }
+    Ok(())
+}
+
+pub(super) fn read_records(
+    file: &mut File,
+    after: u64,
+    limit: usize,
+) -> Result<Vec<JournalRecord>, MemoryError> {
+    let mut records = Vec::with_capacity(limit);
+    let mut bytes = [0_u8; RECORD_BODY_BYTES + DIGEST_BYTES];
+    while records.len() < limit {
+        match file.read_exact(&mut bytes) {
+            Ok(()) => {
+                let record = decode_record(&bytes)?;
+                if record.sequence > after {
+                    records.push(record);
+                }
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
+            Err(err) => return Err(capture(format!("cannot read journal records: {err}"))),
+        }
+    }
+    Ok(records)
+}
+
+pub(super) fn encode_record(record: JournalRecord) -> EncodedRecord {
+    let mut bytes = [0_u8; RECORD_BODY_BYTES + DIGEST_BYTES];
+    let (kind, id) = match record.key {
+        DirtyKey::Fact(id) => (1, id),
+        DirtyKey::OutgoingEdges(id) => (2, id),
+    };
+    bytes[0] = kind;
+    bytes[1..9].copy_from_slice(&record.sequence.to_le_bytes());
+    bytes[9..17].copy_from_slice(&id.to_le_bytes());
+    let checksum = digest(&bytes[..RECORD_BODY_BYTES]);
+    bytes[RECORD_BODY_BYTES..].copy_from_slice(&checksum);
+    bytes
+}
+
+pub(super) fn decode_record(bytes: &EncodedRecord) -> Result<JournalRecord, MemoryError> {
+    if digest(&bytes[..RECORD_BODY_BYTES]) != bytes[RECORD_BODY_BYTES..] {
+        return Err(capture("journal record checksum mismatch"));
+    }
+    let sequence = u64::from_le_bytes(
+        bytes[1..9]
+            .try_into()
+            .map_err(|_| capture("invalid record sequence"))?,
+    );
+    let id = u64::from_le_bytes(
+        bytes[9..17]
+            .try_into()
+            .map_err(|_| capture("invalid record id"))?,
+    );
+    let key = match bytes[0] {
+        1 => DirtyKey::Fact(id),
+        2 => DirtyKey::OutgoingEdges(id),
+        kind => return Err(capture(format!("unknown dirty-key kind {kind}"))),
+    };
+    Ok(JournalRecord::new(sequence, key))
+}
+
+fn digest(bytes: &[u8]) -> [u8; DIGEST_BYTES] {
+    Sha256::digest(bytes).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Seek, SeekFrom};
+
+    use super::{read_header, write_header, JournalHeader};
+    use crate::mutation::journal::EpochIdentity;
+
+    #[test]
+    fn future_header_version_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let identity = EpochIdentity::for_test(
+            dir.path().join("source"),
+            "sha256:source",
+            "target",
+            384,
+            dir.path().join("destination"),
+            "00112233445566778899aabbccddeeff",
+        );
+        let header = JournalHeader {
+            format_version: 2,
+            generation: 0,
+            compacted_through: 0,
+            identity,
+        };
+        let mut file = tempfile::tempfile().expect("file");
+        write_header(&mut file, &header).expect("write");
+        file.seek(SeekFrom::Start(0)).expect("seek");
+        let error = read_header(&mut file).expect_err("future version");
+        assert!(error.to_string().contains("unsupported journal version 2"));
+    }
+}

--- a/crates/velesdb-memory/src/mutation/journal/io.rs
+++ b/crates/velesdb-memory/src/mutation/journal/io.rs
@@ -1,0 +1,120 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use super::format::{
+    decode_record, read_header, write_header, EncodedRecord, JournalHeader, DIGEST_BYTES,
+    RECORD_BODY_BYTES,
+};
+use super::{capture, FaultPoint};
+use crate::MemoryError;
+
+pub(super) fn append_synced<F>(file: &mut File, record: &[u8], fault: F) -> Result<(), MemoryError>
+where
+    F: Fn(FaultPoint) -> Result<(), MemoryError>,
+{
+    write_append(file, record, &fault)?;
+    sync_append(file, &fault)
+}
+
+fn write_append<F>(file: &mut File, record: &[u8], fault: &F) -> Result<(), MemoryError>
+where
+    F: Fn(FaultPoint) -> Result<(), MemoryError>,
+{
+    fault(FaultPoint::BeforeAppend)?;
+    file.seek(SeekFrom::End(0))
+        .map_err(|err| capture(format!("cannot seek journal: {err}")))?;
+    file.write_all(record)
+        .map_err(|err| capture(format!("cannot append journal: {err}")))?;
+    fault(FaultPoint::AfterAppend)?;
+    file.flush()
+        .map_err(|err| capture(format!("cannot flush journal: {err}")))
+}
+
+fn sync_append<F>(file: &File, fault: &F) -> Result<(), MemoryError>
+where
+    F: Fn(FaultPoint) -> Result<(), MemoryError>,
+{
+    fault(FaultPoint::BeforeAppendSync)?;
+    file.sync_all()
+        .map_err(|err| capture(format!("cannot sync journal: {err}")))?;
+    fault(FaultPoint::AfterAppendSync)
+}
+
+pub(super) fn write_compacted<F>(
+    source: &Path,
+    staging: &Path,
+    header: &JournalHeader,
+    watermark: u64,
+    fault: F,
+) -> Result<u64, MemoryError>
+where
+    F: Fn(FaultPoint) -> Result<(), MemoryError>,
+{
+    let mut input = open_record_stream(source)?;
+    let mut output = create_staging(staging)?;
+    let header_bytes = write_header(&mut output, header)?;
+    copy_records_after(&mut input, &mut output, watermark)?;
+    sync_compacted(&mut output, &fault)?;
+    Ok(header_bytes)
+}
+
+fn sync_compacted<F>(output: &mut File, fault: &F) -> Result<(), MemoryError>
+where
+    F: Fn(FaultPoint) -> Result<(), MemoryError>,
+{
+    output
+        .flush()
+        .map_err(|err| capture(format!("cannot flush compacted journal: {err}")))?;
+    fault(FaultPoint::BeforeCompactionSync)?;
+    output
+        .sync_all()
+        .map_err(|err| capture(format!("cannot sync compacted journal: {err}")))?;
+    fault(FaultPoint::AfterCompactionSync)
+}
+
+fn open_record_stream(source: &Path) -> Result<File, MemoryError> {
+    let mut input =
+        File::open(source).map_err(|err| capture(format!("cannot read journal: {err}")))?;
+    let (_, header_bytes) = read_header(&mut input)?;
+    input
+        .seek(SeekFrom::Start(header_bytes))
+        .map_err(|err| capture(format!("cannot seek journal: {err}")))?;
+    Ok(input)
+}
+
+fn create_staging(path: &Path) -> Result<File, MemoryError> {
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|err| capture(format!("cannot create compaction staging file: {err}")))
+}
+
+fn copy_records_after(
+    input: &mut File,
+    output: &mut File,
+    watermark: u64,
+) -> Result<(), MemoryError> {
+    let mut bytes = [0_u8; RECORD_BODY_BYTES + DIGEST_BYTES];
+    loop {
+        match input.read_exact(&mut bytes) {
+            Ok(()) => copy_if_pending(output, &bytes, watermark)?,
+            Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+            Err(err) => return Err(capture(format!("cannot stream journal: {err}"))),
+        }
+    }
+}
+
+fn copy_if_pending(
+    output: &mut File,
+    bytes: &EncodedRecord,
+    watermark: u64,
+) -> Result<(), MemoryError> {
+    if decode_record(bytes)?.sequence <= watermark {
+        return Ok(());
+    }
+    output
+        .write_all(bytes)
+        .map_err(|err| capture(format!("cannot write compacted journal: {err}")))
+}

--- a/crates/velesdb-memory/src/mutation/journal/platform.rs
+++ b/crates/velesdb-memory/src/mutation/journal/platform.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+#[cfg(unix)]
+pub(super) fn promote(staging: &Path, final_path: &Path) -> std::io::Result<()> {
+    std::fs::rename(staging, final_path)
+}
+
+#[cfg(windows)]
+pub(super) fn promote(staging: &Path, final_path: &Path) -> std::io::Result<()> {
+    atomicwrites::replace_atomic(staging, final_path)
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(super) fn promote(_staging: &Path, _final_path: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "journal replacement unsupported",
+    ))
+}
+
+#[cfg(unix)]
+pub(super) fn durability_barrier(workspace: &Path) -> std::io::Result<()> {
+    std::fs::File::open(workspace)?.sync_all()
+}
+
+#[cfg(any(windows, not(any(unix, windows))))]
+pub(super) fn durability_barrier(_workspace: &Path) -> std::io::Result<()> {
+    Ok(())
+}

--- a/crates/velesdb-memory/src/mutation/journal_tests.rs
+++ b/crates/velesdb-memory/src/mutation/journal_tests.rs
@@ -1,0 +1,310 @@
+use std::fs::OpenOptions;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use super::journal::{
+    DirtyJournal, EpochIdentity, FaultPoint, JournalRecord, JOURNAL_FILE, RECORD_BYTES,
+};
+use super::{DirtyKey, MutationObserver};
+use crate::{HashEmbedder, MemoryService};
+
+const CAPACITY: u64 = 16 * 1024;
+
+fn epoch(root: &Path, id: &str) -> EpochIdentity {
+    EpochIdentity::for_test(
+        root.join("source"),
+        "sha256:source",
+        "target-model",
+        384,
+        root.join("destination"),
+        id,
+    )
+}
+
+#[test]
+fn append_is_durable_monotonic_and_recoverable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+    journal.before_mutation(DirtyKey::Fact(7)).expect("fact");
+    journal
+        .before_mutation(DirtyKey::OutgoingEdges(9))
+        .expect("edges");
+    drop(journal);
+
+    let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("reopen");
+    assert_eq!(reopened.last_sequence(), 2);
+    assert_eq!(
+        reopened.records_after(0, 8).expect("records"),
+        vec![
+            JournalRecord::new(1, DirtyKey::Fact(7)),
+            JournalRecord::new(2, DirtyKey::OutgoingEdges(9)),
+        ]
+    );
+}
+
+#[test]
+fn identity_mismatch_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    DirtyJournal::open(
+        dir.path(),
+        &epoch(dir.path(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        CAPACITY,
+    )
+    .expect("create");
+    let error = DirtyJournal::open(
+        dir.path(),
+        &epoch(dir.path(), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        CAPACITY,
+    )
+    .err()
+    .expect("mismatch");
+    assert!(error.to_string().contains("identity mismatch"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn preexisting_broken_symlink_is_refused_without_touching_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let target = dir.path().join("outside-target");
+    symlink(&target, dir.path().join(JOURNAL_FILE)).expect("symlink");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+
+    let error = DirtyJournal::open(dir.path(), &identity, CAPACITY)
+        .err()
+        .expect("symlink refusal");
+    assert!(error.to_string().contains("regular file"), "{error}");
+    assert!(!target.exists());
+}
+
+#[test]
+fn torn_tail_is_truncated_to_the_complete_valid_prefix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+    journal.before_mutation(DirtyKey::Fact(1)).expect("append");
+    drop(journal);
+    let path = dir.path().join(JOURNAL_FILE);
+    let valid_len = std::fs::metadata(&path).expect("metadata").len();
+    OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open append")
+        .write_all(&[0x5a; 11])
+        .expect("write tail");
+
+    let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("recover");
+    assert_eq!(reopened.last_sequence(), 1);
+    assert_eq!(std::fs::metadata(path).expect("metadata").len(), valid_len);
+}
+
+#[test]
+fn interior_corruption_fails_closed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+    for id in 1..=3 {
+        journal.before_mutation(DirtyKey::Fact(id)).expect("append");
+    }
+    let record_start = journal.header_bytes();
+    drop(journal);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(dir.path().join(JOURNAL_FILE))
+        .expect("open journal");
+    file.seek(SeekFrom::Start(record_start + 4)).expect("seek");
+    file.write_all(&[0xff]).expect("corrupt");
+    file.sync_all().expect("sync");
+
+    let error = DirtyJournal::open(dir.path(), &identity, CAPACITY)
+        .err()
+        .expect("corruption");
+    assert!(error.to_string().contains("interior corruption"), "{error}");
+}
+
+#[test]
+fn failed_sync_poisoning_prevents_a_source_write() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let journal_workspace = dir.path().join("journal");
+    std::fs::create_dir(&journal_workspace).expect("journal workspace");
+    let journal = Arc::new(
+        DirtyJournal::open(
+            &journal_workspace,
+            &epoch(dir.path(), "00112233445566778899aabbccddeeff"),
+            CAPACITY,
+        )
+        .expect("open"),
+    );
+    let service = MemoryService::open(dir.path().join("source"), HashEmbedder::new(384))
+        .expect("open source");
+    service
+        .install_mutation_observer(Some(journal.clone()))
+        .expect("install journal");
+    journal.fail_once_at(FaultPoint::BeforeAppendSync);
+
+    assert!(service.remember("must not land", &[], None).is_err());
+    assert_eq!(service.fact_count(), 0);
+    assert!(service.remember("still poisoned", &[], None).is_err());
+}
+
+#[test]
+fn crash_after_source_mutation_leaves_both_source_and_record_durable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let journal_workspace = dir.path().join("journal");
+    let source = dir.path().join("source");
+    std::fs::create_dir(&journal_workspace).expect("journal workspace");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = Arc::new(
+        DirtyJournal::open(&journal_workspace, &identity, CAPACITY).expect("open journal"),
+    );
+    let service = MemoryService::open(&source, HashEmbedder::new(384)).expect("open source");
+    service
+        .install_mutation_observer(Some(journal.clone()))
+        .expect("install journal");
+    service.remember("durable", &[], None).expect("remember");
+    drop(service);
+    drop(journal);
+
+    let recovered = DirtyJournal::open(&journal_workspace, &identity, CAPACITY).expect("recover");
+    let reopened = MemoryService::open(source, HashEmbedder::new(384)).expect("reopen source");
+    assert_eq!(recovered.last_sequence(), 1);
+    assert_eq!(reopened.fact_count(), 1);
+}
+
+#[test]
+fn every_append_boundary_fails_closed_and_recovers_a_valid_prefix() {
+    let points = [
+        FaultPoint::BeforeAppend,
+        FaultPoint::AfterAppend,
+        FaultPoint::BeforeAppendSync,
+        FaultPoint::AfterAppendSync,
+    ];
+    for (index, point) in points.into_iter().enumerate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+        let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+        journal.fail_once_at(point);
+        assert!(journal
+            .before_mutation(DirtyKey::Fact(index as u64))
+            .is_err());
+        assert!(journal.before_mutation(DirtyKey::Fact(99)).is_err());
+        drop(journal);
+
+        let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("recover");
+        assert!(reopened.last_sequence() <= 1);
+        reopened
+            .before_mutation(DirtyKey::Fact(100))
+            .expect("resume");
+    }
+}
+
+#[test]
+fn disk_cap_refuses_before_an_unjournalled_write() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let probe = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("probe");
+    let one_record_cap = probe.header_bytes() + RECORD_BYTES;
+    drop(probe);
+    let journal = DirtyJournal::open(dir.path(), &identity, one_record_cap).expect("reopen");
+    journal.before_mutation(DirtyKey::Fact(1)).expect("first");
+    let error = journal.before_mutation(DirtyKey::Fact(2)).expect_err("cap");
+    assert!(error.to_string().contains("byte cap"), "{error}");
+    assert_eq!(journal.last_sequence(), 1);
+    journal.compact_through(1).expect("compact at cap");
+    journal
+        .before_mutation(DirtyKey::Fact(2))
+        .expect("append after compaction");
+    assert_eq!(journal.last_sequence(), 2);
+}
+
+#[test]
+fn compaction_streams_unacknowledged_records_and_preserves_sequence() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+    for id in 1..=4 {
+        journal.before_mutation(DirtyKey::Fact(id)).expect("append");
+    }
+    journal.compact_through(3).expect("compact");
+    assert_eq!(journal.compacted_through(), 3);
+    assert_eq!(journal.last_sequence(), 4);
+    assert_eq!(journal.records_after(0, 8).expect("records").len(), 1);
+    journal
+        .before_mutation(DirtyKey::OutgoingEdges(5))
+        .expect("append next");
+    drop(journal);
+
+    let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("reopen");
+    assert_eq!(reopened.last_sequence(), 5);
+    assert_eq!(reopened.compacted_through(), 3);
+}
+
+#[test]
+fn interrupted_compaction_keeps_the_authoritative_generation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+    let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+    for id in 1..=3 {
+        journal.before_mutation(DirtyKey::Fact(id)).expect("append");
+    }
+    journal.fail_once_at(FaultPoint::BeforeCompactionReplace);
+    assert!(journal.compact_through(2).is_err());
+    drop(journal);
+
+    let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("recover");
+    assert_eq!(reopened.last_sequence(), 3);
+    assert_eq!(reopened.records_after(0, 8).expect("records").len(), 3);
+}
+
+#[test]
+fn every_compaction_boundary_preserves_all_unacknowledged_records() {
+    let points = [
+        FaultPoint::BeforeCompactionSync,
+        FaultPoint::AfterCompactionSync,
+        FaultPoint::BeforeCompactionReplace,
+        FaultPoint::AfterCompactionReplace,
+        FaultPoint::BeforeDirectorySync,
+        FaultPoint::AfterDirectorySync,
+    ];
+    for point in points {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let identity = epoch(dir.path(), "00112233445566778899aabbccddeeff");
+        let journal = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("open");
+        for id in 1..=3 {
+            journal.before_mutation(DirtyKey::Fact(id)).expect("append");
+        }
+        journal.fail_once_at(point);
+        assert!(journal.compact_through(2).is_err());
+        drop(journal);
+
+        let reopened = DirtyJournal::open(dir.path(), &identity, CAPACITY).expect("recover");
+        assert_eq!(reopened.last_sequence(), 3);
+        let pending = reopened.records_after(2, 8).expect("pending");
+        assert_eq!(pending, vec![JournalRecord::new(3, DirtyKey::Fact(3))]);
+    }
+}
+
+#[test]
+fn generated_epoch_ids_are_random_and_well_formed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = EpochIdentity::new(
+        dir.path().join("source"),
+        "sha256:source".to_owned(),
+        "target-model".to_owned(),
+        384,
+        dir.path().join("destination"),
+    )
+    .expect("first epoch");
+    let second = EpochIdentity::new(
+        dir.path().join("source"),
+        "sha256:source".to_owned(),
+        "target-model".to_owned(),
+        384,
+        dir.path().join("destination"),
+    )
+    .expect("second epoch");
+    assert_ne!(first, second);
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -202,10 +202,13 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
         })
     }
 
-    #[allow(dead_code)] // The durable-journal slice supplies the first production observer.
-    pub(crate) fn install_mutation_observer(&self, observer: Option<Arc<dyn MutationObserver>>) {
+    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
+    pub(crate) fn install_mutation_observer(
+        &self,
+        observer: Option<Arc<dyn MutationObserver>>,
+    ) -> Result<(), MemoryError> {
         let _generation = self.generation_gate.write();
-        self.store.set_mutation_observer(observer);
+        self.store.set_mutation_observer(observer)
     }
 }
 

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -363,9 +363,12 @@ impl NativeStore {
         })
     }
 
-    #[allow(dead_code)] // Reached by the coordinator seam introduced in the same slice.
-    pub(crate) fn set_mutation_observer(&self, observer: Option<Arc<dyn MutationObserver>>) {
-        self.capture.replace(observer);
+    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
+    pub(crate) fn set_mutation_observer(
+        &self,
+        observer: Option<Arc<dyn MutationObserver>>,
+    ) -> Result<(), MemoryError> {
+        self.capture.replace(observer)
     }
 
     fn unrelate_unobserved(&self, edge_id: u64) -> Result<bool, MemoryError> {

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -77,7 +77,9 @@ fn store() -> (tempfile::TempDir, NativeStore) {
 fn every_native_mutation_is_classified_before_the_source_write() {
     let (_dir, store) = store();
     let observer = Arc::new(RecordingObserver::default());
-    store.set_mutation_observer(Some(observer.clone()));
+    store
+        .set_mutation_observer(Some(observer.clone()))
+        .expect("install observer");
     let mut metadata = Metadata::new();
     metadata.insert("tag".to_owned(), Value::from("test"));
 
@@ -116,7 +118,9 @@ fn observer_failure_prevents_the_source_mutation() {
     let (_dir, store) = store();
     let observer = Arc::new(RecordingObserver::default());
     *observer.failure.lock() = Some("journal unavailable".to_owned());
-    store.set_mutation_observer(Some(observer));
+    store
+        .set_mutation_observer(Some(observer))
+        .expect("install observer");
 
     let error = store
         .store(7, "must not persist", &[1.0, 0.0, 0.0, 0.0])
@@ -137,7 +141,9 @@ fn exclusive_capture_activation_waits_for_the_in_flight_request() {
         released: Mutex::new(false),
         wake: Condvar::new(),
     });
-    service.install_mutation_observer(Some(blocking.clone()));
+    service
+        .install_mutation_observer(Some(blocking.clone()))
+        .expect("install observer");
 
     let writer_service = Arc::clone(&service);
     let writer = std::thread::spawn(move || writer_service.remember("first", &[], None));
@@ -150,8 +156,8 @@ fn exclusive_capture_activation_waits_for_the_in_flight_request() {
     let activation_observer = Arc::clone(&next);
     let (activated_tx, activated_rx) = mpsc::channel();
     let activation = std::thread::spawn(move || {
-        activation_service.install_mutation_observer(Some(activation_observer));
-        let _ = activated_tx.send(());
+        let result = activation_service.install_mutation_observer(Some(activation_observer));
+        let _ = activated_tx.send(result);
     });
     assert!(activated_rx
         .recv_timeout(Duration::from_millis(50))
@@ -160,10 +166,16 @@ fn exclusive_capture_activation_waits_for_the_in_flight_request() {
     *blocking.released.lock() = true;
     blocking.wake.notify_all();
     writer.join().expect("writer thread").expect("remember");
+    let error = activated_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("activation result")
+        .expect_err("second observer");
+    assert!(error.to_string().contains("already active"), "{error}");
     activation.join().expect("activation thread");
 
     let second = service.remember("second", &[], None).expect("remember");
-    assert_eq!(*next.keys.lock(), vec![DirtyKey::Fact(second)]);
+    assert!(next.keys.lock().is_empty());
+    assert_ne!(second, 0);
 }
 
 #[test]
@@ -171,7 +183,9 @@ fn service_mutation_surfaces_reach_the_native_observer() {
     let dir = tempfile::tempdir().expect("tempdir");
     let service = MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service");
     let observer = Arc::new(RecordingObserver::default());
-    service.install_mutation_observer(Some(observer.clone()));
+    service
+        .install_mutation_observer(Some(observer.clone()))
+        .expect("install observer");
     let mut metadata = Metadata::new();
     metadata.insert("kind".to_owned(), Value::from("contract"));
 
@@ -205,7 +219,9 @@ fn autograph_and_extraction_writes_are_captured() {
     let extraction_service =
         MemoryService::open(extraction_dir.path(), HashEmbedder::new(4)).expect("open service");
     let extraction_observer = Arc::new(RecordingObserver::default());
-    extraction_service.install_mutation_observer(Some(extraction_observer.clone()));
+    extraction_service
+        .install_mutation_observer(Some(extraction_observer.clone()))
+        .expect("install observer");
     extraction_service
         .remember_extracted("extracted fact", &OneEntityExtractor, None)
         .expect("remember extracted");
@@ -220,7 +236,9 @@ fn autograph_and_extraction_writes_are_captured() {
         .expect("open service")
         .with_autograph(Arc::new(OneEntityExtractor));
     let autograph_observer = Arc::new(RecordingObserver::default());
-    autograph_service.install_mutation_observer(Some(autograph_observer.clone()));
+    autograph_service
+        .install_mutation_observer(Some(autograph_observer.clone()))
+        .expect("install observer");
     autograph_service
         .remember("autograph fact", &[], None)
         .expect("remember autograph");
@@ -243,7 +261,9 @@ fn captured_link_failure_also_captures_the_rollback_delete() {
         key: DirtyKey::OutgoingEdges(source),
         seen: Mutex::new(Vec::new()),
     });
-    service.install_mutation_observer(Some(observer.clone()));
+    service
+        .install_mutation_observer(Some(observer.clone()))
+        .expect("install observer");
 
     let error = service
         .remember(
@@ -276,7 +296,9 @@ fn context_source_and_event_writes_are_captured() {
     let dir = tempfile::tempdir().expect("tempdir");
     let service = MemoryService::open(dir.path(), HashEmbedder::new(4)).expect("open service");
     let observer = Arc::new(RecordingObserver::default());
-    service.install_mutation_observer(Some(observer.clone()));
+    service
+        .install_mutation_observer(Some(observer.clone()))
+        .expect("install observer");
     let request = CompileRequest {
         query: "migration".to_owned(),
         fragments: vec![ContextFragment {


### PR DESCRIPTION
Closes #1927

## Summary
- add a versioned, checksummed dirty-set journal with immutable epoch identity
- sync journal records before source mutations and poison the observer after durability failures
- recover torn tails, reject interior corruption, enforce a byte cap, and compact through an atomic generation swap
- refuse concurrent capture epochs and unsafe journal paths

## Validation
- full pre-commit suite: 5,367 Core tests and 724 Memory tests, 0 failures
- full velesdb-memory persistence suite and Core persistence suite
- workspace/Node/Python/Core clippy gates
- wasm32 check and wasm-pack functional tests
- 485 Python policy tests
- docs/contracts/freshness/hooks, cargo-deny, publish dry-run
- complexity CC <= 8, function NLOC <= 50, file NLOC <= 500
- repository duplication 1.65% (below 2%, no increase)