### PR TITLE
fix(cli): report flush errors after REPL upsert and payload-store

### DIFF
--- a/crates/velesdb-cli/src/repl_data_cmds.rs
+++ b/crates/velesdb-cli/src/repl_data_cmds.rs
@@ -223,7 +223,11 @@ pub(crate) fn cmd_upsert(db: &Database, parts: &[&str]) -> CommandResult {
             let point = velesdb_core::Point::new(id, vector, payload);
             match col.upsert(vec![point]) {
                 Ok(()) => {
-                    let _ = col.flush();
+                    if let Err(e) = col.flush() {
+                        return CommandResult::Error(format!(
+                            "Upsert succeeded but flush failed: {e}"
+                        ));
+                    }
                     println!(
                         "{} Upserted point {} into '{}'\n",
                         "\u{2713}".green(),

--- a/crates/velesdb-cli/src/repl_graph_cmds.rs
+++ b/crates/velesdb-cli/src/repl_graph_cmds.rs
@@ -359,7 +359,9 @@ fn cmd_graph_store_payload(db: &Database, parts: &[&str]) -> CommandResult {
     if let Err(e) = col.upsert_node_payload(node_id, &payload) {
         return CommandResult::Error(format!("{e}"));
     }
-    let _ = col.flush();
+    if let Err(e) = col.flush() {
+        return CommandResult::Error(format!("Payload stored but flush failed: {e}"));
+    }
 
     println!(
         "{} Payload stored on node {}",


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two REPL commands discarded `Collection::flush()` errors with `let _ = col.flush();` and then unconditionally printed a success message, even if the flush failed (disk full, permission error, I/O error). This told the user their write succeeded when it might not have reached disk.

Every other call site doing the same `upsert`/`upsert_node_payload` + `flush` sequence already surfaces the error (`.flush` REPL command in `repl_query_cmds.rs`, and the non-REPL `graph store-payload` CLI subcommand in `graph_handlers.rs`). This makes the two REPL handlers consistent with the rest of the codebase:

- `crates/velesdb-cli/src/repl_data_cmds.rs` — `cmd_upsert` (`.upsert`)
- `crates/velesdb-cli/src/repl_graph_cmds.rs` — `cmd_graph_store_payload` (`.graph store-payload`)

Both now return `CommandResult::Error` with a message that distinguishes "the write itself failed" from "the write landed but flush failed", instead of silently discarding the flush error.

Fixes # (no tracked issue — found during a continuous code-quality review pass)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Existing REPL/BDD test suites already exercise `cmd_upsert` and `cmd_graph_store_payload` on the success path and continue to pass unchanged (flush succeeds in-test, so behavior is unchanged there). No new test was added since there is no existing harness in this crate for injecting an I/O failure into `Collection::flush()`; the change is a straightforward propagate-the-existing-error-type fix mirroring the already-tested `.flush` command.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

Commands run:
```
cargo fmt --all
cargo clippy -p velesdb-cli --all-targets -- -D warnings -D clippy::pedantic
cargo build -p velesdb-cli
cargo test -p velesdb-cli -- --test-threads=1
python3 scripts/check_prod_unwraps.py
python3 scripts/check-todo-annotations.py
python3 scripts/check-ai-attribution.py "develop..HEAD"
```
All green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Scoped, behavior-preserving change (2 files, ~8 lines) found while doing a continuous code-quality review pass. Does not touch the search/recall path, `velesdb-node`'s contract-tested `MemoryService` surface, or the observer control-plane boundary.
