### PR TITLE
feat(memory): add bounded online migration catch-up

### DIFF
--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -6,11 +6,13 @@ use parking_lot::RwLock;
 
 use crate::MemoryError;
 
+#[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
+mod catchup;
 #[allow(dead_code)] // The catch-up slice consumes the journal before the control surface ships.
 mod journal;
 
 /// Idempotent source state that a migration must re-read after a mutation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum DirtyKey {
     Fact(u64),
     OutgoingEdges(u64),
@@ -200,6 +202,9 @@ mod tests {
             .map(|(name, _)| name)
     }
 }
+
+#[cfg(all(test, feature = "persistence"))]
+mod catchup_tests;
 
 #[cfg(test)]
 mod journal_tests;

--- a/crates/velesdb-memory/src/mutation/catchup.rs
+++ b/crates/velesdb-memory/src/mutation/catchup.rs
@@ -1,0 +1,310 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use crate::embedder::Embedder;
+use crate::storage::NativeStore;
+use crate::{MemoryError, MemoryService};
+
+use super::journal::DirtyJournal;
+use super::DirtyKey;
+
+mod facts;
+
+const MAX_BATCH: usize = 4_096;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CatchUpConfig {
+    pub(crate) fact_batch: usize,
+    pub(crate) replay_batch: usize,
+    pub(crate) edge_cap: usize,
+}
+
+impl CatchUpConfig {
+    pub(crate) fn validated(self) -> Result<Self, MemoryError> {
+        let limits = [self.fact_batch, self.replay_batch, self.edge_cap];
+        if limits
+            .into_iter()
+            .any(|value| value == 0 || value > MAX_BATCH)
+        {
+            return Err(capture("online migration limits must be in 1..=4096"));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BaseCopyProgress {
+    pub(crate) facts: u64,
+    pub(crate) edge_sets: u64,
+    pub(crate) batches: u64,
+    pub(crate) start_watermark: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReplayProgress {
+    pub(crate) records: u64,
+    pub(crate) dirty_keys: u64,
+    pub(crate) acknowledged_watermark: u64,
+    pub(crate) backlog: u64,
+}
+
+pub(crate) struct OnlineCatchUp<'a, E: Embedder> {
+    source: &'a MemoryService<E, NativeStore>,
+    destination: &'a NativeStore,
+    target_embedder: &'a dyn Embedder,
+    journal: Arc<DirtyJournal>,
+    config: CatchUpConfig,
+    start_watermark: u64,
+    #[cfg(test)]
+    fault: std::sync::atomic::AtomicU8,
+}
+
+impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
+    pub(crate) fn start(
+        source: &'a MemoryService<E, NativeStore>,
+        destination: &'a NativeStore,
+        target_embedder: &'a dyn Embedder,
+        journal: Arc<DirtyJournal>,
+        config: CatchUpConfig,
+    ) -> Result<Self, MemoryError> {
+        let config = config.validated()?;
+        let start_watermark = journal.last_sequence();
+        source.install_mutation_observer(Some(journal.clone()))?;
+        Ok(Self {
+            source,
+            destination,
+            target_embedder,
+            journal,
+            config,
+            start_watermark,
+            #[cfg(test)]
+            fault: std::sync::atomic::AtomicU8::new(0),
+        })
+    }
+
+    pub(crate) fn copy_base(&self) -> Result<BaseCopyProgress, MemoryError> {
+        self.copy_base_inner(&mut |_| Ok(()))
+    }
+
+    #[cfg(test)]
+    pub(super) fn copy_base_with_page_hook<F>(
+        &self,
+        mut hook: F,
+    ) -> Result<BaseCopyProgress, MemoryError>
+    where
+        F: FnMut(u64) -> Result<(), MemoryError>,
+    {
+        self.copy_base_inner(&mut hook)
+    }
+
+    fn copy_base_inner(
+        &self,
+        hook: &mut dyn FnMut(u64) -> Result<(), MemoryError>,
+    ) -> Result<BaseCopyProgress, MemoryError> {
+        let (facts, batches) = self.copy_facts(hook)?;
+        let edge_sets = self.copy_edges()?;
+        Ok(BaseCopyProgress {
+            facts,
+            edge_sets,
+            batches,
+            start_watermark: self.start_watermark,
+        })
+    }
+
+    pub(crate) fn catch_up_batch(&self) -> Result<ReplayProgress, MemoryError> {
+        self.source.migration_exclusive(|| self.catch_up_locked())
+    }
+
+    fn catch_up_locked(&self) -> Result<ReplayProgress, MemoryError> {
+        let acknowledged = self.journal.compacted_through();
+        let records = self
+            .journal
+            .records_after(acknowledged, self.config.replay_batch)?;
+        if records.is_empty() {
+            return Ok(self.replay_progress(0, 0, acknowledged));
+        }
+        let dirty: BTreeSet<DirtyKey> = records.iter().map(|record| record.key).collect();
+        for key in &dirty {
+            self.sync_key(*key)?;
+        }
+        self.maybe_fail(FaultPoint::BeforeWatermark)?;
+        let watermark = records
+            .last()
+            .map_or(acknowledged, |record| record.sequence);
+        self.journal.compact_through(watermark)?;
+        self.maybe_fail(FaultPoint::AfterWatermark)?;
+        Ok(self.replay_progress(records.len(), dirty.len(), watermark))
+    }
+
+    pub(crate) fn finish(self) -> Result<(), MemoryError> {
+        self.source.install_mutation_observer(None)
+    }
+
+    fn copy_facts(
+        &self,
+        hook: &mut dyn FnMut(u64) -> Result<(), MemoryError>,
+    ) -> Result<(u64, u64), MemoryError> {
+        let mut cursor = None;
+        let mut facts = 0_u64;
+        let mut batches = 0_u64;
+        loop {
+            let (page, next) = self
+                .source
+                .migration_store()
+                .migration_list(cursor, self.config.fact_batch)?;
+            if page.is_empty() {
+                break;
+            }
+            facts::copy_page(self.destination, self.target_embedder, &page)?;
+            facts = facts.saturating_add(to_u64(page.len()));
+            batches = batches.saturating_add(1);
+            hook(batches)?;
+            let Some(next) = next else { break };
+            cursor = Some(next);
+        }
+        Ok((facts, batches))
+    }
+
+    fn copy_edges(&self) -> Result<u64, MemoryError> {
+        let mut cursor = None;
+        let mut edge_sets = 0_u64;
+        loop {
+            let (page, next) = self
+                .source
+                .migration_store()
+                .migration_list(cursor, self.config.fact_batch)?;
+            if page.is_empty() {
+                break;
+            }
+            for fact in page {
+                self.copy_edge_set(fact.id)?;
+                edge_sets = edge_sets.saturating_add(1);
+            }
+            let Some(next) = next else { break };
+            cursor = Some(next);
+        }
+        Ok(edge_sets)
+    }
+
+    fn sync_key(&self, key: DirtyKey) -> Result<(), MemoryError> {
+        match key {
+            DirtyKey::Fact(id) => {
+                facts::sync(
+                    self.source.migration_store(),
+                    self.destination,
+                    self.target_embedder,
+                    id,
+                )?;
+                self.maybe_fail(FaultPoint::AfterFact)
+            }
+            DirtyKey::OutgoingEdges(id) => {
+                self.sync_edges(id)?;
+                self.maybe_fail(FaultPoint::AfterEdges)
+            }
+        }
+    }
+
+    fn sync_edges(&self, from: u64) -> Result<(), MemoryError> {
+        let source = self.source.migration_store();
+        if !facts::sync(source, self.destination, self.target_embedder, from)? {
+            return Ok(());
+        }
+        self.apply_edge_set(from, false)
+    }
+
+    fn copy_edge_set(&self, from: u64) -> Result<(), MemoryError> {
+        self.apply_edge_set(from, true)
+    }
+
+    fn apply_edge_set(&self, from: u64, skip_absent_empty: bool) -> Result<(), MemoryError> {
+        let source = self.source.migration_store();
+        let edges = source.migration_live_edges(from, self.config.edge_cap)?;
+        if !self.ensure_edge_source(from, edges.is_empty(), skip_absent_empty)? {
+            return Ok(());
+        }
+        self.ensure_edge_targets(&edges)?;
+        self.destination
+            .migration_replace_edges(from, &edges, self.config.edge_cap)
+    }
+
+    fn ensure_edge_source(
+        &self,
+        from: u64,
+        edges_empty: bool,
+        skip_absent_empty: bool,
+    ) -> Result<bool, MemoryError> {
+        if self.destination.migration_contains(from)? {
+            return Ok(true);
+        }
+        if skip_absent_empty && edges_empty {
+            return Ok(false);
+        }
+        facts::sync(
+            self.source.migration_store(),
+            self.destination,
+            self.target_embedder,
+            from,
+        )
+    }
+
+    fn ensure_edge_targets(&self, edges: &[velesdb_core::GraphEdge]) -> Result<(), MemoryError> {
+        let source = self.source.migration_store();
+        for target in edges.iter().map(velesdb_core::GraphEdge::target) {
+            if !self.destination.migration_contains(target)? {
+                facts::sync(source, self.destination, self.target_embedder, target)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn replay_progress(&self, records: usize, dirty: usize, watermark: u64) -> ReplayProgress {
+        ReplayProgress {
+            records: to_u64(records),
+            dirty_keys: to_u64(dirty),
+            acknowledged_watermark: watermark,
+            backlog: self.journal.last_sequence().saturating_sub(watermark),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn fail_once_at(&self, point: FaultPoint) {
+        self.fault
+            .store(point as u8, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    #[cfg(test)]
+    fn maybe_fail(&self, point: FaultPoint) -> Result<(), MemoryError> {
+        use std::sync::atomic::Ordering;
+        if self
+            .fault
+            .compare_exchange(point as u8, 0, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            return Err(capture(format!("injected catch-up fault at {point:?}")));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
+    fn maybe_fail(&self, _point: FaultPoint) -> Result<(), MemoryError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub(super) enum FaultPoint {
+    AfterFact = 1,
+    AfterEdges = 2,
+    BeforeWatermark = 3,
+    AfterWatermark = 4,
+}
+
+fn to_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}

--- a/crates/velesdb-memory/src/mutation/catchup/facts.rs
+++ b/crates/velesdb-memory/src/mutation/catchup/facts.rs
@@ -1,0 +1,59 @@
+use serde_json::Value;
+use velesdb_core::Point;
+
+use crate::embedder::Embedder;
+use crate::migration::RawFact;
+use crate::storage::NativeStore;
+use crate::MemoryError;
+
+pub(super) fn copy_page(
+    destination: &NativeStore,
+    embedder: &dyn Embedder,
+    facts: &[RawFact],
+) -> Result<(), MemoryError> {
+    let points = facts
+        .iter()
+        .map(|fact| point_from_raw(fact, embedder))
+        .collect::<Result<Vec<_>, _>>()?;
+    destination.migration_upsert(points)
+}
+
+pub(super) fn sync(
+    source: &NativeStore,
+    destination: &NativeStore,
+    embedder: &dyn Embedder,
+    id: u64,
+) -> Result<bool, MemoryError> {
+    let Some(payload) = source.migration_payload(id)? else {
+        destination.migration_delete(id)?;
+        return Ok(false);
+    };
+    let value = Value::Object(payload.clone());
+    let content = content(&value, id)?;
+    let vector = embedder.embed(content)?;
+    destination.migration_upsert(vec![Point::new(id, vector, Some(payload.into()))])?;
+    Ok(true)
+}
+
+fn point_from_raw(fact: &RawFact, embedder: &dyn Embedder) -> Result<Point, MemoryError> {
+    let payload: Value = serde_json::from_str(&fact.payload).map_err(|error| {
+        capture(format!(
+            "fact {} carries unreadable payload: {error}",
+            fact.id
+        ))
+    })?;
+    let vector = embedder.embed(content(&payload, fact.id)?)?;
+    Ok(Point::new(fact.id, vector, Some(payload)))
+}
+
+fn content(payload: &Value, id: u64) -> Result<&str, MemoryError> {
+    payload
+        .as_object()
+        .and_then(|object| object.get("content"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| capture(format!("fact {id} has no string content")))
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}

--- a/crates/velesdb-memory/src/mutation/catchup_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use super::catchup::{CatchUpConfig, OnlineCatchUp};
+use super::journal::{DirtyJournal, EpochIdentity};
+use crate::storage::NativeStore;
+use crate::{EmbedError, Embedder, MemoryService};
+
+#[path = "catchup_tests/base_tests.rs"]
+mod base;
+#[path = "catchup_tests/faults_tests.rs"]
+mod faults;
+#[path = "catchup_tests/replay_tests.rs"]
+mod replay;
+
+pub(super) struct FixedEmbedder {
+    vector: Vec<f32>,
+}
+
+impl Embedder for FixedEmbedder {
+    fn dimension(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
+        Ok(self.vector.clone())
+    }
+}
+
+pub(super) struct TestRig {
+    pub(super) source: MemoryService<FixedEmbedder>,
+    pub(super) destination: NativeStore,
+    pub(super) target: FixedEmbedder,
+    pub(super) journal: Arc<DirtyJournal>,
+    pub(super) config: CatchUpConfig,
+    _root: tempfile::TempDir,
+}
+
+impl TestRig {
+    pub(super) fn new() -> Self {
+        let root = tempfile::tempdir().expect("root");
+        let source_path = root.path().join("source");
+        let destination_path = root.path().join("destination");
+        let source = MemoryService::open(
+            &source_path,
+            FixedEmbedder {
+                vector: vec![1.0, 2.0],
+            },
+        )
+        .expect("source");
+        let destination = NativeStore::open(&destination_path, 3).expect("destination");
+        let journal = journal(
+            &root.path().join("journal"),
+            &source_path,
+            &destination_path,
+        );
+        Self {
+            source,
+            destination,
+            target: FixedEmbedder {
+                vector: vec![7.0, 8.0, 9.0],
+            },
+            journal,
+            config: CatchUpConfig {
+                fact_batch: 8,
+                replay_batch: 8,
+                edge_cap: 8,
+            },
+            _root: root,
+        }
+    }
+
+    pub(super) fn start(&self) -> OnlineCatchUp<'_, FixedEmbedder> {
+        OnlineCatchUp::start(
+            &self.source,
+            &self.destination,
+            &self.target,
+            Arc::clone(&self.journal),
+            self.config,
+        )
+        .expect("start")
+    }
+}
+
+pub(super) fn journal(workspace: &Path, source: &Path, destination: &Path) -> Arc<DirtyJournal> {
+    std::fs::create_dir_all(workspace).expect("journal workspace");
+    let identity = EpochIdentity::for_test(
+        source.to_owned(),
+        "sha256:source",
+        "target-model",
+        3,
+        destination.to_owned(),
+        "00112233445566778899aabbccddeeff",
+    );
+    Arc::new(DirtyJournal::open(workspace, &identity, 1024 * 1024).expect("journal"))
+}

--- a/crates/velesdb-memory/src/mutation/catchup_tests/base_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests/base_tests.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+use velesdb_core::GraphEdge;
+
+use super::TestRig;
+use crate::storage::MemoryStore;
+use crate::Metadata;
+
+#[test]
+fn base_copy_reembeds_a_fact_into_the_destination() {
+    let rig = TestRig::new();
+    let id = rig.source.remember("alpha", &[], None).expect("remember");
+    let copy = rig.start();
+
+    let progress = copy.copy_base().expect("base copy");
+    let stored = rig.destination.get(id).expect("get").expect("stored");
+    assert_eq!(stored, ("alpha".to_owned(), vec![7.0, 8.0, 9.0]));
+    assert_eq!(progress.facts, 1);
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn base_copy_preserves_raw_payload_expiry_and_edge_properties() {
+    let rig = TestRig::new();
+    let mut metadata = Metadata::new();
+    metadata.insert("tenant".to_owned(), json!("acme"));
+    let from = rig
+        .source
+        .remember_with_ttl("from", &[], Some(&metadata), Some(3_600))
+        .expect("from");
+    let to = rig.source.remember("to", &[], None).expect("to");
+    let edge = edge(from, to, "owns", json!(7));
+    rig.source
+        .migration_store()
+        .migration_replace_edges(from, std::slice::from_ref(&edge), 8)
+        .expect("seed edge");
+    let source_payload = rig
+        .source
+        .migration_store()
+        .migration_payload(from)
+        .expect("source payload");
+    let copy = rig.start();
+
+    copy.copy_base().expect("base copy");
+    let destination_payload = rig
+        .destination
+        .migration_payload(from)
+        .expect("destination payload");
+    let destination_edges = rig
+        .destination
+        .migration_live_edges(from, 8)
+        .expect("destination edges");
+    assert_eq!(destination_payload, source_payload);
+    assert_eq!(destination_edges, vec![edge]);
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn degree_above_the_cap_is_refused_before_edges_are_written() {
+    let mut rig = TestRig::new();
+    let from = rig.source.remember("from", &[], None).expect("from");
+    let targets = ["one", "two", "three"]
+        .map(|fact| rig.source.remember(fact, &[], None).expect("target fact"));
+    let edges: Vec<_> = targets
+        .into_iter()
+        .enumerate()
+        .map(|(index, to)| edge(from, to, &format!("r{index}"), json!(index)))
+        .collect();
+    rig.source
+        .migration_store()
+        .migration_replace_edges(from, &edges, 8)
+        .expect("seed edges");
+    rig.config.edge_cap = 2;
+    let copy = rig.start();
+
+    let error = copy.copy_base().expect_err("degree must be refused");
+    assert!(error.to_string().contains("exceeds migration cap 2"));
+    assert!(rig
+        .destination
+        .migration_live_edges(from, 2)
+        .expect("destination edges")
+        .is_empty());
+    copy.finish().expect("finish");
+}
+
+fn edge(from: u64, to: u64, label: &str, value: serde_json::Value) -> GraphEdge {
+    let id = velesdb_core::hash_edge_id(from, to, label);
+    let mut properties = HashMap::new();
+    properties.insert("weight".to_owned(), value);
+    GraphEdge::new(id, from, to, label)
+        .expect("edge")
+        .with_properties(properties)
+}

--- a/crates/velesdb-memory/src/mutation/catchup_tests/faults_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests/faults_tests.rs
@@ -1,0 +1,169 @@
+use serde_json::json;
+
+use super::{journal, FixedEmbedder, TestRig};
+use crate::mutation::catchup::{CatchUpConfig, FaultPoint};
+use crate::storage::NativeStore;
+use crate::{MemoryService, Metadata};
+
+#[test]
+fn fact_and_pre_watermark_faults_leave_replay_unacknowledged() {
+    for point in [FaultPoint::AfterFact, FaultPoint::BeforeWatermark] {
+        assert_fact_fault_retries(point, false);
+    }
+}
+
+#[test]
+fn edge_fault_leaves_replay_unacknowledged_and_retriable() {
+    let rig = TestRig::new();
+    let from = rig.source.remember("from", &[], None).expect("from");
+    let to = rig.source.remember("to", &[], None).expect("to");
+    let copy = rig.start();
+    copy.copy_base().expect("base copy");
+    rig.source.relate(from, to, "uses").expect("edge");
+    copy.fail_once_at(FaultPoint::AfterEdges);
+
+    copy.catch_up_batch().expect_err("injected edge fault");
+    assert_eq!(rig.journal.compacted_through(), 0);
+    let retry = copy.catch_up_batch().expect("retry");
+    assert_eq!(retry.records, 1);
+    assert_eq!(retry.backlog, 0);
+    assert_eq!(
+        rig.destination
+            .migration_live_edges(from, 8)
+            .expect("destination edge"),
+        rig.source
+            .migration_store()
+            .migration_live_edges(from, 8)
+            .expect("source edge")
+    );
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn post_watermark_fault_reports_error_but_does_not_reapply_records() {
+    assert_fact_fault_retries(FaultPoint::AfterWatermark, true);
+}
+
+#[test]
+fn migration_work_limits_are_positive_and_capped() {
+    for invalid in [0, 4_097] {
+        let config = CatchUpConfig {
+            fact_batch: invalid,
+            replay_batch: 1,
+            edge_cap: 1,
+        };
+        assert!(config.validated().is_err());
+    }
+    assert!(CatchUpConfig {
+        fact_batch: 4_096,
+        replay_batch: 4_096,
+        edge_cap: 4_096,
+    }
+    .validated()
+    .is_ok());
+}
+
+#[test]
+fn reopening_after_an_unacknowledged_replay_converges_idempotently() {
+    let root = tempfile::tempdir().expect("root");
+    let source_path = root.path().join("source");
+    let destination_path = root.path().join("destination");
+    let journal_path = root.path().join("journal");
+    let source = MemoryService::open(
+        &source_path,
+        FixedEmbedder {
+            vector: vec![1.0, 2.0],
+        },
+    )
+    .expect("source");
+    let id = source.remember("alpha", &[], None).expect("alpha");
+    let destination = NativeStore::open(&destination_path, 3).expect("destination");
+    let first_journal = journal(&journal_path, &source_path, &destination_path);
+    let target = FixedEmbedder {
+        vector: vec![7.0, 8.0, 9.0],
+    };
+    let copy = crate::mutation::catchup::OnlineCatchUp::start(
+        &source,
+        &destination,
+        &target,
+        first_journal.clone(),
+        config(),
+    )
+    .expect("start");
+    copy.copy_base().expect("base copy");
+    let mut metadata = Metadata::new();
+    metadata.insert("version".to_owned(), json!(2));
+    source
+        .remember("alpha", &[], Some(&metadata))
+        .expect("overwrite");
+    copy.fail_once_at(FaultPoint::BeforeWatermark);
+    copy.catch_up_batch().expect_err("unacknowledged fault");
+    drop(copy);
+    drop(first_journal);
+    drop(destination);
+    drop(source);
+
+    let source = MemoryService::open(
+        &source_path,
+        FixedEmbedder {
+            vector: vec![1.0, 2.0],
+        },
+    )
+    .expect("reopen source");
+    let destination = NativeStore::open(&destination_path, 3).expect("reopen destination");
+    let resumed = crate::mutation::catchup::OnlineCatchUp::start(
+        &source,
+        &destination,
+        &target,
+        journal(&journal_path, &source_path, &destination_path),
+        config(),
+    )
+    .expect("resume");
+    resumed.copy_base().expect("repeat base copy");
+    assert_eq!(resumed.catch_up_batch().expect("replay").records, 1);
+    assert_eq!(
+        destination.migration_payload(id).expect("destination"),
+        source
+            .migration_store()
+            .migration_payload(id)
+            .expect("source")
+    );
+    resumed.finish().expect("finish");
+}
+
+fn assert_fact_fault_retries(point: FaultPoint, acknowledged: bool) {
+    let rig = TestRig::new();
+    let id = rig.source.remember("alpha", &[], None).expect("alpha");
+    let copy = rig.start();
+    copy.copy_base().expect("base copy");
+    let mut metadata = Metadata::new();
+    metadata.insert("version".to_owned(), json!(2));
+    rig.source
+        .remember("alpha", &[], Some(&metadata))
+        .expect("overwrite");
+    copy.fail_once_at(point);
+
+    copy.catch_up_batch().expect_err("injected fault");
+    assert_eq!(rig.journal.compacted_through() > 0, acknowledged);
+    let retry = copy.catch_up_batch().expect("retry");
+    assert_eq!(retry.records == 0, acknowledged);
+    assert_eq!(retry.backlog, 0);
+    assert_eq!(
+        rig.destination
+            .migration_payload(id)
+            .expect("destination payload"),
+        rig.source
+            .migration_store()
+            .migration_payload(id)
+            .expect("source payload")
+    );
+    copy.finish().expect("finish");
+}
+
+fn config() -> CatchUpConfig {
+    CatchUpConfig {
+        fact_batch: 8,
+        replay_batch: 8,
+        edge_cap: 8,
+    }
+}

--- a/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
@@ -1,0 +1,292 @@
+use std::collections::HashSet;
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use parking_lot::{Condvar, Mutex};
+use serde_json::{json, Value};
+
+use super::{journal, FixedEmbedder, TestRig};
+use crate::mutation::catchup::{CatchUpConfig, OnlineCatchUp};
+use crate::storage::NativeStore;
+use crate::{EmbedError, Embedder, MemoryService, Metadata};
+
+#[test]
+fn repeated_overwrites_coalesce_and_apply_the_latest_source_state() {
+    let rig = TestRig::new();
+    let id = rig.source.remember("alpha", &[], None).expect("alpha");
+    let copy = rig.start();
+    copy.copy_base().expect("base copy");
+    for version in 1..=3 {
+        let mut metadata = Metadata::new();
+        metadata.insert("version".to_owned(), json!(version));
+        rig.source
+            .remember("alpha", &[], Some(&metadata))
+            .expect("overwrite");
+    }
+
+    let progress = copy.catch_up_batch().expect("catch up");
+    assert_eq!(progress.records, 3);
+    assert_eq!(progress.dirty_keys, 1);
+    assert_eq!(progress.backlog, 0);
+    assert_eq!(
+        rig.destination
+            .migration_payload(id)
+            .expect("destination payload"),
+        rig.source
+            .migration_store()
+            .migration_payload(id)
+            .expect("source payload")
+    );
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn deletion_and_edge_replacement_converge_idempotently() {
+    let rig = TestRig::new();
+    let from = rig.source.remember("from", &[], None).expect("from");
+    let old = rig.source.remember("old", &[], None).expect("old");
+    let new = rig.source.remember("new", &[], None).expect("new");
+    let deleted = rig.source.remember("deleted", &[], None).expect("deleted");
+    rig.source.relate(from, old, "uses").expect("old edge");
+    let copy = rig.start();
+    copy.copy_base().expect("base copy");
+
+    rig.source.forget(deleted).expect("delete");
+    rig.source.unrelate(from, old, "uses").expect("unrelate");
+    rig.source.relate(from, new, "uses").expect("new edge");
+    let progress = copy.catch_up_batch().expect("catch up");
+
+    assert_eq!(progress.records, 3);
+    assert_eq!(progress.dirty_keys, 2);
+    assert!(!rig
+        .destination
+        .migration_contains(deleted)
+        .expect("deleted absent"));
+    assert_eq!(
+        rig.destination
+            .migration_live_edges(from, 8)
+            .expect("destination edges"),
+        rig.source
+            .migration_store()
+            .migration_live_edges(from, 8)
+            .expect("source edges")
+    );
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn fuzzy_cursor_plus_bounded_replay_converges_to_current_state() {
+    let mut rig = TestRig::new();
+    rig.config.fact_batch = 2;
+    rig.config.replay_batch = 2;
+    for fact in ["seed-a", "seed-b", "seed-c", "seed-d"] {
+        rig.source.remember(fact, &[], None).expect("seed");
+    }
+    let (first, cursor) = rig
+        .source
+        .migration_store()
+        .migration_list(None, 2)
+        .expect("first page");
+    let cursor = cursor.expect("cursor");
+    let existing: HashSet<u64> = live_ids(&rig.source).into_iter().collect();
+    let lower = find_content(|id| id < cursor && !existing.contains(&id));
+    let higher = find_content(|id| id > cursor && !existing.contains(&id));
+    let deleted = first[0].id;
+    let overwritten = first[1].id;
+    let overwritten_content = content_of(&rig, overwritten);
+    let mut lower_id = 0;
+    let copy = rig.start();
+
+    copy.copy_base_with_page_hook(|page| {
+        if page != 1 {
+            return Ok(());
+        }
+        lower_id = rig.source.remember(&lower, &[], None)?;
+        rig.source.forget(deleted)?;
+        let mut metadata = Metadata::new();
+        metadata.insert("version".to_owned(), json!(2));
+        rig.source
+            .remember(&overwritten_content, &[], Some(&metadata))?;
+        let higher_id = rig.source.remember(&higher, &[], None)?;
+        rig.source.relate(overwritten, higher_id, "references")?;
+        Ok(())
+    })
+    .expect("fuzzy base copy");
+    assert!(!rig
+        .destination
+        .migration_contains(lower_id)
+        .expect("lower not base-copied"));
+    assert!(rig
+        .destination
+        .migration_contains(deleted)
+        .expect("deleted still present before replay"));
+
+    while copy.catch_up_batch().expect("catch-up batch").backlog != 0 {}
+    assert_converged(&rig);
+    copy.finish().expect("finish");
+}
+
+#[test]
+fn replay_waits_for_an_in_flight_mutation_before_acknowledging_it() {
+    let root = tempfile::tempdir().expect("root");
+    let source_path = root.path().join("source");
+    let destination_path = root.path().join("destination");
+    let gate = Arc::new((Mutex::new(false), Condvar::new()));
+    let entered = Arc::new(Mutex::new(None));
+    let source = Arc::new(
+        MemoryService::open(
+            &source_path,
+            BlockingEmbedder {
+                gate: Arc::clone(&gate),
+                entered: Arc::clone(&entered),
+            },
+        )
+        .expect("source"),
+    );
+    let id = source.remember("alpha", &[], None).expect("seed");
+    let destination = NativeStore::open(&destination_path, 3).expect("destination");
+    let journal = journal(
+        &root.path().join("journal"),
+        &source_path,
+        &destination_path,
+    );
+    let target = FixedEmbedder {
+        vector: vec![7.0, 8.0, 9.0],
+    };
+    let copy = OnlineCatchUp::start(
+        source.as_ref(),
+        &destination,
+        &target,
+        journal,
+        CatchUpConfig {
+            fact_batch: 8,
+            replay_batch: 8,
+            edge_cap: 8,
+        },
+    )
+    .expect("start");
+    copy.copy_base().expect("base copy");
+    let (entered_tx, entered_rx) = mpsc::channel();
+    *entered.lock() = Some(entered_tx);
+    *gate.0.lock() = true;
+    let mut metadata = Metadata::new();
+    metadata.insert("version".to_owned(), json!(2));
+
+    let writer_source = Arc::clone(&source);
+    let writer = std::thread::spawn(move || writer_source.remember("alpha", &[], Some(&metadata)));
+    entered_rx.recv().expect("mutation entered embedder");
+    let release_gate = Arc::clone(&gate);
+    let releaser = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(50));
+        *release_gate.0.lock() = false;
+        release_gate.1.notify_all();
+    });
+
+    let progress = copy.catch_up_batch().expect("replay");
+    writer.join().expect("writer thread").expect("overwrite");
+    releaser.join().expect("releaser thread");
+
+    assert_eq!(progress.records, 1);
+    assert_eq!(progress.backlog, 0);
+    assert_eq!(
+        destination.migration_payload(id).expect("destination"),
+        source
+            .migration_store()
+            .migration_payload(id)
+            .expect("source")
+    );
+    copy.finish().expect("finish");
+}
+
+fn live_ids(source: &crate::MemoryService<super::FixedEmbedder>) -> Vec<u64> {
+    let mut cursor = None;
+    let mut ids = Vec::new();
+    loop {
+        let (page, next) = source
+            .migration_store()
+            .migration_list(cursor, 32)
+            .expect("list");
+        ids.extend(page.into_iter().map(|fact| fact.id));
+        let Some(next) = next else { break };
+        cursor = Some(next);
+    }
+    ids
+}
+
+fn assert_converged(rig: &TestRig) {
+    let source_ids = live_ids(&rig.source);
+    let destination_ids = list_store_ids(&rig.destination);
+    assert_eq!(destination_ids, source_ids);
+    for id in source_ids {
+        assert_eq!(
+            rig.destination.migration_payload(id).expect("destination"),
+            rig.source
+                .migration_store()
+                .migration_payload(id)
+                .expect("source")
+        );
+        assert_eq!(
+            rig.destination.migration_live_edges(id, 8).expect("edges"),
+            rig.source
+                .migration_store()
+                .migration_live_edges(id, 8)
+                .expect("source edges")
+        );
+    }
+}
+
+fn list_store_ids(store: &crate::storage::NativeStore) -> Vec<u64> {
+    let mut cursor = None;
+    let mut ids = Vec::new();
+    loop {
+        let (page, next) = store.migration_list(cursor, 32).expect("list store");
+        ids.extend(page.into_iter().map(|fact| fact.id));
+        let Some(next) = next else { break };
+        cursor = Some(next);
+    }
+    ids
+}
+
+fn find_content(predicate: impl Fn(u64) -> bool) -> String {
+    (0..100_000)
+        .map(|index| format!("candidate-{index}"))
+        .find(|content| predicate(crate::id::stable_id(content)))
+        .expect("candidate")
+}
+
+fn content_of(rig: &TestRig, id: u64) -> String {
+    rig.source
+        .migration_store()
+        .migration_payload(id)
+        .expect("payload")
+        .and_then(|payload| payload.get("content").cloned())
+        .and_then(|value| match value {
+            Value::String(content) => Some(content),
+            _ => None,
+        })
+        .expect("content")
+}
+
+struct BlockingEmbedder {
+    gate: Arc<(Mutex<bool>, Condvar)>,
+    entered: Arc<Mutex<Option<mpsc::Sender<()>>>>,
+}
+
+impl Embedder for BlockingEmbedder {
+    fn dimension(&self) -> usize {
+        2
+    }
+
+    fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
+        let mut blocked = self.gate.0.lock();
+        if *blocked {
+            if let Some(entered) = self.entered.lock().take() {
+                let _ = entered.send(());
+            }
+            while *blocked {
+                self.gate.1.wait(&mut blocked);
+            }
+        }
+        Ok(vec![1.0, 2.0])
+    }
+}

--- a/crates/velesdb-memory/src/online_migration.rs
+++ b/crates/velesdb-memory/src/online_migration.rs
@@ -1,0 +1,17 @@
+use crate::embedder::Embedder;
+use crate::storage::NativeStore;
+use crate::MemoryService;
+
+impl<E: Embedder> MemoryService<E, NativeStore> {
+    pub(crate) fn migration_store(&self) -> &NativeStore {
+        &self.store
+    }
+
+    pub(crate) fn migration_exclusive<T>(
+        &self,
+        run: impl FnOnce() -> Result<T, crate::MemoryError>,
+    ) -> Result<T, crate::MemoryError> {
+        let _generation = self.generation_gate.write();
+        run()
+    }
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -37,6 +37,10 @@ use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore, AUTO_DAT
 #[path = "fused_recall.rs"]
 mod fused_recall;
 
+#[cfg(feature = "persistence")]
+#[path = "online_migration.rs"]
+mod online_migration;
+
 /// [`MemoryService::feedback`] and the recall re-ranking it drives (RL Memory).
 /// A child module of `service`, like [`fused_recall`], so it uses
 /// `MemoryService`'s private `store` directly. Gated on `persistence`: it

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -28,6 +28,9 @@ use crate::model::{BoundedMemoryEdges, ColumnFilter, MemoryEdge, Recollection};
 use crate::mutation::{DirtyKey, MutationCapture, MutationObserver};
 use crate::service::Metadata;
 
+#[cfg(feature = "persistence")]
+mod migration;
+
 /// The storage primitives [`crate::service::MemoryService`] needs: write,
 /// vector search, graph edges, and by-id lookup. A backend that implements
 /// this trait can run the full wedge (`remember`/`recall`/`recall_fused`/

--- a/crates/velesdb-memory/src/storage/migration.rs
+++ b/crates/velesdb-memory/src/storage/migration.rs
@@ -1,0 +1,138 @@
+use velesdb_core::{AnyCollection, GraphEdge, Point};
+
+use super::NativeStore;
+use crate::migration::RawFact;
+use crate::MemoryError;
+
+impl NativeStore {
+    pub(crate) fn migration_list(
+        &self,
+        cursor: Option<u64>,
+        limit: usize,
+    ) -> Result<(Vec<RawFact>, Option<u64>), MemoryError> {
+        crate::migration::scroll_page(&self.db, self.collection_name(), cursor, limit)
+    }
+
+    pub(crate) fn migration_payload(
+        &self,
+        id: u64,
+    ) -> Result<Option<crate::Metadata>, MemoryError> {
+        self.memory
+            .semantic()
+            .get_metadata(id)
+            .map_err(MemoryError::from)
+    }
+
+    pub(crate) fn migration_contains(&self, id: u64) -> Result<bool, MemoryError> {
+        Ok(self
+            .migration_collection()?
+            .get(&[id])
+            .into_iter()
+            .next()
+            .flatten()
+            .is_some())
+    }
+
+    pub(crate) fn migration_upsert(&self, points: Vec<Point>) -> Result<(), MemoryError> {
+        if points.is_empty() {
+            return Ok(());
+        }
+        self.migration_collection()?.upsert(points)?;
+        Ok(())
+    }
+
+    pub(crate) fn migration_delete(&self, id: u64) -> Result<(), MemoryError> {
+        let collection = self.migration_collection()?;
+        let AnyCollection::Vector(collection) = collection else {
+            return Err(capture("semantic memory is not a vector collection"));
+        };
+        collection.delete(&[id])?;
+        Ok(())
+    }
+
+    pub(crate) fn migration_live_edges(
+        &self,
+        from: u64,
+        cap: usize,
+    ) -> Result<Vec<GraphEdge>, MemoryError> {
+        let bounded = self.memory.semantic().relations_bounded(from, cap)?;
+        if bounded.truncated {
+            return Err(degree_error(from, cap));
+        }
+        validate_edges(from, &bounded.edges)?;
+        Ok(bounded.edges)
+    }
+
+    pub(crate) fn migration_replace_edges(
+        &self,
+        from: u64,
+        edges: &[GraphEdge],
+        cap: usize,
+    ) -> Result<(), MemoryError> {
+        validate_edges(from, edges)?;
+        let current = self.current_edges_bounded(from, cap)?;
+        self.remove_edges(current)?;
+        self.add_edges(edges)
+    }
+
+    fn remove_edges(&self, edges: Vec<GraphEdge>) -> Result<(), MemoryError> {
+        for edge in edges {
+            if !self.memory.semantic().unrelate(edge.id())? {
+                return Err(capture(format!(
+                    "could not durably remove edge {}",
+                    edge.id()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn add_edges(&self, edges: &[GraphEdge]) -> Result<(), MemoryError> {
+        let collection = self.migration_collection()?;
+        for edge in edges {
+            collection.add_edge(edge.clone())?;
+        }
+        Ok(())
+    }
+
+    fn current_edges_bounded(&self, from: u64, cap: usize) -> Result<Vec<GraphEdge>, MemoryError> {
+        let bounded = self.memory.semantic().relations_bounded(from, cap)?;
+        if bounded.truncated {
+            return Err(degree_error(from, cap));
+        }
+        Ok(self.migration_collection()?.get_outgoing_edges(from))
+    }
+
+    fn migration_collection(&self) -> Result<AnyCollection, MemoryError> {
+        self.db
+            .get_any_collection(self.collection_name())
+            .ok_or_else(|| capture("semantic memory collection is absent"))
+    }
+
+    fn collection_name(&self) -> &str {
+        self.memory.semantic().collection_name()
+    }
+}
+
+fn validate_edges(from: u64, edges: &[GraphEdge]) -> Result<(), MemoryError> {
+    for edge in edges {
+        let derived = velesdb_core::hash_edge_id(edge.source(), edge.target(), edge.label());
+        if edge.source() != from || edge.id() != derived {
+            return Err(capture(format!(
+                "edge {} is not a derived outgoing edge of {from}",
+                edge.id()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn degree_error(from: u64, cap: usize) -> MemoryError {
+    capture(format!(
+        "outgoing degree of {from} exceeds migration cap {cap}"
+    ))
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}


### PR DESCRIPTION
## Summary
- add fuzzy-cursor base copy with target-side re-embedding
- capture and coalesce concurrent fact and graph mutations in bounded replay batches
- preserve raw payloads, absolute expiry, and graph edge properties while refusing over-cap degree
- acknowledge journal records only after durable destination application

## Validation
- full pre-commit gate passed
- 12 migration catch-up tests passed
- 727 velesdb-memory unit tests passed (9 ignored, 0 failed)
- clippy pedantic, no-default-features, complexity, duplication, unwrap, unsafe, TODO and attribution guards passed

Closes #1929