### PR TITLE
docs: remove the unverified Discord invite from both help sections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,11 +174,10 @@ the remaining debt is. Read these when you need the *why* behind a behaviour.
 
 - [GitHub Repository](https://github.com/cyberlife-coder/VelesDB)
 - [crates.io](https://crates.io/crates/velesdb-core)
-- [Discord Community](https://discord.gg/velesdb)
 
 ---
 
 *VelesDB — the explainable, local-first memory engine for AI agents. (Microsecond vector search is the proof, not the pitch.)*
 
 ---
-Last updated: 2026-08-08 · Applies to: velesdb-core 5.1.0
+Last updated: 2026-08-20 · Applies to: velesdb-core 5.1.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -323,9 +323,8 @@ curl -X POST http://localhost:8080/query \
 
 ## Getting Help
 
-- [**Discord**](https://discord.gg/velesdb): Join our community for real-time support
 - [**GitHub Issues**](https://github.com/cyberlife-coder/VelesDB/issues): Report bugs or request features
 - [**GitHub Discussions**](https://github.com/cyberlife-coder/VelesDB/discussions): Ask questions and share ideas
 
 ---
-Last updated: 2026-08-13 · Applies to: velesdb-core 5.1.0
+Last updated: 2026-08-20 · Applies to: velesdb-core 5.1.0


### PR DESCRIPTION
## Description

The `#1890` fix (#1917) linked the Discord line of "Getting Help" to `https://discord.gg/velesdb` — but the project operates no Discord server, and the original audit had already established that no Discord URL exists anywhere in the repository. The invite is therefore a dead end at the exact moment a user is stuck, which is worse than no link at all.

This removes the Discord line from `docs/getting-started.md` ("Getting Help") and `docs/README.md` ("External Resources"), and refreshes the `Last updated` stamps. GitHub Issues and GitHub Discussions were both verified active on the repository and remain linked.

Refs #1890

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Docs-only change; the relevant local gates were run in full:

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` → `Ran 625 tests … OK (skipped=9)`
- `check-promise-contract.py`, `check-version-sync.py`, `check-feature-claims.py`, `check-mcp-doc-contract.py`, `check-doc-contract.sh` → all passed
- `check-doc-freshness.py --mode strict` for all five guards (`stamp`, `index`, `tracked`, `versions`, `decisions`) → PASS
- GitHub Discussions verified reachable; GitHub Issues active
- Cargo/clippy/wasm steps of the pre-push block were not run: no code path is touched by this diff

**Test Configuration:**
- OS: Linux
- Rust version: n/a (docs-only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

If a real VelesDB Discord (or another live chat channel) is created later, re-add the line with its permanent invite URL — and consider pinning that URL in `docs/reference/promise-contract.json` so a dead invite fails the contract instead of shipping.