### PR TITLE
ci: gate PRs on the four feature combinations consumers actually build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,43 @@ jobs:
   # NOTE: compat-matrix.yml also checks WASM; this job provides a dedicated
   # signal visible in the ci-success summary.
   # ===========================================================================
+  # Blocking slice of the feature powerset (#2019). The weekly
+  # feature-powerset.yml sweeps all depth-2 combinations of velesdb-memory's
+  # ~20 features as a safety net, but it is not in CI Success: a cfg
+  # regression on a non-default combination could merge on a Tuesday and
+  # surface the following Monday with no obvious culprit SHA. These four
+  # checks are the combinations downstream consumers actually build —
+  # nothing (API floor), `context` alone (wasm binding), the default set,
+  # and `mcp,persistence` (the MCP daemon) — so a PR that breaks one of
+  # them cannot merge. Full-sweep coverage stays weekly by design: four
+  # `cargo check` runs are the cost this gate is allowed to have.
+  memory-feature-matrix:
+    name: Memory Feature Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "velesdb-ci-memory-feature-matrix"
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+
+      - name: No default features (API floor)
+        run: cargo check -p velesdb-memory --no-default-features
+
+      - name: context alone (wasm consumer)
+        run: cargo check -p velesdb-memory --no-default-features --features context
+
+      - name: Default features (persistence + context)
+        run: cargo check -p velesdb-memory
+
+      - name: mcp + persistence (daemon)
+        run: cargo check -p velesdb-memory --no-default-features --features mcp,persistence
+
   wasm-check:
     name: WASM Build Check
     runs-on: ubuntu-latest
@@ -1556,7 +1593,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, hygiene, wasm-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
+    needs: [lint, test, security, hygiene, wasm-check, memory-feature-matrix, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
     if: always()
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -1567,6 +1604,7 @@ jobs:
           [[ "${{ needs.lint.result }}" == "success" ]] && \
           [[ "${{ needs.test.result }}" == "success" ]] && \
           [[ "${{ needs.wasm-check.result }}" == "success" ]] && \
+          [[ "${{ needs.memory-feature-matrix.result }}" == "success" ]] && \
           [[ "${{ needs.openapi-drift.result }}" == "success" ]] && \
           [[ "${{ needs.mcp-doc-contract.result }}" == "success" ]] && \
           [[ "${{ needs.velesql-conformance.result }}" == "success" ]] && \


### PR DESCRIPTION
## Description

Closes #2019. The weekly `feature-powerset.yml` sweep is the only exercise of velesdb-memory's non-default feature combinations, and it is not in `CI Success` — a cfg regression on `context` alone could merge on a Tuesday and surface the following Monday on develop with no obvious culprit SHA.

The new `memory-feature-matrix` job checks the four combinations downstream consumers actually build, and is wired into `CI Success` (both the `needs` list and the gate expression):

| combination | consumer |
|---|---|
| `--no-default-features` | API floor |
| `--no-default-features --features context` | wasm binding |
| default (`persistence` + `context`) | the crate as shipped |
| `--no-default-features --features mcp,persistence` | the MCP daemon |

The full depth-2 powerset stays weekly by design — four `cargo check` runs are the cost this gate is allowed to have (measured locally: 1m49 cold, then 4 s–1m18 with shared target).

## Type of change

- [x] CI gate

## How has this been tested?

- All four combinations verified green locally before wiring the gate.
- `test_ci_gate_reachability.py` — 48 tests OK (the gate expression and `needs` stay consistent).
- YAML validated.

## Checklist

- [x] Success criterion of #2019 met: a PR that breaks `cargo check -p velesdb-memory --no-default-features --features context` can no longer merge
- [x] Weekly powerset untouched (safety net remains)
