### PR TITLE
fix(core): fsync the parent directory after renaming config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Collection config write now fsyncs the parent directory (power-loss
+  durability).** `save_config` fsynced the temp file and renamed it atomically,
+  but never fsynced the directory, so the rename of `config.json` — which is
+  authoritative and non-reconstructible (HNSW params, storage mode, advanced
+  config) — was not guaranteed durable. A power loss right after creating or
+  reconfiguring a collection could leave a data directory whose collection has
+  no loadable config. The write now applies the same `sync_parent_directory`
+  barrier `storage::atomic_write` uses everywhere else. Off the hot path.
+
 - **WASM: a metadata filter with an unrecognized or missing condition `type`
   now matches nothing instead of everything (#1975).** `search_with_filter`'s
   evaluator returned `true` for any `"type"` it did not recognize, so a typo'd

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -361,6 +361,13 @@ impl Collection {
         writer.flush()?;
         writer.get_ref().sync_all()?;
         std::fs::rename(&tmp_path, &config_path)?;
+        // The file contents are fsynced above, but the *rename* is only durable
+        // once the directory entry is fsynced. `config.json` is authoritative
+        // and not reconstructible (HNSW params, storage mode, advanced config),
+        // so a power loss right after a create/reconfigure could otherwise leave
+        // a data directory whose collection has no loadable config. This mirrors
+        // the barrier `storage::atomic_write` applies everywhere else.
+        crate::storage::atomic_write::sync_parent_directory(&config_path)?;
         Ok(())
     }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

The one **real durability gap** surviving the adversarial pass on #1981 item 1 (the other four sub-claims were refuted or downgraded — the snapshot path already has the full barrier, the HNSW dump is a replay-reconciled derived artifact, and the stats file is a best-effort cache).

`save_config` fsyncs the temp file and renames it atomically, but never fsyncs the parent directory — so the *rename* of `config.json` is not guaranteed durable. Unlike the derived artifacts, `config.json` is authoritative and not reconstructible (HNSW params, storage mode, advanced config), so a power loss right after creating or reconfiguring a collection could leave a data directory whose collection has no loadable config. The fix adds the `sync_parent_directory` barrier that `storage::atomic_write` already applies everywhere else.

The original review claimed this path "lacks `sync_all`" — that was wrong (the content *is* fsynced); the actual gap is only the parent-directory fsync, which is what this changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo build -p velesdb-core --features persistence` — clean
- `cargo test -p velesdb-core --features persistence --lib collection::core::flush` — 5 passed
- `cargo clippy -p velesdb-core --all-targets --all-features` — clean; `cargo fmt --check` — clean

Directory fsync is not unit-observable in isolation (same as the sparse-WAL fsync in #1978); the change is a one-line application of the crate's established atomic-write discipline, off the hot path.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

N/A — no `unsafe` touched.

## High-Risk Change Checklist

- [x] Touches a storage durability path (collection config write). Scope is one added `sync_parent_directory` call after the existing atomic rename; no format change, no behavior change beyond the added barrier. The `test-fault-injection` hook and existing flush tests are untouched and pass.

## Follow-up (not in this PR)

The adversarial review's class-closer — a CI guard banning `File::create(...).flush()` (state/WAL paths) outside the `atomic_write`/`flush_wal` helpers — is tracked in #1981 as a separate item; it is prevention, not a bug, and warrants its own guard-script PR.