### PR TITLE
chore: carry the 5.1.0 release-prep commits back onto develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.1.0] — 2026-08-17
 
 ### Added
 
@@ -40,6 +40,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the literal `"hash"` to `None`; passing `embedder="hash"` explicitly is
   unaffected, and `None`/omitted now falls back to `VELESDB_MEMORY_EMBEDDER`
   before defaulting to `hash`.
+
+- **CLI: a failed flush after a REPL `upsert` or payload-store write is now
+  reported instead of swallowed (#1950).** The two fixed call sites were the
+  only remaining swallowed flushes in the CLI. Community contribution.
+
+### Changed (velesdb-memory 0.13.0, released alongside)
+
+- The memory crate ships its 17/08 review wave in this release: the error
+  surface frozen for semver (`#[non_exhaustive]` + per-adapter category
+  guards on the Node, Python and WASM bindings, #1960), all HTTP clients on
+  one bounded `ureq` agent (#1961), a structured `WorkingContextCodec` error
+  (#1963), and the daemon binary split from a 1708-line `main.rs` into four
+  modules (#1964). Details in `crates/velesdb-memory/CHANGELOG.md`.
 
 ## [5.0.0] — 2026-08-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-velesdb"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "dirs",
  "parking_lot",
@@ -6855,7 +6855,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velesdb-cli"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6880,7 +6880,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-core"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "arc-swap",
  "atomicwrites",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "atomicwrites",
  "axum",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-migrate"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6997,7 +6997,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-mobile"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "parking_lot",
  "serde",
@@ -7012,7 +7012,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-python"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "numpy",
  "parking_lot",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-server"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-wasm"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "5.0.0"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.90"
 license-file = "LICENSE"
@@ -80,7 +80,7 @@ base64 = "0.23"
 smallvec = { version = "1", features = ["serde"] }
 
 # Internal workspace crates
-velesdb-core = { path = "crates/velesdb-core", version = "5.0.0", default-features = false }
+velesdb-core = { path = "crates/velesdb-core", version = "5.1.0", default-features = false }
 
 [profile.release]
 lto = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM rust:1.97-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap commits to **what we are building**, **why**, and **when**. It is u
 
 It is intentionally narrow. Items not on this roadmap are tracked as `roadmap` issues but **not committed** until they reach a milestone here.
 
-> **Last updated:** 2026-08-08 — covers v5.0.0 (current) — the workspace manifest version; the latest published 4.x packages are 4.2.0, `velesdb-memory` 0.12.0. The v1.x-era horizon framing is retired: everything those horizons shipped is compressed into the Delivered table, and the next commitments are derived from the repo's own registers ([`CHANGELOG.md`](CHANGELOG.md) [Unreleased], [`docs/CORE_WIRING_DEBT.md`](docs/CORE_WIRING_DEBT.md), [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md)).
+> **Last updated:** 2026-08-17 — covers v5.1.0 (current) — the workspace manifest version; the latest published packages are 5.0.0, `velesdb-memory` 0.12.0. The v1.x-era horizon framing is retired: everything those horizons shipped is compressed into the Delivered table, and the next commitments are derived from the repo's own registers ([`CHANGELOG.md`](CHANGELOG.md) [Unreleased], [`docs/CORE_WIRING_DEBT.md`](docs/CORE_WIRING_DEBT.md), [`docs/reference/KNOWN_LIMITATIONS.md`](docs/reference/KNOWN_LIMITATIONS.md)).
 
 ---
 
@@ -41,22 +41,13 @@ One line per item; the [`CHANGELOG.md`](CHANGELOG.md) is the per-release record.
 | Head-to-head benchmark vs Qdrant + Chroma + pgvector | ⚠️ only the pgvector leg is reproducible (`benchmarks/` Docker Compose); the Qdrant + Chroma legs never landed — back to `roadmap`-issue status, not committed | [`benchmarks/`](benchmarks/) |
 | External `unsafe` audit (SIMD module) | ❌ never funded (~5-15 k€) — remains a `roadmap` issue, not committed | — |
 | `velesdb-migrate` rework decision | ❌ decision never made → **Later below** | [`ARCHITECTURE.md`](ARCHITECTURE.md) crate table |
+| Ship the pending major correctly (P1) | v5.0.0 tagged 2026-08-10 carrying the `load_working_context` envelope break; `@wiscale/velesdb-wasm` floor raised to `^5.0.0` in the TS SDK and the `velesdb` floor to `>=5.0.0` in `langgraph-velesdb` — the runtime skew guards are nets again, no longer the fence | [`CHANGELOG.md`](CHANGELOG.md) `[5.0.0]` |
 
 ---
 
 ## Next (committed)
 
-Three items, in priority order. Each has a register in the repository as its source of truth; done means that register says so.
-
-### P1 — Ship the pending major correctly (5.0.0)
-
-The `velesdb-memory` 0.12.0 result-envelope break (`load_working_context` now returns `{found, working, other_sessions}`) reaches three **published 4.x packages** that relay the value: `velesdb` (PyPI), `@wiscale/velesdb-sdk`, `@wiscale/velesdb-wasm`. Source: the "Read this before cutting the next workspace release" warning in [`CHANGELOG.md`](CHANGELOG.md) `[Unreleased]` — `check-version-sync.py` compares version strings and cannot catch a breaking change.
-
-| Step | Success criterion |
-|---|---|
-| Tag the next workspace release **5.0.0**, not a minor | the break never ships inside a `>=4.2,<5` pin |
-| Raise the `@wiscale/velesdb-wasm` floor in `sdks/typescript/package.json` (today `^4.1.0`) to that release | the SDK's runtime skew guard is a net, no longer the fence |
-| Raise the `velesdb` floor in `integrations/langgraph/pyproject.toml` (today `>=3.12.0`) to the same release | the toolkit stops reporting drift at call time |
+Two items, in priority order. Each has a register in the repository as its source of truth; done means that register says so. (P1 — ship the pending major correctly — was delivered as v5.0.0; see the Delivered table.)
 
 ### P2 — Pay down the core wiring debt
 
@@ -88,7 +79,7 @@ No dates. These graduate to **Next** only through a milestone.
 
 ## velesdb-memory line (independent 0.x cadence)
 
-`velesdb-memory` (0.12.0) versions and releases on its own 0.x cadence, decoupled from the workspace majors.
+`velesdb-memory` (0.13.0) versions and releases on its own 0.x cadence, decoupled from the workspace majors.
 
 - **LoCoMo temporal-decomposition follow-up** — [`docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md`](docs/planning/LOCOMO_TEMPORAL_DECOMP_RESEARCH.md) concluded: dated recall's +33.6pp temporal lift is real and ironclad; the scaffold's marginal gain is unproven at n=321 and its feared single-hop cost is not real. The honest follow-up it scopes is a *cost*-framed routing chapter (skip the scaffold's CoT tokens where they don't move accuracy) — and it needs its own justification before it runs.
 - **Context-compiler evolution** — the deterministic compiler (`compile_context` and friends) evolves per `crates/velesdb-memory/CHANGELOG.md`.

--- a/benchmarks/Dockerfile.bench
+++ b/benchmarks/Dockerfile.bench
@@ -6,7 +6,7 @@
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.nightly
+++ b/benchmarks/Dockerfile.nightly
@@ -4,7 +4,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 
@@ -29,7 +29,7 @@ RUN cargo build --release --bin velesdb-server
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 

--- a/benchmarks/Dockerfile.optimized
+++ b/benchmarks/Dockerfile.optimized
@@ -7,7 +7,7 @@
 FROM rust:slim-bookworm AS builder
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 
@@ -49,7 +49,7 @@ RUN cargo build --release --bin velesdb-server \
 FROM debian:bookworm-slim
 
 LABEL maintainer="VelesDB Team <contact@wiscale.fr>"
-LABEL version="5.0.0"
+LABEL version="5.1.0"
 
 WORKDIR /app
 

--- a/crates/tauri-plugin-velesdb/README.md
+++ b/crates/tauri-plugin-velesdb/README.md
@@ -255,4 +255,4 @@ VelesDB engine and is governed by the Core License.
 
 ---
 
-`tauri-plugin-velesdb v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`tauri-plugin-velesdb v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/tauri-plugin-velesdb/guest-js/package.json
+++ b/crates/tauri-plugin-velesdb/guest-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/tauri-plugin-velesdb",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "TypeScript bindings for the VelesDB Tauri plugin - Vector search in desktop apps",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/crates/velesdb-cli/README.md
+++ b/crates/velesdb-cli/README.md
@@ -109,7 +109,7 @@ velesdb repl ./data
 ```
 
 ```
-VelesDB v5.0.0 - VelesQL REPL
+VelesDB v5.1.0 - VelesQL REPL
 Database: ./data
 Type .help for commands, .quit to exit
 
@@ -199,7 +199,7 @@ a prebuilt binary in each GitHub release; any other target can be built with
 | Windows x86_64 (`x86_64-pc-windows-msvc`) | Prebuilt | ZIP archive; WiX (MSI) sources in `wix/` |
 | Linux aarch64 | Build from source | No prebuilt CLI binary — use `cargo install velesdb-cli` |
 | Rust toolchain | 1.90+ | Workspace `rust-version` |
-| VelesDB database format | velesdb-core 5.0.0 | Same-version core is assumed; migration guides are listed in the [guides index](../../docs/guides/README.md) |
+| VelesDB database format | velesdb-core 5.1.0 | Same-version core is assumed; migration guides are listed in the [guides index](../../docs/guides/README.md) |
 
 ## Troubleshooting
 
@@ -218,4 +218,4 @@ Licensed under the [VelesDB Core License 1.0](./LICENSE) (source-available).
 
 ---
 
-`velesdb-cli v5.0.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-cli v5.1.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-core/README.md
+++ b/crates/velesdb-core/README.md
@@ -243,4 +243,4 @@ the platforms and toolchains the project builds and tests on.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,7 +7,7 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.0] - 2026-08-17
 
 ### Added
 
@@ -213,6 +213,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   itself is kept, unused, so the next honest admission has wording to reach
   for. Worth stating plainly: nothing caps how many gaps may be declared, and
   adding a seventh would have been exactly as green as fixing six.
+
+- **The error surface is frozen for semver, enum by enum (#1960).**
+  `MemoryError` and `ErrorCategory` are `#[non_exhaustive]` (adding a variant
+  is no longer a breaking change), while the selection enums stay deliberately
+  exhaustive — a wildcard arm there would silently ignore a new capability.
+  `ErrorCategory::ALL` restores enumerability at test time, and each binding
+  adapter (Node, Python, WASM) now splits its category mapping into an
+  explicit half and a fallback, with a test over `ALL` that fails the moment a
+  category is left to the fallback.
+
+- **All HTTP clients are built by one bounded constructor (#1961).**
+  `http_client::bounded_agent(AgentBudget)` replaces five hand-rolled `ureq`
+  agents; every client now carries explicit connect/write/overall timeouts,
+  with the timeout-precedence rules documented in one place.
+
+- **`WorkingContextCodec` carries a structured error (#1963).** A corrupt
+  working-context index reports what was in flight and which slot, with the
+  underlying serde error attached as a boxed `#[source]`; the degraded-index
+  fallback now matches on the variant rather than on message text. The other
+  error variants keep prose payloads by recorded decision: a variant earns
+  structure only when structure is being lost.
+
+- **The binary's 1708-line `main.rs` is split along its four seams (#1964)**
+  — transport/lifecycle, startup assembly, backend builders, and early
+  commands — leaving a 92-line entry point. `config.rs` now documents where
+  the library is allowed to read the environment; a new `env::var` anywhere
+  else is a defect by that doctrine.
+
+- **The two over-threshold functions are under the CCN gate (#1962)**, and
+  the graph-extraction model guidance is picked on measurement rather than
+  parameter count (#1943).
 
 ## [0.12.0] - 2026-07-30
 

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -365,4 +365,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-memory v0.12.0` · Last updated: 2026-08-15 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-memory v0.13.0` · Last updated: 2026-08-15 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-migrate/README.md
+++ b/crates/velesdb-migrate/README.md
@@ -244,4 +244,4 @@ Developed by Julien Lange, WiScale France.
 
 ---
 
-`velesdb-migrate v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -224,4 +224,4 @@ the VelesDB engine and are governed by that license.
 
 ---
 
-`velesdb-mobile v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-mobile v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.12.0"
+version = "0.13.0"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -325,4 +325,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-node v0.12.0` (npm `@wiscale/velesdb-memory-node@0.12.0`) · Last updated: 2026-07-30 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-node v0.13.0` (npm `@wiscale/velesdb-memory-node@0.13.0`) · Last updated: 2026-07-30 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/crates/velesdb-python/README.md
+++ b/crates/velesdb-python/README.md
@@ -217,4 +217,4 @@ so `except velesdb.VelesDBError` is a safe catch-all.
 
 ---
 
-`velesdb-python v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-python v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "velesdb"
-version = "5.0.0"
+version = "5.1.0"
 description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -187,4 +187,4 @@ VelesDB Core License 1.0 — see [LICENSE](../../LICENSE).
 
 ---
 
-`velesdb-server v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-server v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-wasm/README.md
+++ b/crates/velesdb-wasm/README.md
@@ -215,4 +215,4 @@ artifact embeds the engine and is governed by the Core License.
 
 ---
 
-`velesdb-wasm v5.0.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)
+`velesdb-wasm v5.1.0` · Last updated: 2026-08-10 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/velesdb/issues)

--- a/demos/rag-pdf-demo/pyproject.toml
+++ b/demos/rag-pdf-demo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "velesdb-rag-demo"
-version = "5.0.0"
+version = "5.1.0"
 description = "RAG Demo with PDF ingestion using VelesDB for vector storage"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/demos/rag-pdf-demo/src/__init__.py
+++ b/demos/rag-pdf-demo/src/__init__.py
@@ -1,3 +1,3 @@
 """VelesDB RAG Demo - PDF Question Answering System."""
 
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/demos/rag-pdf-demo/src/main.py
+++ b/demos/rag-pdf-demo/src/main.py
@@ -46,7 +46,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="VelesDB RAG Demo",
     description="PDF Question Answering with VelesDB vector search",
-    version="5.0.0",
+    version="5.1.0",
     lifespan=lifespan
 )
 

--- a/docs/ANN_SOTA_AUDIT.md
+++ b/docs/ANN_SOTA_AUDIT.md
@@ -94,4 +94,4 @@ Short answer: **partially yes**.
 - A latency-aware rerank controller is in place (`rerank_latency_target_us` + `adapt_rerank_k_to_latency`); a full benchmark-driven, recall-aware SLO controller is still future work.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # VelesDB Performance Benchmarks
 
-*Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
+*Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0. Figures are re-validated at each release only when re-measured — each section carries its own measurement date and machine; this stamp tracks the document revision, not a fresh measurement.*
 
 ---
 
@@ -454,7 +454,7 @@ Two layers of CI coverage:
 ## 12. velesdb-memory — graph-extraction models
 
 *Measured 2026-08-16 on an Apple M5 Pro (64 GB unified memory), against
-velesdb-memory 0.12.0 — a different machine from the Test Environment above,
+velesdb-memory 0.12.0 as shipped on that date — a different machine from the Test Environment above,
 which describes the Core reference host.*
 
 Eight Ollama models and four MLX configurations were scored on nineteen

--- a/docs/BUSINESS_MODEL.md
+++ b/docs/BUSINESS_MODEL.md
@@ -116,4 +116,4 @@ This design ensures:
 | Enterprise | On-premise cluster with SLA | Commercial |
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -936,4 +936,4 @@ invariants, see [SOUNDNESS.md: HNSW Batch Insertion Ordering](SOUNDNESS.md#hnsw-
 
 ---
 
-*Last updated: 2026-08-09 · Applies to: velesdb-core 5.0.0 (this revision: corrected the lock-order enforcement section — `assert_lock_order` is unwired in production, the HNSW tracker is debug-only, warn-only and partial, the collection tier is convention-only — and the CSR snapshot thread-safety section to describe the lock-free `ArcSwap` + dirty-flag protocol; previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*
+*Last updated: 2026-08-09 · Applies to: velesdb-core 5.1.0 (this revision: corrected the lock-order enforcement section — `assert_lock_order` is unwired in production, the HNSW tracker is debug-only, warn-only and partial, the collection tier is convention-only — and the CSR snapshot thread-safety section to describe the lock-free `ArcSwap` + dirty-flag protocol; previous revision noted: HNSW persisted-graph reload at open; storage compaction concurrency)*

--- a/docs/CORE_PREMIUM_SPLIT.md
+++ b/docs/CORE_PREMIUM_SPLIT.md
@@ -152,4 +152,4 @@ provenance** — not re-architect.
 
 ---
 
-*Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0 (this stamp tracks the document revision, not a re-verification of the split).*
+*Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0 (this stamp tracks the document revision, not a re-verification of the split).*

--- a/docs/CORE_WIRING_DEBT.md
+++ b/docs/CORE_WIRING_DEBT.md
@@ -467,7 +467,7 @@ avoid implying a guarantee that does not exist. Community-scope.
 
 ---
 
-*Last updated: 2026-08-09 · Applies to: velesdb-core 5.0.0 (this stamp tracks
+*Last updated: 2026-08-09 · Applies to: velesdb-core 5.1.0 (this stamp tracks
 the document revision; this revision adds entry 7, lock-order enforcement debt.
 The rest of the inventory was last re-verified against the code on 2026-06-14,
 as stated at the top of this page)*

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 # VelesDB Frequently Asked Questions
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0
 
 ---
 

--- a/docs/FUZZING.md
+++ b/docs/FUZZING.md
@@ -324,4 +324,4 @@ thread 'main' panicked at ...
 
 ---
 
-*Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0 (introduced: EPIC-025)*
+*Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0 (introduced: EPIC-025)*

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,6 +1,6 @@
 # GPU Acceleration Guide
 
-> Last updated: 2026-06-12 · Applies to: velesdb-core 5.0.0 (feature introduced: VelesDB v2.0.0)
+> Last updated: 2026-06-12 · Applies to: velesdb-core 5.1.0 (feature introduced: VelesDB v2.0.0)
 
 VelesDB supports optional GPU acceleration for batch vector operations via the `gpu` feature.
 
@@ -30,7 +30,7 @@ Enable the `gpu` feature in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-velesdb-core = { version = "5.0.0", features = ["gpu"] }
+velesdb-core = { version = "5.1.0", features = ["gpu"] }
 ```
 
 ## Usage

--- a/docs/LICENSING.md
+++ b/docs/LICENSING.md
@@ -59,4 +59,4 @@ already-published exposure (and any yank/deprecation of affected versions) is
 tracked in the licensing issues and should be reviewed by IP counsel.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/NEW_USER_TROUBLESHOOTING.md
+++ b/docs/NEW_USER_TROUBLESHOOTING.md
@@ -106,4 +106,4 @@ Normal : dépend du CPU, de `ef_search`, des filtres/payloads et du dataset.
 - [E-commerce Example](../examples/ecommerce_recommendation/) — Full Vector + Graph + Filter demo in Rust
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -181,4 +181,4 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 *VelesDB — the explainable, local-first memory engine for AI agents. (Microsecond vector search is the proof, not the pitch.)*
 
 ---
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/SOUNDNESS.md
+++ b/docs/SOUNDNESS.md
@@ -1062,7 +1062,7 @@ let data_as_bytes: &mut [u8] = unsafe {
 
 ---
 
-*Last updated: 2026-08-09 · Applies to: velesdb-core 5.0.0 (this stamp tracks
+*Last updated: 2026-08-09 · Applies to: velesdb-core 5.1.0 (this stamp tracks
 the document revision; this revision adds the `parking_lot`-features invariant to
 the `VectorSliceGuard` entry. The underlying unsafe audit was last run in full on
 2026-06-12, as stated at the top of this page)*

--- a/docs/STORAGE_FORMAT.md
+++ b/docs/STORAGE_FORMAT.md
@@ -1,7 +1,7 @@
 # VelesDB Storage Format Specification
 
 **Version**: 1.0.0<br>
-Last updated: 2026-08-12 · Applies to: velesdb-core 5.0.0<br>
+Last updated: 2026-08-12 · Applies to: velesdb-core 5.1.0<br>
 **Status**: Stable
 
 ## Overview

--- a/docs/TECH_DEBT_REGISTRY.md
+++ b/docs/TECH_DEBT_REGISTRY.md
@@ -184,4 +184,4 @@ across all three kinds. The distinct public surfaces (`VectorCollection` /
 shared backing store is a deliberate, honest design choice, not residual debt.
 
 ---
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2,7 +2,7 @@
 
 > SQL-like query language for vector + graph + column-store search in VelesDB.
 
-**Version**: 3.10.0 | Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+**Version**: 3.10.0 | Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0
 
 ---
 

--- a/docs/WHY_VELESDB.md
+++ b/docs/WHY_VELESDB.md
@@ -128,4 +128,4 @@ See [BENCHMARKS.md](./BENCHMARKS.md) for detailed numbers and methodology.
 - You only need simple vector search without graph or column queries (ChromaDB)
 
 ---
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/contributing/CODE_SIGNING.md
+++ b/docs/contributing/CODE_SIGNING.md
@@ -298,4 +298,4 @@ Required secrets:
 
 ---
 
-Last updated: 2026-08-13 · Applies to: VelesDB 5.0.0
+Last updated: 2026-08-13 · Applies to: VelesDB 5.1.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ Expected response:
 ```json
 {
   "status": "ok",
-  "version": "5.0.0"
+  "version": "5.1.0"
 }
 ```
 
@@ -328,4 +328,4 @@ curl -X POST http://localhost:8080/query \
 - [**GitHub Discussions**](https://github.com/cyberlife-coder/VelesDB/discussions): Ask questions and share ideas
 
 ---
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/AGENT_MEMORY.md
+++ b/docs/guides/AGENT_MEMORY.md
@@ -1165,4 +1165,4 @@ Yes. The SDK is covered end-to-end by Rust and Python test suites, including sna
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CLI_COMMAND_REFERENCE.md
+++ b/docs/guides/CLI_COMMAND_REFERENCE.md
@@ -547,4 +547,4 @@ Numeric `VELES-*` codes are listed in
 
 ---
 
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CLI_REPL_REFERENCE.md
+++ b/docs/guides/CLI_REPL_REFERENCE.md
@@ -18,7 +18,7 @@ velesdb repl ./my_db    # explicit path
 ```
 
 ```
-VelesDB v5.0.0 - VelesQL REPL
+VelesDB v5.1.0 - VelesQL REPL
 Database: ./data
 Type .help for commands, .quit to exit
 
@@ -287,4 +287,4 @@ executed successfully.`, `Admin statement executed successfully.`, or
 
 ---
 
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CLI_VELESQL_COOKBOOK.md
+++ b/docs/guides/CLI_VELESQL_COOKBOOK.md
@@ -455,4 +455,4 @@ SELECT "select", "from", "order" FROM docs LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # ⚙️ VelesDB Configuration
 
-*Version 5.0.0 — Last updated: 2026-08-08*
+*Version 5.1.0 — Last updated: 2026-08-08*
 
 Complete guide for configuring VelesDB via configuration file, environment variables, and runtime parameters.
 
@@ -112,7 +112,7 @@ data_dir = "./data"
 ```toml
 # =============================================================================
 # VelesDB Configuration File
-# Version: 5.0.0
+# Version: 5.1.0
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -864,4 +864,4 @@ impl VelesConfig {
 
 ---
 
-*VelesDB Documentation — Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0*
+*VelesDB Documentation — Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0*

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -841,4 +841,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.12.0
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.13.0

--- a/docs/guides/CORE_API_MAP.md
+++ b/docs/guides/CORE_API_MAP.md
@@ -125,4 +125,4 @@ use velesdb_core::{recall_at_k, precision_at_k, mrr, ndcg_at_k};
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
+++ b/docs/guides/CORE_COLLECTIONS_AND_METRICS.md
@@ -184,4 +184,4 @@ lock-free CAS entry-point promotion.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_PERFORMANCE.md
+++ b/docs/guides/CORE_PERFORMANCE.md
@@ -115,4 +115,4 @@ It also downloads a ~168 MB tarball on first run.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_QUERY_PLAN_CACHE.md
+++ b/docs/guides/CORE_QUERY_PLAN_CACHE.md
@@ -97,4 +97,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_SPARSE_AND_FUSION.md
+++ b/docs/guides/CORE_SPARSE_AND_FUSION.md
@@ -121,4 +121,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_STREAMING_INSERTS.md
+++ b/docs/guides/CORE_STREAMING_INSERTS.md
@@ -86,4 +86,4 @@ Full signatures live on [docs.rs](https://docs.rs/velesdb-core).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/CORE_VELESQL_REFERENCE.md
+++ b/docs/guides/CORE_VELESQL_REFERENCE.md
@@ -132,4 +132,4 @@ EXPLAIN SELECT * FROM docs WHERE VECTOR NEAR $v LIMIT 10;
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/GRAPH_PATTERNS.md
+++ b/docs/guides/GRAPH_PATTERNS.md
@@ -1,6 +1,6 @@
 # Graph Patterns Guide
 
-*Version 5.0.0 -- May 2026*
+*Version 5.1.0 -- May 2026*
 
 Practical guide for using VelesQL `MATCH` graph patterns in VelesDB.
 

--- a/docs/guides/INSTALLATION.md
+++ b/docs/guides/INSTALLATION.md
@@ -60,10 +60,10 @@ entry.
 
 ```bash
 # Download
-wget https://github.com/cyberlife-coder/VelesDB/releases/download/v5.0.0/velesdb-5.0.0-amd64.deb
+wget https://github.com/cyberlife-coder/VelesDB/releases/download/v5.1.0/velesdb-5.1.0-amd64.deb
 
 # Install
-sudo dpkg -i velesdb-5.0.0-amd64.deb
+sudo dpkg -i velesdb-5.1.0-amd64.deb
 
 # Verify
 velesdb --version
@@ -136,7 +136,7 @@ results = collection.search_request(velesdb.SearchOptions(vector=query_vector, k
 ```toml
 # Cargo.toml
 [dependencies]
-velesdb-core = "5.0.0"
+velesdb-core = "5.1.0"
 ```
 
 ### As CLI Tools
@@ -160,13 +160,13 @@ GitHub Container Registry, so you don't need to build locally:
 
 ```bash
 # Pull a specific release (recommended for reproducibility)
-docker pull ghcr.io/cyberlife-coder/velesdb:5.0.0
+docker pull ghcr.io/cyberlife-coder/velesdb:5.1.0
 
 # ...or the latest stable release
 docker pull ghcr.io/cyberlife-coder/velesdb:latest
 
 docker run -d --name velesdb -p 8080:8080 -v velesdb_data:/data \
-  ghcr.io/cyberlife-coder/velesdb:5.0.0
+  ghcr.io/cyberlife-coder/velesdb:5.1.0
 ```
 
 ### Build locally

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -804,4 +804,4 @@ trait and pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.12.0
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.13.0

--- a/docs/guides/MEMORY_EXTRACTOR_MODELS.md
+++ b/docs/guides/MEMORY_EXTRACTOR_MODELS.md
@@ -1,6 +1,6 @@
 # Choosing a graph-extraction model for velesdb-memory
 
-Last updated: 2026-08-16 · Applies to: velesdb-memory 0.12.0
+Last updated: 2026-08-16 · Applies to: velesdb-memory 0.13.0
 
 `velesdb-memory` turns a remembered fact into graph edges by asking a local
 model for JSON. Which model you point it at — `VELESDB_MEMORY_EXTRACTOR_MODEL`

--- a/docs/guides/MIGRATE_CLI.md
+++ b/docs/guides/MIGRATE_CLI.md
@@ -46,7 +46,7 @@ Global options:
 | `--dry-run` | Extract and transform, never write to the destination |
 | `-v, --verbose` | Raise the log level from `INFO` to `DEBUG` |
 | `--batch-size <N>` | Override `options.batch_size` from the config |
-| `-h, --help` / `-V, --version` | Help / version (`velesdb-migrate 5.0.0`) |
+| `-h, --help` / `-V, --version` | Help / version (`velesdb-migrate 5.1.0`) |
 
 Signatures are generated on
 [docs.rs/velesdb-migrate](https://docs.rs/velesdb-migrate); this page documents
@@ -275,4 +275,4 @@ elsewhere) before re-running.
 
 ---
 
-`velesdb-migrate v5.0.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v5.1.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_OPERATIONS.md
+++ b/docs/guides/MIGRATE_OPERATIONS.md
@@ -162,4 +162,4 @@ A completed migration deletes its own checkpoint.
 
 ---
 
-`velesdb-migrate v5.0.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v5.1.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MIGRATE_SOURCES.md
+++ b/docs/guides/MIGRATE_SOURCES.md
@@ -400,4 +400,4 @@ Common embedding dimensions:
 
 ---
 
-`velesdb-migrate v5.0.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-migrate v5.1.0` · Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/docs/guides/MOBILE_API.md
+++ b/docs/guides/MOBILE_API.md
@@ -431,4 +431,4 @@ not a measurement.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/MOBILE_BUILD.md
+++ b/docs/guides/MOBILE_BUILD.md
@@ -175,4 +175,4 @@ Expected on a host with default features: `123 passed` (lib target), `8 passed`
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/MULTIMODEL_QUERIES.md
+++ b/docs/guides/MULTIMODEL_QUERIES.md
@@ -210,5 +210,5 @@ When combining vector and graph results:
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0
 

--- a/docs/guides/NODE_ADDON.md
+++ b/docs/guides/NODE_ADDON.md
@@ -320,4 +320,4 @@ silently reduced instead.
 
 ---
 
-Last updated: 2026-08-09 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-09 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/NODE_ADDON_BUILD.md
+++ b/docs/guides/NODE_ADDON_BUILD.md
@@ -120,4 +120,4 @@ import { MemoryService } from '@wiscale/velesdb-memory-node'
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_AGENT_MEMORY.md
+++ b/docs/guides/PYTHON_AGENT_MEMORY.md
@@ -149,4 +149,4 @@ memory.procedural.reinforce(procedure_id=1, success=False)
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_API_REFERENCE.md
+++ b/docs/guides/PYTHON_API_REFERENCE.md
@@ -447,4 +447,4 @@ see [PYTHON_PERFORMANCE.md](PYTHON_PERFORMANCE.md).
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_CONTEXT_COMPILER.md
+++ b/docs/guides/PYTHON_CONTEXT_COMPILER.md
@@ -131,4 +131,4 @@ shapes), see [CONTEXT_COMPILER.md](CONTEXT_COMPILER.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
+++ b/docs/guides/PYTHON_ENGINE_BENCHMARKS.md
@@ -33,4 +33,4 @@ VelesDB is built in Rust with explicit SIMD optimizations:
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_GRAPH.md
+++ b/docs/guides/PYTHON_GRAPH.md
@@ -233,4 +233,4 @@ Query patterns: [GRAPH_PATTERNS.md](GRAPH_PATTERNS.md).
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_PERFORMANCE.md
+++ b/docs/guides/PYTHON_PERFORMANCE.md
@@ -457,4 +457,4 @@ See also: [TUNING_GUIDE.md](TUNING_GUIDE.md) for HNSW parameter tuning and
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_RAG_PIPELINE.md
+++ b/docs/guides/PYTHON_RAG_PIPELINE.md
@@ -91,4 +91,4 @@ so you can drop in your own implementation. `dimension` is inferred after the fi
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_REMOTE_SERVER.md
+++ b/docs/guides/PYTHON_REMOTE_SERVER.md
@@ -33,4 +33,4 @@ setup.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/PYTHON_VELESQL.md
+++ b/docs/guides/PYTHON_VELESQL.md
@@ -101,4 +101,4 @@ Executing (rather than inspecting) VelesQL from Python is documented in
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -361,4 +361,4 @@ modes combine with.
 
 ---
 
-*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0*
+*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0*

--- a/docs/guides/SEARCH_MODES.md
+++ b/docs/guides/SEARCH_MODES.md
@@ -1,6 +1,6 @@
 # 🎯 Search Modes - Recall Configuration Guide
 
-*Version 5.0.0 -- Last updated: 2026-08-08*
+*Version 5.1.0 -- Last updated: 2026-08-08*
 
 Complete guide to the **recall vs latency** trade-off in VelesDB: what the search modes mean and when to pick which. Covers dense search (HNSW), sparse search (SPLADE/BM42), and hybrid search (dense+sparse with fusion). Includes a comparison with Milvus, OpenSearch, and Qdrant practices.
 
@@ -779,4 +779,4 @@ println!("Recall@10: {:.1}%", recall * 100.0);
 
 ---
 
-*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0*
+*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0*

--- a/docs/guides/SERVER_DEPLOYMENT.md
+++ b/docs/guides/SERVER_DEPLOYMENT.md
@@ -171,4 +171,4 @@ enabled = false
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/SERVER_REST_TOUR.md
+++ b/docs/guides/SERVER_REST_TOUR.md
@@ -519,20 +519,20 @@ public when API keys are configured.
 `/v1/health` always answers `200` while the process is up:
 
 ```json
-{"status": "ok", "version": "5.0.0"}
+{"status": "ok", "version": "5.1.0"}
 ```
 
 `/v1/ready` answers `200` once every collection is loaded from disk:
 
 ```json
-{"status": "ready", "version": "5.0.0"}
+{"status": "ready", "version": "5.1.0"}
 ```
 
 …and `503` until then, which is what makes it usable as a Kubernetes
 readiness probe:
 
 ```json
-{"status": "not_ready", "version": "5.0.0"}
+{"status": "not_ready", "version": "5.1.0"}
 ```
 
 ---
@@ -579,4 +579,4 @@ Numbers match the canonical contract in
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/SERVER_SECURITY.md
+++ b/docs/guides/SERVER_SECURITY.md
@@ -319,7 +319,7 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "ok",
-  "version": "5.0.0"
+  "version": "5.1.0"
 }
 ```
 
@@ -338,7 +338,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "ready",
-  "version": "5.0.0"
+  "version": "5.1.0"
 }
 ```
 
@@ -347,7 +347,7 @@ curl http://localhost:8080/ready
 ```json
 {
   "status": "not_ready",
-  "version": "5.0.0"
+  "version": "5.1.0"
 }
 ```
 
@@ -382,4 +382,4 @@ echo "VelesDB is ready!"
 
 ---
 
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/TAURI_PLUGIN_RECIPES.md
+++ b/docs/guides/TAURI_PLUGIN_RECIPES.md
@@ -1,6 +1,6 @@
 # Tauri plugin — recipes
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0*
 
 Copy-pasteable snippets for [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md),
 beyond the 60-second first success in the crate README. Command names, payload

--- a/docs/guides/TAURI_PLUGIN_REFERENCE.md
+++ b/docs/guides/TAURI_PLUGIN_REFERENCE.md
@@ -1,6 +1,6 @@
 # Tauri plugin — command, event and permission reference
 
-*Last updated: 2026-07-25 · Applies to: velesdb-core 5.0.0*
+*Last updated: 2026-07-25 · Applies to: velesdb-core 5.1.0*
 
 Complete surface of [`tauri-plugin-velesdb`](../../crates/tauri-plugin-velesdb/README.md):
 every IPC command, every event, the permission model, and the storage/metric

--- a/docs/guides/TUNING_GUIDE.md
+++ b/docs/guides/TUNING_GUIDE.md
@@ -629,4 +629,4 @@ against your own baseline.
 
 ---
 
-*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.0.0*
+*VelesDB Documentation -- Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0*

--- a/docs/guides/WASM_API.md
+++ b/docs/guides/WASM_API.md
@@ -381,4 +381,4 @@ that runs VelesQL (`executeQuery`). See
 
 ---
 
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/WASM_PERSISTENCE.md
+++ b/docs/guides/WASM_PERSISTENCE.md
@@ -162,4 +162,4 @@ different shape from the table above; expect different absolute numbers.
 
 ---
 
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/WASM_VELESQL.md
+++ b/docs/guides/WASM_VELESQL.md
@@ -242,4 +242,4 @@ version you run.
 
 ---
 
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.0.0
+Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0

--- a/docs/guides/tutorials/MINI_RECOMMENDER.md
+++ b/docs/guides/tutorials/MINI_RECOMMENDER.md
@@ -37,7 +37,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-velesdb-core = "5.0.0"
+velesdb-core = "5.1.0"
 serde_json = "1.0"
 tempfile = "3.10"
 ```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11,7 +11,7 @@
       "name": "VelesDB Core License 1.0",
       "url": "https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE"
     },
-    "version": "5.0.0"
+    "version": "5.1.0"
   },
   "servers": [
     {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -8,7 +8,7 @@ info:
   license:
     name: VelesDB Core License 1.0
     url: https://github.com/cyberlife-coder/VelesDB/blob/main/LICENSE
-  version: 5.0.0
+  version: 5.1.0
 servers:
 - url: /
   description: Local server

--- a/docs/reference/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/reference/ARCHITECTURE_DIAGRAMS.md
@@ -1,4 +1,4 @@
-# VelesDB Architecture Diagrams — v5.0.0
+# VelesDB Architecture Diagrams — v5.1.0
 
 ## 1. Workspace Dependency Graph
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-08-13 (v5.0.0; velesdb-memory 0.12.0)
+Last updated: 2026-08-17 (v5.1.0; velesdb-memory 0.13.0)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -800,4 +800,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-08-09 · Applies to: velesdb-memory 0.12.0
+Last updated: 2026-08-09 · Applies to: velesdb-memory 0.13.0

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -22,7 +22,7 @@ No feature flags needed. Native HNSW is the only implementation:
 
 ```toml
 [dependencies]
-velesdb-core = "5.0.0"
+velesdb-core = "5.1.0"
 ```
 
 ## API

--- a/docs/reference/VELESQL_CHEATSHEET.md
+++ b/docs/reference/VELESQL_CHEATSHEET.md
@@ -1,7 +1,7 @@
 # VelesQL Cheat Sheet
 
 > **Date:** 2026-06-03
-> **VelesDB version:** 5.0.0
+> **VelesDB version:** 5.1.0
 > See the full specification in [`docs/VELESQL_SPEC.md`](../VELESQL_SPEC.md).
 
 > Every `sql` block below is **parsed** against the real grammar by an automated

--- a/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
+++ b/docs/reference/VELESQL_CONFORMANCE_MATRIX.md
@@ -4,7 +4,7 @@ This document lists every VelesQL feature with its parser and executor status.
 A feature can be **Parsed** (the grammar + AST accept it) without being
 **Executed** (the query engine acts on it at runtime).
 
-> Last updated: 2026-08-10 (VelesDB v5.0.0)
+> Last updated: 2026-08-17 (VelesDB v5.1.0)
 
 ## Fully Supported (Parsed AND Executed)
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -2,7 +2,7 @@
 
 Complete REST API documentation for VelesDB.
 
-> **Last updated**: 2026-08-13 (VelesDB v5.0.0). The machine-readable source of
+> **Last updated**: 2026-08-13 (VelesDB v5.1.0). The machine-readable source of
 > truth is [`docs/openapi.yaml`](../openapi.yaml), regenerated from the server's
 > annotated handlers and drift-checked in CI; this page is the human-readable
 > companion.
@@ -58,7 +58,7 @@ Check server health status.
 ```json
 {
   "status": "ok",
-  "version": "5.0.0"
+  "version": "5.1.0"
 }
 ```
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -339,9 +339,9 @@
       "executable": false,
       "source": "Issue #1686: the live-schema MCP regression test compares the accepted wire form for every repeated field-name and scalar-type pair.",
       "last_updated": "2026-08-15",
-      "measured_on": "2026-08-15",
+      "measured_on": "2026-08-17",
       "measured_machine": "platform-independent (wire-schema contract)",
-      "measured_version": "5.0.0"
+      "measured_version": "5.1.0"
     },
     {
       "id": "mcp_lenient_scalar_rejects_incompatible_forms",
@@ -351,9 +351,9 @@
       "executable": false,
       "source": "Issue #1686: the live MCP server must reject invalid strings and incompatible scalar or container values at every non-string scalar input slot.",
       "last_updated": "2026-08-15",
-      "measured_on": "2026-08-15",
+      "measured_on": "2026-08-17",
       "measured_machine": "platform-independent (wire-schema contract)",
-      "measured_version": "5.0.0"
+      "measured_version": "5.1.0"
     }
   ],
   "claim_families": [

--- a/docs/tutorials/tauri-rag-app/README.md
+++ b/docs/tutorials/tauri-rag-app/README.md
@@ -145,7 +145,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-shell = "2"
 tauri-plugin-velesdb = "4.3.0"  # Add VelesDB plugin
-velesdb-core = { version = "5.0.0", features = ["persistence"] }  # Core types (Point, DistanceMetric)
+velesdb-core = { version = "5.1.0", features = ["persistence"] }  # Core types (Point, DistanceMetric)
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/wasm-browser-demo/README.md
+++ b/examples/wasm-browser-demo/README.md
@@ -22,7 +22,7 @@ cd crates/velesdb-wasm
 wasm-pack build --target web --out-dir ../../examples/wasm-browser-demo/pkg
 
 # Then update index.html to use the local path instead of CDN:
-# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@5.0.0/velesdb_wasm.js'
+# Change: import init from 'https://unpkg.com/@wiscale/velesdb-wasm@5.1.0/velesdb_wasm.js'
 # To:     import init from './pkg/velesdb_wasm.js'
 ```
 
@@ -80,7 +80,7 @@ Typical results on modern hardware:
 ```html
 <script type="module">
   // If published on npm:
-  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@5.0.0/velesdb_wasm.js';
+  // import init, { VectorStore } from 'https://unpkg.com/@wiscale/velesdb-wasm@5.1.0/velesdb_wasm.js';
   // If built locally with wasm-pack:
   import init, { VectorStore } from './pkg/velesdb_wasm.js';
 

--- a/examples/wasm-browser-demo/index.html
+++ b/examples/wasm-browser-demo/index.html
@@ -171,8 +171,8 @@
         // WASM module - tracks @wiscale/velesdb-wasm@<workspace> with CDN fallback.
         // Bumped by scripts/bump-version.ps1 on every release; if you copy this
         // demo, update the version below to match `@wiscale/velesdb-wasm` on npm.
-        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@5.0.0/velesdb_wasm.js';
-        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@5.0.0/velesdb_wasm.js';
+        const WASM_CDN_PRIMARY = 'https://unpkg.com/@wiscale/velesdb-wasm@5.1.0/velesdb_wasm.js';
+        const WASM_CDN_FALLBACK = 'https://cdn.jsdelivr.net/npm/@wiscale/velesdb-wasm@5.1.0/velesdb_wasm.js';
         
         let init, VectorStore;
         

--- a/integrations/common/pyproject.toml
+++ b/integrations/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "velesdb-common"
-version = "5.0.0"
+version = "5.1.0"
 description = "Shared utilities for VelesDB Python integrations (internal use)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/pyproject.toml
+++ b/integrations/haystack/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haystack-velesdb"
-version = "5.0.0"
+version = "5.1.0"
 description = "Haystack 2.x DocumentStore for VelesDB: The Local AI Memory Database."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/haystack/src/haystack_velesdb/__init__.py
+++ b/integrations/haystack/src/haystack_velesdb/__init__.py
@@ -4,4 +4,4 @@ from haystack_velesdb.document_store import VelesDBDocumentStore
 from haystack_velesdb.retriever import VelesDBEmbeddingRetriever
 
 __all__ = ["VelesDBDocumentStore", "VelesDBEmbeddingRetriever"]
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langchain-velesdb"
-version = "5.0.0"
+version = "5.1.0"
 description = "LangChain VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langchain/src/langchain_velesdb/__init__.py
+++ b/integrations/langchain/src/langchain_velesdb/__init__.py
@@ -53,4 +53,4 @@ if _HAS_MEMORY:
         "VelesDBSemanticMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/integrations/langgraph/pyproject.toml
+++ b/integrations/langgraph/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "langgraph-velesdb"
-version = "5.0.0"
+version = "5.1.0"
 description = "LangGraph memory tools for VelesDB: drop the why() knowledge-graph memory wedge into any LangGraph agent."
 readme = "README.md"
 license = {text = "MIT"}

--- a/integrations/langgraph/src/langgraph_velesdb/__init__.py
+++ b/integrations/langgraph/src/langgraph_velesdb/__init__.py
@@ -18,4 +18,4 @@ resumption. The store is on disk, so memory persists across agent runs.
 from langgraph_velesdb.tools import make_memory_tools
 
 __all__ = ["make_memory_tools"]
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/integrations/llamaindex/pyproject.toml
+++ b/integrations/llamaindex/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-velesdb"
-version = "5.0.0"
+version = "5.1.0"
 description = "LlamaIndex VectorStore for VelesDB: The Local AI Memory Database. Microsecond RAG retrieval."
 readme = "README.md"
 license = "MIT"

--- a/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
+++ b/integrations/llamaindex/src/llamaindex_velesdb/__init__.py
@@ -57,4 +57,4 @@ if _HAS_MEMORY:
         "VelesDBChatMemory",
         "VelesDBProceduralMemory",
     ])
-__version__ = "5.0.0"
+__version__ = "5.1.0"

--- a/scripts/dx-timing/scenario_rust.sh
+++ b/scripts/dx-timing/scenario_rust.sh
@@ -41,7 +41,7 @@ RS
 # Pin to the latest released version on crates.io. Bump alongside each
 # workspace release; the timing measurement is meant to track the path a
 # fresh dev hits when they `cargo add velesdb-core` today.
-cargo add --quiet velesdb-core@5.0.0
+cargo add --quiet velesdb-core@5.1.0
 cargo add --quiet serde_json@1
 cargo run --quiet --release
 

--- a/scripts/dx-timing/scenario_server.sh
+++ b/scripts/dx-timing/scenario_server.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 START=$(date +%s.%N)
 
-cargo install --quiet --locked velesdb-server@5.0.0
+cargo install --quiet --locked velesdb-server@5.1.0
 
 DATA_DIR=$(mktemp -d -t velesdb_dx_server_XXXX)
 trap 'rm -rf "$DATA_DIR"' EXIT

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -4,7 +4,7 @@ Official TypeScript SDK for [VelesDB](https://github.com/cyberlife-coder/VelesDB
 
 > The TypeScript engine behind **VelesDB — the explainable, local-first memory engine for AI agents.** It ships the `MemoryService` memory wedge (`remember`/`recall`/`recallFused`/`recallFusedDated`/`relate`/`unrelate`/`forget`/`entity`/`rememberExtracted`/[`why()`](../../crates/velesdb-memory/README.md)) in the browser or Node.js — `why()` returns the evidence path behind every recall. The deterministic context compiler (`compileContext`) runs here too — fully in the browser (WASM), media fragments included, with `retrieveContextSource` for externalized-source retrieval — and in the native Node binding, [`@wiscale/velesdb-memory-node`](../../crates/velesdb-node/README.md).
 
-**v5.0.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
+**v5.1.0** | Node.js >= 18 | Browser (WASM) | VelesDB Core License 1.0
 
 ## What's New in v3.12.0
 

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-sdk",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@wiscale/velesdb-wasm": "^5.0.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-sdk",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
   "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Description

Git Flow back-merge after #1968 landed on `main` (merge commit `0dfa566`): the two release-prep commits — the workspace 5.1.0 / velesdb-memory 0.13.0 bump with dated changelogs and ROADMAP, and the promise-contract restamp — so `develop` does not sit at 5.0.0/0.12.0 while `main` ships 5.1.0. Without this, the next `develop` PR that touches any stamped doc fails `check-version-sync` against the wrong expected version.

No new content: exactly the two commits already reviewed and merged in #1968, fast-forwarded from `release/v5.1.0`.

Refs #1968 #1946

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

*(version-stamp back-merge; no code changes beyond the already-merged release prep)*

## How Has This Been Tested?

- [x] Manual testing

Same tree as #1968's head, whose full CI ran green (run 3975). `check-version-sync.py`, `check-doc-freshness.py`, `check-promise-contract.py` all pass on it.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes