### PR TITLE
ci(memory): promote a targeted feature matrix for velesdb-memory to CI Success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,6 +608,46 @@ jobs:
         run: python3 scripts/run-wasm-bindgen-tests.py --root .
 
   # ===========================================================================
+  # velesdb-memory Feature Matrix
+  # feature-powerset.yml's full `cargo hack --feature-powerset --depth 2` stays
+  # weekly/manual — it re-checks the crate ~30 times, too slow for every PR.
+  # These four combinations are the shapes real consumers actually build with
+  # (velesdb-wasm, velesdb-node/velesdb-python, and the stdio MCP daemon
+  # before `context` is layered on) — see #2019. A regression in any of them
+  # breaks a real downstream target the same day, not the following Monday.
+  # ===========================================================================
+  memory-feature-matrix:
+    name: velesdb-memory Feature Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "velesdb-ci-memory-feature-matrix"
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+
+      # The floor every downstream Cargo.toml starts from.
+      - name: Check with no default features
+        run: cargo check -p velesdb-memory --no-default-features
+
+      # velesdb-wasm's shape: context alone, persistence-free.
+      - name: Check context alone (wasm shape)
+        run: cargo check -p velesdb-memory --no-default-features --features context
+
+      # velesdb-node/velesdb-python's shape minus the HTTP embedder/extractor clients.
+      - name: Check persistence+context (native-binding shape)
+        run: cargo check -p velesdb-memory --no-default-features --features persistence,context
+
+      # The stdio MCP daemon without the context compiler layered on top.
+      - name: Check mcp+persistence (daemon shape)
+        run: cargo check -p velesdb-memory --no-default-features --features mcp,persistence
+
+  # ===========================================================================
   # OpenAPI Drift Check
   # Regenerates the committed docs/openapi.{json,yaml} snapshots from the
   # utoipa-derived schema and fails if they differ from what is checked in,
@@ -1556,7 +1596,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, hygiene, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
+    needs: [lint, test, security, hygiene, wasm-check, memory-feature-matrix, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
     if: always()
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -1567,6 +1607,7 @@ jobs:
           [[ "${{ needs.lint.result }}" == "success" ]] && \
           [[ "${{ needs.test.result }}" == "success" ]] && \
           [[ "${{ needs.wasm-check.result }}" == "success" ]] && \
+          [[ "${{ needs.memory-feature-matrix.result }}" == "success" ]] && \
           [[ "${{ needs.openapi-drift.result }}" == "success" ]] && \
           [[ "${{ needs.mcp-doc-contract.result }}" == "success" ]] && \
           [[ "${{ needs.velesql-conformance.result }}" == "success" ]] && \

--- a/.github/workflows/feature-powerset.yml
+++ b/.github/workflows/feature-powerset.yml
@@ -13,11 +13,14 @@ name: Feature Powerset
 # aliases are grouped with their targets: `ollama = [embedder-http]` and
 # `extract = [extractor-http]` add combinations without adding surface.
 #
-# Deliberately OUTSIDE `CI Success` for now (weekly + manual), promotion to
-# a required gate being its own decision once the runtime is known: the
-# powerset re-checks the crate ~30 times and does not belong in every PR's
-# critical path on day one. velesdb-core comes after velesdb-memory proves
-# the harness — its 20+ features need `--depth 2` discipline even more.
+# Deliberately OUTSIDE `CI Success` (weekly + manual): the powerset re-checks
+# the crate ~30 times and does not belong in every PR's critical path. The
+# four combinations real consumers actually build with (velesdb-wasm,
+# velesdb-node/velesdb-python, the stdio MCP daemon) are promoted to a
+# blocking job instead — `memory-feature-matrix` in ci.yml, see #2019. This
+# workflow stays the exhaustive weekly filet for every other combination.
+# velesdb-core comes after velesdb-memory proves the harness — its 20+
+# features need `--depth 2` discipline even more.
 on:
   workflow_dispatch:
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,11 @@ cargo test --doc --package velesdb-server
 # Feature-gate sanity:
 cargo check --no-default-features
 cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
+# velesdb-memory feature matrix (the shapes real consumers build with — #2019):
+cargo check -p velesdb-memory --no-default-features
+cargo check -p velesdb-memory --no-default-features --features context
+cargo check -p velesdb-memory --no-default-features --features persistence,context
+cargo check -p velesdb-memory --no-default-features --features mcp,persistence
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
 # Guards and contracts. Every one of these blocks a PR through `CI Success`, and


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

`feature-powerset.yml`'s full `cargo hack --feature-powerset --depth 2` over `velesdb-memory` stays weekly/manual (it re-checks the crate ~30 times, too slow for every PR's critical path). That left the crate's non-default feature combinations — the only gate exercising them at all — checked at most once a week: a `cfg` regression on a non-default combination could merge on a Tuesday and not surface until the following Monday, on `develop`, with no obvious culprit SHA.

This adds a new blocking `memory-feature-matrix` job to `ci.yml` that checks the four shapes real downstream consumers actually build `velesdb-memory` with, instead of the full powerset:

- `--no-default-features` — the floor every downstream `Cargo.toml` starts from
- `--features context` — `velesdb-wasm`'s shape (persistence-free)
- `--features persistence,context` — `velesdb-node`/`velesdb-python`'s shape minus the HTTP embedder/extractor clients
- `--features mcp,persistence` — the stdio MCP daemon before `context` is layered on

Each combination was verified to compile cleanly before wiring it in (Working principle #9 — baseline before gating). The job is added to `CI Success`'s `needs:` and its explicit result check. `feature-powerset.yml`'s header comment is updated to describe the split: exhaustive powerset stays weekly, this targeted subset is now the blocking one. `AGENTS.md`'s pre-push block gets the same four `cargo check` lines so a local run mirrors CI exactly (Hardened execution method #10).

Fixes #2019

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement

(CI-only change — none of the above apply cleanly; closest is a new CI gate, no runtime code touched.)

## How Has This Been Tested?

- [x] Manual testing

Ran all four target `cargo check` invocations locally against the current `velesdb-memory` tree before adding the CI job — all pass cleanly:

```
cargo check -p velesdb-memory --no-default-features
cargo check -p velesdb-memory --no-default-features --features context
cargo check -p velesdb-memory --no-default-features --features persistence,context
cargo check -p velesdb-memory --no-default-features --features mcp,persistence
```

Also validated: `ci.yml`/`feature-powerset.yml` YAML parses (`yaml.safe_load`), and the repo's doc/version/attribution guards (`check-doc-contract.sh`, `check-doc-freshness.py` for all five guards, `check-version-sync.py`, `check-ai-attribution.py`) all pass against this diff.

**Test Configuration:**
- OS: Linux (CI sandbox)
- Rust version: 1.90.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — not applicable, this *is* the test (a new CI gate)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Only `velesdb-memory`'s targeted matrix is promoted here, matching the smaller of the two options the issue raised. The full powerset stays the weekly exhaustive filet for every other feature combination; `velesdb-core`'s own powerset work (mentioned in the workflow's comment) is out of scope for this PR.
