### PR TITLE
fix(memory): align scalar wire tolerance

### DIFF
--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -167,18 +167,30 @@ pub struct MemoryScope {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
     /// How many memories to consider (adapter-clamped).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::wire::lenient"
+    )]
     pub k: Option<usize>,
     /// Graph-walk depth of the fused recall (default 2). Deeper hops reach
     /// longer cause/fix chains from the vector seed.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::wire::lenient"
+    )]
     pub hops: Option<usize>,
     /// Fusion weight added to graph-reached memories (default 0.15). Raise
     /// it (e.g. `0.5`–`0.8`) when pulling from curated fact chains built
     /// with `relate`: evidence that shares **no vocabulary** with the query
     /// can then out-rank lexically-noisy near-misses — the tri-engine's
     /// answer to the purely lexical relevance of caller fragments.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::wire::lenient"
+    )]
     pub graph_boost: Option<f64>,
 }
 
@@ -384,6 +396,7 @@ pub struct CompileRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_model: Option<String>,
     /// Hard token ceiling for the assembled content.
+    #[serde(deserialize_with = "crate::wire::lenient")]
     pub token_budget: u64,
     /// Which memories may be pulled in (US-002; ignored by the memoryless core).
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -143,6 +143,10 @@ pub mod storage;
 /// behind `http` since it exists only to serve that transport.
 #[cfg(feature = "http")]
 pub mod tls;
+/// Shared defensive deserialization for non-string scalar and structured
+/// inputs whose client-side schema can degrade to untyped JSON.
+#[cfg(any(feature = "mcp", feature = "context"))]
+mod wire;
 
 /// Default embedding dimension — the single source of truth, taken from the
 /// SDK's own default so the server, library, and tests never restate the

--- a/crates/velesdb-memory/src/mcp/wire.rs
+++ b/crates/velesdb-memory/src/mcp/wire.rs
@@ -1,46 +1,6 @@
-//! Lenient wire-side deserialization for MCP tool parameters.
-//!
-//! Real MCP client harnesses (observed 2026-07-24 with Claude Code) can
-//! serialize a non-string tool argument as a JSON-encoded STRING when their
-//! own view of the advertised schema has degraded to "untyped" — `limit: 6`
-//! arrives as `"6"`, `filter: {"project": "x"}` as `"{\"project\": \"x\"}"`,
-//! and `save_working_context`'s whole `working` object as one escaped JSON
-//! string. Rejecting those loses the call (and, for `save_working_context`,
-//! silently loses a session handoff).
-//!
-//! [`lenient`] is the server-side half of the harness-proof wire contract
-//! (the schema half is `crate::schema::inline_ref_only_properties`): accept
-//! the properly-typed JSON value first, and fall back to parsing a string
-//! argument AS JSON into the target type. Same defensive-interop class as
-//! the #1468 string-or-number id contract in `crate::context::wire`.
-//!
-//! Never applied to genuinely string-typed parameters — a real string must
-//! not be re-interpreted as JSON.
+//! MCP-local path for the crate-wide defensive wire deserializer.
 
-use serde::de::{DeserializeOwned, Error as DeError};
-use serde::{Deserialize, Deserializer};
-
-/// Deserializes `T` from either its proper JSON representation or from a
-/// JSON-encoded string containing it. The non-string path is byte-for-byte
-/// the plain serde behaviour; the error of the direct interpretation is the
-/// one reported when the string fallback fails too, so a genuinely malformed
-/// argument keeps a precise message.
-pub(super) fn lenient<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-where
-    T: DeserializeOwned,
-    D: Deserializer<'de>,
-{
-    let raw = serde_json::Value::deserialize(deserializer)?;
-    match raw {
-        serde_json::Value::String(text) => serde_json::from_str(&text).map_err(|err| {
-            DeError::custom(format!(
-                "argument arrived as a JSON-encoded string and could not be \
-                 parsed as the expected type: {err}"
-            ))
-        }),
-        value => serde_json::from_value(value).map_err(DeError::custom),
-    }
-}
+pub(super) use crate::wire::lenient;
 
 #[cfg(test)]
 #[path = "wire_tests.rs"]

--- a/crates/velesdb-memory/src/wire.rs
+++ b/crates/velesdb-memory/src/wire.rs
@@ -1,0 +1,31 @@
+//! Lenient deserialization shared by canonical domain and MCP wire types.
+//!
+//! Real MCP client harnesses can serialize a non-string tool argument as a
+//! JSON-encoded string when their view of the advertised schema has degraded
+//! to "untyped". [`lenient`] accepts the properly typed JSON value first and
+//! falls back to parsing a string argument as JSON into the target type.
+//!
+//! Never apply it to genuinely string-typed parameters: a real string must
+//! not be reinterpreted as JSON.
+
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer};
+
+/// Deserializes `T` from its proper JSON representation or a JSON-encoded
+/// string containing it.
+pub(crate) fn lenient<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    match raw {
+        serde_json::Value::String(text) => serde_json::from_str(&text).map_err(|err| {
+            DeError::custom(format!(
+                "argument arrived as a JSON-encoded string and could not be \
+                 parsed as the expected type: {err}"
+            ))
+        }),
+        value => serde_json::from_value(value).map_err(DeError::custom),
+    }
+}

--- a/crates/velesdb-memory/tests/mcp_schema_bdd.rs
+++ b/crates/velesdb-memory/tests/mcp_schema_bdd.rs
@@ -25,9 +25,9 @@
 
 #![cfg(all(feature = "mcp", feature = "context", feature = "persistence"))]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use rmcp::model::CallToolRequestParams;
+use rmcp::model::{CallToolRequestParams, Tool};
 use rmcp::service::RunningService;
 use rmcp::{RoleClient, ServiceExt};
 use serde_json::{json, Map, Value};
@@ -840,7 +840,7 @@ const PROBE_MAP_KEY: &str = "probe";
 /// unconfigured extractor) is a legitimate answer to a well-formed call.
 const ARGUMENT_TYPE_REFUSAL: &str = "failed to deserialize parameters:";
 
-/// Every slot the schema announces as a single scalar `integer` or `string`,
+/// Every slot the schema announces as a single scalar,
 /// with the path needed to reach it.
 ///
 /// `properties`, `items` and `additionalProperties` are followed: the three
@@ -885,10 +885,8 @@ fn walk_probes(node: &Value, path: &mut Vec<Step>, found: &mut Vec<(Vec<Step>, S
     }
 }
 
-/// `"integer"` or `"string"`, and only those: the probe sends the two forms
-/// an id can take on the wire, so it is meaningless on a boolean or an
-/// object. An enumerated slot is skipped too — its value set is closed, and
-/// neither `1` nor `"1"` belongs to it.
+/// An enumerated slot is skipped: its value set is closed, so an arbitrary
+/// scalar probe would test the enum rather than the wire type.
 fn probed_scalar(slot: &Value) -> Option<String> {
     let Value::Object(map) = slot else {
         return None;
@@ -897,9 +895,38 @@ fn probed_scalar(slot: &Value) -> Option<String> {
         return None;
     }
     match map.get("type") {
-        Some(Value::String(kind)) if kind == "integer" || kind == "string" => Some(kind.clone()),
+        Some(Value::String(kind))
+            if matches!(kind.as_str(), "boolean" | "integer" | "number" | "string") =>
+        {
+            Some(kind.clone())
+        }
         _ => None,
     }
+}
+
+fn announced_scalar(kind: &str) -> Value {
+    match kind {
+        "boolean" => json!(true),
+        "number" => json!(0.5),
+        "string" => json!("1"),
+        _ => json!(1),
+    }
+}
+
+fn stringified_scalar(kind: &str) -> Option<Value> {
+    match kind {
+        "boolean" => Some(json!("true")),
+        "integer" => Some(json!("6")),
+        "number" => Some(json!("0.5")),
+        _ => None,
+    }
+}
+
+fn leaf_property(path: &[Step]) -> Option<&str> {
+    path.iter().rev().find_map(|step| match step {
+        Step::Property(name) => Some(name.as_str()),
+        Step::Items | Step::MapValue => None,
+    })
 }
 
 /// The minimal call that carries `value` at `path`: every required sibling
@@ -989,10 +1016,7 @@ async fn every_scalar_input_slot_accepts_the_form_it_announces() {
         let schema = Value::Object((*tool.input_schema).clone());
         for (path, kind) in probed_slots(&schema) {
             probed += 1;
-            let announced = match kind.as_str() {
-                "string" => json!("1"),
-                _ => json!(1),
-            };
+            let announced = announced_scalar(&kind);
             let arguments = call_carrying(&schema, &path, &announced);
             let complaint = complaint_about(&client, &tool.name, arguments.clone()).await;
             if complaint.contains(ARGUMENT_TYPE_REFUSAL) {
@@ -1015,6 +1039,140 @@ async fn every_scalar_input_slot_accepts_the_form_it_announces() {
         "{} of {probed} scalar slot(s) refuse the very form their schema announces:\n{}",
         broken.len(),
         broken.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+struct ScalarToleranceProbe {
+    tool: String,
+    schema: Value,
+    path: Vec<Step>,
+}
+
+fn scalar_tolerance_groups(
+    tools: &[Tool],
+) -> BTreeMap<(String, String), Vec<ScalarToleranceProbe>> {
+    let mut groups = BTreeMap::new();
+    for tool in tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for (path, kind) in probed_slots(&schema) {
+            let Some(name) = leaf_property(&path) else {
+                continue;
+            };
+            if stringified_scalar(&kind).is_none() {
+                continue;
+            }
+            groups
+                .entry((name.to_owned(), kind))
+                .or_insert_with(Vec::new)
+                .push(ScalarToleranceProbe {
+                    tool: tool.name.to_string(),
+                    schema: schema.clone(),
+                    path,
+                });
+        }
+    }
+    groups
+}
+
+/// A field name and its announced scalar type define one wire contract.
+/// Every occurrence must therefore make the same decision about the
+/// JSON-encoded string form that degraded MCP harnesses can send.
+#[tokio::test]
+async fn same_named_scalar_input_slots_share_wire_tolerance() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let groups = scalar_tolerance_groups(&tools);
+    let mut compared = 0usize;
+    let mut asymmetric = Vec::new();
+    for ((name, kind), probes) in groups.into_iter().filter(|(_, probes)| probes.len() > 1) {
+        compared += 1;
+        let encoded = stringified_scalar(&kind).expect("grouped kinds have a string probe");
+        let mut accepted = Vec::new();
+        let mut refused = Vec::new();
+        for probe in probes {
+            let arguments = call_carrying(&probe.schema, &probe.path, &encoded);
+            let complaint = complaint_about(&client, &probe.tool, arguments).await;
+            let location = format!("{} {}", probe.tool, render_path(&probe.path));
+            if complaint.contains(ARGUMENT_TYPE_REFUSAL) {
+                refused.push(location);
+            } else {
+                accepted.push(location);
+            }
+        }
+        if !accepted.is_empty() && !refused.is_empty() {
+            asymmetric.push(format!(
+                "`{name}` ({kind}) accepts {encoded} at {accepted:?}, but refuses it at {refused:?}"
+            ));
+        }
+    }
+
+    assert!(compared > 0, "no repeated scalar contract was found");
+    assert!(
+        asymmetric.is_empty(),
+        "same field name + same announced scalar type must have one wire tolerance:\n{}",
+        asymmetric.join("\n")
+    );
+    client.cancel().await.expect("close the MCP session");
+}
+
+fn incompatible_scalar_values(kind: &str) -> Option<Vec<Value>> {
+    match kind {
+        "boolean" => Some(vec![json!("1"), json!(1), json!([]), json!({})]),
+        "integer" => Some(vec![
+            json!("abc"),
+            json!("1.5"),
+            json!(true),
+            json!(0.5),
+            json!([]),
+            json!({}),
+        ]),
+        "number" => Some(vec![
+            json!("abc"),
+            json!("true"),
+            json!(true),
+            json!([]),
+            json!({}),
+        ]),
+        _ => None,
+    }
+}
+
+/// Leniency is one narrow exception for a JSON-encoded value of the same
+/// advertised type. It must not become a general scalar or container
+/// coercion, including on a field that has no same-named peer to compare.
+#[tokio::test]
+async fn every_non_string_scalar_input_rejects_incompatible_forms() {
+    let (_store, client) = connected().await;
+    let tools = client.list_all_tools().await.expect("list tools");
+    let mut probed = 0usize;
+    let mut accepted = Vec::new();
+    for tool in &tools {
+        let schema = Value::Object((*tool.input_schema).clone());
+        for (path, kind) in probed_slots(&schema) {
+            let Some(values) = incompatible_scalar_values(&kind) else {
+                continue;
+            };
+            for value in values {
+                probed += 1;
+                let arguments = call_carrying(&schema, &path, &value);
+                let complaint = complaint_about(&client, &tool.name, arguments).await;
+                if !complaint.contains(ARGUMENT_TYPE_REFUSAL) {
+                    accepted.push(format!(
+                        "{} {} announces `{kind}` but accepted {value}",
+                        tool.name,
+                        render_path(&path)
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(probed > 0, "no non-string scalar slot was probed");
+    assert!(
+        accepted.is_empty(),
+        "incompatible scalar forms reached tool execution:\n{}",
+        accepted.join("\n")
     );
     client.cancel().await.expect("close the MCP session");
 }

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -44,6 +44,27 @@ database capabilities (`query`, `create_collection`, `upsert`, `traverse`) —
 that boundary is what keeps local, embedded use inside the VelesDB Core
 License.
 
+## Scalar inputs on the wire
+
+Every input slot advertises exactly one scalar type. Input unions are not
+published because degraded MCP harnesses flatten them into an untyped `{}`;
+the single advertised type is the form a schema-driven caller should send.
+
+Some harnesses nevertheless JSON-encode a non-string scalar inside a string.
+For a lenient slot, the server accepts that string only when decoding it as
+JSON produces the same advertised scalar value: an integer slot may accept
+both `6` and `"6"`, but still rejects `"abc"`, `"1.5"`, arrays, objects and
+booleans. Leniency is never applied to a genuine string slot, whose content
+must not be reinterpreted as JSON.
+
+**Invariant:** same field name + same advertised scalar type means identical tolerance for the JSON-encoded string form.
+The live MCP schema test `same_named_scalar_input_slots_share_wire_tolerance`
+enforces this rule without maintaining a list of field names.
+
+**Rejection invariant:** leniency never accepts an invalid JSON string or a value of another scalar or container type.
+The live test `every_non_string_scalar_input_rejects_incompatible_forms`
+checks every boolean, integer and number slot, including uniquely named fields.
+
 ## Ids on the wire (read this before relaying any id)
 
 Memory ids and fragment ids are `u64` and routinely exceed 2^53, where a JSON

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -330,6 +330,30 @@
       "measured_on": "2026-07-26",
       "measured_machine": "platform-independent (committed corpus, deterministic tokenizer)",
       "measured_version": "4.0.0"
+    },
+    {
+      "id": "mcp_same_named_scalar_wire_tolerance",
+      "file": "docs/reference/MCP_TOOLS.md",
+      "must_contain": "**Invariant:** same field name + same advertised scalar type means identical tolerance for the JSON-encoded string form.",
+      "validation_command": "cargo test -p velesdb-memory --test mcp_schema_bdd same_named_scalar_input_slots_share_wire_tolerance -- --exact --test-threads=1",
+      "executable": false,
+      "source": "Issue #1686: the live-schema MCP regression test compares the accepted wire form for every repeated field-name and scalar-type pair.",
+      "last_updated": "2026-08-15",
+      "measured_on": "2026-08-15",
+      "measured_machine": "platform-independent (wire-schema contract)",
+      "measured_version": "5.0.0"
+    },
+    {
+      "id": "mcp_lenient_scalar_rejects_incompatible_forms",
+      "file": "docs/reference/MCP_TOOLS.md",
+      "must_contain": "**Rejection invariant:** leniency never accepts an invalid JSON string or a value of another scalar or container type.",
+      "validation_command": "cargo test -p velesdb-memory --test mcp_schema_bdd every_non_string_scalar_input_rejects_incompatible_forms -- --exact --test-threads=1",
+      "executable": false,
+      "source": "Issue #1686: the live MCP server must reject invalid strings and incompatible scalar or container values at every non-string scalar input slot.",
+      "last_updated": "2026-08-15",
+      "measured_on": "2026-08-15",
+      "measured_machine": "platform-independent (wire-schema contract)",
+      "measured_version": "5.0.0"
     }
   ],
   "claim_families": [


### PR DESCRIPTION
## Summary
- centralize defensive scalar deserialization across MCP and context request types
- make repeated scalar fields share the same JSON-string tolerance while preserving single-type schemas
- add live-schema acceptance and rejection coverage plus the documented promise contract

## Validation
- full pre-commit suite
- velesdb-memory all features
- velesdb-core persistence suite and doctests
- workspace and crate Clippy gates
- no-default-feature and wasm-pack gates
- Python, documentation, hook, Cargo Deny, complexity and duplication gates

Closes #1686