### PR TITLE
chore(deps): bump whoami to 2.1.3 and adapt to its fallible username()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3016,14 +3016,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.9.2",
 ]
 
 [[package]]
@@ -3193,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3593,6 +3593,15 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4260,7 +4269,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4551,9 +4560,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7150,6 +7159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7160,9 +7178,12 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "0.1.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -7606,11 +7627,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
+ "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -378,7 +378,7 @@ version = "0.4"
 optional = true
 
 [dependencies.whoami]
-version = "1.5"
+version = "2.1"
 optional = true
 
 [dependencies.reqwest]

--- a/crates/velesdb-core/src/update_check/instance_id.rs
+++ b/crates/velesdb-core/src/update_check/instance_id.rs
@@ -93,7 +93,7 @@ fn get_fallback_id() -> String {
         |h| h.to_string_lossy().to_string(),
     );
 
-    let username = whoami::username();
+    let username = whoami::username().unwrap_or_else(|_| "unknown".to_string());
 
     format!("fallback:{hostname}:{username}")
 }


### PR DESCRIPTION
## Description

Carries dependabot's whoami 1.6.1 → 2.1.3 bump (#1954), which could not merge on its own: whoami 2.x is a semver-major that makes `username()` return `Result<String, Error>`, so the bare bump broke compilation across the workspace (6 red jobs on #1954 — Tests, Lint, VelesQL Conformance, Binary Size, OpenAPI Drift, Propagation Guard).

The single call site, `update_check/instance_id.rs::get_fallback_id`, now degrades to `"unknown"` on error — mirroring the hostname fallback one line above it. `Cargo.toml`'s constraint moves to `2.1` (dependabot's own edit, rebased onto current develop).

## Type of change

- [x] Dependency update (with the one-line API adaptation it requires)

## How has this been tested?

- `cargo test -p velesdb-core --features update-check,persistence --lib instance_id` — 5 passed
- `cargo clippy -p velesdb-core --features update-check,persistence --lib -- -D warnings -D clippy::pedantic` — clean
- The pre-fix state reproduces #1954's CI failure locally (E0277: `Result` is not `Display` in the `format!`)

## Checklist

- [x] Single call site adapted; no behavioral change beyond the error fallback
- [x] Supersedes #1954 (same lockfile/manifest change, plus the required code fix)
