### PR TITLE
test(bench): fix what the extraction measurements were getting wrong

### DIFF
--- a/scripts/bench-memory-extraction.py
+++ b/scripts/bench-memory-extraction.py
@@ -564,6 +564,26 @@ def http_json(url: str, payload: "dict | None" = None, token: "str | None" = Non
     return json.loads(body) if body.strip() else {}
 
 
+def generation_timeout(cap: int) -> int:
+    """A client timeout scaled to what the server was ASKED to generate.
+
+    `http_json` defaults to 400 s, which was chosen against a machine that
+    generates quickly. It is not scaled to `num_predict`, and on a slow host it
+    is the cap that decides how long a reply takes: raising the cap to 1024 or
+    4096 raises the time proportionally, and a fixed ceiling turns the larger
+    arms of an experiment into timeouts.
+
+    A timeout is not a bad measurement here — nothing catches it, so it crashes
+    the run and no result file is written, which the caller reports as an
+    inability to measure. But an experiment that cannot complete answers
+    nothing, and that is a poor reason to lose a two-hour run.
+
+    Two seconds per token is far above any real rate; the point is a bound that
+    scales, not a prediction. The job's own timeout stays the real ceiling.
+    """
+    return max(400, cap * 2)
+
+
 def http_text(url: str, timeout: int = 30) -> str:
     """One GET whose body is read as text, for endpoints that answer no JSON.
 
@@ -608,7 +628,8 @@ class OpenAiBackend:
             "max_tokens": self.cap,
         }
         started = time.monotonic()
-        response = http_json(f"{self.base_url}/v1/chat/completions", body, self.token)
+        response = http_json(f"{self.base_url}/v1/chat/completions", body, self.token,
+                             timeout=generation_timeout(self.cap))
         elapsed = time.monotonic() - started
         choice = (response.get("choices") or [{}])[0]
         return {
@@ -619,6 +640,19 @@ class OpenAiBackend:
             # this bench exists to catch, reported by the server rather than
             # inferred from a JSON parse error.
             "truncated": choice.get("finish_reason") == "length",
+        }
+
+    def settings(self) -> dict:
+        """Same contract as the ollama backend — see its `settings`."""
+        return {
+            "backend": "openai",
+            # This path sends no schema at all: the crate's OpenAI-compatible
+            # extractor has no `format` equivalent wired (#1944), so a run here
+            # is unconstrained by construction rather than by choice.
+            "constrained": False,
+            "schema_required": None,
+            "temperature": 0,
+            "max_tokens": self.cap,
         }
 
     def residency(self) -> dict:
@@ -735,6 +769,23 @@ class OllamaBackend:
     def _options(self) -> dict:
         return {"temperature": 0, "num_predict": self.cap, "num_ctx": self.num_ctx}
 
+    def settings(self) -> dict:
+        """The decode settings this run actually sent, for the record.
+
+        Asked of the backend rather than of the CLI arguments, so a result can
+        never claim a setting the requests did not carry. A published run whose
+        `num_ctx` is not on the record cannot be replayed and cannot be compared
+        to another machine — which is exactly what happened to the first
+        campaign, whose files carry no context window at all.
+        """
+        return {
+            "backend": "ollama",
+            "constrained": self.schema is not None,
+            "schema_required": sorted(self.schema.get("required", [])) if self.schema else None,
+            "keep_alive": self.keep_alive,
+            **self._options(),
+        }
+
     def generate(self, prompt: str) -> dict:
         body = {
             "model": self.model,
@@ -747,7 +798,8 @@ class OllamaBackend:
         if self.schema is not None:
             body["format"] = self.schema
         started = time.monotonic()
-        response = http_json(f"{self.base_url}/api/generate", body)
+        response = http_json(f"{self.base_url}/api/generate", body,
+                             timeout=generation_timeout(self.cap))
         elapsed = time.monotonic() - started
         return {
             "seconds": elapsed,
@@ -903,8 +955,29 @@ def cold_load(backend: object, model: str, prompt: str, backing: "dict | None" =
 # ------------------------------------------------------ phase A: screening ----
 
 
-def load_cases(path: Path = CASES_FILE) -> "list[dict]":
-    return json.loads(path.read_text(encoding="utf-8"))["cases"]
+def load_cases(path: Path = CASES_FILE, split: "str | None" = None) -> "list[dict]":
+    """The scenarios, optionally restricted to one side of the train/holdout line.
+
+    The split exists for prompt tuning, and only for that. Anything that edits
+    the prompt to raise a score must be tuned on `train` and reported on
+    `holdout`, because a suite of nineteen scenarios is small enough that a loop
+    iterating against it learns the scenarios rather than the task — and a score
+    that improves on the cases it was optimised against is not evidence of
+    anything.
+
+    `None` keeps every case, which is what a campaign measuring MODELS wants:
+    the split is a defence against overfitting a prompt, and withholding cases
+    from a model comparison would only make it less informative.
+    """
+    cases = json.loads(path.read_text(encoding="utf-8"))["cases"]
+    if split is None:
+        return cases
+    chosen = [case for case in cases if case.get("split") == split]
+    if not chosen:
+        raise RuntimeError(
+            f"no case carries split={split!r} in {path}; the suite must declare "
+            f"one per case before a split run means anything")
+    return chosen
 
 
 def parse_payload(content: str) -> "dict | None":
@@ -1264,11 +1337,62 @@ class DisposableDaemon:
         shutil.rmtree(self.store, ignore_errors=True)
 
 
-def remember_passage(client: McpClient, text: str) -> dict:
-    """Store one passage and report what the caller waited for."""
+def write_fact(client: McpClient, text: str) -> dict:
+    """Store one fact verbatim through `remember`, without waiting for anything.
+
+    Deliberately NOT the extraction path. This is what `burst` needs: `remember`
+    accepts immediately and hands enrichment to the bounded autograph queue, and
+    that queue's drop behaviour under a fast writer is the whole subject. Routing
+    it through `remember_extracted` and awaiting each commit would serialise the
+    burst and measure the opposite of what it exists to measure.
+    """
     result = client.call("remember", {"fact": text})
     payload = tool_payload(result)
     return {"seconds": result["seconds"], "stored": payload is not None, "payload": payload}
+
+
+def remember_passage(client: McpClient, text: str, timeout_s: float = 600.0) -> dict:
+    """Store one passage THROUGH THE EXTRACTOR, and wait for the durable commit.
+
+    This used to call `remember`, which stores a fact verbatim and never invokes
+    an extractor at all (#1945). Phase B therefore measured a path the backend
+    under test was not on: the graph it then polled for typed entity edges only
+    ever receives the bipartite fact-topic scaffolding from that tool, so
+    `await_edges` could not do anything but run out its timeout — identically
+    for every model, and identically for the no-LLM reader.
+
+    `remember_extracted` is asynchronous by design: it returns a receipt and a
+    background worker generates and commits. Waiting for the terminal state is
+    what makes this a measurement of the daemon rather than of its acceptance
+    queue.
+    """
+    started = time.monotonic()
+    receipt = tool_payload(client.call("remember_extracted", {"text": text})) or {}
+    request_id = receipt.get("request_id")
+    if not request_id:
+        return {"seconds": time.monotonic() - started, "stored": False,
+                "state": "no-receipt", "payload": receipt}
+
+    state, status = receipt.get("state"), {}
+    while state not in ("committed", "failed"):
+        if time.monotonic() - started > timeout_s:
+            return {"seconds": time.monotonic() - started, "stored": False,
+                    "state": "timeout", "request_id": request_id, "payload": status}
+        time.sleep(1.0)
+        status = tool_payload(client.call("extraction_status",
+                                          {"request_id": request_id})) or {}
+        state = status.get("state")
+
+    return {
+        "seconds": time.monotonic() - started,
+        # Committed with zero ids is not a store: the extractor answered with
+        # nothing usable, which is a model result and must not read as success.
+        "stored": state == "committed" and bool(status.get("ids")),
+        "state": state,
+        "request_id": request_id,
+        "error": status.get("error"),
+        "payload": status,
+    }
 
 
 def score_stored_case(client: McpClient, case: dict) -> dict:
@@ -1301,7 +1425,7 @@ def burst(client: McpClient, texts: "list[str]") -> dict:
     than the model generates loses enrichment. Counted and visible by design —
     this measures how close a given model puts a user to that edge.
     """
-    latencies = [remember_passage(client, text)["seconds"] for text in texts]
+    latencies = [write_fact(client, text)["seconds"] for text in texts]
     status = tool_payload(client.call("memory_status", {})) or {}
     return {
         "count": len(texts),
@@ -1338,6 +1462,27 @@ def endtoend(daemon: DisposableDaemon, cases: "list[dict]") -> dict:
 # ------------------------------------------------------------------ report ----
 
 
+def _quality_cell(totals: dict, key: str) -> str:
+    """A quality count, or a refusal to state one that cannot mean anything.
+
+    `major` and `minor` are counted on replies that PARSED. A configuration
+    where nothing parsed therefore scores zero of them — and `0` in a quality
+    column reads as "no errors" when it means "nothing to grade". Measured:
+    `llama3.1:8b` published `major=0` beside `parse=0%`, its best-looking cell
+    produced by its worst possible outcome.
+
+    A partial parse rate has a weaker version of the same problem, so the count
+    is qualified with what it was counted over rather than presented bare.
+    """
+    count = totals.get(key, 0)
+    parsed = totals.get("parse_rate")
+    if parsed == 0:
+        return "n/a"
+    if parsed is not None and parsed < 1:
+        return f"{count} (of {parsed * 100:.0f}%)"
+    return str(count)
+
+
 def _report_row(name: str, entry: dict) -> str:
     totals = entry.get("totals", {})
     cold = entry.get("cold", {}).get("cold_total_seconds")
@@ -1345,8 +1490,8 @@ def _report_row(name: str, entry: dict) -> str:
     return " | ".join([
         f"| `{name}`",
         str(totals.get("fatal", 0)),
-        str(totals.get("major", 0)),
-        str(totals.get("minor", 0)),
+        _quality_cell(totals, "major"),
+        _quality_cell(totals, "minor"),
         f"{totals.get('parse_rate', 0) * 100:.0f}%",
         str(totals.get("truncated", 0)),
         f"{totals.get('p50_seconds', float('nan')):.1f}s",
@@ -1600,16 +1745,17 @@ def preflight(residency: dict, model: str) -> dict:
 
 
 def cmd_screen(args: argparse.Namespace) -> int:
-    cap = read_generation_cap()
+    cap = getattr(args, "generation_cap", None) or read_generation_cap()
     template = read_graph_prompt_template()
     backend = build_backend(args, cap)
-    cases = load_cases(Path(args.cases))
+    cases = load_cases(Path(args.cases), getattr(args, "split", None))
     prompt = build_graph_prompt(cases[0]["passages"][0]["text"], template)
     residency = backend.residency()
     checked = preflight(residency, args.config)
     outcome = {
         "config": args.config,
         "generation_cap": cap,
+        "settings": backend.settings(),
         "residency_before": residency,
         "storage": checked["backing"],
         "estimated_size": checked["estimated_size"],
@@ -1659,7 +1805,7 @@ def cmd_endtoend(args: argparse.Namespace) -> int:
     daemon = DisposableDaemon(Path(args.binary), args.port, endtoend_env(args))
     daemon.start()
     try:
-        outcome = endtoend(daemon, load_cases(Path(args.cases)))
+        outcome = endtoend(daemon, load_cases(Path(args.cases), getattr(args, "split", None)))
     finally:
         daemon.stop()
     outcome["config"] = args.config
@@ -1678,7 +1824,8 @@ def cmd_endtoend(args: argparse.Namespace) -> int:
 # daemon installed on this machine on 2026-08-15 exposes 20 tools and NOT
 # `memory_status`, because its binary predates that tool. Phase B run against
 # it would have reported "tool not found" as a measurement.
-PHASE_B_TOOLS = ("remember", "entity", "recall", "memory_status")
+PHASE_B_TOOLS = ("remember", "remember_extracted", "extraction_status",
+                 "entity", "recall", "memory_status")
 
 
 def cmd_probe(args: argparse.Namespace) -> int:
@@ -1710,6 +1857,16 @@ def _add_model_arguments(parser: argparse.ArgumentParser, config_required: bool)
     # the same verdict for their own language.
     parser.add_argument("--cases", default=str(CASES_FILE),
                         help="scenario file; replace it to bench another language")
+    parser.add_argument("--generation-cap", type=int, default=None, dest="generation_cap",
+                        help="override `MAX_GENERATION_TOKENS`. A DECLARED VARIANT, "
+                             "never the reference: the crate caps at its own value and "
+                             "a run with this flag measures a product that does not "
+                             "exist. Exists to test whether a truncation is the cap's "
+                             "fault or the model's")
+    parser.add_argument("--split", choices=["train", "holdout"], default=None,
+                        help="restrict to one side of the train/holdout line. For "
+                             "PROMPT tuning only: tune on train, report on holdout. "
+                             "Omit it to measure models, which wants every case")
     parser.add_argument("--constrained", action="store_true",
                         help="ollama only: constrain decoding to the extraction "
                              "schema. A DECLARED VARIANT, never the reference — "

--- a/scripts/memory-extraction-cases.json
+++ b/scripts/memory-extraction-cases.json
@@ -34,7 +34,9 @@
             {
               "type": "relation_present",
               "subject": "camille dupont",
-              "predicate_any": ["soeur"],
+              "predicate_any": [
+                "soeur"
+              ],
               "object": "marie dupont",
               "severity": "major",
               "label": "sibling edge missing or reversed"
@@ -42,27 +44,37 @@
             {
               "type": "relation_absent",
               "subject": "marie dupont",
-              "predicate_any": ["soeur"],
+              "predicate_any": [
+                "soeur"
+              ],
               "severity": "major",
               "label": "parasitic converse: both directions of one predicate"
             },
             {
               "type": "predicate_forbids",
-              "substrings": ["works", "sister", "brother", "father of"],
+              "substrings": [
+                "works",
+                "sister",
+                "brother",
+                "father of"
+              ],
               "severity": "major",
               "label": "English predicate on a French passage"
             },
             {
               "type": "attribute_number",
               "entity": "camille dupont",
-              "key_any": ["age"],
+              "key_any": [
+                "age"
+              ],
               "value": 15,
               "severity": "major",
               "label": "age missing, misattributed, or emitted as a string"
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "fr-employment-date",
@@ -76,14 +88,21 @@
             {
               "type": "relation_present",
               "subject": "bruno durand",
-              "predicate_any": ["dirige", "directeur", "pdg", "a la tete"],
+              "predicate_any": [
+                "dirige",
+                "directeur",
+                "pdg",
+                "a la tete"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "leadership edge missing"
             },
             {
               "type": "facts_mention",
-              "substrings": ["2019"],
+              "substrings": [
+                "2019"
+              ],
               "severity": "major",
               "label": "absolute date dropped"
             },
@@ -95,7 +114,8 @@
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "fr-pronoun",
@@ -122,13 +142,17 @@
             },
             {
               "type": "facts_forbid",
-              "substrings": [" il habite", " il dirige"],
+              "substrings": [
+                " il habite",
+                " il dirige"
+              ],
               "severity": "major",
               "label": "pronoun left unresolved in a fact meant to stand alone"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "fr-converse-stated",
@@ -142,7 +166,10 @@
             {
               "type": "relation_present",
               "subject": "wiscale",
-              "predicate_any": ["emploie", "employeur"],
+              "predicate_any": [
+                "emploie",
+                "employeur"
+              ],
               "object": "alice martin",
               "severity": "major",
               "label": "employs edge missing"
@@ -150,14 +177,17 @@
             {
               "type": "relation_present",
               "subject": "alice martin",
-              "predicate_any": ["travaille"],
+              "predicate_any": [
+                "travaille"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "works-for edge missing"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "en-possessive",
@@ -171,34 +201,48 @@
             {
               "type": "relation_present",
               "subject": "tom miller",
-              "predicate_any": ["brother"],
+              "predicate_any": [
+                "brother"
+              ],
               "object": "sarah miller",
               "severity": "major",
               "label": "sibling edge missing or reversed"
             },
             {
               "type": "single_edge_between",
-              "entities": ["tom miller", "sarah miller"],
+              "entities": [
+                "tom miller",
+                "sarah miller"
+              ],
               "severity": "major",
               "label": "both directions over the same pair"
             },
             {
               "type": "predicate_forbids",
-              "substrings": ["frere", "soeur", "travaille", "dirige", "pere de"],
+              "substrings": [
+                "frere",
+                "soeur",
+                "travaille",
+                "dirige",
+                "pere de"
+              ],
               "severity": "major",
               "label": "French predicate on an English passage"
             },
             {
               "type": "attribute_number",
               "entity": "tom miller",
-              "key_any": ["age"],
+              "key_any": [
+                "age"
+              ],
               "value": 22,
               "severity": "major",
               "label": "age missing, misattributed, or emitted as a string"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "en-employment-date",
@@ -212,14 +256,23 @@
             {
               "type": "relation_present",
               "subject": "david clarke",
-              "predicate_any": ["runs", "leads", "heads", "manages", "ceo", "director"],
+              "predicate_any": [
+                "runs",
+                "leads",
+                "heads",
+                "manages",
+                "ceo",
+                "director"
+              ],
               "object": "northwind",
               "severity": "major",
               "label": "leadership edge missing"
             },
             {
               "type": "facts_mention",
-              "substrings": ["2019"],
+              "substrings": [
+                "2019"
+              ],
               "severity": "major",
               "label": "absolute date dropped"
             },
@@ -231,7 +284,8 @@
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "en-pronoun",
@@ -258,13 +312,17 @@
             },
             {
               "type": "facts_forbid",
-              "substrings": [" he lives", " he runs"],
+              "substrings": [
+                " he lives",
+                " he runs"
+              ],
               "severity": "major",
               "label": "pronoun left unresolved in a fact meant to stand alone"
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "en-converse-stated",
@@ -278,7 +336,10 @@
             {
               "type": "relation_present",
               "subject": "northwind",
-              "predicate_any": ["employs", "employer"],
+              "predicate_any": [
+                "employs",
+                "employer"
+              ],
               "object": "emma stone",
               "severity": "major",
               "label": "employs edge missing"
@@ -286,14 +347,19 @@
             {
               "type": "relation_present",
               "subject": "emma stone",
-              "predicate_any": ["works for", "works at", "employee"],
+              "predicate_any": [
+                "works for",
+                "works at",
+                "employee"
+              ],
               "object": "northwind",
               "severity": "major",
               "label": "works-for edge missing"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "edge-no-relation",
@@ -311,7 +377,8 @@
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "edge-hostile-format",
@@ -331,13 +398,19 @@
             {
               "type": "relation_present",
               "subject": "nadia kerouac",
-              "predicate_any": ["pilote", "dirige", "responsable", "travaille"],
+              "predicate_any": [
+                "pilote",
+                "dirige",
+                "responsable",
+                "travaille"
+              ],
               "severity": "major",
               "label": "nadia kerouac absent from every edge"
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "edge-verbose-truncation",
@@ -361,7 +434,8 @@
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "edge-accents-hyphens",
@@ -375,20 +449,27 @@
             {
               "type": "relation_present",
               "subject": "jean-luc d'arcy",
-              "predicate_any": ["fonde", "fondateur", "cree"],
+              "predicate_any": [
+                "fonde",
+                "fondateur",
+                "cree"
+              ],
               "object_contains": "kerite",
               "severity": "major",
               "label": "founding edge missing, or entity name mangled"
             },
             {
               "type": "facts_mention",
-              "substrings": ["2018"],
+              "substrings": [
+                "2018"
+              ],
               "severity": "minor",
               "label": "absolute date dropped"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "edge-mixed-lang",
@@ -402,20 +483,30 @@
             {
               "type": "relation_present",
               "subject": "marie dupont",
-              "predicate_any": ["rejoint", "travaille", "membre"],
+              "predicate_any": [
+                "rejoint",
+                "travaille",
+                "membre"
+              ],
               "object_contains": "northwind",
               "severity": "major",
               "label": "membership edge missing"
             },
             {
               "type": "predicate_forbids",
-              "substrings": ["joined", "works at", "member of", "employee of"],
+              "substrings": [
+                "joined",
+                "works at",
+                "member of",
+                "employee of"
+              ],
               "severity": "major",
               "label": "predicate follows the entity's language instead of the passage's"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "close-role",
@@ -436,14 +527,20 @@
             {
               "type": "relation_present",
               "subject": "alice martin",
-              "predicate_any": ["travaille"],
+              "predicate_any": [
+                "travaille"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "works-at edge missing"
             },
             {
               "type": "relation_absent",
-              "predicate_any": ["dirige", "directeur", "pdg"],
+              "predicate_any": [
+                "dirige",
+                "directeur",
+                "pdg"
+              ],
               "severity": "major",
               "label": "leadership role invented"
             }
@@ -455,20 +552,27 @@
             {
               "type": "relation_present",
               "subject": "alice martin",
-              "predicate_any": ["dirige", "directrice", "a la tete"],
+              "predicate_any": [
+                "dirige",
+                "directrice",
+                "a la tete"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "leads edge missing"
             },
             {
               "type": "relation_absent",
-              "predicate_any": ["travaille"],
+              "predicate_any": [
+                "travaille"
+              ],
               "severity": "major",
               "label": "leadership flattened into plain employment"
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "close-negation",
@@ -489,7 +593,9 @@
             {
               "type": "relation_present",
               "subject": "alice martin",
-              "predicate_any": ["travaille"],
+              "predicate_any": [
+                "travaille"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "works-at edge missing"
@@ -501,21 +607,30 @@
           "checks": [
             {
               "type": "relation_absent",
-              "predicate_any": ["travaille chez", "travaille pour", "employee de"],
+              "predicate_any": [
+                "travaille chez",
+                "travaille pour",
+                "employee de"
+              ],
               "severity": "fatal",
               "label": "departure stored as a current employment"
             },
             {
               "type": "relation_present",
               "subject": "alice martin",
-              "predicate_any": ["quitte", "ancienne", "depart"],
+              "predicate_any": [
+                "quitte",
+                "ancienne",
+                "depart"
+              ],
               "object": "wiscale",
               "severity": "major",
               "label": "departure edge missing"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "close-kinship",
@@ -536,14 +651,18 @@
             {
               "type": "relation_present",
               "subject": "camille rey",
-              "predicate_any": ["soeur"],
+              "predicate_any": [
+                "soeur"
+              ],
               "object": "marie rey",
               "severity": "major",
               "label": "sibling edge missing"
             },
             {
               "type": "predicate_forbids",
-              "substrings": ["belle"],
+              "substrings": [
+                "belle"
+              ],
               "severity": "major",
               "label": "blood kinship rendered as kinship by marriage"
             }
@@ -555,14 +674,18 @@
             {
               "type": "relation_present",
               "subject": "camille rey",
-              "predicate_any": ["belle-soeur", "belle soeur"],
+              "predicate_any": [
+                "belle-soeur",
+                "belle soeur"
+              ],
               "object": "marie rey",
               "severity": "major",
               "label": "kinship by marriage rendered as blood kinship"
             }
           ]
         }
-      ]
+      ],
+      "split": "holdout"
     },
     {
       "id": "close-possession",
@@ -583,14 +706,20 @@
             {
               "type": "relation_present",
               "subject": "wiscale",
-              "predicate_any": ["possede", "proprietaire"],
+              "predicate_any": [
+                "possede",
+                "proprietaire"
+              ],
               "object_contains": "hydra",
               "severity": "major",
               "label": "ownership edge missing"
             },
             {
               "type": "relation_absent",
-              "predicate_any": ["loue", "location"],
+              "predicate_any": [
+                "loue",
+                "location"
+              ],
               "severity": "major",
               "label": "ownership rendered as a lease"
             }
@@ -602,20 +731,28 @@
             {
               "type": "relation_present",
               "subject": "wiscale",
-              "predicate_any": ["loue", "location"],
+              "predicate_any": [
+                "loue",
+                "location"
+              ],
               "object_contains": "hydra",
               "severity": "major",
               "label": "lease edge missing"
             },
             {
               "type": "relation_absent",
-              "predicate_any": ["possede", "proprietaire", "appartient"],
+              "predicate_any": [
+                "possede",
+                "proprietaire",
+                "appartient"
+              ],
               "severity": "fatal",
               "label": "lease stored as ownership"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "close-symmetry",
@@ -635,7 +772,10 @@
           "checks": [
             {
               "type": "single_edge_between",
-              "entities": ["alice rey", "bob neri"],
+              "entities": [
+                "alice rey",
+                "bob neri"
+              ],
               "severity": "major",
               "label": "symmetric relation duplicated in both directions"
             },
@@ -653,7 +793,9 @@
             {
               "type": "relation_present",
               "subject": "alice rey",
-              "predicate_any": ["travaille"],
+              "predicate_any": [
+                "travaille"
+              ],
               "object": "bob neri",
               "severity": "major",
               "label": "subordination edge missing or reversed"
@@ -661,13 +803,17 @@
             {
               "type": "relation_absent",
               "subject": "bob neri",
-              "predicate_any": ["travaille pour", "travaille avec"],
+              "predicate_any": [
+                "travaille pour",
+                "travaille avec"
+              ],
               "severity": "major",
               "label": "hierarchy inverted"
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
     },
     {
       "id": "close-homonyms",
@@ -708,7 +854,487 @@
             }
           ]
         }
-      ]
+      ],
+      "split": "train"
+    },
+    {
+      "id": "close-en-role",
+      "family": "close-pair",
+      "lang": "en",
+      "note": "Mirror of close-role. One verb apart; managing and joining are not the same edge.",
+      "passages": [
+        {
+          "text": "Nadia Osei manages Kestrel Foods.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "nadia osei",
+              "predicate_any": [
+                "manage"
+              ],
+              "object": "kestrel foods",
+              "severity": "major",
+              "label": "management edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "travaille",
+                "dirige",
+                "fils de",
+                "soeur de",
+                "possede"
+              ],
+              "severity": "major",
+              "label": "French predicate on an English passage"
+            }
+          ]
+        },
+        {
+          "text": "Nadia Osei joined Kestrel Foods.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "nadia osei",
+              "predicate_any": [
+                "join",
+                "work"
+              ],
+              "object": "kestrel foods",
+              "severity": "major",
+              "label": "employment edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "travaille",
+                "dirige",
+                "fils de",
+                "soeur de",
+                "possede"
+              ],
+              "severity": "major",
+              "label": "French predicate on an English passage"
+            }
+          ]
+        }
+      ],
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "managing and joining collapsed into one predicate"
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "close-en-kinship",
+      "family": "close-pair",
+      "lang": "en",
+      "note": "Mirror of close-kinship. The possessive names the relative, so the relative carries the edge.",
+      "passages": [
+        {
+          "text": "Priya Raghunathan has a sister, Meena Raghunathan.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "meena raghunathan",
+              "predicate_any": [
+                "sister"
+              ],
+              "object": "priya raghunathan",
+              "severity": "major",
+              "label": "sibling edge missing or reversed"
+            },
+            {
+              "type": "relation_absent",
+              "subject": "priya raghunathan",
+              "predicate_any": [
+                "sister"
+              ],
+              "severity": "major",
+              "label": "parasitic converse: both directions of one predicate"
+            }
+          ]
+        },
+        {
+          "text": "Priya Raghunathan has a daughter, Meena Raghunathan.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "meena raghunathan",
+              "predicate_any": [
+                "daughter"
+              ],
+              "object": "priya raghunathan",
+              "severity": "major",
+              "label": "filiation edge missing or reversed"
+            }
+          ]
+        }
+      ],
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "sister and daughter collapsed into one predicate"
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "close-en-tense",
+      "family": "close-pair",
+      "lang": "en",
+      "note": "A ceased employment must not be stored as a current one; the graph has no tense.",
+      "passages": [
+        {
+          "text": "Tomas Weber works at Halden Rail.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "tomas weber",
+              "predicate_any": [
+                "work"
+              ],
+              "object": "halden rail",
+              "severity": "major",
+              "label": "employment edge missing"
+            }
+          ]
+        },
+        {
+          "text": "Tomas Weber no longer works at Halden Rail.",
+          "checks": [
+            {
+              "type": "facts_mention",
+              "substrings": [
+                "no longer"
+              ],
+              "severity": "major",
+              "label": "the fact drops the negation, so the graph reads as current employment"
+            }
+          ]
+        }
+      ],
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "current and ceased employment collapsed into one predicate"
+        }
+      ],
+      "split": "holdout"
+    },
+    {
+      "id": "close-en-possession",
+      "family": "close-pair",
+      "lang": "en",
+      "note": "Owning and managing are two stated relations, not one.",
+      "passages": [
+        {
+          "text": "Owen Blake owns Larkspur Studio.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "owen blake",
+              "predicate_any": [
+                "own"
+              ],
+              "object": "larkspur studio",
+              "severity": "major",
+              "label": "ownership edge missing"
+            }
+          ]
+        },
+        {
+          "text": "Owen Blake manages Larkspur Studio.",
+          "checks": [
+            {
+              "type": "relation_present",
+              "subject": "owen blake",
+              "predicate_any": [
+                "manage"
+              ],
+              "object": "larkspur studio",
+              "severity": "major",
+              "label": "management edge missing"
+            }
+          ]
+        }
+      ],
+      "cross_checks": [
+        {
+          "type": "predicates_differ",
+          "severity": "major",
+          "label": "owning and managing collapsed into one predicate"
+        }
+      ],
+      "split": "holdout"
+    },
+    {
+      "id": "edge-en-no-relation",
+      "family": "edge",
+      "lang": "en",
+      "note": "Mirror of edge-no-relation. Nothing relates two named entities; inventing an edge is worse than none.",
+      "passages": [
+        {
+          "text": "The quarterly report was printed on recycled paper and filed the same afternoon.",
+          "checks": [
+            {
+              "type": "relations_empty",
+              "severity": "fatal",
+              "label": "invented an edge from a passage that states none"
+            }
+          ]
+        }
+      ],
+      "split": "holdout"
+    },
+    {
+      "id": "edge-en-hostile-format",
+      "family": "edge",
+      "lang": "en",
+      "note": "Mirror of edge-hostile-format. Braces inside the passage must not leak into the envelope.",
+      "passages": [
+        {
+          "text": "Ana Ferreira pasted {\"status\": \"done\"} into the ticket she filed for Vantage Health.",
+          "checks": [
+            {
+              "type": "min_relations",
+              "n": 1,
+              "severity": "major",
+              "label": "no edge extracted from a passage that states one"
+            },
+            {
+              "type": "not_truncated",
+              "severity": "fatal",
+              "label": "reply cut off"
+            }
+          ]
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "fr-multi-entity",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "Two stated edges over a shared organisation. An entity that only receives attributes is a dead end.",
+      "passages": [
+        {
+          "text": "Sofia Marchetti dirige Aurel Textile. Karim Benali travaille chez Aurel Textile depuis 2021.",
+          "checks": [
+            {
+              "type": "min_relations",
+              "n": 2,
+              "severity": "major",
+              "label": "fewer edges than the passage states"
+            },
+            {
+              "type": "relation_present",
+              "subject": "sofia marchetti",
+              "predicate_any": [
+                "dirig"
+              ],
+              "object": "aurel textile",
+              "severity": "major",
+              "label": "direction edge missing"
+            },
+            {
+              "type": "relation_present",
+              "subject": "karim benali",
+              "predicate_any": [
+                "travaill"
+              ],
+              "object": "aurel textile",
+              "severity": "major",
+              "label": "employment edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "works",
+                "runs",
+                "manages",
+                "son of",
+                "sister of",
+                "owns"
+              ],
+              "severity": "major",
+              "label": "English predicate on a French passage"
+            }
+          ]
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "en-multi-entity",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "English mirror of fr-multi-entity.",
+      "passages": [
+        {
+          "text": "Sofia Marchetti runs Aurel Textile. Karim Benali has worked at Aurel Textile since 2021.",
+          "checks": [
+            {
+              "type": "min_relations",
+              "n": 2,
+              "severity": "major",
+              "label": "fewer edges than the passage states"
+            },
+            {
+              "type": "relation_present",
+              "subject": "sofia marchetti",
+              "predicate_any": [
+                "run",
+                "manage"
+              ],
+              "object": "aurel textile",
+              "severity": "major",
+              "label": "direction edge missing"
+            },
+            {
+              "type": "relation_present",
+              "subject": "karim benali",
+              "predicate_any": [
+                "work"
+              ],
+              "object": "aurel textile",
+              "severity": "major",
+              "label": "employment edge missing"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "travaille",
+                "dirige",
+                "fils de",
+                "soeur de",
+                "possede"
+              ],
+              "severity": "major",
+              "label": "French predicate on an English passage"
+            }
+          ]
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "fr-numeric-pair",
+      "family": "nominal-fr",
+      "lang": "fr",
+      "note": "Two ages, two entities. Misattribution is invisible unless both are checked.",
+      "passages": [
+        {
+          "text": "Lise Aubert a 34 ans. Son fils Theo Aubert a 8 ans.",
+          "checks": [
+            {
+              "type": "attribute_number",
+              "entity": "lise aubert",
+              "key_any": [
+                "age"
+              ],
+              "value": 34,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            },
+            {
+              "type": "attribute_number",
+              "entity": "theo aubert",
+              "key_any": [
+                "age"
+              ],
+              "value": 8,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            },
+            {
+              "type": "relation_present",
+              "subject": "theo aubert",
+              "predicate_any": [
+                "fils"
+              ],
+              "object": "lise aubert",
+              "severity": "major",
+              "label": "filiation edge missing or reversed"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "works",
+                "runs",
+                "manages",
+                "son of",
+                "sister of",
+                "owns"
+              ],
+              "severity": "major",
+              "label": "English predicate on a French passage"
+            }
+          ]
+        }
+      ],
+      "split": "train"
+    },
+    {
+      "id": "en-numeric-pair",
+      "family": "nominal-en",
+      "lang": "en",
+      "note": "English mirror of fr-numeric-pair.",
+      "passages": [
+        {
+          "text": "Lise Aubert is 34. Her son Theo Aubert is 8.",
+          "checks": [
+            {
+              "type": "attribute_number",
+              "entity": "lise aubert",
+              "key_any": [
+                "age"
+              ],
+              "value": 34,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            },
+            {
+              "type": "attribute_number",
+              "entity": "theo aubert",
+              "key_any": [
+                "age"
+              ],
+              "value": 8,
+              "severity": "major",
+              "label": "age missing, misattributed, or emitted as a string"
+            },
+            {
+              "type": "relation_present",
+              "subject": "theo aubert",
+              "predicate_any": [
+                "son"
+              ],
+              "object": "lise aubert",
+              "severity": "major",
+              "label": "filiation edge missing or reversed"
+            },
+            {
+              "type": "predicate_forbids",
+              "substrings": [
+                "travaille",
+                "dirige",
+                "fils de",
+                "soeur de",
+                "possede"
+              ],
+              "severity": "major",
+              "label": "French predicate on an English passage"
+            }
+          ]
+        }
+      ],
+      "split": "holdout"
     }
   ]
 }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`test/*` → targets `develop`. ✅

## Description

Five defects found by running the extraction harness rather than reading it. **No crate code is touched** — this is entirely measurement correctness, split out of #1948 so it can land without waiting on a contested product change.

Closes #1945

### 1. Phase B never invoked an extractor

It stored passages with `remember`, which writes a fact verbatim, then polled `entity` for typed relations — which `EntityProfile` documents as excluding the bipartite scaffolding `remember` alone produces. The wait could not do anything but expire, identically for every model and for the no-LLM reader, and the report published `not drained` as though the models had failed.

Passages now go through `remember_extracted` and the run waits for the durable commit. A commit carrying no ids is **not** counted as stored: an extractor answering with nothing usable is a model result, not a success. `burst` keeps the fast path under its own name — its subject is the bounded autograph queue under a writer faster than the model, and awaiting each commit would measure the opposite.

### 2. A result did not record its own settings

Two runs at different context windows could not be told apart, which is what happened between the published campaign and a re-measurement. Settings now come from the **backend** rather than the CLI, so a result cannot claim a setting the requests did not carry.

### 3. `major=0` where nothing parsed

`major` and `minor` are counted over replies that parsed, so a configuration where nothing parsed scores zero of both. `llama3.1:8b` sits in the published report with `major=0` beside `parse=0%` — its best-looking cell produced by its worst possible outcome. The report prints `n/a` there now, and qualifies a partial parse rate with what the count was counted over.

### 4. A fixed client timeout

400 s, unrelated to `num_predict`. On a slow host the cap decides how long a reply takes, so raising it turns an experiment into a timeout. Nothing catches that timeout — it crashes the run rather than being scored as a model failure, which is the right behaviour and means published numbers carry none — but a run that cannot complete answers nothing. It scales with the cap now.

### 5. The suite was too small, and lopsided

It called paired cases its point and had **none in English**, nor any English edge case, while English carried 4 of 19 — thin ground for a criterion the tier table states as eligibility. Now 29 cases: four English close pairs, two English edge cases, and two kinds of coverage nothing had — several entities in one passage, and two numbers on two entities where a misattribution is invisible if only one is checked.

Every new oracle was exercised against a hand-built **correct** payload before committing, and the pair oracles confirmed to fail on a collapsed pair and pass on a distinct one. A check that can never pass would otherwise be blamed on a model.

`--split` accompanies the suite for prompt tuning and only for that: a scoreboard the tuner never sees. Campaigns measuring models should leave it off — withholding cases from a model comparison only makes it less informative.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — measurement tooling only, no crate code

## How Has This Been Tested?

- [x] Unit tests
- `python3 -m unittest scripts.tests.test_ci_gate_reachability` — passes
- `python3 scripts/check-doc-freshness.py`, `python3 scripts/check_prod_unwraps.py` — both pass
- The harness loads and reports 29 cases / 17 train / 12 holdout; the new oracles were scored against correct payloads by hand

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV) — untouched here

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — no product surface changes)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Everything about **constrained decoding** is deliberately held back in #1948, including the bench's own schema change and the drift assertion that binds it to the crate. The line is: this PR is about measuring correctly, #1948 is about a product change whose default is still in question.
