### PR TITLE
refactor(core): make the two lock-rank tables one source of truth, enforced by the compiler

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
@@ -61,6 +61,12 @@ use super::safety_counters::HNSW_COUNTERS;
 /// `gpu_vectors_snapshot → vectors → columnar → layers → neighbors`.
 /// Any code path that acquires multiple locks must acquire them
 /// in strictly increasing rank order.
+/// Discriminants are defined FROM the public ordinal registry
+/// (`crate::lock_rank::LockRank`), not repeated: the two tables cannot
+/// diverge without a compile error, so "kept in lock-step" is enforced by
+/// the compiler rather than promised by prose (#2013). The registry is the
+/// authority on the numbers; this enum stays the private mechanism wired
+/// into the debug tracker below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 pub(crate) enum LockRank {
@@ -72,17 +78,17 @@ pub(crate) enum LockRank {
     // Only exercised when the `gpu` feature is active; stays in the enum so
     // lock-ordering logic is the same across feature configurations.
     #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
-    GpuVectorsSnapshot = 5,
+    GpuVectorsSnapshot = crate::lock_rank::LockRank::GPU_VECTORS_SNAPSHOT.ordinal(),
     /// `vectors` RwLock — rank 10 (acquired first among the core HNSW locks)
-    Vectors = 10,
+    Vectors = crate::lock_rank::LockRank::VECTORS.ordinal(),
     /// `columnar` RwLock — rank 15 (PDX block-columnar layout)
     #[allow(dead_code)] // Reason: PDX columnar lock rank — used when PDX search is wired
-    Columnar = 15,
+    Columnar = crate::lock_rank::LockRank::COLUMNAR.ordinal(),
     /// `layers` RwLock — rank 20 (acquired after vectors/columnar)
-    Layers = 20,
+    Layers = crate::lock_rank::LockRank::LAYERS.ordinal(),
     /// Per-node neighbor lists — rank 30 (acquired last)
     #[allow(dead_code)] // Reason: Neighbor-level lock rank — reserved for fine-grained locking
-    Neighbors = 30,
+    Neighbors = crate::lock_rank::LockRank::NEIGHBORS.ordinal(),
 }
 
 // F-25: Thread-local stack only in debug builds to avoid ~10-20ns overhead

--- a/crates/velesdb-core/src/lock_rank.rs
+++ b/crates/velesdb-core/src/lock_rank.rs
@@ -1,15 +1,32 @@
-//! Compiled lock-rank invariant for the global lock-acquisition order.
+//! The ordinal registry for the global lock-acquisition order — and the
+//! declared premium extension point for lock ranks.
 //!
-//! Lock ordering was historically documented as convention in
-//! [`docs/CONCURRENCY_MODEL.md`]. This module promotes that convention to a
-//! typed [`LockRank`] newtype so the global acquisition order is expressed in
-//! code, with a debug-only [`assert_lock_order`] check that compiles to
-//! nothing in release builds (zero release overhead).
+//! Two things live here, and naming them precisely is the point (#2013):
 //!
-//! Locks MUST be acquired in strictly ascending rank. Core ranks occupy the
-//! low ordinals (`gpu < vectors < columnar < layers < neighbors`); the
-//! inclusive range `[40, 59]` is reserved for premium-owned lock classes so
-//! premium can order its locks relative to core without collision.
+//! 1. **The authoritative ordinal table.** Core's enforced ordering
+//!    mechanism is the *private* `HnswLockRank` enum in
+//!    `index/hnsw/native/graph/locking.rs` (a debug-only, warn-only tracker
+//!    on the HNSW hot path; see `CONCURRENCY_MODEL.md` for exactly what it
+//!    does and does not check). That enum's discriminants are defined FROM
+//!    the constants below, so the two tables cannot diverge without a
+//!    compile error — this module owns the numbers, the private enum owns
+//!    the mechanism.
+//! 2. **The premium ordinal reservation.** The inclusive range `[40, 59]`
+//!    and the [`LockRank::premium`] constructor exist for out-of-tree
+//!    premium lock classes to order themselves relative to core without
+//!    collision. Alongside the observer port (`core/src/observer/`), this
+//!    is one of the two declared premium extension points in core — which
+//!    is why the type is public despite having no in-tree production
+//!    caller: its consumer is `velesdb-private`. Zero in-tree usage is the
+//!    expected state of a reservation, not dead code.
+//!
+//! [`assert_lock_order`] is offered to implementations that adopt this
+//! registry (it is what premium builds its checks on); core's own hot path
+//! deliberately keeps its private tracker instead of taking a dependency on
+//! a public type it would then freeze.
+//!
+//! Locks MUST be acquired in strictly ascending rank:
+//! `gpu < vectors < columnar < layers < neighbors`, then premium `[40, 59]`.
 
 #[cfg(test)]
 #[path = "lock_rank_tests.rs"]

--- a/docs/CONCURRENCY_MODEL.md
+++ b/docs/CONCURRENCY_MODEL.md
@@ -177,8 +177,14 @@ Enforcement in practice, by build and by tier:
   tests, not on any runtime mechanism.
 
 The ordinal table below is the human-readable record of the intended order; it
-is not enforced by a compiled assertion at acquisition time. The code constants
-and this table are still kept in lock-step and MUST NOT diverge.
+is not enforced by a compiled assertion at acquisition time. Two `LockRank`
+types carry it in code, with distinct roles (#2013): the **public registry**
+(`crate::lock_rank::LockRank`) owns the numbers and the premium reservation,
+and the **private mechanism** (`HnswLockRank`,
+`index/hnsw/native/graph/locking.rs`) is what the debug tracker actually
+records. Their lock-step is not a promise: the private enum's discriminants
+are defined *from* the registry's constants, so any divergence is a compile
+error.
 
 For HNSW index operations that touch the GPU snapshot cache, vector storage,
 the PDX columnar layout, graph layers, and neighbor lists, the global lock
@@ -189,7 +195,7 @@ gpu_vectors_snapshot (rank 5) → vectors (rank 10) → columnar (rank 15)
     → layers (rank 20) → neighbors (rank 30)
 ```
 
-| Lock | Rank | `LockRank` constant | Component | Notes |
+| Lock | Rank | Registry constant (= `HnswLockRank` discriminant) | Component | Notes |
 |------|------|---------------------|-----------|-------|
 | `gpu_vectors_snapshot` | 5 | `LockRank::GPU_VECTORS_SNAPSHOT` | GPU flat-vector snapshot cache (`Mutex`) | Acquired before `vectors` in the GPU path (`gpu` feature); writers release `vectors` before reacquiring it to invalidate |
 | `vectors` | 10 | `LockRank::VECTORS` | `ContiguousVectors` (single vector store since PERF1) | Acquired first among the core HNSW locks in upsert and search paths |


### PR DESCRIPTION
## Description

Closes #2013. Two `LockRank` types carried the global lock order with nothing but prose keeping them equal: the **public registry** in `lock_rank.rs` (whose doc claimed to "promote the convention to a type" while no production code used it) and the **private `HnswLockRank` enum** actually wired into the debug tracker.

The resolution keeps both types — because they have different jobs — and removes every way they can lie:

- **One source of truth, compiler-enforced.** The private enum's discriminants are now defined *from* the registry's constants (`ordinal()` is `const fn`, valid in discriminant position). "Kept in lock-step" stops being a comment: any divergence is a compile error. No runtime cost, no test to forget.
- **The hot path stays private.** Tightening the HNSW tracker (tracing `Columnar`, adding a rank) never becomes a semver event, which is what adopting the public type on the hot path would have caused.
- **The public type's doc now says what it is**: the authoritative ordinal table **plus the premium ordinal reservation** (`[40, 59]` + `premium()`), declared as one of core's two premium extension points alongside the observer port. That resolves the issue's sharpest finding — a second, undeclared premium extension point — and explains the "zero in-tree usage": the consumer is `velesdb-private`, out of tree; zero in-tree usage is the expected state of a reservation, not dead code.
- **`CONCURRENCY_MODEL.md`'s rank table** names both types with their real roles and states the lock-step is compiler-enforced.

Issue success criteria: one table cited by the doc ✓ (and it provably equals the mechanism's); the `LockRank` grep no longer shows a public type *pretending* to be the enforcement — it shows a documented reservation ✓.

## Type of change

- [x] Refactor (no behavioral change; discriminant values bit-identical)

## How has this been tested?

- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- All 64 lock-related core tests (lock_rank + hnsw locking) — 63 passed, 1 pre-existing ignore.
- Doc-contract and doc-freshness guards — green.

## Checklist

- [x] `repr(u8)` and every discriminant value unchanged (5/10/15/20/30)
- [x] No new public API; no `#[allow]` added
