### PR TITLE
docs(memory): dispatch doctrine, assembler budget, and the no-GPU decision

### DIFF
--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -327,6 +327,17 @@ Other verified clients: Cursor, Cline, Zed, opencode, Devin CLI.
   [surface matrix](../../docs/guides/CONTEXT_COMPILER.md#where-the-compiler-is-available).
 - **No selective source purge.** Compiled sources are kept permanently by
   default; you can set a TTL going forward, or delete the whole store.
+- **The daemon never uses the GPU — by design, not omission.** This crate
+  pins `velesdb-core` with `default-features = false` plus `persistence`
+  only: an agent-memory store is thousands of facts, far below the scale
+  where core's GPU paths (PQ k-means, HNSW traversal) pay for their
+  transfer overhead, and a daemon that quietly initialized a GPU context
+  would be a strange neighbor on a developer machine. The same applies to
+  the Node binding (`@wiscale/velesdb-memory-node`), which wraps this crate
+  and is forbidden a direct `velesdb-core` dependency by its license
+  boundary. If a measured memory workload ever demands it, the path is a
+  `gpu` passthrough feature here first — reopen the discussion with that
+  measurement in hand (#1965).
 
 ## Troubleshooting
 
@@ -365,4 +376,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-memory v0.12.0` · Last updated: 2026-08-15 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-memory v0.12.0` · Last updated: 2026-08-17 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -24,6 +24,29 @@
 //! `traverse(graph)`). Exposing the raw engine would constitute a "Substantial
 //! Set" of the Software's features and breach the `VelesDB` Core License 1.0
 //! (§1, No Hosted or Managed Service). See `VISION.md` §5 and `PLAN.md` Phase 4A.
+//!
+//! ## Generics at the core, `dyn` at the edges (doctrine)
+//!
+//! Two dispatch styles coexist in this crate, and the split is a rule, not an
+//! accident of history:
+//!
+//! - **Compile-time seams are generic parameters.**
+//!   [`service::MemoryService`]`<E: Embedder, S: MemoryStore>` is monomorphized
+//!   over its embedder and its storage backend: each consumer (native daemon,
+//!   WASM binding) compiles exactly the backend it uses, recall paths carry
+//!   no vtable, and a backend that cannot support an operation fails at
+//!   compile time instead of at a customer.
+//! - **Runtime choices are type-erased once, at the edge.** A backend picked
+//!   by configuration — `VELESDB_MEMORY_EMBEDDER`, an `extractor` argument, a
+//!   bring-your-own reranker — crosses into the crate as [`DynEmbedder`],
+//!   [`DynExtractor`] or [`DynReranker`], built once at startup. The erasure
+//!   happens at construction, never inside an operation.
+//!
+//! A new abstraction follows the same test: chosen at compile time → generic
+//! parameter; chosen by configuration → a `Dyn*` alias resolved at startup.
+//! And an adapter over one of these traits forwards the **whole** trait —
+//! partial forwarding is how a binding silently loses a capability the server
+//! already publishes (the #1690–#1692 gap family), and is rejected in review.
 
 /// Wall-clock "today" as a `YYYYMMDD` integer, read only by `remember`'s
 /// auto-date stamping (see [`storage::AUTO_DATE_FIELD`]) — never by the

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -1,4 +1,22 @@
 //! The memory service: five operations over the in-core Agent Memory SDK.
+//!
+//! # Role: the crate's assembler — declared, with a budget
+//!
+//! This module is the ONE place allowed to know every seam at once — store,
+//! embedder, extractor, fusion, autograph, online migration, the working
+//! context bridge — and wire them into the operations the adapters call.
+//! That role is why it is the crate's largest module (measured ~1 076 NLOC on
+//! 2026-08-17, against the ~500-NLOC file budget the child-module splits aim
+//! at), and why its size is a *declared* cost rather than an accident: an
+//! assembler that was split by size alone would scatter the wiring it exists
+//! to make readable.
+//!
+//! The budget still binds. Growth goes into child modules that keep private
+//! access (`fused_recall.rs` and `online_migration.rs` are the pattern —
+//! `#[path]` children of `service`, not siblings), never into this file; the
+//! next named cut is the working-context bridge (#1967, decided together with
+//! the store facetting of #1959). A change that adds an operation body here
+//! instead of a child module needs to say why in review.
 
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "persistence")]


### PR DESCRIPTION
## Description

Three decisions from the 17/08 architecture review (#1967, #1965), written down where the next reader will meet them instead of being re-litigated per PR:

- **`lib.rs` — the dispatch doctrine.** Generics at the core (`MemoryService<E: Embedder, S: MemoryStore>` — compile-time seams are generic parameters), `dyn` at the edges (configuration-time choices cross as `DynEmbedder`/`DynExtractor`/`DynReranker`, type-erased once at startup). Plus the no-partial-forwarding rule: an adapter over these traits forwards the whole trait — partial forwarding is how the #1690–#1692 binding gaps happened.
- **`service.rs` — the assembler role declared with a budget.** It is the one module allowed to know every seam, its measured size (~1 076 NLOC on 2026-08-17) is stated against the ~500-NLOC file budget, growth goes to `#[path]` child modules (the `fused_recall.rs` pattern), and the next named cut is the working-context bridge (#1967, decided together with #1959).
- **README known limits — the daemon never uses the GPU, by design.** The crate pins `velesdb-core` with `default-features = false` + `persistence`; agent-memory scale is below where core's GPU paths pay for transfer overhead. This also resolves the #1965 "node `gpu` passthrough (parity with python)" item as a documented won't-do: `velesdb-node` wraps `velesdb-memory` only and its manifest forbids a direct `velesdb-core` dependency (license boundary + lean prebuild), so the parity framing with `velesdb-python` (a full-DB binding) was miscast. The written path to reopen: a measured memory workload, then a `gpu` passthrough on `velesdb-memory` first.

Refs #1965 #1967

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

`cargo clippy -p velesdb-memory --all-features -- -D warnings -D clippy::pedantic` clean; `cargo fmt --check` clean; `check-doc-freshness.py` and `check_prod_unwraps.py` pass. Doc-comment-only change plus one README section.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes