### PR TITLE
build(core): bridge the loom feature to cfg(loom) so the concurrency tests actually run

### DIFF
--- a/crates/velesdb-core/build.rs
+++ b/crates/velesdb-core/build.rs
@@ -1,0 +1,24 @@
+//! Bridges the `loom` Cargo feature to the `cfg(loom)` the concurrency tests
+//! and `src/sync.rs` gate on.
+//!
+//! The loom tests are gated with a raw `#[cfg(loom)]` (loom's own convention),
+//! but `loom` is exposed as a Cargo *feature*, which only ever sets
+//! `cfg(feature = "loom")` — never `cfg(loom)`. Without this bridge the natural
+//! developer command `cargo test --features loom` compiled the loom crate yet
+//! ran zero tests, because the `#[cfg(loom)]` gates stayed inactive. (CI already
+//! sets `RUSTFLAGS="--cfg loom"` explicitly, so this only fixes the local
+//! developer experience; passing `--cfg loom` twice is idempotent.)
+//!
+//! `cfg(loom)` is registered for the unexpected-cfgs lint in `Cargo.toml`
+//! (`[lints.rust] unexpected_cfgs`); it is re-registered here so the crate also
+//! builds cleanly when compiled by a bare `rustc` invocation that does not read
+//! those manifest lints.
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(loom)");
+    // `CARGO_FEATURE_LOOM` is set by Cargo whenever the `loom` feature is on.
+    if std::env::var_os("CARGO_FEATURE_LOOM").is_some() {
+        println!("cargo::rustc-cfg=loom");
+    }
+    // Only re-run when this file changes; the crate has no other build inputs.
+    println!("cargo::rerun-if-changed=build.rs");
+}

--- a/crates/velesdb-core/src/sync.rs
+++ b/crates/velesdb-core/src/sync.rs
@@ -14,9 +14,22 @@
 //!
 //! # Testing with Loom
 //!
+//! The loom tests are gated on `cfg(loom)`. The crate's `build.rs` bridges the
+//! `loom` Cargo feature to that cfg, so the feature flag alone is enough — no
+//! `RUSTFLAGS` needed. Both the integration models and the storage models
+//! additionally require the `persistence` feature:
+//!
 //! ```bash
-//! cargo +nightly test --features loom --test loom_tests
+//! # Integration models (tests/loom_tests.rs):
+//! cargo test -p velesdb-core --features loom,persistence --test loom_tests
+//! # Storage models (src/storage/loom_tests.rs, a unit-test target):
+//! cargo test -p velesdb-core --features loom,persistence --lib storage::loom
 //! ```
+//!
+//! CI runs the same models on a schedule with `RUSTFLAGS="--cfg loom"` set
+//! explicitly (`quality-deep.yml`); the build.rs makes local runs work without
+//! it. Note: these validate hand-written loom *models* of the lock ordering,
+//! not the production `parking_lot`/`dashmap` types directly.
 //!
 //! # EPIC-023: Loom Concurrency Testing
 

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -907,12 +907,24 @@ design is the baseline for correctness validation.
 
 ### Running Loom Tests
 
+These validate **hand-written loom models** of the lock ordering
+(`tests/loom_tests.rs`, `src/storage/loom_tests.rs`), not the production
+`parking_lot`/`dashmap` types directly. The tests gate on `cfg(loom)`; the
+crate's `build.rs` bridges the `loom` Cargo feature to that cfg, so the feature
+flag alone activates them — `RUSTFLAGS="--cfg loom"` is **not** required locally
+(CI still sets it explicitly, which is harmless — the cfg is idempotent). A bare
+`cargo test --features loom` (without the bridge) would compile loom but run
+zero tests, which is the trap the build.rs removes.
+
 ```bash
-# Run all loom tests
-cargo +nightly test --features loom,persistence --test loom_tests
+# Integration models (tests/loom_tests.rs)
+cargo test -p velesdb-core --features loom,persistence --test loom_tests
+
+# Storage models (src/storage/loom_tests.rs, a unit-test target)
+cargo test -p velesdb-core --features loom,persistence --lib storage::loom
 
 # With limited preemptions (faster)
-LOOM_MAX_PREEMPTIONS=2 cargo +nightly test --features loom,persistence --test loom_tests
+LOOM_MAX_PREEMPTIONS=2 cargo test -p velesdb-core --features loom,persistence --test loom_tests
 ```
 
 ### Stress Testing


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`build/*`… → targets `develop`. ✅ (branch prefix `fix/`)

## Description

Item 3 of #1981, **adversarially reviewed** — and the review plus my own CI check narrowed it: the loom models **do** run in CI (the scheduled `quality-deep.yml` and `compat-matrix.yml` jobs set `RUSTFLAGS="--cfg loom"` explicitly). The real gap is the **local developer path**: the loom tests gate on a raw `#[cfg(loom)]`, but `loom` is a Cargo *feature* (only sets `cfg(feature = "loom")`), and nothing bridged the two locally — so the documented command `cargo test --features loom --test loom_tests` compiled loom yet ran **zero tests**. That is the "green but empty" trap for anyone writing a new concurrent path and testing it locally.

**Fix:** a 6-line `build.rs` maps `CARGO_FEATURE_LOOM` → `--cfg loom` (the loom-standard pattern). The natural feature command now discovers all models with no `RUSTFLAGS`.

- Verified locally: `cargo test -p velesdb-core --features loom,persistence --test loom_tests -- --list` went from **0 → 5 tests**.
- **Safe for CI**: the normal `Tests` job passes no `--features loom`, so `cfg(loom)` stays off there and nothing new runs; the loom jobs already set `RUSTFLAGS="--cfg loom"`, and `--cfg loom` is idempotent. The default build is unchanged (the `build.rs` is a no-op without the feature — confirmed by a clean `cargo check -p velesdb-core`).
- Docs (`sync.rs`, `CONCURRENCY_MODEL.md`) corrected: the models are **hand-written loom models** of the lock ordering (not the production `parking_lot`/`dashmap` types), the feature flag alone now suffices locally, and both the integration and storage models require `persistence`.

**Not done (deliberately):** `crate::sync` remains an unused on-ramp (0 production consumers; the models use `loom::sync` directly). Removing it is a breaking `pub`-API change, and routing production through it is blocked by `dashmap`/`parking_lot` APIs loom can't model — so that decision is left to you rather than churned here.

## Type of Change

- [x] 🧰 Build/tooling (makes an existing test harness actually run locally)
- [x] 📝 Documentation

## How Has This Been Tested?

- `cargo test -p velesdb-core --features loom,persistence --test loom_tests -- --list` → 5 tests (was 0)
- `cargo check -p velesdb-core --features loom,persistence` → clean (build.rs activates cfg(loom) without RUSTFLAGS; no unexpected-cfg warning)
- `cargo check -p velesdb-core` (no loom) → clean (default build unaffected)
- `cargo fmt --check` — clean; file-budget guard — clean

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

N/A — no `unsafe` touched.

## High-Risk Change Checklist

N/A — no runtime logic changed; `build.rs` only emits a cfg for `--features loom` builds.
