### PR TITLE
test(memory): prove the offline reader lands a typed edge in the graph

### DIFF
--- a/crates/velesdb-memory/src/mcp/server_tests.rs
+++ b/crates/velesdb-memory/src/mcp/server_tests.rs
@@ -1090,6 +1090,66 @@ async fn explicit_outline_works_without_a_daemon_default() {
     assert_eq!(stored.ids.len(), 1);
 }
 
+/// A typed edge must reach the graph through the *offline* reader — no model,
+/// no network, no HTTP backend anywhere in the picture (#1945).
+///
+/// The extraction campaign's end-to-end rows read `not drained` with the
+/// outline extractor as well as with a live model, which left two readings
+/// open: an extraction→graph path that links nothing, or a measurement that
+/// stops before the write lands. This closes the first. It asserts the edge is
+/// **readable back** through `entity`, never that the call merely returned —
+/// a green write with an empty graph is exactly the failure being ruled out.
+///
+/// The bounded wait is the instrument, not a workaround: it separates "the
+/// edge never arrives" from "the edge arrives late", and those are different
+/// defects with different owners.
+#[tokio::test]
+async fn outline_extraction_lands_a_typed_edge_in_the_graph() {
+    let (_dir, srv) = server();
+
+    let Json(receipt) = srv
+        .remember_extracted(Parameters(RememberExtractedParams {
+            text: "fact: Alice ships the parser.\nedge: Alice | works_with | Bob".to_owned(),
+            metadata: None,
+            extractor: Some("outline".to_owned()),
+            idempotency_key: None,
+        }))
+        .await
+        .expect("the offline reader must not need a daemon default");
+    let stored = committed_extraction(&srv, receipt).await;
+    assert_eq!(stored.ids.len(), 1, "the `fact:` line is the only fact");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let Json(profile) = srv
+            .entity(Parameters(EntityParams {
+                name: "alice".to_owned(),
+            }))
+            .await
+            .expect("entity lookup");
+        let edge = profile.relations.iter().find(|relation| {
+            relation.predicate == "works_with" && relation.target.to_lowercase().ends_with("bob")
+        });
+        if edge.is_some() {
+            assert!(profile.found, "an entity with an edge is a found entity");
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no `works_with` edge reached the graph from the offline reader; \
+             found={} relations=[{}]",
+            profile.found,
+            profile
+                .relations
+                .iter()
+                .map(|relation| format!("{} -> {}", relation.predicate, relation.target))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
 #[tokio::test]
 async fn unknown_per_call_extractor_returns_invalid_params() {
     let (_dir, srv) = server();


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/*` → targets `develop`. ✅

## Description

Settles the half of #1945 that could have been a product defect, and points at the half that is not.

The extraction campaign merged in #1943 reported its tenth defect as `not drained`: no edge reaches the graph in a disposable daemon, **with the offline reader as well as with a live model**. Two readings were open — an extraction→graph path that links nothing, or a measurement that stops before the write lands.

This adds the test that separates them. Through `remember_extracted` with the in-process `outline` reader — no model, no network, no HTTP backend — a `works_with` edge is readable back through the `entity` tool once the durable job commits. **It passes.** The product path is sound.

### Where the campaign's `not drained` actually comes from

Running the test down made the cause visible in the harness rather than the crate. `scripts/bench-memory-extraction.py` writes its end-to-end passages through `remember_passage`, which calls the **`remember`** tool:

```python
def remember_passage(client: McpClient, text: str) -> dict:
    result = client.call("remember", {"fact": text})
```

It then polls `await_edges`, which only returns once the `entity` profile carries `relations` or `attributes`. But `EntityProfile` documents both fields as *bipartite scaffolding excluded* (`crates/velesdb-memory/src/model.rs:440`) — they are the typed entity→entity edges, and a plain `remember` builds the bipartite fact↔topic graph, not those.

So the end-to-end phase never invokes an extractor at all, and `await_edges` can only ever run out its 180 s timeout. That is exactly why the offline reader behaved identically to a live model: the backend under test was not on the path being measured.

Repairing that is a change to a measurement harness and would invalidate the published end-to-end rows, so it belongs in a PR that can re-run the campaign — not folded in here. #1945 carries the diagnosis and stays open for it.

Refs #1945

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — test-only, no production code touched

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-memory --all-features` — **793 passed, 0 failed, 9 ignored** on the lib target, every integration target green
- `cargo clippy -p velesdb-memory --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt -p velesdb-memory -- --check` — clean

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — no surface change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

The bounded wait inside the test is deliberate, and it is the instrument rather than a workaround: it distinguishes *the edge never arrives* from *the edge arrives late*, which are different defects with different owners. The assertion is on the edge being **readable back**, never on the call returning — a green write over an empty graph is precisely the failure being ruled out.
