### PR TITLE
refactor(memory): deprecate the MemoryStore alias; rename its napi homonym

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -7,6 +7,19 @@ released on its own `velesdb-memory-vX.Y.Z` tag.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Deprecated
+
+- **The `MemoryStore` supertrait alias (#2018).** Since the 0.14 facet split
+  no bound in the workspace names it — facet bounds (`S: GraphStore`-style)
+  everywhere — so it exists only as a compat shim for pre-facet out-of-tree
+  implementors. It now carries `#[deprecated]` pointing at the facet traits,
+  and will be removed in 0.15. Unrelated homonym cleaned up on the other
+  side of the binding seam: `velesdb-node`'s napi class (JS-visible as
+  `MemoryService` via `js_name`) no longer uses the Rust identifier
+  `MemoryStore`; being name-mapped, the rename is invisible to JS consumers.
+
 ## [0.14.1] - 2026-08-19
 
 ### Added

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -233,4 +233,8 @@ pub use rerank::{DynReranker, RerankError, Reranker};
 pub use service::{AutographWorkerHandle, MemoryService, Metadata};
 #[cfg(feature = "persistence")]
 pub use storage::NativeStore;
-pub use storage::{ColumnStore, FactStore, GraphStore, MemoryStore, RecallStore, AUTO_DATE_FIELD};
+pub use storage::{ColumnStore, FactStore, GraphStore, RecallStore, AUTO_DATE_FIELD};
+// Re-exported separately so the deprecation shim's allowance covers only the
+// alias, never the facet traits above.
+#[allow(deprecated)]
+pub use storage::MemoryStore;

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -330,8 +330,27 @@ pub trait GraphStore {
 /// Implementors migrating from the pre-facet monolith (≤ 0.13): the
 /// methods did not change — they moved. `impl MemoryStore` becomes
 /// `impl FactStore + RecallStore + GraphStore + ColumnStore` (#1959).
+///
+/// Not to be confused with `velesdb-node`'s napi **class** `MemoryStore`,
+/// which is unrelated: that is the JS-facing service object (a
+/// `MemoryService` wrapper), not this storage trait. Same name, opposite
+/// sides of the binding seam (#2018).
+///
+/// Since the facet split shipped, no bound in this workspace names the
+/// alias (`S: GraphStore`-style facet bounds everywhere) — it exists only
+/// so pre-facet out-of-tree code keeps compiling, and it goes away in the
+/// next breaking cycle.
+#[deprecated(
+    since = "0.14.2",
+    note = "bound on the facet traits you use (FactStore / RecallStore / \
+            GraphStore / ColumnStore); MemoryStore is a compat alias since \
+            the 0.14 facet split and will be removed in 0.15"
+)]
 pub trait MemoryStore: RecallStore + GraphStore + ColumnStore {}
 
+// The blanket impl IS the compat shim the deprecation announces — it must
+// keep compiling until the alias is removed with it in 0.15.
+#[allow(deprecated)]
 impl<T: RecallStore + GraphStore + ColumnStore> MemoryStore for T {}
 
 /// One fact as [`FactStore::list`] hands it to the service layer: content

--- a/crates/velesdb-memory/tests/binding_parity_bdd.rs
+++ b/crates/velesdb-memory/tests/binding_parity_bdd.rs
@@ -138,7 +138,10 @@ const BINDINGS: &[Binding] = &[
     Binding {
         name: "velesdb-node",
         path: "crates/velesdb-node/src/lib.rs",
-        surface_impl: "impl MemoryStore {",
+        // The Rust-side name, not the JS one: the napi class is js_name-mapped
+        // to "MemoryService", and the struct was renamed away from the
+        // trait-colliding `MemoryStore` (#2018).
+        surface_impl: "impl NodeMemoryService {",
     },
     Binding {
         name: "velesdb-python",

--- a/crates/velesdb-node/src/dto.rs
+++ b/crates/velesdb-node/src/dto.rs
@@ -306,7 +306,7 @@ impl From<UnrelateOutcome> for UnrelateJs {
     }
 }
 
-/// Result of [`compileContext`](crate::MemoryStore::compile_context): the
+/// Result of [`compileContext`](crate::NodeMemoryService::compile_context): the
 /// top-level fields are typed; the nested trees (`decisions`, `sources`, …)
 /// are plain JSON objects in exactly the MCP wire shape (`snake_case` keys),
 /// with every id field already converted to a decimal string.

--- a/crates/velesdb-node/src/lib.rs
+++ b/crates/velesdb-node/src/lib.rs
@@ -154,9 +154,13 @@ fn warn_hash_embedder_not_semantic(semantic: bool) {
 ///
 /// Exposed to JS as `MemoryService` (matching the `PyO3` binding and the core
 /// type); the Rust struct keeps a distinct name only to avoid colliding with the
-/// imported [`velesdb_memory::MemoryService`] it wraps.
+/// imported [`velesdb_memory::MemoryService`] it wraps. `NodeMemoryService`
+/// rather than the old `MemoryStore`: that name collided with
+/// `velesdb_memory`'s storage-trait alias on the other side of the binding
+/// seam, exactly where ambiguity costs the most (#2018) — and being
+/// `js_name`-mapped, the Rust identifier is invisible to JS consumers.
 #[napi(js_name = "MemoryService")]
-pub struct MemoryStore {
+pub struct NodeMemoryService {
     inner: Arc<MemoryService<DynEmbedder>>,
     /// The embedder identity resolved at [`Self::open`] — what
     /// [`Self::memory_status`] reports as RUNNING. The service itself only
@@ -170,7 +174,7 @@ pub struct MemoryStore {
 }
 
 #[napi]
-impl MemoryStore {
+impl NodeMemoryService {
     /// Open (or create) a memory store at `path`.
     ///
     /// `embedder` is `"hash"` (default, offline), `"ollama"` or `"openai"`


### PR DESCRIPTION
## Description

Closes #2018, both halves.

**The alias.** Since the 0.14 facet split, no bound in the workspace names the `MemoryStore` supertrait alias (the issue's census: 68 facet-trait bounds, zero `S: MemoryStore`). It exists only as a compat shim for pre-facet out-of-tree implementors, and now carries `#[deprecated(since = "0.14.2")]` pointing at the facet traits, with removal announced for 0.15. The `#[allow(deprecated)]` shim allowances are scoped to exactly two sites — the blanket impl (which *is* the compat mechanism) and the alias's own re-export, split off from the facet traits' re-export so the allowance never covers them.

**The homonym.** Better than documenting around it: `velesdb-node`'s napi class is `js_name`-mapped to `"MemoryService"`, so its Rust identifier is **invisible to JS consumers** — the trait-colliding `MemoryStore` struct is renamed `NodeMemoryService` with zero user-facing impact. `binding_parity_bdd`'s `surface_impl` anchor now names the renamed block, with a comment stating which side of the seam it greps (the test already fails loudly on a rename, so the anchor cannot rot silently).

Result: no symbol named `MemoryStore` is left whose meaning depends on which crate you are reading — the issue's success criterion.

## Type of change

- [x] Deprecation + internal rename (no behavioral change; JS surface unchanged)

## How has this been tested?

- `cargo clippy -p velesdb-memory --all-features --all-targets -- -D warnings -D clippy::pedantic` — clean (the deprecation triggers no internal warnings: nothing in-tree uses the alias).
- `cargo clippy -p velesdb-node --lib -- -D warnings` — clean after the rename.
- `binding_parity_bdd` — 28 passed with the new anchor.
- `check-version-sync`, AI-attribution guard, learning-loop policy tests — green.
- CHANGELOG (`[Unreleased]`, Deprecated) documents the shim's timeline.

## Checklist

- [x] JS/npm surface untouched (`js_name` mapping proven at the definition site)
- [x] Allowances scoped to the shim only
- [x] Removal path stated (0.15) in code and CHANGELOG