### PR TITLE
refactor(memory): freeze the error surface for semver, enum by enum

### DIFF
--- a/crates/velesdb-memory/src/config.rs
+++ b/crates/velesdb-memory/src/config.rs
@@ -38,6 +38,7 @@ pub const CONFIG_FILE_NAME: &str = "velesdb-memory.toml";
 
 /// Why a config file could not be used.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum ConfigError {
     /// The file could not be read.
     #[error("config file {path} could not be read: {source}")]

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -84,6 +84,7 @@ const MIN_LOG_RUN_LINES: usize = 8;
 /// Which transcript format to assume, or detect automatically.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive] // formats grow; matching externally requires a wildcard arm
 pub enum SegmentFormat {
     /// Detect `jsonl` vs `plain` from the transcript itself (the default).
     Auto,
@@ -100,6 +101,7 @@ pub enum SegmentFormat {
 /// left for [`super::classify`]'s rule table to judge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive] // kinds grow; matching externally requires a wildcard arm
 pub enum SegmentKind {
     /// Ordinary text — [`ContextFragment::kind`] stays `None`, so the
     /// existing classification rules (code fence, URL, negative constraint,

--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 /// Failure produced by an [`Embedder`] backend (e.g. a network-backed embedder
 /// that cannot reach its model). The in-memory [`HashEmbedder`] never fails.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum EmbedError {
     /// The embedding backend (network, subprocess, …) returned an error.
     #[error("embedding backend error: {0}")]
@@ -103,6 +104,11 @@ impl<T: Embedder + ?Sized> Embedder for Box<T> {
 /// `Disabled`. "No extraction" is a real choice — the graph simply does not
 /// build — while a memory store cannot exist without an embedder. Every
 /// accepted name therefore resolves to something usable.
+/// **Deliberately exhaustive** (no `non_exhaustive`): every variant demands
+/// caller wiring — construct a backend, ask for configuration, run nothing —
+/// and a wildcard arm would silently ignore a new capability instead of
+/// failing to compile where it must be handled. Adding a variant is therefore
+/// a breaking change, made on purpose, in a minor bump while the crate is 0.x.
 pub enum EmbedderSelection {
     /// Ready to use as-is: needs no configuration, no network, and no optional
     /// dependency.

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -11,7 +11,14 @@ use crate::rerank::RerankError;
 /// The transport-neutral class of a [`MemoryError`] — the single source of
 /// truth every adapter maps onto its own error channel (JSON-RPC code, napi
 /// status, `PyO3` exception type), so the taxonomy can never drift between them.
+/// `non_exhaustive` so a future category is a wildcard arm downstream instead
+/// of a breaking release. That trades away the compile-time exhaustiveness the
+/// in-repo adapters relied on, so [`ErrorCategory::ALL`] restores it as a
+/// test-time guard: each adapter iterates `ALL` and asserts its mapping is
+/// total, which turns "someone added a category" from a silent fallback into
+/// a red test naming the unmapped variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorCategory {
     /// The caller supplied bad input (empty fact, reserved key, malformed
     /// filter) — a 4xx-style fault.
@@ -22,8 +29,24 @@ pub enum ErrorCategory {
     Internal,
 }
 
+impl ErrorCategory {
+    /// Every category, for adapter coverage tests — see the type-level doc.
+    ///
+    /// Lives here because only the defining crate can enumerate a
+    /// `non_exhaustive` enum; an adapter hand-listing the variants would just
+    /// re-create the drift this exists to catch. Adding a variant without
+    /// extending this slice fails `all_lists_every_category` below.
+    pub const ALL: &'static [Self] = &[Self::InvalidInput, Self::NotFound, Self::Internal];
+}
+
 /// Errors returned by [`crate::service::MemoryService`].
+///
+/// `non_exhaustive`: adapters classify through [`MemoryError::category`], never
+/// by variant, so new variants must be a non-event downstream — which is also
+/// what lets the stringly-typed variants gain structured payloads one minor
+/// release at a time instead of in one breaking batch.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MemoryError {
     /// Failure in the underlying `VelesDB` storage engine.
     #[error("storage error: {0}")]
@@ -314,3 +337,7 @@ impl MemoryError {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/crates/velesdb-memory/src/error_tests.rs
+++ b/crates/velesdb-memory/src/error_tests.rs
@@ -1,0 +1,25 @@
+use super::*;
+
+/// The compile-time guard `ALL` cannot have: only this crate can enumerate a
+/// `non_exhaustive` enum, so only this crate can notice `ALL` going stale.
+/// A `match` over `Self` keeps it honest — adding a category without touching
+/// `ALL` fails to compile HERE (the defining crate still matches
+/// exhaustively), and the assertion documents the contract for readers.
+#[test]
+fn all_lists_every_category() {
+    let mut seen = 0usize;
+    for category in ErrorCategory::ALL {
+        // Exhaustive on purpose; a new variant must be added to `ALL` and to
+        // this match in the same change.
+        match category {
+            ErrorCategory::InvalidInput | ErrorCategory::NotFound | ErrorCategory::Internal => {
+                seen += 1;
+            }
+        }
+    }
+    assert_eq!(
+        seen,
+        ErrorCategory::ALL.len(),
+        "ALL carries a duplicate or an unmatched entry"
+    );
+}

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -665,6 +665,7 @@ pub(crate) fn orient_kinship(passage: &str, relations: &mut [ExtractedRelation])
 /// Failure produced by an [`Extractor`] backend (e.g. a network-backed model
 /// that cannot be reached, or output that cannot be parsed into facts).
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum ExtractError {
     /// The extraction backend (network, subprocess, …) returned an error.
     #[error("extraction backend error: {0}")]
@@ -875,6 +876,11 @@ impl Extractor for OutlineExtractor {
 /// lets the dependency-free backends be selected in **any** build: only the
 /// [`Self::NeedsRemoteConfig`] arm requires an optional dependency and the URL
 /// and model that go with it, and only that arm's construction is feature-gated.
+/// **Deliberately exhaustive** (no `non_exhaustive`): every variant demands
+/// caller wiring — construct a backend, ask for configuration, run nothing —
+/// and a wildcard arm would silently ignore a new capability instead of
+/// failing to compile where it must be handled. Adding a variant is therefore
+/// a breaking change, made on purpose, in a minor bump while the crate is 0.x.
 pub enum ExtractorSelection {
     /// No extraction. Tools that need an extractor answer "not configured".
     Disabled,

--- a/crates/velesdb-memory/src/http/session_limit.rs
+++ b/crates/velesdb-memory/src/http/session_limit.rs
@@ -92,6 +92,7 @@ impl<SM> BoundedSessionManager<SM> {
 /// Error type for [`BoundedSessionManager`]: either its own bound was hit,
 /// or the wrapped `SessionManager` failed on its own terms.
 #[derive(Debug, Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum BoundedSessionManagerError<E> {
     /// `max_sessions` concurrent MCP sessions are already live.
     #[error("too many concurrent MCP sessions (max {0}); close an existing one and retry")]

--- a/crates/velesdb-memory/src/http_client.rs
+++ b/crates/velesdb-memory/src/http_client.rs
@@ -29,6 +29,7 @@ use crate::http_retry;
 /// server wants nothing at all, and a future provider will want something
 /// else again. Widening an `Option<String>` later would break every caller;
 /// adding a variant here does not.
+#[non_exhaustive] // authentication schemes grow; matching externally requires a wildcard arm
 pub enum Auth {
     /// Send no credential header at all.
     ///

--- a/crates/velesdb-memory/src/model.rs
+++ b/crates/velesdb-memory/src/model.rs
@@ -118,6 +118,7 @@ pub struct Recollection {
 /// [`MemoryService::recall_where`](crate::service::MemoryService::recall_where).
 #[derive(Debug, Clone, Copy, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive] // mirrors VelesQL operators, which grow; adapters only construct it; matching externally requires a wildcard arm
 pub enum ColumnOp {
     /// `=`
     Eq,

--- a/crates/velesdb-memory/src/reachability.rs
+++ b/crates/velesdb-memory/src/reachability.rs
@@ -44,6 +44,7 @@ use std::time::Duration;
 
 /// What a probe found. Every variant is one distinct next action.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive] // diagnosis outcomes grow as failure modes are learned; matching externally requires a wildcard arm
 pub enum Reachability {
     /// The server answered and lists the configured model.
     Reachable,

--- a/crates/velesdb-memory/src/rerank.rs
+++ b/crates/velesdb-memory/src/rerank.rs
@@ -19,6 +19,7 @@ use crate::model::Recollection;
 /// that cannot be reached, or output that cannot be mapped back to
 /// candidates).
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum RerankError {
     /// The reranking backend (network, subprocess, …) returned an error.
     #[error("rerank backend error: {0}")]

--- a/crates/velesdb-memory/src/tls.rs
+++ b/crates/velesdb-memory/src/tls.rs
@@ -91,6 +91,7 @@ const NOT_BEFORE_SLACK_HOURS: i64 = 1;
 /// distinct from [`crate::error::MemoryError`] — these are infra/filesystem
 /// concerns, not store/domain ones.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive] // error enum, grows by nature; matching externally requires a wildcard arm
 pub enum TlsError {
     #[error("failed to create TLS material directory {path}: {source}")]
     CreateDir { path: PathBuf, source: io::Error },

--- a/crates/velesdb-node/src/error.rs
+++ b/crates/velesdb-node/src/error.rs
@@ -20,12 +20,24 @@ pub const CODE_INTERNAL: &str = "INTERNAL";
 /// server's and the `PyO3` binding's.
 pub fn to_napi_err(e: MemoryError) -> Error {
     let msg = e.to_string();
-    let (status, code) = match e.category() {
+    let (status, code) =
+        known_category_mapping(e.category()).unwrap_or((Status::GenericFailure, CODE_INTERNAL));
+    Error::new(status, format!("[{code}] {msg}"))
+}
+
+/// The explicit half of the mapping, split from the fallback so
+/// `every_category_is_mapped_explicitly` can tell them apart: `ErrorCategory`
+/// is `non_exhaustive`, so the compiler no longer forces this match to cover a
+/// new category — the test walking [`ErrorCategory::ALL`] does instead. The
+/// runtime fallback (`INTERNAL`, the coarsest 5xx-style bucket) only ever
+/// serves a binding built against a newer `velesdb-memory` than this file.
+fn known_category_mapping(category: ErrorCategory) -> Option<(Status, &'static str)> {
+    Some(match category {
         ErrorCategory::InvalidInput => (Status::InvalidArg, CODE_INVALID_INPUT),
         ErrorCategory::NotFound => (Status::InvalidArg, CODE_NOT_FOUND),
         ErrorCategory::Internal => (Status::GenericFailure, CODE_INTERNAL),
-    };
-    Error::new(status, format!("[{code}] {msg}"))
+        _ => return None,
+    })
 }
 
 /// Build an `INVALID_INPUT` napi error for adapter-side validation failures
@@ -36,3 +48,7 @@ pub fn invalid_input(msg: impl AsRef<str>) -> Error {
         format!("[{CODE_INVALID_INPUT}] {}", msg.as_ref()),
     )
 }
+
+#[cfg(test)]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/crates/velesdb-node/src/error_tests.rs
+++ b/crates/velesdb-node/src/error_tests.rs
@@ -1,0 +1,19 @@
+use super::known_category_mapping;
+use velesdb_memory::ErrorCategory;
+
+/// `ErrorCategory` is `non_exhaustive`, so the compiler no longer fails this
+/// adapter when a category is added upstream — this test does, by walking the
+/// authoritative list only the defining crate can produce. A category served
+/// by the runtime fallback is a taxonomy hole, not a mapping.
+#[test]
+fn every_category_is_mapped_explicitly() {
+    for category in ErrorCategory::ALL {
+        assert!(
+            known_category_mapping(*category).is_some(),
+            "category {category:?} would fall through to the INTERNAL fallback; \
+             map it explicitly in known_category_mapping; \
+             the PyO3 adapter (velesdb-python agent_memory_service.rs) has the \
+             same mapping and no test of its own — update it in the same change"
+        );
+    }
+}

--- a/crates/velesdb-python/src/agent_memory_service.rs
+++ b/crates/velesdb-python/src/agent_memory_service.rs
@@ -61,11 +61,27 @@ macro_rules! python_to_serde {
 /// memory id → `KeyError`, the rest → `RuntimeError`.
 fn to_py_err(e: MemoryError) -> PyErr {
     let msg = e.to_string();
-    match e.category() {
+    known_category_err(e.category(), msg.clone()).unwrap_or_else(|| PyRuntimeError::new_err(msg))
+}
+
+/// The explicit half of the mapping, split from the runtime fallback
+/// (`RuntimeError`, the coarsest bucket) so the two are distinguishable.
+///
+/// `ErrorCategory` is `non_exhaustive`, so a new category no longer fails this
+/// match at compile time. Unlike the Node and wasm adapters, no local test
+/// walks [`ErrorCategory::ALL`] here: this crate's Rust tests never run (PyO3
+/// linkage keeps it out of `cargo test --workspace`, see `AGENTS.md`). The
+/// guard is transitive instead — a new category turns the Node and wasm
+/// coverage tests red in the same workspace CI that gates this wheel, and
+/// whoever fixes those two must find this third mapping by the cross-reference
+/// they carry. Keep the three in sync.
+fn known_category_err(category: ErrorCategory, msg: String) -> Option<PyErr> {
+    Some(match category {
         ErrorCategory::InvalidInput => PyValueError::new_err(msg),
         ErrorCategory::NotFound => PyKeyError::new_err(msg),
         ErrorCategory::Internal => PyRuntimeError::new_err(msg),
-    }
+        _ => return None,
+    })
 }
 
 /// Parse a column-filter operator token (`eq`/`ne`/`lt`/`le`/`gt`/`ge`).

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -72,12 +72,23 @@ const CODE_INTERNAL: &str = "INTERNAL";
 use crate::wasm_error::structured_js_error;
 
 fn category_code(e: &MemoryError) -> &'static str {
+    known_category_code(e.category()).unwrap_or(CODE_INTERNAL)
+}
+
+/// The explicit half of the mapping, split from the fallback so the coverage
+/// test over [`velesdb_memory::ErrorCategory::ALL`] can tell them apart:
+/// `ErrorCategory` is `non_exhaustive`, so a new category no longer fails this
+/// match at compile time — the test does instead. The runtime fallback
+/// (`INTERNAL`, the coarsest bucket) only ever serves a binding built against
+/// a newer `velesdb-memory` than this file.
+fn known_category_code(category: velesdb_memory::ErrorCategory) -> Option<&'static str> {
     use velesdb_memory::ErrorCategory;
-    match e.category() {
+    Some(match category {
         ErrorCategory::InvalidInput => CODE_INVALID_INPUT,
         ErrorCategory::NotFound => CODE_NOT_FOUND,
         ErrorCategory::Internal => CODE_INTERNAL,
-    }
+        _ => return None,
+    })
 }
 
 fn to_js_err(e: MemoryError) -> JsValue {

--- a/crates/velesdb-wasm/src/memory_service_tests.rs
+++ b/crates/velesdb-wasm/src/memory_service_tests.rs
@@ -729,3 +729,20 @@ fn test_unrelate_serializes_to_the_documented_wire_shape() {
     .expect("UnrelateOut is serializable");
     assert_eq!(wire, serde_json::json!({ "found": true, "removed": 2 }));
 }
+
+/// `ErrorCategory` is `non_exhaustive`, so a category added upstream no longer
+/// fails this adapter's mapping at compile time — this test does, by walking
+/// the authoritative list only the defining crate can produce. A category
+/// served by the runtime fallback is a taxonomy hole, not a mapping.
+#[test]
+fn every_error_category_is_mapped_explicitly() {
+    for category in velesdb_memory::ErrorCategory::ALL {
+        assert!(
+            super::known_category_code(*category).is_some(),
+            "category {category:?} would fall through to the INTERNAL fallback; \
+             map it explicitly in known_category_code; \
+             the PyO3 adapter (velesdb-python agent_memory_service.rs) has the \
+             same mapping and no test of its own — update it in the same change"
+        );
+    }
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

First outcome of the 2026-08-17 architecture review, and the one that should land **before the next release (#1946)**: every release shipped with the current surface makes the eventual fix more expensive.

Thirty-one public enums, classified one by one rather than blanket-attributed:

**Thirteen gain `#[non_exhaustive]`** — the eight error enums (`MemoryError`, `ErrorCategory`, `ExtractError`, `EmbedError`, `RerankError`, `ConfigError`, `TlsError`, `BoundedSessionManagerError`), which grow by nature and which nothing sound matches exhaustively, plus five data enums with predictable growth (`ColumnOp` mirrors VelesQL operators; `Auth`, `Reachability`, `SegmentFormat`, `SegmentKind`). Adding a variant to any of them stops being a breaking release. Verified **before** the attribute, not after: the adapters only construct `ColumnOp` (string → variant), the integration-test crates compare `ErrorCategory` with `assert_eq!`, and nothing external matches the rest.

**Two stay exhaustive on purpose**, and say so in their docs: `EmbedderSelection` and `ExtractorSelection`. Every variant demands caller wiring — construct a backend, ask for configuration, run nothing — and a wildcard arm would silently ignore a new capability instead of failing to compile where it must be handled.

### The delicate one: `ErrorCategory`

The three bindings map it exhaustively to their error channels (napi status, PyO3 exception type, JS code token). That exhaustiveness **was** the propagation guard: adding a category broke the workspace build until every adapter handled it. `non_exhaustive` deletes that guard, so this PR rebuilds it at test time:

- `ErrorCategory::ALL`, enumerable only by the defining crate, itself kept honest by an in-crate test whose `match` is still exhaustive (the defining crate keeps that power);
- a coverage test in the **node** and **wasm** adapters walking `ALL` and refusing any category served by the runtime fallback;
- each adapter's mapping split into an explicit half and a distinct fallback (coarsest bucket: `INTERNAL` / `RuntimeError`), so "mapped" and "fell through" are distinguishable by the tests and by a reader;
- **python deliberately has no local test** — its Rust tests never run (PyO3 linkage keeps it out of the workspace gate, per `AGENTS.md`), and a test that never runs is false confidence. Instead the node and wasm failure messages name the third mapping to update in the same change.

### What this unlocks

Typing the ten `String`-payload `MemoryError` variants one minor release at a time instead of in one breaking batch — the follow-up flagged in the same review.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — attributes, one const, adapter mapping splits; runtime behaviour is byte-identical for every category that exists today

## How Has This Been Tested?

- [x] Unit tests
- `cargo clippy -p velesdb-memory -p velesdb-node -p velesdb-wasm -p velesdb-python --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt` (four crates) `-- --check` — clean
- `cargo test -p velesdb-node -p velesdb-wasm` — green, including the two new coverage guards
- `cargo test -p velesdb-memory --all-features` — full suite running in parallel with this CI; the change is attributes plus adapter splits, and the lib target's `error_tests` pass
- `check_prod_unwraps`, `check-doc-freshness`, `check-ai-attribution` — pass

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the reasoning lives in the type-level docs, where it is enforced by review)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched (`#[deny(unsafe_code)]` holds).

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Companion issues from the same review: #1958 (the working-context index race the intra-process lock documents but cannot close) and #1959 (faceting the 22-method `MemoryStore` trait — design first, the wasm implementation constrains the shape). The review's remaining items (ureq client consolidation, typed error payloads, `main.rs` split, env centralization, the two CCN-9 functions) each get their own PR.
