### PR TITLE
ci(contract): fail the build when a claim is a full major behind the shipping workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CollectionStats::graph_stats` (optional, serde-defaulted — stats files
   persisted by older versions load unchanged), giving the MATCH planner and
   the cost estimator one shared source for graph statistics.
+- **The promise contract now fails the build when a documentary claim was
+  measured a full major behind the shipping workspace.** Minor drift stays
+  advisory (unchanged), but a figure taken on a previous major describes a
+  product that no longer ships — both real drifts this guard exists for
+  crossed exactly that line. A claim may carry an explicit, dated
+  `stale_accepted` waiver scoped to the current workspace major
+  (self-expiring at the next major bump); the two 4.0.0-era size claims
+  carry one until the next release build re-measures them.
 
 ### Fixed
 

--- a/docs/reference/promise-contract.json
+++ b/docs/reference/promise-contract.json
@@ -245,7 +245,12 @@
       "last_updated": "2026-06-12",
       "measured_on": "2026-07-25",
       "measured_machine": "aarch64-apple-darwin (size varies by target)",
-      "measured_version": "4.0.0"
+      "measured_version": "4.0.0",
+      "stale_accepted": {
+        "reason": "binary size can only be re-measured on a release build of the reference toolchain; scheduled for the next release cut, figure verified against Binary Size Gate ceilings meanwhile",
+        "granted": "2026-08-21",
+        "for_workspace_major": 5
+      }
     },
     {
       "id": "readme_wasm_bundle_gzipped",
@@ -257,7 +262,12 @@
       "last_updated": "2026-06-12",
       "measured_on": "2026-07-25",
       "measured_machine": "platform-independent (published artifact)",
-      "measured_version": "4.0.0"
+      "measured_version": "4.0.0",
+      "stale_accepted": {
+        "reason": "bundle size requires the published npm artifact of the next release; the WASM Build Check job bounds regressions meanwhile",
+        "granted": "2026-08-21",
+        "for_workspace_major": 5
+      }
     },
     {
       "id": "readme_rest_endpoint_count",

--- a/scripts/check-promise-contract.py
+++ b/scripts/check-promise-contract.py
@@ -242,6 +242,70 @@ def stale_claims(claims: list[dict], workspace_version: str) -> list[str]:
     return stale
 
 
+def _major(version: str) -> "int | None":
+    """The numeric major of a semver-ish string, or None when unparsable."""
+    head = version.split(".", 1)[0].strip()
+    return int(head) if head.isdigit() else None
+
+
+def stale_major_failures(
+    claims: "list[dict]", workspace_version: str
+) -> "tuple[list[str], list[str]]":
+    """Splits major-stale claims into (fatal, accepted-with-waiver).
+
+    ``stale_claims`` above stays advisory for minor drift — re-measuring every
+    figure at every patch release would only teach people to copy the version
+    string. A figure measured on a previous MAJOR is different in kind: it
+    describes a product that no longer ships, and both real drifts this guard
+    exists for (WASM +25-28%, binary size) crossed exactly that line. Those
+    claims fail the build unless the registry carries an explicit, dated
+    ``stale_accepted`` waiver scoped to the current workspace major:
+
+        "stale_accepted": {
+            "reason": "...why re-measuring must wait...",
+            "granted": "YYYY-MM-DD",
+            "for_workspace_major": 5
+        }
+
+    Scoping the waiver to a major makes it self-expiring: at the next major
+    bump the claim fails again and the waiver must be consciously renewed.
+    """
+    ws_major = _major(workspace_version)
+    if ws_major is None:
+        return [], []
+    fatal: "list[str]" = []
+    accepted: "list[str]" = []
+    for claim in claims:
+        if claim.get("executable", False):
+            continue
+        measured = str(claim.get("measured_version", "")).strip()
+        if not measured or measured.lower() in {"unknown", "n/a"}:
+            continue
+        measured_major = _major(measured)
+        if measured_major is None or measured_major >= ws_major:
+            continue
+        claim_id = claim.get("id", "<unknown>")
+        waiver = claim.get("stale_accepted")
+        if (
+            isinstance(waiver, dict)
+            and str(waiver.get("reason", "")).strip()
+            and waiver.get("for_workspace_major") == ws_major
+        ):
+            accepted.append(
+                f"[{claim_id}] measured on {measured} — waived for {ws_major}.x "
+                f"(granted {waiver.get('granted', 'undated')}): {waiver['reason']}"
+            )
+            continue
+        fatal.append(
+            f"[{claim_id}] measured on {measured}, workspace ships "
+            f"{workspace_version} — a full major behind. Re-run "
+            f"{claim.get('validation_command')!r} and update measured_version, "
+            f"or record a dated 'stale_accepted' waiver scoped to "
+            f"for_workspace_major {ws_major}"
+        )
+    return fatal, accepted
+
+
 def workspace_version(root: pathlib.Path) -> str:
     """The `[workspace.package]` version, the single source of truth."""
     manifest = (root / "Cargo.toml").read_text(encoding="utf-8")
@@ -455,6 +519,14 @@ def run(root: pathlib.Path) -> int:
     stale = stale_claims(claims, version)
     _report(f"Claims measured on an older release than {version} (re-measure):", stale)
 
+    stale_fatal, stale_waived = stale_major_failures(claims, version)
+    _report("Claims a full major behind (accepted by a dated waiver):", stale_waived)
+    _report(
+        "Claims a full major behind the shipping workspace (FATAL — "
+        "re-measure or waive explicitly):",
+        stale_fatal,
+    )
+
     failure_groups = (
         registry_failures,
         family_failures,
@@ -463,6 +535,7 @@ def run(root: pathlib.Path) -> int:
         mcpb_link_failures,
         execution_failures,
         provenance_failures,
+        stale_fatal,
     )
     if any(failure_groups):
         return 1

--- a/scripts/tests/test_check_promise_contract.py
+++ b/scripts/tests/test_check_promise_contract.py
@@ -344,6 +344,85 @@ class ReleaseLinkGuardTests(unittest.TestCase):
         self.assertEqual(attempts, cpc.RELEASE_ASSET_ATTEMPTS)
 
 
+class StaleMajorTests(unittest.TestCase):
+    """The major-staleness gate: fatal without a scoped waiver, self-expiring."""
+
+    @staticmethod
+    def _claim(**overrides) -> dict:
+        claim = {
+            "id": "c1",
+            "executable": False,
+            "measured_version": "4.0.0",
+            "validation_command": "true",
+        }
+        claim.update(overrides)
+        return claim
+
+    def test_full_major_behind_is_fatal_without_waiver(self) -> None:
+        fatal, waived = cpc.stale_major_failures([self._claim()], "5.1.0")
+        self.assertEqual(len(fatal), 1)
+        self.assertEqual(waived, [])
+        self.assertIn("a full major behind", fatal[0])
+
+    def test_scoped_waiver_downgrades_to_report(self) -> None:
+        claim = self._claim(
+            stale_accepted={
+                "reason": "next release build",
+                "granted": "2026-08-21",
+                "for_workspace_major": 5,
+            }
+        )
+        fatal, waived = cpc.stale_major_failures([claim], "5.1.0")
+        self.assertEqual(fatal, [])
+        self.assertEqual(len(waived), 1)
+        self.assertIn("waived for 5.x", waived[0])
+
+    def test_waiver_expires_at_the_next_major(self) -> None:
+        claim = self._claim(
+            stale_accepted={
+                "reason": "next release build",
+                "granted": "2026-08-21",
+                "for_workspace_major": 5,
+            }
+        )
+        fatal, waived = cpc.stale_major_failures([claim], "6.0.0")
+        self.assertEqual(len(fatal), 1)
+        self.assertEqual(waived, [])
+
+    def test_empty_waiver_reason_does_not_waive(self) -> None:
+        claim = self._claim(
+            stale_accepted={"reason": "  ", "for_workspace_major": 5}
+        )
+        fatal, _ = cpc.stale_major_failures([claim], "5.1.0")
+        self.assertEqual(len(fatal), 1)
+
+    def test_minor_drift_stays_advisory(self) -> None:
+        fatal, waived = cpc.stale_major_failures(
+            [self._claim(measured_version="5.0.0")], "5.1.0"
+        )
+        self.assertEqual((fatal, waived), ([], []))
+
+    def test_executable_and_unknown_claims_are_ignored(self) -> None:
+        claims = [
+            self._claim(executable=True),
+            self._claim(measured_version="unknown"),
+            self._claim(measured_version=""),
+        ]
+        fatal, waived = cpc.stale_major_failures(claims, "5.1.0")
+        self.assertEqual((fatal, waived), ([], []))
+
+    def test_real_registry_has_no_unwaived_major_stale_claim(self) -> None:
+        import json
+
+        registry = cpc.registry_path(cpc.ROOT)
+        claims = json.loads(registry.read_text(encoding="utf-8"))["claims"]
+        version = cpc.workspace_version(cpc.ROOT)
+        fatal, _ = cpc.stale_major_failures(claims, version)
+        self.assertEqual(
+            fatal, [], "major-stale claims must be re-measured or carry a dated waiver"
+        )
+
+
 class RealRegistryExecutableClaimsTests(unittest.TestCase):
     """Integration tests against the real docs/reference/promise-contract.json."""
 


### PR DESCRIPTION
## Description

`stale_claims` stays advisory for minor drift — re-measuring every figure at every patch would only teach people to copy the version string. But a figure measured on a **previous major** describes a product that no longer ships, and both real drifts this guard exists for (WASM bundle +25-28 %, binary size) crossed exactly that line.

- `check-promise-contract.py` gains `stale_major_failures()`: a documentary claim whose `measured_version` is a full major behind the workspace **fails the build**, unless the registry carries an explicit, dated `stale_accepted` waiver **scoped to the current workspace major** — making every waiver self-expiring at the next major bump, where it must be consciously renewed.
- Baseline before gating (AGENTS.md §9): at 5.1.0 the gate bites on exactly two claims (`readme_binary_size_9mb`, `readme_wasm_bundle_gzipped`, both measured on 4.0.0). Each now carries a dated waiver naming why re-measuring waits for the next release build and which CI job bounds regressions meanwhile.
- Waived claims remain **reported** on every run, never silent.

Part of the "câblage réel" plan (lot 6.1): the promise contract stops being purely documentary.

## Type of Change

- [x] 🔧 Refactoring (no functional changes to shipped code — CI guard only)

## How Has This Been Tested?

- [x] Unit tests

Seven new self-tests in `scripts/tests/test_check_promise_contract.py` pin the gate: fatal without waiver; scoped waiver downgrades to a report; waiver expires at the next major; empty reason does not waive; minor drift stays advisory; executable/unknown claims ignored; and the real registry stays clean.

- `python3 -m unittest discover -s scripts/tests` — Ran 632 tests, OK (skipped=9)
- `python3 scripts/check-promise-contract.py` — passes with the two waivers reported

**Test Configuration:**
- OS: Linux (x86_64)
- Python 3

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes