### PR TITLE
fix(wasm): reject size-overflowing v1 import; saturating capacity hints

### DIFF
--- a/crates/velesdb-wasm/CHANGELOG.md
+++ b/crates/velesdb-wasm/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-sourcing; output is unchanged. (Issue #1545.)
 
 ### Fixed
+- **`import_from_bytes` (v1) rejects a size-overflowing blob instead of
+  aborting.** `import_v1` computed `count * dimension` and `count * vector_size`
+  unchecked. On `wasm32` (32-bit `usize`, `overflow-checks` off in release) a
+  hostile or corrupt blob could wrap those products, spoof the length guard, and
+  read out of bounds — a panic that `panic = "abort"` turns into a module abort.
+  The size arithmetic moved into a checked `v1_layout` helper that returns a
+  clean error (matching the v2 path). The capacity hints in `reserve()` and the
+  `with_capacity` constructor also use `saturating_mul` so a 32-bit wasm build
+  cannot silently under-reserve.
 - **JOIN `ON` condition side order (#1555)**: `ON joined.col = base.col`
   silently matched nothing (every row came back with NULL joined columns)
   because the join key resolution read the two sides of the condition

--- a/crates/velesdb-wasm/src/coverage_v3_tests.rs
+++ b/crates/velesdb-wasm/src/coverage_v3_tests.rs
@@ -276,3 +276,26 @@ fn test_enrich_row_skips_when_referenced_payload_not_object() {
     // A non-object referenced payload merges nothing.
     assert!(data["b"].as_object().expect("test: b is object").len() <= 3);
 }
+
+#[test]
+fn v1_layout_rejects_size_overflow() {
+    // Regression: `import_v1` computed `count * dimension` and
+    // `count * vector_size` unchecked. On wasm32 (32-bit usize) a hostile blob
+    // could wrap those, spoof the length guard, and read out of bounds; the
+    // checked `v1_layout` now returns an error instead. Native usize is 64-bit,
+    // so this uses u64-overflowing values to exercise the same checked path.
+    use crate::serialization::v1_layout;
+
+    let err =
+        v1_layout(2_000_000_000, u32::MAX as usize).expect_err("count * vector_size must overflow");
+    assert!(err.contains("overflow"), "unexpected error: {err}");
+
+    // A sane layout is accepted and its sizes are exact.
+    let ok = v1_layout(2, 4).expect("sane layout");
+    assert_eq!(ok.total_floats, 8);
+    assert_eq!(ok.data_bytes_len, 16);
+    assert_eq!(
+        ok.expected_size,
+        crate::serialization::HEADER_SIZE + 2 * (8 + 16)
+    );
+}

--- a/crates/velesdb-wasm/src/serialization.rs
+++ b/crates/velesdb-wasm/src/serialization.rs
@@ -222,6 +222,41 @@ fn import_v2(bytes: &[u8]) -> Result<VectorStore, JsValue> {
 }
 
 /// Reads the legacy v1 format (id + f32 vectors only; Full mode, no payloads).
+/// Checked byte/element sizes for a v1 blob body.
+#[derive(Debug)]
+pub(crate) struct V1Layout {
+    /// Total expected blob length (header + all `count` vector records).
+    pub expected_size: usize,
+    /// Bytes of vector data per record (`dimension * 4`).
+    pub data_bytes_len: usize,
+    /// Total `f32` elements across all vectors (`count * dimension`).
+    pub total_floats: usize,
+}
+
+/// Computes the [`V1Layout`] for `count` vectors of `dimension` floats, or an
+/// error string on any size-arithmetic overflow.
+///
+/// Every product is `checked_*`. On `wasm32` `usize` is 32-bit and
+/// `overflow-checks` is off in release, so an unchecked `count * dimension`
+/// (or `count * vector_size`) could wrap, spoof `import_v1`'s length guard, and
+/// admit an out-of-bounds read on a hostile or corrupt blob. Returns `String`
+/// (not `JsValue`) so it is unit-testable off `wasm32`.
+pub(crate) fn v1_layout(count: usize, dimension: usize) -> Result<V1Layout, String> {
+    const OVERFLOW: &str = "Invalid data: vector size arithmetic overflow";
+    let data_bytes_len = dimension.checked_mul(4).ok_or(OVERFLOW)?;
+    let vector_size = data_bytes_len.checked_add(8).ok_or(OVERFLOW)?;
+    let expected_size = count
+        .checked_mul(vector_size)
+        .and_then(|body| body.checked_add(HEADER_SIZE))
+        .ok_or(OVERFLOW)?;
+    let total_floats = count.checked_mul(dimension).ok_or(OVERFLOW)?;
+    Ok(V1Layout {
+        expected_size,
+        data_bytes_len,
+        total_floats,
+    })
+}
+
 fn import_v1(bytes: &[u8]) -> Result<VectorStore, JsValue> {
     if bytes.len() < HEADER_SIZE {
         return Err(JsValue::from_str("Invalid data: too short"));
@@ -239,21 +274,24 @@ fn import_v1(bytes: &[u8]) -> Result<VectorStore, JsValue> {
         bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15], bytes[16], bytes[17],
     ]) as usize;
 
-    // Validate data size
-    let vector_size = 8 + dimension * 4;
-    let expected_size = HEADER_SIZE + count * vector_size;
-    if bytes.len() < expected_size {
+    // Validate data size with checked arithmetic (see `v1_layout`): on wasm32
+    // `usize` is 32-bit and `overflow-checks` is off in release, so an unchecked
+    // `count * dimension` could wrap, spoof the length guard, and admit an
+    // out-of-bounds read on a hostile/corrupt blob.
+    let layout = v1_layout(count, dimension).map_err(|e| JsValue::from_str(&e))?;
+    if bytes.len() < layout.expected_size {
         return Err(JsValue::from_str(&format!(
-            "Invalid data: expected {expected_size} bytes, got {}",
+            "Invalid data: expected {} bytes, got {}",
+            layout.expected_size,
             bytes.len()
         )));
     }
 
     // Perf: Pre-allocate contiguous buffers
     let mut ids = Vec::with_capacity(count);
-    let total_floats = count * dimension;
+    let total_floats = layout.total_floats;
     let mut data = vec![0.0_f32; total_floats];
-    let data_bytes_len = dimension * 4;
+    let data_bytes_len = layout.data_bytes_len;
 
     // Read all IDs first (cache-friendly sequential access)
     let mut offset = HEADER_SIZE;

--- a/crates/velesdb-wasm/src/store_new.rs
+++ b/crates/velesdb-wasm/src/store_new.rs
@@ -37,20 +37,26 @@ pub fn create_with_capacity(
 ) -> VectorStore {
     let mut store = create_store(dimension, metric, storage_mode);
     store.ids.reserve(capacity);
+    // These are capacity hints; `saturating_mul` keeps a 32-bit-usize wasm32
+    // build from silently under-reserving on a huge `capacity` (a wrapping `*`
+    // would). A genuinely oversized request still aborts on allocation.
+    let elems = capacity.saturating_mul(dimension);
     match storage_mode {
-        StorageMode::Full => store.data.reserve(capacity * dimension),
+        StorageMode::Full => store.data.reserve(elems),
         StorageMode::SQ8 => {
-            store.data_sq8.reserve(capacity * dimension);
+            store.data_sq8.reserve(elems);
             store.sq8_mins.reserve(capacity);
             store.sq8_scales.reserve(capacity);
         }
         StorageMode::Binary => {
             let bytes_per = dimension.div_ceil(8);
-            store.data_binary.reserve(capacity * bytes_per);
+            store
+                .data_binary
+                .reserve(capacity.saturating_mul(bytes_per));
         }
         // ProductQuantization/RaBitQ fall back to SQ8 in WASM context
         StorageMode::ProductQuantization | StorageMode::RaBitQ => {
-            store.data_sq8.reserve(capacity * dimension);
+            store.data_sq8.reserve(elems);
             store.sq8_mins.reserve(capacity);
             store.sq8_scales.reserve(capacity);
         }

--- a/crates/velesdb-wasm/src/vector_store.rs
+++ b/crates/velesdb-wasm/src/vector_store.rs
@@ -580,7 +580,11 @@ impl VectorStore {
     #[wasm_bindgen]
     pub fn reserve(&mut self, additional: usize) {
         self.ids.reserve(additional);
-        self.data.reserve(additional * self.dimension);
+        // `reserve` is a capacity hint, so a `saturating_mul` (rather than a
+        // wrapping `*`) keeps a 32-bit-usize wasm32 build from silently
+        // under-reserving on a huge `additional`; a genuinely oversized request
+        // still aborts on allocation, which is the caller's explicit ask.
+        self.data.reserve(additional.saturating_mul(self.dimension));
     }
 
     /// Batch insert. Input: `[[id, Float32Array], ...]`.
@@ -598,7 +602,8 @@ impl VectorStore {
             }
         }
         self.ids.reserve(batch.len());
-        self.data.reserve(batch.len() * self.dimension);
+        self.data
+            .reserve(batch.len().saturating_mul(self.dimension));
         for (id, vector) in batch {
             if let Some(idx) = self.ids.iter().position(|&x| x == id) {
                 self.remove_at_index(idx);


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Item 5 of #1981, **adversarially reviewed and re-scoped**: only `import_v1` is a real (bounded) DoS; `import_v2` is already protected (the original claim was inaccurate), and `reserve`/`with_capacity` are P3 hygiene.

**`import_v1` — real DoS, now a clean error.** It computed `count * dimension` and `count * vector_size` unchecked. On `wasm32` (`usize` is 32-bit, `overflow-checks` off in release) a hostile or corrupt blob — reachable via `import_from_bytes` / `VectorStore.load()` — could wrap those products, spoof the length guard, and read out of bounds: a panic that `panic = "abort"` turns into a module abort. The adversarial pass confirmed all memory accesses are bounds-checked, so this was a DoS, not corruption; the fix turns the abort into a clean error. The size arithmetic moved into a checked `v1_layout` helper returning a `String` error (matching the v2 path's overflow family), which is also **unit-testable off `wasm32`** (the public `import_from_bytes` returns `JsValue`, which is not).

**`reserve`/`with_capacity` — hygiene.** `Vec::reserve` is a hint, so a wrap only under-reserves and re-grows; these now use `saturating_mul` so a 32-bit wasm build cannot silently under-reserve. A genuinely oversized request still aborts on allocation (the caller's explicit ask) — unchanged.

**Not touched:** `import_v2` (already guarded).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New native regression test `v1_layout_rejects_size_overflow` (uses u64-overflowing values to exercise the same checked path native usize can reach): passes; the old unchecked code would panic on overflow in a debug/test build.
- `cargo test -p velesdb-wasm --lib` — 663 passed, 0 failed (serialization round-trip unchanged)
- `cargo clippy -p velesdb-wasm --all-targets --all-features` — clean; `cargo fmt --check` — clean; inline-tests and file-budget guards — clean

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

- [x] The existing `unsafe` bulk-copy block in `import_v1` is untouched; the change only makes the sizes feeding it (and the length guard) overflow-checked, which strengthens that block's precondition.

## High-Risk Change Checklist

N/A — no `hnsw`/`storage`/`Drop`/SIMD paths; the change is bounds arithmetic on the import path.