### PR TITLE
fix(memory): correct the working-index lock's cross-process claim and prove it with two real daemons

### DIFF
--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -146,12 +146,23 @@ static EVENT_SEQ: AtomicU64 = AtomicU64::new(0);
 /// therefore `load_working_context`'s `other_sessions` recovery hint) no
 /// longer knows it exists, and nothing anywhere returns an error.
 ///
-/// **Scope, honestly: this is an INTRA-PROCESS lock only.** Two processes
-/// opening the same store still race, because nothing below this layer offers
-/// a compare-and-swap. The durable fix is a CAS or a transaction on the
-/// [`MemoryStore`] trait itself; until then, the single-process case (the MCP
-/// server, whose `spawn_blocking` handlers are exactly what made this
-/// reachable) is covered and the multi-process case is not.
+/// **Scope: intra-process — which is the WHOLE problem (#1958).** An earlier
+/// version of this comment claimed two processes opening the same store
+/// still race past this lock. They cannot: `velesdb-core`'s
+/// `Database::open_impl` takes an exclusive `flock` on `velesdb.lock` at
+/// open and holds it for the `Database`'s entire lifetime — not per write —
+/// so a second process fails at `open` with `DatabaseLocked` before it can
+/// reach any read-modify-write, of this index or of anything else. Proven
+/// with real processes by `tests/http_lock_contention.rs` and
+/// `tests/working_index_two_daemons_process.rs` (the latter is #1958's
+/// success criterion verbatim: sessions saved under contention and across a
+/// process handoff, zero index entries lost). A trait-level compare-and-swap
+/// was considered there and declined: flock is the only cross-process
+/// primitive available here, and the store boundary already holds it — a
+/// second one around the index would guard against a concurrency the first
+/// makes unreachable. This mutex therefore covers the only concurrency that
+/// exists: threads of the one process allowed to hold the store (the MCP
+/// server's `spawn_blocking` handlers are exactly what made it reachable).
 ///
 /// One global lock rather than one per project: index writes are rare (one
 /// per `save_working_context`), so the contention is negligible, whereas a

--- a/crates/velesdb-memory/tests/working_index_two_daemons_process.rs
+++ b/crates/velesdb-memory/tests/working_index_two_daemons_process.rs
@@ -1,0 +1,264 @@
+//! Two OS processes saving working-contexts on the same store lose no index
+//! entries (#1958) — because they never run concurrently in the first place.
+//!
+//! #1958 asked for a compare-and-swap on the storage trait so the working-
+//! context index's read-modify-write could not race across processes. The
+//! premise was the index lock's own doc-comment, which claimed "two
+//! processes opening the same store still race". That claim was stale:
+//! `velesdb-core`'s `Database::open_impl` takes an exclusive `flock` on
+//! `velesdb.lock` AT OPEN and holds it for the `Database`'s whole lifetime —
+//! not per write. A second process fails at `open` with `DatabaseLocked`
+//! before it can reach ANY read-modify-write, of the index or of anything
+//! else. Cross-process index atomicity is therefore guaranteed by mutual
+//! exclusion at the store boundary, and the intra-process mutex
+//! (`WORKING_INDEX_WRITE`, proven by
+//! `working_index_lock_contention_bdd.rs` and
+//! `memory_bridge_tests.rs::test_concurrent_saves_on_one_project_keep_both_sessions_in_the_index`)
+//! is the complete defense for the only concurrency that can exist.
+//!
+//! This test enacts the issue's success criterion with real processes:
+//! daemon A saves sessions in a loop; daemon B tries to work on the same
+//! store mid-loop and must fail fast at open (never writing anything);
+//! A keeps saving unharmed; after A exits, a successor process C sees
+//! EVERY session A saved — zero index entries lost, across contention
+//! and across the process handoff.
+//!
+//! Harness notes: MCP-over-stdio plumbing follows
+//! `online_migration_process.rs`'s `ProcessClient`; the contender-fails-fast
+//! half mirrors `http_lock_contention.rs` (same store lock, stdio variant).
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use serde_json::{json, Value};
+
+/// Bound on the contender's fail-fast exit: generously above
+/// `daemon_startup`'s bounded lock retry (3 × 500 ms), far below a hang.
+const CONTENDER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The project every session is saved under — contention on the index is
+/// per project, so one shared project is the interesting case.
+const PROJECT: &str = "two-daemons";
+
+/// Sessions daemon A saves before the contender attempts its open, and
+/// after the contender has failed — proving the failed attempt disturbed
+/// nothing on either side of it.
+const SESSIONS_BEFORE: [&str; 3] = ["a1", "a2", "a3"];
+const SESSIONS_AFTER: [&str; 3] = ["a4", "a5", "a6"];
+
+struct StdioDaemon {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl StdioDaemon {
+    fn spawn(store: &std::path::Path, home: &std::path::Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+            .env("HOME", home)
+            .env("VELESDB_MEMORY_PATH", store)
+            .env("VELESDB_MEMORY_EMBEDDER", "hash")
+            .env("VELESDB_MEMORY_QUIET", "1")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn velesdb-memory daemon");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let mut daemon = Self {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            next_id: 1,
+        };
+        daemon.initialize();
+        daemon
+    }
+
+    fn initialize(&mut self) {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion":"2024-11-05",
+                "capabilities":{},
+                "clientInfo":{"name":"working-index-two-daemons","version":"1"}
+            }),
+        );
+        self.send(&json!({"jsonrpc":"2.0","method":"notifications/initialized"}));
+    }
+
+    fn call(&mut self, name: &str, arguments: Value) -> Value {
+        let mut params = json!({"name":name});
+        params["arguments"] = arguments;
+        let response = self.request("tools/call", params);
+        assert_ne!(
+            response["result"]["isError"], true,
+            "tool {name}: {response}"
+        );
+        response["result"]["structuredContent"].clone()
+    }
+
+    fn save_session(&mut self, session: &str) {
+        let saved = self.call(
+            "save_working_context",
+            json!({
+                "project": PROJECT,
+                "session": session,
+                "working": {"goal": format!("goal of {session}")}
+            }),
+        );
+        assert!(
+            saved["id"].as_u64().is_some(),
+            "save must return the stored fact id, got: {saved}"
+        );
+    }
+
+    fn listed_sessions(&mut self) -> Vec<String> {
+        let listed = self.call("list_working_contexts", json!({"project": PROJECT}));
+        listed["sessions"]
+            .as_array()
+            .expect("sessions array")
+            .iter()
+            .map(|entry| entry["session"].as_str().expect("session name").to_owned())
+            .collect()
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let mut frame = json!({"jsonrpc":"2.0","id":id,"method":method});
+        frame["params"] = params;
+        self.send(&frame);
+        let mut line = String::new();
+        self.stdout.read_line(&mut line).expect("read response");
+        let response: Value = serde_json::from_str(&line).expect("JSON response");
+        assert_eq!(response["id"], id, "unexpected response: {response}");
+        assert!(
+            response.get("error").is_none(),
+            "request failed: {response}"
+        );
+        response
+    }
+
+    fn send(&mut self, frame: &Value) {
+        let stdin = self.stdin.as_mut().expect("live stdin");
+        serde_json::to_writer(&mut *stdin, frame).expect("write frame");
+        stdin.write_all(b"\n").expect("newline");
+        stdin.flush().expect("flush");
+    }
+
+    /// EOF on stdin, then a clean exit — the lock-releasing shutdown
+    /// `mcp_lifecycle.rs` proves.
+    fn shutdown(mut self) {
+        drop(self.stdin.take());
+        let status = self.child.wait().expect("daemon exit");
+        assert!(status.success(), "daemon status: {status}");
+    }
+}
+
+/// Poll `Child::try_wait` until exit or `timeout` — same bounded wait as
+/// `http_lock_contention.rs`.
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Read all of `reader` on a helper thread, bounded — a direct
+/// `read_to_string` on a hung child would hang the suite with it.
+fn drain_with_timeout<R: Read + Send + 'static>(mut reader: R, timeout: Duration) -> String {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = reader.read_to_string(&mut buf);
+        let _ = tx.send(buf);
+    });
+    rx.recv_timeout(timeout).unwrap_or_default()
+}
+
+#[test]
+fn two_processes_saving_working_contexts_lose_no_index_entries() {
+    let store_dir = tempfile::tempdir().expect("scratch store dir");
+    let home_dir = tempfile::tempdir().expect("scratch home dir");
+
+    // Given daemon A holding the store and saving sessions in a loop
+    let mut daemon_a = StdioDaemon::spawn(store_dir.path(), home_dir.path());
+    for session in SESSIONS_BEFORE {
+        daemon_a.save_session(session);
+    }
+
+    // When daemon B tries to open the same store mid-loop, it fails at
+    // open — before it can reach any read-modify-write of the index — with
+    // the same actionable lock message the other transports print.
+    let mut contender = Command::new(env!("CARGO_BIN_EXE_velesdb-memory"))
+        .env("HOME", home_dir.path())
+        .env("VELESDB_MEMORY_PATH", store_dir.path())
+        .env("VELESDB_MEMORY_EMBEDDER", "hash")
+        .env("VELESDB_MEMORY_QUIET", "1")
+        .stdin(Stdio::piped()) // held open: B must die from the lock, not EOF
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn contender daemon");
+    let contender_stderr = contender.stderr.take().expect("contender stderr");
+    let status = wait_for_exit(&mut contender, CONTENDER_EXIT_TIMEOUT).unwrap_or_else(|| {
+        let _ = contender.kill();
+        let _ = contender.wait();
+        panic!(
+            "a second daemon on an already-held store did not exit within \
+             {CONTENDER_EXIT_TIMEOUT:?} — it must fail fast at open, not run \
+             alongside the holder"
+        );
+    });
+    assert!(
+        !status.success(),
+        "a second daemon on an already-held store must exit non-zero, got: {status:?}"
+    );
+    let stderr_text = drain_with_timeout(contender_stderr, Duration::from_secs(2)).to_lowercase();
+    assert!(
+        stderr_text.contains("velesdb_memory_path") && stderr_text.contains("pkill"),
+        "expected the actionable lock-contention guidance, got: {stderr_text:?}"
+    );
+
+    // And A keeps saving, unharmed by the failed contender
+    for session in SESSIONS_AFTER {
+        daemon_a.save_session(session);
+    }
+
+    // Then A's index lists every session it saved...
+    let seen_by_a = daemon_a.listed_sessions();
+    for session in SESSIONS_BEFORE.iter().chain(&SESSIONS_AFTER) {
+        assert!(
+            seen_by_a.iter().any(|s| s == session),
+            "session {session} missing from the index while A still runs: {seen_by_a:?}"
+        );
+    }
+    daemon_a.shutdown();
+
+    // ...and so does successor process C after the handoff: zero index
+    // entries lost across the whole two-process scenario.
+    let mut daemon_c = StdioDaemon::spawn(store_dir.path(), home_dir.path());
+    let seen_by_c = daemon_c.listed_sessions();
+    for session in SESSIONS_BEFORE.iter().chain(&SESSIONS_AFTER) {
+        assert!(
+            seen_by_c.iter().any(|s| s == session),
+            "session {session} lost across the process handoff: {seen_by_c:?}"
+        );
+    }
+    assert_eq!(
+        seen_by_c.len(),
+        SESSIONS_BEFORE.len() + SESSIONS_AFTER.len(),
+        "the index must hold exactly the saved sessions: {seen_by_c:?}"
+    );
+    daemon_c.shutdown();
+}


### PR DESCRIPTION
## Description

#1958 asked for a compare-and-swap on the storage trait so the working-context index's read-modify-write could not race across processes. The premise was `WORKING_INDEX_WRITE`'s own doc-comment, which claimed *"two processes opening the same store still race"*. That claim is stale — and this PR replaces it with the proven truth instead of building the CAS on top of it:

- `velesdb-core`'s `Database::open_impl` takes an exclusive `flock` on `velesdb.lock` **at open** and holds it for the `Database`'s entire lifetime — not per write. A second process fails at `open` with `DatabaseLocked` before it can reach any read-modify-write, of the index or of anything else. Cross-process index atomicity is guaranteed by mutual exclusion at the store boundary.
- The intra-process mutex therefore covers the only concurrency that can exist — threads of the one process holding the store — and that half was already proven (`working_index_lock_contention_bdd.rs`, `memory_bridge_tests.rs::test_concurrent_saves_on_one_project_keep_both_sessions_in_the_index`).

**What this PR does:**

1. **New process test** `working_index_two_daemons_process.rs` — #1958's success criterion enacted verbatim with real OS processes: daemon A saves sessions in a loop; a contender daemon on the same store fails fast at open mid-loop (non-zero exit, actionable lock guidance on stderr, nothing written); A keeps saving unharmed; a successor process sees **every** saved session after the handoff — zero index entries lost.
2. **Doc-comment rewrite** of `WORKING_INDEX_WRITE` — the issue's other explicit deliverable ("le doc-comment du verrou est réécrit pour décrire ce qu'il reste au verrou"). It now states the real invariant and points at the process tests that pin it.

**Why the trait-level CAS is declined, on evidence:** flock is the only cross-process primitive available at this layer, and the store boundary already holds it for the whole process lifetime — a second flock around the index would guard a concurrency the first makes unreachable. Per the issue's own design constraints (22-method trait, out-of-crate wasm implementor that is single-process by construction, "contrainte de simplicité"), adding a 5-parameter CAS method to protect an unreachable scenario is dead weight. If the store's single-writer open-lock is ever relaxed, this PR's process test fails immediately and re-opens the question with a harness already in place.

Fixes #1958

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

`cargo test -p velesdb-memory --all-features` (full suite green, including the new process test and the existing `http_lock_contention.rs`), `cargo clippy -p velesdb-memory --all-features --all-targets -- -D warnings -D clippy::pedantic`, `cargo fmt --all -- --check`, `python3 scripts/check-file-budgets.py` (PASSED).

**Test Configuration:**
- OS: Linux
- Rust version: workspace toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## High-Risk Change Checklist

- [x] I listed the invariants impacted by this change (store-boundary `flock` at open = the cross-process exclusion; `WORKING_INDEX_WRITE` = the intra-process serialization; both now stated in the rewritten doc-comment).
- [x] I documented crash/durability semantics when relevant (n/a — no write-path change; the test covers the clean-shutdown lock release already proven by `mcp_lifecycle.rs`).
- [x] I added/updated tests for concurrency or lifecycle (the two-daemon process test covers contention and the process handoff).
- [ ] I requested review from at least 2 maintainers/reviewers for this risky path.

## Additional Notes

No production code changes — one doc-comment corrected, one regression proof added. The change is deliberately the smallest thing that satisfies both of #1958's explicit success criteria.
