### PR TITLE
feat(memory): reach https:// endpoints with the same env vars as local servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6932,7 +6932,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-memory"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "atomicwrites",
  "axum",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "velesdb-node"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,23 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-08-19
+
+### Added
+
+- **`https://` endpoints work for both HTTP roles (#2025).** The outbound
+  client was built without TLS, so the `openai` backend — documented as
+  reaching "hosted providers" — could in fact only reach `http://` servers.
+  rustls now ships inside the existing `embedder-http`/`extractor-http`
+  features: the URL's scheme is the whole local-or-cloud switch, with the
+  same three variables per role and nothing to rebuild or discover. The
+  default posture is unchanged — `hash` stays offline, and no remote host is
+  contacted unless the user sets an `https://` URL themselves. A provider
+  that serves only chat completions (OpenRouter) can back the extractor
+  while the embedder stays local; the roles are independent on purpose.
+  Pinned by a transport-level test: an `https://` URL must fail at the
+  network, never on a client built without TLS.
+
 ## [0.14.0] - 2026-08-19
 
 ### Changed

--- a/crates/velesdb-memory/Cargo.toml
+++ b/crates/velesdb-memory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-memory"
 # Independent of the workspace version: velesdb-memory is a young MCP wrapper
 # with its own release cadence, decoupled from the core engine's 3.x line.
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 license-file = "../../LICENSE"
@@ -64,7 +64,12 @@ tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 # Optional real-recall backend (off by default). HTTP-only to a local Ollama;
 # `default-features = false` drops TLS to keep the binary small.
-ureq = { version = "2", optional = true, default-features = false }
+# `tls` (rustls) so the SAME env vars reach a local server over http:// or a
+# cloud endpoint over https:// — the user pastes a URL, nothing to rebuild or
+# discover. Local stays the default posture; TLS is capability, not policy.
+ureq = { version = "2", optional = true, default-features = false, features = [
+    "tls",
+] }
 # HTTP transport (multi-client daemon), behind the `http` feature only — the
 # default binary stays offline/stdio-only. `axum`/`tower` are already
 # workspace dependencies (velesdb-server); `tokio-util` provides the
@@ -140,8 +145,9 @@ optional = true
 # rebuild. The runtime default stays `hash`: fully offline, no model
 # contacted unless the user opts in. Library consumers disable defaults to
 # pick only what they need. The cost of the two extra defaults is one small
-# HTTP client (`ureq`, no TLS); the least technical install paths were the
-# ones locked out of the product's own pitch without them (#1846 aftermath).
+# HTTP client (`ureq` + rustls, so https:// endpoints work out of the box —
+# #2025); the least technical install paths were the ones locked out of the
+# product's own pitch without them (#1846 aftermath).
 default = ["mcp", "persistence", "context", "embedder-http", "extractor-http"]
 mcp = [
     "dep:rmcp",

--- a/crates/velesdb-memory/README.md
+++ b/crates/velesdb-memory/README.md
@@ -376,4 +376,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-memory v0.14.0` · Last updated: 2026-08-19 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-memory v0.14.1` · Last updated: 2026-08-19 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-memory/src/http_client_tests.rs
+++ b/crates/velesdb-memory/src/http_client_tests.rs
@@ -71,3 +71,31 @@ fn debug_redacts_a_custom_header_value_but_keeps_its_name() {
          configured with the wrong scheme diagnosable at all: {printed}"
     );
 }
+
+/// An `https://` base URL must fail at the *network* (nothing listens on the
+/// discard port), never at the scheme: before #2025 the client was built
+/// without TLS, and every https endpoint — a cloud OpenAI-compatible
+/// provider, `OpenRouter` for extraction — died with a "TLS not enabled"
+/// transport error before a single byte left the machine. The same env vars
+/// now reach http:// (local) and https:// (cloud) alike; this pins the
+/// capability so a dependency-feature regression cannot silently take it
+/// back.
+#[test]
+fn https_scheme_reaches_the_network_instead_of_dying_on_missing_tls() {
+    let agent = bounded_agent(AgentBudget::uniform(std::time::Duration::from_secs(2)));
+    let client = HttpJsonClient::new("https://127.0.0.1:9", Auth::None, agent);
+    let failure = client
+        .post_json("/v1/embeddings", "{}")
+        .expect_err("nothing listens on the discard port");
+    let cause = failure.cause.to_lowercase();
+    assert!(
+        !cause.contains("tls") && !cause.contains("scheme"),
+        "https must be refused by the network, not by a client built without \
+         TLS — got: {cause}"
+    );
+    assert!(
+        cause.contains("connect") || cause.contains("connection"),
+        "the failure should be the TCP connect (proof the scheme was \
+         accepted and dialing began), got: {cause}"
+    );
+}

--- a/crates/velesdb-memory/src/remote_endpoint.rs
+++ b/crates/velesdb-memory/src/remote_endpoint.rs
@@ -36,6 +36,13 @@ impl RemoteEndpoint {
     /// list is obliged to know. Ollama keeps its defaults because it genuinely
     /// has one canonical local address.
     ///
+    /// The URL's scheme is the local-or-cloud switch, and nothing else is:
+    /// `http://` reaches a server on this machine, `https://` a hosted
+    /// provider (TLS in the client since 0.14.1, #2025) — same variables
+    /// either way. A provider that serves only chat completions (`OpenRouter`)
+    /// can back the *extractor* role while the embedder stays local: the
+    /// roles are configured independently on purpose.
+    ///
     /// # Errors
     /// A message naming the exact variable that is missing, per role.
     pub fn require(self, prefix: &str) -> Result<(String, String, Auth), String> {

--- a/crates/velesdb-node/Cargo.toml
+++ b/crates/velesdb-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "velesdb-node"
 # Tracks velesdb-memory's independent cadence (the npm package version),
 # not the workspace 3.x engine line. Never crates.io-published (publish=false).
-version = "0.14.0"
+version = "0.14.1"
 # Never cargo-published: this cdylib ships to npm as @wiscale/velesdb-memory-node
 # per-platform prebuilds, not to crates.io.
 publish = false

--- a/crates/velesdb-node/README.md
+++ b/crates/velesdb-node/README.md
@@ -325,4 +325,4 @@ Questions: contact@wiscale.fr.
 
 ---
 
-`velesdb-node v0.14.0` (npm `@wiscale/velesdb-memory-node@0.14.0`) · Last updated: 2026-08-19 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)
+`velesdb-node v0.14.1` (npm `@wiscale/velesdb-memory-node@0.14.1`) · Last updated: 2026-08-19 · Applies to: velesdb-core 5.1.0 · [Report a docs error](https://github.com/cyberlife-coder/VelesDB/issues)

--- a/crates/velesdb-node/package-lock.json
+++ b/crates/velesdb-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wiscale/velesdb-memory-node",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@napi-rs/cli": "^3.0.0"

--- a/crates/velesdb-node/package.json
+++ b/crates/velesdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiscale/velesdb-memory-node",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Local-first agent memory for Node.js (napi-rs): remember/recall/relate/forget/why with the why() knowledge-graph wedge, plus auto-extraction.",
   "license": "SEE LICENSE IN LICENSE",
   "author": "Julien Lange <contact@wiscale.fr>",

--- a/docs/guides/CONTEXT_COMPILER.md
+++ b/docs/guides/CONTEXT_COMPILER.md
@@ -841,4 +841,4 @@ skill teaches an agent the full workflow — including when *not* to compress.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.14.0
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.14.1

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -708,6 +708,40 @@ same endpoint. Server consoles advertise the version-prefixed form
 (`http://127.0.0.1:8019/v1`) next to a copy button, so pasting it must work
 rather than silently produce `/v1/v1/embeddings` and a `404`.
 
+### Local or cloud: the same three variables
+
+The URL's scheme is the whole switch. `http://` reaches a server on your
+machine; `https://` reaches a hosted provider (supported since
+velesdb-memory 0.14.1) — same variables, nothing to rebuild, nothing else to
+learn:
+
+```bash
+# Local (LM Studio, llama.cpp server, vLLM, oMLX…) — memory never leaves
+# the machine:
+VELESDB_MEMORY_EMBEDDER=openai \
+VELESDB_MEMORY_EMBEDDER_URL=http://127.0.0.1:8019 \
+VELESDB_MEMORY_EMBEDDER_MODEL=bge-m3 \
+  /path/to/velesdb-memory
+
+# Cloud (any OpenAI-compatible embeddings provider):
+VELESDB_MEMORY_EMBEDDER=openai \
+VELESDB_MEMORY_EMBEDDER_URL=https://api.openai.com \
+VELESDB_MEMORY_EMBEDDER_MODEL=text-embedding-3-small \
+VELESDB_MEMORY_EMBEDDER_API_TOKEN=sk-... \
+  /path/to/velesdb-memory
+```
+
+The extractor mirrors this exactly with its own `VELESDB_MEMORY_EXTRACTOR*`
+variables — including providers that only serve chat completions: OpenRouter,
+for instance, speaks `/v1/chat/completions` but not `/v1/embeddings`, so it
+can back the **extractor** while the **embedder** stays local or on an
+embeddings-serving provider.
+
+**Choosing a cloud URL is choosing to send that text off the machine.** The
+default posture does not change: `hash` needs no network at all, local
+servers keep everything on your hardware, and nothing contacts a remote host
+unless you set an `https://` URL yourself.
+
 **API tokens are read from the environment only.** There is deliberately no
 `api_token` field in `velesdb-memory.toml`, and putting one there is refused at
 startup: a credential at rest in a versionable file is one `git add .` away

--- a/docs/guides/MCP_SERVER_SETUP.md
+++ b/docs/guides/MCP_SERVER_SETUP.md
@@ -838,4 +838,4 @@ trait and pass it to `MemoryService::remember_extracted` from Rust.
 
 ---
 
-Last updated: 2026-07-25 · Applies to: velesdb-memory 0.14.0
+Last updated: 2026-07-25 · Applies to: velesdb-memory 0.14.1

--- a/docs/guides/MEMORY_EXTRACTOR_MODELS.md
+++ b/docs/guides/MEMORY_EXTRACTOR_MODELS.md
@@ -1,6 +1,6 @@
 # Choosing a graph-extraction model for velesdb-memory
 
-Last updated: 2026-08-16 · Applies to: velesdb-memory 0.14.0
+Last updated: 2026-08-16 · Applies to: velesdb-memory 0.14.1
 
 `velesdb-memory` turns a remembered fact into graph edges by asking a local
 model for JSON. Which model you point it at — `VELESDB_MEMORY_EXTRACTOR_MODEL`

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -1,6 +1,6 @@
 # VelesQL Ecosystem Parity Matrix
 
-Last updated: 2026-08-19 (v5.1.0; velesdb-memory 0.14.0)
+Last updated: 2026-08-19 (v5.1.0; velesdb-memory 0.14.1)
 
 This matrix tracks runtime contract and feature parity across the VelesDB ecosystem.
 

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -800,4 +800,4 @@ so the MCP taxonomy cannot drift from the bindings':
 
 ---
 
-Last updated: 2026-08-09 · Applies to: velesdb-memory 0.14.0
+Last updated: 2026-08-09 · Applies to: velesdb-memory 0.14.1

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cyberlife-coder/velesdb-memory",
   "title": "VelesDB Memory",
-  "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store — why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
-  "version": "0.14.0",
+  "description": "Agentic memory for AI agents in one tiny offline binary. remember/recall/relate/forget/why over a tri-engine that fuses vector search, a knowledge graph, and a columnar store \u2014 why() walks the graph to reconnect a decision with its context across sessions, surfacing linked facts that share no words with the query.",
+  "version": "0.14.1",
   "repository": {
     "url": "https://github.com/cyberlife-coder/VelesDB",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "cargo",
       "registryBaseUrl": "https://crates.io",
       "identifier": "velesdb-memory",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "transport": {
         "type": "stdio"
       },
@@ -26,7 +26,7 @@
         },
         {
           "name": "VELESDB_MEMORY_EMBEDDER",
-          "description": "Embedding backend: 'hash' (default, offline, zero-dep), 'ollama' (real semantic recall via a local model), or 'openai' (any OpenAI-compatible server — oMLX, llama.cpp, LM Studio, vLLM, a hosted provider — set VELESDB_MEMORY_EMBEDDER_URL and _MODEL). Both remote backends need a binary built --features embedder-http.",
+          "description": "Embedding backend: 'hash' (default, offline, zero-dep), 'ollama' (real semantic recall via a local model), or 'openai' (any OpenAI-compatible server \u2014 oMLX, llama.cpp, LM Studio, vLLM, a hosted provider \u2014 set VELESDB_MEMORY_EMBEDDER_URL and _MODEL). Both remote backends need a binary built --features embedder-http.",
           "isRequired": false,
           "default": "hash"
         }


### PR DESCRIPTION
## Description

Closes #2025, shaped by the product decision on it: **the user chooses local or cloud, and the choice must cost nothing to learn.** So TLS lands inside the *existing* `embedder-http`/`extractor-http` features — no new feature to discover, no rebuild: the URL's scheme is the whole switch.

- **Before**: the outbound client (`ureq`, `default-features = false`) had no TLS. The `openai` backend — documented as reaching "hosted providers" — could only reach `http://`; every `https://` URL died on an opaque transport error. The README's claim was untrue.
- **After**: rustls ships in the HTTP features. `http://127.0.0.1:8019` (LM Studio, llama.cpp server, vLLM, oMLX) and `https://api.openai.com` work with the same three variables per role (`_URL`, `_MODEL`, optional `_API_TOKEN`). A chat-only provider (OpenRouter) can back the **extractor** while the embedder stays local — the roles are independent on purpose.
- **Default posture unchanged**: `hash` stays offline; nothing contacts a remote host unless the user sets an `https://` URL themselves. The setup guide states the privacy consequence plainly.

**Docs / parity** (all the surfaces that speak about backends):
- `docs/guides/MCP_SERVER_SETUP.md`: new "Local or cloud: the same three variables" section — the two forms side by side, the OpenRouter nuance, the privacy line;
- `remote_endpoint.rs` rustdoc extended (scheme = the switch; roles independent);
- `crates/velesdb-memory/CHANGELOG.md` gains `[0.14.1]`; version bumped and stamped across the eight policed sites (node crate/package/lock ×2/README, `server.json` ×2, `ECOSYSTEM_PARITY.md`, memory README footer) — `check-version-sync.py`: all match;
- the memory README's "hosted providers" sentence becomes true instead of aspirational.

**Proof**: a transport-level test pins the capability — an `https://` URL must fail at the *network* (connect refused on the discard port), never on "client built without TLS", so a dependency-feature regression cannot silently take it back.

**Binary size**: the size gate covers `velesdb-server`/`velesdb`/`velesdb-migrate`, none of which enable memory's HTTP features — no ceiling is affected; the memory daemon grows by the rustls footprint, accepted as the cost of the capability.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

New `https_scheme_reaches_the_network_instead_of_dying_on_missing_tls` green; `cargo clippy -p velesdb-memory --all-features --all-targets -- -D warnings -D clippy::pedantic` clean; `cargo fmt --all -- --check` clean; `check-version-sync.py` all match; `check-feature-claims.py`, `check-doc-contract.sh`, `check-inline-tests.py`, `check-file-budgets.py` all PASSED. The full suite runs in PR CI (the local all-features run died on the sandbox's disk quota, not on a test).

**Test Configuration:**
- OS: Linux
- Rust version: workspace toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Follow-up once merged: cut `velesdb-memory 0.14.1` through the same release train as 0.14.0 (release-memory + release-mcpb), so the "supported since 0.14.1" claim is live on the registries rather than only in the tree.
