### PR TITLE
fix(core): fsync the sparse-index WAL on the acknowledged append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Sparse-index WAL now fsyncs the acknowledged write (power-loss
+  durability).** `wal_append_upsert` / `wal_append_delete` flushed the buffer
+  but never `sync_all`ed, so an upsert carrying `sparse_vectors` could be
+  acknowledged while its bytes sat only in the OS page cache — and sparse
+  vectors are stored nowhere else, so a power loss before the next compaction
+  lost them silently. The append path now shares the BM25 and edge WALs'
+  durability discipline (a single `flush` + `sync_all` per acked append). A
+  process crash was already safe; this closes the power-loss / kernel-panic
+  window.
 - **WASM: a metadata filter with an unrecognized or missing condition `type`
   now matches nothing instead of everything (#1975).** `search_with_filter`'s
   evaluator returned `true` for any `"type"` it did not recognize, so a typo'd

--- a/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
@@ -142,3 +142,34 @@ fn stale_wal_generation_is_not_replayed_over_new_snapshot() {
     std::fs::write(dir.path().join("sparse.wal"), stale_wal).expect("test: restore stale WAL");
     assert_complete_recovery(&dir);
 }
+
+#[test]
+fn wal_append_fsyncs_the_acked_write() {
+    // The sparse WAL append path used to `flush()` only, so an acknowledged
+    // upsert could sit in the page cache and be lost on power loss — and sparse
+    // vectors live nowhere else to rebuild from. It now shares the BM25/edge
+    // durability discipline (one `flush` + `sync_all` per acked append), which
+    // `count_wal_io` observes as a durability barrier (`syncs`).
+    use crate::index::wal_framing::io_counters::count_wal_io;
+
+    let dir = TempDir::new().expect("test: temp dir");
+    let wal_path = dir.path().join("sparse.wal");
+    let v = vector(7, 1.0);
+
+    let (_, counts) = count_wal_io(&wal_path, || {
+        wal_append_upsert(&wal_path, 7, &v).expect("test: append");
+    });
+    assert_eq!(
+        counts.syncs, 1,
+        "an acked upsert must be fsynced exactly once"
+    );
+
+    let (_, del_counts) = count_wal_io(&wal_path, || {
+        crate::index::sparse::persistence::wal_append_delete(&wal_path, 7)
+            .expect("test: delete append");
+    });
+    assert_eq!(
+        del_counts.syncs, 1,
+        "an acked delete must be fsynced exactly once"
+    );
+}

--- a/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_durability_tests.rs
@@ -156,7 +156,7 @@ fn wal_append_fsyncs_the_acked_write() {
     let wal_path = dir.path().join("sparse.wal");
     let v = vector(7, 1.0);
 
-    let (_, counts) = count_wal_io(&wal_path, || {
+    let ((), counts) = count_wal_io(&wal_path, || {
         wal_append_upsert(&wal_path, 7, &v).expect("test: append");
     });
     assert_eq!(
@@ -164,7 +164,7 @@ fn wal_append_fsyncs_the_acked_write() {
         "an acked upsert must be fsynced exactly once"
     );
 
-    let (_, del_counts) = count_wal_io(&wal_path, || {
+    let ((), del_counts) = count_wal_io(&wal_path, || {
         crate::index::sparse::persistence::wal_append_delete(&wal_path, 7)
             .expect("test: delete append");
     });

--- a/crates/velesdb-core/src/index/sparse/persistence_wal.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_wal.rs
@@ -65,7 +65,7 @@ pub fn wal_append_upsert(wal_path: &Path, point_id: u64, vector: &SparseVector) 
     let mut w = open_wal_writer(wal_path)?;
     write_upsert_header(&mut w, total_len, point_id, nnz)?;
     write_term_value_pairs(&mut w, &vector.indices, &vector.values)?;
-    flush_wal(&mut w)
+    flush_wal(&mut w, wal_path)
 }
 
 /// Writes the upsert WAL entry header (length prefix, opcode, point ID, nnz).
@@ -94,10 +94,18 @@ fn write_term_value_pairs(
     Ok(())
 }
 
-/// Flushes the WAL writer, mapping I/O errors to `SparseIndexError`.
-fn flush_wal(w: &mut BufWriter<std::fs::File>) -> Result<()> {
-    w.flush()
-        .map_err(|e| Error::SparseIndexError(format!("WAL flush failed: {e}")))
+/// Flushes AND fsyncs the WAL writer, mapping I/O errors to `SparseIndexError`.
+///
+/// A sparse upsert/delete is acknowledged only after this returns `Ok`, and the
+/// sparse vectors live nowhere else — a lost WAL entry is not rebuilt from any
+/// snapshot or payload. So the acked append path must be durable against power
+/// loss, exactly like the BM25 and edge WALs: this delegates to the shared
+/// `wal_framing::flush_wal` (a single `flush` + `sync_all`) rather than a
+/// buffer-only `flush`, which left acknowledged writes in the page cache. The
+/// framing helper's `Error::Index` is remapped to this module's error contract.
+fn flush_wal(w: &mut BufWriter<std::fs::File>, wal_path: &Path) -> Result<()> {
+    crate::index::wal_framing::flush_wal(w, wal_path, "sparse WAL")
+        .map_err(|e| Error::SparseIndexError(format!("WAL flush/fsync failed: {e}")))
 }
 
 /// Computes the total byte length of an upsert WAL entry using checked arithmetic.
@@ -171,7 +179,7 @@ pub fn wal_append_delete(wal_path: &Path, point_id: u64) -> Result<()> {
     wal_write(&mut w, &total_len.to_le_bytes())?;
     wal_write(&mut w, &[WAL_OP_DELETE])?;
     wal_write(&mut w, &point_id.to_le_bytes())?;
-    flush_wal(&mut w)
+    flush_wal(&mut w, wal_path)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`wal_append_upsert` / `wal_append_delete` flushed the `BufWriter` but never `sync_all`'d, so an upsert carrying `sparse_vectors` was acknowledged with its bytes only in the OS page cache. Sparse vectors are persisted **nowhere else** — not via `MmapStorage`, not via `payloads.log` — so a power loss or kernel panic before the next compaction lost acknowledged writes silently. This is an asymmetry: in the same `upsert()`, the dense vector and payload are fsynced (`log_payload` default `DurabilityMode::Fsync`), and the sibling BM25 and edge WALs already fsync on their acked append path via `wal_framing::flush_wal`.

The sparse append path now delegates its flush to that same shared helper (one `flush` + `sync_all`), remapping its `Error::Index` to the module's `SparseIndexError` contract. A process crash (`kill -9`) was already safe (bytes were in the page cache); this closes the power-loss / kernel-panic window.

Adversarial note: the review flagged this as P0; on second look the process-crash case was never at risk, so the real exposure is power-loss durability — still a correctness gap for a database that acknowledges the write, hence this fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --lib index::sparse` — 23 passed, 0 failed
- New test `wal_append_fsyncs_the_acked_write` asserts the acked upsert and delete each fsync exactly once, observed via the existing `count_wal_io` harness (the same mechanism the BM25 WAL uses)
- `cargo clippy -p velesdb-core --lib` — clean
- `cargo fmt -p velesdb-core -- --check` — clean

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (root CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code touched.

## High-Risk Change Checklist

- [x] Touches a `storage` / WAL durability path
- Scope is confined to the sparse WAL append; on-disk format is unchanged (same bytes, only an added fsync syscall). Replay is untouched. The delegated helper is the one already used by the BM25/edge WALs, and its fault-injection behavior is covered by the existing sparse durability tests.
