### PR TITLE
docs(ci): document the promoted memory feature matrix in the pre-push block and the powerset header

### DIFF
--- a/.github/workflows/feature-powerset.yml
+++ b/.github/workflows/feature-powerset.yml
@@ -13,11 +13,13 @@ name: Feature Powerset
 # aliases are grouped with their targets: `ollama = [embedder-http]` and
 # `extract = [extractor-http]` add combinations without adding surface.
 #
-# Deliberately OUTSIDE `CI Success` for now (weekly + manual), promotion to
-# a required gate being its own decision once the runtime is known: the
-# powerset re-checks the crate ~30 times and does not belong in every PR's
-# critical path on day one. velesdb-core comes after velesdb-memory proves
-# the harness — its 20+ features need `--depth 2` discipline even more.
+# Deliberately OUTSIDE `CI Success` (weekly + manual): the powerset re-checks
+# the crate ~30 times and does not belong in every PR's critical path. The
+# blocking slice lives in ci.yml's `memory-feature-matrix` job (#2019), which
+# gates every PR on the four combinations downstream consumers actually
+# build; this sweep stays the weekly safety net for everything else.
+# velesdb-core comes after velesdb-memory proves the harness — its 20+
+# features need `--depth 2` discipline even more.
 on:
   workflow_dispatch:
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ cargo test --doc --package velesdb-server
 # Feature-gate sanity:
 cargo check --no-default-features
 cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
+# Memory feature matrix — mirrors CI's blocking `memory-feature-matrix` job (#2019),
+# the four shapes downstream consumers actually build:
+cargo check -p velesdb-memory --no-default-features
+cargo check -p velesdb-memory --no-default-features --features context
+cargo check -p velesdb-memory
+cargo check -p velesdb-memory --no-default-features --features mcp,persistence
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
 # Guards and contracts. Every one of these blocks a PR through `CI Success`, and


### PR DESCRIPTION
## Description

#2032 promoted the four-combination `memory-feature-matrix` job into `CI Success` (closing #2019), but left two documents describing the previous state:

- `AGENTS.md`'s pre-push block did not mirror the new gate — a local run following it exactly could push a `cfg` regression that only the CI job would catch (Hardened execution method #10: local checks mirror CI flags exactly). The block now carries the same four `cargo check -p velesdb-memory` lines as the job, verbatim.
- `.github/workflows/feature-powerset.yml`'s header still said promotion to a required gate was "its own decision once the runtime is known" — that decision has since been taken, in the form of the targeted slice. The header now names ci.yml's `memory-feature-matrix` as the blocking slice and keeps the weekly powerset described as the safety net.

These are the two deltas of #2029 that #2032 did not carry; #2029 is closed as superseded in favor of this PR.

Refs #2019

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Manual testing

Comment/doc-only diff — no job logic, no code path touched:

- `yaml.safe_load` parses the edited `feature-powerset.yml`
- The four documented commands are exactly the ones `memory-feature-matrix` runs in `ci.yml` (compared against the merged job step by step)
- Doc and attribution guards pass on the branch range

**Test Configuration:**
- OS: Linux
- Rust version: n/a (doc/comment-only)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings