### PR TITLE
refactor(memory): drop stale dead_code allows now the migration control plane is wired

### DIFF
--- a/crates/velesdb-memory/src/migration.rs
+++ b/crates/velesdb-memory/src/migration.rs
@@ -52,7 +52,6 @@ mod edges;
 mod enumeration;
 mod execute;
 mod filesystem;
-#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
 mod live;
 mod orchestrate;
 mod rebuild;
@@ -80,7 +79,6 @@ pub(crate) use execute::journal_workspace;
 pub(crate) use execute::target_embedder_witness;
 pub use execute::{execute, ExecuteOutcome};
 pub use filesystem::{bytes_on_disk, fingerprint};
-#[allow(unused_imports)] // Wired by the control-surface slice after this internal seam.
 pub(crate) use live::prepare_live_switch;
 pub use orchestrate::{migrate, MigrateOutcome};
 #[cfg(test)]

--- a/crates/velesdb-memory/src/migration/switchover.rs
+++ b/crates/velesdb-memory/src/migration/switchover.rs
@@ -36,9 +36,7 @@ use super::execute::journal_workspace;
 use super::state::{MigrationLock, MigrationState, Phase, SwitchState};
 
 #[path = "switchover/live.rs"]
-#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
 mod live;
-#[allow(unused_imports)] // Wired by the control-surface slice after this internal seam.
 pub(crate) use live::{
     finalize_staged_live_switch, rollback_staged_live_switch, stage_live_switch,
 };
@@ -69,7 +67,6 @@ pub fn switch_over(store: &Path, destination: &Path) -> Result<SwitchOutcome, cr
     run_switch(store, destination, true, false)
 }
 
-#[allow(dead_code)] // Wired by the control-surface slice after this internal seam.
 pub(crate) fn commit_retained_switch(
     store: &Path,
     destination: &Path,

--- a/crates/velesdb-memory/src/mutation.rs
+++ b/crates/velesdb-memory/src/mutation.rs
@@ -6,11 +6,8 @@ use parking_lot::RwLock;
 
 use crate::MemoryError;
 
-#[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
 pub(crate) mod catchup;
-#[allow(dead_code)] // Internal until the control-surface slice exposes online migration.
 pub(crate) mod controller;
-#[allow(dead_code)] // The catch-up slice consumes the journal before the control surface ships.
 pub(crate) mod journal;
 
 #[cfg(test)]
@@ -43,7 +40,6 @@ impl MutationCapture {
         }
     }
 
-    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
     pub(crate) fn replace(
         &self,
         observer: Option<Arc<dyn MutationObserver>>,

--- a/crates/velesdb-memory/src/mutation/catchup.rs
+++ b/crates/velesdb-memory/src/mutation/catchup.rs
@@ -191,6 +191,10 @@ impl<'a, E: Embedder> OnlineCatchUp<'a, E> {
         ))
     }
 
+    // Only reached from tests today: production teardown (online_migration's
+    // job_runner and manager) calls `install_mutation_observer(None)`
+    // directly instead of going through this method.
+    #[allow(dead_code)]
     pub(crate) fn finish(self) -> Result<(), MemoryError> {
         self.source.install_mutation_observer(None)
     }

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -214,7 +214,6 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
         })
     }
 
-    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
     pub(crate) fn install_mutation_observer(
         &self,
         observer: Option<Arc<dyn MutationObserver>>,

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -366,7 +366,6 @@ impl NativeStore {
         })
     }
 
-    #[allow(dead_code)] // The journal activation path remains internal until slice 6.
     pub(crate) fn set_mutation_observer(
         &self,
         observer: Option<Arc<dyn MutationObserver>>,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Continuous code-quality pass over `velesdb-memory`. Six `#[allow(dead_code)]` / `#[allow(unused_imports)]` suppressions were left over from the online-migration control-plane rollout, each commented "internal until the control-surface slice" or "wired by the control-surface slice after this internal seam." That slice has since landed — the `online_migration` control plane, cutover, recovery, and startup paths now call every one of these items directly:

- `mutation::{catchup, controller, journal}` modules — used from `online_migration/{job_runner,manager,job_state,cutover,recovery,startup}.rs` and `mcp/migration_tools.rs`.
- `MutationCapture::replace` and `NativeStore::set_mutation_observer` — used from `service.rs`'s `install_mutation_observer`.
- `MemoryService::install_mutation_observer` — used from `mutation/catchup.rs` and `online_migration/{job_runner,manager}.rs`.
- `migration::live::prepare_live_switch` — used from `online_migration/cutover.rs`.
- `switchover::{stage_live_switch, rollback_staged_live_switch, finalize_staged_live_switch, commit_retained_switch}` — used from `online_migration/{cutover,recovery,startup}.rs`.

Each removal was confirmed against real (non-test) call sites before editing.

Removing the module-level allow on `mutation::catchup` surfaced one method, `OnlineCatchUp::finish`, that genuinely is dead outside tests today — production teardown calls `install_mutation_observer(None)` directly instead of going through it. Per the repo's surgical-changes principle (leave real pre-existing dead code alone rather than guess at wiring it in), that one allow was kept, narrowed from the whole module down to just the method, with a comment describing the current state accurately.

No behavior change — attribute/comment cleanup only.

Fixes # (none — proactive code-quality pass, no tracked issue)

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- `cargo clippy -p velesdb-memory --all-targets -- -D warnings -D clippy::pedantic` (default features) — clean
- `cargo clippy -p velesdb-memory --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean (this is what surfaced the one genuine dead-code case above)
- `cargo fmt -p velesdb-memory -- --check` — clean
- `cargo test -p velesdb-memory --all-features` — passed (0 failures)

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — internal attributes only)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (attribute-only change, no new behavior to test)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Scoped down from a broader review pass; a same-family stale allow on `service.rs`'s whole `mod online_migration;` (behind mixed `persistence`/`mcp` cfg gates) was deliberately left alone — it needs a per-item audit rather than a grep-confirmed removal, so it's out of scope here.