### PR TITLE
fix(server): prevent two API-reachable crash/DoS vectors (top_k abort, TLS rate-limit 500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Server: an unbounded `top_k` on hybrid search no longer aborts the
+  process.** The hybrid/fused search path reserved `BinaryHeap::with_capacity(k
+  + 1)` from the caller-supplied `top_k`, which is unclamped there (unlike the
+  dense path). A large value in a `POST /collections/{c}/search/hybrid` body
+  requested a terabyte-scale allocation; the allocation failure calls
+  `handle_alloc_error`, which aborts the whole server rather than failing the
+  request. The reservation is now bounded by the candidate count
+  (`min(k, candidates) + 1`), which changes no result — the heap still trims to
+  `top_k`.
+- **Server: HTTPS + rate limiting now work together.** The manual TLS accept
+  path built its hyper service without injecting `ConnectInfo<SocketAddr>`, so
+  the rate limiter's `SmartIpKeyExtractor` could not extract a key and returned
+  `500` for every HTTPS request that carried no
+  `X-Forwarded-For`/`X-Real-Ip`/`Forwarded` header — i.e. every normal REST
+  client. Since TLS is the recommended production step and rate limiting is on
+  by default, the two were unusable together. The TLS path now inserts
+  `ConnectInfo` per request, exactly as the plaintext path's
+  `into_make_service_with_connect_info` does.
 - **WASM: a metadata filter with an unrecognized or missing condition `type`
   now matches nothing instead of everything (#1975).** `search_with_filter`'s
   evaluator returned `true` for any `"type"` it did not recognize, so a typo'd

--- a/crates/velesdb-core/src/collection/search/text.rs
+++ b/crates/velesdb-core/src/collection/search/text.rs
@@ -284,14 +284,23 @@ impl Collection {
     }
 
     /// Extracts top-k IDs from fused scores using a streaming min-heap.
-    fn top_k_from_scores(
+    pub(super) fn top_k_from_scores(
         fused_scores: rustc_hash::FxHashMap<u64, f32>,
         k: usize,
     ) -> Vec<(u64, f32)> {
         use std::cmp::Reverse;
         use std::collections::BinaryHeap;
 
-        let mut heap: BinaryHeap<Reverse<(OrderedFloat, u64)>> = BinaryHeap::with_capacity(k + 1);
+        // Bound the eager reservation by the candidate count, not by the raw
+        // `k`. The heap holds at most `k + 1` entries transiently, and there are
+        // only `fused_scores.len()` candidates, so `min(k, len) + 1` is an exact
+        // upper bound on what the heap ever needs. A caller-supplied `top_k` is
+        // otherwise unclamped on this (hybrid/fused) path — a huge value made
+        // `with_capacity(k + 1)` request terabytes, and the resulting
+        // allocation failure aborts the whole process rather than the request.
+        // This changes no result: the `heap.len() > k` trim below is untouched.
+        let cap = k.min(fused_scores.len()).saturating_add(1);
+        let mut heap: BinaryHeap<Reverse<(OrderedFloat, u64)>> = BinaryHeap::with_capacity(cap);
         for (id, score) in fused_scores {
             heap.push(Reverse((OrderedFloat(score), id)));
             if heap.len() > k {

--- a/crates/velesdb-core/src/collection/search/text_tests.rs
+++ b/crates/velesdb-core/src/collection/search/text_tests.rs
@@ -192,3 +192,43 @@ fn test_hybrid_search_dimension_mismatch_error() {
     let result = col.hybrid_search(&bad_vec, "rust", 5, None, None);
     assert!(result.is_err(), "wrong dimension should error");
 }
+
+#[test]
+fn test_top_k_from_scores_huge_k_does_not_over_reserve() {
+    // Regression: `top_k_from_scores` reserved `with_capacity(k + 1)` from the
+    // caller-supplied `k`, which is unclamped on the hybrid/fused path. A huge
+    // `k` (reachable from a `POST /search/hybrid` body) requested a terabyte-
+    // scale heap; the allocation failure aborts the whole process. The
+    // reservation is now bounded by the candidate count.
+    //
+    // `1 << 60` is chosen so the *old* code's `(k + 1) * size_of` exceeds
+    // `isize::MAX` — a deterministic `capacity overflow` panic (caught here as a
+    // failure) in both debug and release, rather than a process abort. With the
+    // fix, capacity is `min(k, 3) + 1`, so this simply returns the 3 candidates.
+    let mut fused: rustc_hash::FxHashMap<u64, f32> = rustc_hash::FxHashMap::default();
+    fused.insert(1, 0.9);
+    fused.insert(2, 0.5);
+    fused.insert(3, 0.1);
+
+    let out = Collection::top_k_from_scores(fused, 1usize << 60);
+
+    assert_eq!(out.len(), 3, "cannot return more than the candidate count");
+    // Sorted by descending score.
+    assert_eq!(out[0].0, 1);
+    assert_eq!(out[2].0, 3);
+}
+
+#[test]
+fn test_top_k_from_scores_respects_small_k() {
+    let mut fused: rustc_hash::FxHashMap<u64, f32> = rustc_hash::FxHashMap::default();
+    for id in 0..10u64 {
+        fused.insert(id, id as f32);
+    }
+    let out = Collection::top_k_from_scores(fused, 3);
+    assert_eq!(out.len(), 3, "must trim to k");
+    // Top 3 by score are ids 9, 8, 7.
+    assert_eq!(
+        out.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+        vec![9, 8, 7]
+    );
+}

--- a/crates/velesdb-core/src/collection/search/text_tests.rs
+++ b/crates/velesdb-core/src/collection/search/text_tests.rs
@@ -221,8 +221,11 @@ fn test_top_k_from_scores_huge_k_does_not_over_reserve() {
 #[test]
 fn test_top_k_from_scores_respects_small_k() {
     let mut fused: rustc_hash::FxHashMap<u64, f32> = rustc_hash::FxHashMap::default();
+    // Ascending, distinct scores without a lossy u64->f32 cast (clippy pedantic).
+    let mut score = 0.0f32;
     for id in 0..10u64 {
-        fused.insert(id, id as f32);
+        fused.insert(id, score);
+        score += 1.0;
     }
     let out = Collection::top_k_from_scores(fused, 3);
     assert_eq!(out.len(), 3, "must trim to k");

--- a/crates/velesdb-server/src/main.rs
+++ b/crates/velesdb-server/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::doc_markdown)]
 //! `VelesDB` Server - REST API for the `VelesDB` vector database.
 
-use axum::{http::HeaderValue, middleware::Next, Router};
+use axum::{extract::ConnectInfo, http::HeaderValue, middleware::Next, Router};
 use clap::Parser;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
@@ -300,8 +300,8 @@ async fn tls_accept_loop(
         tokio::select! {
             result = listener.accept() => {
                 match result {
-                    Ok((stream, _peer_addr)) => {
-                        spawn_tls_connection(stream, tls_acceptor.clone(), app.clone(), active_conns.clone());
+                    Ok((stream, peer_addr)) => {
+                        spawn_tls_connection(stream, peer_addr, tls_acceptor.clone(), app.clone(), active_conns.clone());
                     }
                     Err(e) => {
                         tracing::warn!("Failed to accept TCP connection: {e}");
@@ -322,6 +322,7 @@ async fn tls_accept_loop(
 
 fn spawn_tls_connection(
     stream: tokio::net::TcpStream,
+    peer_addr: SocketAddr,
     acceptor: TlsAcceptor,
     app: Router,
     conns: Arc<std::sync::atomic::AtomicUsize>,
@@ -335,8 +336,18 @@ fn spawn_tls_connection(
         };
 
         let io = hyper_util::rt::TokioIo::new(tls_stream);
-        let hyper_service = hyper::service::service_fn(move |request| {
+        let hyper_service = hyper::service::service_fn(move |mut request| {
             let clone = app.clone();
+            // The rate limiter's `SmartIpKeyExtractor` reads `ConnectInfo<SocketAddr>`
+            // from request extensions. The plaintext path supplies it via
+            // `into_make_service_with_connect_info`, but this manual hyper TLS
+            // path builds the service by hand, so it must insert `ConnectInfo`
+            // itself. Without it every HTTPS request that carries no
+            // `X-Forwarded-For`/`X-Real-Ip`/`Forwarded` header (i.e. every
+            // normal REST client) failed key extraction and got a blanket 500,
+            // making TLS + rate limiting — both on by default in production —
+            // unusable together.
+            request.extensions_mut().insert(ConnectInfo(peer_addr));
             async move { clone.oneshot(request).await }
         });
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two independent, API-reachable defects on the serving path, both surfaced by the expert review + adversarial verification pass. Both were confirmed as the highest-severity survivors.

**1. Unbounded `top_k` on hybrid search aborts the process (core).** `Collection::top_k_from_scores` reserved `BinaryHeap::with_capacity(k + 1)` from the caller-supplied `top_k`, which is *unclamped* on the hybrid/fused path — the dense path caps via `BoundedTopK`'s `.min(4096)`, but hybrid has its own uncapped `top_k_from_scores`. A large value in a `POST /collections/{c}/search/hybrid` body (unauthenticated by default) requested a terabyte-scale allocation; the failure calls `handle_alloc_error`, which **aborts the whole server** — not catchable in the `spawn_blocking` worker. The reservation is now bounded by the candidate count (`min(k, candidates) + 1`), an exact upper bound on what the streaming min-heap ever holds. **No result changes** — the `heap.len() > k` trim is untouched.

**2. HTTPS + rate limiting return 500 for every normal client (server).** The manual TLS accept loop built its hyper service via `service_fn` without inserting `ConnectInfo`, so the `GovernorLayer`'s `SmartIpKeyExtractor` could not extract a client key and returned `500` for every HTTPS request that carried no `X-Forwarded-For`/`X-Real-Ip`/`Forwarded` header (i.e. every normal REST client). TLS is the recommended production step and rate limiting is on by default (`DEFAULT_RATE_LIMIT = 100`), so the two were unusable together. The TLS path now inserts `ConnectInfo(peer_addr)` into each request's extensions, exactly as the plaintext path's `into_make_service_with_connect_info` does.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --features persistence --lib collection::search::text_tests` — 10 passed, 0 failed. New: `test_top_k_from_scores_huge_k_does_not_over_reserve` (uses `k = 1<<60`, a deterministic capacity-overflow panic under the old code in both debug and release) and `test_top_k_from_scores_respects_small_k`.
- `cargo build -p velesdb-server` — clean; `cargo clippy -p velesdb-server --all-targets` + `-p velesdb-core --lib` — clean; `cargo fmt --check` — clean.

**Known coverage gap (called out honestly):** the TLS + `GovernorLayer` combination has no integration test in the tree — a real handshake + rate-limit exercise would need self-signed cert generation and load, and would be flaky. The fix is a direct mirror of the working plaintext path; the abort-vector for `top_k` is covered by a unit test.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (root CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (top_k; TLS gap noted above)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code touched.

## High-Risk Change Checklist

N/A — no `hnsw`/`storage`/`Drop`/`unsafe`/SIMD paths touched. The `top_k` change is allocation-sizing only; the TLS change is request-extension plumbing.