### PR TITLE
fix(core): scale GEO_DISTANCE epsilon by magnitude; log swallowed PQ errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`GEO_DISTANCE(...) = threshold` / `<>` now tolerates realistic
+  floating-point noise instead of demanding near bit-exact equality.** The
+  distance is computed via several `sin`/`cos`/`sqrt`/`atan2` calls
+  (`haversine_distance_m`), so `f64::EPSILON` — the ULP at magnitude 1.0 — was
+  far tighter than the actual precision at real-world distances (meters),
+  making `Eq`/`NotEq` on `GEO_DISTANCE` spuriously fail for values that were,
+  for all practical purposes, equal. The comparator now scales the epsilon by
+  the compared magnitudes, matching the relative-epsilon fix already applied
+  to the `HAVING` threshold comparator (`aggregation/having.rs`).
+- **A failed PQ (Product Quantization) training pass or codebook save is now
+  logged instead of silently discarded.** `cache_pq_vector` trains the
+  quantizer once its buffer reaches `PQ_TRAINING_SAMPLES`, then drains that
+  buffer unconditionally; a training failure (e.g. degenerate input) left the
+  quantizer permanently unset and threw the accumulated samples away with no
+  operator-visible signal — the collection silently ran without PQ
+  quantization from then on. `save_codebook`'s failure was swallowed the same
+  way, silently leaving the quantizer working in memory but unpersisted
+  across restarts. Both now emit a `tracing::warn!` with the underlying error.
 - **A panic in a binding no longer aborts the host process (mobile + Node,
   #1980).** Mobile release builds now use the new `release-mobile` workspace
   profile (`panic = "unwind"`, mirroring `release-node`), so UniFFI's

--- a/crates/velesdb-core/src/collection/core/crud_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/crud_helpers.rs
@@ -110,15 +110,26 @@ impl Collection {
                 let training: Vec<Vec<f32>> =
                     buffer.iter().map(|(_, vector)| vector.clone()).collect();
                 let num_centroids = 256usize.min(training.len().max(2));
-                let trained = ProductQuantizer::train(
+                let trained = match ProductQuantizer::train(
                     &training,
                     auto_num_subspaces(point.vector.len()),
                     num_centroids,
-                )
-                .ok();
+                ) {
+                    Ok(pq) => Some(pq),
+                    Err(error) => {
+                        // The training buffer is drained below regardless of
+                        // outcome, so a failure here silently disables PQ for
+                        // this batch (and every point already buffered) with
+                        // no other signal — log it so it is observable.
+                        tracing::warn!(%error, "PQ training failed; buffer discarded, quantizer stays unset");
+                        None
+                    }
+                };
                 #[cfg(feature = "persistence")]
                 if let Some(ref pq) = trained {
-                    let _ = pq.save_codebook(&self.storage.path);
+                    if let Err(error) = pq.save_codebook(&self.storage.path) {
+                        tracing::warn!(%error, "PQ codebook save failed; quantizer stays in-memory only");
+                    }
                 }
                 *quantizer_guard = trained;
                 backfill_samples = buffer.drain(..).collect();

--- a/crates/velesdb-core/src/filter/matching.rs
+++ b/crates/velesdb-core/src/filter/matching.rs
@@ -459,9 +459,16 @@ fn haversine_distance_m(lat1: f64, lng1: f64, lat2: f64, lng2: f64) -> f64 {
 /// Applies a comparison operator to a geo-distance value and threshold.
 fn compare_geo_distance(dist: f64, threshold: f64, op: crate::velesql::CompareOp) -> bool {
     use crate::velesql::CompareOp;
+    // `dist` is computed via several sin/cos/sqrt/atan2 calls (see
+    // `haversine_distance_m`), so plain `f64::EPSILON` — the ULP at magnitude
+    // 1.0 — is tighter than the actual floating-point precision at real-world
+    // distances (meters), making `Eq`/`NotEq` spuriously fail. Scale by
+    // magnitude, floored at 1.0, matching the HAVING threshold comparator
+    // (`aggregation/having.rs::compare_values`).
+    let relative_epsilon = f64::EPSILON * dist.abs().max(threshold.abs()).max(1.0);
     match op {
-        CompareOp::Eq => (dist - threshold).abs() < f64::EPSILON,
-        CompareOp::NotEq => (dist - threshold).abs() >= f64::EPSILON,
+        CompareOp::Eq => (dist - threshold).abs() < relative_epsilon,
+        CompareOp::NotEq => (dist - threshold).abs() >= relative_epsilon,
         CompareOp::Gt => dist > threshold,
         CompareOp::Gte => dist >= threshold,
         CompareOp::Lt => dist < threshold,

--- a/crates/velesdb-core/src/filter/matching_tests.rs
+++ b/crates/velesdb-core/src/filter/matching_tests.rs
@@ -1,9 +1,31 @@
-use super::{like_match, CompiledLikePattern};
+use super::{compare_geo_distance, like_match, CompiledLikePattern};
 use crate::filter::Condition;
+use crate::velesql::CompareOp;
 use serde_json::json;
 
 fn payload(json: serde_json::Value) -> serde_json::Value {
     json
+}
+
+// A haversine distance is built from several sin/cos/sqrt/atan2 calls, so two
+// otherwise-equal distances can differ by an amount well above `f64::EPSILON`
+// (the ULP at magnitude 1.0) once the magnitude is realistic (meters). This
+// difference sits strictly between the old absolute tolerance and the new
+// relative one, so it reproduces the false "not equal" the absolute epsilon
+// used to produce while still being far too small to be a genuine distance
+// difference.
+#[test]
+fn geo_distance_eq_tolerates_realistic_float_noise() {
+    let dist = 1000.0;
+    let threshold = dist + 1e-13;
+    assert!(compare_geo_distance(dist, threshold, CompareOp::Eq));
+    assert!(!compare_geo_distance(dist, threshold, CompareOp::NotEq));
+}
+
+#[test]
+fn geo_distance_eq_still_rejects_real_differences() {
+    assert!(!compare_geo_distance(1000.0, 1000.5, CompareOp::Eq));
+    assert!(compare_geo_distance(1000.0, 1000.5, CompareOp::NotEq));
 }
 
 // Verify that comparing against null never matches ordering predicates.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two independent, small correctness/observability fixes in `velesdb-core`, found during a code-quality review pass:

1. **`GEO_DISTANCE(...) = threshold` / `<>` used a plain `f64::EPSILON` tolerance.** `compare_geo_distance` compared haversine distances (`sin`/`cos`/`sqrt`/`atan2`) against a threshold using an *absolute* `f64::EPSILON` (~2.22e-16 — the ULP at magnitude 1.0). At real-world distances (meters), that tolerance is far tighter than the actual floating-point precision of the computation, so `Eq`/`NotEq` spuriously failed for distances that were equal for all practical purposes. `compare_geo_distance` now scales the epsilon by the compared magnitudes, mirroring the relative-epsilon fix already shipped for the `HAVING` threshold comparator (`aggregation/having.rs::compare_values`).
2. **A failed PQ (Product Quantization) training pass or codebook save was silently discarded.** `cache_pq_vector` accumulates points into a training buffer and, once it reaches `PQ_TRAINING_SAMPLES`, trains the quantizer and unconditionally drains that buffer regardless of outcome. `ProductQuantizer::train(...).ok()` threw the `Err` away with no logging: on failure the quantizer stayed permanently unset, the accumulated samples were lost, and the collection silently ran without PQ quantization from then on with zero operator-visible signal. `save_codebook`'s failure was swallowed the same way (`let _ = ...`), silently leaving the quantizer usable in memory but never persisted across a restart. Both failures are now logged via `tracing::warn!` with the underlying error — no control flow or return type changes.

Not in scope: the general JSON-payload float-equality comparator (`values_equal`) has the same absolute-epsilon issue, but it is deliberately mirrored bit-for-bit by the ColumnStore fast-path equality filter (`payload_mirror/translate.rs::leaf_eq`, documented as replicating `values_equal` "exactly"). Fixing one without the other would make the fast path (`Eval::exact`, trusted without re-checking against the JSON payload) diverge from the slow path for the same query — a correctness regression bigger than the bug being fixed. That needs its own PR touching both sites together.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added `geo_distance_eq_tolerates_realistic_float_noise` and `geo_distance_eq_still_rejects_real_differences` to `filter/matching_tests.rs`. The first test was verified to fail against the pre-fix comparator (reproduces the exact bug) and passes against the fix; the second confirms the relative epsilon still rejects genuinely different distances.
- `cargo test -p velesdb-core --lib --features persistence filter::matching -- --test-threads=1` — 9 passed.
- `cargo test -p velesdb-core --features persistence -- --test-threads=1` (full crate suite + doctests) — all green.
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- `cargo fmt --all -- --check` — clean.
- `python3 scripts/check_prod_unwraps.py` — PASSED.
- `python3 scripts/check-inline-tests.py` / `check-file-budgets.py` — PASSED (baselines unchanged).
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` — PASSED.
- Doc-freshness guards (`stamp`, `index`, `tracked`, `versions`, `decisions`), `check-version-sync.py`, `check-feature-claims.py`, `check-promise-contract.py`, `check-doc-contract.sh` — all PASSED.

**Test Configuration:**
- OS: Linux (CI-equivalent sandbox)
- Rust version: 1.90.0 (pinned MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (`CHANGELOG.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` code added or modified.

## High-Risk Change Checklist

N/A — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Both issues were found via an independent code-quality review pass (not tied to a filed GitHub issue), scoped deliberately narrow after checking each finding against its actual blast radius — see the "Not in scope" note above for the one finding from that pass that was *not* fixed here on purpose.
