### PR TITLE
refactor(memory): bring the two over-threshold functions under the CCN gate

### DIFF
--- a/crates/velesdb-memory/src/context/media.rs
+++ b/crates/velesdb-memory/src/context/media.rs
@@ -108,16 +108,11 @@ fn decode_quad(quad: &[u8], out: &mut Vec<u8>) -> Result<usize, DecodeError> {
         | (u32::from(sextets[1]) << 12)
         | (u32::from(sextets[2]) << 6)
         | u32::from(sextets[3]);
-    #[allow(clippy::cast_possible_truncation)]
-    out.push((word >> 16) as u8);
-    if pad < 2 {
-        #[allow(clippy::cast_possible_truncation)]
-        out.push((word >> 8) as u8);
-    }
-    if pad < 1 {
-        #[allow(clippy::cast_possible_truncation)]
-        out.push(word as u8);
-    }
+    // The 24 decoded bits sit in the low three bytes of the big-endian word;
+    // padding shortens the tail. Slicing `to_be_bytes` says exactly that, and
+    // says it without the three truncating casts (each carrying its own
+    // clippy allow) that the shift-and-push spelling needed.
+    out.extend_from_slice(&word.to_be_bytes()[1..4 - pad]);
     Ok(pad)
 }
 

--- a/crates/velesdb-memory/src/main.rs
+++ b/crates/velesdb-memory/src/main.rs
@@ -416,8 +416,6 @@ fn open_store_with_actionable_lock_error(
     store_path: &str,
     configured: ConfiguredEmbedder,
 ) -> Result<MemoryService<DynEmbedder>, Box<dyn std::error::Error>> {
-    use velesdb_memory::MemoryError;
-
     let ConfiguredEmbedder { embedder, model } = configured;
     let dimension = embedder.dimension();
     // Read BEFORE the store is opened, so a mismatch is refused instead of
@@ -429,33 +427,50 @@ fn open_store_with_actionable_lock_error(
     velesdb_memory::embedding_provenance::check(recorded.as_ref(), &model, dimension)?;
     let unrecorded = recorded.is_none();
 
+    match open_through_lock_retries(store_path, dimension) {
+        Ok(store) => {
+            if unrecorded {
+                record_embedding_model(store_dir, &store, &model, dimension);
+            }
+            Ok(MemoryService::with_store(store, embedder))
+        }
+        // A dimension mismatch surfaces here, from the core. When the store
+        // carries no model record, that dimension was the ONLY thing that
+        // could be compared, and saying so is what stops a caller reading
+        // the core's message as a full compatibility verdict.
+        Err(other) if unrecorded => Err(format!(
+            "{other}\n{}",
+            velesdb_memory::embedding_provenance::unrecorded_model_note(&model)
+        )
+        .into()),
+        Err(other) => Err(other.into()),
+    }
+}
+
+/// The lock-retry loop alone: open the store, sitting out up to
+/// [`LOCK_RETRY_ATTEMPTS`] × [`LOCK_RETRY_DELAY`] of `DatabaseLocked`.
+///
+/// A lock that outlives every retry prints the actionable message and exits
+/// the process rather than returning — that message, not a generic `Result`
+/// bubble-up, is the point: a bare `Storage(DatabaseLocked(..))` debug dump
+/// gives a user nothing to act on (#1448). Every other error returns to the
+/// caller, which owns the provenance context this loop knows nothing about.
+fn open_through_lock_retries(
+    store_path: &str,
+    dimension: usize,
+) -> Result<NativeStore, velesdb_memory::MemoryError> {
+    use velesdb_memory::MemoryError;
+
     let mut last_locked_path: Option<String> = None;
     for attempt in 0..LOCK_RETRY_ATTEMPTS {
         match NativeStore::open(store_path, dimension) {
-            Ok(store) => {
-                if unrecorded {
-                    record_embedding_model(store_dir, &store, &model, dimension);
-                }
-                return Ok(MemoryService::with_store(store, embedder));
-            }
             Err(MemoryError::Storage(velesdb_core::Error::DatabaseLocked(locked_path))) => {
                 last_locked_path = Some(locked_path);
                 if attempt + 1 < LOCK_RETRY_ATTEMPTS {
                     std::thread::sleep(LOCK_RETRY_DELAY);
                 }
             }
-            // A dimension mismatch surfaces here, from the core. When the store
-            // carries no model record, that dimension was the ONLY thing that
-            // could be compared, and saying so is what stops a caller reading
-            // the core's message as a full compatibility verdict.
-            Err(other) if unrecorded => {
-                return Err(format!(
-                    "{other}\n{}",
-                    velesdb_memory::embedding_provenance::unrecorded_model_note(&model)
-                )
-                .into())
-            }
-            Err(other) => return Err(other.into()),
+            outcome => return outcome,
         }
     }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Third outcome of the 2026-08-17 architecture review (P2.8). The workspace's own complexity bar is `lizard -C 8`; exactly two production functions in `velesdb-memory` sat above it, both at CCN 9. Neither reduction is complexity golf — each removes something worth removing on its own.

**`decode_quad`** (`context/media.rs`) spelled its output as three shift-and-truncate pushes, each carrying its own `#[allow(clippy::cast_possible_truncation)]`, with two pad conditionals deciding how many ran. The 24 decoded bits sit in the low three bytes of the big-endian word and padding shortens the tail — slicing `to_be_bytes()` says exactly that, in one line, with no casts to excuse. **CCN 9 → 7, three allows gone.**

**`open_store_with_actionable_lock_error`** (`main.rs`) interleaved two concerns: the lock-retry loop (whose terminal case prints the actionable message #1448 exists for, then exits) and the embedding-provenance context that decides how every *other* error is worded. Split along that line: `open_through_lock_retries` keeps the exit and its rationale, the caller keeps the provenance wording it alone understands, and `outcome => return outcome` hands everything else back untouched. **CCN 9 → 6 and 5.**

Measured after: no production function in the crate above CCN 7.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — behavior byte-identical on every path

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-memory --all-features --lib media` — **56 passed** (the base64 decoder's full suite, padding and malformed-input vectors included)
- `cargo clippy -p velesdb-memory --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt -p velesdb-memory -- --check` — clean
- `lizard -C 8` on both files — no function above the gate

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the split function's doc moved with its rationale)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (pure refactor under existing coverage — the media suite exercises every pad path of the rewritten slice)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Independent of #1960 and #1961 — disjoint files, any merge order. Review items remaining after this: typed error payloads (P1.4), `main.rs` module split (P1.5), env centralization (P1.6), and the `MemoryStore` faceting design (#1959).
