### PR TITLE
fix(node): update js-yaml to 4.3.1

### DIFF
--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1770,9 +1770,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- update the locked `js-yaml` transitive development dependency from 4.3.0 to 4.3.1
- remediate GHSA-5p4m-2wfm-xmqj / Dependabot alert #112
- keep the existing `@napi-rs/cli` dependency range and all runtime code unchanged

## Root cause

`@napi-rs/cli` 3.7.2 permits `js-yaml ^4.2.0`; the lockfile had selected vulnerable 4.3.0 even though patched 4.3.1 satisfies the same range.

## Validation

- `npm audit --package-lock-only`: 0 vulnerabilities
- `npm ls js-yaml --all`: 4.3.1, no dependency problems
- exact Node CI gate: dependency install, N-API build, 71 specs; 70 passed, 0 failed, 1 intentional Ollama skip
- repository pre-commit and pre-push hooks passed
- attribution guard passed
