### PR TITLE
feat(memory): add migration convergence controller

### DIFF
--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -8,8 +8,13 @@ use crate::MemoryError;
 
 #[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
 mod catchup;
+#[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
+mod controller;
 #[allow(dead_code)] // The catch-up slice consumes the journal before the control surface ships.
 mod journal;
+
+#[cfg(test)]
+mod controller_tests;
 
 /// Idempotent source state that a migration must re-read after a mutation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/velesdb-memory/src/mutation/catchup.rs
+++ b/crates/velesdb-memory/src/mutation/catchup.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use crate::embedder::Embedder;
 use crate::storage::NativeStore;
 use crate::{MemoryError, MemoryService};
 
-use super::journal::DirtyJournal;
+use super::journal::{DirtyJournal, RECORD_BYTES};
 use super::DirtyKey;
 
 mod facts;
@@ -44,8 +45,14 @@ pub(crate) struct BaseCopyProgress {
 pub(crate) struct ReplayProgress {
     pub(crate) records: u64,
     pub(crate) dirty_keys: u64,
-    pub(crate) acknowledged_watermark: u64,
+    pub(crate) distinct_dirty_facts: u64,
+    pub(crate) distinct_edge_sources: u64,
+    pub(crate) input_watermark: u64,
+    pub(crate) output_watermark: u64,
     pub(crate) backlog: u64,
+    pub(crate) pending_journal_bytes: u64,
+    pub(crate) elapsed: Duration,
+    pub(crate) largest_apply_latency: Duration,
 }
 
 pub(crate) struct OnlineCatchUp<'a, E: Embedder> {
@@ -116,16 +123,28 @@ impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
     }
 
     fn catch_up_locked(&self) -> Result<ReplayProgress, MemoryError> {
+        let started = Instant::now();
+        let input_watermark = self.journal.last_sequence();
         let acknowledged = self.journal.compacted_through();
         let records = self
             .journal
             .records_after(acknowledged, self.config.replay_batch)?;
         if records.is_empty() {
-            return Ok(self.replay_progress(0, 0, acknowledged));
+            return Ok(Self::replay_progress(
+                0,
+                DirtyCounts::default(),
+                input_watermark,
+                acknowledged,
+                started.elapsed(),
+                Duration::ZERO,
+            ));
         }
         let dirty: BTreeSet<DirtyKey> = records.iter().map(|record| record.key).collect();
+        let mut largest_apply_latency = Duration::ZERO;
         for key in &dirty {
+            let apply_started = Instant::now();
             self.sync_key(*key)?;
+            largest_apply_latency = largest_apply_latency.max(apply_started.elapsed());
         }
         self.maybe_fail(FaultPoint::BeforeWatermark)?;
         let watermark = records
@@ -133,7 +152,14 @@ impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
             .map_or(acknowledged, |record| record.sequence);
         self.journal.compact_through(watermark)?;
         self.maybe_fail(FaultPoint::AfterWatermark)?;
-        Ok(self.replay_progress(records.len(), dirty.len(), watermark))
+        Ok(Self::replay_progress(
+            records.len(),
+            DirtyCounts::from_keys(&dirty),
+            input_watermark,
+            watermark,
+            started.elapsed(),
+            largest_apply_latency,
+        ))
     }
 
     pub(crate) fn finish(self) -> Result<(), MemoryError> {
@@ -257,12 +283,26 @@ impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
         Ok(())
     }
 
-    fn replay_progress(&self, records: usize, dirty: usize, watermark: u64) -> ReplayProgress {
+    fn replay_progress(
+        records: usize,
+        dirty: DirtyCounts,
+        input_watermark: u64,
+        output_watermark: u64,
+        elapsed: Duration,
+        largest_apply_latency: Duration,
+    ) -> ReplayProgress {
+        let backlog = input_watermark.saturating_sub(output_watermark);
         ReplayProgress {
             records: to_u64(records),
-            dirty_keys: to_u64(dirty),
-            acknowledged_watermark: watermark,
-            backlog: self.journal.last_sequence().saturating_sub(watermark),
+            dirty_keys: dirty.facts.saturating_add(dirty.edge_sources),
+            distinct_dirty_facts: dirty.facts,
+            distinct_edge_sources: dirty.edge_sources,
+            input_watermark,
+            output_watermark,
+            backlog,
+            pending_journal_bytes: backlog.saturating_mul(RECORD_BYTES),
+            elapsed,
+            largest_apply_latency,
         }
     }
 
@@ -289,6 +329,26 @@ impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
     #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
     fn maybe_fail(&self, _point: FaultPoint) -> Result<(), MemoryError> {
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct DirtyCounts {
+    facts: u64,
+    edge_sources: u64,
+}
+
+impl DirtyCounts {
+    fn from_keys(keys: &BTreeSet<DirtyKey>) -> Self {
+        keys.iter().fold(Self::default(), |mut counts, key| {
+            match key {
+                DirtyKey::Fact(_) => counts.facts = counts.facts.saturating_add(1),
+                DirtyKey::OutgoingEdges(_) => {
+                    counts.edge_sources = counts.edge_sources.saturating_add(1);
+                }
+            }
+            counts
+        })
     }
 }
 

--- a/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
@@ -7,6 +7,8 @@ use serde_json::{json, Value};
 
 use super::{journal, FixedEmbedder, TestRig};
 use crate::mutation::catchup::{CatchUpConfig, OnlineCatchUp};
+use crate::mutation::controller::ConvergenceSample;
+use crate::mutation::journal::RECORD_BYTES;
 use crate::storage::NativeStore;
 use crate::{EmbedError, Embedder, MemoryService, Metadata};
 
@@ -27,7 +29,16 @@ fn repeated_overwrites_coalesce_and_apply_the_latest_source_state() {
     let progress = copy.catch_up_batch().expect("catch up");
     assert_eq!(progress.records, 3);
     assert_eq!(progress.dirty_keys, 1);
+    assert_eq!(progress.distinct_dirty_facts, 1);
+    assert_eq!(progress.distinct_edge_sources, 0);
+    assert_eq!(progress.input_watermark, 3);
+    assert_eq!(progress.output_watermark, 3);
     assert_eq!(progress.backlog, 0);
+    assert_eq!(progress.pending_journal_bytes, 0);
+    assert!(progress.elapsed >= progress.largest_apply_latency);
+    let sample = ConvergenceSample::from_replay(Duration::from_secs(1), progress);
+    assert_eq!(sample.input_watermark, progress.input_watermark);
+    assert_eq!(sample.output_watermark, progress.output_watermark);
     assert_eq!(
         rig.destination
             .migration_payload(id)
@@ -58,6 +69,8 @@ fn deletion_and_edge_replacement_converge_idempotently() {
 
     assert_eq!(progress.records, 3);
     assert_eq!(progress.dirty_keys, 2);
+    assert_eq!(progress.distinct_dirty_facts, 1);
+    assert_eq!(progress.distinct_edge_sources, 1);
     assert!(!rig
         .destination
         .migration_contains(deleted)
@@ -121,6 +134,12 @@ fn fuzzy_cursor_plus_bounded_replay_converges_to_current_state() {
         .migration_contains(deleted)
         .expect("deleted still present before replay"));
 
+    let first_replay = copy.catch_up_batch().expect("first catch-up batch");
+    assert!(first_replay.backlog > 0);
+    assert_eq!(
+        first_replay.pending_journal_bytes,
+        first_replay.backlog * RECORD_BYTES
+    );
     while copy.catch_up_batch().expect("catch-up batch").backlog != 0 {}
     assert_converged(&rig);
     copy.finish().expect("finish");

--- a/crates/velesdb-memory/src/mutation/controller.rs
+++ b/crates/velesdb-memory/src/mutation/controller.rs
@@ -1,0 +1,435 @@
+use std::time::Duration;
+
+use crate::MemoryError;
+
+use super::catchup::ReplayProgress;
+
+mod state;
+
+use state::{ControllerState, StateStore};
+
+const MAX_WINDOW: usize = 64;
+const MAX_BUDGET: Duration = Duration::from_secs(24 * 60 * 60);
+const RESUME_CATCH_UP: &str = "reopen source and resume catch-up";
+const RECOVER_CUTOVER: &str = "complete or recover cutover before serving traffic";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ControllerConfig {
+    pub(crate) observation_window: usize,
+    pub(crate) pause_budget: Duration,
+    pub(crate) verification_reserve: Duration,
+}
+
+impl ControllerConfig {
+    fn validate(self) -> Result<Self, MemoryError> {
+        if !(2..=MAX_WINDOW).contains(&self.observation_window) {
+            return Err(capture("controller observation window must be in 2..=64"));
+        }
+        if self.pause_budget.is_zero() || self.pause_budget > MAX_BUDGET {
+            return Err(capture("controller pause budget must be in 1ns..=24h"));
+        }
+        if self.verification_reserve > self.pause_budget {
+            return Err(capture("verification reserve exceeds pause budget"));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ConvergenceSample {
+    pub(crate) observed_at: Duration,
+    pub(crate) input_watermark: u64,
+    pub(crate) output_watermark: u64,
+    pub(crate) distinct_dirty_facts: u64,
+    pub(crate) distinct_edge_sources: u64,
+    pub(crate) pending_journal_bytes: u64,
+    pub(crate) replay_elapsed: Duration,
+    pub(crate) largest_apply_latency: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConvergenceMetrics {
+    pub(crate) input_watermark: u64,
+    pub(crate) output_watermark: u64,
+    pub(crate) backlog_records: u64,
+    pub(crate) backlog_grew: bool,
+    pub(crate) distinct_dirty_facts: u64,
+    pub(crate) distinct_edge_sources: u64,
+    pub(crate) pending_journal_bytes: u64,
+    pub(crate) arrival_rate: MeasuredRate,
+    pub(crate) replay_rate: MeasuredRate,
+    pub(crate) window_elapsed: Duration,
+    pub(crate) replay_elapsed: Duration,
+    pub(crate) largest_apply_latency: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MeasuredRate {
+    pub(crate) records: u64,
+    pub(crate) elapsed: Duration,
+}
+
+impl ConvergenceSample {
+    pub(crate) fn from_replay(observed_at: Duration, progress: ReplayProgress) -> Self {
+        Self {
+            observed_at,
+            input_watermark: progress.input_watermark,
+            output_watermark: progress.output_watermark,
+            distinct_dirty_facts: progress.distinct_dirty_facts,
+            distinct_edge_sources: progress.distinct_edge_sources,
+            pending_journal_bytes: progress.pending_journal_bytes,
+            replay_elapsed: progress.elapsed,
+            largest_apply_latency: progress.largest_apply_latency,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum ConvergenceVerdict {
+    CatchingUp,
+    CutoverReady,
+    NonConverging,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ConvergenceObservation {
+    pub(crate) metrics: ConvergenceMetrics,
+    pub(crate) estimated_pause: Option<Duration>,
+    pub(crate) verdict: ConvergenceVerdict,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) enum ControllerPhase {
+    CatchingUp,
+    CutoverReady,
+    NonConverging,
+    Quiescing { deadline: Duration },
+    Activated,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CancellationPermit {
+    epoch_id: String,
+}
+
+impl CancellationPermit {
+    pub(crate) fn epoch_id(&self) -> &str {
+        &self.epoch_id
+    }
+}
+
+pub(crate) struct ConvergenceController {
+    config: ControllerConfig,
+    store: StateStore,
+    state: ControllerState,
+}
+
+impl ConvergenceController {
+    pub(crate) fn open(
+        workspace: &std::path::Path,
+        epoch_id: &str,
+        config: ControllerConfig,
+    ) -> Result<Self, MemoryError> {
+        let config = config.validate()?;
+        let (store, mut state, resumed) = StateStore::open(workspace, epoch_id, config)?;
+        if resumed && prepare_resumed_state(&mut state) {
+            store.save(&state)?;
+        }
+        Ok(Self {
+            config,
+            store,
+            state,
+        })
+    }
+
+    pub(crate) fn observe(
+        &mut self,
+        sample: ConvergenceSample,
+    ) -> Result<ConvergenceObservation, MemoryError> {
+        ensure_observable(self.state.phase)?;
+        validate_sample(self.state.samples.last(), &sample)?;
+        let mut next = self.state.clone();
+        next.samples.push(sample);
+        if next.samples.len() > self.config.observation_window {
+            next.samples.remove(0);
+        }
+        let observation = assess(&next.samples, self.config);
+        next.phase = phase_for(observation.verdict);
+        next.last_observation = Some(sample);
+        next.last_verdict = Some(observation.verdict);
+        next.recovery_action = None;
+        self.replace_state(next)?;
+        Ok(observation)
+    }
+
+    pub(crate) fn begin_quiescing(&mut self, now: Duration) -> Result<(), MemoryError> {
+        if self.state.phase != ControllerPhase::CutoverReady {
+            return Err(capture("cutover is not ready for quiescing"));
+        }
+        ensure_clock_after_sample(&self.state, now)?;
+        let deadline = now
+            .checked_add(self.config.pause_budget)
+            .ok_or_else(|| capture("cutover deadline overflow"))?;
+        let mut next = self.state.clone();
+        next.phase = ControllerPhase::Quiescing { deadline };
+        self.replace_state(next)
+    }
+
+    pub(crate) fn activate(&mut self, now: Duration) -> Result<(), MemoryError> {
+        if self.state.recovery_action.as_deref() == Some(RECOVER_CUTOVER) {
+            return Err(capture("cutover recovery is required after restart"));
+        }
+        let ControllerPhase::Quiescing { deadline } = self.state.phase else {
+            return Err(capture("migration is not quiescing"));
+        };
+        ensure_activation_time(now, deadline, self.config.pause_budget)?;
+        if now > deadline {
+            let mut next = self.state.clone();
+            next.phase = ControllerPhase::CatchingUp;
+            next.recovery_action = Some(RESUME_CATCH_UP.to_owned());
+            self.replace_state(next)?;
+            return Err(capture("cutover deadline expired"));
+        }
+        let mut next = self.state.clone();
+        next.phase = ControllerPhase::Activated;
+        next.recovery_action = None;
+        self.replace_state(next)
+    }
+
+    pub(crate) fn cancel(
+        &mut self,
+        source_authoritative: bool,
+        epoch_id: &str,
+    ) -> Result<CancellationPermit, MemoryError> {
+        if epoch_id != self.state.epoch_id {
+            return Err(capture("controller epoch ownership mismatch"));
+        }
+        if matches!(
+            self.state.phase,
+            ControllerPhase::Quiescing { .. } | ControllerPhase::Activated
+        ) {
+            let mut next = self.state.clone();
+            next.recovery_action = Some(RECOVER_CUTOVER.to_owned());
+            self.replace_state(next)?;
+            return Err(capture("cutover recovery is required; rollback is unsafe"));
+        }
+        if !source_authoritative {
+            return Err(capture("source is not authoritative; cancellation refused"));
+        }
+        let mut next = self.state.clone();
+        next.phase = ControllerPhase::Cancelled;
+        next.recovery_action = None;
+        self.replace_state(next)?;
+        Ok(CancellationPermit {
+            epoch_id: epoch_id.to_owned(),
+        })
+    }
+
+    pub(crate) fn phase(&self) -> ControllerPhase {
+        self.state.phase
+    }
+
+    pub(crate) fn recovery_action(&self) -> Option<&str> {
+        self.state.recovery_action.as_deref()
+    }
+
+    fn replace_state(&mut self, next: ControllerState) -> Result<(), MemoryError> {
+        self.store.save(&next)?;
+        self.state = next;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn retained_samples(&self) -> usize {
+        self.state.samples.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn last_observation(&self) -> Option<ConvergenceSample> {
+        self.state.last_observation
+    }
+}
+
+fn prepare_resumed_state(state: &mut ControllerState) -> bool {
+    match state.phase {
+        ControllerPhase::CatchingUp
+        | ControllerPhase::CutoverReady
+        | ControllerPhase::NonConverging => {
+            state.samples.clear();
+            state.phase = ControllerPhase::CatchingUp;
+            state.recovery_action = Some(RESUME_CATCH_UP.to_owned());
+            true
+        }
+        ControllerPhase::Quiescing { .. } | ControllerPhase::Activated => {
+            state.recovery_action = Some(RECOVER_CUTOVER.to_owned());
+            true
+        }
+        ControllerPhase::Cancelled => false,
+    }
+}
+
+fn validate_sample(
+    previous: Option<&ConvergenceSample>,
+    sample: &ConvergenceSample,
+) -> Result<(), MemoryError> {
+    if sample.output_watermark > sample.input_watermark {
+        return Err(capture("output watermark exceeds input watermark"));
+    }
+    if sample.largest_apply_latency > sample.replay_elapsed {
+        return Err(capture("largest apply latency exceeds replay elapsed time"));
+    }
+    if let Some(previous) = previous {
+        if sample.observed_at <= previous.observed_at {
+            return Err(capture("controller observations must use monotonic time"));
+        }
+        if sample.input_watermark < previous.input_watermark
+            || sample.output_watermark < previous.output_watermark
+        {
+            return Err(capture("controller watermarks must be monotonic"));
+        }
+    }
+    Ok(())
+}
+
+fn assess(samples: &[ConvergenceSample], config: ControllerConfig) -> ConvergenceObservation {
+    let metrics = metrics(samples);
+    if samples.len() < config.observation_window {
+        return observation(metrics, None, ConvergenceVerdict::CatchingUp);
+    }
+    let estimate = pause_estimate(metrics, config.verification_reserve);
+    let verdict = verdict(metrics, estimate, config.pause_budget);
+    observation(metrics, estimate, verdict)
+}
+
+fn metrics(samples: &[ConvergenceSample]) -> ConvergenceMetrics {
+    let first = &samples[0];
+    let last = &samples[samples.len() - 1];
+    ConvergenceMetrics {
+        input_watermark: last.input_watermark,
+        output_watermark: last.output_watermark,
+        backlog_records: last.input_watermark.saturating_sub(last.output_watermark),
+        backlog_grew: last.input_watermark.saturating_sub(last.output_watermark)
+            > first.input_watermark.saturating_sub(first.output_watermark),
+        distinct_dirty_facts: last.distinct_dirty_facts,
+        distinct_edge_sources: last.distinct_edge_sources,
+        pending_journal_bytes: last.pending_journal_bytes,
+        arrival_rate: MeasuredRate {
+            records: last.input_watermark.saturating_sub(first.input_watermark),
+            elapsed: last.observed_at.saturating_sub(first.observed_at),
+        },
+        replay_rate: MeasuredRate {
+            records: last.output_watermark.saturating_sub(first.output_watermark),
+            elapsed: last.observed_at.saturating_sub(first.observed_at),
+        },
+        window_elapsed: last.observed_at.saturating_sub(first.observed_at),
+        replay_elapsed: last.replay_elapsed,
+        largest_apply_latency: samples
+            .iter()
+            .map(|sample| sample.largest_apply_latency)
+            .max()
+            .unwrap_or_default(),
+    }
+}
+
+fn pause_estimate(metrics: ConvergenceMetrics, reserve: Duration) -> Option<Duration> {
+    if metrics.replay_rate.records == 0 {
+        return None;
+    }
+    if metrics.backlog_records == 0 {
+        return metrics.largest_apply_latency.checked_add(reserve);
+    }
+    let net_replay = metrics
+        .replay_rate
+        .records
+        .checked_sub(metrics.arrival_rate.records)?;
+    if net_replay == 0 || metrics.window_elapsed.is_zero() {
+        return None;
+    }
+    let drain = ceil_duration_product(metrics.window_elapsed, metrics.backlog_records, net_replay);
+    drain
+        .checked_add(metrics.largest_apply_latency)?
+        .checked_add(reserve)
+}
+
+fn verdict(
+    metrics: ConvergenceMetrics,
+    estimate: Option<Duration>,
+    budget: Duration,
+) -> ConvergenceVerdict {
+    if metrics.backlog_grew
+        || (metrics.arrival_rate.records > 0
+            && metrics.arrival_rate.records >= metrics.replay_rate.records)
+    {
+        return ConvergenceVerdict::NonConverging;
+    }
+    match estimate {
+        Some(duration) if duration <= budget => ConvergenceVerdict::CutoverReady,
+        _ => ConvergenceVerdict::CatchingUp,
+    }
+}
+
+fn ceil_duration_product(duration: Duration, count: u64, divisor: u64) -> Duration {
+    let numerator = duration.as_nanos().saturating_mul(u128::from(count));
+    let rounded =
+        numerator.saturating_add(u128::from(divisor).saturating_sub(1)) / u128::from(divisor);
+    Duration::from_nanos(u64::try_from(rounded).unwrap_or(u64::MAX))
+}
+
+fn observation(
+    metrics: ConvergenceMetrics,
+    estimated_pause: Option<Duration>,
+    verdict: ConvergenceVerdict,
+) -> ConvergenceObservation {
+    ConvergenceObservation {
+        metrics,
+        estimated_pause,
+        verdict,
+    }
+}
+
+fn phase_for(verdict: ConvergenceVerdict) -> ControllerPhase {
+    match verdict {
+        ConvergenceVerdict::CatchingUp => ControllerPhase::CatchingUp,
+        ConvergenceVerdict::CutoverReady => ControllerPhase::CutoverReady,
+        ConvergenceVerdict::NonConverging => ControllerPhase::NonConverging,
+    }
+}
+
+fn ensure_observable(phase: ControllerPhase) -> Result<(), MemoryError> {
+    match phase {
+        ControllerPhase::CatchingUp
+        | ControllerPhase::CutoverReady
+        | ControllerPhase::NonConverging => Ok(()),
+        _ => Err(capture("controller phase does not accept observations")),
+    }
+}
+
+fn ensure_clock_after_sample(state: &ControllerState, now: Duration) -> Result<(), MemoryError> {
+    if state
+        .samples
+        .last()
+        .is_some_and(|sample| now < sample.observed_at)
+    {
+        return Err(capture("cutover clock predates the latest observation"));
+    }
+    Ok(())
+}
+
+fn ensure_activation_time(
+    now: Duration,
+    deadline: Duration,
+    budget: Duration,
+) -> Result<(), MemoryError> {
+    let started = deadline
+        .checked_sub(budget)
+        .ok_or_else(|| capture("invalid cutover deadline"))?;
+    if now < started {
+        return Err(capture("cutover activation time is not monotonic"));
+    }
+    Ok(())
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}

--- a/crates/velesdb-memory/src/mutation/controller/state.rs
+++ b/crates/velesdb-memory/src/mutation/controller/state.rs
@@ -1,0 +1,326 @@
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use super::{
+    assess, phase_for, validate_sample, ControllerConfig, ControllerPhase, ConvergenceSample,
+    RECOVER_CUTOVER, RESUME_CATCH_UP,
+};
+use crate::MemoryError;
+
+const STATE_VERSION: u32 = 1;
+const STATE_FILE: &str = "online-migration-controller.json";
+const STAGING_FILE: &str = "online-migration-controller.json.tmp";
+const MAX_STATE_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(super) struct ControllerState {
+    pub(super) version: u32,
+    pub(super) epoch_id: String,
+    pub(super) config: ControllerConfig,
+    pub(super) phase: ControllerPhase,
+    pub(super) samples: Vec<ConvergenceSample>,
+    pub(super) last_observation: Option<ConvergenceSample>,
+    pub(super) last_verdict: Option<super::ConvergenceVerdict>,
+    pub(super) recovery_action: Option<String>,
+}
+
+pub(super) struct StateStore {
+    workspace: PathBuf,
+    path: PathBuf,
+}
+
+impl StateStore {
+    pub(super) fn open(
+        workspace: &Path,
+        epoch_id: &str,
+        config: ControllerConfig,
+    ) -> Result<(Self, ControllerState, bool), MemoryError> {
+        validate_workspace(workspace)?;
+        validate_epoch_id(epoch_id)?;
+        let store = Self {
+            workspace: workspace.to_owned(),
+            path: workspace.join(STATE_FILE),
+        };
+        store.recover_staging()?;
+        let resumed = path_exists(&store.path)?;
+        let state = if resumed {
+            store.load(epoch_id, config)?
+        } else {
+            let state = ControllerState {
+                version: STATE_VERSION,
+                epoch_id: epoch_id.to_owned(),
+                config,
+                phase: ControllerPhase::CatchingUp,
+                samples: Vec::with_capacity(config.observation_window),
+                last_observation: None,
+                last_verdict: None,
+                recovery_action: None,
+            };
+            store.save(&state)?;
+            state
+        };
+        Ok((store, state, resumed))
+    }
+
+    pub(super) fn save(&self, state: &ControllerState) -> Result<(), MemoryError> {
+        self.recover_staging()?;
+        let bytes = serde_json::to_vec_pretty(state)
+            .map_err(|err| capture(format!("cannot encode controller state: {err}")))?;
+        if bytes.len() as u64 > MAX_STATE_BYTES {
+            return Err(capture("controller state exceeds 64 KiB safety limit"));
+        }
+        let staging = self.workspace.join(STAGING_FILE);
+        write_synced(&staging, &bytes)?;
+        promote(&staging, &self.path)
+            .map_err(|err| capture(format!("cannot publish controller state: {err}")))?;
+        sync_directory(&self.workspace)
+            .map_err(|err| capture(format!("cannot sync controller directory: {err}")))
+    }
+
+    fn load(
+        &self,
+        epoch_id: &str,
+        config: ControllerConfig,
+    ) -> Result<ControllerState, MemoryError> {
+        let bytes = read_state_bytes(&self.path)?;
+        let state: ControllerState = serde_json::from_slice(&bytes)
+            .map_err(|err| capture(format!("invalid controller state: {err}")))?;
+        validate_loaded(&state, epoch_id, config)?;
+        Ok(state)
+    }
+
+    fn recover_staging(&self) -> Result<(), MemoryError> {
+        let staging = self.workspace.join(STAGING_FILE);
+        if !path_exists(&staging)? {
+            return Ok(());
+        }
+        validate_regular_file(&staging)?;
+        std::fs::remove_file(&staging)
+            .map_err(|err| capture(format!("cannot remove controller staging file: {err}")))
+    }
+}
+
+fn read_state_bytes(path: &Path) -> Result<Vec<u8>, MemoryError> {
+    validate_regular_file(path)?;
+    let mut file =
+        File::open(path).map_err(|err| capture(format!("cannot open controller state: {err}")))?;
+    let length = file
+        .metadata()
+        .map_err(|err| capture(format!("cannot size controller state: {err}")))?
+        .len();
+    if length > MAX_STATE_BYTES {
+        return Err(capture("controller state exceeds 64 KiB safety limit"));
+    }
+    let capacity = usize::try_from(length)
+        .map_err(|_| capture("controller state length does not fit memory"))?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.read_to_end(&mut bytes)
+        .map_err(|err| capture(format!("cannot read controller state: {err}")))?;
+    Ok(bytes)
+}
+
+fn validate_loaded(
+    state: &ControllerState,
+    epoch_id: &str,
+    config: ControllerConfig,
+) -> Result<(), MemoryError> {
+    validate_header(state, epoch_id, config)?;
+    validate_samples(&state.samples)?;
+    if let Some(sample) = state.last_observation.as_ref() {
+        validate_sample(None, sample)?;
+    }
+    validate_audit_fields(state)?;
+    validate_phase(state)
+}
+
+fn validate_header(
+    state: &ControllerState,
+    epoch_id: &str,
+    config: ControllerConfig,
+) -> Result<(), MemoryError> {
+    if state.version != STATE_VERSION {
+        return Err(capture(format!(
+            "unsupported controller state version {}",
+            state.version
+        )));
+    }
+    if state.epoch_id != epoch_id {
+        return Err(capture("controller epoch ownership mismatch"));
+    }
+    if state.config != config || state.samples.len() > config.observation_window {
+        return Err(capture("controller configuration mismatch"));
+    }
+    Ok(())
+}
+
+fn validate_audit_fields(state: &ControllerState) -> Result<(), MemoryError> {
+    if state.last_observation.is_some() != state.last_verdict.is_some() {
+        return Err(capture("incomplete durable controller audit state"));
+    }
+    if let Some(last) = state.samples.last() {
+        if state.last_observation.as_ref() != Some(last)
+            || state.last_verdict != Some(assess(&state.samples, state.config).verdict)
+        {
+            return Err(capture(
+                "controller audit state disagrees with measured window",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_samples(samples: &[ConvergenceSample]) -> Result<(), MemoryError> {
+    let mut previous = None;
+    for sample in samples {
+        validate_sample(previous, sample)?;
+        previous = Some(sample);
+    }
+    Ok(())
+}
+
+fn validate_phase(state: &ControllerState) -> Result<(), MemoryError> {
+    match state.phase {
+        ControllerPhase::CatchingUp
+        | ControllerPhase::CutoverReady
+        | ControllerPhase::NonConverging => validate_observation_phase(state),
+        ControllerPhase::Quiescing { deadline } => validate_quiescing(state, deadline),
+        ControllerPhase::Activated => validate_activated(state),
+        ControllerPhase::Cancelled => validate_recovery(state, &[None]),
+    }
+}
+
+fn validate_observation_phase(state: &ControllerState) -> Result<(), MemoryError> {
+    if state.samples.is_empty() && state.phase != ControllerPhase::CatchingUp {
+        return Err(capture("controller phase requires a measured window"));
+    }
+    let resuming = state.phase == ControllerPhase::CatchingUp
+        && state.recovery_action.as_deref() == Some(RESUME_CATCH_UP);
+    if !resuming
+        && !state.samples.is_empty()
+        && phase_for(assess(&state.samples, state.config).verdict) != state.phase
+    {
+        return Err(capture("controller phase disagrees with measured window"));
+    }
+    let allowed = if state.phase == ControllerPhase::CatchingUp {
+        [None, Some(RESUME_CATCH_UP)]
+    } else {
+        [None, None]
+    };
+    validate_recovery(state, &allowed)
+}
+
+fn validate_quiescing(
+    state: &ControllerState,
+    deadline: std::time::Duration,
+) -> Result<(), MemoryError> {
+    if !has_cutover_ready_window(state)
+        || state
+            .samples
+            .last()
+            .is_some_and(|sample| deadline < sample.observed_at)
+    {
+        return Err(capture("invalid durable quiescing state"));
+    }
+    validate_recovery(state, &[None, Some(RECOVER_CUTOVER)])
+}
+
+fn validate_activated(state: &ControllerState) -> Result<(), MemoryError> {
+    if !has_cutover_ready_window(state) {
+        return Err(capture("invalid durable activated state"));
+    }
+    validate_recovery(state, &[None, Some(RECOVER_CUTOVER)])
+}
+
+fn has_cutover_ready_window(state: &ControllerState) -> bool {
+    !state.samples.is_empty()
+        && phase_for(assess(&state.samples, state.config).verdict) == ControllerPhase::CutoverReady
+}
+
+fn validate_recovery(state: &ControllerState, allowed: &[Option<&str>]) -> Result<(), MemoryError> {
+    if allowed.contains(&state.recovery_action.as_deref()) {
+        Ok(())
+    } else {
+        Err(capture("invalid durable controller recovery action"))
+    }
+}
+
+fn write_synced(path: &Path, bytes: &[u8]) -> Result<(), MemoryError> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|err| capture(format!("cannot create controller staging file: {err}")))?;
+    file.write_all(bytes)
+        .and_then(|()| file.flush())
+        .and_then(|()| file.sync_all())
+        .map_err(|err| capture(format!("cannot sync controller state: {err}")))
+}
+
+fn validate_workspace(workspace: &Path) -> Result<(), MemoryError> {
+    let metadata = std::fs::symlink_metadata(workspace)
+        .map_err(|err| capture(format!("cannot inspect controller workspace: {err}")))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(capture("controller workspace must be a real directory"));
+    }
+    Ok(())
+}
+
+fn validate_regular_file(path: &Path) -> Result<(), MemoryError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|err| capture(format!("cannot inspect controller file: {err}")))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(capture("controller path must be a regular file"));
+    }
+    Ok(())
+}
+
+fn path_exists(path: &Path) -> Result<bool, MemoryError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(capture(format!(
+            "cannot inspect {}: {error}",
+            path.display()
+        ))),
+    }
+}
+
+#[cfg(unix)]
+fn promote(staging: &Path, final_path: &Path) -> std::io::Result<()> {
+    std::fs::rename(staging, final_path)
+}
+
+#[cfg(windows)]
+fn promote(staging: &Path, final_path: &Path) -> std::io::Result<()> {
+    atomicwrites::replace_atomic(staging, final_path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn promote(_staging: &Path, _final_path: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "controller state replacement unsupported",
+    ))
+}
+
+#[cfg(unix)]
+fn sync_directory(workspace: &Path) -> std::io::Result<()> {
+    File::open(workspace)?.sync_all()
+}
+
+#[cfg(any(windows, not(any(unix, windows))))]
+fn sync_directory(_workspace: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+fn validate_epoch_id(epoch_id: &str) -> Result<(), MemoryError> {
+    if epoch_id.len() != 32 || !epoch_id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(capture("epoch id must be 32 hexadecimal characters"));
+    }
+    Ok(())
+}
+
+fn capture(message: impl Into<String>) -> MemoryError {
+    MemoryError::MigrationCapture(message.into())
+}

--- a/crates/velesdb-memory/src/mutation/controller_tests.rs
+++ b/crates/velesdb-memory/src/mutation/controller_tests.rs
@@ -1,0 +1,301 @@
+use std::time::Duration;
+
+use super::controller::{
+    ControllerConfig, ControllerPhase, ConvergenceController, ConvergenceSample, ConvergenceVerdict,
+};
+
+#[path = "controller_tests/state_tests.rs"]
+mod state;
+
+const EPOCH: &str = "00112233445566778899aabbccddeeff";
+
+#[test]
+fn measured_net_drain_within_budget_becomes_cutover_ready() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+
+    assert_eq!(
+        controller
+            .observe(sample(0, 100, 80))
+            .expect("first")
+            .verdict,
+        ConvergenceVerdict::CatchingUp
+    );
+    controller.observe(sample(1, 110, 100)).expect("second");
+    let observation = controller.observe(sample(2, 120, 120)).expect("third");
+
+    assert_eq!(observation.metrics.arrival_rate.records, 20);
+    assert_eq!(observation.metrics.replay_rate.records, 40);
+    assert_eq!(
+        observation.metrics.arrival_rate.elapsed,
+        Duration::from_secs(2)
+    );
+    assert_eq!(observation.metrics.window_elapsed, Duration::from_secs(2));
+    assert_eq!(observation.metrics.distinct_dirty_facts, 2);
+    assert_eq!(observation.metrics.distinct_edge_sources, 1);
+    assert_eq!(observation.metrics.pending_journal_bytes, 0);
+    assert_eq!(
+        observation.metrics.largest_apply_latency,
+        Duration::from_millis(20)
+    );
+    assert_eq!(observation.estimated_pause, Some(Duration::from_millis(70)));
+    assert_eq!(observation.verdict, ConvergenceVerdict::CutoverReady);
+    assert_eq!(controller.phase(), ControllerPhase::CutoverReady);
+}
+
+#[test]
+fn growing_backlog_or_arrivals_matching_replay_is_non_converging() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    controller.observe(sample(0, 100, 80)).expect("first");
+    controller.observe(sample(1, 110, 85)).expect("second");
+    let observation = controller.observe(sample(2, 120, 90)).expect("third");
+
+    assert_eq!(observation.metrics.backlog_records, 30);
+    assert!(observation.metrics.backlog_grew);
+    assert_eq!(observation.metrics.arrival_rate.records, 20);
+    assert_eq!(observation.metrics.replay_rate.records, 10);
+    assert_eq!(observation.verdict, ConvergenceVerdict::NonConverging);
+    assert_eq!(controller.phase(), ControllerPhase::NonConverging);
+}
+
+#[test]
+fn drain_estimate_over_operator_budget_keeps_catching_up() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    controller.observe(sample(0, 100, 20)).expect("first");
+    controller.observe(sample(1, 110, 31)).expect("second");
+    let observation = controller.observe(sample(2, 120, 42)).expect("third");
+
+    assert!(observation.estimated_pause.expect("estimate") > Duration::from_millis(500));
+    assert_eq!(observation.verdict, ConvergenceVerdict::CatchingUp);
+}
+
+#[test]
+fn observations_refuse_non_monotonic_or_inconsistent_watermarks() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    controller.observe(sample(1, 100, 80)).expect("first");
+
+    let time_error = controller
+        .observe(sample(1, 101, 81))
+        .expect_err("equal time must fail");
+    assert!(time_error.to_string().contains("monotonic"), "{time_error}");
+    let watermark_error = controller
+        .observe(sample(2, 79, 80))
+        .expect_err("output ahead of input must fail");
+    assert!(
+        watermark_error.to_string().contains("watermark"),
+        "{watermark_error}"
+    );
+}
+
+#[test]
+fn restart_preserves_audit_sample_but_requires_a_fresh_window() {
+    let root = tempfile::tempdir().expect("root");
+    {
+        let mut controller = open_controller(root.path());
+        make_ready(&mut controller);
+        assert_eq!(controller.retained_samples(), 3);
+    }
+
+    let mut resumed = open_controller(root.path());
+    assert_eq!(resumed.phase(), ControllerPhase::CatchingUp);
+    assert_eq!(resumed.retained_samples(), 0);
+    assert_eq!(
+        resumed
+            .last_observation()
+            .expect("last observation")
+            .output_watermark,
+        120
+    );
+    assert_eq!(
+        resumed.recovery_action(),
+        Some("reopen source and resume catch-up")
+    );
+    make_ready(&mut resumed);
+    resumed
+        .begin_quiescing(Duration::from_secs(3))
+        .expect("quiesce");
+    assert_eq!(
+        resumed.phase(),
+        ControllerPhase::Quiescing {
+            deadline: Duration::from_millis(3_500)
+        }
+    );
+    let error = resumed
+        .activate(Duration::from_millis(3_501))
+        .expect_err("expired deadline");
+    assert!(error.to_string().contains("deadline"), "{error}");
+    assert_eq!(resumed.phase(), ControllerPhase::CatchingUp);
+    assert_eq!(
+        resumed.recovery_action(),
+        Some("reopen source and resume catch-up")
+    );
+
+    let restored = open_controller(root.path());
+    assert_eq!(restored.phase(), ControllerPhase::CatchingUp);
+    assert_eq!(
+        restored.recovery_action(),
+        Some("reopen source and resume catch-up")
+    );
+}
+
+#[test]
+fn restart_during_quiescing_requires_recovery_even_before_deadline() {
+    let root = tempfile::tempdir().expect("root");
+    drop(quiescing_controller(root.path()));
+
+    let mut resumed = open_controller(root.path());
+    assert_eq!(
+        resumed.recovery_action(),
+        Some("complete or recover cutover before serving traffic")
+    );
+    let error = resumed
+        .activate(Duration::from_millis(3_100))
+        .expect_err("restart invalidates deadline ownership");
+    assert!(error.to_string().contains("recovery"), "{error}");
+    assert!(matches!(resumed.phase(), ControllerPhase::Quiescing { .. }));
+}
+
+#[test]
+fn equal_nonzero_arrival_and_replay_rates_are_non_converging() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    for (second, watermark) in [(0, 100), (1, 110)] {
+        controller
+            .observe(sample(second, watermark, watermark))
+            .expect("observe");
+    }
+    let observation = controller.observe(sample(2, 120, 120)).expect("third");
+    assert_eq!(observation.verdict, ConvergenceVerdict::NonConverging);
+}
+
+#[test]
+fn cancellation_permit_requires_source_authority_and_epoch_ownership() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+
+    let mismatch = controller
+        .cancel(true, "ffeeddccbbaa99887766554433221100")
+        .expect_err("wrong epoch");
+    assert!(mismatch.to_string().contains("epoch"), "{mismatch}");
+    let authority = controller
+        .cancel(false, EPOCH)
+        .expect_err("not authoritative");
+    assert!(
+        authority.to_string().contains("authoritative"),
+        "{authority}"
+    );
+
+    let permit = controller.cancel(true, EPOCH).expect("cancel");
+    assert_eq!(permit.epoch_id(), EPOCH);
+    assert_eq!(controller.phase(), ControllerPhase::Cancelled);
+    assert_eq!(
+        open_controller(root.path()).phase(),
+        ControllerPhase::Cancelled
+    );
+}
+
+#[test]
+fn cancellation_phase_matrix_refuses_only_after_cutover_started() {
+    let scenarios: [(fn(&mut ConvergenceController), bool); 3] = [
+        (make_ready, true),
+        (make_nonconverging, true),
+        (make_activated, false),
+    ];
+    for (setup, allowed) in scenarios {
+        let root = tempfile::tempdir().expect("root");
+        let mut controller = open_controller(root.path());
+        setup(&mut controller);
+        let result = controller.cancel(true, EPOCH);
+        assert_eq!(result.is_ok(), allowed);
+        if !allowed {
+            assert_eq!(
+                controller.recovery_action(),
+                Some("complete or recover cutover before serving traffic")
+            );
+        }
+    }
+}
+
+#[test]
+fn cancellation_after_quiescing_records_recovery_instead_of_rollback() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = quiescing_controller(root.path());
+
+    let error = controller
+        .cancel(false, EPOCH)
+        .expect_err("cannot roll back");
+    assert!(error.to_string().contains("recovery"), "{error}");
+    assert_eq!(
+        controller.recovery_action(),
+        Some("complete or recover cutover before serving traffic")
+    );
+    assert_eq!(
+        open_controller(root.path()).recovery_action(),
+        Some("complete or recover cutover before serving traffic")
+    );
+}
+
+fn open_controller(workspace: &std::path::Path) -> ConvergenceController {
+    ConvergenceController::open(
+        workspace,
+        EPOCH,
+        ControllerConfig {
+            observation_window: 3,
+            pause_budget: Duration::from_millis(500),
+            verification_reserve: Duration::from_millis(50),
+        },
+    )
+    .expect("controller")
+}
+
+fn make_ready(controller: &mut ConvergenceController) {
+    for (second, input, output) in [(0, 100, 80), (1, 110, 100), (2, 120, 120)] {
+        controller
+            .observe(sample(second, input, output))
+            .expect("observe");
+    }
+}
+
+fn make_nonconverging(controller: &mut ConvergenceController) {
+    for (second, watermark) in [(0, 100), (1, 110), (2, 120)] {
+        controller
+            .observe(sample(second, watermark, watermark))
+            .expect("observe");
+    }
+}
+
+fn make_activated(controller: &mut ConvergenceController) {
+    make_ready(controller);
+    controller
+        .begin_quiescing(Duration::from_secs(3))
+        .expect("quiesce");
+    controller
+        .activate(Duration::from_millis(3_100))
+        .expect("activate");
+}
+
+fn quiescing_controller(workspace: &std::path::Path) -> ConvergenceController {
+    let mut controller = open_controller(workspace);
+    make_ready(&mut controller);
+    controller
+        .begin_quiescing(Duration::from_secs(3))
+        .expect("quiesce");
+    controller
+}
+
+fn sample(second: u64, input: u64, output: u64) -> ConvergenceSample {
+    let backlog = input.saturating_sub(output);
+    ConvergenceSample {
+        observed_at: Duration::from_secs(second),
+        input_watermark: input,
+        output_watermark: output,
+        distinct_dirty_facts: 2,
+        distinct_edge_sources: 1,
+        pending_journal_bytes: backlog * 49,
+        replay_elapsed: Duration::from_millis(25),
+        largest_apply_latency: Duration::from_millis(20),
+    }
+}

--- a/crates/velesdb-memory/src/mutation/controller_tests.rs
+++ b/crates/velesdb-memory/src/mutation/controller_tests.rs
@@ -199,23 +199,22 @@ fn cancellation_permit_requires_source_authority_and_epoch_ownership() {
 
 #[test]
 fn cancellation_phase_matrix_refuses_only_after_cutover_started() {
-    let scenarios: [(fn(&mut ConvergenceController), bool); 3] = [
-        (make_ready, true),
-        (make_nonconverging, true),
-        (make_activated, false),
-    ];
-    for (setup, allowed) in scenarios {
-        let root = tempfile::tempdir().expect("root");
-        let mut controller = open_controller(root.path());
-        setup(&mut controller);
-        let result = controller.cancel(true, EPOCH);
-        assert_eq!(result.is_ok(), allowed);
-        if !allowed {
-            assert_eq!(
-                controller.recovery_action(),
-                Some("complete or recover cutover before serving traffic")
-            );
-        }
+    assert_cancellation(make_ready, true);
+    assert_cancellation(make_nonconverging, true);
+    assert_cancellation(make_activated, false);
+}
+
+fn assert_cancellation(setup: fn(&mut ConvergenceController), allowed: bool) {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    setup(&mut controller);
+    let result = controller.cancel(true, EPOCH);
+    assert_eq!(result.is_ok(), allowed);
+    if !allowed {
+        assert_eq!(
+            controller.recovery_action(),
+            Some("complete or recover cutover before serving traffic")
+        );
     }
 }
 

--- a/crates/velesdb-memory/src/mutation/controller_tests/state_tests.rs
+++ b/crates/velesdb-memory/src/mutation/controller_tests/state_tests.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::time::Duration;
+
+use super::{open_controller, sample, ControllerConfig, ConvergenceController, EPOCH};
+
+const STATE_FILE: &str = "online-migration-controller.json";
+const STAGING_FILE: &str = "online-migration-controller.json.tmp";
+
+#[test]
+fn controller_configuration_bounds_memory_and_pause_inputs() {
+    let root = tempfile::tempdir().expect("root");
+    for observation_window in [0, 1, 65] {
+        assert!(ConvergenceController::open(
+            root.path(),
+            EPOCH,
+            ControllerConfig {
+                observation_window,
+                pause_budget: Duration::from_secs(1),
+                verification_reserve: Duration::ZERO,
+            },
+        )
+        .is_err());
+    }
+    assert!(ConvergenceController::open(
+        root.path(),
+        EPOCH,
+        ControllerConfig {
+            observation_window: 2,
+            pause_budget: Duration::ZERO,
+            verification_reserve: Duration::ZERO,
+        },
+    )
+    .is_err());
+}
+
+#[test]
+fn corrupted_or_epoch_mismatched_state_fails_closed() {
+    let root = tempfile::tempdir().expect("root");
+    drop(open_controller(root.path()));
+    let path = root.path().join(STATE_FILE);
+    let original = fs::read_to_string(&path).expect("state");
+
+    fs::write(&path, "{truncated").expect("corrupt");
+    let corrupt = ConvergenceController::open(root.path(), EPOCH, config())
+        .err()
+        .expect("corrupt");
+    assert!(corrupt.to_string().contains("invalid controller state"));
+
+    fs::write(&path, original).expect("restore");
+    let mismatch =
+        ConvergenceController::open(root.path(), "ffeeddccbbaa99887766554433221100", config())
+            .err()
+            .expect("epoch mismatch");
+    assert!(mismatch.to_string().contains("epoch ownership"));
+}
+
+#[test]
+fn activated_state_without_a_cutover_ready_window_fails_closed() {
+    let root = tempfile::tempdir().expect("root");
+    drop(open_controller(root.path()));
+    let path = root.path().join(STATE_FILE);
+    let mut state: serde_json::Value =
+        serde_json::from_slice(&fs::read(&path).expect("state")).expect("json");
+    state["phase"] = serde_json::Value::String("Activated".to_owned());
+    fs::write(&path, serde_json::to_vec_pretty(&state).expect("encode")).expect("tamper");
+
+    let error = ConvergenceController::open(root.path(), EPOCH, config())
+        .err()
+        .expect("invalid activated state");
+    assert!(error.to_string().contains("activated state"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_state_is_refused_without_touching_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("root");
+    let victim = root.path().join("victim");
+    fs::write(&victim, b"untouched").expect("victim");
+    symlink(&victim, root.path().join(STATE_FILE)).expect("symlink");
+
+    let error = ConvergenceController::open(root.path(), EPOCH, config())
+        .err()
+        .expect("symlink");
+    assert!(error.to_string().contains("regular file"), "{error}");
+    assert_eq!(fs::read(&victim).expect("victim"), b"untouched");
+}
+
+#[cfg(unix)]
+#[test]
+fn failed_persistence_does_not_advance_in_memory_state_or_touch_target() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    let victim = root.path().join("victim");
+    fs::write(&victim, b"untouched").expect("victim");
+    symlink(&victim, root.path().join(STAGING_FILE)).expect("symlink");
+
+    controller
+        .observe(sample(0, 10, 10))
+        .expect_err("save fails");
+    assert_eq!(controller.retained_samples(), 0);
+    assert_eq!(fs::read(&victim).expect("victim"), b"untouched");
+}
+
+#[test]
+fn durable_state_contains_only_bounded_controller_facts() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = open_controller(root.path());
+    for second in 0..100 {
+        controller
+            .observe(sample(second, second, second))
+            .expect("observe");
+    }
+    let bytes = fs::read(root.path().join(STATE_FILE)).expect("state");
+    assert!(bytes.len() < 64 * 1024);
+    assert_eq!(controller.retained_samples(), 3);
+    let text = String::from_utf8(bytes).expect("utf8");
+    assert!(!text.contains("source_path"));
+    assert!(!text.contains("destination_path"));
+    assert!(!text.contains("credential"));
+}
+
+fn config() -> ControllerConfig {
+    ControllerConfig {
+        observation_window: 3,
+        pause_budget: Duration::from_millis(500),
+        verification_reserve: Duration::from_millis(50),
+    }
+}


### PR DESCRIPTION
## Summary

- publish measured replay watermarks, dirty-key counts, pending journal bytes, rates, elapsed time, and maximum apply latency
- add a bounded deterministic convergence controller with explicit CutoverReady and NonConverging verdicts
- persist controller phase, bounded observations, deadline, recovery action, and epoch ownership atomically
- require an epoch-bound cancellation permit while the source remains authoritative
- fail closed on restart during cutover and require fresh monotonic measurements after ordinary restart

## Safety

- readiness uses durable measured throughput plus a conservative drain, apply-latency, and verification reserve estimate
- deadline expiry returns to catch-up with an explicit recovery action
- semantic state validation rejects forged activation without a measured CutoverReady window
- durable state excludes credentials and source/destination paths; state and staging symlinks are refused
- bounded window: max 64 observations; state file: max 64 KiB

## Verification

- 16 controller and persistence regression tests
- 743 velesdb-memory tests passed, 0 failed
- 5,367 velesdb-core tests plus integrations and doctests passed, 0 failed
- workspace pre-commit tests and strict clippy passed
- wasm32 check and wasm-pack functional tests passed
- cargo deny: advisories, bans, licenses, sources all OK
- lizard: 0 functions above CC 8 or 50 NLOC
- jscpd on changed files: 0 clones, 0 duplicated lines
- policy, documentation, freshness, hooks, unsafe, TODO and attribution guards passed

Closes #1931