### PR TITLE
refactor(core): drop superfluous unsafe Send/Sync impls; align guard docs; fail-closed doctrine

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -548,20 +548,15 @@ impl NativeHnswInner {
 // Send + Sync for thread safety
 // ============================================================================
 
-// SAFETY: `NativeHnswInner` is `Send` because ownership transfer preserves invariants.
-// - Condition 1: Internal mutability is synchronized via `parking_lot::RwLock`/atomics.
-// - Condition 2: No thread-affine resources are stored in the wrapper.
-// SAFETY: Moving the index wrapper between threads is sound.
-unsafe impl Send for NativeHnswInner {}
-// SAFETY: `NativeHnswInner` is `Sync` because shared references are concurrency-safe.
-// - Condition 1: Concurrent access to mutable graph state is lock/atomic protected.
-// - Condition 2: Exposed APIs do not bypass synchronization primitives.
-// SAFETY: `&NativeHnswInner` can be shared safely across threads.
-unsafe impl Sync for NativeHnswInner {}
-
-// Compile-time assertion: NativeHnswInner must satisfy Send + Sync.
-// If the struct gains a non-Send/Sync field, this causes a build error
-// rather than a subtle runtime data race.
+// `NativeHnswInner` is auto-`Send + Sync`: every field is either lock/atomic
+// protected or itself `Send + Sync`. Its only raw pointer lives in
+// `ContiguousVectors` (`perf_optimizations.rs`), which carries its own audited
+// `unsafe impl Send`/`Sync` — so that `NonNull` is already "whitewashed" one
+// level down, and `NativeHnswInner` needs no `unsafe impl` of its own. An
+// unconditional `unsafe impl` here would be worse than nothing: it would
+// silently mask a future non-`Send` field. The compile-time assertion below is
+// the real guard — with no `unsafe impl` shadowing it, adding a `!Send`/`!Sync`
+// field breaks the build here instead of introducing a subtle data race.
 const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<NativeHnswInner>();

--- a/crates/velesdb-core/src/simd_native/dispatch/mod.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/mod.rs
@@ -195,16 +195,16 @@ impl std::fmt::Debug for DistanceEngine {
     }
 }
 
-// SAFETY: `DistanceEngine` stores only plain function pointers and a `usize`.
-// - Condition 1: All fields are `fn(...)` pointers and `usize`, both inherently `Send`.
-// - Condition 2: No interior mutability or non-`Send` types like `Rc`, raw pointers, or thread-local refs.
-// SAFETY: Function pointers are safe to transfer across threads.
-unsafe impl Send for DistanceEngine {}
-// SAFETY: Function pointers are immutable references to static code.
-// - Condition 1: All fields are `fn(...)` pointers and `usize`, both inherently `Sync`.
-// - Condition 2: No mutable shared state; the struct is read-only after construction.
-// SAFETY: Multiple threads can safely share a `&DistanceEngine` for distance computation.
-unsafe impl Sync for DistanceEngine {}
+// `DistanceEngine` holds only `fn(...)` pointers and a `usize`, all of which are
+// `Send + Sync` by construction, so the auto-derived impls are correct — an
+// explicit `unsafe impl` would only be noise (and, being unconditional, would
+// silently mask a future non-`Send` field). This compile-time assertion is the
+// real guard: adding a `!Send`/`!Sync` field breaks the build here rather than
+// permitting a data race.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<DistanceEngine>();
+};
 
 impl DistanceEngine {
     /// Creates a distance engine and resolves SIMD kernels once for `dimension`.

--- a/crates/velesdb-core/src/storage/guard.rs
+++ b/crates/velesdb-core/src/storage/guard.rs
@@ -8,8 +8,13 @@
 //! gracefully.
 //!
 //! The `Deref` and `AsRef<[f32]>` implementations exist for ergonomics in
-//! contexts where panicking on epoch mismatch is acceptable (e.g., short-lived
-//! guards within a single function scope where remap cannot happen).
+//! short-lived, single-scope contexts where a remap cannot happen. On an epoch
+//! mismatch they return `&[]` and log (they do **not** panic — a panicking
+//! `Deref` is an anti-pattern). In production that branch is unreachable: the
+//! guard holds the mmap read lock for its whole lifetime, and the epoch is only
+//! bumped under the mmap *write* lock, so the epoch cannot change while a guard
+//! is alive. The `&[]` fallback is defense in depth, exercised directly by the
+//! guard tests (which force a mismatch via the shared epoch counter).
 
 use memmap2::MmapMut;
 use parking_lot::RwLockReadGuard;
@@ -55,7 +60,11 @@ use std::sync::atomic::AtomicU64;
 /// # Epoch Validation
 ///
 /// The guard captures the epoch at creation and validates it on each access.
-/// If the mmap was remapped (epoch changed), access panics to prevent UB.
+/// If the mmap was remapped (epoch changed), the fallible accessors
+/// ([`as_slice`](Self::as_slice) / [`try_deref`](Self::try_deref)) return
+/// `Error::EpochMismatch`, and the infallible `Deref`/`AsRef` return `&[]` with
+/// a logged error (they do not panic). The read lock the guard holds makes an
+/// in-flight remap impossible, so that mismatch is unreachable in practice.
 ///
 /// The epoch uses wrapping `u64` arithmetic. Overflow is theoretically possible
 /// after 2^64 remaps (~584 years at 1B/sec) but practically irrelevant.

--- a/docs/contributing/CODING_RULES.md
+++ b/docs/contributing/CODING_RULES.md
@@ -89,6 +89,19 @@ flaky/random tests.
 - `cargo audit` and `cargo deny check` must pass.
 - No `unsafe` without a documented `// SAFETY:` comment.
 - Validate all user input; no secrets in code.
+- **Fail closed on untrusted shapes.** Any matcher, guard, or evaluator that
+  interprets untrusted input — filter conditions, operator dispatch, mode/type
+  parsing, wire-format tags — must treat an *unknown, absent, or malformed*
+  shape as no-match / error, never as match-all. This is enforced by mechanism,
+  not just convention:
+  - **In-crate enums** (`#[non_exhaustive]` defined in this workspace): match
+    exhaustively with **no permissive wildcard**, so a new variant breaks the
+    build until it is handled. Exemplar:
+    `collection::search::query::match_exec::where_eval::eval_match_condition`.
+  - **Cross-crate enums** (the compiler forces a wildcard): the wildcard must be
+    `_ => false` / `_ => Err(..)`, **never** `_ => true` / `_ => Ok(true)`, and
+    must carry a regression test. Exemplar: `velesdb-wasm`'s `filter::evaluate_condition`
+    with `filter_tests.rs`'s fail-closed cases.
 
 ---
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*`… targets `develop`. ✅ (branch prefix `fix/`)

## Description

Soundness-hygiene items from #1981, each **adversarially reviewed** (confirmed real, fix confirmed zero-perf-cost and non-churning). No behavior change.

**1. Superfluous `unsafe impl Send/Sync` removed (items 4).** `DistanceEngine` (fn-pointers + `usize`) and `NativeHnswInner` are both already auto-`Send + Sync`: the only raw pointer in the HNSW tree lives in `ContiguousVectors`, which carries its own audited `unsafe impl`, so it is whitewashed one level down. An *unconditional* `unsafe impl` is worse than none — it silently masks a future non-`Send` field, and the accompanying comment claimed a compile-time guard it did not provide. Both types now rely on the auto-derive plus a `const _: fn() = || assert_send_sync::<T>()` assertion, which — with no `unsafe impl` shadowing it — is *now* the real build-time guard the comment promises. The build passing is the proof the auto-derive suffices. Soundness of the `NonNull` is unchanged (still carried entirely by `ContiguousVectors`).

**2. `VectorSliceGuard` doc/impl drift fixed (item 7).** The module and type docs said `Deref`/`AsRef` "panic" on epoch mismatch; the impls actually return `&[]` and log. The guard holds the mmap read lock for its lifetime and the epoch only bumps under the *write* lock, so the mismatch is unreachable in production — the `&[]` fallback is defense in depth, and is exercised directly by the existing guard tests (which force a mismatch via the shared epoch counter). Docs now match the code. (A panicking `Deref` would be an anti-pattern, so the fix is doc-side; the adversarial pass initially suggested a `debug_assert!` on the branch, but that would break the tests that deliberately exercise the `&[]` fallback — so it was dropped.)

**3. Fail-closed doctrine documented (item 6).** `CODING_RULES.md` §Security now states the rule that matchers/guards on untrusted shapes fail closed, anchored to the *executable* mechanisms already in the tree (exhaustive in-crate match with no permissive wildcard; `_ => false`/`Err` + regression test cross-crate). No code change — the audit found no un-fixed fail-open site beyond `filter.rs` (#1975/#1977).

## Type of Change

- [x] 🧹 Refactor / hardening (no behavior change)
- [x] 📝 Documentation

## How Has This Been Tested?

- `cargo build -p velesdb-core` — clean (proves the auto-derive suffices; the assertions compile)
- `cargo test -p velesdb-core --lib storage::guard` — 6 passed (the `&[]`-on-mismatch tests still pass — no behavior change)
- `cargo clippy -p velesdb-core --all-targets --all-features` — clean
- `cargo fmt --check` — clean

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

- [x] This PR **removes** four `unsafe impl` blocks that were superfluous; it adds none. The remaining `unsafe` in `ContiguousVectors` (the actual `NonNull` guard) is untouched.

## High-Risk Change Checklist

N/A — no `hnsw`/`storage`/`Drop`/SIMD *logic* touched; only the `unsafe impl` declarations (replaced by verified auto-derive) and documentation.
