### PR TITLE
ci(release-memory): build the aarch64 node addon with the apt cross gcc

### DIFF
--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -266,11 +266,25 @@ jobs:
       - name: Install build deps (@napi-rs/cli)
         run: npm install
 
+      # Same recipe as the daemon-archive job below: apt's cross gcc. The
+      # napi-rs bundled cross toolchain's gcc is too old for ring's ARM
+      # assembly (`#error "ARM assembler must define __ARM_ARCH"`), which the
+      # crate pulls in since TLS ships in the default HTTP features (0.14.1) —
+      # while the daemon job has been building the same crate for the same
+      # target with the apt toolchain all along. cc-rs finds
+      # aarch64-linux-gnu-gcc by target convention once no TARGET_CC overrides
+      # it, so dropping --use-napi-cross is the whole switch.
+      - name: Install aarch64 linux cross linker
+        if: matrix.cross
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
       - name: Build addon
         # napi reads the profile from package.json's build script; pass the
-        # target explicitly for cross/host builds. --use-napi-cross supplies the
-        # zig-based sysroot for the one cross target (no Docker needed).
-        run: npx napi build --platform --profile release-node --target ${{ matrix.target }} ${{ matrix.cross && '--use-napi-cross' || '' }}
+        # target explicitly for cross/host builds.
+        run: npx napi build --platform --profile release-node --target ${{ matrix.target }}
 
       - name: Smoke-test the addon (native targets only)
         # HARDENING (tracked): this skips x86_64-apple-darwin (Rosetta on the arm


### PR DESCRIPTION
## Description

The 0.14.1 release run published crates.io, the GitHub release, the daemon archives and the MCPB bundles — but `Build node (aarch64-unknown-linux-gnu)` failed, which gated `publish-npm` into a skip. Root cause: `ring` entered the node addon's dependency graph when TLS became part of the default HTTP features (#2026), and the napi-rs bundled cross-toolchain's gcc is too old for ring's ARM assembly:

```
ring-core/asm_base.h:73:2: error: #error "ARM assembler must define __ARM_ARCH"
```

The daemon-archive job builds the **same crate for the same target** with apt's `gcc-aarch64-linux-gnu` and passed in the same run — so the node leg now uses that identical recipe (install apt cross gcc, set the cargo linker env) and drops `--use-napi-cross`. cc-rs finds `aarch64-linux-gnu-gcc` by target convention once no `TARGET_CC` overrides it.

After merge, the plan is to re-dispatch `release-memory.yml` for 0.14.1 with `publish_crate=false` and `publish_daemon_archive=false` so only the node build + npm publish re-run.

## Type of change

- [x] CI/workflow fix

## How has this been tested?

Failure and fix are both evidenced by run 32308938672: the failing node leg (napi cross toolchain, 28 s, ring asm error) versus the passing `Build daemon archive (aarch64-unknown-linux-gnu)` leg (apt toolchain, full crate incl. ring, 4 m 46 s).

## Checklist

- [x] The root cause is stated in the workflow comment at the change site
- [x] No version or packaging metadata touched — workflow only
