### PR TITLE
refactor(memory): give WorkingContextCodec its source chain, and write down why the others keep prose

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -796,8 +796,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         if working.is_empty() {
             return Err(MemoryError::EmptyWorkingContext);
         }
-        let content = serde_json::to_string(working)
-            .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))?;
+        let content =
+            serde_json::to_string(working).map_err(|err| MemoryError::WorkingContextCodec {
+                detail: "encoding the working context for storage".to_owned(),
+                source: Some(Box::new(err)),
+            })?;
         if content.len() > crate::limits::MAX_FACT_BYTES {
             return Err(MemoryError::ContextOverLimit(format!(
                 "working context of {} bytes exceeds the cap of {} bytes",
@@ -871,14 +874,23 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             return Ok(None);
         }
         let Some((content, _)) = self.store.get(slot)? else {
-            return Err(MemoryError::WorkingContextCodec(format!(
-                "working context for project '{project}', session '{session}' is corrupt: \
-                 the reserved marker is present but the stored body is gone"
-            )));
+            return Err(MemoryError::WorkingContextCodec {
+                detail: format!(
+                    "working context for project '{project}', session '{session}' is corrupt: \
+                     the reserved marker is present but the stored body is gone"
+                ),
+                source: None,
+            });
         };
         serde_json::from_str(&content)
             .map(Some)
-            .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))
+            .map_err(|err| MemoryError::WorkingContextCodec {
+                detail: format!(
+                    "decoding the stored working context for project '{project}', \
+                     session '{session}'"
+                ),
+                source: Some(Box::new(err)),
+            })
     }
 
     /// The full resumption envelope for `project` + `session`: what
@@ -991,11 +1003,14 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             // The trait promises one result per id. A backend that breaks
             // that promise must not be silently read as "these sessions are
             // dead" — that would delete real entries on the write path.
-            return Err(MemoryError::WorkingContextCodec(format!(
-                "storage returned {} metadata rows for {} working-context ids",
-                payloads.len(),
-                ids.len()
-            )));
+            return Err(MemoryError::WorkingContextCodec {
+                detail: format!(
+                    "storage returned {} metadata rows for {} working-context ids",
+                    payloads.len(),
+                    ids.len()
+                ),
+                source: None,
+            });
         }
         Ok(sessions
             .into_iter()
@@ -1070,13 +1085,19 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
             return Ok(None);
         }
         match self.store.get(slot)? {
-            Some((content, _)) => serde_json::from_str(&content)
-                .map(Some)
-                .map_err(|err| MemoryError::WorkingContextCodec(err.to_string())),
-            None => Err(MemoryError::WorkingContextCodec(format!(
-                "working-context index for project '{project}' is corrupt: the index \
-                 marker is present but the stored body is gone"
-            ))),
+            Some((content, _)) => serde_json::from_str(&content).map(Some).map_err(|err| {
+                MemoryError::WorkingContextCodec {
+                    detail: format!("decoding the working-context index for project '{project}'"),
+                    source: Some(Box::new(err)),
+                }
+            }),
+            None => Err(MemoryError::WorkingContextCodec {
+                detail: format!(
+                    "working-context index for project '{project}' is corrupt: the index \
+                     marker is present but the stored body is gone"
+                ),
+                source: None,
+            }),
         }
     }
 
@@ -1112,7 +1133,7 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // only writer of the index is this function. Rebuild instead.
         let mut index = match self.working_index(project) {
             Ok(index) => index.unwrap_or_default(),
-            Err(MemoryError::WorkingContextCodec(_)) => WorkingContextIndex::default(),
+            Err(MemoryError::WorkingContextCodec { .. }) => WorkingContextIndex::default(),
             Err(err) => return Err(err),
         };
         let now = now_unix_secs();
@@ -1128,8 +1149,11 @@ impl<E: Embedder, S: MemoryStore> MemoryService<E, S> {
         // stored moments ago, before this call); this only sheds the ones a
         // `forget` orphaned.
         index.sessions = self.live_sessions(project, index.sessions)?;
-        let content = serde_json::to_string(&index)
-            .map_err(|err| MemoryError::WorkingContextCodec(err.to_string()))?;
+        let content =
+            serde_json::to_string(&index).map_err(|err| MemoryError::WorkingContextCodec {
+                detail: format!("encoding the working-context index for project '{project}'"),
+                source: Some(Box::new(err)),
+            })?;
         self.write_working_index(project, &content, &embedding)
     }
 

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -43,8 +43,22 @@ impl ErrorCategory {
 ///
 /// `non_exhaustive`: adapters classify through [`MemoryError::category`], never
 /// by variant, so new variants must be a non-event downstream — which is also
-/// what lets the stringly-typed variants gain structured payloads one minor
-/// release at a time instead of in one breaking batch.
+/// what lets a variant's payload gain structure one minor release at a time
+/// instead of in one breaking batch.
+///
+/// # `String` payloads are a decision here, not a debt
+///
+/// Every adapter consumes this type through [`MemoryError::category`] plus
+/// `Display`; no payload is read programmatically outside this crate. So a
+/// variant earns a structured payload only when structure is being **lost** —
+/// a source error flattened out of the `source()` chain, or an in-crate
+/// consumer parsing prose — and [`Self::WorkingContextCodec`] is the one that
+/// qualified (it had both). The others carry prose on purpose: their messages
+/// are heterogeneous narratives written for the person reading them
+/// ([`Self::IngestPath`] additionally cites the *requested* path and never the
+/// canonical one, a security decision its module documents), and forcing one
+/// struct template over them would flatten exactly the nuance they exist to
+/// deliver. Re-litigating this per variant is what this paragraph is for.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum MemoryError {
@@ -231,9 +245,24 @@ pub enum MemoryError {
 
     /// A persisted working context could not be (de)serialized — the stored
     /// payload predates or postdates this crate's schema.
+    ///
+    /// The one String-payload variant that gained structure, because it is
+    /// the one that had lost some: half its construction sites flattened a
+    /// `serde_json::Error` into prose, destroying the `source()` chain
+    /// `thiserror` exists to preserve — and it is also the only variant
+    /// matched programmatically (the index reader falls back to an empty
+    /// index on it rather than failing a load). `source` is `None` where the
+    /// corruption is structural (a marker with no body) rather than a codec
+    /// refusal.
     #[cfg(feature = "context")]
-    #[error("working context codec error: {0}")]
-    WorkingContextCodec(String),
+    #[error("working context codec error: {detail}")]
+    WorkingContextCodec {
+        /// What was being encoded or decoded, and for which slot.
+        detail: String,
+        /// The codec's own refusal, when there is one to preserve.
+        #[source]
+        source: Option<Box<serde_json::Error>>,
+    },
 
     /// A context fragment carried a `path` (V2b-1 path ingestion) but no
     /// filesystem root is configured (`VELESDB_MEMORY_INGEST_ROOTS` unset or
@@ -324,7 +353,7 @@ impl MemoryError {
             #[cfg(feature = "context")]
             Self::UnknownHandle(_) => ErrorCategory::NotFound,
             #[cfg(feature = "context")]
-            Self::WorkingContextCodec(_) => ErrorCategory::Internal,
+            Self::WorkingContextCodec { .. } => ErrorCategory::Internal,
             Self::UnknownMemory(_) => ErrorCategory::NotFound,
             #[cfg(feature = "persistence")]
             Self::Memory(_) | Self::MigrationCapture(_) => ErrorCategory::Internal,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Fourth outcome of the 2026-08-17 architecture review (P1.4), and the one where **reading every construction site overturned most of the finding**. The review flagged ten `String`-payload `MemoryError` variants as stringly-typed debt. The honest resolution is one conversion plus a recorded decision — not ten conversions.

### The criterion

Every adapter consumes `MemoryError` through `category()` plus `Display`; no payload is read programmatically outside the crate. So a variant earns a structured payload only when structure is being **lost**. Exactly one qualified.

### The conversion

`WorkingContextCodec` had both disqualifiers at once: five of its eight sites flattened a `serde_json::Error` into prose — destroying the `source()` chain `thiserror` exists to preserve — and it is the only variant **matched programmatically** (the index reader falls back to an empty index on it rather than failing every future save of the project, a documented recovery path).

It becomes:

```rust
WorkingContextCodec {
    detail: String,                          // what was in flight, for which slot
    source: Option<Box<serde_json::Error>>,  // the codec's own refusal, when there is one
}
```

`detail` now says *what was being encoded or decoded* — which the old payload, being the bare serde message, never did. `source` is `None` where the corruption is structural (a marker with no body). `Box`, because `serde_json::Error` is three words wide and the payload would otherwise grow every `MemoryError`. This is exactly the evolution #1960's `non_exhaustive` groundwork was for — done in a minor, breaking no one.

### The recorded decision

The other nine keep prose **on purpose**, and the type-level doc now carries the paragraph saying so and why: their messages are heterogeneous narratives written for the person reading them — `IngestPath` additionally cites the *requested* path and never the canonical one, a security decision its module documents — and one struct template would flatten exactly the nuance the messages exist to deliver. The paragraph exists so the next review doesn't re-litigate this per variant.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — every rendered message is preserved or strictly enriched (the codec sites now name the operation and slot where they previously showed only the bare serde text)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- `cargo clippy -p velesdb-memory --all-targets --all-features -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt -p velesdb-memory -- --check` — clean
- `cargo test -p velesdb-memory --all-features --lib context` — **282 passed**
- `--test context_memory_bdd` — **50 passed** (the working-context round-trips, corruption-recovery paths included)
- `check_prod_unwraps` — pass

**Test Configuration:**
- OS: Linux (container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the decision paragraph *is* the documentation)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (payload reshape under existing coverage — the corruption-recovery match site is exercised by the bdd suite)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (#1960's `non_exhaustive` is what makes this non-breaking)

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

Last review item after this: the `main.rs` module split + library env-read centralization (P1.5/P1.6), which lands as its own PR. The `MemoryStore` faceting stays a design discussion in #1959.
