### PR TITLE
feat(memory): bascule live de migration sans handle survivant

### DIFF
--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -52,6 +52,8 @@ mod edges;
 mod enumeration;
 mod execute;
 mod filesystem;
+#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
+mod live;
 mod orchestrate;
 mod rebuild;
 mod state;
@@ -74,8 +76,11 @@ pub use enumeration::{
     enumerate_by_cursor, enumerate_collection, enumerate_page, reinsert, reinsert_batch,
     scroll_page, BatchReinsertion, RawFact, Reinsertion, AGENT_COLLECTIONS,
 };
+pub(crate) use execute::target_embedder_witness;
 pub use execute::{execute, ExecuteOutcome};
 pub use filesystem::{bytes_on_disk, fingerprint};
+#[allow(unused_imports)] // Wired by the control-surface slice after this internal seam.
+pub(crate) use live::prepare_live_switch;
 pub use orchestrate::{migrate, MigrateOutcome};
 #[cfg(test)]
 pub(crate) use rebuild::rebuild_with_stop;
@@ -87,6 +92,10 @@ pub use state::{
     PHASES, STATE_FILE, STATE_FORMAT_VERSION, STATE_TEMP_FILE,
 };
 pub use strategy::{assess, resolve, Compatibility, Resolution, Strategy};
+pub(crate) use switchover::{
+    commit_retained_switch, finalize_staged_live_switch, rollback_staged_live_switch,
+    stage_live_switch,
+};
 pub use switchover::{switch_over, SwitchOutcome, ARCHIVE_SUFFIX};
 #[cfg(test)]
 pub(crate) use validate::divergence_explained_by_expiry;

--- a/crates/velesdb-memory/src/migration/execute.rs
+++ b/crates/velesdb-memory/src/migration/execute.rs
@@ -242,26 +242,30 @@ fn embedder_witness(
 ) -> Result<Option<String>, crate::MemoryError> {
     match resolution {
         Resolution::Reuse => Ok(None),
-        Resolution::Reembed { .. } => {
-            use sha2::Digest;
-            let vector = embedder.embed(WITNESS_SENTENCE).map_err(|err| {
-                query_error(format!(
-                    "the target embedder cannot embed the witness: {err}"
-                ))
-            })?;
-            let mut hash = sha2::Sha256::new();
-            for value in &vector {
-                hash.update(value.to_le_bytes());
-            }
-            Ok(Some(format!(
-                "sha256:{}",
-                super::filesystem::encode_hex(&hash.finalize())
-            )))
-        }
+        Resolution::Reembed { .. } => target_embedder_witness(embedder).map(Some),
         Resolution::Refuse { .. } => {
             unreachable!("execute gated Refuse before the witness was computed")
         }
     }
+}
+
+pub(crate) fn target_embedder_witness(
+    embedder: &dyn Embedder,
+) -> Result<String, crate::MemoryError> {
+    use sha2::Digest;
+    let vector = embedder.embed(WITNESS_SENTENCE).map_err(|err| {
+        query_error(format!(
+            "the target embedder cannot embed the witness: {err}"
+        ))
+    })?;
+    let mut hash = sha2::Sha256::new();
+    for value in &vector {
+        hash.update(value.to_le_bytes());
+    }
+    Ok(format!(
+        "sha256:{}",
+        super::filesystem::encode_hex(&hash.finalize())
+    ))
 }
 
 /// Read-and-verify the existing journal, or write the first entry.

--- a/crates/velesdb-memory/src/migration/live.rs
+++ b/crates/velesdb-memory/src/migration/live.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::{
+    execute::journal_workspace, fingerprint, query_error, CollectionProgress, MigrationLock,
+    MigrationState, Phase, AGENT_COLLECTIONS, STATE_FORMAT_VERSION,
+};
+
+pub(crate) fn prepare_live_switch(
+    source: &Path,
+    destination: &Path,
+    target_model: &str,
+    target_dimension: usize,
+    target_witness: &str,
+) -> Result<PathBuf, crate::MemoryError> {
+    verify_target_provenance(destination, target_model, target_dimension)?;
+    let source = source
+        .canonicalize()
+        .map_err(|err| query_error(format!("cannot resolve live source: {err}")))?;
+    let source_fingerprint = fingerprint(&source)?;
+    let workspace = journal_workspace(destination)?;
+    let lock = MigrationLock::acquire(&workspace, "migrate-live-prepare").map_err(query_error)?;
+    let result = prepare_locked(
+        &workspace,
+        &lock,
+        source,
+        source_fingerprint,
+        target_model,
+        target_dimension,
+        target_witness,
+    );
+    super::execute::reconcile(result, lock.release())?;
+    Ok(workspace)
+}
+
+fn prepare_locked(
+    workspace: &Path,
+    lock: &MigrationLock,
+    source_path: PathBuf,
+    source_fingerprint: String,
+    target_model: &str,
+    target_dimension: usize,
+    target_witness: &str,
+) -> Result<(), crate::MemoryError> {
+    if let Some(existing) = MigrationState::read(workspace).map_err(query_error)? {
+        existing
+            .may_resume(
+                &source_path,
+                &source_fingerprint,
+                target_model,
+                target_dimension,
+            )
+            .map_err(query_error)?;
+        if existing.embedder_witness.as_deref() != Some(target_witness) {
+            return Err(query_error(
+                "live switch target embedder witness changed; start a fresh migration",
+            ));
+        }
+        return require_validated(existing.phase);
+    }
+    let mut state = new_state(
+        source_path,
+        source_fingerprint,
+        target_model,
+        target_dimension,
+        target_witness,
+    );
+    state.write(workspace, lock).map_err(query_error)?;
+    state.phase = Phase::DestinationValidated;
+    state.write(workspace, lock).map_err(query_error)
+}
+
+fn new_state(
+    source_path: PathBuf,
+    source_fingerprint: String,
+    target_model: &str,
+    target_dimension: usize,
+    target_witness: &str,
+) -> MigrationState {
+    let progress = AGENT_COLLECTIONS
+        .iter()
+        .map(|name| ((*name).to_owned(), CollectionProgress::Complete))
+        .collect::<BTreeMap<_, _>>();
+    MigrationState {
+        format_version: STATE_FORMAT_VERSION,
+        phase: Phase::Prepared,
+        source_path,
+        source_fingerprint,
+        target_model: target_model.to_owned(),
+        target_dimension,
+        progress,
+        embedder_witness: Some(target_witness.to_owned()),
+    }
+}
+
+fn require_validated(phase: Phase) -> Result<(), crate::MemoryError> {
+    if phase == Phase::DestinationValidated {
+        return Ok(());
+    }
+    Err(query_error(format!(
+        "live switch preparation found journal phase {phase:?}; recovery must finish first"
+    )))
+}
+
+fn verify_target_provenance(
+    destination: &Path,
+    target_model: &str,
+    target_dimension: usize,
+) -> Result<(), crate::MemoryError> {
+    let recorded = crate::embedding_provenance::read(destination).map_err(query_error)?;
+    crate::embedding_provenance::check(recorded.as_ref(), target_model, target_dimension)
+        .map_err(query_error)
+}

--- a/crates/velesdb-memory/src/migration/switchover.rs
+++ b/crates/velesdb-memory/src/migration/switchover.rs
@@ -35,6 +35,14 @@ use std::path::{Path, PathBuf};
 use super::execute::journal_workspace;
 use super::state::{MigrationLock, MigrationState, Phase, SwitchState};
 
+#[path = "switchover/live.rs"]
+#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
+mod live;
+#[allow(unused_imports)] // Wired by the control-surface slice after this internal seam.
+pub(crate) use live::{
+    finalize_staged_live_switch, rollback_staged_live_switch, stage_live_switch,
+};
+
 /// The archive slot: a sibling of the source, named after it.
 pub const ARCHIVE_SUFFIX: &str = ".archive";
 
@@ -58,9 +66,33 @@ pub struct SwitchOutcome {
 /// validation, the archive slot is occupied, the disk is in a shape no step of
 /// this migration produces, or a rename, deletion, or journal write fails.
 pub fn switch_over(store: &Path, destination: &Path) -> Result<SwitchOutcome, crate::MemoryError> {
+    run_switch(store, destination, true, false)
+}
+
+#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
+pub(crate) fn commit_retained_switch(
+    store: &Path,
+    destination: &Path,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    run_switch(store, destination, false, true)
+}
+
+fn run_switch(
+    store: &Path,
+    destination: &Path,
+    verify_open: bool,
+    allow_completed: bool,
+) -> Result<SwitchOutcome, crate::MemoryError> {
     let workspace = journal_workspace(destination)?;
     let lock = MigrationLock::acquire(&workspace, "migrate-switch").map_err(query_error)?;
-    let result = switch_locked(store, destination, &workspace, &lock);
+    let result = switch_locked(
+        store,
+        destination,
+        &workspace,
+        &lock,
+        verify_open,
+        allow_completed,
+    );
     super::execute::reconcile(result, lock.release())
 }
 
@@ -69,8 +101,10 @@ fn switch_locked(
     destination: &Path,
     workspace: &Path,
     lock: &MigrationLock,
+    verify_open: bool,
+    allow_completed: bool,
 ) -> Result<SwitchOutcome, crate::MemoryError> {
-    let mut state = entry_state(workspace)?;
+    let mut state = entry_state(workspace, allow_completed)?;
     let slots = Slots::resolve(store, &state, destination)?;
     loop {
         match state.phase {
@@ -83,14 +117,20 @@ fn switch_locked(
             }
             Phase::DestinationValidated => step_archive(&slots, &mut state, workspace, lock)?,
             Phase::SourceArchived => step_activate(&slots, &mut state, workspace, lock)?,
-            Phase::DestinationActivated => step_commit(&slots, &mut state, workspace, lock)?,
+            Phase::DestinationActivated => {
+                step_commit(&slots, &mut state, workspace, lock, verify_open)?;
+            }
             Phase::Committed => {
-                return Ok(SwitchOutcome {
-                    activated: slots.source.clone(),
-                    archive: slots.archive.clone(),
-                });
+                return Ok(outcome(&slots));
             }
         }
+    }
+}
+
+fn outcome(slots: &Slots) -> SwitchOutcome {
+    SwitchOutcome {
+        activated: slots.source.clone(),
+        archive: slots.archive.clone(),
     }
 }
 
@@ -100,7 +140,10 @@ fn switch_locked(
 /// `Committed` reports its outcome, while a fresh invocation on a committed
 /// journal has nothing left to do — the recovery table has said since C1 that
 /// replaying a step would act on a store that is already the new one.
-fn entry_state(workspace: &Path) -> Result<MigrationState, crate::MemoryError> {
+fn entry_state(
+    workspace: &Path,
+    allow_completed: bool,
+) -> Result<MigrationState, crate::MemoryError> {
     let state = MigrationState::read(workspace)
         .map_err(query_error)?
         .ok_or_else(|| {
@@ -109,7 +152,7 @@ fn entry_state(workspace: &Path) -> Result<MigrationState, crate::MemoryError> {
                 workspace.display()
             ))
         })?;
-    if state.phase == Phase::Committed {
+    if state.phase == Phase::Committed && !allow_completed {
         return Err(query_error(
             "this migration is complete; there is nothing left to switch, and \
              replaying a step would act on a store that is already the new one",
@@ -174,6 +217,11 @@ fn step_archive(
     workspace: &Path,
     lock: &MigrationLock,
 ) -> Result<(), crate::MemoryError> {
+    archive_source(slots, state)?;
+    advance(state, Phase::SourceArchived, workspace, lock)
+}
+
+fn archive_source(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
     match slots.on_disk() {
         // The step is pending: the slot must be free, or renaming would eat
         // whatever sits there — and the source must still BE the store the
@@ -213,7 +261,7 @@ fn step_archive(
         }
         other => return Err(unrecognised_disk(other, Phase::DestinationValidated)),
     }
-    advance(state, Phase::SourceArchived, workspace, lock)
+    Ok(())
 }
 
 /// Second rename: the destination takes the source's name.
@@ -223,6 +271,11 @@ fn step_activate(
     workspace: &Path,
     lock: &MigrationLock,
 ) -> Result<(), crate::MemoryError> {
+    activate_destination(slots, state)?;
+    advance(state, Phase::DestinationActivated, workspace, lock)
+}
+
+fn activate_destination(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
     match slots.on_disk() {
         SwitchState {
             source: false,
@@ -257,7 +310,7 @@ fn step_activate(
         } => redo_after_manual_restore(slots, state)?,
         other => return Err(unrecognised_disk(other, Phase::SourceArchived)),
     }
-    advance(state, Phase::DestinationActivated, workspace, lock)
+    Ok(())
 }
 
 /// The second rename already happened and only the journal is behind. Two
@@ -287,9 +340,10 @@ fn step_commit(
     state: &mut MigrationState,
     workspace: &Path,
     lock: &MigrationLock,
+    verify_open: bool,
 ) -> Result<(), crate::MemoryError> {
     require_target_stamp(slots, state)?;
-    {
+    if verify_open {
         let _opens = velesdb_core::Database::open(&slots.source)?;
     }
     if slots.archive.exists() {

--- a/crates/velesdb-memory/src/migration/switchover/live.rs
+++ b/crates/velesdb-memory/src/migration/switchover/live.rs
@@ -1,0 +1,143 @@
+use std::path::Path;
+
+use super::{
+    activate_destination, advance, archive_source, entry_state, journal_workspace, late_activation,
+    outcome, query_error, rename_durably, require_journalled_fingerprint, unrecognised_disk,
+    MigrationLock, MigrationState, Phase, Slots, SwitchOutcome, SwitchState,
+};
+
+pub(crate) fn stage_live_switch(
+    store: &Path,
+    destination: &Path,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    run_live_action(store, destination, stage_locked, false)
+}
+
+pub(crate) fn rollback_staged_live_switch(
+    store: &Path,
+    destination: &Path,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    run_live_action(store, destination, rollback_locked, false)
+}
+
+pub(crate) fn finalize_staged_live_switch(
+    store: &Path,
+    destination: &Path,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    run_live_action(store, destination, finalize_locked, true)
+}
+
+type LiveAction =
+    fn(&Slots, &mut MigrationState, &Path, &MigrationLock) -> Result<(), crate::MemoryError>;
+
+fn run_live_action(
+    store: &Path,
+    destination: &Path,
+    action: LiveAction,
+    allow_completed: bool,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    let workspace = journal_workspace(destination)?;
+    let lock = MigrationLock::acquire(&workspace, "migrate-live-switch").map_err(query_error)?;
+    let result = live_action_locked(
+        store,
+        destination,
+        &workspace,
+        &lock,
+        action,
+        allow_completed,
+    );
+    crate::migration::execute::reconcile(result, lock.release())
+}
+
+fn live_action_locked(
+    store: &Path,
+    destination: &Path,
+    workspace: &Path,
+    lock: &MigrationLock,
+    action: LiveAction,
+    allow_completed: bool,
+) -> Result<SwitchOutcome, crate::MemoryError> {
+    let mut state = entry_state(workspace, allow_completed)?;
+    let slots = Slots::resolve(store, &state, destination)?;
+    action(&slots, &mut state, workspace, lock)?;
+    Ok(outcome(&slots))
+}
+
+fn stage_locked(
+    slots: &Slots,
+    state: &mut MigrationState,
+    _workspace: &Path,
+    _lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    require_phase(state.phase, Phase::DestinationValidated, "stage")?;
+    archive_source(slots, state)?;
+    activate_destination(slots, state)
+}
+
+fn rollback_locked(
+    slots: &Slots,
+    state: &mut MigrationState,
+    _workspace: &Path,
+    _lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    require_phase(state.phase, Phase::DestinationValidated, "roll back")?;
+    match slots.on_disk() {
+        SwitchState {
+            source: true,
+            archive: false,
+            destination: true,
+        } => Ok(()),
+        SwitchState {
+            source: false,
+            archive: true,
+            destination: true,
+        } => restore_first_rename(slots, state),
+        SwitchState {
+            source: true,
+            archive: true,
+            destination: false,
+        } => restore_both_renames(slots, state),
+        other => Err(unrecognised_disk(other, Phase::DestinationValidated)),
+    }
+}
+
+fn restore_first_rename(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
+    require_journalled_fingerprint(&slots.archive, state, "archive")?;
+    rename_durably(&slots.archive, &slots.source)
+}
+
+fn restore_both_renames(slots: &Slots, state: &MigrationState) -> Result<(), crate::MemoryError> {
+    late_activation(slots, state)?;
+    rename_durably(&slots.source, &slots.destination)?;
+    rename_durably(&slots.archive, &slots.source)
+}
+
+fn finalize_locked(
+    slots: &Slots,
+    state: &mut MigrationState,
+    workspace: &Path,
+    lock: &MigrationLock,
+) -> Result<(), crate::MemoryError> {
+    if state.phase == Phase::Committed {
+        return Ok(());
+    }
+    late_activation(slots, state)?;
+    if state.phase == Phase::DestinationValidated {
+        advance(state, Phase::SourceArchived, workspace, lock)?;
+    }
+    require_phase(state.phase, Phase::SourceArchived, "finalize")?;
+    advance(state, Phase::DestinationActivated, workspace, lock)
+}
+
+fn require_phase(
+    actual: Phase,
+    expected: Phase,
+    operation: &str,
+) -> Result<(), crate::MemoryError> {
+    if actual == expected {
+        return Ok(());
+    }
+    Err(query_error(format!(
+        "cannot {operation} live switch from journal phase {actual:?}; expected {expected:?}"
+    )))
+}

--- a/crates/velesdb-memory/src/migration/tests/switchover.rs
+++ b/crates/velesdb-memory/src/migration/tests/switchover.rs
@@ -83,6 +83,91 @@ fn a_full_switch_activates_the_destination_and_frees_the_archive() {
 }
 
 #[test]
+fn a_live_switch_retains_the_archive_until_the_new_generation_is_installed() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    super::super::stage_live_switch(&store, &executed.destination).expect("stage");
+    super::super::finalize_staged_live_switch(&store, &executed.destination).expect("finalize");
+    assert!(
+        archive.exists(),
+        "the old generation still has a recovery copy"
+    );
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationActivated
+    );
+
+    super::super::commit_retained_switch(&store, &executed.destination)
+        .expect("commit after installing the new generation");
+    assert!(!archive.exists(), "commit may now release the archive");
+    assert_eq!(journal(&executed.workspace).phase, Phase::Committed);
+}
+
+#[test]
+fn a_staged_live_switch_can_roll_back_before_activation() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+
+    super::super::stage_live_switch(&store, &executed.destination).expect("stage");
+    assert!(store.exists() && archive.exists());
+    assert!(!executed.destination.exists());
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationValidated,
+        "physical staging must remain pre-activation in durable state"
+    );
+
+    super::super::rollback_staged_live_switch(&store, &executed.destination).expect("rollback");
+    assert!(store.exists());
+    assert!(!archive.exists());
+    assert!(executed.destination.exists());
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationValidated
+    );
+}
+
+#[test]
+fn a_live_crash_after_the_first_rename_rolls_back_to_source_authority() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+    let archive = root.path().join("store.archive");
+    std::fs::rename(&store, &archive).expect("first rename");
+
+    super::super::rollback_staged_live_switch(&store, &executed.destination)
+        .expect("rollback first rename");
+
+    assert!(store.exists());
+    assert!(executed.destination.exists());
+    assert!(!archive.exists());
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationValidated
+    );
+}
+
+#[test]
+fn a_staged_live_switch_is_journalled_only_after_activation() {
+    let root = root_with_source();
+    let executed = validated(root.path());
+    let store = root.path().join("store");
+
+    super::super::stage_live_switch(&store, &executed.destination).expect("stage");
+    super::super::finalize_staged_live_switch(&store, &executed.destination).expect("finalize");
+    assert_eq!(
+        journal(&executed.workspace).phase,
+        Phase::DestinationActivated
+    );
+    assert!(root.path().join("store.archive").exists());
+}
+
+#[test]
 fn a_switch_before_validation_is_refused() {
     let root = root_with_source();
     let executed = run(root.path()).expect("execute");

--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -9,9 +9,9 @@ use crate::MemoryError;
 #[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
 mod catchup;
 #[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
-mod controller;
+pub(crate) mod controller;
 #[allow(dead_code)] // The catch-up slice consumes the journal before the control surface ships.
-mod journal;
+pub(crate) mod journal;
 
 #[cfg(test)]
 mod controller_tests;

--- a/crates/velesdb-memory/src/mutation/catchup_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests.rs
@@ -89,6 +89,7 @@ pub(super) fn journal(workspace: &Path, source: &Path, destination: &Path) -> Ar
         "sha256:source",
         "target-model",
         3,
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         destination.to_owned(),
         "00112233445566778899aabbccddeeff",
     );

--- a/crates/velesdb-memory/src/mutation/controller.rs
+++ b/crates/velesdb-memory/src/mutation/controller.rs
@@ -177,6 +177,24 @@ impl ConvergenceController {
     }
 
     pub(crate) fn activate(&mut self, now: Duration) -> Result<(), MemoryError> {
+        self.ensure_cutover_start(now)?;
+        let ControllerPhase::Quiescing { deadline } = self.state.phase else {
+            return Err(capture("migration is not quiescing"));
+        };
+        let started = deadline
+            .checked_sub(self.config.pause_budget)
+            .ok_or_else(|| capture("cutover deadline predates its pause budget"))?;
+        let elapsed = now
+            .checked_sub(started)
+            .ok_or_else(|| capture("activation time predates quiescing"))?;
+        let mut next = self.state.clone();
+        next.phase = ControllerPhase::Activated;
+        next.recovery_action = None;
+        next.measured_cutover = Some(elapsed);
+        self.replace_state(next)
+    }
+
+    pub(crate) fn ensure_cutover_start(&mut self, now: Duration) -> Result<(), MemoryError> {
         if self.state.recovery_action.as_deref() == Some(RECOVER_CUTOVER) {
             return Err(capture("cutover recovery is required after restart"));
         }
@@ -191,10 +209,7 @@ impl ConvergenceController {
             self.replace_state(next)?;
             return Err(capture("cutover deadline expired"));
         }
-        let mut next = self.state.clone();
-        next.phase = ControllerPhase::Activated;
-        next.recovery_action = None;
-        self.replace_state(next)
+        Ok(())
     }
 
     pub(crate) fn cancel(
@@ -234,10 +249,50 @@ impl ConvergenceController {
         self.state.recovery_action.as_deref()
     }
 
+    pub(crate) fn complete_source_recovery(&mut self) -> Result<(), MemoryError> {
+        self.require_recovery_phase(false)?;
+        let mut next = self.state.clone();
+        next.phase = ControllerPhase::CatchingUp;
+        next.samples.clear();
+        next.last_observation = None;
+        next.last_verdict = None;
+        next.recovery_action = Some(RESUME_CATCH_UP.to_owned());
+        self.replace_state(next)
+    }
+
+    pub(crate) fn complete_target_recovery(&mut self) -> Result<(), MemoryError> {
+        self.require_recovery_phase(true)?;
+        let mut next = self.state.clone();
+        next.recovery_action = None;
+        self.replace_state(next)
+    }
+
+    pub(crate) fn measured_cutover(&self) -> Option<Duration> {
+        self.state.measured_cutover
+    }
+
+    pub(crate) fn epoch_id(&self) -> &str {
+        &self.state.epoch_id
+    }
+
     fn replace_state(&mut self, next: ControllerState) -> Result<(), MemoryError> {
         self.store.save(&next)?;
         self.state = next;
         Ok(())
+    }
+
+    fn require_recovery_phase(&self, activated: bool) -> Result<(), MemoryError> {
+        let expected = if activated {
+            matches!(self.state.phase, ControllerPhase::Activated)
+        } else {
+            matches!(self.state.phase, ControllerPhase::Quiescing { .. })
+        };
+        if expected && self.state.recovery_action.as_deref() == Some(RECOVER_CUTOVER) {
+            return Ok(());
+        }
+        Err(capture(
+            "controller is not in the requested cutover recovery phase",
+        ))
     }
 
     #[cfg(test)]

--- a/crates/velesdb-memory/src/mutation/controller/state.rs
+++ b/crates/velesdb-memory/src/mutation/controller/state.rs
@@ -23,6 +23,8 @@ pub(super) struct ControllerState {
     pub(super) last_observation: Option<ConvergenceSample>,
     pub(super) last_verdict: Option<super::ConvergenceVerdict>,
     pub(super) recovery_action: Option<String>,
+    #[serde(default)]
+    pub(super) measured_cutover: Option<std::time::Duration>,
 }
 
 pub(super) struct StateStore {
@@ -56,6 +58,7 @@ impl StateStore {
                 last_observation: None,
                 last_verdict: None,
                 recovery_action: None,
+                measured_cutover: None,
             };
             store.save(&state)?;
             state
@@ -180,6 +183,9 @@ fn validate_samples(samples: &[ConvergenceSample]) -> Result<(), MemoryError> {
 }
 
 fn validate_phase(state: &ControllerState) -> Result<(), MemoryError> {
+    if state.phase != ControllerPhase::Activated && state.measured_cutover.is_some() {
+        return Err(capture("cutover duration exists before activation"));
+    }
     match state.phase {
         ControllerPhase::CatchingUp
         | ControllerPhase::CutoverReady
@@ -226,7 +232,11 @@ fn validate_quiescing(
 }
 
 fn validate_activated(state: &ControllerState) -> Result<(), MemoryError> {
-    if !has_cutover_ready_window(state) {
+    if !has_cutover_ready_window(state)
+        || state
+            .measured_cutover
+            .is_none_or(|elapsed| elapsed > state.config.pause_budget)
+    {
         return Err(capture("invalid durable activated state"));
     }
     validate_recovery(state, &[None, Some(RECOVER_CUTOVER)])

--- a/crates/velesdb-memory/src/mutation/controller_tests.rs
+++ b/crates/velesdb-memory/src/mutation/controller_tests.rs
@@ -276,6 +276,23 @@ fn make_activated(controller: &mut ConvergenceController) {
         .expect("activate");
 }
 
+#[test]
+fn activation_persists_the_measured_cutover_window() {
+    let root = tempfile::tempdir().expect("root");
+    let mut controller = quiescing_controller(root.path());
+    controller
+        .activate(Duration::from_millis(3_125))
+        .expect("activate");
+    assert_eq!(
+        controller.measured_cutover(),
+        Some(Duration::from_millis(125))
+    );
+    assert_eq!(
+        open_controller(root.path()).measured_cutover(),
+        Some(Duration::from_millis(125))
+    );
+}
+
 fn quiescing_controller(workspace: &std::path::Path) -> ConvergenceController {
     let mut controller = open_controller(workspace);
     make_ready(&mut controller);

--- a/crates/velesdb-memory/src/mutation/journal.rs
+++ b/crates/velesdb-memory/src/mutation/journal.rs
@@ -30,8 +30,19 @@ pub(crate) struct EpochIdentity {
     source_provenance: String,
     target_model: String,
     target_dimension: usize,
+    target_witness: String,
     destination_path: PathBuf,
     epoch_id: String,
+}
+
+pub(crate) struct CutoverIdentity<'a> {
+    pub(crate) source: &'a Path,
+    pub(crate) destination: &'a Path,
+    pub(crate) source_provenance: &'a str,
+    pub(crate) target_model: &'a str,
+    pub(crate) target_dimension: usize,
+    pub(crate) target_witness: &'a str,
+    pub(crate) epoch_id: &'a str,
 }
 
 impl EpochIdentity {
@@ -40,6 +51,7 @@ impl EpochIdentity {
         source_provenance: String,
         target_model: String,
         target_dimension: usize,
+        target_witness: String,
         destination_path: PathBuf,
     ) -> Result<Self, MemoryError> {
         let mut random = [0_u8; 16];
@@ -56,6 +68,7 @@ impl EpochIdentity {
             source_provenance,
             target_model,
             target_dimension,
+            target_witness,
             destination_path,
             epoch_id,
         )
@@ -66,6 +79,7 @@ impl EpochIdentity {
         source_provenance: String,
         target_model: String,
         target_dimension: usize,
+        target_witness: String,
         destination_path: PathBuf,
         epoch_id: String,
     ) -> Result<Self, MemoryError> {
@@ -79,23 +93,26 @@ impl EpochIdentity {
                 "epoch paths must differ and target dimension must be positive",
             ));
         }
+        validate_witness(&target_witness)?;
         validate_epoch_id(&epoch_id)?;
         Ok(Self {
             source_path,
             source_provenance,
             target_model,
             target_dimension,
+            target_witness,
             destination_path,
             epoch_id,
         })
     }
 
     #[cfg(test)]
-    pub(super) fn for_test(
+    pub(crate) fn for_test(
         source_path: PathBuf,
         source_provenance: &str,
         target_model: &str,
         target_dimension: usize,
+        target_witness: &str,
         destination_path: PathBuf,
         epoch_id: &str,
     ) -> Self {
@@ -104,6 +121,7 @@ impl EpochIdentity {
             source_provenance.to_owned(),
             target_model.to_owned(),
             target_dimension,
+            target_witness.to_owned(),
             destination_path,
             epoch_id.to_owned(),
         )
@@ -167,6 +185,29 @@ impl DirtyJournal {
 
     pub(crate) fn compacted_through(&self) -> u64 {
         self.inner.lock().header.compacted_through
+    }
+
+    pub(crate) fn verify_cutover_identity(
+        &self,
+        expected: &CutoverIdentity<'_>,
+    ) -> Result<(), MemoryError> {
+        let inner = self.inner.lock();
+        let identity = &inner.header.identity;
+        if identity.source_path != expected.source
+            || identity.destination_path != expected.destination
+            || identity.source_provenance != expected.source_provenance
+            || identity.target_model != expected.target_model
+            || identity.target_dimension != expected.target_dimension
+            || identity.target_witness != expected.target_witness
+            || identity.epoch_id != expected.epoch_id
+        {
+            return Err(capture("cutover identity disagrees with journal epoch"));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn workspace(&self) -> &Path {
+        &self.workspace
     }
 
     pub(crate) fn records_after(
@@ -286,6 +327,16 @@ impl DirtyJournal {
     fn maybe_fail(&self, _point: FaultPoint) -> Result<(), MemoryError> {
         Ok(())
     }
+}
+
+fn validate_witness(witness: &str) -> Result<(), MemoryError> {
+    let digest = witness
+        .strip_prefix("sha256:")
+        .ok_or_else(|| capture("target witness must use sha256"))?;
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(capture("target witness must contain 64 hexadecimal digits"));
+    }
+    Ok(())
 }
 
 impl MutationObserver for DirtyJournal {

--- a/crates/velesdb-memory/src/mutation/journal/format.rs
+++ b/crates/velesdb-memory/src/mutation/journal/format.rs
@@ -242,6 +242,7 @@ mod tests {
             "sha256:source",
             "target",
             384,
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
             dir.path().join("destination"),
             "00112233445566778899aabbccddeeff",
         );

--- a/crates/velesdb-memory/src/mutation/journal_tests.rs
+++ b/crates/velesdb-memory/src/mutation/journal_tests.rs
@@ -17,6 +17,7 @@ fn epoch(root: &Path, id: &str) -> EpochIdentity {
         "sha256:source",
         "target-model",
         384,
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         root.join("destination"),
         id,
     )
@@ -60,6 +61,29 @@ fn identity_mismatch_is_refused() {
     )
     .err()
     .expect("mismatch");
+    assert!(error.to_string().contains("identity mismatch"), "{error}");
+}
+
+#[test]
+fn changed_target_witness_is_refused_under_the_same_model_and_dimension() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let id = "00112233445566778899aabbccddeeff";
+    let original = epoch(dir.path(), id);
+    drop(DirtyJournal::open(dir.path(), &original, CAPACITY).expect("create"));
+    let changed = EpochIdentity::for_test(
+        dir.path().join("source"),
+        "sha256:source",
+        "target-model",
+        384,
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        dir.path().join("destination"),
+        id,
+    );
+
+    let error = DirtyJournal::open(dir.path(), &changed, CAPACITY)
+        .err()
+        .expect("witness mismatch");
+
     assert!(error.to_string().contains("identity mismatch"), "{error}");
 }
 
@@ -295,6 +319,7 @@ fn generated_epoch_ids_are_random_and_well_formed() {
         "sha256:source".to_owned(),
         "target-model".to_owned(),
         384,
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
         dir.path().join("destination"),
     )
     .expect("first epoch");
@@ -303,6 +328,7 @@ fn generated_epoch_ids_are_random_and_well_formed() {
         "sha256:source".to_owned(),
         "target-model".to_owned(),
         384,
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_owned(),
         dir.path().join("destination"),
     )
     .expect("second epoch");

--- a/crates/velesdb-memory/src/online_migration.rs
+++ b/crates/velesdb-memory/src/online_migration.rs
@@ -2,6 +2,70 @@ use crate::embedder::Embedder;
 use crate::storage::NativeStore;
 use crate::MemoryService;
 
+#[path = "online_migration/cutover.rs"]
+mod cutover;
+pub(crate) use cutover::LiveCutover;
+#[path = "online_migration/recovery.rs"]
+mod recovery;
+pub(crate) use recovery::LiveRecovery;
+
+pub(crate) struct LiveGenerationSlot<E: Embedder> {
+    generation: parking_lot::RwLock<Option<ActiveGeneration<E>>>,
+}
+
+pub(crate) struct ActiveGeneration<E: Embedder> {
+    service: MemoryService<E, NativeStore>,
+    model: String,
+}
+
+impl<E: Embedder> ActiveGeneration<E> {
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
+    pub(crate) fn dimension(&self) -> usize {
+        self.service.embedder.dimension()
+    }
+}
+
+impl<E: Embedder> LiveGenerationSlot<E> {
+    pub(crate) fn new(service: MemoryService<E, NativeStore>, model: impl Into<String>) -> Self {
+        Self {
+            generation: parking_lot::RwLock::new(Some(ActiveGeneration {
+                service,
+                model: model.into(),
+            })),
+        }
+    }
+
+    pub(crate) fn with_generation<T>(
+        &self,
+        run: impl FnOnce(&ActiveGeneration<E>) -> T,
+    ) -> Result<T, crate::MemoryError> {
+        let generation = self.generation.read();
+        generation
+            .as_ref()
+            .map(run)
+            .ok_or_else(|| unavailable("service generation is recovering"))
+    }
+
+    #[cfg(test)]
+    pub(super) fn replace_for_test(
+        &self,
+        service: MemoryService<E, NativeStore>,
+        model: impl Into<String>,
+    ) {
+        *self.generation.write() = Some(ActiveGeneration {
+            service,
+            model: model.into(),
+        });
+    }
+}
+
+fn unavailable(message: impl Into<String>) -> crate::MemoryError {
+    velesdb_core::Error::Query(message.into()).into()
+}
+
 impl<E: Embedder> MemoryService<E, NativeStore> {
     pub(crate) fn migration_store(&self) -> &NativeStore {
         &self.store
@@ -15,3 +79,7 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
         run()
     }
 }
+
+#[cfg(test)]
+#[path = "online_migration_tests.rs"]
+mod tests;

--- a/crates/velesdb-memory/src/online_migration/cutover.rs
+++ b/crates/velesdb-memory/src/online_migration/cutover.rs
@@ -1,0 +1,251 @@
+use std::path::Path;
+use std::time::Duration;
+
+use super::{ActiveGeneration, LiveGenerationSlot};
+use crate::embedder::Embedder;
+use crate::migration::{
+    commit_retained_switch, finalize_staged_live_switch, prepare_live_switch,
+    rollback_staged_live_switch, stage_live_switch,
+};
+use crate::mutation::controller::ConvergenceController;
+use crate::mutation::journal::{CutoverIdentity, DirtyJournal};
+use crate::storage::NativeStore;
+use crate::{MemoryError, MemoryService};
+
+pub(crate) struct LiveCutover<'a> {
+    pub(crate) controller: &'a mut ConvergenceController,
+    pub(crate) journal: &'a DirtyJournal,
+    pub(crate) source: &'a Path,
+    pub(crate) destination: &'a Path,
+    pub(crate) target_model: &'a str,
+    pub(crate) started_at: Duration,
+    pub(crate) completed_at: Duration,
+}
+
+struct RetiredGeneration<E: Embedder> {
+    embedder: E,
+    model: String,
+    runtime: RuntimeState,
+}
+
+struct RuntimeState {
+    autograph: Option<crate::extract::DynExtractor>,
+    autograph_queue: crate::service::AutographQueue,
+}
+
+impl<E: Embedder> LiveGenerationSlot<E> {
+    pub(crate) fn cut_over(
+        &self,
+        mut cutover: LiveCutover<'_>,
+        target_embedder: E,
+        seal: impl FnOnce(&MemoryService<E, NativeStore>) -> Result<(), MemoryError>,
+    ) -> Result<(), MemoryError> {
+        let target_witness = crate::migration::target_embedder_witness(&target_embedder)?;
+        let mut generation = self.generation.write();
+        let retired = take_retired(
+            &mut generation,
+            &mut cutover,
+            &target_embedder,
+            &target_witness,
+            seal,
+        )?;
+        let (target, retired) =
+            stage_or_restore(&mut generation, &cutover, retired, target_embedder)?;
+        let (target, retired) =
+            activate_or_restore(&mut generation, &mut cutover, retired, target)?;
+        *generation = Some(transplant(target, retired.runtime, cutover.target_model));
+        drop(generation);
+        finish_switch(&cutover)
+    }
+}
+
+fn take_retired<E: Embedder>(
+    generation: &mut Option<ActiveGeneration<E>>,
+    cutover: &mut LiveCutover<'_>,
+    target_embedder: &E,
+    target_witness: &str,
+    seal: impl FnOnce(&MemoryService<E, NativeStore>) -> Result<(), MemoryError>,
+) -> Result<RetiredGeneration<E>, MemoryError> {
+    let active = generation
+        .as_ref()
+        .ok_or_else(|| super::unavailable("service generation is recovering"))?;
+    preflight(active, cutover, target_embedder, target_witness, seal)?;
+    let retired = retire(
+        generation
+            .take()
+            .ok_or_else(|| super::unavailable("service generation disappeared"))?,
+    );
+    if let Err(error) = prove_source_handle_closed(cutover, retired.embedder.dimension()) {
+        return restore(generation, cutover, retired, error);
+    }
+    Ok(retired)
+}
+
+fn stage_or_restore<E: Embedder>(
+    generation: &mut Option<ActiveGeneration<E>>,
+    cutover: &LiveCutover<'_>,
+    retired: RetiredGeneration<E>,
+    target_embedder: E,
+) -> Result<(MemoryService<E, NativeStore>, RetiredGeneration<E>), MemoryError> {
+    match stage_and_open(cutover, target_embedder) {
+        Ok(target) => Ok((target, retired)),
+        Err(error) => restore(generation, cutover, retired, error),
+    }
+}
+
+fn activate_or_restore<E: Embedder>(
+    generation: &mut Option<ActiveGeneration<E>>,
+    cutover: &mut LiveCutover<'_>,
+    retired: RetiredGeneration<E>,
+    target: MemoryService<E, NativeStore>,
+) -> Result<(MemoryService<E, NativeStore>, RetiredGeneration<E>), MemoryError> {
+    if let Err(error) = cutover.controller.activate(cutover.completed_at) {
+        drop(target);
+        return restore(generation, cutover, retired, error);
+    }
+    Ok((target, retired))
+}
+
+fn finish_switch(cutover: &LiveCutover<'_>) -> Result<(), MemoryError> {
+    finalize_staged_live_switch(cutover.source, cutover.destination)?;
+    commit_retained_switch(cutover.source, cutover.destination)?;
+    Ok(())
+}
+
+fn prove_source_handle_closed(
+    cutover: &LiveCutover<'_>,
+    source_dimension: usize,
+) -> Result<(), MemoryError> {
+    let probe = NativeStore::open(cutover.source, source_dimension).map_err(|error| {
+        super::unavailable(format!("source handle survived retirement: {error}"))
+    })?;
+    drop(probe);
+    Ok(())
+}
+
+fn preflight<E: Embedder>(
+    active: &ActiveGeneration<E>,
+    cutover: &mut LiveCutover<'_>,
+    target_embedder: &E,
+    target_witness: &str,
+    seal: impl FnOnce(&MemoryService<E, NativeStore>) -> Result<(), MemoryError>,
+) -> Result<(), MemoryError> {
+    cutover
+        .controller
+        .ensure_cutover_start(cutover.started_at)?;
+    seal(&active.service)?;
+    ensure_journal_drained(cutover.journal)?;
+    cutover.journal.verify_cutover_identity(&CutoverIdentity {
+        source: cutover.source,
+        destination: cutover.destination,
+        source_provenance: active.model(),
+        target_model: cutover.target_model,
+        target_dimension: target_embedder.dimension(),
+        target_witness,
+        epoch_id: cutover.controller.epoch_id(),
+    })?;
+    let workspace = prepare_live_switch(
+        cutover.source,
+        cutover.destination,
+        cutover.target_model,
+        target_embedder.dimension(),
+        target_witness,
+    )?;
+    if workspace != cutover.journal.workspace() {
+        return Err(super::unavailable(
+            "cutover workspace disagrees with dirty journal",
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_journal_drained(journal: &DirtyJournal) -> Result<(), MemoryError> {
+    if journal.last_sequence() == journal.compacted_through() {
+        return Ok(());
+    }
+    Err(super::unavailable(
+        "dirty journal is not drained at the final watermark",
+    ))
+}
+
+fn stage_and_open<E: Embedder>(
+    cutover: &LiveCutover<'_>,
+    target_embedder: E,
+) -> Result<MemoryService<E, NativeStore>, MemoryError> {
+    stage_live_switch(cutover.source, cutover.destination)?;
+    MemoryService::open(cutover.source, target_embedder)
+        .map_err(|error| super::unavailable(format!("cannot open activated target: {error}")))
+}
+
+fn retire<E: Embedder>(generation: ActiveGeneration<E>) -> RetiredGeneration<E> {
+    let MemoryService {
+        store,
+        embedder,
+        autograph,
+        autograph_queue,
+        generation_gate: _,
+    } = generation.service;
+    drop(store);
+    RetiredGeneration {
+        embedder,
+        model: generation.model,
+        runtime: RuntimeState {
+            autograph,
+            autograph_queue,
+        },
+    }
+}
+
+fn restore<T, E: Embedder>(
+    slot: &mut Option<ActiveGeneration<E>>,
+    cutover: &LiveCutover<'_>,
+    retired: RetiredGeneration<E>,
+    original: MemoryError,
+) -> Result<T, MemoryError> {
+    rollback_staged_live_switch(cutover.source, cutover.destination)
+        .map_err(|recovery| combined(&original, &recovery))?;
+    let store = NativeStore::open(cutover.source, retired.embedder.dimension())
+        .map_err(|recovery| combined(&original, &recovery))?;
+    *slot = Some(assemble(
+        store,
+        retired.embedder,
+        retired.runtime,
+        retired.model,
+    ));
+    Err(original)
+}
+
+fn transplant<E: Embedder>(
+    target: MemoryService<E, NativeStore>,
+    runtime: RuntimeState,
+    model: &str,
+) -> ActiveGeneration<E> {
+    let MemoryService {
+        store, embedder, ..
+    } = target;
+    assemble(store, embedder, runtime, model.to_owned())
+}
+
+fn assemble<E: Embedder>(
+    store: NativeStore,
+    embedder: E,
+    runtime: RuntimeState,
+    model: String,
+) -> ActiveGeneration<E> {
+    ActiveGeneration {
+        service: MemoryService {
+            store,
+            embedder,
+            autograph: runtime.autograph,
+            autograph_queue: runtime.autograph_queue,
+            generation_gate: parking_lot::RwLock::new(()),
+        },
+        model,
+    }
+}
+
+fn combined(original: &MemoryError, recovery: &MemoryError) -> MemoryError {
+    super::unavailable(format!(
+        "cutover failed: {original}; source recovery also failed: {recovery}"
+    ))
+}

--- a/crates/velesdb-memory/src/online_migration/recovery.rs
+++ b/crates/velesdb-memory/src/online_migration/recovery.rs
@@ -1,0 +1,85 @@
+use std::path::Path;
+
+use super::LiveGenerationSlot;
+use crate::embedder::Embedder;
+use crate::migration::{
+    commit_retained_switch, finalize_staged_live_switch, rollback_staged_live_switch,
+    target_embedder_witness, ARCHIVE_SUFFIX,
+};
+use crate::mutation::controller::{ControllerPhase, ConvergenceController};
+use crate::mutation::journal::{CutoverIdentity, DirtyJournal};
+use crate::{MemoryError, MemoryService};
+
+pub(crate) struct LiveRecovery<'a> {
+    pub(crate) controller: &'a mut ConvergenceController,
+    pub(crate) journal: &'a DirtyJournal,
+    pub(crate) source: &'a Path,
+    pub(crate) destination: &'a Path,
+    pub(crate) source_model: &'a str,
+    pub(crate) target_model: &'a str,
+}
+
+impl<E: Embedder> LiveGenerationSlot<E> {
+    pub(crate) fn recover(
+        mut recovery: LiveRecovery<'_>,
+        source_embedder: E,
+        target_embedder: E,
+    ) -> Result<Self, MemoryError> {
+        verify_identity(&recovery, &target_embedder)?;
+        match recovery.controller.phase() {
+            ControllerPhase::Quiescing { .. } => recover_source(&mut recovery, source_embedder),
+            ControllerPhase::Activated => recover_target(&mut recovery, target_embedder),
+            _ => Err(super::unavailable(
+                "controller does not require live cutover recovery",
+            )),
+        }
+    }
+}
+
+fn verify_identity<E: Embedder>(
+    recovery: &LiveRecovery<'_>,
+    target_embedder: &E,
+) -> Result<(), MemoryError> {
+    let witness = target_embedder_witness(target_embedder)?;
+    recovery.journal.verify_cutover_identity(&CutoverIdentity {
+        source: recovery.source,
+        destination: recovery.destination,
+        source_provenance: recovery.source_model,
+        target_model: recovery.target_model,
+        target_dimension: target_embedder.dimension(),
+        target_witness: &witness,
+        epoch_id: recovery.controller.epoch_id(),
+    })
+}
+
+fn recover_source<E: Embedder>(
+    recovery: &mut LiveRecovery<'_>,
+    source_embedder: E,
+) -> Result<LiveGenerationSlot<E>, MemoryError> {
+    let archive = recovery.source.with_file_name(format!(
+        "{}{}",
+        recovery
+            .source
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| super::unavailable("source has no usable directory name"))?,
+        ARCHIVE_SUFFIX
+    ));
+    if archive.exists() || !recovery.destination.exists() {
+        rollback_staged_live_switch(recovery.source, recovery.destination)?;
+    }
+    let service = MemoryService::open(recovery.source, source_embedder)?;
+    recovery.controller.complete_source_recovery()?;
+    Ok(LiveGenerationSlot::new(service, recovery.source_model))
+}
+
+fn recover_target<E: Embedder>(
+    recovery: &mut LiveRecovery<'_>,
+    target_embedder: E,
+) -> Result<LiveGenerationSlot<E>, MemoryError> {
+    let service = MemoryService::open(recovery.source, target_embedder)?;
+    finalize_staged_live_switch(recovery.source, recovery.destination)?;
+    commit_retained_switch(recovery.source, recovery.destination)?;
+    recovery.controller.complete_target_recovery()?;
+    Ok(LiveGenerationSlot::new(service, recovery.target_model))
+}

--- a/crates/velesdb-memory/src/online_migration_tests.rs
+++ b/crates/velesdb-memory/src/online_migration_tests.rs
@@ -1,0 +1,447 @@
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use parking_lot::{Condvar, Mutex};
+
+use super::{LiveCutover, LiveGenerationSlot, LiveRecovery};
+use crate::embedding_provenance::{self, EmbeddingProvenance};
+use crate::migration::{
+    commit_retained_switch, finalize_staged_live_switch, prepare_live_switch, stage_live_switch,
+    target_embedder_witness,
+};
+use crate::mutation::controller::{
+    ControllerConfig, ControllerPhase, ConvergenceController, ConvergenceSample,
+};
+use crate::mutation::journal::{DirtyJournal, EpochIdentity};
+use crate::mutation::{DirtyKey, MutationObserver};
+use crate::storage::NativeStore;
+use crate::{HashEmbedder, MemoryService};
+
+#[test]
+fn replacement_waits_for_inflight_generation_and_swaps_the_pair() {
+    let root = tempfile::tempdir().expect("root");
+    let source =
+        MemoryService::open(root.path().join("source"), HashEmbedder::new(2)).expect("source");
+    let slot = Arc::new(LiveGenerationSlot::new(source, "source-model"));
+    let entered = mpsc::sync_channel(0);
+    let release = Arc::new((Mutex::new(false), Condvar::new()));
+    let reader_slot = Arc::clone(&slot);
+    let reader_release = Arc::clone(&release);
+    let reader = std::thread::spawn(move || {
+        reader_slot
+            .with_generation(|generation| {
+                entered.0.send(()).expect("signal entered");
+                let mut released = reader_release.0.lock();
+                while !*released {
+                    reader_release.1.wait(&mut released);
+                }
+                assert_eq!(generation.model(), "source-model");
+                assert_eq!(generation.dimension(), 2);
+            })
+            .expect("source generation");
+    });
+    entered.1.recv().expect("reader entered");
+
+    let target =
+        MemoryService::open(root.path().join("target"), HashEmbedder::new(3)).expect("target");
+    let writer_slot = Arc::clone(&slot);
+    let (replaced_tx, replaced_rx) = mpsc::channel();
+    let writer = std::thread::spawn(move || {
+        writer_slot.replace_for_test(target, "target-model");
+        replaced_tx.send(()).expect("signal replaced");
+    });
+
+    assert!(replaced_rx.recv_timeout(Duration::from_millis(50)).is_err());
+    *release.0.lock() = true;
+    release.1.notify_all();
+    reader.join().expect("reader");
+    writer.join().expect("writer");
+    slot.with_generation(|generation| {
+        assert_eq!(generation.model(), "target-model");
+        assert_eq!(generation.dimension(), 3);
+    })
+    .expect("target generation");
+}
+
+#[test]
+fn dropping_both_native_handles_allows_the_two_rename_open() {
+    let root = tempfile::tempdir().expect("root");
+    let source = root.path().join("source");
+    let destination = root.path().join("destination");
+    let archive = root.path().join("source.archive");
+    let service = MemoryService::open(&source, HashEmbedder::new(2)).expect("source");
+    let target = NativeStore::open(&destination, 3).expect("destination");
+    drop(service);
+    drop(target);
+    std::fs::rename(&source, &archive).expect("archive");
+    std::fs::rename(&destination, &source).expect("activate");
+    drop(NativeStore::open(&source, 3).expect("open activated target"));
+}
+
+#[test]
+fn live_cutover_installs_target_and_persists_the_measured_window() {
+    let rig = CutoverRig::new();
+    let mut controller = rig.quiescing_controller();
+    rig.slot
+        .cut_over(
+            LiveCutover {
+                controller: &mut controller,
+                journal: &rig.journal,
+                source: &rig.source,
+                destination: &rig.destination,
+                target_model: "target-model",
+                started_at: Duration::from_secs(3),
+                completed_at: Duration::from_millis(3_125),
+            },
+            HashEmbedder::new(3),
+            |_| Ok(()),
+        )
+        .expect("cut over");
+
+    assert_eq!(controller.phase(), ControllerPhase::Activated);
+    assert_eq!(
+        controller.measured_cutover(),
+        Some(Duration::from_millis(125))
+    );
+    rig.slot
+        .with_generation(|generation| {
+            assert_eq!(generation.model(), "target-model");
+            assert_eq!(generation.dimension(), 3);
+        })
+        .expect("target generation");
+    assert!(!rig.source.with_file_name("source.archive").exists());
+}
+
+#[test]
+fn deadline_expiry_reopens_the_source_without_activation() {
+    let rig = CutoverRig::new();
+    let mut controller = rig.quiescing_controller();
+    let error = rig
+        .slot
+        .cut_over(
+            LiveCutover {
+                controller: &mut controller,
+                journal: &rig.journal,
+                source: &rig.source,
+                destination: &rig.destination,
+                target_model: "target-model",
+                started_at: Duration::from_secs(3),
+                completed_at: Duration::from_millis(3_501),
+            },
+            HashEmbedder::new(3),
+            |_| Ok(()),
+        )
+        .expect_err("deadline must expire");
+
+    assert!(error.to_string().contains("deadline"), "{error}");
+    assert_eq!(controller.phase(), ControllerPhase::CatchingUp);
+    rig.slot
+        .with_generation(|generation| {
+            assert_eq!(generation.model(), "source-model");
+            assert_eq!(generation.dimension(), 2);
+        })
+        .expect("source reopened");
+    assert!(rig.source.exists());
+    assert!(rig.destination.exists());
+    assert!(!rig.source.with_file_name("source.archive").exists());
+}
+
+#[test]
+fn dirty_final_watermark_refuses_before_moving_or_retiring_source() {
+    let rig = CutoverRig::new();
+    rig.journal
+        .before_mutation(DirtyKey::Fact(7))
+        .expect("dirty record");
+    let mut controller = rig.quiescing_controller();
+    let error = rig
+        .slot
+        .cut_over(rig.cutover(&mut controller), HashEmbedder::new(3), |_| {
+            Ok(())
+        })
+        .expect_err("dirty journal must refuse");
+
+    assert!(error.to_string().contains("not drained"), "{error}");
+    assert_source_generation(&rig.slot);
+    rig.assert_unmoved();
+}
+
+#[test]
+fn seal_failure_refuses_before_moving_or_retiring_source() {
+    let rig = CutoverRig::new();
+    let mut controller = rig.quiescing_controller();
+    let error = rig
+        .slot
+        .cut_over(rig.cutover(&mut controller), HashEmbedder::new(3), |_| {
+            Err(velesdb_core::Error::Query("seal failed".to_owned()).into())
+        })
+        .expect_err("seal must fail");
+
+    assert!(error.to_string().contains("seal failed"), "{error}");
+    assert_source_generation(&rig.slot);
+    rig.assert_unmoved();
+}
+
+#[test]
+fn source_provenance_mismatch_refuses_before_movement() {
+    let rig = CutoverRig::with_active_model("unexpected-source-model");
+    let mut controller = rig.quiescing_controller();
+    let error = rig
+        .slot
+        .cut_over(rig.cutover(&mut controller), HashEmbedder::new(3), |_| {
+            Ok(())
+        })
+        .expect_err("source identity must fail");
+
+    assert!(error.to_string().contains("identity"), "{error}");
+    rig.assert_unmoved();
+}
+
+#[test]
+fn restart_while_quiescing_restores_the_staged_source() {
+    let rig = CutoverRig::new();
+    let controller = rig.quiescing_controller();
+    rig.prepare_switch();
+    let crashed = rig.crash();
+    stage_live_switch(&crashed.source, &crashed.destination).expect("stage");
+    drop(controller);
+    let mut resumed = crashed.resumed_controller();
+
+    let slot = crashed.recover(&mut resumed).expect("recover source");
+
+    assert_eq!(resumed.phase(), ControllerPhase::CatchingUp);
+    assert_source_generation(&slot);
+    crashed.assert_unmoved();
+}
+
+#[test]
+fn restart_after_activation_finishes_forward_and_clears_archive() {
+    let rig = CutoverRig::new();
+    let mut controller = rig.quiescing_controller();
+    rig.prepare_switch();
+    let crashed = rig.crash();
+    stage_live_switch(&crashed.source, &crashed.destination).expect("stage");
+    drop(MemoryService::open(&crashed.source, HashEmbedder::new(3)).expect("target proof"));
+    controller
+        .activate(Duration::from_millis(3_125))
+        .expect("activate");
+    drop(controller);
+    let mut resumed = crashed.resumed_controller();
+
+    let slot = crashed.recover(&mut resumed).expect("recover target");
+
+    assert_eq!(resumed.phase(), ControllerPhase::Activated);
+    assert_eq!(resumed.recovery_action(), None);
+    assert_target_generation(&slot);
+    assert!(!crashed.archive().exists());
+}
+
+#[test]
+fn restart_after_archive_commit_is_idempotent() {
+    let rig = CutoverRig::new();
+    let mut controller = rig.quiescing_controller();
+    rig.prepare_switch();
+    let crashed = rig.crash();
+    stage_live_switch(&crashed.source, &crashed.destination).expect("stage");
+    drop(MemoryService::open(&crashed.source, HashEmbedder::new(3)).expect("target proof"));
+    controller
+        .activate(Duration::from_millis(3_125))
+        .expect("activate");
+    finalize_staged_live_switch(&crashed.source, &crashed.destination).expect("finalize");
+    commit_retained_switch(&crashed.source, &crashed.destination).expect("commit");
+    drop(controller);
+    let mut resumed = crashed.resumed_controller();
+
+    let slot = crashed.recover(&mut resumed).expect("recover committed");
+
+    assert_target_generation(&slot);
+    assert_eq!(resumed.recovery_action(), None);
+    assert!(!crashed.archive().exists());
+}
+
+struct CutoverRig {
+    _root: tempfile::TempDir,
+    source: std::path::PathBuf,
+    destination: std::path::PathBuf,
+    workspace: std::path::PathBuf,
+    journal: Arc<DirtyJournal>,
+    slot: LiveGenerationSlot<HashEmbedder>,
+}
+
+impl CutoverRig {
+    fn new() -> Self {
+        Self::with_active_model("source-model")
+    }
+
+    fn with_active_model(active_model: &str) -> Self {
+        let root = tempfile::tempdir().expect("root");
+        let source = root.path().join("source");
+        let destination = root.path().join("destination");
+        let workspace = root.path().join("destination.migration-journal");
+        let service = MemoryService::open(&source, HashEmbedder::new(2)).expect("source");
+        drop(NativeStore::open(&destination, 3).expect("destination"));
+        embedding_provenance::write(&destination, &EmbeddingProvenance::new("target-model", 3))
+            .expect("target provenance");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        let target_witness =
+            crate::migration::target_embedder_witness(&HashEmbedder::new(3)).expect("witness");
+        let identity = EpochIdentity::for_test(
+            source.clone(),
+            "source-model",
+            "target-model",
+            3,
+            &target_witness,
+            destination.clone(),
+            EPOCH,
+        );
+        let journal = Arc::new(DirtyJournal::open(&workspace, &identity, 1024).expect("journal"));
+        Self {
+            _root: root,
+            source,
+            destination,
+            workspace,
+            journal,
+            slot: LiveGenerationSlot::new(service, active_model),
+        }
+    }
+
+    fn cutover<'a>(&'a self, controller: &'a mut ConvergenceController) -> LiveCutover<'a> {
+        LiveCutover {
+            controller,
+            journal: &self.journal,
+            source: &self.source,
+            destination: &self.destination,
+            target_model: "target-model",
+            started_at: Duration::from_secs(3),
+            completed_at: Duration::from_millis(3_125),
+        }
+    }
+
+    fn prepare_switch(&self) {
+        let witness = target_embedder_witness(&HashEmbedder::new(3)).expect("witness");
+        prepare_live_switch(&self.source, &self.destination, "target-model", 3, &witness)
+            .expect("prepare live switch");
+    }
+
+    fn assert_unmoved(&self) {
+        assert!(self.source.exists());
+        assert!(self.destination.exists());
+        assert!(!self.source.with_file_name("source.archive").exists());
+    }
+
+    fn crash(self) -> RecoveryRig {
+        let Self {
+            _root: root,
+            source,
+            destination,
+            workspace,
+            journal,
+            slot,
+        } = self;
+        drop(slot);
+        RecoveryRig {
+            _root: root,
+            source,
+            destination,
+            workspace,
+            journal,
+        }
+    }
+
+    fn quiescing_controller(&self) -> ConvergenceController {
+        let mut controller =
+            ConvergenceController::open(&self.workspace, EPOCH, config()).expect("controller");
+        for (second, input, output) in [(0, 100, 80), (1, 110, 100), (2, 120, 120)] {
+            controller
+                .observe(sample(second, input, output))
+                .expect("observe");
+        }
+        controller
+            .begin_quiescing(Duration::from_secs(3))
+            .expect("quiesce");
+        controller
+    }
+}
+
+struct RecoveryRig {
+    _root: tempfile::TempDir,
+    source: std::path::PathBuf,
+    destination: std::path::PathBuf,
+    workspace: std::path::PathBuf,
+    journal: Arc<DirtyJournal>,
+}
+
+impl RecoveryRig {
+    fn resumed_controller(&self) -> ConvergenceController {
+        let controller =
+            ConvergenceController::open(&self.workspace, EPOCH, config()).expect("resume");
+        assert!(controller.recovery_action().is_some());
+        controller
+    }
+
+    fn recover(
+        &self,
+        controller: &mut ConvergenceController,
+    ) -> Result<LiveGenerationSlot<HashEmbedder>, crate::MemoryError> {
+        LiveGenerationSlot::recover(
+            LiveRecovery {
+                controller,
+                journal: &self.journal,
+                source: &self.source,
+                destination: &self.destination,
+                source_model: "source-model",
+                target_model: "target-model",
+            },
+            HashEmbedder::new(2),
+            HashEmbedder::new(3),
+        )
+    }
+
+    fn archive(&self) -> std::path::PathBuf {
+        self.source.with_file_name("source.archive")
+    }
+
+    fn assert_unmoved(&self) {
+        assert!(self.source.exists());
+        assert!(self.destination.exists());
+        assert!(!self.archive().exists());
+    }
+}
+
+fn assert_source_generation(slot: &LiveGenerationSlot<HashEmbedder>) {
+    slot.with_generation(|generation| {
+        assert_eq!(generation.model(), "source-model");
+        assert_eq!(generation.dimension(), 2);
+    })
+    .expect("source generation");
+}
+
+fn assert_target_generation(slot: &LiveGenerationSlot<HashEmbedder>) {
+    slot.with_generation(|generation| {
+        assert_eq!(generation.model(), "target-model");
+        assert_eq!(generation.dimension(), 3);
+    })
+    .expect("target generation");
+}
+
+const EPOCH: &str = "00112233445566778899aabbccddeeff";
+
+fn config() -> ControllerConfig {
+    ControllerConfig {
+        observation_window: 3,
+        pause_budget: Duration::from_millis(500),
+        verification_reserve: Duration::from_millis(50),
+    }
+}
+
+fn sample(second: u64, input: u64, output: u64) -> ConvergenceSample {
+    ConvergenceSample {
+        observed_at: Duration::from_secs(second),
+        input_watermark: input,
+        output_watermark: output,
+        distinct_dirty_facts: 2,
+        distinct_edge_sources: 1,
+        pending_journal_bytes: (input - output) * 49,
+        replay_elapsed: Duration::from_millis(20),
+        largest_apply_latency: Duration::from_millis(20),
+    }
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -38,6 +38,7 @@ use crate::storage::{is_reserved_key, strip_reserved_keys, MemoryStore, AUTO_DAT
 mod fused_recall;
 
 #[cfg(feature = "persistence")]
+#[allow(dead_code, unused_imports)] // Wired by the control-surface slice after this internal seam.
 #[path = "online_migration.rs"]
 mod online_migration;
 

--- a/scripts/tests/test_create_release_tag.py
+++ b/scripts/tests/test_create_release_tag.py
@@ -54,6 +54,8 @@ class ReleaseTagScriptTests(unittest.TestCase):
         run(["git", "init", "--initial-branch=main", str(self.repo)], self.root)
         git(self.repo, "config", "user.name", "Release Test")
         git(self.repo, "config", "user.email", "release-test@example.invalid")
+        git(self.repo, "config", "commit.gpgSign", "false")
+        git(self.repo, "config", "tag.gpgSign", "false")
         git(self.repo, "remote", "add", "origin", str(self.remote))
         self.main_sha = commit_file(self.repo, "main.txt", "main\n", "seed main")
         git(self.repo, "push", "--set-upstream", "origin", "main")


### PR DESCRIPTION
Closes #1933

## Résultat
- remplace atomiquement la génération mémoire après drainage des requêtes en vol
- garantit la fermeture de l’ancien store avant les renommages
- reprend par rollback avant activation et par finalisation en avant après activation
- lie la bascule à la provenance source et à un témoin vectoriel cible
- conserve l’archive tant que la finalisation n’est pas prouvée
- isole les fixtures de tag de la configuration Git de la machine

## Validation
- suites ciblées migration et bascule live
- Clippy strict et seuils CC/NLOC
- suite workspace complète et tests WASM fonctionnels
- gardes documentaires, contrats MCP, hooks et cargo-deny
- zéro violation de sécurité, TODO ou attribution