### PR TITLE
refactor(migrate): share connector metric normalisation via one helper

### DIFF
--- a/crates/velesdb-migrate/src/connectors/common.rs
+++ b/crates/velesdb-migrate/src/connectors/common.rs
@@ -325,6 +325,25 @@ pub fn format_count(count: Option<u64>) -> String {
     count.map_or_else(|| "unknown".to_string(), |c| c.to_string())
 }
 
+/// Lowercases `raw` and rewrites it to a canonical distance-metric name
+/// using `aliases`, falling back to the lowercased value verbatim.
+///
+/// Every source connector exposes its own vendor-specific metric labels
+/// (Milvus's `L2`/`IP`, Qdrant's `Euclid`, pgvector's `vector_l2_ops`, ...)
+/// and normalises them to the VelesDB core vocabulary (`cosine`, `dot`,
+/// `euclidean`, `hamming`, `jaccard`) so `Pipeline::check_metric_fidelity`
+/// can compare a source metric against a destination collection's metric.
+/// `aliases` lists `(vendor_label, canonical_name)` pairs matched against
+/// the lowercased input; unknown labels are lowercased and returned
+/// verbatim so mismatch errors stay actionable rather than being masked.
+pub fn normalise_metric(raw: &str, aliases: &[(&str, &str)]) -> String {
+    let lower = raw.to_ascii_lowercase();
+    aliases
+        .iter()
+        .find(|(alias, _)| *alias == lower)
+        .map_or(lower, |(_, canonical)| (*canonical).to_string())
+}
+
 /// Detects payload fields from a sample JSON document, excluding specified fields.
 ///
 /// Each non-excluded key produces a `FieldInfo` with type inferred via [`json_type_name`].
@@ -650,5 +669,30 @@ mod tests {
     #[test]
     fn test_format_count_none() {
         assert_eq!(format_count(None), "unknown");
+    }
+
+    #[test]
+    fn test_normalise_metric_maps_known_alias() {
+        assert_eq!(normalise_metric("L2", &[("l2", "euclidean")]), "euclidean");
+    }
+
+    #[test]
+    fn test_normalise_metric_matches_case_insensitively() {
+        assert_eq!(normalise_metric("Ip", &[("ip", "dot")]), "dot");
+    }
+
+    #[test]
+    fn test_normalise_metric_preserves_unknown_value() {
+        assert_eq!(
+            normalise_metric("manhattan", &[("l2", "euclidean")]),
+            "manhattan"
+        );
+    }
+
+    #[test]
+    fn test_normalise_metric_supports_multiple_aliases_to_same_canonical() {
+        let aliases = [("l2", "euclidean"), ("vector_l2_ops", "euclidean")];
+        assert_eq!(normalise_metric("vector_l2_ops", &aliases), "euclidean");
+        assert_eq!(normalise_metric("l2", &aliases), "euclidean");
     }
 }

--- a/crates/velesdb-migrate/src/connectors/elasticsearch.rs
+++ b/crates/velesdb-migrate/src/connectors/elasticsearch.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use crate::connectors::common::{
     check_response, create_http_client, detect_fields_from_sample, extract_payload_from_object,
-    parse_vector_from_json,
+    normalise_metric, parse_vector_from_json,
 };
 use crate::connectors::{ExtractedBatch, ExtractedPoint, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
@@ -169,12 +169,7 @@ impl ElasticsearchConnector {
     /// Unknown labels are lowercased and returned verbatim so
     /// mismatch errors stay actionable rather than masked.
     fn normalise_elasticsearch_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "dot_product" => "dot".to_string(),
-            "l2_norm" => "euclidean".to_string(),
-            _ => lower,
-        }
+        normalise_metric(raw, &[("dot_product", "dot"), ("l2_norm", "euclidean")])
     }
 
     /// Best-effort retrieval of the distance metric from the

--- a/crates/velesdb-migrate/src/connectors/milvus.rs
+++ b/crates/velesdb-migrate/src/connectors/milvus.rs
@@ -7,6 +7,7 @@ use tracing::{debug, info, warn};
 
 use super::common::{
     build_numeric_offset_batch, check_response, create_http_client, extract_id_from_value,
+    normalise_metric,
 };
 use super::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::config::MilvusConfig;
@@ -312,12 +313,7 @@ impl MilvusConnector {
     /// `TANIMOTO` are lowercased and returned verbatim so mismatch
     /// errors remain actionable instead of being silently dropped.
     fn normalise_milvus_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "l2" => "euclidean".to_string(),
-            "ip" => "dot".to_string(),
-            _ => lower,
-        }
+        normalise_metric(raw, &[("l2", "euclidean"), ("ip", "dot")])
     }
 
     /// Extract the distance metric for the given vector field from

--- a/crates/velesdb-migrate/src/connectors/pinecone.rs
+++ b/crates/velesdb-migrate/src/connectors/pinecone.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use tracing::{debug, info};
 
-use super::common::{check_response, create_http_client};
+use super::common::{check_response, create_http_client, normalise_metric};
 use super::{ExtractedBatch, ExtractedPoint, SourceConnector, SourceSchema};
 use crate::config::PineconeConfig;
 use crate::error::{Error, Result};
@@ -43,11 +43,7 @@ impl PineconeConnector {
     /// `check_metric_fidelity` can surface them verbatim in the
     /// mismatch error instead of swallowing them.
     fn normalise_pinecone_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "dotproduct" => "dot".to_string(),
-            _ => lower,
-        }
+        normalise_metric(raw, &[("dotproduct", "dot")])
     }
 
     fn api_request(&self, method: reqwest::Method, url: &str) -> reqwest::RequestBuilder {

--- a/crates/velesdb-migrate/src/connectors/qdrant.rs
+++ b/crates/velesdb-migrate/src/connectors/qdrant.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
-use super::common::{check_response, create_http_client};
+use super::common::{check_response, create_http_client, normalise_metric};
 use super::{ExtractedBatch, ExtractedPoint, SourceConnector, SourceSchema};
 use crate::config::QdrantConfig;
 use crate::error::Result;
@@ -37,11 +37,7 @@ impl QdrantConnector {
     /// verbatim so mismatch errors stay actionable instead of being
     /// silently dropped.
     fn normalise_qdrant_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "euclid" => "euclidean".to_string(),
-            _ => lower,
-        }
+        normalise_metric(raw, &[("euclid", "euclidean")])
     }
 
     /// Pick the "primary" named vector from a multi-vector Qdrant

--- a/crates/velesdb-migrate/src/connectors/redis.rs
+++ b/crates/velesdb-migrate/src/connectors/redis.rs
@@ -11,7 +11,8 @@ use tokio::sync::Mutex;
 
 use crate::config::RedisConfig;
 use crate::connectors::common::{
-    build_numeric_offset_batch, extract_payload_from_hashmap, parse_vector_from_json,
+    build_numeric_offset_batch, extract_payload_from_hashmap, normalise_metric,
+    parse_vector_from_json,
 };
 use crate::connectors::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::error::{Error, Result};
@@ -180,12 +181,7 @@ impl RedisConnector {
     /// `COSINE` → `cosine`. Unknown labels are lowercased and returned
     /// verbatim so mismatch errors stay actionable.
     fn normalise_redis_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "l2" => "euclidean".to_string(),
-            "ip" => "dot".to_string(),
-            _ => lower,
-        }
+        normalise_metric(raw, &[("l2", "euclidean"), ("ip", "dot")])
     }
 }
 

--- a/crates/velesdb-migrate/src/connectors/supabase.rs
+++ b/crates/velesdb-migrate/src/connectors/supabase.rs
@@ -11,7 +11,7 @@ use tracing::{debug, info, warn};
 
 use super::common::{
     build_numeric_offset_batch, check_response, create_http_client, extract_id_from_value,
-    json_type_name,
+    json_type_name, normalise_metric,
 };
 use super::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::config::SupabaseConfig;
@@ -46,13 +46,16 @@ impl SupabaseConnector {
     /// Unknown values are lowercased and returned verbatim so
     /// mismatch errors stay actionable rather than being masked.
     fn normalise_supabase_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "vector_cosine_ops" => "cosine".to_string(),
-            "l2" | "vector_l2_ops" => "euclidean".to_string(),
-            "ip" | "vector_ip_ops" => "dot".to_string(),
-            _ => lower,
-        }
+        normalise_metric(
+            raw,
+            &[
+                ("vector_cosine_ops", "cosine"),
+                ("l2", "euclidean"),
+                ("vector_l2_ops", "euclidean"),
+                ("ip", "dot"),
+                ("vector_ip_ops", "dot"),
+            ],
+        )
     }
 
     fn request(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {

--- a/crates/velesdb-migrate/src/connectors/weaviate.rs
+++ b/crates/velesdb-migrate/src/connectors/weaviate.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{debug, info};
 
-use super::common::{check_response, create_http_client};
+use super::common::{check_response, create_http_client, normalise_metric};
 use super::{ExtractedBatch, ExtractedPoint, FieldInfo, SourceConnector, SourceSchema};
 use crate::config::WeaviateConfig;
 use crate::error::{Error, Result};
@@ -38,11 +38,14 @@ impl WeaviateConnector {
     /// lowercased and returned verbatim so mismatch errors stay
     /// actionable.
     fn normalise_weaviate_metric(raw: &str) -> String {
-        let lower = raw.to_ascii_lowercase();
-        match lower.as_str() {
-            "l2-squared" | "l2_squared" | "l2" => "euclidean".to_string(),
-            _ => lower,
-        }
+        normalise_metric(
+            raw,
+            &[
+                ("l2-squared", "euclidean"),
+                ("l2_squared", "euclidean"),
+                ("l2", "euclidean"),
+            ],
+        )
     }
 
     /// Extract the distance metric from a class schema, preferring


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`, per Git Flow.

## Description

Seven `velesdb-migrate` source connectors (Elasticsearch, Milvus, Pinecone, Qdrant, Redis, Supabase, Weaviate) each carried a private `normalise_<vendor>_metric` function with the identical shape: lowercase the raw label, look it up in a small vendor-specific alias table, fall back to the lowercased value verbatim.

This extracts the shared shape into one helper, `connectors::common::normalise_metric(raw, aliases)`, and has every connector's function delegate to it with its own alias table. Function signatures and call sites are unchanged (each connector still exposes its own named `normalise_<vendor>_metric` function), so no other code needed to change.

No functional/behavioral change — every existing per-connector test still exercises the exact same mapping through the unchanged public signature.

Not fixing an issue; this is a routine DRY cleanup found during a codebase quality sweep.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests — existing per-connector `normalise_*_metric` tests (24 total across the 7 connectors) pass unchanged, plus 4 new unit tests added for the shared helper itself in `common.rs`.
- [x] Integration tests — `metric_fidelity_wiremock.rs` (17 tests) and `pipeline_e2e.rs` (16 tests) pass unchanged.

```
cargo test -p velesdb-migrate -- --test-threads=1   # 263 lib + 17 wiremock + 16 e2e, all green
cargo clippy -p velesdb-migrate --all-targets -- -D warnings -D clippy::pedantic   # clean
cargo fmt --all -- --check                          # clean
python3 scripts/check_prod_unwraps.py                # PASSED
```

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a — no public API/behavior change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code touched.

## High-Risk Change Checklist

N/A — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Runner-up candidates considered and deliberately left alone: `velesdb-cli/src/handlers/data.rs` JSON-parse helpers (lower payoff), and merging the Qdrant/Pinecone connector implementations behind a shared trait (real DRY opportunity but an architectural decision, out of scope for a small safe refactor).
