### PR TITLE
ci(bench): probe OpenAI-protocol response_format through GitHub Models

### DIFF
--- a/.github/workflows/github-models-probe.yml
+++ b/.github/workflows/github-models-probe.yml
@@ -1,0 +1,96 @@
+name: GitHub Models Probe
+
+# The #1944 probe: does OpenAI-protocol `response_format` lift extraction the
+# way Ollama's `format` did (measured, model-dependent, #1948), or does it
+# regress it? Manual-dispatch only, and deliberately OUTSIDE `CI Success`: it
+# spends a shared free-tier quota and answers a design question, it does not
+# gate a merge.
+#
+# Zero configured secrets by construction: the ambient GITHUB_TOKEN carries
+# `models: read` (owner decision of 2026-08-17 — GitHub Models over paid
+# providers for probes). Quality counts only, per the CPU-runner discipline:
+# latencies from a shared, queued endpoint are context, never results.
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "GitHub Models model id (catalog spelling, e.g. openai/gpt-4o-mini)"
+        default: "openai/gpt-4o-mini"
+      response_format:
+        description: "Probe arm for #1944"
+        type: choice
+        options: [off_arm, json_object, json_schema]
+        default: json_schema
+      baseline_too:
+        description: "Also run the unconstrained arm for a paired comparison"
+        type: boolean
+        default: true
+      split:
+        description: "Case split (train keeps quota; empty = every case)"
+        type: choice
+        options: [train, holdout, all]
+        default: train
+      request_delay:
+        description: "Seconds slept before each request (free-tier pacing)"
+        default: "4"
+
+permissions:
+  contents: read
+  models: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # `off_arm` in the dispatch menu is `off` to the bench: GitHub's YAML
+      # parser reads a literal `off` option as a boolean before the workflow
+      # ever sees it.
+      - name: Resolve arm names
+        id: arms
+        run: |
+          arm="${{ inputs.response_format }}"
+          [ "$arm" = "off_arm" ] && arm="off"
+          echo "arm=$arm" >> "$GITHUB_OUTPUT"
+          split="${{ inputs.split }}"
+          if [ "$split" = "all" ]; then echo "split_flag=" >> "$GITHUB_OUTPUT";
+          else echo "split_flag=--split $split" >> "$GITHUB_OUTPUT"; fi
+
+      - name: Screen (selected arm)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # `screen` exits 1 when a case is fatal — that is a MEASUREMENT this
+        # probe exists to record, not a workflow failure. A missing result
+        # file is the failure.
+        run: |
+          python3 scripts/bench-memory-extraction.py screen \
+            --backend github-models \
+            --config "${{ inputs.model }}" \
+            --response-format "${{ steps.arms.outputs.arm }}" \
+            --request-delay "${{ inputs.request_delay }}" \
+            ${{ steps.arms.outputs.split_flag }} \
+            --out "probe-${{ steps.arms.outputs.arm }}.json" || true
+          test -s "probe-${{ steps.arms.outputs.arm }}.json"
+
+      - name: Screen (unconstrained baseline)
+        if: ${{ inputs.baseline_too && steps.arms.outputs.arm != 'off' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/bench-memory-extraction.py screen \
+            --backend github-models \
+            --config "${{ inputs.model }}" \
+            --response-format off \
+            --request-delay "${{ inputs.request_delay }}" \
+            ${{ steps.arms.outputs.split_flag }} \
+            --out "probe-off.json" || true
+          test -s "probe-off.json"
+
+      - name: Upload results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: github-models-probe-${{ github.run_id }}
+          path: probe-*.json
+          if-no-files-found: error

--- a/scripts/bench-memory-extraction.py
+++ b/scripts/bench-memory-extraction.py
@@ -702,6 +702,152 @@ class OpenAiBackend:
         return False
 
 
+GITHUB_MODELS_URL = "https://models.github.ai/inference"
+
+
+def github_models_token() -> str:
+    """The GitHub Models credential: the workflow's own `GITHUB_TOKEN`.
+
+    Environment-only, mirroring the crate's token rule — and on Actions it is
+    the ambient token with `models: read`, so the probe needs zero configured
+    secrets (the reason this hosted backend was chosen over alternatives).
+    """
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        raise SystemExit(
+            "github-models needs GITHUB_TOKEN (or GH_TOKEN) in the environment: "
+            "on Actions grant `permissions: models: read`; locally export a PAT.")
+    return token
+
+
+def strict_object_schema(schema: dict) -> dict:
+    """The strict-mode spelling of the same contract.
+
+    OpenAI-protocol `json_schema` with `strict: true` requires every object
+    level to declare `additionalProperties: false`; the crate's schema states
+    the contract without it (Ollama's grammar needs no such clause). Same
+    keys, same requireds — one mechanical clause added per object, so the
+    probe constrains exactly what the crate would.
+    """
+    import copy
+
+    def close(node: object) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "object":
+                node["additionalProperties"] = False
+            for value in node.values():
+                close(value)
+
+    closed = copy.deepcopy(schema)
+    close(closed)
+    return closed
+
+
+class GitHubModelsBackend:
+    """The OpenAI protocol as GitHub Models serves it, plus `response_format`.
+
+    Two deliberate differences from `OpenAiBackend`, both properties of the
+    hosted service rather than choices of this bench:
+
+      - the chat path is unversioned (`/inference/chat/completions`, no `/v1`
+        segment — which is also why `endtoend` refuses this backend: the
+        daemon's `openai` module speaks the `/v1`-suffixed spelling);
+      - there is no residency to manage — `residency`/`set_loaded` are no-ops
+        so the screen choreography runs unchanged, and `cold`/`warm-up`
+        figures measure network + queueing, never weights loading. On shared
+        CI they are context, not results (#1949 discipline: quality counts
+        only).
+
+    The `response_format` arm is the probe #1944 exists for: `off` sends the
+    body `openai::chat_body` builds today; `json_object` asks for
+    syntactically valid JSON; `json_schema` sends the crate's schema in
+    strict mode. 429s are retried with the server's own `Retry-After` and
+    counted on the record, because a free-tier probe that silently waited
+    would publish latencies it never measured.
+    """
+
+    hosted = True
+
+    def __init__(self, model: str, token: str, cap: int, response_format: str = "off",
+                 request_delay: float = 0.0, base_url: str = GITHUB_MODELS_URL) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.token = token
+        self.cap = cap
+        self.response_format = response_format
+        self.request_delay = request_delay
+        self.rate_limit_hits = 0
+
+    def _response_format(self) -> "dict | None":
+        if self.response_format == "json_object":
+            return {"type": "json_object"}
+        if self.response_format == "json_schema":
+            return {"type": "json_schema",
+                    "json_schema": {"name": "extraction", "strict": True,
+                                    "schema": strict_object_schema(EXTRACTION_SCHEMA)}}
+        return None
+
+    def generate(self, prompt: str) -> dict:
+        body = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "max_tokens": self.cap,
+        }
+        response_format = self._response_format()
+        if response_format is not None:
+            body["response_format"] = response_format
+        if self.request_delay:
+            time.sleep(self.request_delay)
+        started = time.monotonic()
+        response = self._post_with_backoff(body)
+        elapsed = time.monotonic() - started
+        choice = (response.get("choices") or [{}])[0]
+        return {
+            "seconds": elapsed,
+            "content": (choice.get("message") or {}).get("content", ""),
+            "completion_tokens": (response.get("usage") or {}).get("completion_tokens"),
+            "truncated": choice.get("finish_reason") == "length",
+        }
+
+    def _post_with_backoff(self, body: dict) -> dict:
+        for attempt in range(4):
+            try:
+                return http_json(f"{self.base_url}/chat/completions", body, self.token,
+                                 timeout=generation_timeout(self.cap))
+            except urllib.error.HTTPError as exc:
+                if exc.code != 429 or attempt == 3:
+                    raise
+                self.rate_limit_hits += 1
+                retry_after = exc.headers.get("Retry-After") if exc.headers else None
+                try:
+                    pause = min(float(retry_after), 120.0) if retry_after else 15.0
+                except ValueError:
+                    pause = 15.0
+                time.sleep(pause)
+        raise AssertionError("unreachable: the loop returns or raises")
+
+    def settings(self) -> dict:
+        """Same contract as the other backends — see `OllamaBackend.settings`."""
+        return {
+            "backend": "github-models",
+            "constrained": self.response_format != "off",
+            "response_format": self.response_format,
+            "schema_required": (EXTRACTION_SCHEMA["required"]
+                                if self.response_format == "json_schema" else None),
+            "temperature": 0,
+            "max_tokens": self.cap,
+            "request_delay": self.request_delay,
+            "rate_limit_hits": self.rate_limit_hits,
+        }
+
+    def residency(self) -> dict:
+        return {"hosted": "github-models", "models": []}
+
+    def set_loaded(self, model: str, loaded: bool) -> None:
+        """Hosted service: residency is the provider's problem, not the probe's."""
+
+
 # Ollama derives its default context from the HOST's VRAM (4k under 24 GiB,
 # 32k from 24 to 48, 256k beyond), and `OllamaExtractor` sends no `num_ctx`.
 # Left implicit, the same model reserves a KV cache of a different size on the
@@ -1715,6 +1861,11 @@ def build_backend(args: argparse.Namespace, cap: int) -> object:
                              num_ctx=getattr(args, "num_ctx", DEFAULT_NUM_CTX),
                              schema=EXTRACTION_SCHEMA
                              if getattr(args, "constrained", False) else None)
+    if args.backend == "github-models":
+        return GitHubModelsBackend(args.config, github_models_token(), cap,
+                                   response_format=getattr(args, "response_format", "off"),
+                                   request_delay=getattr(args, "request_delay", 0.0),
+                                   base_url=args.url or GITHUB_MODELS_URL)
     return OpenAiBackend(args.url or "http://127.0.0.1:8019", args.config, extractor_token(), cap)
 
 
@@ -1793,6 +1944,16 @@ def endtoend_env(args: argparse.Namespace) -> "dict[str, str]":
         "VELESDB_MEMORY_EXTRACTOR": args.backend,
         "VELESDB_MEMORY_EXTRACTOR_MODEL": args.config or "",
     }
+    if args.backend == "github-models":
+        # The daemon's `openai` module speaks the `/v1`-suffixed spelling of
+        # the protocol; GitHub Models serves an unversioned path, so pointing
+        # the daemon at it would request `/inference/v1/...` and 404. Phase B
+        # against GitHub Models needs #1944's wiring first — refusing here is
+        # itself a finding for that issue, not a harness gap to paper over.
+        raise SystemExit(
+            "endtoend cannot run against github-models: the daemon's OpenAI "
+            "path appends /v1, which this host does not serve. Screen (phase "
+            "A) is the supported probe; see #1944.")
     if args.backend == "openai":
         env["VELESDB_MEMORY_EXTRACTOR_URL"] = args.url or "http://127.0.0.1:8019"
         env["VELESDB_MEMORY_EXTRACTOR_API_TOKEN"] = extractor_token()
@@ -1847,7 +2008,8 @@ def cmd_probe(args: argparse.Namespace) -> int:
 
 def _add_model_arguments(parser: argparse.ArgumentParser, config_required: bool) -> None:
     parser.add_argument("--config", required=config_required, help="model id")
-    parser.add_argument("--backend", choices=["openai", "ollama", "outline"], default="openai")
+    parser.add_argument("--backend", choices=["openai", "ollama", "outline", "github-models"],
+                        default="openai")
     parser.add_argument("--url")
     parser.add_argument("--out")
     # velesdb-memory is used in whatever language its user writes in, and the
@@ -1877,6 +2039,17 @@ def _add_model_arguments(parser: argparse.ArgumentParser, config_required: bool)
                         help="ollama context window, stated rather than inherited "
                              "from the host's VRAM (its default varies 4k/32k/256k "
                              "by card, which makes runs incomparable across machines)")
+    parser.add_argument("--response-format", choices=["off", "json_object", "json_schema"],
+                        default="off", dest="response_format",
+                        help="github-models only: the #1944 probe arm. `off` sends the "
+                             "body `openai::chat_body` builds today; the other two are "
+                             "DECLARED VARIANTS measuring a wiring the crate does not "
+                             "have yet, and their numbers belong in their own column")
+    parser.add_argument("--request-delay", type=float, default=0.0, dest="request_delay",
+                        help="github-models only: seconds slept before each request, so "
+                             "a free-tier per-minute quota shapes pacing instead of "
+                             "killing the run; 429s are additionally retried with the "
+                             "server's Retry-After and counted on the record")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1003,6 +1003,12 @@
       "workflow": ".github/workflows/ci.yml",
       "job": "perf-smoke",
       "reason": "Produces the artefact compare_perf.py then judges (ci.yml:1108, one step before). It has no non-zero exit path at all — measured — so it cannot refuse anything, and declaring it a guard would overstate the registry. The claim is checked: the suite reads its source and fails this entry if a failure path ever appears."
+    },
+    {
+      "script": "scripts/bench-memory-extraction.py",
+      "workflow": ".github/workflows/github-models-probe.yml",
+      "job": "probe",
+      "reason": "A measurement harness, not a gate: manual-dispatch probe for #1944 whose exit 1 means 'a case scored fatal' - a result to record, which is why the workflow runs it with `|| true` and fails only on a missing result file. It refuses nothing on any merge path and sits outside CI Success by design."
     }
   ]
 }


### PR DESCRIPTION
## Description

The #1944 question — does OpenAI-protocol `response_format` lift extraction the way Ollama's `format` grammar did (measured and model-dependent on #1948's branch), or regress it — needs a hosted OpenAI-protocol server that actually implements it. Per the owner decision of 2026-08-17, that server is **GitHub Models**: zero configured secrets, the ambient `GITHUB_TOKEN` with `permissions: models: read`.

- `scripts/bench-memory-extraction.py` gains a `github-models` backend: same body `openai::chat_body` builds; unversioned chat path (the hosted service serves no `/v1` — also why `endtoend` refuses this backend until #1944 wires the daemon, a refusal that is itself a finding for that issue); no residency choreography; 429s retried on the server's own `Retry-After` and counted on the record; `--request-delay` so a free-tier per-minute quota shapes pacing instead of killing the run.
- `--response-format {off,json_object,json_schema}` arms, declared variants per the bench's own doctrine: `off` is the product as built; `json_schema` sends the crate's extraction schema in strict spelling (every object level closed with `additionalProperties: false`, derived mechanically — same keys, same requireds).
- `.github/workflows/github-models-probe.yml`, `workflow_dispatch` only and outside `CI Success`: runs the chosen arm plus an unconstrained baseline for a paired comparison, keeps quality counts only (shared-runner latencies are context, per the CPU-runner discipline), and fails on a *missing result file*, never on a fatal case (`screen` exit 1 is a measurement).
- `scripts/guards.json`: registered `not_a_gate` — the reachability suite requires every workflow-run script to be accounted for.

Results feed #1944 (whether `OpenAiExtractor` should wire `response_format`, and which flavor).

Refs #1944

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

*(bench harness + manual-dispatch workflow; no product code touched)*

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

`ast.parse` and YAML-parse clean; `python3 -m unittest scripts.tests.test_ci_gate_reachability` passes with the new registry entry; token refusal exits with an actionable message when `GITHUB_TOKEN` is absent; backend unit checks verified both arms' `settings()` records, the strict-schema derivation (original schema unmutated), and the `off` arm sending no `response_format`. The live probe run is deliberately manual (`workflow_dispatch`) — it spends a shared free-tier quota.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90 (untouched — Python/YAML only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes