### PR TITLE
refactor(memory): one bounded ureq agent instead of five hand-rolled ones

### DIFF
--- a/crates/velesdb-memory/src/embedder.rs
+++ b/crates/velesdb-memory/src/embedder.rs
@@ -420,44 +420,13 @@ fn parse_embedding_response(body: &str) -> Result<Vec<f32>, EmbedError> {
 #[cfg(feature = "embedder-http")]
 const EMBED_TIMEOUT_SECS: u64 = 60;
 
-/// Ceiling on establishing the TCP connection.
-///
-/// The one setting here that genuinely changes behavior. `ureq` already applies
-/// a connect timeout, but its default is 30 s (`agent.rs`) — a sane figure for
-/// the open internet and an absurd one for a daemon on `localhost`, which either
-/// accepts immediately or is not running. Since retries multiply this wait, 30 s
-/// would turn a dead Ollama into a 90 s stall.
-#[cfg(feature = "embedder-http")]
-const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Ceiling on writing the request. Applied to the socket at connect time, so —
-/// unlike the read timeout below — it is in force independently of the global
-/// deadline.
-#[cfg(feature = "embedder-http")]
-const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-
-/// Agent used for every embeddings request, with [`EMBED_TIMEOUT_SECS`]
-/// applied. Same pattern as [`crate::extract::OllamaExtractor`], which has
-/// bounded its own Ollama calls since it was written.
-///
-/// # Precedence, stated plainly
-///
-/// `ureq` documents that `.timeout()` "takes precedence over `.timeout_read()`
-/// and `.timeout_write()`, but not `.timeout_connect()`", and its
-/// `DeadlineStream` rewrites the socket read deadline to the remaining global
-/// budget before every read. So `.timeout_read()` below is **subordinate**: it
-/// is declared for the day the global bound is lifted, and must not be read as
-/// a per-read ceiling today. `.timeout_connect()` and `.timeout_write()` are the
-/// two that bite. Saying otherwise in a doc — or writing a test that claimed to
-/// prove a per-read bound — would be a reassurance with nothing behind it.
+/// Agent for every embeddings request: the shared local-daemon transport
+/// budget with [`EMBED_TIMEOUT_SECS`] as the whole-request deadline. The
+/// timeout-precedence contract lives on
+/// [`crate::http_client::bounded_agent`], its single authoritative copy.
 #[cfg(feature = "embedder-http")]
 fn embed_agent(timeout: std::time::Duration) -> ureq::Agent {
-    ureq::AgentBuilder::new()
-        .timeout_connect(CONNECT_TIMEOUT)
-        .timeout_write(WRITE_TIMEOUT)
-        .timeout_read(timeout)
-        .timeout(timeout)
-        .build()
+    crate::http_client::bounded_agent(crate::http_client::AgentBudget::local_daemon(timeout))
 }
 
 /// How one embeddings attempt failed, kept apart just long enough to classify

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -960,17 +960,6 @@ pub const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
 #[cfg(feature = "extractor-http")]
 const REQUEST_TIMEOUT_SECS: u64 = 300;
 
-/// Ceiling on establishing the TCP connection to Ollama. Short on purpose: a
-/// local daemon accepts at once or is not running, and `ureq`'s 30 s default
-/// would be paid once per replay.
-#[cfg(feature = "extractor-http")]
-const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Ceiling on writing the request (prompt upload). Unlike the read bound, this
-/// one is applied to the socket at connect time and is genuinely in force.
-#[cfg(feature = "extractor-http")]
-const WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
-
 /// Ceiling on how many tokens one extraction call may generate.
 ///
 /// Unbounded, the real graph-extraction prompt measured 3 933 completion
@@ -1065,13 +1054,10 @@ impl OllamaExtractor {
     /// with replays, that idle wait would be paid three times over.
     #[must_use]
     pub fn new(base_url: impl Into<String>, model: impl Into<String>) -> Self {
-        let timeout = std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS);
-        let agent = ureq::AgentBuilder::new()
-            .timeout_connect(CONNECT_TIMEOUT)
-            .timeout_write(WRITE_TIMEOUT)
-            .timeout_read(timeout)
-            .timeout(timeout)
-            .build();
+        let agent =
+            crate::http_client::bounded_agent(crate::http_client::AgentBudget::local_daemon(
+                std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            ));
         Self {
             base_url: base_url.into(),
             model: model.into(),
@@ -1137,13 +1123,10 @@ impl OpenAiExtractor {
         model: impl Into<String>,
         auth: crate::http_client::Auth,
     ) -> Self {
-        let timeout = std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS);
-        let agent = ureq::AgentBuilder::new()
-            .timeout_connect(CONNECT_TIMEOUT)
-            .timeout_write(WRITE_TIMEOUT)
-            .timeout_read(timeout)
-            .timeout(timeout)
-            .build();
+        let agent =
+            crate::http_client::bounded_agent(crate::http_client::AgentBudget::local_daemon(
+                std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            ));
         Self {
             client: crate::http_client::HttpJsonClient::new(
                 crate::openai::base_url(&base_url.into()),

--- a/crates/velesdb-memory/src/http_client.rs
+++ b/crates/velesdb-memory/src/http_client.rs
@@ -188,6 +188,80 @@ fn call_is_retryable(err: &Call) -> bool {
     }
 }
 
+/// The three timeout ceilings a remote-inference agent is built from.
+///
+/// A budget, not an agent: the *values* are role knowledge (an embedding that
+/// has not answered in a minute is not going to; a generation legitimately
+/// takes hundreds of seconds), so they stay declared next to the role. What
+/// lives here is the *shape* — which knobs exist and what they actually do —
+/// because it was declared four times over three files, each copy one edit
+/// away from drifting from the others.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentBudget {
+    /// Ceiling on establishing the TCP connection. The one knob that
+    /// genuinely changes behavior over `ureq`'s defaults: its own connect
+    /// default is 30 s (`agent.rs`) — sane for the open internet, absurd for
+    /// a daemon on `localhost`, which either accepts immediately or is not
+    /// running. With replays, that idle wait would be paid three times over.
+    pub connect: std::time::Duration,
+    /// Ceiling on writing the request. Applied to the socket at connect time,
+    /// so — unlike the read deadline — it is in force independently of the
+    /// overall budget.
+    pub write: std::time::Duration,
+    /// Whole-request deadline, connect included.
+    pub overall: std::time::Duration,
+}
+
+impl AgentBudget {
+    /// Budget for a model daemon expected on `localhost`: 2 s to connect,
+    /// 10 s to write, `overall` to answer. The connect and write figures are
+    /// shared by the embedding and extraction roles on purpose — they bound
+    /// the *transport* to a local daemon, which is the same transport for
+    /// both; only `overall` is role knowledge.
+    #[must_use]
+    pub const fn local_daemon(overall: std::time::Duration) -> Self {
+        Self {
+            connect: std::time::Duration::from_secs(2),
+            write: std::time::Duration::from_secs(10),
+            overall,
+        }
+    }
+
+    /// One figure for every ceiling — for probes whose caller states a single
+    /// whole budget and means it.
+    #[must_use]
+    pub const fn uniform(budget: std::time::Duration) -> Self {
+        Self {
+            connect: budget,
+            write: budget,
+            overall: budget,
+        }
+    }
+}
+
+/// Build the agent a budget describes.
+///
+/// # Precedence, stated plainly (the authoritative copy)
+///
+/// `ureq` documents that `.timeout()` "takes precedence over `.timeout_read()`
+/// and `.timeout_write()`, but not `.timeout_connect()`", and its
+/// `DeadlineStream` rewrites the socket read deadline to the remaining global
+/// budget before every read. So the `.timeout_read()` set here is
+/// **subordinate**: declared for the day the global bound is lifted, and not
+/// to be read as a per-read ceiling today. `.timeout_connect()` and
+/// `.timeout_write()` are the two that bite alongside the global deadline.
+/// Saying otherwise in a doc — or writing a test that claimed to prove a
+/// per-read bound — would be a reassurance with nothing behind it.
+#[must_use]
+pub fn bounded_agent(budget: AgentBudget) -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(budget.connect)
+        .timeout_write(budget.write)
+        .timeout_read(budget.overall)
+        .timeout(budget.overall)
+        .build()
+}
+
 #[cfg(test)]
 #[path = "http_client_tests.rs"]
 mod tests;

--- a/crates/velesdb-memory/src/reachability.rs
+++ b/crates/velesdb-memory/src/reachability.rs
@@ -87,11 +87,13 @@ pub fn probe_openai(
     timeout: Duration,
 ) -> Reachability {
     let url = format!("{}{MODELS_PATH}", crate::openai::base_url(base_url));
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(timeout)
-        .timeout_read(timeout)
-        .timeout_write(timeout)
-        .build();
+    // `uniform` also sets the OVERALL deadline, which this construction never
+    // did: the doc above has always promised "the whole budget", but without
+    // `.timeout()` the worst case was one budget each for connect, write and
+    // read — three times the promise. Aligning the code with its own contract
+    // is the one behavioral change of the agent consolidation.
+    let agent =
+        crate::http_client::bounded_agent(crate::http_client::AgentBudget::uniform(timeout));
     let mut request = agent.get(&url);
     if let Some(secret) = token {
         request = request.set("Authorization", &format!("Bearer {secret}"));


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Second outcome of the 2026-08-17 architecture review (P1.3). Five call sites across four files built their own `ureq::Agent` — the embedder, both extractor constructors (Ollama and OpenAI-compatible), and the reachability probe — each re-stating the same three pieces of knowledge:

1. `ureq`'s 30 s connect default is absurd for a `localhost` daemon (which either accepts immediately or is not running, and replays multiply the wait);
2. the global deadline subordinates `.timeout_read()`, so declaring it is future-proofing, not a per-read guarantee;
3. the builder incantation itself.

The timeout-precedence explanation existed in two near-identical copies, one pointing at the other.

`http_client` — which already owns the role-blind transport layer and says so in its module doc — gains `AgentBudget` and `bounded_agent()`. **The budgets stay declared next to the roles** (an embedding that has not answered in a minute is not going to; a generation legitimately takes hundreds of seconds): the values are role knowledge, only the shape moves. The shared 2 s connect / 10 s write figures become `AgentBudget::local_daemon`, where their rationale now lives once. The precedence contract lives on `bounded_agent`, marked as the authoritative copy.

### One behavioral change, deliberate and stated

Confined to the reachability probe: its doc has always promised the caller's timeout *"is the whole budget"*, but the construction never set the overall deadline — the worst case was one budget each for connect, write and read, **three times the promise**. Routing it through `AgentBudget::uniform` aligns the code with its own contract. The in-code comment at the call site records this as the consolidation's only behavioral delta.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — except the reachability deadline fix above, called out explicitly

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- `cargo clippy -p velesdb-memory --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean, and again with default features
- `cargo fmt -p velesdb-memory -- --check` — clean
- `cargo test -p velesdb-memory --all-features --lib` — **793 passed, 0 failed**
- `--test http_transport --test http_tls` — green (the transport-adjacent integration targets)
- `check_prod_unwraps` — pass

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the moved doc-comments are the documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (consolidation covered by the existing embedder/extractor/reachability suites; the reachability deadline has no wall-clock test on purpose — the repo's own campaign showed shared-runner timing tests are noise)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Independent of #1960 (error-surface freeze) — the two PRs touch disjoint lines and can merge in either order. Remaining review items each get their own PR: typed error payloads, `main.rs` split, env centralization, the two CCN-9 functions.
