### PR TITLE
test(memory): bound every wait in the two-daemon process test and correct three stale facet docs

### DIFF
--- a/crates/velesdb-memory/src/service_graph.rs
+++ b/crates/velesdb-memory/src/service_graph.rs
@@ -1,9 +1,14 @@
-//! The graph facet of [`MemoryService`]: `relate`/`unrelate`/`forget`, the
-//! entity-hub lifecycle, and the `why`/`traverse`/`expand` walks — split out
-//! to keep `service.rs` inside the crate's file budget, same pattern as
-//! `fused_recall.rs`. A child module of `service`, so it shares full access
-//! to `MemoryService`'s private fields and methods. Every method here needs
-//! at least `S: GraphStore` (#1959) — that is the seam this file cuts along.
+//! Part of the graph facet of [`MemoryService`]: `relate`/`unrelate`/
+//! `forget`, the *destruction* half of the entity-hub lifecycle, and the
+//! `why`/`traverse`/`expand` walks — split out to keep `service.rs` inside
+//! the crate's file budget, same pattern as `fused_recall.rs`. A child
+//! module of `service`, so it shares full access to `MemoryService`'s
+//! private fields and methods. Every method here needs at least
+//! `S: GraphStore` (#1959) — but the converse does not hold yet: the
+//! *wiring* half of the graph surface (`wire_entities`, `entity_profile`,
+//! `add_edge`, the `remember*`/`autograph*` family) still lives in
+//! `service.rs` with the same bound. Finishing that cut is the natural next
+//! slice when `service.rs` needs to shrink again.
 
 use super::{
     reject_reserved_keys, validate_relation, Embedder, Explanation, FactStore, GraphStore, HashSet,
@@ -239,7 +244,9 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
 
     /// Explain a `decision`: find the best-matching memory (optionally scoped to
     /// a metadata `filter`, e.g. the current project), then walk its typed links
-    /// up to `max_hops` away — fusing the vector, `ColumnStore`, and graph facets.
+    /// up to `max_hops` away — fusing the [`RecallStore`] and [`GraphStore`]
+    /// facets (the `filter` goes through `query_filtered`, not the columnar
+    /// path).
     ///
     /// Returns an empty [`Explanation`] when nothing matches the decision.
     ///

--- a/crates/velesdb-memory/tests/working_index_two_daemons_process.rs
+++ b/crates/velesdb-memory/tests/working_index_two_daemons_process.rs
@@ -26,16 +26,29 @@
 //! Harness notes: MCP-over-stdio plumbing follows
 //! `online_migration_process.rs`'s `ProcessClient`; the contender-fails-fast
 //! half mirrors `http_lock_contention.rs` (same store lock, stdio variant).
+//! Every wait in here is bounded — including the request/response round
+//! trips: the failure mode this test guards against is a daemon that stops
+//! answering, which a bare `read_line` would turn into a suite hang instead
+//! of a red test.
+
+#![cfg(all(feature = "mcp", feature = "persistence"))]
 
 use std::io::{BufRead, BufReader, Read, Write};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use serde_json::{json, Value};
 
 /// Bound on the contender's fail-fast exit: generously above
-/// `daemon_startup`'s bounded lock retry (3 × 500 ms), far below a hang.
+/// `daemon_startup`'s bounded lock retry (three attempts separated by two
+/// 500 ms pauses), far below a hang.
 const CONTENDER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bound on any single request/response round trip (and on shutdown). These
+/// are local-process saves against a hash embedder — sub-second in practice,
+/// so ten seconds separates "slow" from "hung" unambiguously.
+const STEP: Duration = Duration::from_secs(10);
 
 /// The project every session is saved under — contention on the index is
 /// per project, so one shared project is the interesting case.
@@ -50,8 +63,21 @@ const SESSIONS_AFTER: [&str; 3] = ["a4", "a5", "a6"];
 struct StdioDaemon {
     child: Child,
     stdin: Option<ChildStdin>,
-    stdout: BufReader<ChildStdout>,
+    /// Response lines, fed by a dedicated reader thread — so every receive
+    /// can carry a deadline. The thread ends on the daemon's stdout EOF,
+    /// which drops the sender and turns further receives into clean errors.
+    lines: mpsc::Receiver<String>,
     next_id: u64,
+}
+
+/// A panic anywhere mid-test (a failed assert) must not leave a live daemon
+/// behind: it would outlive the `TempDir` it is writing into. Redundant
+/// after a clean [`StdioDaemon::shutdown`] (both calls then fail, ignored).
+impl Drop for StdioDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
 }
 
 impl StdioDaemon {
@@ -68,10 +94,19 @@ impl StdioDaemon {
             .expect("spawn velesdb-memory daemon");
         let stdin = child.stdin.take().expect("stdin");
         let stdout = BufReader::new(child.stdout.take().expect("stdout"));
+        let (line_tx, lines) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in stdout.lines() {
+                let Ok(line) = line else { break };
+                if line_tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
         let mut daemon = Self {
             child,
             stdin: Some(stdin),
-            stdout,
+            lines,
             next_id: 1,
         };
         daemon.initialize();
@@ -132,8 +167,9 @@ impl StdioDaemon {
         let mut frame = json!({"jsonrpc":"2.0","id":id,"method":method});
         frame["params"] = params;
         self.send(&frame);
-        let mut line = String::new();
-        self.stdout.read_line(&mut line).expect("read response");
+        let line = self.lines.recv_timeout(STEP).unwrap_or_else(|_| {
+            panic!("no response to {method} within {STEP:?} — the daemon is hung or dead")
+        });
         let response: Value = serde_json::from_str(&line).expect("JSON response");
         assert_eq!(response["id"], id, "unexpected response: {response}");
         assert!(
@@ -151,10 +187,12 @@ impl StdioDaemon {
     }
 
     /// EOF on stdin, then a clean exit — the lock-releasing shutdown
-    /// `mcp_lifecycle.rs` proves.
+    /// `mcp_lifecycle.rs` proves. Bounded: a daemon that ignores EOF is a
+    /// red test, not a hung suite.
     fn shutdown(mut self) {
         drop(self.stdin.take());
-        let status = self.child.wait().expect("daemon exit");
+        let status = wait_for_exit(&mut self.child, STEP)
+            .unwrap_or_else(|| panic!("daemon did not exit within {STEP:?} of stdin EOF"));
         assert!(status.success(), "daemon status: {status}");
     }
 }
@@ -164,8 +202,12 @@ impl StdioDaemon {
 fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
     let deadline = Instant::now() + timeout;
     loop {
-        if let Ok(Some(status)) = child.try_wait() {
-            return Some(status);
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => {}
+            // Surface the real cause instead of letting the caller blame a
+            // timeout that never happened.
+            Err(err) => panic!("try_wait failed: {err}"),
         }
         if Instant::now() >= deadline {
             return None;

--- a/crates/velesdb-wasm/src/memory_store.rs
+++ b/crates/velesdb-wasm/src/memory_store.rs
@@ -405,8 +405,8 @@ impl GraphStore for WasmStore {
 }
 
 impl WasmStore {
-    /// Shared vector-search core for [`MemoryStore::query_filtered`],
-    /// [`MemoryStore::query_excluding`], and [`MemoryStore::query_columnar`]:
+    /// Shared vector-search core for [`RecallStore::query_filtered`],
+    /// [`RecallStore::query_excluding`], and [`ColumnStore::query_columnar`]:
     /// score every non-expired fact whose payload passes `predicate` against
     /// `embedding`, rank, take `k` after `offset`, and build each returned
     /// row with `row`.
@@ -473,7 +473,7 @@ impl WasmStore {
     }
 
     /// [`Self::query_ranked`] specialised to the `(id, score, content)`
-    /// triple [`MemoryStore::query_filtered`]/[`MemoryStore::query_excluding`]
+    /// triple [`RecallStore::query_filtered`]/[`RecallStore::query_excluding`]
     /// return.
     fn query_scored(
         &self,


### PR DESCRIPTION
## Description

Pre-release hardening from the full architecture + implementation review. Two independent findings, both in the same test/doc neighborhood:

**1. The two-daemon process test (#2011) was only bounded where failure was unlikely.** The contender's exit was polled with a deadline, but the daemons' own request/response round trips went through a bare `read_line` and `shutdown` through a bare `wait()` — so the exact failure mode the test guards against (a `save_working_context` that stops answering under the working-index lock) would have hung the CI suite instead of failing it. Now:
- responses flow through a dedicated reader thread into a deadline-carrying channel (`recv_timeout(STEP)` on every round trip);
- `shutdown` polls with the same bounded `wait_for_exit` as the contender;
- a `Drop` impl kills any daemon a mid-test panic would otherwise orphan over its vanishing `TempDir`;
- the file carries the same `#[cfg(all(feature = "mcp", feature = "persistence"))]` gate as the process-test model it copies;
- the retry-budget comment states the real pause count (three attempts, two 500 ms pauses);
- `wait_for_exit` surfaces a `try_wait` error instead of swallowing it into a misleading timeout panic.

**2. Three docs the facet split (#1959/#2010) left behind:**
- `velesdb-wasm/src/memory_store.rs` linked `query_filtered`/`query_excluding`/`query_columnar` to `MemoryStore`, which no longer declares them — retargeted to `RecallStore`/`ColumnStore`;
- `service_graph.rs`'s module doc claimed "every `GraphStore`-bounded method lives here" while 21 such methods (the wiring half: `wire_entities`, `entity_profile`, `add_edge`, `remember*`/`autograph*`) still sit in `service.rs` — the doc now states the real cut and names the natural next slice;
- `why()`'s doc named `ColumnStore` for a filter that goes through `RecallStore::query_filtered`.

No production code changes — test harness and documentation only.

## Type of Change

- [x] 📚 Documentation update

*(plus test-harness robustness; no production code touched)*

## How Has This Been Tested?

- [x] Integration tests

`cargo test -p velesdb-memory --test working_index_two_daemons_process --all-features` green (4.8 s); `cargo clippy -p velesdb-memory -p velesdb-wasm --all-features --all-targets -- -D warnings -D clippy::pedantic` clean after touching both lib.rs (cold fingerprints); `cargo fmt --all -- --check` clean.

**Test Configuration:**
- OS: Linux
- Rust version: workspace toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

First of the release-train PRs: this hardening lands on `develop` before `release/v5.1.0` is re-cut from it, so the release carries a process test that can fail red but never hang a runner.
