### PR TITLE
ci: check manifest vs public registries daily, not only after a publish

### DIFF
--- a/.github/workflows/registry-drift.yml
+++ b/.github/workflows/registry-drift.yml
@@ -1,0 +1,42 @@
+name: Registry Drift
+
+# The manifest↔registry guard (`check-version-sync.py
+# --check-memory-registries`) runs in exactly one place: the
+# `verify-registries` job of release-memory.yml, which by construction runs
+# only AFTER a publish. It proves a release propagated; it cannot see the
+# drift that motivated it (#1884): manifests and docs bumped to a version no
+# registry serves because no release was ever cut. If nobody tags, the guard
+# never runs, and that state stays invisible until a user hits it (#2030).
+#
+# This schedule decouples the check from the release train: it bounds the
+# lifetime of such drift to one day instead of "until the next tag". The
+# one legitimate red is the transient release window — manifest bumped,
+# publish still in flight — which lasts minutes, not days; a red here that
+# persists across two consecutive runs is real drift.
+#
+# Deliberately NOT a PR gate: "manifest > registry" is the normal transient
+# state of every release-prep PR, so the naive PR-time form would red on
+# exactly the PRs that fix it (the counter-example #2030 records).
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily 05:23 UTC — off the busy on-the-hour spike.
+    - cron: '23 5 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/registry-drift.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  registry-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: develop
+
+      - name: Manifest vs public registries
+        run: python3 scripts/check-version-sync.py --check-memory-registries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,10 @@ wasm-pack test --node crates/velesdb-wasm
 # path, so read `Ran N tests` + `OK`, never grep for FAILED.
 python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .
 python3 scripts/check-version-sync.py
+# ^ checks stamps against each other, not against crates.io/npm. Manifest↔registry
+#   coherence is proved at release time (release-memory.yml `verify-registries`)
+#   and daily by registry-drift.yml — never at PR time, where "manifest > registry"
+#   is the normal transient state of every release-prep PR (#2030).
 python3 scripts/check-feature-claims.py
 python3 scripts/check-perf-claims.py --no-criterion
 python3 scripts/check-promise-contract.py


### PR DESCRIPTION
## Description

Closes #2030. The manifest↔registry guard (`check-version-sync.py --check-memory-registries`) runs in exactly one place — the `verify-registries` job of `release-memory.yml` — which by construction runs only **after** a publish. It proves a release propagated; it cannot see the drift that motivated it (#1884): manifests and shipped docs at a version no registry serves, because no release was cut. If nobody tags, the guard never runs.

This implements options 1 + 3 of the issue (option 2, the tolerant PR-time variant, is left untaken — its N-day statefulness buys little over a daily bound):

- **`registry-drift.yml`**: daily 05:23 UTC + manual dispatch, checks out `develop` explicitly (schedules run on the default branch) and runs the existing flag. Bounds the drift's lifetime to one day instead of "until the next tag". Deliberately **not** a PR gate — "manifest > registry" is the normal transient state of every release-prep PR, the counter-example the issue records against the naive form. The workflow header states the one legitimate red (the in-flight release window, minutes long).
- **`AGENTS.md`**: the pre-push block now states the guard's temporal coverage next to its invocation — stamps are checked against each other at PR time; registry coherence is proved at release time and daily.

## Type of change

- [x] CI schedule + doc note

## How has this been tested?

- `python3 scripts/check-version-sync.py --check-memory-registries` run locally against the live registries: green (`crates.io and all npm packages publish 0.14.1`).
- YAML validated; doc-contract and doc-freshness guards green after the AGENTS.md edit.
- The `pull_request` path-filter trigger exercises the job on this PR itself.

## Checklist

- [x] Existing `verify-registries` release job untouched
- [x] No new guard logic — only a schedule for the existing flag
