### PR TITLE
chore(deps): remove three unused dependencies found by cargo-machete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6885,7 +6885,6 @@ dependencies = [
  "arc-swap",
  "atomicwrites",
  "bytemuck",
- "bytes",
  "clap",
  "criterion",
  "dashmap",
@@ -7005,7 +7004,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "tracing",
  "uniffi",
  "velesdb-core",
 ]
@@ -7017,7 +7015,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "serde",
  "serde_json",
  "velesdb-memory",
 ]

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -41,9 +41,6 @@ version = "0.12"
 [dependencies.arc-swap]
 version = "1.9"
 
-[dependencies.bytes]
-version = "1.11"
-
 [dependencies.rustc-hash]
 version = "2.1"
 

--- a/crates/velesdb-mobile/Cargo.toml
+++ b/crates/velesdb-mobile/Cargo.toml
@@ -30,7 +30,6 @@ parking_lot = "0.12"
 thiserror = "2.0"
 serde = { workspace = true }
 serde_json = "1.0"
-tracing = "0.1"
 
 # iOS targets (add via: rustup target add <target>)
 # - aarch64-apple-ios (device)
@@ -52,9 +51,6 @@ loom = ["velesdb-core/loom"]
 [dev-dependencies]
 tempfile = "3.14"
 
-# tokio is required as async runtime by uniffi's "tokio" feature — not directly imported
-[package.metadata.cargo-machete]
-ignored = ["tokio"]
 
 [lints]
 workspace = true

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -32,7 +32,6 @@ crate-type = ["cdylib"]
 velesdb-memory = { path = "../velesdb-memory", default-features = false, features = ["persistence", "embedder-http", "extractor-http", "context"] }
 napi = { version = "3", default-features = false, features = ["napi9", "serde-json"] }
 napi-derive = "3"
-serde = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`chore/*` → targets `develop`. ✅

## Description

First deliverable of the quality-toolchain plan (#1987). `cargo-machete` was run on the whole workspace; each finding was **verified individually before removal** (grep across each crate's src/tests/benches — zero usage, no macro or feature indirection):

- **`velesdb-core` → `bytes`**: declared, never imported. The "prefer `Bytes`" zero-copy note in `CODING_RULES.md` was an intention never realized — the crate uses `&[u8]`/`memmap2` directly.
- **`velesdb-node` → `serde`**: napi's `serde-json` feature carries its own serde; the crate-level dep was unused.
- **`velesdb-mobile` → `tracing`**: never imported.

Also drops `velesdb-mobile`'s stale `[package.metadata.cargo-machete] ignored = ["tokio"]`: machete now *detects* tokio as used (uniffi's `tokio` feature), so the ignore entry only masked a real future signal.

The lockfile diff is exactly the three dependency edges — no version moves.

## Type of Change

- [x] 🧹 Chore (dependency hygiene, no code change)

## How Has This Been Tested?

- `cargo check` — clean on `velesdb-core` (persistence), `velesdb-node`, `velesdb-mobile`
- `cargo machete` — reports the whole workspace clean (zero unused deps, zero stale ignores)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

N/A — manifest-only.

## High-Risk Change Checklist

N/A — removing an unused dependency cannot change behavior; all three crates compile unchanged.