### PR TITLE
perf(core): cache the JOIN-side ColumnStore keyed by collection generation

### DIFF
--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -298,6 +298,7 @@ impl Database {
         self.graph_colls.write().remove(name);
         self.metadata_colls.write().remove(name);
         self.collection_stats.write().remove(name);
+        self.join_store_cache.write().remove(name);
     }
 
     /// Creates a new collection with a specific type (Vector, Graph, or `MetadataOnly`).

--- a/crates/velesdb-core/src/database/database_helpers.rs
+++ b/crates/velesdb-core/src/database/database_helpers.rs
@@ -274,7 +274,7 @@ impl Database {
     }
 
     /// Builds a `ColumnStore` from a slice of point references.
-    fn build_column_store_from_points(points: &[&crate::Point]) -> Result<ColumnStore> {
+    pub(super) fn build_column_store_from_points(points: &[&crate::Point]) -> Result<ColumnStore> {
         let owned: Vec<crate::Point> = points.iter().copied().cloned().collect();
         let schema = Self::infer_column_schema(&owned);
         let schema_refs: Vec<(&str, crate::column_store::ColumnType)> = schema
@@ -295,23 +295,20 @@ impl Database {
     pub(super) fn build_join_column_store(
         collection: &crate::collection::Collection,
     ) -> Result<ColumnStore> {
+        let points = Self::fetch_join_points(collection);
+        let refs: Vec<&crate::Point> = points.iter().collect();
+        Self::build_column_store_from_points(&refs)
+    }
+
+    /// Fetches every live point of `collection` for JOIN-side materialization.
+    ///
+    /// Goes through `Collection::get`, so lazily-expired TTL points are
+    /// already excluded from the result.
+    pub(super) fn fetch_join_points(
+        collection: &crate::collection::Collection,
+    ) -> Vec<crate::Point> {
         let ids = collection.all_ids();
-        let points: Vec<_> = collection.get(&ids).into_iter().flatten().collect();
-
-        let schema = Self::infer_column_schema(&points);
-        let schema_refs: Vec<(&str, crate::column_store::ColumnType)> = schema
-            .iter()
-            .map(|(name, ty)| (name.as_str(), ty.clone()))
-            .collect();
-
-        let mut store = ColumnStore::with_primary_key(&schema_refs, "id")
-            .map_err(|e| Error::ColumnStoreError(e.to_string()))?;
-
-        for point in &points {
-            Self::insert_point_row(point, &schema_refs, &mut store)?;
-        }
-
-        Ok(store)
+        collection.get(&ids).into_iter().flatten().collect()
     }
 
     /// Infers a consistent column schema from point payloads.

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -55,6 +55,8 @@ mod graph_ops_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod query_engine_tests;
 #[cfg(all(test, feature = "persistence"))]
+mod query_join_tests;
+#[cfg(all(test, feature = "persistence"))]
 mod stats_tests;
 
 pub use gated_search::GatedRead;
@@ -111,6 +113,15 @@ pub struct Database {
     /// Stores recently compiled `QueryPlan` instances keyed by `PlanKey`.
     /// Default sizing: L1 = 1K hot entries, L2 = 10K LRU entries.
     compiled_plan_cache: crate::cache::CompiledPlanCache,
+    /// JOIN-side `ColumnStore` cache keyed by collection name (CACHE-03).
+    ///
+    /// An entry is valid only while its `(schema_version, write_generation)`
+    /// stamp matches the live counters, so any mutation — or a drop/recreate
+    /// under the same name — forces a rebuild. Entries are also purged
+    /// eagerly on `delete_collection`. Collections carrying TTL points are
+    /// never cached (expiry does not bump `write_generation`).
+    join_store_cache:
+        parking_lot::RwLock<std::collections::HashMap<String, query_join::JoinStoreEntry>>,
 }
 
 #[cfg(feature = "persistence")]
@@ -231,6 +242,7 @@ impl Database {
             observer,
             schema_version: std::sync::atomic::AtomicU64::new(0),
             compiled_plan_cache: crate::cache::CompiledPlanCache::new(1_000, 10_000),
+            join_store_cache: parking_lot::RwLock::new(std::collections::HashMap::new()),
         };
 
         // Auto-load all existing collections from disk (replaces manual load_collections()).

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -4,6 +4,17 @@ use crate::{Result, SearchResult};
 
 use super::Database;
 
+/// One cached JOIN-side `ColumnStore` with the counters it was built under.
+///
+/// See `Database::join_store_cache` (CACHE-03) for the validity contract.
+pub(super) struct JoinStoreEntry {
+    /// `(schema_version, write_generation)` read *before* the store was built,
+    /// so a mutation racing the build can only make the entry look stale.
+    stamp: (u64, u64),
+    /// The shared store, cloned out cheaply per query.
+    store: std::sync::Arc<crate::column_store::ColumnStore>,
+}
+
 impl Database {
     /// Returns `true` if the join condition references the primary key (`id`) on both sides.
     ///
@@ -129,9 +140,12 @@ impl Database {
         }
 
         let column_store = if pushed.is_empty() {
-            Self::build_join_column_store(&join_collection)?
+            self.cached_join_column_store(&join.table, &join_collection)?
         } else {
-            Self::build_filtered_join_column_store(&join_collection, pushed)?
+            std::sync::Arc::new(Self::build_filtered_join_column_store(
+                &join_collection,
+                pushed,
+            )?)
         };
 
         let joined = crate::collection::search::query::join::execute_join(
@@ -141,5 +155,55 @@ impl Database {
             row_budget,
         )?;
         Ok(crate::collection::search::query::join::joined_to_search_results(joined))
+    }
+
+    /// Returns the JOIN-side `ColumnStore` for `collection`, rebuilding only
+    /// when the collection changed since the cached copy was built.
+    ///
+    /// The `(schema_version, write_generation)` stamp is read *before* the
+    /// build: a mutation racing the build can only make the cached entry look
+    /// older than it is, forcing a rebuild on the next query — never a stale
+    /// hit. Collections carrying TTL points are never cached, because expiry
+    /// is evaluated lazily at read time and does not bump `write_generation`.
+    pub(super) fn cached_join_column_store(
+        &self,
+        name: &str,
+        collection: &crate::collection::Collection,
+    ) -> Result<std::sync::Arc<crate::column_store::ColumnStore>> {
+        let stamp = (
+            self.schema_version
+                .load(std::sync::atomic::Ordering::Acquire),
+            collection.write_generation(),
+        );
+        if let Some(entry) = self.join_store_cache.read().get(name) {
+            if entry.stamp == stamp {
+                return Ok(std::sync::Arc::clone(&entry.store));
+            }
+        }
+
+        let points = Self::fetch_join_points(collection);
+        let carries_ttl = Self::points_carry_ttl(&points);
+        let refs: Vec<&crate::Point> = points.iter().collect();
+        let store = std::sync::Arc::new(Self::build_column_store_from_points(&refs)?);
+        if !carries_ttl {
+            self.join_store_cache.write().insert(
+                name.to_string(),
+                JoinStoreEntry {
+                    stamp,
+                    store: std::sync::Arc::clone(&store),
+                },
+            );
+        }
+        Ok(store)
+    }
+
+    /// Returns `true` if any point carries the reserved durable-TTL payload key.
+    fn points_carry_ttl(points: &[crate::Point]) -> bool {
+        points.iter().any(|p| {
+            p.payload
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|map| map.contains_key(crate::collection::expiry::EXPIRES_AT_KEY))
+        })
     }
 }

--- a/crates/velesdb-core/src/database/query_join_tests.rs
+++ b/crates/velesdb-core/src/database/query_join_tests.rs
@@ -1,0 +1,116 @@
+//! Tests for the JOIN-side `ColumnStore` cache (CACHE-03).
+//!
+//! The cache contract: a cached store is reused only while the collection's
+//! `(schema_version, write_generation)` stamp is unchanged; any mutation, a
+//! drop/recreate under the same name, or the presence of TTL points must
+//! force a rebuild (TTL points are never cached at all, because lazy expiry
+//! does not bump `write_generation`).
+
+use super::*;
+use crate::point::Point;
+use crate::DistanceMetric;
+use tempfile::tempdir;
+
+fn open_db_with_collection(dir: &std::path::Path) -> Database {
+    let db = Database::open(dir).unwrap();
+    db.create_collection("orders", 4, DistanceMetric::Cosine)
+        .unwrap();
+    upsert_order(&db, 1, "a");
+    db
+}
+
+fn upsert_order(db: &Database, id: u64, sku: &str) {
+    let coll = db.resolve_collection("orders").unwrap();
+    coll.upsert([Point::new(
+        id,
+        vec![0.0, 1.0, 0.0, 0.0],
+        Some(serde_json::json!({ "sku": sku })),
+    )])
+    .unwrap();
+}
+
+fn cached_store(db: &Database) -> std::sync::Arc<crate::column_store::ColumnStore> {
+    let coll = db.resolve_collection("orders").unwrap();
+    db.cached_join_column_store("orders", &coll).unwrap()
+}
+
+#[test]
+fn unchanged_collection_reuses_the_cached_store() {
+    let dir = tempdir().unwrap();
+    let db = open_db_with_collection(dir.path());
+
+    let first = cached_store(&db);
+    let second = cached_store(&db);
+    assert!(
+        std::sync::Arc::ptr_eq(&first, &second),
+        "two joins without any mutation must share the same cached store"
+    );
+}
+
+#[test]
+fn upsert_invalidates_the_cached_store() {
+    let dir = tempdir().unwrap();
+    let db = open_db_with_collection(dir.path());
+
+    let first = cached_store(&db);
+    upsert_order(&db, 2, "b");
+    let second = cached_store(&db);
+    assert!(
+        !std::sync::Arc::ptr_eq(&first, &second),
+        "an upsert bumps write_generation and must force a rebuild"
+    );
+    assert!(second.primary_index.contains_key(&2));
+}
+
+#[test]
+fn delete_and_recreate_never_serves_the_old_store() {
+    let dir = tempdir().unwrap();
+    let db = open_db_with_collection(dir.path());
+
+    let first = cached_store(&db);
+    db.delete_collection("orders").unwrap();
+    assert!(
+        !db.join_store_cache.read().contains_key("orders"),
+        "delete_collection must purge the cache entry eagerly"
+    );
+
+    db.create_collection("orders", 4, DistanceMetric::Cosine)
+        .unwrap();
+    upsert_order(&db, 9, "z");
+    let second = cached_store(&db);
+    assert!(
+        !std::sync::Arc::ptr_eq(&first, &second),
+        "a recreated collection must never reuse the deleted collection's store"
+    );
+    assert!(second.primary_index.contains_key(&9));
+    assert!(!second.primary_index.contains_key(&1));
+}
+
+#[test]
+fn ttl_points_disable_caching() {
+    let dir = tempdir().unwrap();
+    let db = open_db_with_collection(dir.path());
+
+    let coll = db.resolve_collection("orders").unwrap();
+    let far_future = 4_000_000_000_u64;
+    coll.upsert([Point::new(
+        2,
+        vec![1.0, 0.0, 0.0, 0.0],
+        Some(serde_json::json!({
+            "sku": "ttl",
+            crate::collection::expiry::EXPIRES_AT_KEY: far_future,
+        })),
+    )])
+    .unwrap();
+
+    let first = cached_store(&db);
+    let second = cached_store(&db);
+    assert!(
+        !std::sync::Arc::ptr_eq(&first, &second),
+        "a collection carrying TTL points must never be served from cache"
+    );
+    assert!(
+        !db.join_store_cache.read().contains_key("orders"),
+        "TTL-carrying builds must not populate the cache"
+    );
+}


### PR DESCRIPTION
## Description

Every non-pushdown JOIN rebuilt the target collection's `ColumnStore` from scratch — `all_ids()` → `get()` → row-by-row insertion — on **every query** (`build_join_column_store`, `database_helpers.rs`). This PR caches the store per collection on `Database` (CACHE-03, following the `collection_stats` / `CompiledPlanCache` precedents):

- **Validity stamp `(schema_version, write_generation)`** read *before* the build: a mutation racing the build can only make the entry look older than it is, forcing a rebuild on the next query — never a stale hit. A drop/recreate under the same name changes `schema_version`, so the old store can never be reused; `delete_collection` also purges eagerly.
- **TTL points disable caching**: lazy `_veles_expires_at` expiry does not bump `write_generation`, so a cached copy could serve rows past their expiry — collections carrying TTL points are rebuilt per query, exactly as before this PR.
- The filtered-join path (`pushed` non-empty) is unchanged: its content depends on the pushed conditions.
- `build_join_column_store` is split into `fetch_join_points` + the pre-existing `build_column_store_from_points` (reused, not duplicated).

Part of the "câblage réel" plan (lot 4.1) from the unified-engine audit.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

Four new tests in `database/query_join_tests.rs` pin the cache contract via `Arc::ptr_eq`:
- unchanged collection → same store instance reused,
- upsert → rebuild,
- delete + recreate under the same name → old store never served, entry purged eagerly,
- TTL-carrying collection → never cached.

Local validation, mirroring CI flags:
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `cargo test -p velesdb-core --lib --features persistence query_join -- --test-threads=1` — 4 passed (plus stats/match/BDD suites green)
- `cargo check -p velesdb-core --no-default-features` — clean
- `cargo fmt --all` — clean
- `python3 scripts/check-ai-attribution.py` — PASSED

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches the JOIN execution path (not hnsw/storage/Drop/unsafe/SIMD dispatch).

- [x] I listed the invariants impacted by this change — cache validity is exactly `(schema_version, write_generation)` equality with the stamp read pre-build; TTL exempts a collection from caching entirely.
- [x] I documented crash/durability semantics when relevant — the cache is in-memory only; nothing is persisted.
- [x] I added/updated tests for concurrency or lifecycle (drop, recreate, mutation) where applicable.

## Additional Notes

The cached store is shared as `Arc<ColumnStore>` (verified auto-`Send + Sync`: only `HashMap`/`Vec`/`RoaringBitmap` fields, no interior mutability).