### PR TITLE
fix(wasm): fail closed on an unrecognized metadata-filter condition type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to VelesDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **WASM: a metadata filter with an unrecognized or missing condition `type`
+  now matches nothing instead of everything (#1975).** `search_with_filter`'s
+  evaluator returned `true` for any `"type"` it did not recognize, so a typo'd
+  operator (`"eqals"`) — or a condition object with no `"type"` at all —
+  silently returned unfiltered results. Both now fail closed. An absent
+  `filter`, or a filter without a `condition` key, still matches everything:
+  "no filter" and "a filter the evaluator cannot interpret" are different
+  claims, and only the second one is an error.
+
 ## [5.1.0] — 2026-08-17
 
 ### Added

--- a/crates/velesdb-wasm/src/filter.rs
+++ b/crates/velesdb-wasm/src/filter.rs
@@ -38,7 +38,14 @@ pub fn matches_filter(payload: &Value, filter: &Value) -> bool {
 }
 
 /// Evaluates a single condition against a payload.
+///
+/// Fails closed on any condition it cannot interpret: an unrecognized
+/// `"type"`, a missing `"type"`, or a non-string one all match nothing.
+/// The permissive case is reserved for [`matches_filter`]'s *absent*
+/// `condition` key — "no filter" and "a filter this evaluator cannot
+/// interpret" are different claims, and only the second is an error.
 pub fn evaluate_condition(payload: &Value, condition: &Value) -> bool {
+    // A missing or non-string "type" funnels into the fail-closed arm below.
     let cond_type = condition.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
     match cond_type {

--- a/crates/velesdb-wasm/src/filter.rs
+++ b/crates/velesdb-wasm/src/filter.rs
@@ -76,7 +76,9 @@ pub fn evaluate_condition(payload: &Value, condition: &Value) -> bool {
         "not" => condition
             .get("condition")
             .is_none_or(|c| !evaluate_condition(payload, c)),
-        _ => true,
+        // Fail closed: an unrecognized/misspelled "type" must not silently
+        // match everything, or a filter typo would leak unfiltered results.
+        _ => false,
     }
 }
 
@@ -126,106 +128,5 @@ pub fn get_nested_field<'a>(payload: &'a Value, field: &str) -> Option<&'a Value
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_filter_eq() {
-        let payload = json!({"category": "tech"});
-        let filter = json!({
-            "condition": {
-                "type": "eq",
-                "field": "category",
-                "value": "tech"
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_filter_neq() {
-        let payload = json!({"category": "tech"});
-        let filter = json!({
-            "condition": {
-                "type": "neq",
-                "field": "category",
-                "value": "sports"
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_filter_gt() {
-        let payload = json!({"score": 85.0});
-        let filter = json!({
-            "condition": {
-                "type": "gt",
-                "field": "score",
-                "value": 80.0
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_filter_and() {
-        let payload = json!({"category": "tech", "score": 90.0});
-        let filter = json!({
-            "condition": {
-                "type": "and",
-                "conditions": [
-                    {"type": "eq", "field": "category", "value": "tech"},
-                    {"type": "gt", "field": "score", "value": 80.0}
-                ]
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_filter_or() {
-        let payload = json!({"category": "sports"});
-        let filter = json!({
-            "condition": {
-                "type": "or",
-                "conditions": [
-                    {"type": "eq", "field": "category", "value": "tech"},
-                    {"type": "eq", "field": "category", "value": "sports"}
-                ]
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_filter_not() {
-        let payload = json!({"category": "tech"});
-        let filter = json!({
-            "condition": {
-                "type": "not",
-                "condition": {
-                    "type": "eq",
-                    "field": "category",
-                    "value": "sports"
-                }
-            }
-        });
-        assert!(matches_filter(&payload, &filter));
-    }
-
-    #[test]
-    fn test_nested_field() {
-        let payload = json!({"user": {"profile": {"name": "John"}}});
-        let value = get_nested_field(&payload, "user.profile.name");
-        assert_eq!(value, Some(&json!("John")));
-    }
-
-    #[test]
-    fn test_no_filter_matches_all() {
-        let payload = json!({"anything": "value"});
-        let filter = json!({});
-        assert!(matches_filter(&payload, &filter));
-    }
-}
+#[path = "filter_tests.rs"]
+mod tests;

--- a/crates/velesdb-wasm/src/filter_tests.rs
+++ b/crates/velesdb-wasm/src/filter_tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn test_filter_eq() {
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "type": "eq",
+            "field": "category",
+            "value": "tech"
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_filter_neq() {
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "type": "neq",
+            "field": "category",
+            "value": "sports"
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_filter_gt() {
+    let payload = json!({"score": 85.0});
+    let filter = json!({
+        "condition": {
+            "type": "gt",
+            "field": "score",
+            "value": 80.0
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_filter_and() {
+    let payload = json!({"category": "tech", "score": 90.0});
+    let filter = json!({
+        "condition": {
+            "type": "and",
+            "conditions": [
+                {"type": "eq", "field": "category", "value": "tech"},
+                {"type": "gt", "field": "score", "value": 80.0}
+            ]
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_filter_or() {
+    let payload = json!({"category": "sports"});
+    let filter = json!({
+        "condition": {
+            "type": "or",
+            "conditions": [
+                {"type": "eq", "field": "category", "value": "tech"},
+                {"type": "eq", "field": "category", "value": "sports"}
+            ]
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_filter_not() {
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "type": "not",
+            "condition": {
+                "type": "eq",
+                "field": "category",
+                "value": "sports"
+            }
+        }
+    });
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_nested_field() {
+    let payload = json!({"user": {"profile": {"name": "John"}}});
+    let value = get_nested_field(&payload, "user.profile.name");
+    assert_eq!(value, Some(&json!("John")));
+}
+
+#[test]
+fn test_no_filter_matches_all() {
+    let payload = json!({"anything": "value"});
+    let filter = json!({});
+    assert!(matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_unknown_condition_type_fails_closed() {
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "type": "eqals",
+            "field": "category",
+            "value": "tech"
+        }
+    });
+    assert!(!matches_filter(&payload, &filter));
+}

--- a/crates/velesdb-wasm/src/filter_tests.rs
+++ b/crates/velesdb-wasm/src/filter_tests.rs
@@ -112,3 +112,31 @@ fn test_unknown_condition_type_fails_closed() {
     });
     assert!(!matches_filter(&payload, &filter));
 }
+
+#[test]
+fn test_missing_condition_type_fails_closed() {
+    // A condition OBJECT with no "type" is an uninterpretable filter, not an
+    // absent one — it funnels into the same fail-closed arm as a typo'd type.
+    // (An absent `condition` key stays permissive: test_no_filter_matches_all.)
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "field": "category",
+            "value": "tech"
+        }
+    });
+    assert!(!matches_filter(&payload, &filter));
+}
+
+#[test]
+fn test_non_string_condition_type_fails_closed() {
+    let payload = json!({"category": "tech"});
+    let filter = json!({
+        "condition": {
+            "type": 7,
+            "field": "category",
+            "value": "tech"
+        }
+    });
+    assert!(!matches_filter(&payload, &filter));
+}

--- a/scripts/inline-tests-baseline.txt
+++ b/scripts/inline-tests-baseline.txt
@@ -147,7 +147,6 @@ crates/velesdb-server/src/lib.rs	461
 crates/velesdb-server/src/rate_limit.rs	48
 crates/velesdb-server/src/tls.rs	40
 crates/velesdb-wasm/src/agent.rs	58
-crates/velesdb-wasm/src/filter.rs	104
 crates/velesdb-wasm/src/fusion.rs	338
 crates/velesdb-wasm/src/graph_persistence.rs	5
 crates/velesdb-wasm/src/graph_store.rs	141


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`evaluate_condition`'s default match arm in `crates/velesdb-wasm/src/filter.rs` returned `true` for any `"type"` it did not recognize (`_ => true`). `search_with_filter` — the WASM/browser SDK's only metadata-filter entry point — passes the parsed filter straight into this evaluator with no validation of `"type"` beyond JSON shape. So a typo'd or unsupported condition type (e.g. `"eqals"` instead of `"eq"`, or a future/unimplemented operator) silently matched *every* payload instead of being rejected, meaning a malformed filter would quietly return unfiltered results to the caller.

This flips the default arm to fail closed (`_ => false`) so an unrecognized condition type excludes rather than includes.

**Review hardening (second commit)**: a condition object with no `"type"` at all — or a non-string one — funnels through `unwrap_or("")` into the same flipped arm, so its behavior changed too, from match-everything to match-nothing, initially without a test or doc saying so. Two tests now pin those cases, the evaluator doc states the fail-closed rule and its boundary (an absent `condition` KEY stays permissive — "no filter" and "an uninterpretable filter" are different claims), and the CHANGELOG records the user-visible change on the published wasm surface. Parity was checked: the only other `_ => true` in production (`hybrid_sparse.rs`) is a legitimate "no filter provided" arm, and the other bindings go through core's typed `Filter`, which rejects unknown operators at parse time — this evaluator was the only JSON-wildcard one.

While adding the regression test, the inline `#[cfg(test)] mod tests { ... }` block in `filter.rs` would have grown past this repo's frozen inline-test-module baseline (`scripts/inline-tests-baseline.txt`, only allowed to shrink). Moved the test module to a sibling `filter_tests.rs`, matching the convention already used throughout the crate (`#[path = "..."] mod tests;`), and updated the baseline to drop the now-empty `filter.rs` entry.

No public API/signature change — `evaluate_condition`/`matches_filter` keep returning `bool`.

Fixes # (no tracked issue; found via a proactive multi-angle code review)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`test_unknown_condition_type_fails_closed`, `test_missing_condition_type_fails_closed`, `test_non_string_condition_type_fails_closed` — plus the existing suite (38 filter tests pass).

Also ran locally on the amended branch:
- `cargo fmt --all -- --check`
- `cargo clippy -p velesdb-wasm --lib -- -D warnings -D clippy::pedantic` (clean)
- `python3 scripts/check-inline-tests.py` / `check-file-budgets.py` / `check-ai-attribution.py` (all pass)

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (evaluator doc + CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code touched.

## High-Risk Change Checklist

N/A — not `hnsw`/`storage`/`Drop`/`unsafe`/SIMD.