### PR TITLE
perf(memory): bench the graph-extraction models velesdb-memory can run on

### DIFF
--- a/scripts/bench-memory-extraction.py
+++ b/scripts/bench-memory-extraction.py
@@ -1,0 +1,1262 @@
+#!/usr/bin/env python3
+"""
+Measure where velesdb-memory's write path spends its time, and which local
+model to run its graph extraction on.
+
+Four subcommands, cheapest first:
+
+  from-log   Digest the daemon's own `mcp tool call` events into a per-tool
+             latency map. Costs nothing, needs no model, and is the only view of
+             what real sessions actually paid.
+  screen     Phase A. Send each scenario straight to the model's API and score
+             the JSON it returns. Eliminates a candidate on a broken schema, a
+             truncated answer or an invented relation before anything more
+             expensive runs.
+  endtoend   Phase B. Drive a DISPOSABLE daemon through its real MCP tools over
+             its real transport, and assert on the graph that comes back out.
+  report     Render the frozen markdown report from a result file. The report is
+             generated, never typed: that is what keeps the published table and
+             the measurement behind it from drifting apart.
+
+Three rules the rest of the file exists to enforce.
+
+**The bench must not drift from the product.** The prompt and the generation cap
+are read out of `crates/velesdb-memory/src/extract.rs`, and the request body is
+the one `openai::chat_body` builds — `temperature: 0` and `max_tokens` included.
+A bench that hand-copies the prompt measures a fossil: the 2026-08-07 campaign
+sent no cap at all, so it never once exercised the truncation the cap introduced.
+
+**One set of expectations, two levels.** Phase B does not restate what phase A
+checks. The same declarative `relation_present` / `attribute_on` specs are
+applied to the stored graph instead of the raw JSON, so the two levels cannot
+disagree about what a passage means.
+
+**A number is unreadable without its conditions.** Every scored run carries the
+cold-load time, the warm-up trace and the residency proof that surround it. A
+p95 with no idea whether it was taken cold, warm, or under the memory guard is
+not a measurement.
+
+Usage:
+
+    python3 scripts/bench-memory-extraction.py from-log [--log PATH] [--since ISO]
+    python3 scripts/bench-memory-extraction.py screen --config MODEL [--runs N]
+    python3 scripts/bench-memory-extraction.py endtoend --config MODEL --binary PATH
+    python3 scripts/bench-memory-extraction.py report --results PATH
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import shutil
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+import unicodedata
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+EXTRACT_RS = ROOT / "crates" / "velesdb-memory" / "src" / "extract.rs"
+CASES_FILE = Path(__file__).resolve().parent / "memory-extraction-cases.json"
+DEFAULT_LOG = Path.home() / "Library" / "Logs" / "velesdb-memory" / "daemon.err.log"
+
+# The daemon's tool-level trace event (mcp.rs, issue #1780). Pinned as a whole
+# line shape rather than a loose `elapsed_ms` grep: the same key appears on the
+# HTTP-layer event, and mixing the two averages a 200-second `remember` with a
+# 0-millisecond POST.
+TOOL_EVENT_RE = re.compile(
+    r"tool=(?P<tool>\S+) session=(?P<session>\S+) "
+    r"verdict=(?P<verdict>\S+) elapsed_ms=(?P<ms>\d+)"
+)
+HTTP_EVENT_RE = re.compile(
+    r"mcp http request method=(?P<method>\S+) session=\S+ "
+    r"status=(?P<status>\d+) elapsed_ms=(?P<ms>\d+)"
+)
+LOG_TIMESTAMP_RE = re.compile(r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})")
+
+SEVERITIES = ("fatal", "major", "minor")
+
+
+# --------------------------------------------------------------------- text --
+
+
+def fold(value: object) -> str:
+    """Case- and accent-fold for matching.
+
+    The ligatures are mapped by hand because NFKD does not decompose them:
+    U+0153 has no decomposition at all, so the ASCII pass drops it outright and
+    `soeur` folds to `sur`. Every kinship check in the suite would then stop
+    matching without failing — the worst kind of broken oracle, one that reports
+    success.
+    """
+    text = str(value).lower()
+    for ligature, expansion in (("œ", "oe"), ("æ", "ae")):
+        text = text.replace(ligature, expansion)
+    return unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode()
+
+
+def strip_code_fence(content: str) -> str:
+    """Drop a markdown fence some models wrap their JSON in.
+
+    Tolerated rather than scored: the contract says "no markdown fence", but a
+    fence is recoverable and uninteresting, while what the JSON says is not.
+    Models that fence are visible in the raw answers, not disqualified for it.
+    """
+    text = content.strip()
+    if not text.startswith("```"):
+        return text
+    parts = text.split("```")
+    return parts[1].removeprefix("json").strip() if len(parts) > 1 else text
+
+
+# ------------------------------------------------------- prompt, from source --
+
+
+def _unescape_rust_literal(raw: str) -> str:
+    """Turn one Rust string literal's body into the text it denotes."""
+    # Line continuations first: a trailing backslash eats the newline and the
+    # indentation that follows it.
+    text = re.sub(r"\\\n\s*", "", raw)
+    for escape, literal in (("\\n", "\n"), ("\\t", "\t"), ('\\"', '"'), ("\\\\", "\\")):
+        text = text.replace(escape, literal)
+    return text
+
+
+def read_graph_prompt_template(source: Path = EXTRACT_RS) -> str:
+    """Read `build_graph_prompt`'s literal out of the crate.
+
+    Sourced rather than copied so the bench cannot measure a prompt the product
+    no longer sends. A parse failure is raised, never defaulted: quietly falling
+    back to a bundled copy is exactly the drift this guards against.
+    """
+    text = source.read_text(encoding="utf-8")
+    start = text.find("fn build_graph_prompt(")
+    if start < 0:
+        raise RuntimeError(f"build_graph_prompt not found in {source}")
+    # The literal runs to its first UNESCAPED quote. A lazy `"(.*?)"\s*\)` looks
+    # equivalent and is not: the prompt contains `(e.g. \"bruno durand\")`, whose
+    # `")` ends the match two thirds of the way in, and the bench then measures a
+    # prompt that stops mid-sentence.
+    literal = re.search(r'format!\(\s*"((?:[^"\\]|\\.)*)"', text[start:], re.DOTALL)
+    if not literal:
+        raise RuntimeError(f"no format! literal under build_graph_prompt in {source}")
+    return _unescape_rust_literal(literal.group(1))
+
+
+def read_generation_cap(source: Path = EXTRACT_RS) -> int:
+    """Read `MAX_GENERATION_TOKENS` out of the crate, for the same reason."""
+    text = source.read_text(encoding="utf-8")
+    match = re.search(r"const MAX_GENERATION_TOKENS: u32 = (\d+);", text)
+    if not match:
+        raise RuntimeError(f"MAX_GENERATION_TOKENS not found in {source}")
+    return int(match.group(1))
+
+
+def build_graph_prompt(passage: str, template: str) -> str:
+    """Apply the crate's template to one passage.
+
+    The template is a Rust `format!` string: `{text}` is the passage and every
+    literal brace is doubled. The passage goes in BEFORE the braces are
+    collapsed, so a brace inside the passage stays a brace.
+    """
+    filled = template.replace("{text}", passage)
+    prompt = filled.replace("{{", "{").replace("}}", "}")
+    # The LAST marker is the one that matters. A truncated parse still carries
+    # the passage and the opening sections, so a guard that only looks at the
+    # head passes on a prompt cut two thirds of the way through — which is
+    # exactly what the first version of this function shipped.
+    for marker in (passage, "STEP 0", '"relations"', '"attributes"', '"entity": string'):
+        if marker not in prompt:
+            raise RuntimeError(f"prompt built from source lacks {marker!r}; the parse is wrong")
+    if not prompt.rstrip().endswith("}"):
+        raise RuntimeError("prompt built from source does not end on the JSON contract")
+    return prompt
+
+
+# -------------------------------------------------------------- the scorer ----
+
+
+def relation_triples(payload: dict) -> "list[tuple[str, str, str]] | None":
+    """Fold `relations` into comparable triples, or None if the schema broke.
+
+    None is the case that matters: a model answering with arrays instead of
+    objects produces JSON that parses and enrichment that silently vanishes,
+    because `RawRelation` refuses it and autograph is deliberately infallible.
+    """
+    triples = []
+    for relation in payload.get("relations") or []:
+        if not isinstance(relation, dict):
+            return None
+        triples.append((
+            fold(relation.get("subject", "")),
+            fold(relation.get("predicate", "")),
+            fold(relation.get("object", "")),
+        ))
+    return triples
+
+
+def _endpoints_match(triple: "tuple[str, str, str]", spec: dict) -> bool:
+    """Do the triple's two ends satisfy the spec? Absent keys constrain nothing."""
+    subject, _, obj = triple
+    if "subject" in spec and subject != fold(spec["subject"]):
+        return False
+    if "object" in spec and obj != fold(spec["object"]):
+        return False
+    return "object_contains" not in spec or fold(spec["object_contains"]) in obj
+
+
+def _predicate_matches(predicate: str, spec: dict) -> bool:
+    """Any listed term appearing in the predicate is a match; no list matches all."""
+    wanted = spec.get("predicate_any")
+    return not wanted or any(fold(term) in predicate for term in wanted)
+
+
+def _matches(triple: "tuple[str, str, str]", spec: dict) -> bool:
+    """Does one triple satisfy a relation spec?"""
+    return _endpoints_match(triple, spec) and _predicate_matches(triple[1], spec)
+
+
+def _check_relation_present(ctx: dict, spec: dict) -> bool:
+    return any(_matches(triple, spec) for triple in ctx["triples"])
+
+
+def _check_relation_absent(ctx: dict, spec: dict) -> bool:
+    return not any(_matches(triple, spec) for triple in ctx["triples"])
+
+
+def _check_relations_empty(ctx: dict, _spec: dict) -> bool:
+    return not ctx["triples"]
+
+
+def _check_min_relations(ctx: dict, spec: dict) -> bool:
+    return len(ctx["triples"]) >= spec["n"]
+
+
+def _check_single_edge_between(ctx: dict, spec: dict) -> bool:
+    pair = {fold(name) for name in spec["entities"]}
+    return len([t for t in ctx["triples"] if {t[0], t[2]} == pair]) <= 1
+
+
+def _check_predicate_forbids(ctx: dict, spec: dict) -> bool:
+    banned = [fold(term) for term in spec["substrings"]]
+    return not any(term in predicate for _, predicate, _ in ctx["triples"] for term in banned)
+
+
+def _check_predicate_max_words(ctx: dict, spec: dict) -> bool:
+    return all(len(predicate.split()) <= spec["n"] for _, predicate, _ in ctx["triples"])
+
+
+def _attributes(ctx: dict) -> "list[dict]":
+    return [a for a in ctx["payload"].get("attributes") or [] if isinstance(a, dict)]
+
+
+def _attribute_selected(attribute: dict, spec: dict) -> bool:
+    """Is this the attribute the spec is about?"""
+    keys = [fold(key) for key in spec["key_any"]]
+    if not any(key in fold(attribute.get("key", "")) for key in keys):
+        return False
+    return "entity" not in spec or fold(attribute.get("entity", "")) == fold(spec["entity"])
+
+
+def _is_number(value: object) -> bool:
+    """A JSON number, and not a bool.
+
+    `isinstance(True, int)` is True in Python, so an age of `true` would sail
+    through a naive numeric check and be stored as one.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _check_attribute_number(ctx: dict, spec: dict) -> bool:
+    for attribute in _attributes(ctx):
+        if not _attribute_selected(attribute, spec):
+            continue
+        value = attribute.get("value")
+        return _is_number(value) and ("value" not in spec or value == spec["value"])
+    return False
+
+
+def _attribute_holders(ctx: dict, value: str) -> "list[str]":
+    wanted = fold(value)
+    return [
+        fold(a.get("entity", ""))
+        for a in _attributes(ctx)
+        if wanted in fold(a.get("value", ""))
+    ]
+
+
+def _check_attribute_on(ctx: dict, spec: dict) -> bool:
+    return fold(spec["entity"]) in _attribute_holders(ctx, spec["value"])
+
+
+def _check_attribute_not_on(ctx: dict, spec: dict) -> bool:
+    return fold(spec["entity"]) not in _attribute_holders(ctx, spec["value"])
+
+
+def _facts_text(ctx: dict) -> str:
+    facts = ctx["payload"].get("facts") or []
+    joined = " ".join(fold(f.get("fact", "")) for f in facts if isinstance(f, dict))
+    # Padded so a check for " il habite" also matches a fact that opens with it.
+    return f" {joined} "
+
+
+def _check_facts_mention(ctx: dict, spec: dict) -> bool:
+    return all(fold(term) in _facts_text(ctx) for term in spec["substrings"])
+
+
+def _check_facts_forbid(ctx: dict, spec: dict) -> bool:
+    return not any(fold(term) in _facts_text(ctx) for term in spec["substrings"])
+
+
+def _check_not_truncated(ctx: dict, _spec: dict) -> bool:
+    return not ctx.get("truncated", False)
+
+
+CHECKS = {
+    "relation_present": _check_relation_present,
+    "relation_absent": _check_relation_absent,
+    "relations_empty": _check_relations_empty,
+    "min_relations": _check_min_relations,
+    "single_edge_between": _check_single_edge_between,
+    "predicate_forbids": _check_predicate_forbids,
+    "predicate_max_words": _check_predicate_max_words,
+    "attribute_number": _check_attribute_number,
+    "attribute_on": _check_attribute_on,
+    "attribute_not_on": _check_attribute_not_on,
+    "facts_mention": _check_facts_mention,
+    "facts_forbid": _check_facts_forbid,
+    "not_truncated": _check_not_truncated,
+}
+
+
+def score_passage(payload: "dict | None", checks: "list[dict]",
+                  truncated: bool = False) -> "list[dict]":
+    """Run one passage's checks, returning the failures.
+
+    An unusable payload short-circuits to a single fatal finding: running the
+    other checks against nothing reports a dozen derived failures and buries the
+    one that caused them.
+    """
+    if payload is None:
+        return [{"severity": "fatal", "label": "response is not valid JSON", "type": "parse"}]
+    triples = relation_triples(payload)
+    if triples is None:
+        return [{"severity": "fatal", "label": "relations are not objects", "type": "schema"}]
+    ctx = {"payload": payload, "triples": triples, "truncated": truncated}
+    failures = []
+    for spec in checks:
+        check = CHECKS.get(spec["type"])
+        if check is None:
+            raise RuntimeError(f"unknown check type {spec['type']!r}")
+        if not check(ctx, spec):
+            failures.append(
+                {"severity": spec["severity"], "label": spec["label"], "type": spec["type"]}
+            )
+    return failures
+
+
+def _predicate_set(payload: "dict | None") -> "set[str]":
+    triples = relation_triples(payload) if payload else None
+    return {predicate for _, predicate, _ in triples or []}
+
+
+def score_cross_checks(payloads: "list[dict | None]", checks: "list[dict]") -> "list[dict]":
+    """Run a paired case's cross-passage checks.
+
+    The point of a close pair: the two passages differ by one word, so identical
+    predicate sets mean the model collapsed a distinction the passage draws, and
+    the graph inherits the collapse.
+    """
+    failures = []
+    for spec in checks:
+        if spec["type"] != "predicates_differ":
+            raise RuntimeError(f"unknown cross-check type {spec['type']!r}")
+        sets = [_predicate_set(payload) for payload in payloads]
+        if len(sets) == 2 and sets[0] and sets[0] == sets[1]:
+            failures.append(
+                {"severity": spec["severity"], "label": spec["label"], "type": spec["type"]}
+            )
+    return failures
+
+
+def tally(failures: "list[dict]") -> "dict[str, int]":
+    counts = {severity: 0 for severity in SEVERITIES}
+    for failure in failures:
+        counts[failure["severity"]] += 1
+    return counts
+
+
+# ---------------------------------------------- the same checks, on the graph --
+
+
+def entity_as_payload(name: str, profile: dict) -> dict:
+    """Reshape an `entity` response into what the phase-A checks already read.
+
+    Phase B asks the same questions of the stored graph rather than a second set
+    of expectations: the outgoing edges become triples, the attribute map becomes
+    entity/key/value rows. `relations_in` is deliberately left out — an incoming
+    edge belongs to its SOURCE entity, and folding it in here would credit this
+    entity with an edge it does not carry.
+    """
+    subject = fold(profile.get("name") or name)
+    relations = [
+        {
+            "subject": subject,
+            "predicate": edge.get("predicate", ""),
+            # `target` reads `Entity: <name>`; the prefix is a storage detail.
+            "object": re.sub(r"^entity:\s*", "", fold(edge.get("target", ""))),
+        }
+        for edge in profile.get("relations") or []
+    ]
+    attributes = [
+        {"entity": subject, "key": key, "value": value}
+        for key, value in (profile.get("attributes") or {}).items()
+    ]
+    return {"facts": [], "relations": relations, "attributes": attributes}
+
+
+# Checks that mean the same thing about a stored entity as about raw JSON. The
+# others are about the ANSWER (its language, its verbosity, whether it was cut),
+# not about the graph, and applying them here would score the same defect twice.
+GRAPH_CHECK_TYPES = frozenset({
+    "relation_present", "relation_absent", "attribute_on", "attribute_not_on", "attribute_number",
+})
+
+
+def graph_checks_for(passage: dict) -> "list[dict]":
+    """The subset of a passage's checks that a stored entity can answer."""
+    return [
+        spec for spec in passage["checks"]
+        if spec["type"] in GRAPH_CHECK_TYPES and (spec.get("subject") or spec.get("entity"))
+    ]
+
+
+def check_subject(spec: dict) -> str:
+    """Which entity a graph check must be run against."""
+    return spec.get("subject") or spec["entity"]
+
+
+# ------------------------------------------------------------- log digest ----
+
+
+def percentile(values: "list[float]", quantile: float) -> float:
+    """Nearest-rank percentile.
+
+    Spelled out because a bench that does not say which definition it uses
+    invites two readers to compare incomparable p95s.
+    """
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), math.ceil(quantile * len(ordered))))
+    return ordered[rank - 1]
+
+
+def _digest_line(line: str, tools: dict, https: list, verdicts: dict,
+                 since: "str | None") -> None:
+    if since:
+        stamp = LOG_TIMESTAMP_RE.match(line)
+        if not stamp or stamp.group("ts") < since:
+            return
+    tool_event = TOOL_EVENT_RE.search(line)
+    if tool_event:
+        tools.setdefault(tool_event.group("tool"), []).append(int(tool_event.group("ms")))
+        key = (tool_event.group("tool"), tool_event.group("verdict"))
+        verdicts[key] = verdicts.get(key, 0) + 1
+        return
+    http_event = HTTP_EVENT_RE.search(line)
+    if http_event and http_event.group("method") == "POST":
+        https.append(int(http_event.group("ms")))
+
+
+def _summary(values: "list[int]") -> dict:
+    return {
+        "n": len(values),
+        "p50_ms": percentile(values, 0.50),
+        "p95_ms": percentile(values, 0.95),
+        "max_ms": max(values) if values else None,
+    }
+
+
+def digest_log(path: Path, since: "str | None" = None) -> dict:
+    """Turn the daemon's trace events into a per-tool latency map."""
+    tools: "dict[str, list[int]]" = {}
+    https: "list[int]" = []
+    verdicts: "dict[tuple[str, str], int]" = {}
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            _digest_line(line, tools, https, verdicts, since)
+    return {
+        "source": str(path),
+        "since": since,
+        "tools": {name: _summary(values) for name, values in tools.items()},
+        "http_post": _summary(https),
+        "verdicts": {
+            f"{tool}:{verdict}": count for (tool, verdict), count in sorted(verdicts.items())
+        },
+    }
+
+
+def print_digest(digest: dict) -> None:
+    rows = sorted(digest["tools"].items(), key=lambda kv: -(kv[1]["p95_ms"] or 0))
+    print(f"{'tool':30} {'n':>5} {'p50':>10} {'p95':>10} {'max':>10}   (ms)")
+    for name, stats in rows:
+        print(f"{name:30} {stats['n']:>5} {stats['p50_ms']:>10.0f} "
+              f"{stats['p95_ms']:>10.0f} {stats['max_ms']:>10}")
+    http = digest["http_post"]
+    print(f"\n{'MCP HTTP POST':30} {http['n']:>5} {http['p50_ms']:>10.0f} "
+          f"{http['p95_ms']:>10.0f} {http['max_ms']:>10}")
+    bad = {key: n for key, n in digest["verdicts"].items() if not key.endswith(":ok")}
+    print(f"\nnon-ok verdicts: {bad or 'none'}")
+
+
+# ---------------------------------------------------------------- backends ----
+
+
+def insecure_context(url: str) -> "ssl.SSLContext | None":
+    """Skip verification for the daemon's own loopback HTTPS.
+
+    velesdb-memory terminates HTTPS with a certificate it generates locally, so
+    there is no chain to verify and nothing gained by pretending otherwise.
+    Restricted to loopback `https://`; anything else gets the default context and
+    fails honestly.
+    """
+    if not url.startswith(("https://127.0.0.1", "https://localhost")):
+        return None
+    return ssl._create_unverified_context()  # noqa: S323 - loopback, self-signed
+
+
+def http_json(url: str, payload: "dict | None" = None, token: "str | None" = None,
+              timeout: int = 400) -> dict:
+    """One JSON request. Loopback only; see `insecure_context` for the TLS note."""
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = urllib.request.Request(url, data=data, method="POST" if data is not None else "GET")
+    request.add_header("Content-Type", "application/json")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=timeout, context=insecure_context(url)) as response:
+        body = response.read().decode("utf-8", errors="replace")
+    return json.loads(body) if body.strip() else {}
+
+
+def extractor_token() -> str:
+    """Read the extractor token from the installed LaunchAgent, as the daemon does."""
+    plist = Path.home() / "Library" / "LaunchAgents" / "com.velesdb.memory.plist"
+    output = subprocess.run(["plutil", "-p", str(plist)],
+                            capture_output=True, text=True, check=True).stdout
+    match = re.search(r'EXTRACTOR_API_TOKEN"\s*=>\s*"([^"]*)"', output)
+    if not match:
+        raise RuntimeError(f"no EXTRACTOR_API_TOKEN in {plist}")
+    return match.group(1)
+
+
+class OpenAiBackend:
+    """The `openai` extractor path: an OpenAI-compatible server such as omlx.
+
+    The body is what `openai::chat_body` builds — same temperature, same cap.
+    Anything else measures a request velesdb-memory never sends.
+    """
+
+    def __init__(self, base_url: str, model: str, token: str, cap: int) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.token = token
+        self.cap = cap
+
+    def generate(self, prompt: str) -> dict:
+        body = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": self.cap,
+        }
+        started = time.monotonic()
+        response = http_json(f"{self.base_url}/v1/chat/completions", body, self.token)
+        elapsed = time.monotonic() - started
+        choice = (response.get("choices") or [{}])[0]
+        return {
+            "seconds": elapsed,
+            "content": (choice.get("message") or {}).get("content", ""),
+            "completion_tokens": (response.get("usage") or {}).get("completion_tokens"),
+            # `length` is the server saying it stopped AT the cap: the truncation
+            # this bench exists to catch, reported by the server rather than
+            # inferred from a JSON parse error.
+            "truncated": choice.get("finish_reason") == "length",
+        }
+
+    def residency(self) -> dict:
+        return http_json(f"{self.base_url}/v1/models/status", token=self.token, timeout=30)
+
+    def set_loaded(self, model: str, loaded: bool) -> None:
+        action = "load" if loaded else "unload"
+        http_json(f"{self.base_url}/v1/models/{model}/{action}",
+                  payload={}, token=self.token, timeout=900)
+
+
+class OllamaBackend:
+    """The `ollama` extractor path, body-for-body with `OllamaExtractor`."""
+
+    def __init__(self, base_url: str, model: str, cap: int, keep_alive: object = -1) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.cap = cap
+        self.keep_alive = keep_alive
+
+    def generate(self, prompt: str) -> dict:
+        body = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "think": False,
+            "keep_alive": self.keep_alive,
+            "options": {"temperature": 0, "num_predict": self.cap},
+        }
+        started = time.monotonic()
+        response = http_json(f"{self.base_url}/api/generate", body)
+        elapsed = time.monotonic() - started
+        return {
+            "seconds": elapsed,
+            "content": response.get("response", ""),
+            "completion_tokens": response.get("eval_count"),
+            "truncated": response.get("done_reason") == "length",
+        }
+
+    def residency(self) -> dict:
+        # `/api/ps` is what is LOADED. `/api/tags` is what is INSTALLED, and
+        # reading it instead is how a cold model gets mistaken for a warm one.
+        return http_json(f"{self.base_url}/api/ps", timeout=30)
+
+    def set_loaded(self, model: str, loaded: bool) -> None:
+        http_json(f"{self.base_url}/api/generate", {
+            "model": model, "prompt": "ok",
+            "keep_alive": -1 if loaded else 0,
+            "options": {"num_predict": 1},
+        }, timeout=900)
+
+
+# ------------------------------------------------- step 0: isolate and warm --
+
+
+WARMUP_TOLERANCE = 0.10
+WARMUP_WINDOW = 3
+WARMUP_MAX_ROUNDS = 6
+
+
+def is_stable(latencies: "list[float]", window: int = WARMUP_WINDOW,
+              tolerance: float = WARMUP_TOLERANCE) -> bool:
+    """Have the last `window` runs settled within `tolerance` of their median?
+
+    A stabilisation criterion rather than a fixed number of warm-up calls: how
+    many rounds a model needs is exactly what is unknown, and guessing either
+    wastes minutes or scores a model that had not settled.
+    """
+    if len(latencies) < window:
+        return False
+    recent = latencies[-window:]
+    middle = sorted(recent)[window // 2]
+    if middle <= 0:
+        return False
+    return all(abs(value - middle) / middle <= tolerance for value in recent)
+
+
+def warm_up(backend: object, prompt: str) -> dict:
+    """Run a real extraction until latency settles, and report the trace.
+
+    A real prompt, never a one-token ping: the ~600-token prefill and the KV
+    cache are part of what must be warm, and a ping warms neither. Failing to
+    stabilise is a finding about the model, not a bench error, so it comes back
+    in the result rather than raising.
+    """
+    latencies: "list[float]" = []
+    for _ in range(WARMUP_MAX_ROUNDS):
+        latencies.append(backend.generate(prompt)["seconds"])
+        if is_stable(latencies):
+            return {"rounds": len(latencies), "latencies": latencies, "stabilised": True}
+    return {"rounds": len(latencies), "latencies": latencies, "stabilised": False}
+
+
+def cold_load(backend: object, model: str, prompt: str) -> dict:
+    """Load the model and time the first real answer.
+
+    A metric, not discarded warm-up: this is what a developer pays on the first
+    `remember` after a restart, and it decides whether a model is usable at all
+    on a smaller machine.
+    """
+    started = time.monotonic()
+    backend.set_loaded(model, True)
+    load_seconds = time.monotonic() - started
+    first = backend.generate(prompt)
+    return {
+        "load_seconds": load_seconds,
+        "first_answer_seconds": first["seconds"],
+        "cold_total_seconds": load_seconds + first["seconds"],
+    }
+
+
+# ------------------------------------------------------ phase A: screening ----
+
+
+def load_cases(path: Path = CASES_FILE) -> "list[dict]":
+    return json.loads(path.read_text(encoding="utf-8"))["cases"]
+
+
+def parse_payload(content: str) -> "dict | None":
+    try:
+        parsed = json.loads(strip_code_fence(content))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def screen_passage(backend: object, template: str, passage: dict) -> dict:
+    """One scored call: generate, parse, score, and keep the raw answer.
+
+    The raw answer is kept because it is the only thing that can later feed the
+    scorer's own tests: a fixture written by hand proves the scorer reacts, a
+    captured one proves it reacts to what models actually produce.
+    """
+    prompt = build_graph_prompt(passage["text"], template)
+    result = backend.generate(prompt)
+    payload = parse_payload(result["content"])
+    return {
+        "text": passage["text"],
+        "seconds": result["seconds"],
+        "completion_tokens": result["completion_tokens"],
+        "truncated": result["truncated"],
+        "parse_ok": payload is not None,
+        "raw": result["content"],
+        "failures": score_passage(payload, passage["checks"], result["truncated"]),
+        "payload": payload,
+    }
+
+
+def screen_case(backend: object, template: str, case: dict) -> dict:
+    """Score one case, cross-checks included."""
+    passages = [screen_passage(backend, template, passage) for passage in case["passages"]]
+    cross = score_cross_checks([p["payload"] for p in passages], case.get("cross_checks") or [])
+    failures = [f for p in passages for f in p["failures"]] + cross
+    for passage in passages:
+        passage.pop("payload", None)
+    return {
+        "id": case["id"],
+        "family": case["family"],
+        "lang": case["lang"],
+        "passages": passages,
+        "cross_failures": cross,
+        "counts": tally(failures),
+    }
+
+
+def _print_case_line(scored: dict) -> None:
+    counts = scored["counts"]
+    verdict = "OK " if not any(counts.values()) else "ERR"
+    seconds = sum(p["seconds"] for p in scored["passages"])
+    labels = "; ".join(
+        f["label"] for p in scored["passages"] for f in p["failures"]
+    ) or "; ".join(f["label"] for f in scored["cross_failures"])
+    print(f"{verdict} [{scored['id']}] run{scored['run']} {seconds:.1f}s "
+          f"fatal={counts['fatal']} major={counts['major']} {labels}")
+
+
+def _scored_passages(results: "list[dict]") -> "list[dict]":
+    return [passage for case in results for passage in case["passages"]]
+
+
+def totals_of(results: "list[dict]") -> dict:
+    passages = _scored_passages(results)
+    latencies = [passage["seconds"] for passage in passages]
+    parses = [passage["parse_ok"] for passage in passages]
+    counts = {severity: sum(case["counts"][severity] for case in results) for severity in SEVERITIES}
+    return {
+        **counts,
+        "parse_rate": (sum(parses) / len(parses)) if parses else 0.0,
+        "truncated": sum(passage["truncated"] for passage in passages),
+        "p50_seconds": percentile(latencies, 0.50),
+        "p95_seconds": percentile(latencies, 0.95),
+    }
+
+
+def screen(backend: object, template: str, cases: "list[dict]", runs: int = 1) -> dict:
+    """Phase A over every case, `runs` times each, strictly sequentially."""
+    results = []
+    for index in range(runs):
+        for case in cases:
+            scored = screen_case(backend, template, case)
+            scored["run"] = index + 1
+            results.append(scored)
+            _print_case_line(scored)
+    return {"phase": "screen", "runs": runs, "cases": results, "totals": totals_of(results)}
+
+
+# ------------------------------------------------- phase B: the real server ----
+
+
+class McpClient:
+    """A minimal streamable-HTTP MCP client, talking to the daemon as an agent does.
+
+    Phase B exists because phase A proves nothing about storage: it measures a
+    model, not velesdb-memory. Here the calls cross the real transport, the real
+    handlers and the real single writer, and the assertions are about the graph
+    that comes back out.
+    """
+
+    def __init__(self, base_url: str) -> None:
+        self.url = base_url.rstrip("/") + "/mcp"
+        self.session: "str | None" = None
+        self._next_id = 0
+
+    def _post(self, payload: dict, timeout: int = 400) -> "dict | None":
+        request = urllib.request.Request(
+            self.url, data=json.dumps(payload).encode(), method="POST"
+        )
+        request.add_header("Content-Type", "application/json")
+        request.add_header("Accept", "application/json, text/event-stream")
+        if self.session:
+            request.add_header("mcp-session-id", self.session)
+        context = insecure_context(self.url)
+        with urllib.request.urlopen(request, timeout=timeout, context=context) as response:
+            self.session = self.session or response.headers.get("mcp-session-id")
+            body = response.read().decode("utf-8", errors="replace")
+        return decode_mcp_body(body)
+
+    def initialize(self) -> dict:
+        self._next_id += 1
+        result = self._post({
+            "jsonrpc": "2.0", "id": self._next_id, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "bench-memory-extraction", "version": "1"},
+            },
+        })
+        self._post({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        return result or {}
+
+    def call(self, tool: str, arguments: dict, timeout: int = 400) -> dict:
+        self._next_id += 1
+        started = time.monotonic()
+        response = self._post({
+            "jsonrpc": "2.0", "id": self._next_id, "method": "tools/call",
+            "params": {"name": tool, "arguments": arguments},
+        }, timeout=timeout)
+        return {"seconds": time.monotonic() - started, "response": response or {}}
+
+    def tool_names(self) -> "list[str]":
+        """What this server actually exposes, asked rather than assumed."""
+        self._next_id += 1
+        listing = self._post(
+            {"jsonrpc": "2.0", "id": self._next_id, "method": "tools/list", "params": {}}
+        ) or {}
+        return sorted(
+            tool.get("name", "") for tool in (listing.get("result") or {}).get("tools", [])
+        )
+
+
+def decode_mcp_body(body: str) -> "dict | None":
+    """Read a JSON-RPC reply out of either a plain body or an SSE stream.
+
+    The stream opens with a priming frame — `data: ` with an empty payload, then
+    `id:` and `retry:` — before the reply. Taking the FIRST `data:` line reads
+    that empty frame and dies on it, so every frame is tried and the first one
+    that parses wins.
+    """
+    text = body.strip()
+    if not text:
+        return None
+    if not text.startswith(("event:", "data:", "id:", "retry:")):
+        return json.loads(text)
+    for line in text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if not payload:
+            continue
+        try:
+            return json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            continue
+    return None
+
+
+def tool_payload(result: dict) -> "dict | None":
+    """Pull a tool's structured content out of its MCP envelope.
+
+    A REFUSED tool call comes back as a valid result carrying `isError`, not as a
+    protocol error. Reading only the outer reply would score every refusal as a
+    success — the exact misreading the daemon's own trace event was built to
+    prevent.
+    """
+    payload = (result.get("response") or {}).get("result") or {}
+    if payload.get("isError"):
+        return None
+    for item in payload.get("content") or []:
+        if item.get("type") == "text":
+            try:
+                return json.loads(item["text"])
+            except (json.JSONDecodeError, ValueError):
+                return {"text": item["text"]}
+    return payload.get("structuredContent")
+
+
+def await_edges(client: McpClient, entity: str, timeout_s: float = 180.0) -> dict:
+    """Poll `entity` until the autograph worker's edges land, or give up.
+
+    Edges derived from a `remember` are asynchronous by design (#1846), so the
+    delay is measured rather than slept away: it is the drain time that decides
+    how many writes a session can sustain before the queue starts dropping
+    enrichment.
+    """
+    started = time.monotonic()
+    while time.monotonic() - started < timeout_s:
+        profile = tool_payload(client.call("entity", {"name": entity})) or {}
+        if profile.get("relations") or profile.get("attributes"):
+            return {"drained": True, "seconds": time.monotonic() - started, "profile": profile}
+        time.sleep(1.0)
+    return {"drained": False, "seconds": time.monotonic() - started, "profile": {}}
+
+
+class DisposableDaemon:
+    """A velesdb-memory server on a scratch store, for one configuration.
+
+    A scratch store rather than the installed one, because phase B writes: it
+    must never touch the memory an actual session depends on, and a fresh store
+    also keeps recall ranking free of an unrelated corpus.
+    """
+
+    def __init__(self, binary: Path, port: int, env: "dict[str, str]") -> None:
+        self.binary = binary
+        self.port = port
+        self.env = env
+        self.store = Path(tempfile.mkdtemp(prefix="velesdb-bench-"))
+        self.process: "subprocess.Popen | None" = None
+
+    @property
+    def url(self) -> str:
+        return f"https://127.0.0.1:{self.port}"
+
+    def start(self, timeout_s: float = 60.0) -> None:
+        (self.store / "velesdb-memory.toml").write_text(
+            "[graph]\nautograph = true\n", encoding="utf-8"
+        )
+        environment = {**os.environ, **self.env, "VELESDB_MEMORY_PATH": str(self.store)}
+        self.process = subprocess.Popen(  # noqa: S603 - fixed binary, no shell
+            [str(self.binary), "--http", "--http-port", str(self.port)],
+            env=environment, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        self._await_health(timeout_s)
+
+    def _await_health(self, timeout_s: float) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            try:
+                http_json(f"{self.url}/health", timeout=5)
+                return
+            except OSError:
+                time.sleep(0.5)
+        self.stop()
+        raise RuntimeError(f"daemon on port {self.port} never became healthy")
+
+    def stop(self) -> None:
+        if self.process and self.process.poll() is None:
+            # Terminate, not kill: shutdown is what drains the autograph queue
+            # and joins the worker, and killing it would report drops that only
+            # the bench caused.
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+        shutil.rmtree(self.store, ignore_errors=True)
+
+
+def remember_passage(client: McpClient, text: str) -> dict:
+    """Store one passage and report what the caller waited for."""
+    result = client.call("remember", {"fact": text})
+    payload = tool_payload(result)
+    return {"seconds": result["seconds"], "stored": payload is not None, "payload": payload}
+
+
+def score_stored_case(client: McpClient, case: dict) -> dict:
+    """Check the graph a case's passages actually produced."""
+    entities: "dict[str, dict]" = {}
+    drains = []
+    failures = []
+    for passage in case["passages"]:
+        for spec in graph_checks_for(passage):
+            name = check_subject(spec)
+            if name not in entities:
+                drain = await_edges(client, name)
+                drains.append(drain["seconds"])
+                entities[name] = drain["profile"]
+            payload = entity_as_payload(name, entities[name])
+            failures += score_passage(payload, [spec])
+    return {
+        "id": case["id"],
+        "failures": failures,
+        "counts": tally(failures),
+        "drain_seconds": max(drains) if drains else 0.0,
+        "entities": entities,
+    }
+
+
+def burst(client: McpClient, texts: "list[str]") -> dict:
+    """Write a burst, then read what the bounded queue had to drop.
+
+    The queue holds 64 and one worker drains it; a session that writes faster
+    than the model generates loses enrichment. Counted and visible by design —
+    this measures how close a given model puts a user to that edge.
+    """
+    latencies = [remember_passage(client, text)["seconds"] for text in texts]
+    status = tool_payload(client.call("memory_status", {})) or {}
+    return {
+        "count": len(texts),
+        "p50_seconds": percentile(latencies, 0.50),
+        "p95_seconds": percentile(latencies, 0.95),
+        "autograph_dropped": (status.get("extraction") or status).get("autograph_dropped"),
+    }
+
+
+def endtoend(daemon: DisposableDaemon, cases: "list[dict]") -> dict:
+    """Phase B: store every passage, then assert on the stored graph."""
+    client = McpClient(daemon.url)
+    client.initialize()
+    writes = []
+    for case in cases:
+        for passage in case["passages"]:
+            writes.append(remember_passage(client, passage["text"])["seconds"])
+    stored = [score_stored_case(client, case) for case in cases]
+    burst_texts = [f"Note de charge {index} sur le projet Ardoise." for index in range(20)]
+    return {
+        "phase": "endtoend",
+        "write_p50_seconds": percentile(writes, 0.50),
+        "write_p95_seconds": percentile(writes, 0.95),
+        "cases": stored,
+        "burst": burst(client, burst_texts),
+        "totals": {
+            "fatal": sum(case["counts"]["fatal"] for case in stored),
+            "major": sum(case["counts"]["major"] for case in stored),
+            "max_drain_seconds": max((case["drain_seconds"] for case in stored), default=0.0),
+        },
+    }
+
+
+# ------------------------------------------------------------------ report ----
+
+
+def _report_row(name: str, entry: dict) -> str:
+    totals = entry.get("totals", {})
+    cold = entry.get("cold", {}).get("cold_total_seconds")
+    warm = entry.get("warmup", {})
+    return " | ".join([
+        f"| `{name}`",
+        str(totals.get("fatal", 0)),
+        str(totals.get("major", 0)),
+        str(totals.get("minor", 0)),
+        f"{totals.get('parse_rate', 0) * 100:.0f}%",
+        str(totals.get("truncated", 0)),
+        f"{totals.get('p50_seconds', float('nan')):.1f}s",
+        f"{totals.get('p95_seconds', float('nan')):.1f}s",
+        "n/a" if cold is None else f"{cold:.1f}s",
+        f"{warm.get('rounds', '?')}{'' if warm.get('stabilised', True) else ' (unstable)'} |",
+    ])
+
+
+def render_report(results: dict) -> str:
+    """Render the frozen markdown report from a result file.
+
+    Generated, never typed: the class of error where a published table and the
+    measurement behind it drift apart cannot exist if the table is derived.
+    """
+    lines = [
+        f"# velesdb-memory extraction bench — {results.get('campaign', 'undated')}",
+        "",
+        "Generated by `scripts/bench-memory-extraction.py report`. Do not edit:",
+        "re-run the generator instead.",
+        "",
+        "## Environment",
+        "",
+    ]
+    lines += [f"- **{key}**: {value}" for key, value in sorted(results.get("environment", {}).items())]
+    lines += [
+        "",
+        "## Configurations",
+        "",
+        "| configuration | fatal | major | minor | parse | cut | p50 | p95 | cold | warm-up |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    lines += [_report_row(name, entry) for name, entry in results.get("configurations", {}).items()]
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------- cli ----
+
+
+def cmd_from_log(args: argparse.Namespace) -> int:
+    digest = digest_log(Path(args.log), args.since)
+    print_digest(digest)
+    if args.out:
+        Path(args.out).write_text(json.dumps(digest, indent=2), encoding="utf-8")
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    results = json.loads(Path(args.results).read_text(encoding="utf-8"))
+    rendered = render_report(results)
+    if args.out:
+        Path(args.out).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+def build_backend(args: argparse.Namespace, cap: int) -> object:
+    if args.backend == "ollama":
+        return OllamaBackend(args.url or "http://localhost:11434", args.config, cap)
+    return OpenAiBackend(args.url or "http://127.0.0.1:8019", args.config, extractor_token(), cap)
+
+
+def cmd_screen(args: argparse.Namespace) -> int:
+    cap = read_generation_cap()
+    template = read_graph_prompt_template()
+    backend = build_backend(args, cap)
+    cases = load_cases()
+    prompt = build_graph_prompt(cases[0]["passages"][0]["text"], template)
+    outcome = {
+        "config": args.config,
+        "generation_cap": cap,
+        "residency_before": backend.residency(),
+        "cold": cold_load(backend, args.config, prompt),
+        "warmup": warm_up(backend, prompt),
+    }
+    print(f"# {args.config}: cold {outcome['cold']['cold_total_seconds']:.1f}s, "
+          f"warm-up {outcome['warmup']['rounds']} rounds, "
+          f"stabilised={outcome['warmup']['stabilised']}")
+    outcome.update(screen(backend, template, cases, args.runs))
+    totals = outcome["totals"]
+    print(f"## {args.config}: fatal={totals['fatal']} major={totals['major']} "
+          f"parse={totals['parse_rate'] * 100:.0f}% p95={totals['p95_seconds']:.1f}s")
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(outcome, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    return 1 if totals["fatal"] else 0
+
+
+def endtoend_env(args: argparse.Namespace) -> "dict[str, str]":
+    """The extractor and embedder the disposable daemon runs with.
+
+    The embedder stays bge-m3 through Ollama: it is the product's choice and the
+    bench has no business varying it.
+    """
+    env = {
+        "VELESDB_MEMORY_EMBEDDER": "ollama",
+        "VELESDB_MEMORY_OLLAMA_MODEL": args.embedder,
+        "VELESDB_MEMORY_EXTRACTOR": args.backend,
+        "VELESDB_MEMORY_EXTRACTOR_MODEL": args.config or "",
+    }
+    if args.backend == "openai":
+        env["VELESDB_MEMORY_EXTRACTOR_URL"] = args.url or "http://127.0.0.1:8019"
+        env["VELESDB_MEMORY_EXTRACTOR_API_TOKEN"] = extractor_token()
+    elif args.backend == "ollama":
+        env["VELESDB_MEMORY_EXTRACTOR_URL"] = args.url or "http://localhost:11434"
+    return env
+
+
+def cmd_endtoend(args: argparse.Namespace) -> int:
+    daemon = DisposableDaemon(Path(args.binary), args.port, endtoend_env(args))
+    daemon.start()
+    try:
+        outcome = endtoend(daemon, load_cases())
+    finally:
+        daemon.stop()
+    outcome["config"] = args.config
+    totals = outcome["totals"]
+    print(f"## {args.config}: fatal={totals['fatal']} major={totals['major']} "
+          f"drain_max={totals['max_drain_seconds']:.1f}s "
+          f"dropped={outcome['burst']['autograph_dropped']}")
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(outcome, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    return 1 if totals["fatal"] else 0
+
+
+# What phase B calls. Checked against the server rather than assumed: the
+# daemon installed on this machine on 2026-08-15 exposes 20 tools and NOT
+# `memory_status`, because its binary predates that tool. Phase B run against
+# it would have reported "tool not found" as a measurement.
+PHASE_B_TOOLS = ("remember", "entity", "recall", "memory_status")
+
+
+def cmd_probe(args: argparse.Namespace) -> int:
+    """Read-only handshake against a running daemon, to prove the client works.
+
+    Reads nothing but the tool list and one millisecond-scale read, so it is
+    safe against a daemon another session is using.
+    """
+    client = McpClient(args.url or "https://127.0.0.1:18090")
+    client.initialize()
+    names = client.tool_names()
+    missing = [tool for tool in PHASE_B_TOOLS if tool not in names]
+    contexts = tool_payload(client.call("list_working_contexts", {"project": "velesdb"}, timeout=60))
+    print(f"tools: {len(names)}")
+    print(f"read-only call ok: {contexts is not None}")
+    print(f"missing for phase B: {missing or 'none'}")
+    return 1 if missing or contexts is None else 0
+
+
+def _add_model_arguments(parser: argparse.ArgumentParser, config_required: bool) -> None:
+    parser.add_argument("--config", required=config_required, help="model id")
+    parser.add_argument("--backend", choices=["openai", "ollama", "outline"], default="openai")
+    parser.add_argument("--url")
+    parser.add_argument("--out")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    from_log = subparsers.add_parser("from-log", help="digest the daemon's tool-call events")
+    from_log.add_argument("--log", default=str(DEFAULT_LOG))
+    from_log.add_argument("--since", help="ISO timestamp prefix, e.g. 2026-08-15T00")
+    from_log.add_argument("--out")
+    from_log.set_defaults(func=cmd_from_log)
+
+    screen_parser = subparsers.add_parser("screen", help="phase A: score the model's JSON")
+    _add_model_arguments(screen_parser, config_required=True)
+    screen_parser.add_argument("--runs", type=int, default=1)
+    screen_parser.set_defaults(func=cmd_screen)
+
+    e2e = subparsers.add_parser("endtoend", help="phase B: drive a disposable MCP server")
+    _add_model_arguments(e2e, config_required=False)
+    e2e.add_argument("--binary", required=True, help="velesdb-memory binary built from develop")
+    e2e.add_argument("--port", type=int, default=18099)
+    e2e.add_argument("--embedder", default="bge-m3")
+    e2e.set_defaults(func=cmd_endtoend)
+
+    probe = subparsers.add_parser("probe", help="read-only MCP handshake against a running daemon")
+    probe.add_argument("--url")
+    probe.set_defaults(func=cmd_probe)
+
+    report = subparsers.add_parser("report", help="render the markdown report from a result file")
+    report.add_argument("--results", required=True)
+    report.add_argument("--out")
+    report.set_defaults(func=cmd_report)
+    return parser
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-memory-extraction.py
+++ b/scripts/bench-memory-extraction.py
@@ -782,6 +782,55 @@ def totals_of(results: "list[dict]") -> dict:
     }
 
 
+def totals_by_language(results: "list[dict]") -> dict:
+    """Totals per passage language.
+
+    Reported, but NOT comparable across languages on its own: this suite is
+    deliberately unbalanced (the edge and close-pair families are French), so a
+    raw fr-vs-en total compares 15 cases against 4. Use `mirror_gap` for the
+    comparison that means something.
+    """
+    languages = sorted({case["lang"] for case in results})
+    return {
+        language: totals_of([case for case in results if case["lang"] == language])
+        for language in languages
+    }
+
+
+def totals_by_family(results: "list[dict]") -> dict:
+    families = sorted({case["family"] for case in results})
+    return {
+        family: totals_of([case for case in results if case["family"] == family])
+        for family in families
+    }
+
+
+def mirror_gap(results: "list[dict]") -> dict:
+    """Compare the two nominal families, which are case-for-case mirrors.
+
+    This is the language verdict. `nominal-fr` and `nominal-en` state the same
+    four situations in two languages, so their scores ARE comparable, and a
+    model that passes one and fails the other is visible here and nowhere else.
+    A good global score hides exactly this: it is what killed prompt v2, which
+    over-corrected towards French and looked fine on average.
+    """
+    french = totals_of([case for case in results if case["family"] == "nominal-fr"])
+    english = totals_of([case for case in results if case["family"] == "nominal-en"])
+    weighted = {
+        language: totals["fatal"] * 10 + totals["major"]
+        for language, totals in (("fr", french), ("en", english))
+    }
+    return {
+        "fr": french,
+        "en": english,
+        "weighted_fr": weighted["fr"],
+        "weighted_en": weighted["en"],
+        "gap": abs(weighted["fr"] - weighted["en"]),
+        "weaker": None if weighted["fr"] == weighted["en"] else
+                  ("fr" if weighted["fr"] > weighted["en"] else "en"),
+    }
+
+
 def screen(backend: object, template: str, cases: "list[dict]", runs: int = 1) -> dict:
     """Phase A over every case, `runs` times each, strictly sequentially."""
     results = []
@@ -791,7 +840,15 @@ def screen(backend: object, template: str, cases: "list[dict]", runs: int = 1) -
             scored["run"] = index + 1
             results.append(scored)
             _print_case_line(scored)
-    return {"phase": "screen", "runs": runs, "cases": results, "totals": totals_of(results)}
+    return {
+        "phase": "screen",
+        "runs": runs,
+        "cases": results,
+        "totals": totals_of(results),
+        "by_language": totals_by_language(results),
+        "by_family": totals_by_family(results),
+        "mirror_gap": mirror_gap(results),
+    }
 
 
 # ------------------------------------------------- phase B: the real server ----
@@ -1090,8 +1147,41 @@ def render_report(results: dict) -> str:
         "| configuration | fatal | major | minor | parse | cut | p50 | p95 | cold | warm-up |",
         "|---|---|---|---|---|---|---|---|---|---|",
     ]
-    lines += [_report_row(name, entry) for name, entry in results.get("configurations", {}).items()]
+    configurations = results.get("configurations", {})
+    lines += [_report_row(name, entry) for name, entry in configurations.items()]
+    lines += _language_section(configurations)
     return "\n".join(lines) + "\n"
+
+
+def _language_section(configurations: dict) -> "list[str]":
+    """The French/English verdict, on the mirrored families only.
+
+    Kept as its own table because the overall score cannot answer it: the suite
+    is deliberately unbalanced towards French, and only `nominal-fr` and
+    `nominal-en` state the same four situations twice.
+    """
+    lines = [
+        "",
+        "## Language symmetry (mirrored families only)",
+        "",
+        "`nominal-fr` and `nominal-en` state the same four situations in two",
+        "languages. A model that passes one and fails the other is disqualified",
+        "on that alone: `works at` and `travaille chez` are two graph predicates",
+        "for one relation, and the graph fragments accordingly.",
+        "",
+        "| configuration | fatal fr | major fr | fatal en | major en | gap | weaker |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for name, entry in configurations.items():
+        gap = entry.get("mirror_gap")
+        if not gap:
+            continue
+        lines.append(
+            f"| `{name}` | {gap['fr']['fatal']} | {gap['fr']['major']} | "
+            f"{gap['en']['fatal']} | {gap['en']['major']} | {gap['gap']} | "
+            f"{gap['weaker'] or 'balanced'} |"
+        )
+    return lines
 
 
 # --------------------------------------------------------------------- cli ----
@@ -1125,7 +1215,7 @@ def cmd_screen(args: argparse.Namespace) -> int:
     cap = read_generation_cap()
     template = read_graph_prompt_template()
     backend = build_backend(args, cap)
-    cases = load_cases()
+    cases = load_cases(Path(args.cases))
     prompt = build_graph_prompt(cases[0]["passages"][0]["text"], template)
     outcome = {
         "config": args.config,
@@ -1139,8 +1229,12 @@ def cmd_screen(args: argparse.Namespace) -> int:
           f"stabilised={outcome['warmup']['stabilised']}")
     outcome.update(screen(backend, template, cases, args.runs))
     totals = outcome["totals"]
+    gap = outcome["mirror_gap"]
     print(f"## {args.config}: fatal={totals['fatal']} major={totals['major']} "
           f"parse={totals['parse_rate'] * 100:.0f}% p95={totals['p95_seconds']:.1f}s")
+    print(f"## language: fr fatal={gap['fr']['fatal']} major={gap['fr']['major']} | "
+          f"en fatal={gap['en']['fatal']} major={gap['en']['major']} | "
+          f"gap={gap['gap']} weaker={gap['weaker'] or 'balanced'}")
     if args.out:
         Path(args.out).write_text(
             json.dumps(outcome, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -1172,7 +1266,7 @@ def cmd_endtoend(args: argparse.Namespace) -> int:
     daemon = DisposableDaemon(Path(args.binary), args.port, endtoend_env(args))
     daemon.start()
     try:
-        outcome = endtoend(daemon, load_cases())
+        outcome = endtoend(daemon, load_cases(Path(args.cases)))
     finally:
         daemon.stop()
     outcome["config"] = args.config
@@ -1216,6 +1310,13 @@ def _add_model_arguments(parser: argparse.ArgumentParser, config_required: bool)
     parser.add_argument("--backend", choices=["openai", "ollama", "outline"], default="openai")
     parser.add_argument("--url")
     parser.add_argument("--out")
+    # velesdb-memory is used in whatever language its user writes in, and the
+    # extractor model is THEIR choice (`VELESDB_MEMORY_EXTRACTOR_MODEL`). The
+    # shipped suite measures French and English because those are the two this
+    # campaign answers for; anyone else points this at their own cases and gets
+    # the same verdict for their own language.
+    parser.add_argument("--cases", default=str(CASES_FILE),
+                        help="scenario file; replace it to bench another language")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/bench-memory-extraction.py
+++ b/scripts/bench-memory-extraction.py
@@ -681,21 +681,89 @@ def warm_up(backend: object, prompt: str) -> dict:
     return {"rounds": len(latencies), "latencies": latencies, "stabilised": False}
 
 
-def cold_load(backend: object, model: str, prompt: str) -> dict:
+def storage_backing(path: "str | None") -> dict:
+    """Which device a model's weights actually sit on, and by what route.
+
+    Recorded because cold-load time is a property of the DISK as much as of the
+    model. Once a machine spreads its weights over an internal SSD and an
+    external one — measured here at ~2.7 GB/s against a few GB/s internally —
+    a 27 GB model costs about five seconds more from the slower device, and a
+    bench that ignores this reports a disk difference as a model difference.
+
+    A symlink is followed and reported: a model behind a link to an unplugged
+    volume is UNREACHABLE, which is a different outcome from a model that failed.
+    """
+    if not path:
+        return {"path": None, "reachable": False, "reason": "no path reported"}
+    target = Path(path)
+    record = {
+        "path": path,
+        "symlink": target.is_symlink(),
+        "resolved": str(target.resolve()) if target.exists() else None,
+        "reachable": target.exists(),
+    }
+    if not record["reachable"]:
+        record["reason"] = "path does not resolve (unplugged volume, or moved weights)"
+        return record
+    mount = subprocess.run(["df", "-P", str(target)], capture_output=True, text=True, check=False)
+    lines = mount.stdout.strip().splitlines()
+    if len(lines) > 1:
+        columns = lines[1].split()
+        record["device"] = columns[0]
+        record["mount"] = columns[-1]
+    return record
+
+
+# Sequential read of the devices this campaign uses, in MB/s. Only MEASURED
+# values belong here: an entry that is a guess would turn the page-cache verdict
+# below into a guess too. The internal SSD has no entry because purging the page
+# cache needs admin rights, so no clean figure was obtainable.
+DEVICE_THROUGHPUT_MBS: "dict[str, float]" = {}
+
+
+def page_cache_verdict(size_bytes: "int | None", seconds: float,
+                       throughput_mbs: "float | None") -> str:
+    """Did those weights come off the disk, or out of the page cache?
+
+    A machine with 64 GiB of RAM keeps a 28 GB model resident after its first
+    load, so every later "cold" load reads memory and reports a throughput no
+    SSD can reach. Rather than pretend, the implied throughput is compared with
+    what the device can actually do: far above it means the file was cached.
+
+    Without a measured figure for the device the answer is `unknown`, never a
+    guess — a mislabelled cold load is worse than an absent one.
+    """
+    if not size_bytes or seconds <= 0:
+        return "unknown"
+    if throughput_mbs is None:
+        return "unknown"
+    implied = (size_bytes / 1e6) / seconds
+    return "page-cache" if implied > throughput_mbs * 1.5 else "cold"
+
+
+def cold_load(backend: object, model: str, prompt: str, backing: "dict | None" = None,
+              size_bytes: "int | None" = None) -> dict:
     """Load the model and time the first real answer.
 
     A metric, not discarded warm-up: this is what a developer pays on the first
     `remember` after a restart, and it decides whether a model is usable at all
-    on a smaller machine.
+    on a smaller machine. It is reported with its conditions and NEVER ranks a
+    model — the disk it sits on and the state of the page cache move it more
+    than the model does.
     """
     started = time.monotonic()
     backend.set_loaded(model, True)
     load_seconds = time.monotonic() - started
     first = backend.generate(prompt)
+    device = (backing or {}).get("device")
     return {
         "load_seconds": load_seconds,
         "first_answer_seconds": first["seconds"],
         "cold_total_seconds": load_seconds + first["seconds"],
+        "storage": backing,
+        "cache_state": page_cache_verdict(
+            size_bytes, load_seconds, DEVICE_THROUGHPUT_MBS.get(device)
+        ),
     }
 
 
@@ -1119,9 +1187,19 @@ def _report_row(name: str, entry: dict) -> str:
         str(totals.get("truncated", 0)),
         f"{totals.get('p50_seconds', float('nan')):.1f}s",
         f"{totals.get('p95_seconds', float('nan')):.1f}s",
-        "n/a" if cold is None else f"{cold:.1f}s",
+        "n/a" if cold is None else f"{cold:.1f}s{_cache_mark(entry)}",
         f"{warm.get('rounds', '?')}{'' if warm.get('stabilised', True) else ' (unstable)'} |",
     ])
+
+
+def _cache_mark(entry: dict) -> str:
+    """Flag a cold-load figure that actually came out of the page cache.
+
+    Published unmarked, the number reads as a disk measurement; it is not one,
+    and on a machine whose RAM exceeds the model it usually is not.
+    """
+    state = entry.get("cold", {}).get("cache_state")
+    return {"page-cache": " ⚠cache", "unknown": " ?"}.get(state, "")
 
 
 def render_report(results: dict) -> str:
@@ -1211,17 +1289,48 @@ def build_backend(args: argparse.Namespace, cap: int) -> object:
     return OpenAiBackend(args.url or "http://127.0.0.1:8019", args.config, extractor_token(), cap)
 
 
+def model_record(residency: dict, model: str) -> dict:
+    """What the server says about one model: where its weights are, and how big."""
+    for entry in residency.get("models") or []:
+        if entry.get("id") == model:
+            return entry
+    return {}
+
+
+def preflight(residency: dict, model: str) -> dict:
+    """Refuse to bench a model whose weights are not reachable.
+
+    Weights spread across an internal and an external volume make this a real
+    outcome, not a theoretical one: a symlink into an unplugged disk yields a
+    model that is UNREACHABLE. Scoring that as a failed model would blame the
+    model for a cable.
+    """
+    record = model_record(residency, model)
+    backing = storage_backing(record.get("model_path"))
+    if record and not backing.get("reachable"):
+        raise RuntimeError(
+            f"{model}: weights unreachable at {backing.get('path')} "
+            f"({backing.get('reason')}) — this is a storage problem, not a model result"
+        )
+    return {"backing": backing, "estimated_size": record.get("estimated_size")}
+
+
 def cmd_screen(args: argparse.Namespace) -> int:
     cap = read_generation_cap()
     template = read_graph_prompt_template()
     backend = build_backend(args, cap)
     cases = load_cases(Path(args.cases))
     prompt = build_graph_prompt(cases[0]["passages"][0]["text"], template)
+    residency = backend.residency()
+    checked = preflight(residency, args.config)
     outcome = {
         "config": args.config,
         "generation_cap": cap,
-        "residency_before": backend.residency(),
-        "cold": cold_load(backend, args.config, prompt),
+        "residency_before": residency,
+        "storage": checked["backing"],
+        "estimated_size": checked["estimated_size"],
+        "cold": cold_load(backend, args.config, prompt,
+                          checked["backing"], checked["estimated_size"]),
         "warmup": warm_up(backend, prompt),
     }
     print(f"# {args.config}: cold {outcome['cold']['cold_total_seconds']:.1f}s, "

--- a/scripts/memory-extraction-cases.json
+++ b/scripts/memory-extraction-cases.json
@@ -1,0 +1,714 @@
+{
+  "version": 1,
+  "about": [
+    "Scenarios for scripts/bench-memory-extraction.py: what a graph-extraction",
+    "model must get right before velesdb-memory's autograph can be trusted with",
+    "it. Every check is declarative, so the cases stay data and the scorer stays",
+    "testable without a model.",
+    "",
+    "Severities. `fatal` means the stored graph is WRONG, or the enrichment is",
+    "lost without a trace: a broken schema, an invented relation, an attribute",
+    "landing on the wrong entity. `major` means the graph is poorer or split:",
+    "a reversed edge, a predicate in the wrong language (`works at` and",
+    "`travaille chez` fragment one relation into two graph predicates), a number",
+    "stored as a string. `minor` is cosmetic.",
+    "",
+    "Matching is case- and accent-folded, and the folding maps the oe/ae",
+    "ligatures explicitly: NFKD does NOT decompose U+0153, so a naive fold turns",
+    "`soeur` into `sur` and every kinship check silently stops matching.",
+    "",
+    "Paired cases carry two passages one word apart. They are the point of the",
+    "suite: a model that answers both the same way has collapsed a distinction",
+    "the passage makes, and the graph inherits the collapse."
+  ],
+  "cases": [
+    {
+      "id": "fr-possessive",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "Issue #1754. The possessive names the sibling, so the sibling carries the edge.",
+      "passages": [
+        {
+          "text": "Marie Dupont a une soeur, Camille Dupont. Camille Dupont a 15 ans et travaille chez Wiscale.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "camille dupont",
+              "predicate_any": ["soeur"],
+              "object": "marie dupont",
+              "severity": "major",
+              "label": "sibling edge missing or reversed"
+            },
+            {
+              "type": "relation_absent",
+              "subject": "marie dupont",
+              "predicate_any": ["soeur"],
+              "severity": "major",
+              "label": "parasitic converse: both directions of one predicate"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": ["works", "sister", "brother", "father of"],
+              "severity": "major",
+              "label": "English predicate on a French passage"
+            },
+            {
+              "type": "attribute_number",
+              "entity": "camille dupont",
+              "key_any": ["age"],
+              "value": 15,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "fr-employment-date",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "An absolute date must survive into the fact; the predicate stays a label.",
+      "passages": [
+        {
+          "text": "Bruno Durand dirige Wiscale depuis 2019.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "bruno durand",
+              "predicate_any": ["dirige", "directeur", "pdg", "a la tete"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "leadership edge missing"
+            },
+            {
+              "type": "facts_mention",
+              "substrings": ["2019"],
+              "severity": "major",
+              "label": "absolute date dropped"
+            },
+            {
+              "type": "predicate_max_words",
+              "n": 3,
+              "severity": "minor",
+              "label": "predicate longer than 3 words"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "fr-pronoun",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "`Il` must resolve to Bruno Durand, and Lyon must not land on Wiscale.",
+      "passages": [
+        {
+          "text": "Bruno Durand dirige Wiscale. Il habite a Lyon.",
+          "checks": [
+            {
+              "type": "attribute_on",
+              "entity": "bruno durand",
+              "value": "lyon",
+              "severity": "major",
+              "label": "city not attached to bruno durand"
+            },
+            {
+              "type": "attribute_not_on",
+              "entity": "wiscale",
+              "value": "lyon",
+              "severity": "fatal",
+              "label": "city attached to the wrong entity"
+            },
+            {
+              "type": "facts_forbid",
+              "substrings": [" il habite", " il dirige"],
+              "severity": "major",
+              "label": "pronoun left unresolved in a fact meant to stand alone"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "fr-converse-stated",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "Two DIFFERENT predicates the passage states separately: both are kept. The counter-case to the parasitic converse above.",
+      "passages": [
+        {
+          "text": "Wiscale emploie Alice Martin. Alice Martin travaille pour Wiscale depuis 2019.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "wiscale",
+              "predicate_any": ["emploie", "employeur"],
+              "object": "alice martin",
+              "severity": "major",
+              "label": "employs edge missing"
+            },
+            {
+              "type": "relation_present",
+              "subject": "alice martin",
+              "predicate_any": ["travaille"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "works-for edge missing"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "en-possessive",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "Exact mirror of fr-possessive. Passing one language and failing the other is what this pair exists to catch.",
+      "passages": [
+        {
+          "text": "Sarah Miller has a brother, Tom Miller. Tom Miller is 22 and works at Northwind.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "tom miller",
+              "predicate_any": ["brother"],
+              "object": "sarah miller",
+              "severity": "major",
+              "label": "sibling edge missing or reversed"
+            },
+            {
+              "type": "single_edge_between",
+              "entities": ["tom miller", "sarah miller"],
+              "severity": "major",
+              "label": "both directions over the same pair"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": ["frere", "soeur", "travaille", "dirige", "pere de"],
+              "severity": "major",
+              "label": "French predicate on an English passage"
+            },
+            {
+              "type": "attribute_number",
+              "entity": "tom miller",
+              "key_any": ["age"],
+              "value": 22,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "en-employment-date",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "Mirror of fr-employment-date.",
+      "passages": [
+        {
+          "text": "David Clarke runs Northwind since 2019.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "david clarke",
+              "predicate_any": ["runs", "leads", "heads", "manages", "ceo", "director"],
+              "object": "northwind",
+              "severity": "major",
+              "label": "leadership edge missing"
+            },
+            {
+              "type": "facts_mention",
+              "substrings": ["2019"],
+              "severity": "major",
+              "label": "absolute date dropped"
+            },
+            {
+              "type": "predicate_max_words",
+              "n": 3,
+              "severity": "minor",
+              "label": "predicate longer than 3 words"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "en-pronoun",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "Mirror of fr-pronoun.",
+      "passages": [
+        {
+          "text": "David Clarke runs Northwind. He lives in Leeds.",
+          "checks": [
+            {
+              "type": "attribute_on",
+              "entity": "david clarke",
+              "value": "leeds",
+              "severity": "major",
+              "label": "city not attached to david clarke"
+            },
+            {
+              "type": "attribute_not_on",
+              "entity": "northwind",
+              "value": "leeds",
+              "severity": "fatal",
+              "label": "city attached to the wrong entity"
+            },
+            {
+              "type": "facts_forbid",
+              "substrings": [" he lives", " he runs"],
+              "severity": "major",
+              "label": "pronoun left unresolved in a fact meant to stand alone"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "en-converse-stated",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "Mirror of fr-converse-stated.",
+      "passages": [
+        {
+          "text": "Northwind employs Emma Stone. Emma Stone works for Northwind since 2019.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "northwind",
+              "predicate_any": ["employs", "employer"],
+              "object": "emma stone",
+              "severity": "major",
+              "label": "employs edge missing"
+            },
+            {
+              "type": "relation_present",
+              "subject": "emma stone",
+              "predicate_any": ["works for", "works at", "employee"],
+              "object": "northwind",
+              "severity": "major",
+              "label": "works-for edge missing"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-no-relation",
+      "family": "edge",
+      "lang": "fr",
+      "note": "Hallucination control. No named entity, no relation to find; inventing one poisons the graph with a fact nobody wrote.",
+      "passages": [
+        {
+          "text": "Il pleuvait sur la ville hier soir.",
+          "checks": [
+            {
+              "type": "relations_empty",
+              "severity": "fatal",
+              "label": "relation invented on a passage that states none"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-hostile-format",
+      "family": "edge",
+      "lang": "fr",
+      "note": "Quotes and braces inside the passage must not break the JSON contract.",
+      "passages": [
+        {
+          "text": "Le projet \"Ardoise {beta}\" est pilote par Nadia Kerouac chez Wiscale.",
+          "checks": [
+            {
+              "type": "min_relations",
+              "n": 1,
+              "severity": "major",
+              "label": "no edge extracted from a passage that states one"
+            },
+            {
+              "type": "relation_present",
+              "subject": "nadia kerouac",
+              "predicate_any": ["pilote", "dirige", "responsable", "travaille"],
+              "severity": "major",
+              "label": "nadia kerouac absent from every edge"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-verbose-truncation",
+      "family": "edge",
+      "lang": "fr",
+      "note": "Six dense sentences. Production caps generation at MAX_GENERATION_TOKENS = 512 (extract.rs) and a cut answer is invalid JSON: the failure mode no pre-cap bench ever exercised.",
+      "passages": [
+        {
+          "text": "Nadia Kerouac dirige Wiscale depuis 2018. Wiscale possede le serveur Hydra, qui dispose de 128 Go de RAM. Bruno Durand, 42 ans, est le directeur technique de Wiscale et habite a Lyon. Alice Martin a rejoint l'equipe en janvier 2025 comme ingenieure. Le projet Ardoise, lance en mars 2025, est pilote par Alice Martin. Wiscale emploie 37 personnes et son siege est a Geneve.",
+          "checks": [
+            {
+              "type": "not_truncated",
+              "severity": "fatal",
+              "label": "answer cut off by the generation cap"
+            },
+            {
+              "type": "min_relations",
+              "n": 3,
+              "severity": "major",
+              "label": "dense passage reduced to fewer than 3 edges"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-accents-hyphens",
+      "family": "edge",
+      "lang": "fr",
+      "note": "Apostrophe, hyphen, accents and a company suffix inside one entity name.",
+      "passages": [
+        {
+          "text": "Jean-Luc D'Arcy a fonde Eco-Kerite S.a r.l. a Geneve en 2018.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "jean-luc d'arcy",
+              "predicate_any": ["fonde", "fondateur", "cree"],
+              "object_contains": "kerite",
+              "severity": "major",
+              "label": "founding edge missing, or entity name mangled"
+            },
+            {
+              "type": "facts_mention",
+              "substrings": ["2018"],
+              "severity": "minor",
+              "label": "absolute date dropped"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "edge-mixed-lang",
+      "family": "edge",
+      "lang": "fr",
+      "note": "A French passage naming an English organisation. The predicate follows the PASSAGE, not the entity.",
+      "passages": [
+        {
+          "text": "Marie Dupont a rejoint Northwind Data Services en janvier 2025.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "marie dupont",
+              "predicate_any": ["rejoint", "travaille", "membre"],
+              "object_contains": "northwind",
+              "severity": "major",
+              "label": "membership edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": ["joined", "works at", "member of", "employee of"],
+              "severity": "major",
+              "label": "predicate follows the entity's language instead of the passage's"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-role",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "Working somewhere and running it are not the same edge. Emitting `travaille chez` for B is the collapse this pair looks for.",
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "both passages yield the same predicate"
+        }
+      ],
+      "passages": [
+        {
+          "text": "Alice Martin travaille chez Wiscale.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "alice martin",
+              "predicate_any": ["travaille"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "works-at edge missing"
+            },
+            {
+              "type": "relation_absent",
+              "predicate_any": ["dirige", "directeur", "pdg"],
+              "severity": "major",
+              "label": "leadership role invented"
+            }
+          ]
+        },
+        {
+          "text": "Alice Martin dirige Wiscale.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "alice martin",
+              "predicate_any": ["dirige", "directrice", "a la tete"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "leads edge missing"
+            },
+            {
+              "type": "relation_absent",
+              "predicate_any": ["travaille"],
+              "severity": "major",
+              "label": "leadership flattened into plain employment"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-negation",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "A departure is not an employment. Storing `travaille chez` for B records the opposite of what the passage says.",
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "both passages yield the same predicate"
+        }
+      ],
+      "passages": [
+        {
+          "text": "Alice Martin travaille chez Wiscale.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "alice martin",
+              "predicate_any": ["travaille"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "works-at edge missing"
+            }
+          ]
+        },
+        {
+          "text": "Alice Martin a quitte Wiscale en 2024.",
+          "checks": [
+            {
+              "type": "relation_absent",
+              "predicate_any": ["travaille chez", "travaille pour", "employee de"],
+              "severity": "fatal",
+              "label": "departure stored as a current employment"
+            },
+            {
+              "type": "relation_present",
+              "subject": "alice martin",
+              "predicate_any": ["quitte", "ancienne", "depart"],
+              "object": "wiscale",
+              "severity": "major",
+              "label": "departure edge missing"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-kinship",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "In-law kinship. `belle-soeur` folds to `belle-soeur` only if the fold maps the oe ligature; NFKD alone turns it into `belle-sur`.",
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "both passages yield the same predicate"
+        }
+      ],
+      "passages": [
+        {
+          "text": "Camille Rey est la soeur de Marie Rey.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "camille rey",
+              "predicate_any": ["soeur"],
+              "object": "marie rey",
+              "severity": "major",
+              "label": "sibling edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": ["belle"],
+              "severity": "major",
+              "label": "blood kinship rendered as kinship by marriage"
+            }
+          ]
+        },
+        {
+          "text": "Camille Rey est la belle-soeur de Marie Rey.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "camille rey",
+              "predicate_any": ["belle-soeur", "belle soeur"],
+              "object": "marie rey",
+              "severity": "major",
+              "label": "kinship by marriage rendered as blood kinship"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-possession",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "Owning and renting differ in who bears the asset. Both collapse to `a` in a careless extraction.",
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "both passages yield the same predicate"
+        }
+      ],
+      "passages": [
+        {
+          "text": "Wiscale possede le serveur Hydra.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "wiscale",
+              "predicate_any": ["possede", "proprietaire"],
+              "object_contains": "hydra",
+              "severity": "major",
+              "label": "ownership edge missing"
+            },
+            {
+              "type": "relation_absent",
+              "predicate_any": ["loue", "location"],
+              "severity": "major",
+              "label": "ownership rendered as a lease"
+            }
+          ]
+        },
+        {
+          "text": "Wiscale loue le serveur Hydra.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "wiscale",
+              "predicate_any": ["loue", "location"],
+              "object_contains": "hydra",
+              "severity": "major",
+              "label": "lease edge missing"
+            },
+            {
+              "type": "relation_absent",
+              "predicate_any": ["possede", "proprietaire", "appartient"],
+              "severity": "fatal",
+              "label": "lease stored as ownership"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-symmetry",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "`avec` is symmetric and takes ONE edge; `pour` is oriented and its direction carries the hierarchy.",
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "both passages yield the same predicate"
+        }
+      ],
+      "passages": [
+        {
+          "text": "Alice Rey travaille avec Bob Neri.",
+          "checks": [
+            {
+              "type": "single_edge_between",
+              "entities": ["alice rey", "bob neri"],
+              "severity": "major",
+              "label": "symmetric relation duplicated in both directions"
+            },
+            {
+              "type": "min_relations",
+              "n": 1,
+              "severity": "major",
+              "label": "collaboration not extracted"
+            }
+          ]
+        },
+        {
+          "text": "Alice Rey travaille pour Bob Neri.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "alice rey",
+              "predicate_any": ["travaille"],
+              "object": "bob neri",
+              "severity": "major",
+              "label": "subordination edge missing or reversed"
+            },
+            {
+              "type": "relation_absent",
+              "subject": "bob neri",
+              "predicate_any": ["travaille pour", "travaille avec"],
+              "severity": "major",
+              "label": "hierarchy inverted"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "close-homonyms",
+      "family": "close-pair",
+      "lang": "fr",
+      "note": "Two names one letter apart. Merging them, or crossing their cities, makes the graph assert something no passage says.",
+      "passages": [
+        {
+          "text": "Marie Dupont habite a Lyon. Marie Dupond habite a Nantes.",
+          "checks": [
+            {
+              "type": "attribute_on",
+              "entity": "marie dupont",
+              "value": "lyon",
+              "severity": "major",
+              "label": "lyon not attached to marie dupont"
+            },
+            {
+              "type": "attribute_on",
+              "entity": "marie dupond",
+              "value": "nantes",
+              "severity": "major",
+              "label": "nantes not attached to marie dupond"
+            },
+            {
+              "type": "attribute_not_on",
+              "entity": "marie dupont",
+              "value": "nantes",
+              "severity": "fatal",
+              "label": "cross-contamination: nantes on marie dupont"
+            },
+            {
+              "type": "attribute_not_on",
+              "entity": "marie dupond",
+              "value": "lyon",
+              "severity": "fatal",
+              "label": "cross-contamination: lyon on marie dupond"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/tests/test_bench_memory_extraction.py
+++ b/scripts/tests/test_bench_memory_extraction.py
@@ -582,6 +582,81 @@ class OtherLanguageTest(unittest.TestCase):
         self.assertEqual(gap["gap"], 0)
 
 
+# ----------------------------------------------------------------- storage ----
+
+
+class ColdLoadConditionsTest(unittest.TestCase):
+    """Cold-load time measures the disk and the page cache as much as the model.
+
+    Both defects are real on this machine: weights are being split between an
+    internal SSD and an external one measured at ~2.7 GB/s, and 64 GiB of RAM
+    keeps a 28 GB model resident after its first load — a second "cold" load
+    then reports a throughput no SSD can reach.
+    """
+
+    def test_a_speed_no_disk_can_reach_is_called_page_cache(self):
+        # 28 GB in 2.5 s = 11 200 MB/s, against a 2 703 MB/s device.
+        verdict = bench.page_cache_verdict(28_000_000_000, 2.5, 2703.0)
+        self.assertEqual(verdict, "page-cache")
+
+    def test_a_plausible_disk_speed_is_called_cold(self):
+        verdict = bench.page_cache_verdict(28_000_000_000, 11.0, 2703.0)
+        self.assertEqual(verdict, "cold")
+
+    def test_an_unmeasured_device_yields_unknown_not_a_guess(self):
+        """A mislabelled cold load is worse than an absent one."""
+        self.assertEqual(bench.page_cache_verdict(28_000_000_000, 2.5, None), "unknown")
+
+    def test_missing_size_yields_unknown(self):
+        self.assertEqual(bench.page_cache_verdict(None, 2.5, 2703.0), "unknown")
+
+    def test_the_report_marks_a_cached_figure(self):
+        results = {"campaign": "x", "environment": {}, "configurations": {
+            "m": {"totals": {"fatal": 0, "major": 0, "minor": 0, "parse_rate": 1.0,
+                             "truncated": 0, "p50_seconds": 1.0, "p95_seconds": 1.0},
+                  "cold": {"cold_total_seconds": 3.0, "cache_state": "page-cache"}}}}
+        self.assertIn("cache", bench.render_report(results))
+
+
+class StorageBackingTest(unittest.TestCase):
+    def test_a_real_path_reports_its_device(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            backing = bench.storage_backing(tmp)
+        self.assertTrue(backing["reachable"])
+        self.assertIn("device", backing)
+
+    def test_a_dead_symlink_is_unreachable_with_a_reason(self):
+        """A model behind a link to an unplugged volume is a cable problem."""
+        with tempfile.TemporaryDirectory() as tmp:
+            link = Path(tmp) / "model"
+            link.symlink_to(Path(tmp) / "absent-volume" / "weights")
+            backing = bench.storage_backing(str(link))
+        self.assertFalse(backing["reachable"])
+        self.assertIn("unplugged", backing["reason"])
+
+    def test_no_path_is_unreachable_not_an_exception(self):
+        self.assertFalse(bench.storage_backing(None)["reachable"])
+
+    def test_preflight_refuses_unreachable_weights(self):
+        """It must NOT be scored as a failing model."""
+        residency = {"models": [{"id": "m", "model_path": "/Volumes/absent/m",
+                                 "estimated_size": 1}]}
+        with self.assertRaises(RuntimeError) as raised:
+            bench.preflight(residency, "m")
+        self.assertIn("storage problem, not a model result", str(raised.exception))
+
+    def test_preflight_passes_a_reachable_model_and_carries_its_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            residency = {"models": [{"id": "m", "model_path": tmp, "estimated_size": 4242}]}
+            checked = bench.preflight(residency, "m")
+        self.assertEqual(checked["estimated_size"], 4242)
+        self.assertTrue(checked["backing"]["reachable"])
+
+    def test_a_backend_reporting_no_models_does_not_block_the_run(self):
+        """Ollama has no such endpoint; absence of a record is not a failure."""
+        self.assertEqual(bench.preflight({}, "m")["estimated_size"], None)
+
+
 # --------------------------------------------------------------- warm-up ----
 
 

--- a/scripts/tests/test_bench_memory_extraction.py
+++ b/scripts/tests/test_bench_memory_extraction.py
@@ -461,6 +461,127 @@ class CasesFileTest(unittest.TestCase):
                 self.assertIn(passage["text"], prompt)
 
 
+# ---------------------------------------------------------------- language ----
+
+
+def scored_case(case_id, family, lang, fatal=0, major=0, seconds=1.0):
+    """A minimal scored case, shaped as `screen_case` returns one."""
+    failures = ([{"severity": "fatal", "label": "f", "type": "t"}] * fatal
+                + [{"severity": "major", "label": "m", "type": "t"}] * major)
+    return {
+        "id": case_id, "family": family, "lang": lang,
+        "passages": [{"seconds": seconds, "parse_ok": True, "truncated": False,
+                      "failures": failures}],
+        "cross_failures": [], "counts": bench.tally(failures),
+    }
+
+
+class LanguageVerdictTest(unittest.TestCase):
+    """The verdict a global score cannot give.
+
+    velesdb-memory is used in whatever language its user writes in, and the
+    extractor model is theirs to choose. A model strong in English and weak in
+    French does not merely score slightly lower — `works at` and `travaille
+    chez` become two graph predicates for one relation, and the graph fragments.
+    """
+
+    def test_an_english_only_failure_names_english_as_weaker(self):
+        results = [
+            scored_case("fr1", "nominal-fr", "fr"),
+            scored_case("fr2", "nominal-fr", "fr"),
+            scored_case("en1", "nominal-en", "en", major=3),
+            scored_case("en2", "nominal-en", "en"),
+        ]
+        gap = bench.mirror_gap(results)
+        self.assertEqual(gap["weaker"], "en")
+        self.assertEqual(gap["gap"], 3)
+
+    def test_a_fatal_outweighs_majors_in_the_gap(self):
+        """One fatal is not three majors: it means the graph is wrong, not poorer."""
+        results = [
+            scored_case("fr1", "nominal-fr", "fr", fatal=1),
+            scored_case("en1", "nominal-en", "en", major=5),
+        ]
+        gap = bench.mirror_gap(results)
+        self.assertEqual(gap["weaker"], "fr")
+
+    def test_a_balanced_model_names_no_weaker_side(self):
+        results = [
+            scored_case("fr1", "nominal-fr", "fr", major=1),
+            scored_case("en1", "nominal-en", "en", major=1),
+        ]
+        self.assertIsNone(bench.mirror_gap(results)["weaker"])
+
+    def test_the_gap_ignores_the_french_only_families(self):
+        """The suite is unbalanced on purpose; only the mirrors are comparable.
+
+        Edge and close-pair cases are French, so counting them would report
+        every model as 'weaker in French' regardless of what it did.
+        """
+        results = [
+            scored_case("fr1", "nominal-fr", "fr"),
+            scored_case("en1", "nominal-en", "en"),
+            scored_case("edge1", "edge", "fr", fatal=2),
+            scored_case("close1", "close-pair", "fr", major=4),
+        ]
+        gap = bench.mirror_gap(results)
+        self.assertEqual(gap["gap"], 0)
+        self.assertIsNone(gap["weaker"])
+
+    def test_by_language_still_reports_both_sides(self):
+        results = [scored_case("fr1", "nominal-fr", "fr", major=2),
+                   scored_case("en1", "nominal-en", "en")]
+        by_language = bench.totals_by_language(results)
+        self.assertEqual(by_language["fr"]["major"], 2)
+        self.assertEqual(by_language["en"]["major"], 0)
+
+    def test_the_report_carries_the_language_table(self):
+        results = {"campaign": "x", "environment": {}, "configurations": {
+            "m": {"totals": {"fatal": 0, "major": 3, "minor": 0, "parse_rate": 1.0,
+                             "truncated": 0, "p50_seconds": 1.0, "p95_seconds": 1.0},
+                  "mirror_gap": bench.mirror_gap([
+                      scored_case("fr1", "nominal-fr", "fr"),
+                      scored_case("en1", "nominal-en", "en", major=3)])}}}
+        rendered = bench.render_report(results)
+        self.assertIn("Language symmetry", rendered)
+        self.assertIn("| `m` |", rendered.split("Language symmetry")[1])
+        self.assertIn("en", rendered.split("Language symmetry")[1])
+
+
+class OtherLanguageTest(unittest.TestCase):
+    """A user writing in neither French nor English must be able to decide too.
+
+    The model is their choice (`VELESDB_MEMORY_EXTRACTOR_MODEL`); this suite
+    answers for French and English, and `--cases` is what makes the same verdict
+    reachable for any other language.
+    """
+
+    def test_an_alternate_cases_file_is_accepted(self):
+        cases = {"version": 1, "cases": [{
+            "id": "de-possessive", "family": "nominal-de", "lang": "de",
+            "passages": [{"text": "Marie Dupont hat eine Schwester, Camille Dupont.",
+                          "checks": [{"type": "relation_present",
+                                      "subject": "camille dupont",
+                                      "predicate_any": ["schwester"],
+                                      "object": "marie dupont",
+                                      "severity": "major", "label": "sibling edge missing"}]}],
+        }]}
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "de.json"
+            path.write_text(json.dumps(cases), encoding="utf-8")
+            loaded = bench.load_cases(path)
+        self.assertEqual(loaded[0]["lang"], "de")
+        payload = {"relations": [{"subject": "camille dupont", "predicate": "schwester von",
+                                  "object": "marie dupont"}]}
+        self.assertEqual(bench.score_passage(payload, loaded[0]["passages"][0]["checks"]), [])
+
+    def test_a_suite_without_mirrors_reports_no_language_verdict(self):
+        """No mirrored families means no comparison — and it must say so, not invent one."""
+        gap = bench.mirror_gap([scored_case("de1", "nominal-de", "de", major=2)])
+        self.assertIsNone(gap["weaker"])
+        self.assertEqual(gap["gap"], 0)
+
+
 # --------------------------------------------------------------- warm-up ----
 
 

--- a/scripts/tests/test_bench_memory_extraction.py
+++ b/scripts/tests/test_bench_memory_extraction.py
@@ -1,0 +1,537 @@
+"""Tests for scripts/bench-memory-extraction.py — above all, its refusals.
+
+A bench reports a verdict on models. If its scorer cannot fail, every model
+passes and the campaign publishes a number that means nothing. So each severity
+has a vector here that MUST produce it, next to a positive control that must
+produce nothing.
+
+Three of these tests exist because the code they cover was already wrong, and
+only running it showed that:
+
+  * **The prompt parse stopped two thirds of the way in.** A lazy
+    `format!\\(\\s*"(.*?)"\\s*\\)` ends on the `")` inside the prompt's own
+    example, `(e.g. \\"bruno durand\\")`. It produced 904 characters of a
+    2,696-character prompt, and the sanity guard missed it because every marker
+    it checked — the passage, `STEP 0`, `"relations"` — appears in the surviving
+    head. Guards now check the TAIL, and `test_prompt_is_whole` pins the closing
+    JSON contract.
+  * **The SSE decoder read the priming frame.** The daemon opens its stream with
+    `data: ` carrying an empty payload before the reply, so taking the first
+    `data:` line dies on empty input. Every frame is tried now.
+  * **`memory_status` is not everywhere.** The daemon installed on this machine
+    on 2026-08-15 exposes 20 tools and not that one — its binary predates it.
+    Phase B calls it, so `probe` checks the tool list against the server instead
+    of assuming, and reports "tool not found" as a missing capability rather
+    than as a measurement.
+
+The fixtures below are written by hand, which proves the scorer REACTS but not
+that it reacts to what models produce. The campaign's raw answers are kept for
+exactly that reason: once one has run, these fixtures get replaced by captured
+ones.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "bench-memory-extraction.py"
+CASES_PATH = Path(__file__).resolve().parent.parent / "memory-extraction-cases.json"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("bench_memory_extraction", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bench = load_module()
+
+
+def case_by_id(case_id: str) -> dict:
+    for case in bench.load_cases(CASES_PATH):
+        if case["id"] == case_id:
+            return case
+    raise AssertionError(f"no case {case_id!r}")
+
+
+def severities(failures: "list[dict]") -> "list[str]":
+    return [failure["severity"] for failure in failures]
+
+
+# ------------------------------------------------------------------- folding --
+
+
+class FoldTest(unittest.TestCase):
+    def test_ligature_expands_instead_of_vanishing(self):
+        """NFKD does not decompose U+0153: the ASCII pass would drop it entirely.
+
+        Without the explicit mapping `soeur` folds to `sur`, and every kinship
+        check stops matching while still reporting success.
+        """
+        self.assertEqual(bench.fold("sœur"), "soeur")
+        self.assertEqual(bench.fold("belle-sœur"), "belle-soeur")
+        self.assertEqual(bench.fold("œuvre"), "oeuvre")
+        self.assertEqual(bench.fold("Ex æquo"), "ex aequo")
+
+    def test_folds_case_and_accents(self):
+        self.assertEqual(bench.fold("Éco-Kérité"), "eco-kerite")
+        self.assertEqual(bench.fold("Marie DUPONT"), "marie dupont")
+
+    def test_folds_non_strings(self):
+        self.assertEqual(bench.fold(15), "15")
+        self.assertEqual(bench.fold(None), "none")
+
+
+# ------------------------------------------------- the prompt, read from Rust --
+
+
+class PromptSourcingTest(unittest.TestCase):
+    def test_prompt_is_whole(self):
+        """The parse must reach the closing JSON contract, not stop at an escaped quote."""
+        template = bench.read_graph_prompt_template()
+        prompt = bench.build_graph_prompt("Marie Dupont a une soeur, Camille Dupont.", template)
+        self.assertIn("Marie Dupont a une soeur", prompt)
+        self.assertIn('"attributes"', prompt)
+        self.assertIn('"entity": string', prompt)
+        self.assertTrue(prompt.rstrip().endswith("}"), prompt[-80:])
+        # The truncated parse produced 904 characters; the whole prompt is ~2.7k.
+        self.assertGreater(len(prompt), 2000)
+
+    def test_braces_collapse_but_passage_braces_survive(self):
+        template = bench.read_graph_prompt_template()
+        prompt = bench.build_graph_prompt('Projet "Ardoise {beta}" chez Wiscale.', template)
+        self.assertIn("Ardoise {beta}", prompt)
+        self.assertIn('{"facts"', prompt)
+
+    def test_refuses_a_truncated_template(self):
+        """A template cut before the contract must raise, never be sent."""
+        with self.assertRaises(RuntimeError):
+            bench.build_graph_prompt("passage", "STEP 0 and \"relations\" but cut here")
+
+    def test_refuses_a_source_without_the_function(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "extract.rs"
+            empty.write_text("fn other() {}\n", encoding="utf-8")
+            with self.assertRaises(RuntimeError):
+                bench.read_graph_prompt_template(empty)
+            with self.assertRaises(RuntimeError):
+                bench.read_generation_cap(empty)
+
+    def test_generation_cap_matches_the_crate(self):
+        self.assertEqual(bench.read_generation_cap(), 512)
+
+
+# ------------------------------------------------------- scorer: the control --
+
+
+GOOD_POSSESSIVE = {
+    "facts": [{"fact": "Camille Dupont a 15 ans.", "entities": ["camille dupont"]}],
+    "relations": [{"subject": "camille dupont", "predicate": "soeur de", "object": "marie dupont"}],
+    "attributes": [
+        {"entity": "camille dupont", "key": "age", "value": 15},
+        {"entity": "camille dupont", "key": "employeur", "value": "Wiscale"},
+    ],
+}
+
+
+class PositiveControlTest(unittest.TestCase):
+    def test_a_correct_answer_scores_nothing(self):
+        """Without this, a scorer that never fires would look like a strict one."""
+        case = case_by_id("fr-possessive")
+        failures = bench.score_passage(GOOD_POSSESSIVE, case["passages"][0]["checks"])
+        self.assertEqual(failures, [], failures)
+
+    def test_a_correct_empty_answer_scores_nothing(self):
+        case = case_by_id("edge-no-relation")
+        payload = {"facts": [{"fact": "Il pleuvait hier soir.", "entities": []}],
+                   "relations": [], "attributes": []}
+        self.assertEqual(bench.score_passage(payload, case["passages"][0]["checks"]), [])
+
+
+# --------------------------------------------------- scorer: refusal vectors --
+
+
+class RefusalVectorTest(unittest.TestCase):
+    def test_relations_as_arrays_are_fatal(self):
+        """The silent one: this JSON parses, RawRelation refuses it, enrichment vanishes."""
+        payload = {"relations": [["camille dupont", "soeur de", "marie dupont"]]}
+        failures = bench.score_passage(payload, case_by_id("fr-possessive")["passages"][0]["checks"])
+        self.assertEqual(severities(failures), ["fatal"])
+        self.assertEqual(failures[0]["type"], "schema")
+
+    def test_unparsable_response_is_one_fatal_not_a_cascade(self):
+        failures = bench.score_passage(None, case_by_id("fr-possessive")["passages"][0]["checks"])
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0]["type"], "parse")
+
+    def test_reversed_orientation_is_major(self):
+        payload = {**GOOD_POSSESSIVE, "relations": [
+            {"subject": "marie dupont", "predicate": "soeur de", "object": "camille dupont"},
+        ]}
+        failures = bench.score_passage(payload, case_by_id("fr-possessive")["passages"][0]["checks"])
+        labels = [failure["label"] for failure in failures]
+        self.assertIn("sibling edge missing or reversed", labels)
+        self.assertIn("parasitic converse: both directions of one predicate", labels)
+
+    def test_wrong_language_predicate_is_major(self):
+        payload = {**GOOD_POSSESSIVE, "relations": [
+            {"subject": "camille dupont", "predicate": "sister of", "object": "marie dupont"},
+        ]}
+        failures = bench.score_passage(payload, case_by_id("fr-possessive")["passages"][0]["checks"])
+        self.assertIn("English predicate on a French passage",
+                      [failure["label"] for failure in failures])
+
+    def test_number_as_string_is_major(self):
+        payload = {**GOOD_POSSESSIVE,
+                   "attributes": [{"entity": "camille dupont", "key": "age", "value": "15"}]}
+        failures = bench.score_passage(payload, case_by_id("fr-possessive")["passages"][0]["checks"])
+        self.assertIn("age missing, misattributed, or emitted as a string",
+                      [failure["label"] for failure in failures])
+
+    def test_boolean_is_not_a_number(self):
+        """`True` is an int in Python; an age of `true` must not pass as 15."""
+        payload = {**GOOD_POSSESSIVE,
+                   "attributes": [{"entity": "camille dupont", "key": "age", "value": True}]}
+        failures = bench.score_passage(payload, case_by_id("fr-possessive")["passages"][0]["checks"])
+        self.assertTrue(failures)
+
+    def test_invented_relation_is_fatal(self):
+        payload = {"facts": [], "relations": [
+            {"subject": "la ville", "predicate": "a eu", "object": "pluie"},
+        ], "attributes": []}
+        failures = bench.score_passage(payload, case_by_id("edge-no-relation")["passages"][0]["checks"])
+        self.assertEqual(severities(failures), ["fatal"])
+
+    def test_truncation_is_fatal_and_comes_from_the_server(self):
+        case = case_by_id("edge-verbose-truncation")
+        payload = {"facts": [], "relations": [
+            {"subject": "a", "predicate": "p", "object": "b"},
+            {"subject": "c", "predicate": "p", "object": "d"},
+            {"subject": "e", "predicate": "p", "object": "f"},
+        ], "attributes": []}
+        clean = bench.score_passage(payload, case["passages"][0]["checks"], truncated=False)
+        cut = bench.score_passage(payload, case["passages"][0]["checks"], truncated=True)
+        self.assertEqual(clean, [])
+        self.assertEqual(severities(cut), ["fatal"])
+
+    def test_cross_contamination_is_fatal(self):
+        case = case_by_id("close-homonyms")
+        payload = {"facts": [], "relations": [], "attributes": [
+            {"entity": "marie dupont", "key": "ville", "value": "Lyon"},
+            {"entity": "marie dupont", "key": "ville", "value": "Nantes"},
+            {"entity": "marie dupond", "key": "ville", "value": "Nantes"},
+        ]}
+        failures = bench.score_passage(payload, case["passages"][0]["checks"])
+        self.assertIn("fatal", severities(failures))
+
+    def test_pronoun_left_unresolved_is_major(self):
+        case = case_by_id("fr-pronoun")
+        payload = {"facts": [{"fact": "Il habite a Lyon.", "entities": []}],
+                   "relations": [], "attributes": [
+                       {"entity": "bruno durand", "key": "ville", "value": "Lyon"}]}
+        failures = bench.score_passage(payload, case["passages"][0]["checks"])
+        self.assertIn("pronoun left unresolved in a fact meant to stand alone",
+                      [failure["label"] for failure in failures])
+
+    def test_both_directions_of_one_predicate_is_major(self):
+        case = case_by_id("en-possessive")
+        payload = {"facts": [], "relations": [
+            {"subject": "tom miller", "predicate": "brother of", "object": "sarah miller"},
+            {"subject": "sarah miller", "predicate": "brother of", "object": "tom miller"},
+        ], "attributes": [{"entity": "tom miller", "key": "age", "value": 22}]}
+        failures = bench.score_passage(payload, case["passages"][0]["checks"])
+        self.assertIn("both directions over the same pair",
+                      [failure["label"] for failure in failures])
+
+    def test_unknown_check_type_raises(self):
+        """A typo in the cases file must stop the campaign, not skip a check."""
+        with self.assertRaises(RuntimeError):
+            bench.score_passage({"relations": []}, [{"type": "nope", "severity": "major", "label": "x"}])
+
+
+class CrossCheckTest(unittest.TestCase):
+    def test_identical_predicates_across_a_close_pair_is_major(self):
+        case = case_by_id("close-role")
+        collapsed = {"relations": [
+            {"subject": "alice martin", "predicate": "travaille chez", "object": "wiscale"}]}
+        failures = bench.score_cross_checks([collapsed, collapsed], case["cross_checks"])
+        self.assertEqual(severities(failures), ["major"])
+
+    def test_distinct_predicates_pass(self):
+        case = case_by_id("close-role")
+        works = {"relations": [
+            {"subject": "alice martin", "predicate": "travaille chez", "object": "wiscale"}]}
+        leads = {"relations": [
+            {"subject": "alice martin", "predicate": "dirige", "object": "wiscale"}]}
+        self.assertEqual(bench.score_cross_checks([works, leads], case["cross_checks"]), [])
+
+    def test_two_empty_answers_do_not_count_as_a_collapse(self):
+        """Both empty is a different defect, already scored by the per-passage checks."""
+        case = case_by_id("close-role")
+        empty = {"relations": []}
+        self.assertEqual(bench.score_cross_checks([empty, empty], case["cross_checks"]), [])
+
+
+# ------------------------------------------------------ the same checks, graph --
+
+
+class GraphViewTest(unittest.TestCase):
+    def test_entity_response_becomes_scorable(self):
+        profile = {
+            "found": True, "name": "camille dupont",
+            "attributes": {"age": 15},
+            "relations": [{"predicate": "soeur de", "target": "Entity: marie dupont"}],
+            "relations_in": [{"predicate": "employe", "target": "Entity: wiscale"}],
+        }
+        payload = bench.entity_as_payload("camille dupont", profile)
+        triples = bench.relation_triples(payload)
+        self.assertEqual(triples, [("camille dupont", "soeur de", "marie dupont")])
+        self.assertEqual(payload["attributes"],
+                         [{"entity": "camille dupont", "key": "age", "value": 15}])
+
+    def test_incoming_edges_are_not_credited_to_this_entity(self):
+        """An incoming edge belongs to its SOURCE; folding it in invents an edge."""
+        profile = {"name": "wiscale", "attributes": {}, "relations": [],
+                   "relations_in": [{"predicate": "travaille chez", "target": "Entity: alice martin"}]}
+        payload = bench.entity_as_payload("wiscale", profile)
+        self.assertEqual(payload["relations"], [])
+
+    def test_graph_checks_keep_only_what_a_stored_entity_can_answer(self):
+        case = case_by_id("fr-possessive")
+        kept = {spec["type"] for spec in bench.graph_checks_for(case["passages"][0])}
+        self.assertIn("relation_present", kept)
+        self.assertIn("attribute_number", kept)
+        # About the ANSWER, not the graph: scoring it here would double-count.
+        self.assertNotIn("predicate_forbids", kept)
+
+    def test_a_missing_entity_fails_its_graph_check(self):
+        case = case_by_id("fr-possessive")
+        empty = bench.entity_as_payload("camille dupont", {"found": False, "name": "camille dupont"})
+        specs = bench.graph_checks_for(case["passages"][0])
+        self.assertTrue(bench.score_passage(empty, specs))
+
+
+# ---------------------------------------------------------------- transport --
+
+
+class McpBodyTest(unittest.TestCase):
+    def test_sse_priming_frame_is_skipped(self):
+        """The exact body the daemon returned on 2026-08-15."""
+        body = ('data: \nid: 0\nretry: 3000\n\n'
+                'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n')
+        decoded = bench.decode_mcp_body(body)
+        self.assertEqual(decoded["result"]["protocolVersion"], "2025-06-18")
+
+    def test_plain_json_body(self):
+        self.assertEqual(bench.decode_mcp_body('{"jsonrpc":"2.0","id":1}')["id"], 1)
+
+    def test_empty_body_is_none(self):
+        self.assertIsNone(bench.decode_mcp_body("   "))
+
+    def test_sse_without_any_payload_is_none(self):
+        self.assertIsNone(bench.decode_mcp_body("data: \nid: 0\nretry: 3000\n\n"))
+
+
+class ToolPayloadTest(unittest.TestCase):
+    def test_refusal_inside_a_valid_result_is_not_a_success(self):
+        """`isError` rides INSIDE a well-formed result; reading the outer reply lies."""
+        refused = {"response": {"result": {"isError": True, "content": [
+            {"type": "text", "text": "refused"}]}}}
+        self.assertIsNone(bench.tool_payload(refused))
+
+    def test_text_content_is_parsed_as_json(self):
+        ok = {"response": {"result": {"content": [{"type": "text", "text": '{"found": true}'}]}}}
+        self.assertEqual(bench.tool_payload(ok), {"found": True})
+
+    def test_non_json_text_is_kept_verbatim(self):
+        ok = {"response": {"result": {"content": [{"type": "text", "text": "plain"}]}}}
+        self.assertEqual(bench.tool_payload(ok), {"text": "plain"})
+
+
+# ------------------------------------------------------------ log digestion --
+
+
+SAMPLE_LOG = """\
+2026-08-15T09:23:21.000000Z  INFO velesdb_memory::mcp: tool=remember session=abc verdict=ok elapsed_ms=132033 "mcp tool call"
+2026-08-15T09:24:00.000000Z  INFO velesdb_memory::mcp: tool=recall session=abc verdict=ok elapsed_ms=128 "mcp tool call"
+2026-08-15T09:24:01.000000Z  INFO velesdb_memory::mcp: tool=recall session=abc verdict=tool_error elapsed_ms=5 "mcp tool call"
+2026-08-15T09:24:02.000000Z  INFO velesdb_memory::http: mcp http request method=POST session=abc status=200 elapsed_ms=2
+2026-08-14T23:40:41.000000Z  INFO velesdb_memory::mcp: tool=remember session=abc verdict=ok elapsed_ms=300403 "mcp tool call"
+"""
+
+
+class DigestTest(unittest.TestCase):
+    def digest(self, since=None):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "daemon.err.log"
+            path.write_text(SAMPLE_LOG, encoding="utf-8")
+            return bench.digest_log(path, since)
+
+    def test_tool_and_http_events_are_not_mixed(self):
+        """Both carry `elapsed_ms`; averaging them buries a 132-second write."""
+        digest = self.digest()
+        self.assertEqual(digest["tools"]["remember"]["n"], 2)
+        self.assertEqual(digest["http_post"]["n"], 1)
+        self.assertNotIn("mcp", digest["tools"])
+
+    def test_verdicts_separate_refusals_from_successes(self):
+        digest = self.digest()
+        self.assertEqual(digest["verdicts"]["recall:tool_error"], 1)
+        self.assertEqual(digest["verdicts"]["recall:ok"], 1)
+
+    def test_since_filters_by_timestamp(self):
+        digest = self.digest(since="2026-08-15T00")
+        self.assertEqual(digest["tools"]["remember"]["n"], 1)
+        self.assertEqual(digest["tools"]["remember"]["max_ms"], 132033)
+
+
+class PercentileTest(unittest.TestCase):
+    def test_nearest_rank(self):
+        values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        self.assertEqual(bench.percentile(values, 0.50), 5)
+        self.assertEqual(bench.percentile(values, 0.95), 10)
+        self.assertEqual(bench.percentile([7], 0.95), 7)
+
+    def test_empty_is_nan_not_a_crash(self):
+        self.assertTrue(math.isnan(bench.percentile([], 0.5)))
+
+
+# ------------------------------------------------------- the cases file itself --
+
+
+class CasesFileTest(unittest.TestCase):
+    """The cases are data, so their integrity is a test, not a runtime surprise.
+
+    A mistyped check type raises mid-campaign otherwise — after the model has
+    been loaded, warmed and half-scored.
+    """
+
+    def setUp(self):
+        self.cases = bench.load_cases(CASES_PATH)
+
+    def test_every_check_type_is_implemented(self):
+        for case in self.cases:
+            for passage in case["passages"]:
+                for spec in passage["checks"]:
+                    self.assertIn(spec["type"], bench.CHECKS, f"{case['id']}: {spec['type']}")
+            for spec in case.get("cross_checks") or []:
+                self.assertEqual(spec["type"], "predicates_differ", case["id"])
+
+    def test_every_check_declares_a_known_severity_and_a_label(self):
+        for case in self.cases:
+            specs = [s for p in case["passages"] for s in p["checks"]]
+            specs += case.get("cross_checks") or []
+            for spec in specs:
+                self.assertIn(spec["severity"], bench.SEVERITIES, case["id"])
+                self.assertTrue(spec["label"].strip(), case["id"])
+
+    def test_the_suite_covers_every_family_the_plan_names(self):
+        families = {case["family"] for case in self.cases}
+        self.assertEqual(families, {"nominal-fr", "nominal-en", "edge", "close-pair"})
+
+    def test_french_and_english_nominals_mirror_each_other(self):
+        """A model passing one language and failing the other must be visible."""
+        fr = sum(1 for case in self.cases if case["family"] == "nominal-fr")
+        en = sum(1 for case in self.cases if case["family"] == "nominal-en")
+        self.assertEqual(fr, en)
+
+    def test_close_pairs_carry_two_passages_and_a_cross_check(self):
+        pairs = [case for case in self.cases
+                 if case["family"] == "close-pair" and len(case["passages"]) == 2]
+        self.assertTrue(pairs)
+        for case in pairs:
+            self.assertTrue(case.get("cross_checks"), case["id"])
+
+    def test_case_ids_are_unique(self):
+        ids = [case["id"] for case in self.cases]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_every_passage_builds_a_valid_prompt(self):
+        """Cheap, and it proves no passage breaks the format! substitution."""
+        template = bench.read_graph_prompt_template()
+        for case in self.cases:
+            for passage in case["passages"]:
+                prompt = bench.build_graph_prompt(passage["text"], template)
+                self.assertIn(passage["text"], prompt)
+
+
+# --------------------------------------------------------------- warm-up ----
+
+
+class WarmUpTest(unittest.TestCase):
+    def test_stability_needs_a_full_window(self):
+        self.assertFalse(bench.is_stable([10.0, 10.0]))
+
+    def test_settled_latencies_are_stable(self):
+        self.assertTrue(bench.is_stable([50.0, 10.1, 10.0, 9.9]))
+
+    def test_a_drifting_model_is_not_stable(self):
+        self.assertFalse(bench.is_stable([10.0, 13.0, 17.0]))
+
+    def test_warm_up_reports_failure_to_settle_instead_of_raising(self):
+        """Not stabilising is a finding about the model, not a bench error."""
+
+        class Drifting:
+            def __init__(self):
+                self.calls = 0
+
+            def generate(self, _prompt):
+                self.calls += 1
+                return {"seconds": float(self.calls) * 3}
+
+        trace = bench.warm_up(Drifting(), "prompt")
+        self.assertFalse(trace["stabilised"])
+        self.assertEqual(trace["rounds"], bench.WARMUP_MAX_ROUNDS)
+
+
+# ----------------------------------------------------------------- report ----
+
+
+class ReportTest(unittest.TestCase):
+    def test_report_is_derived_from_the_results(self):
+        results = {
+            "campaign": "2026-08-15",
+            "environment": {"machine": "M5 Pro", "daemon_mtime": "2026-08-15T10:00"},
+            "configurations": {
+                "default:fast": {
+                    "totals": {"fatal": 0, "major": 1, "minor": 0, "parse_rate": 1.0,
+                               "truncated": 0, "p50_seconds": 10.4, "p95_seconds": 11.2},
+                    "cold": {"cold_total_seconds": 92.3},
+                    "warmup": {"rounds": 3, "stabilised": True},
+                },
+            },
+        }
+        rendered = bench.render_report(results)
+        self.assertIn("`default:fast`", rendered)
+        self.assertIn("10.4s", rendered)
+        self.assertIn("92.3s", rendered)
+        self.assertIn("M5 Pro", rendered)
+
+    def test_a_missing_cold_load_is_reported_not_faked(self):
+        results = {"campaign": "x", "environment": {}, "configurations": {
+            "m": {"totals": {"fatal": 0, "major": 0, "minor": 0, "parse_rate": 1.0,
+                             "truncated": 0, "p50_seconds": 1.0, "p95_seconds": 1.0}}}}
+        self.assertIn("n/a", bench.render_report(results))
+
+    def test_an_unstable_warm_up_is_flagged_in_the_table(self):
+        results = {"campaign": "x", "environment": {}, "configurations": {
+            "m": {"totals": {"fatal": 0, "major": 0, "minor": 0, "parse_rate": 1.0,
+                             "truncated": 0, "p50_seconds": 1.0, "p95_seconds": 1.0},
+                  "warmup": {"rounds": 6, "stabilised": False}}}}
+        self.assertIn("unstable", bench.render_report(results))
+
+    def test_report_is_reproducible(self):
+        """Same input, same bytes — the check that the table was not hand-edited."""
+        results = json.loads(json.dumps({"campaign": "x", "environment": {"a": "b"},
+                                         "configurations": {}}))
+        self.assertEqual(bench.render_report(results), bench.render_report(results))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

The daemon already records what every tool call costs (`log_tool_call`, #1780).
Digesting eight days of it says where the write path spends its time:

| tool | n | p50 | p95 |
|---|---|---|---|
| `remember` | 44 | **132 s** | 254 s (max 300,4 s) |
| `recall` | 20 | 128 ms | 518 ms |
| MCP HTTP POST | 843 | **0 ms** | **2 ms** |

Transport and reads are eliminated by measurement, not by argument. The 300 s
ceiling is `REQUEST_TIMEOUT_SECS`: those calls burned five minutes and then lost
their enrichment in silence, because autograph is deliberately infallible.

So the model is what is left to choose, and nothing in-tree could choose it.
This PR adds the tooling. It runs no campaign and changes no production code.

## What

- **`scripts/bench-memory-extraction.py`** — `from-log`, `screen`, `endtoend`,
  `report`, `probe`. The prompt and `MAX_GENERATION_TOKENS` are **read out of
  `extract.rs`**, and the request body is the one `openai::chat_body` builds, so
  the bench cannot measure a request the product no longer sends. The previous
  ad-hoc bench hand-copied its prompt and sent no cap at all, which is why the
  truncation the cap introduced had never once been exercised.
- **`scripts/memory-extraction-cases.json`** — 19 declarative scenarios: 4
  French, their 4 English mirrors, 5 edges, and 6 close pairs whose two passages
  differ by one word (`travaille chez`/`dirige`, `travaille chez`/`a quitté`,
  `sœur`/`belle-sœur`, `possède`/`loue`, `avec`/`pour`, `Dupont`/`Dupond`).
  Severity says what the graph suffers: fatal for an invented relation or a
  crossed attribute, major for a reversed edge or a predicate in the wrong
  language — `works at` and `travaille chez` are two graph predicates for one
  relation, so an asymmetric model does not degrade the graph, it fragments it.
- **`scripts/tests/test_bench_memory_extraction.py`** — 75 tests, a positive
  control and one refusal vector per severity.

## Three defects the tests found in this code

Only running it showed them:

- a lazy regex ended the prompt parse on the `")` inside the prompt's own
  example, yielding **869 of 2,659 characters** — and the sanity guard missed it
  because every marker it checked lives in the surviving head. The guards check
  the tail now, and the mutation is pinned by a test.
- the SSE decoder read the daemon's empty priming frame instead of the reply.
- `memory_status` is not everywhere: the daemon installed on that machine
  exposes 20 tools and not that one. `probe` asks the server for its tool list
  rather than assuming, so a missing capability is reported as missing instead
  of being measured as a failure.

## Scope

The bench is **not** a CI gate — it needs a live model. Its scorer is: the suite
is picked up by `gate-contracts.yml`'s `unittest discover -s scripts/tests`,
checked by re-running the CI command rather than assumed.

`endtoend` is written but **has never run**: it needs a daemon built from
`develop`. It is not presented as validated.

No production code is touched — not `build_graph_prompt`, not the 512-token cap,
not `REQUEST_TIMEOUT_SECS`, not the queue. Two findings deserve their own issues
rather than a change smuggled in here: the 300 s timeout that loses enrichment
without a trace, and `OllamaExtractor` sending neither `num_ctx` nor `format`.