### PR TITLE
refactor(memory): one MemoryService shape — the generation gate's type varies, never the field list

### DIFF
--- a/crates/velesdb-memory/src/online_migration/cutover.rs
+++ b/crates/velesdb-memory/src/online_migration/cutover.rs
@@ -250,7 +250,7 @@ fn assemble<E: Embedder>(
             embedder,
             autograph: runtime.autograph,
             autograph_queue: runtime.autograph_queue,
-            generation_gate: parking_lot::RwLock::new(()),
+            generation_gate: crate::service::GenerationGate::new(),
         },
         model,
     }

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -135,14 +135,19 @@ const ABOUT_RELATION: &str = "about";
 /// Two definitions, `persistence`-gated: the default type parameter itself
 /// references [`NativeStore`], which doesn't exist as a type at all without
 /// the feature, so a `persistence`-free build (e.g. `velesdb-wasm`) drops the
-/// default and every caller names its own storage backend explicitly.
+/// default and every caller names its own storage backend explicitly. The
+/// duplication stops at the type-parameter list: the field lists are
+/// identical by contract — what varies per feature is the *type* of
+/// [`GenerationGate`], never the shape of the service — and
+/// `tests/service_field_drift.rs` fails the build of any change that lets
+/// them diverge again (#2017).
 #[cfg(feature = "persistence")]
 pub struct MemoryService<E: Embedder, S: FactStore = NativeStore> {
     store: S,
     embedder: E,
     autograph: Option<crate::extract::DynExtractor>,
     autograph_queue: AutographQueue,
-    generation_gate: parking_lot::RwLock<()>,
+    generation_gate: GenerationGate,
 }
 #[cfg(not(feature = "persistence"))]
 pub struct MemoryService<E: Embedder, S: FactStore> {
@@ -150,14 +155,12 @@ pub struct MemoryService<E: Embedder, S: FactStore> {
     embedder: E,
     autograph: Option<crate::extract::DynExtractor>,
     autograph_queue: AutographQueue,
+    generation_gate: GenerationGate,
 }
 
-struct GenerationGuard<'a> {
-    #[cfg(feature = "persistence")]
-    _guard: parking_lot::RwLockReadGuard<'a, ()>,
-    #[cfg(not(feature = "persistence"))]
-    _lifetime: std::marker::PhantomData<&'a ()>,
-}
+#[path = "service_generation.rs"]
+mod service_generation;
+use service_generation::{GenerationGate, GenerationGuard};
 
 /// One deferred autograph: the stored fact a background worker will read for
 /// entities, edges and attributes (#1846).
@@ -239,7 +242,7 @@ impl<E: Embedder> MemoryService<E, NativeStore> {
             embedder,
             autograph: None,
             autograph_queue: AutographQueue::default(),
-            generation_gate: parking_lot::RwLock::new(()),
+            generation_gate: GenerationGate::new(),
         })
     }
 
@@ -266,23 +269,13 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             embedder,
             autograph: None,
             autograph_queue: AutographQueue::default(),
-            #[cfg(feature = "persistence")]
-            generation_gate: parking_lot::RwLock::new(()),
+            generation_gate: GenerationGate::new(),
         }
     }
 
-    #[cfg(feature = "persistence")]
     fn enter_generation(&self) -> GenerationGuard<'_> {
         GenerationGuard {
             _guard: self.generation_gate.read(),
-        }
-    }
-
-    #[cfg(not(feature = "persistence"))]
-    fn enter_generation(&self) -> GenerationGuard<'_> {
-        let _ = self;
-        GenerationGuard {
-            _lifetime: std::marker::PhantomData,
         }
     }
 

--- a/crates/velesdb-memory/src/service_generation.rs
+++ b/crates/velesdb-memory/src/service_generation.rs
@@ -1,0 +1,46 @@
+//! The store-generation gate and its guard — `service.rs`'s concurrency
+//! seam, split out under the file-budget rule (#1974) the same way
+//! `service_graph.rs` was. A `#[path]` child of `service`, so the private
+//! field types stay private to the service subtree.
+
+/// The store-generation gate: mutation paths hold it shared, generation
+/// writers (observer install, online migration's swap) take it exclusive.
+/// Under `persistence` it is a real lock; without the feature (wasm,
+/// single-threaded by construction) it is a ZST with the same read-side
+/// API, so the service keeps one shape and the no-op compiles out instead
+/// of the *field* silently disappearing (#2017).
+#[cfg(feature = "persistence")]
+pub(super) struct GenerationGate(parking_lot::RwLock<()>);
+#[cfg(feature = "persistence")]
+impl GenerationGate {
+    pub(super) fn new() -> Self {
+        Self(parking_lot::RwLock::new(()))
+    }
+    pub(super) fn read(&self) -> GenerationReadGuard<'_> {
+        self.0.read()
+    }
+    pub(super) fn write(&self) -> parking_lot::RwLockWriteGuard<'_, ()> {
+        self.0.write()
+    }
+}
+#[cfg(not(feature = "persistence"))]
+pub(super) struct GenerationGate;
+#[cfg(not(feature = "persistence"))]
+impl GenerationGate {
+    pub(super) fn new() -> Self {
+        Self
+    }
+    pub(super) fn read(&self) -> GenerationReadGuard<'_> {
+        let Self = *self;
+        std::marker::PhantomData
+    }
+}
+
+#[cfg(feature = "persistence")]
+pub(super) type GenerationReadGuard<'a> = parking_lot::RwLockReadGuard<'a, ()>;
+#[cfg(not(feature = "persistence"))]
+pub(super) type GenerationReadGuard<'a> = std::marker::PhantomData<&'a ()>;
+
+pub(super) struct GenerationGuard<'a> {
+    pub(super) _guard: GenerationReadGuard<'a>,
+}

--- a/crates/velesdb-memory/tests/service_field_drift.rs
+++ b/crates/velesdb-memory/tests/service_field_drift.rs
@@ -1,0 +1,59 @@
+//! `MemoryService` exists twice by necessity — its default type parameter
+//! names `NativeStore`, a type that does not exist without `persistence` —
+//! but the *shape* of the service is one contract: what varies per feature
+//! is the type of `GenerationGate`, never the field list (#2017). This test
+//! reads the source and fails any change that lets the two definitions
+//! diverge again, which is exactly the failure mode the issue records: a
+//! field added under one cfg silently missing under the other.
+
+/// Extract the field names of every `struct MemoryService` definition in
+/// `service.rs`, in source order.
+fn memory_service_field_lists() -> Vec<Vec<String>> {
+    let source = include_str!("../src/service.rs");
+    let mut lists = Vec::new();
+    let mut rest = source;
+    while let Some(pos) = rest.find("pub struct MemoryService<") {
+        let body_start = match rest[pos..].find('{') {
+            Some(brace) => pos + brace + 1,
+            None => break,
+        };
+        let body_end = rest[body_start..]
+            .find('}')
+            .map_or(rest.len(), |end| body_start + end);
+        let fields: Vec<String> = rest[body_start..body_end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                let (name, _ty) = line.split_once(':')?;
+                Some(name.trim().to_string())
+            })
+            .collect();
+        lists.push(fields);
+        rest = &rest[body_end..];
+    }
+    lists
+}
+
+#[test]
+fn both_memory_service_definitions_declare_the_same_fields() {
+    let lists = memory_service_field_lists();
+    assert_eq!(
+        lists.len(),
+        2,
+        "expected exactly two cfg-gated MemoryService definitions, found {}: \
+         if the dual definition was unified, delete this test; if a third \
+         appeared, it needs the same field contract",
+        lists.len()
+    );
+    assert_eq!(
+        lists[0], lists[1],
+        "the two MemoryService definitions declare different fields — a field \
+         added under one cfg is silently absent under the other (#2017); add \
+         it to both, cfg-typing the field's *type* if it must vary"
+    );
+    assert!(
+        lists[0].contains(&"generation_gate".to_string()),
+        "generation_gate left the field contract — if that is deliberate, \
+         update this test and the GenerationGate doc together"
+    );
+}

--- a/scripts/file-budgets-baseline.txt
+++ b/scripts/file-budgets-baseline.txt
@@ -3,7 +3,7 @@ crates/velesdb-core/src/simd_native/x86_avx512.rs	1469
 crates/velesdb-memory/src/context.rs	1097
 crates/velesdb-memory/src/extract.rs	1559
 crates/velesdb-memory/src/schema.rs	1119
-crates/velesdb-memory/src/service.rs	1723
+crates/velesdb-memory/src/service.rs	1716
 crates/velesdb-python/src/agent_memory_service.rs	1097
 crates/velesdb-python/src/options.rs	1123
 crates/velesdb-wasm/src/memory_service.rs	1080


### PR DESCRIPTION
## Description

Closes #2017. `MemoryService` was defined twice under a `persistence` cfg with **diverging fields**: the wasm-path definition silently lacked `generation_gate`, so the concurrency mechanism disappeared per-feature and every new field had to be added twice on pain of silent drift. The dual definition itself is forced — the default type parameter names `NativeStore`, which does not exist as a type without the feature — but the divergence was not.

- Both definitions now declare **identical field lists**; what varies per feature is the *type* of `GenerationGate` — a real `parking_lot::RwLock` under `persistence`, a ZST with the same read-side API on the single-threaded wasm path, where the no-op compiles out (the issue's first suggested shape).
- `enter_generation` collapses to one implementation and `GenerationGuard` loses its per-cfg fields.
- The gate machinery lives in `service_generation.rs`, a `#[path]` child of `service` (same pattern as `service_graph.rs`), so `service.rs` **shrinks** 1723 → 1716 and the file-budget baseline tightens (shrink-only, per the guard's rule).
- **`tests/service_field_drift.rs`** pins the contract: it parses the two definitions from source and fails any change that lets their field lists diverge again — the issue's success criterion ("adding a field can no longer compile on only one path without an explicit failure somewhere") made mechanical.

## Type of change

- [x] Refactor (no behavioral change)

## How has this been tested?

- `cargo check` + `cargo clippy -D warnings -D pedantic` on both shapes: `--all-features --all-targets` and `--no-default-features --features context` (the wasm consumer shape) — clean.
- `cargo test -p velesdb-memory --lib` — 779 passed.
- New drift test passes; deleting a field from one definition makes it fail (exercised during development).
- `check-file-budgets.py` — PASSED with the tightened baseline; `check-inline-tests.py` — PASSED.

## Checklist

- [x] No `#[allow]` added — both pedantic lints on the ZST path fixed structurally (`new()` constructors, receiver consumed by pattern)
- [x] `online_migration/cutover.rs` construction site updated to the new type