### PR TITLE
docs: correct the benchmarks licence notice and the microsecond claim in package descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ keywords = [
     "semantic-search",
 ]
 categories = ["database", "data-structures", "algorithms", "science"]
-description = "VelesDB: The Local Vector Database for Rust & AI. Microsecond semantic search, zero network latency, runs anywhere."
+description = "VelesDB: The Local Vector Database for Rust & AI. Sub-millisecond semantic search, zero network latency, runs anywhere."
 authors = ["Julien Lange <contact@wiscale.fr>"]
 
 [workspace.dependencies]

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,4 +114,5 @@ let params = HnswParams::million_scale(768);
 
 ## License
 
-MIT License
+This benchmark suite is part of the VelesDB repository and is covered by the
+[VelesDB Core License 1.0](../LICENSE), like the rest of the tree.

--- a/crates/velesdb-python/pyproject.toml
+++ b/crates/velesdb-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "velesdb"
 version = "5.1.0"
-description = "VelesDB: The Local Vector Database for Python & AI. Microsecond semantic search, zero network latency."
+description = "VelesDB: The Local Vector Database for Python & AI. Sub-millisecond semantic search, zero network latency."
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wiscale/velesdb-sdk",
   "version": "5.1.0",
-  "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Microsecond semantic search in Browser & Node.js.",
+  "description": "VelesDB TypeScript SDK: The Local Vector Database for AI & RAG. Sub-millisecond semantic search in Browser & Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Two public-facing corrections surfaced by a full audit of the unified engine against the repository's own acceptance test (AGENTS.md §6, "the r/rust bar"):

- `benchmarks/README.md` declared **"MIT License"** inside a repository governed by the VelesDB Core License 1.0. It now points at the real licence at the repository root.
- The workspace manifest description, the npm SDK description (`sdks/typescript/package.json`) and the PyPI description (`crates/velesdb-python/pyproject.toml`) promised **"Microsecond semantic search"**, while the committed end-to-end figure is 450 µs p50. They now say **"Sub-millisecond"**, which the committed harness actually supports.

No pinned promise-contract string covers these lines, so no contract entry needed updating.

Note for the reviewer: the branch name violates the enforced prefix list (`claude/*` is rejected by `pr-governance`); it was imposed by the session that produced this PR. If governance blocks the merge, re-point the same commit from a `docs/`-prefixed branch.

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests

Text/metadata-only change — the relevant gates were run locally and are green:

- `python3 scripts/check-promise-contract.py` — 30 claims pass
- `python3 scripts/check-perf-claims.py --no-criterion` — PASSED
- `python3 scripts/check-feature-claims.py` — PASSED
- `bash scripts/check-doc-contract.sh` and the five `check-doc-freshness.py` guards — pass
- `python3 scripts/check-version-sync.py` — all versions match
- `python3 -m unittest discover -s scripts/tests` — Ran 625 tests, OK (skipped=9)
- `cargo check -p velesdb-core --features persistence` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The wording "sub-millisecond" was chosen over re-measuring because the reference machine (i9-14900KF) is not available to this environment; re-running the headline numbers on 5.1.0 remains open (450 µs was measured on v1.7.2, SIFT1M on v3.3.0, the WASM size on 4.0.0).
