### PR TITLE
build(deps): bump h2 0.4.14 -> 0.4.16 (RUSTSEC-2026-0258)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`build/*` → targets `develop`. ✅

## Description

RUSTSEC-2026-0258 was published today against `h2` ≤ 0.4.15: the crate accepted and queued empty DATA frames without limit, risking unbounded memory growth (or a length-overflow panic) when streams are not actively drained. Low severity, patched in 0.4.16. `develop`'s lockfile pins 0.4.14, so the `Security Audit` job (cargo-deny advisories) now fails on every PR until the lock moves.

This is a lockfile-only bump: the `h2` entry's `version` and `checksum` lines change, nothing else. The edit is surgical rather than `cargo update -p h2` because a full re-resolution also churned unrelated `windows-sys`/`windows-link` edges under the local toolchain; the two-line diff keeps the lock otherwise byte-identical. h2 0.4.16 is a patch release with an unchanged dependency set, so no manifest changes follow.

Already validated on #1948's branch, where the same bump took `Security Audit` from red (RUSTSEC-2026-0258) to green.

Fixes # (no tracked issue — advisory published 2026-08-18, breaks CI repo-wide)

## Type of Change

- [x] 🧹 Chore (dependency bump, no code change)

## How Has This Been Tested?

- [x] `cargo metadata --locked` accepts the edited lock (no drift)
- [x] `cargo check -p velesdb-server --locked` clean
- [x] `Security Audit` green with this exact lock on #1948 (run 32116843347)

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A, lockfile only
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — N/A, covered by the Security Audit gate itself
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code touched.

## High-Risk Change Checklist

N/A — not `hnsw`/`storage`/`Drop`/`unsafe`/SIMD.
