### PR TITLE
ci: check the velesdb-memory feature powerset weekly at depth 2

### DIFF
--- a/.github/workflows/feature-powerset.yml
+++ b/.github/workflows/feature-powerset.yml
@@ -1,0 +1,53 @@
+name: Feature Powerset
+
+# Every feature-gated `cfg` boundary in velesdb-memory is a compilation
+# surface CI never sees: the workspace gate builds the default set and
+# `--all-features`, so a `use` that only breaks when `context` is on WITHOUT
+# `persistence` (a real consumer shape — the wasm binding's) merges green and
+# fails the first library consumer who picks features à la carte.
+#
+# `cargo hack --feature-powerset --depth 2` checks every single feature and
+# every PAIR — the depth where gating bugs actually live (a triple that
+# breaks while all its pairs build requires three interacting gates, which
+# this crate's feature graph does not express). The two compatibility
+# aliases are grouped with their targets: `ollama = [embedder-http]` and
+# `extract = [extractor-http]` add combinations without adding surface.
+#
+# Deliberately OUTSIDE `CI Success` for now (weekly + manual), promotion to
+# a required gate being its own decision once the runtime is known: the
+# powerset re-checks the crate ~30 times and does not belong in every PR's
+# critical path on day one. velesdb-core comes after velesdb-memory proves
+# the harness — its 20+ features need `--depth 2` discipline even more.
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 04:12 UTC — off the busy on-the-hour spike.
+    - cron: '12 4 * * 1'
+  pull_request:
+    paths:
+      - '.github/workflows/feature-powerset.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  memory-powerset:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: feature-powerset
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: cargo-hack
+      - name: Check velesdb-memory feature powerset (depth 2)
+        run: |
+          cargo hack check -p velesdb-memory \
+            --feature-powerset --depth 2 \
+            --group-features ollama,embedder-http \
+            --group-features extract,extractor-http \
+            --no-dev-deps


### PR DESCRIPTION
## Description

Phase D′ item from #1967: every feature-gated `cfg` boundary in `velesdb-memory` is a compilation surface CI never sees — the workspace gate builds the default set and `--all-features`, so a `use` that only breaks when `context` is on **without** `persistence` (a real consumer shape: the wasm binding's) merges green and fails the first à-la-carte library consumer.

- `.github/workflows/feature-powerset.yml`: `cargo hack check -p velesdb-memory --feature-powerset --depth 2 --no-dev-deps` — every single feature and every pair, the depth where gating bugs actually live. The two compatibility aliases are grouped with their targets (`--group-features ollama,embedder-http` / `extract,extractor-http`) so they add combinations without adding surface.
- Deliberately **outside `CI Success`** (weekly cron + `workflow_dispatch` + self-path PR trigger), promotion to a required gate being its own decision once the runtime is known. `velesdb-core` follows after memory proves the harness — its larger feature graph needs the depth-2 discipline even more.
- Validated locally before shipping: the depth-2 powerset (with the alias groupings) is green on today's `develop`, so the job is not born red.

Refs #1967

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

*(a new scheduled CI job; no Rust code touched)*

## How Has This Been Tested?

- [x] Manual testing

Ran the exact command locally with a prebuilt `cargo-hack`: exit 0 across the full depth-2 powerset of `velesdb-memory` on current `develop`. Workflow YAML parse-checked; all action pins match the ones already used in this repository.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes