### PR TITLE
refactor(core): rename the MATCH planner's CollectionStats to MatchGraphStats; expose it as ANALYZE's graph view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`velesql::match_planner::CollectionStats` is renamed `MatchGraphStats`**;
+  the old name remains as a deprecated type alias, so callers compile
+  unchanged. The old name collided with the tabular
+  `collection::stats::CollectionStats` while sharing no field with it. The
+  graph-shape view is now also filled by `ANALYZE` into
+  `CollectionStats::graph_stats` (optional, serde-defaulted — stats files
+  persisted by older versions load unchanged), giving the MATCH planner and
+  the cost estimator one shared source for graph statistics.
+
 ### Fixed
 
 - **`GEO_DISTANCE(...) = threshold` / `<>` now tolerates realistic

--- a/crates/velesdb-core/src/collection/core/statistics.rs
+++ b/crates/velesdb-core/src/collection/core/statistics.rs
@@ -94,6 +94,9 @@ impl Collection {
         let calibrated = calibrate_cost_factors(&stats, &OperationCostFactors::default());
         stats.calibrated_cost_factors = Some(calibrated);
 
+        // Graph-shape view: single source shared with the MATCH planner.
+        stats.graph_stats = Some(self.compute_match_collection_stats());
+
         Ok(stats)
     }
 

--- a/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_dispatch.rs
@@ -28,7 +28,7 @@ impl Collection {
     #[allow(clippy::cast_precision_loss)]
     pub(crate) fn compute_match_collection_stats(
         &self,
-    ) -> crate::velesql::match_planner::CollectionStats {
+    ) -> crate::velesql::match_planner::MatchGraphStats {
         let total_nodes = self.len();
         let total_edges = self.graph.edge_store.len();
         let avg_degree = if total_nodes > 0 {
@@ -42,7 +42,7 @@ impl Collection {
         } else {
             1.0
         };
-        crate::velesql::match_planner::CollectionStats {
+        crate::velesql::match_planner::MatchGraphStats {
             total_nodes,
             total_edges,
             avg_degree,

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -60,6 +60,11 @@ pub struct CollectionStats {
     /// Persisted in `collection.stats.json` to survive restarts.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calibrated_cost_factors: Option<OperationCostFactors>,
+    /// Graph-shape view of the collection (nodes, edges, labels), filled by
+    /// `ANALYZE` so the MATCH planner and the cost estimator read the same
+    /// source. `None` on stats persisted before 5.2.0 or never analyzed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graph_stats: Option<crate::velesql::match_planner::MatchGraphStats>,
 }
 
 impl CollectionStats {

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -754,3 +754,44 @@ fn test_zero_width_merge_trailing_does_not_double_count_distinct() {
         "trailing zero-width merge should use max for distinct_count"
     );
 }
+
+// =========================================================================
+// graph_stats — serde compatibility of the optional graph-shape view
+// =========================================================================
+
+/// Stats persisted before 5.2.0 carry no `graph_stats` key; they must load
+/// with the field defaulting to `None` (`#[serde(default)]`).
+#[test]
+fn stats_json_without_graph_stats_deserializes_to_none() {
+    let legacy = r#"{
+        "total_points": 3,
+        "payload_size_bytes": 0,
+        "field_stats": {},
+        "row_count": 3,
+        "deleted_count": 0,
+        "avg_row_size_bytes": 0,
+        "total_size_bytes": 0,
+        "column_stats": {},
+        "index_stats": {},
+        "last_analyzed_epoch_ms": null
+    }"#;
+    let stats: CollectionStats = serde_json::from_str(legacy).unwrap();
+    assert!(stats.graph_stats.is_none());
+}
+
+/// A populated `graph_stats` view must survive a serde round-trip unchanged.
+#[test]
+fn graph_stats_roundtrips_through_serde() {
+    let mut stats = CollectionStats::new();
+    stats.graph_stats = Some(crate::velesql::match_planner::MatchGraphStats {
+        total_nodes: 10,
+        total_edges: 25,
+        avg_degree: 2.5,
+        label_count: 5,
+        label_selectivity: 0.2,
+    });
+
+    let json = serde_json::to_string(&stats).unwrap();
+    let back: CollectionStats = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.graph_stats, stats.graph_stats);
+}

--- a/crates/velesdb-core/src/database/collection_ops.rs
+++ b/crates/velesdb-core/src/database/collection_ops.rs
@@ -208,7 +208,7 @@ impl Database {
     pub(crate) fn match_stats_for(
         &self,
         name: &str,
-    ) -> Option<crate::velesql::match_planner::CollectionStats> {
+    ) -> Option<crate::velesql::match_planner::MatchGraphStats> {
         if let Some(vc) = self.vector_colls.read().get(name) {
             return Some(vc.inner.compute_match_collection_stats());
         }

--- a/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/plan_cost.rs
@@ -108,7 +108,7 @@ impl CostEstimator<'_> {
     fn estimate_match_traversal_cost(&self, mt: &MatchTraversalPlan) -> Cost {
         // Approximate traversal fan-out: assume average degree ≈ 4 when the
         // core CollectionStats has no graph info; a future wiring will plug
-        // `match_planner::CollectionStats::avg_degree` through this path.
+        // `match_planner::MatchGraphStats::avg_degree` through this path.
         let avg_degree: f64 = 4.0;
         let depth = f64::from(mt.max_depth.max(1));
         // Frontier ≈ avg_degree^depth (geometric expansion), capped to total.

--- a/crates/velesdb-core/src/velesql/explain/plan_builder.rs
+++ b/crates/velesdb-core/src/velesql/explain/plan_builder.rs
@@ -15,7 +15,7 @@ use super::types::{
 };
 use crate::collection::stats::CollectionStats as CoreCollectionStats;
 use crate::velesql::ast::{Condition, LetBinding, SelectStatement, DEFAULT_SELECT_LIMIT};
-use crate::velesql::match_planner::{CollectionStats, MatchExecutionStrategy, MatchQueryPlanner};
+use crate::velesql::match_planner::{MatchExecutionStrategy, MatchGraphStats, MatchQueryPlanner};
 use crate::velesql::MatchClause;
 
 impl QueryPlan {
@@ -112,7 +112,7 @@ impl QueryPlan {
 
     /// Creates a full query plan from a `Query`, threading both calibrated
     /// `CoreCollectionStats` (SELECT cost estimation) and graph
-    /// `CollectionStats` (MATCH traversal-strategy selection).
+    /// `MatchGraphStats` (MATCH traversal-strategy selection).
     ///
     /// MATCH queries route through [`Self::from_match`] so the EXPLAIN/exec
     /// path emits a `MatchTraversal` node with a real strategy instead of a
@@ -124,10 +124,10 @@ impl QueryPlan {
         query: &crate::velesql::ast::Query,
         indexed_fields: &HashSet<String>,
         stats: Option<&CoreCollectionStats>,
-        match_stats: Option<&CollectionStats>,
+        match_stats: Option<&MatchGraphStats>,
     ) -> Self {
         let mut plan = if let Some(ref match_clause) = query.match_clause {
-            let default_stats = CollectionStats::default();
+            let default_stats = MatchGraphStats::default();
             Self::from_match(match_clause, match_stats.unwrap_or(&default_stats))
         } else {
             // Compound queries have no implicit default LIMIT either.
@@ -140,7 +140,7 @@ impl QueryPlan {
 
     /// Creates a new query plan from a MATCH clause (EPIC-046 US-004).
     #[must_use]
-    pub fn from_match(match_clause: &MatchClause, stats: &CollectionStats) -> Self {
+    pub fn from_match(match_clause: &MatchClause, stats: &MatchGraphStats) -> Self {
         let strategy = MatchQueryPlanner::plan(match_clause, stats);
         let strategy_explanation = MatchQueryPlanner::explain(&strategy);
 

--- a/crates/velesdb-core/src/velesql/match_planner.rs
+++ b/crates/velesdb-core/src/velesql/match_planner.rs
@@ -57,9 +57,14 @@ impl Default for MatchExecutionStrategy {
     }
 }
 
-/// Statistics about a collection for cost estimation.
-#[derive(Debug, Clone, Default)]
-pub struct CollectionStats {
+/// Graph-shape statistics used to choose a MATCH execution strategy.
+///
+/// Renamed from `CollectionStats` (5.2.0): the old name collided with the
+/// tabular [`crate::collection::stats::CollectionStats`] while sharing no
+/// field with it — this type describes only the graph (nodes, edges,
+/// labels). Persisted inside the tabular stats as an optional view.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct MatchGraphStats {
     /// Total number of nodes/points.
     pub total_nodes: usize,
     /// Total number of edges.
@@ -71,6 +76,13 @@ pub struct CollectionStats {
     /// Estimated selectivity per label (0.0-1.0).
     pub label_selectivity: f64,
 }
+
+/// Former name of [`MatchGraphStats`].
+#[deprecated(
+    since = "5.2.0",
+    note = "renamed to MatchGraphStats — same fields, graph-only scope"
+)]
+pub type CollectionStats = MatchGraphStats;
 
 /// Query planner for MATCH queries.
 #[derive(Debug, Default)]
@@ -88,7 +100,7 @@ impl MatchQueryPlanner {
     ///
     /// The optimal execution strategy.
     #[must_use]
-    pub fn plan(match_clause: &MatchClause, stats: &CollectionStats) -> MatchExecutionStrategy {
+    pub fn plan(match_clause: &MatchClause, stats: &MatchGraphStats) -> MatchExecutionStrategy {
         let has_similarity = Self::has_similarity_condition(match_clause.where_clause.as_ref());
         let start_labels = Self::extract_start_labels(match_clause);
         let max_depth = Self::count_hops(match_clause);
@@ -203,7 +215,7 @@ impl MatchQueryPlanner {
     /// Plans a vector-first strategy.
     fn plan_vector_first(
         match_clause: &MatchClause,
-        stats: &CollectionStats,
+        stats: &MatchGraphStats,
         similarity_info: Option<(String, f32, String)>,
     ) -> MatchExecutionStrategy {
         let (alias, threshold, _) = similarity_info.unwrap_or_default();
@@ -217,7 +229,7 @@ impl MatchQueryPlanner {
     /// Plans a parallel (graph + vector) strategy.
     fn plan_parallel(
         match_clause: &MatchClause,
-        stats: &CollectionStats,
+        stats: &MatchGraphStats,
         similarity_info: Option<(String, f32, String)>,
         start_labels: Vec<String>,
         max_depth: u32,
@@ -300,7 +312,7 @@ impl MatchQueryPlanner {
     /// Estimate top-k based on limit and selectivity.
     fn estimate_top_k(
         match_clause: &MatchClause,
-        stats: &CollectionStats,
+        stats: &MatchGraphStats,
         threshold: f32,
     ) -> usize {
         let limit = match_clause
@@ -332,7 +344,7 @@ impl MatchQueryPlanner {
 
     /// Decide if parallel execution is beneficial.
     fn should_use_parallel(
-        stats: &CollectionStats,
+        stats: &MatchGraphStats,
         similarity_info: Option<&(String, f32, String)>,
     ) -> bool {
         // Use parallel when:

--- a/crates/velesdb-core/src/velesql/match_planner_tests.rs
+++ b/crates/velesdb-core/src/velesql/match_planner_tests.rs
@@ -6,8 +6,8 @@ use crate::velesql::{
     ReturnClause, SimilarityCondition, VectorExpr,
 };
 
-fn default_stats() -> CollectionStats {
-    CollectionStats {
+fn default_stats() -> MatchGraphStats {
+    MatchGraphStats {
         total_nodes: 1000,
         total_edges: 5000,
         avg_degree: 5.0,
@@ -135,7 +135,7 @@ fn test_count_hops() {
 #[test]
 fn test_planner_with_empty_collection_stats_defaults_to_graph_first() {
     let match_clause = make_match_clause(false, Some(10));
-    let stats = CollectionStats::default();
+    let stats = MatchGraphStats::default();
     let strategy = MatchQueryPlanner::plan(&match_clause, &stats);
     assert!(
         matches!(strategy, MatchExecutionStrategy::GraphFirst { .. }),
@@ -145,7 +145,7 @@ fn test_planner_with_empty_collection_stats_defaults_to_graph_first() {
 
 #[test]
 fn test_planner_with_zero_labels_sets_full_selectivity() {
-    let stats = CollectionStats {
+    let stats = MatchGraphStats {
         total_nodes: 100,
         total_edges: 50,
         avg_degree: 0.5,
@@ -248,7 +248,7 @@ fn test_planner_forces_graph_first_over_parallel_when_edge_alias_referenced() {
         expression: "r.since".to_string(),
         alias: None,
     }];
-    let stats = CollectionStats {
+    let stats = MatchGraphStats {
         total_nodes: 50_000,
         total_edges: 500_000,
         avg_degree: 10.0,

--- a/crates/velesdb-core/tests/bdd/match_graph_first.rs
+++ b/crates/velesdb-core/tests/bdd/match_graph_first.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 
 use serde_json::json;
 use velesdb_core::velesql::match_planner::{
-    CollectionStats, MatchExecutionStrategy, MatchQueryPlanner,
+    MatchExecutionStrategy, MatchGraphStats, MatchQueryPlanner,
 };
 use velesdb_core::{Database, GraphEdge, Point};
 
@@ -175,8 +175,8 @@ fn collection_param(collection: &str) -> HashMap<String, serde_json::Value> {
 }
 
 /// Stats representative of the seeded collection: 5 nodes, 1 edge, 2 labels.
-fn seeded_stats() -> CollectionStats {
-    CollectionStats {
+fn seeded_stats() -> MatchGraphStats {
+    MatchGraphStats {
         total_nodes: 5,
         total_edges: 1,
         avg_degree: 0.2,


### PR DESCRIPTION
## Description

Two unrelated types shared the name `CollectionStats`: the tabular, persisted stats (`collection::stats`) and the MATCH planner's five graph-shape fields — `explain/plan_builder.rs` already had to alias one (`CoreCollectionStats`) just to import both. This PR:

- renames the planner type to **`MatchGraphStats`**, keeping the old name as a **deprecated type alias** (`since = "5.2.0"`), so out-of-tree callers compile unchanged;
- derives `Serialize`/`Deserialize`/`PartialEq` on it and exposes it as **`CollectionStats::graph_stats`** (`#[serde(default, skip_serializing_if = "Option::is_none")]`), filled by `ANALYZE` from `compute_match_collection_stats` — one shared source of graph statistics for the MATCH planner and the cost estimator;
- older `collection.stats.json` files load unchanged (serde default → `None`), pinned by a backward-compat test.

Groundwork for costing `GraphMatch` from real stats instead of the hardcoded `0.5` selectivity (`cost_estimator/mod.rs`). Part of the "câblage réel" plan (lot 2.1) from the unified-engine audit.

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests

- New: legacy stats JSON (no `graph_stats` key) deserializes to `None`; populated `graph_stats` round-trips through serde unchanged.
- `cargo test -p velesdb-core --lib --features persistence stats -- --test-threads=1` — 95 passed
- `cargo test -p velesdb-core --lib --features persistence match_planner -- --test-threads=1` — 17 passed
- `cargo test -p velesdb-core --features persistence --test bdd match_graph -- --test-threads=1` — 14 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic; the BDD suite was migrated off the deprecated alias)
- `cargo check -p velesdb-core --no-default-features` — clean
- `cargo test --doc -p velesdb-core --features persistence` — 50 passed

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

CHANGELOG carries the rename under Unreleased/Changed. The deprecated alias keeps this a minor-level change under the workspace's SemVer.