### PR TITLE
fix(bindings): keep binding panics from aborting the host process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Bias toward caution over speed. For trivial tasks, use judgment.
 - **Git Flow:** branch off and target `develop`, never `main`. Release/hotfix branches target `main`.
 - **Crate quirks that `ls` won't tell you:** `velesdb-python` is excluded from the strict clippy
   line above (N-API/PyO3 link); `velesdb-node` builds with the `release-node` profile
-  (`panic = "unwind"`); `velesdb-wasm` has no `persistence` feature.
+  and mobile device builds with `release-mobile` (both `panic = "unwind"`); `velesdb-wasm` has no `persistence` feature.
 - **Node binding surface is contract-tested:** any method added to `MemoryService` requires updating the allowlist in `crates/velesdb-node/__test__/index.spec.mjs` plus a behavior test, or CI fails.
 - **No std clock in wasm-reachable code:** `SystemTime::now()`/`Instant` abort on `wasm32-unknown-unknown`; cfg-gate them (pattern: `now_nanos()` in `velesdb-memory/src/context/memory_bridge.rs`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A panic in a binding no longer aborts the host process (mobile + Node,
+  #1980).** Mobile release builds now use the new `release-mobile` workspace
+  profile (`panic = "unwind"`, mirroring `release-node`), so UniFFI's
+  `catch_unwind` trampolines can convert a Rust panic — including the one
+  UniFFI raises when a Swift/Kotlin callback throws unexpectedly — into a
+  catchable foreign exception instead of a SIGABRT of the whole app. On the
+  Node side, the async task path (`Job::compute`) now catches panics itself:
+  napi's async trampoline is a plain `extern "C"` call with no net of its own,
+  so a panicking background job aborted the Node process even under the
+  `release-node` unwind profile. It now rejects the Promise with an
+  `[INTERNAL]` error carrying the panic message.
 - **Sparse-index WAL now fsyncs the acknowledged write (power-loss
   durability).** `wal_append_upsert` / `wal_append_delete` flushed the buffer
   but never `sync_all`ed, so an upsert carrying `sparse_vectors` could be

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,15 @@ strip = true
 inherits = "release"
 panic = "unwind"
 
+# UniFFI's FFI trampolines rely on catch_unwind to turn a Rust panic — including
+# the panic it raises itself when a Kotlin/Swift callback throws unexpectedly —
+# into a foreign exception. Under `panic = "abort"` that safety net is a no-op
+# and the whole app SIGABRTs instead. Mobile release builds use this profile
+# (`cargo build --profile release-mobile`, see docs/guides/MOBILE_BUILD.md).
+[profile.release-mobile]
+inherits = "release"
+panic = "unwind"
+
 [profile.bench]
 lto = true
 codegen-units = 1

--- a/crates/velesdb-mobile/README.md
+++ b/crates/velesdb-mobile/README.md
@@ -70,8 +70,14 @@ bindings from source:
 ```bash
 git clone https://github.com/cyberlife-coder/velesdb.git
 cd velesdb
-cargo build --release -p velesdb-mobile
+cargo build --profile release-mobile -p velesdb-mobile
 ```
+
+The `release-mobile` profile is not optional for device builds: the default
+release profile sets `panic = "abort"`, which disables the `catch_unwind` net
+inside UniFFI's trampolines — a throwing Swift/Kotlin callback would abort the
+whole app instead of raising a catchable exception. `release-mobile` restores
+`panic = "unwind"` and inherits everything else from `release`.
 
 A Rust application (including a Tauri or desktop host) can depend on the crate
 directly instead:

--- a/crates/velesdb-node/src/tasks.rs
+++ b/crates/velesdb-node/src/tasks.rs
@@ -79,42 +79,5 @@ impl<O: Send + 'static + ToNapiValue + TypeName> Task for Job<O> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn compute_returns_closure_result() {
-        let mut job: Job<u32> = Job::new(|| Ok(7));
-        assert_eq!(job.compute().expect("closure result"), 7);
-    }
-
-    #[test]
-    fn compute_twice_is_an_error_not_a_panic() {
-        let mut job: Job<u32> = Job::new(|| Ok(7));
-        let _ = job.compute();
-        let err = job.compute().expect_err("second compute must fail");
-        assert!(err.reason.contains("[INTERNAL]"), "got: {}", err.reason);
-    }
-
-    #[test]
-    fn compute_converts_panic_into_error() {
-        let mut job: Job<u32> = Job::new(|| panic!("boom in background job"));
-        let err = job.compute().expect_err("panic must become an error");
-        assert!(
-            err.reason.contains("boom in background job"),
-            "panic message must be preserved, got: {}",
-            err.reason
-        );
-    }
-
-    #[test]
-    fn compute_handles_non_string_panic_payload() {
-        let mut job: Job<u32> = Job::new(|| std::panic::panic_any(42_i32));
-        let err = job.compute().expect_err("panic must become an error");
-        assert!(
-            err.reason.contains("non-string panic payload"),
-            "got: {}",
-            err.reason
-        );
-    }
-}
+#[path = "tasks_tests.rs"]
+mod tasks_tests;

--- a/crates/velesdb-node/src/tasks.rs
+++ b/crates/velesdb-node/src/tasks.rs
@@ -56,10 +56,65 @@ impl<O: Send + 'static + ToNapiValue + TypeName> Task for Job<O> {
             .work
             .take()
             .ok_or_else(|| Error::from_reason("[INTERNAL] task computed twice"))?;
-        work()
+        // napi's async trampoline calls `compute` from a plain `extern "C"`
+        // function with no catch_unwind of its own, so a panic here would
+        // abort the Node process even under the `release-node` unwind
+        // profile. AssertUnwindSafe is sound: on panic the closure and
+        // everything it captured are discarded and only an error escapes.
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(work)).unwrap_or_else(|payload| {
+            let msg = payload
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_owned())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_owned());
+            Err(Error::from_reason(format!(
+                "[INTERNAL] background task panicked: {msg}"
+            )))
+        })
     }
 
     fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_returns_closure_result() {
+        let mut job: Job<u32> = Job::new(|| Ok(7));
+        assert_eq!(job.compute().expect("closure result"), 7);
+    }
+
+    #[test]
+    fn compute_twice_is_an_error_not_a_panic() {
+        let mut job: Job<u32> = Job::new(|| Ok(7));
+        let _ = job.compute();
+        let err = job.compute().expect_err("second compute must fail");
+        assert!(err.reason.contains("[INTERNAL]"), "got: {}", err.reason);
+    }
+
+    #[test]
+    fn compute_converts_panic_into_error() {
+        let mut job: Job<u32> = Job::new(|| panic!("boom in background job"));
+        let err = job.compute().expect_err("panic must become an error");
+        assert!(
+            err.reason.contains("boom in background job"),
+            "panic message must be preserved, got: {}",
+            err.reason
+        );
+    }
+
+    #[test]
+    fn compute_handles_non_string_panic_payload() {
+        let mut job: Job<u32> = Job::new(|| std::panic::panic_any(42_i32));
+        let err = job.compute().expect_err("panic must become an error");
+        assert!(
+            err.reason.contains("non-string panic payload"),
+            "got: {}",
+            err.reason
+        );
     }
 }

--- a/crates/velesdb-node/src/tasks_tests.rs
+++ b/crates/velesdb-node/src/tasks_tests.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+#[test]
+fn compute_returns_closure_result() {
+    let mut job: Job<u32> = Job::new(|| Ok(7));
+    assert_eq!(job.compute().expect("closure result"), 7);
+}
+
+#[test]
+fn compute_twice_is_an_error_not_a_panic() {
+    let mut job: Job<u32> = Job::new(|| Ok(7));
+    let _ = job.compute();
+    let err = job.compute().expect_err("second compute must fail");
+    assert!(err.reason.contains("[INTERNAL]"), "got: {}", err.reason);
+}
+
+#[test]
+fn compute_converts_panic_into_error() {
+    let mut job: Job<u32> = Job::new(|| panic!("boom in background job"));
+    let err = job.compute().expect_err("panic must become an error");
+    assert!(
+        err.reason.contains("boom in background job"),
+        "panic message must be preserved, got: {}",
+        err.reason
+    );
+}
+
+#[test]
+fn compute_handles_non_string_panic_payload() {
+    let mut job: Job<u32> = Job::new(|| std::panic::panic_any(42_i32));
+    let err = job.compute().expect_err("panic must become an error");
+    assert!(
+        err.reason.contains("non-string panic payload"),
+        "got: {}",
+        err.reason
+    );
+}

--- a/docs/guides/MOBILE_BUILD.md
+++ b/docs/guides/MOBILE_BUILD.md
@@ -82,21 +82,30 @@ sources are identical across targets; only the linked binary differs.
 
 ## 3. iOS: static libraries and XCFramework
 
+Device builds use the `release-mobile` profile, **not** `--release`. The default
+release profile sets `panic = "abort"`, which turns the `catch_unwind` safety net
+inside UniFFI's FFI trampolines into a no-op: any Rust panic — including the one
+UniFFI raises when a Swift/Kotlin observer callback throws unexpectedly — aborts
+the whole app instead of surfacing as a catchable exception. The
+`release-mobile` profile (workspace `Cargo.toml`) inherits everything else from
+`release` and restores `panic = "unwind"`; the cost is unwind tables in the
+binary.
+
 ```bash
-cargo build --release --target aarch64-apple-ios -p velesdb-mobile
-cargo build --release --target aarch64-apple-ios-sim -p velesdb-mobile
-cargo build --release --target x86_64-apple-ios -p velesdb-mobile
+cargo build --profile release-mobile --target aarch64-apple-ios -p velesdb-mobile
+cargo build --profile release-mobile --target aarch64-apple-ios-sim -p velesdb-mobile
+cargo build --profile release-mobile --target x86_64-apple-ios -p velesdb-mobile
 
 # One fat simulator slice (a single XCFramework slice cannot hold two archs
 # for the same platform variant otherwise).
 mkdir -p target/universal-sim
 lipo -create \
-    target/aarch64-apple-ios-sim/release/libvelesdb_mobile.a \
-    target/x86_64-apple-ios/release/libvelesdb_mobile.a \
+    target/aarch64-apple-ios-sim/release-mobile/libvelesdb_mobile.a \
+    target/x86_64-apple-ios/release-mobile/libvelesdb_mobile.a \
     -output target/universal-sim/libvelesdb_mobile.a
 
 xcodebuild -create-xcframework \
-    -library target/aarch64-apple-ios/release/libvelesdb_mobile.a \
+    -library target/aarch64-apple-ios/release-mobile/libvelesdb_mobile.a \
     -headers bindings/swift \
     -library target/universal-sim/libvelesdb_mobile.a \
     -headers bindings/swift \
@@ -117,17 +126,20 @@ before assuming the layout above is complete.
 
 ## 4. Android: shared libraries, jniLibs, JNA
 
+Same profile requirement as iOS — `--profile release-mobile`, not `--release`
+(see §3 for why):
+
 ```bash
 cargo ndk -t arm64-v8a -t armeabi-v7a -t x86_64 \
-    build --release -p velesdb-mobile
+    build --profile release-mobile -p velesdb-mobile
 ```
 
 Artifacts land in the usual per-target directories:
 
 ```text
-target/aarch64-linux-android/release/libvelesdb_mobile.so
-target/armv7-linux-androideabi/release/libvelesdb_mobile.so
-target/x86_64-linux-android/release/libvelesdb_mobile.so
+target/aarch64-linux-android/release-mobile/libvelesdb_mobile.so
+target/armv7-linux-androideabi/release-mobile/libvelesdb_mobile.so
+target/x86_64-linux-android/release-mobile/libvelesdb_mobile.so
 ```
 
 Package them under the ABI names the Android runtime expects:
@@ -140,7 +152,7 @@ app/src/main/jniLibs/x86_64/libvelesdb_mobile.so
 
 `cargo-ndk`'s `-o <dir>` flag writes that layout directly (unverified on current
 toolchain — confirm with your `cargo-ndk` version: `cargo ndk -o app/src/main/jniLibs
--t arm64-v8a build --release -p velesdb-mobile`).
+-t arm64-v8a build --profile release-mobile -p velesdb-mobile`).
 
 Two Gradle-side requirements come from the generated Kotlin itself:
 


### PR DESCRIPTION
Implements option 1 of #1980 (per-binding unwind profiles) plus the async-path gap it identified on the Node side. Closes #1980.

## The mechanism

The workspace `[profile.release]` sets `panic = "abort"`, which turns the `catch_unwind` safety nets at both FFI boundaries into no-ops. Three surfaces were confirmed in the adversarial pass; this PR addresses the two fixable ones and documents why the third stays as is.

## Changes

### mobile / UniFFI — new `release-mobile` profile
- `Cargo.toml`: `[profile.release-mobile]` (inherits `release`, `panic = "unwind"`), mirroring the existing `release-node` precedent, with a comment explaining why. UniFFI's trampolines rely on `catch_unwind` to convert a Rust panic — including the one UniFFI itself raises when a Kotlin/Swift observer callback throws unexpectedly — into a catchable foreign exception; under abort that was a SIGABRT of the whole app.
- `docs/guides/MOBILE_BUILD.md`: iOS and Android device builds switched from `--release` to `--profile release-mobile` (artifact paths updated to `release-mobile/`), with the rationale stated in §3 and referenced in §4.
- `crates/velesdb-mobile/README.md`: installation build uses the new profile, with a short explanation.
- `AGENTS.md`: crate-quirks line extended to name `release-mobile` next to `release-node`.
- Verified: `cargo check -p velesdb-mobile --profile release-mobile` resolves and compiles clean.

### node / napi — panic net inside the async path
- `crates/velesdb-node/src/tasks.rs`: `Job::compute` now wraps the boxed closure in `catch_unwind`. napi's async trampoline calls `compute` from a plain `extern "C"` function with no net of its own, so a panicking background job aborted the Node process **even under the `release-node` unwind profile** — the profile alone was insufficient for this path. A panic now rejects the Promise with an `[INTERNAL]` error carrying the panic message (`&str`, `String`, and non-string payloads all handled). `AssertUnwindSafe` is justified in a comment: on panic the closure and everything it captured are discarded and only an error escapes.
- Unit tests in a sibling `tasks_tests.rs` via `#[path]` (the `error_tests.rs` pattern, as the inline-tests guard requires): closure result passthrough, double-compute error, panic-to-error with message preservation, non-string payload fallback. The napi cdylib harness cannot link outside a Node host on Linux (why CI clippys `--lib` only), so the tests are compile-checked via `cargo check -p velesdb-node --tests`, and the exact `catch_unwind` block semantics were additionally executed standalone (all four assertions pass).

### wasm — unchanged, deliberate
No unwinding on `wasm32-unknown-unknown`; the reachable panics were removed in #1977. The profile stays `abort`.

## Validation
- `python3 scripts/check-inline-tests.py --root .` — passes (first push had the tests inline; the guard caught it and they were moved, not baselined)
- `cargo check -p velesdb-node --tests` — clean
- `cargo clippy -p velesdb-node --lib -- -D warnings` — clean (CI-parity invocation for this crate)
- `cargo check -p velesdb-mobile --profile release-mobile` — clean
- `cargo fmt --check` — clean
- CHANGELOG entry under Unreleased/Fixed