### PR TITLE
chore(core): flag duplicate adjacent SAFETY headers in the unsafe guard; fix the two vestigial sites

### DIFF
--- a/crates/velesdb-core/src/simd_native/dispatch/cosine.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/cosine.rs
@@ -59,9 +59,8 @@ pub fn cosine_similarity_native(a: &[f32], b: &[f32]) -> f32 {
     // NEON cosine dispatch for aarch64 (EPIC-054 US-004).
     #[cfg(target_arch = "aarch64")]
     if a.len() >= 4 {
-        // SAFETY: `cosine_neon` is a pure-Rust NEON function; no CPU feature detection
-        // needed because NEON is always present on aarch64.
-        // SAFETY: dispatch to the optimized NEON fused cosine kernel.
+        // `cosine_neon` is a safe pure-Rust NEON kernel; no CPU feature
+        // detection needed because NEON is always present on aarch64.
         return crate::simd_native::cosine_neon(a, b);
     }
     crate::simd_native::scalar::cosine_scalar(a, b)

--- a/crates/velesdb-core/src/storage/guard.rs
+++ b/crates/velesdb-core/src/storage/guard.rs
@@ -86,7 +86,7 @@ pub struct VectorSliceGuard<'a> {
 // - Condition 1: `_guard` pins the mapping and prevents concurrent remap mutation.
 // - Condition 2: Epoch checks reject stale pointers after remap.
 // SAFETY: Transferring read-only guard ownership across threads preserves invariants.
-// SAFETY: sound only while parking_lot's `deadlock_detection`/`send_guard` features
+// Sound only while parking_lot's `deadlock_detection`/`send_guard` features
 // stay off — moving a guard across threads corrupts the detector's per-thread
 // bookkeeping; do not enable those features without revisiting this impl.
 unsafe impl Send for VectorSliceGuard<'_> {}

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -193,6 +193,19 @@
       "--files",
       "{root}/src/lib.rs"
      ]
+    },
+    {
+     "vector": "a second SAFETY header restating the one above it, with no condition bullet between them",
+     "files": {
+      "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // SAFETY: writing through the caller's pointer is sound.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // Reason: the caller owns the allocation and cannot express that in the type.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+     },
+     "accepts": {
+      "src/lib.rs": "pub fn write(target: *mut u8) {\n    // SAFETY: the caller upholds the invariants below.\n    // - target is non-null, aligned and valid for one byte of writes\n    // - no other reference aliases target for the duration of this call\n    // SAFETY: writing through the caller's pointer is sound.\n    unsafe {\n        *target = 1;\n    }\n}\n"
+     },
+     "argv": [
+      "--files",
+      "{root}/src/lib.rs"
+     ]
     }
    ],
    "blind_spot": {

--- a/scripts/verify_unsafe_safety_template.py
+++ b/scripts/verify_unsafe_safety_template.py
@@ -119,6 +119,52 @@ def check_safety_template(lines: List[str]) -> Tuple[bool, List[str]]:
     return len(missing) == 0, missing
 
 
+def find_adjacent_safety_duplicates(content: str) -> List[Tuple[int, str, List[str]]]:
+    """
+    Flags a ``// SAFETY:`` header that immediately restates another one.
+
+    The canonical template deliberately uses TWO ``// SAFETY:`` lines — a
+    header, condition bullets, then a second SAFETY line acting as the
+    Reason (see check_safety_template). That form is NOT flagged here: the
+    bullets between the two headers identify it.
+
+    What IS flagged is two SAFETY headers within 3 lines of each other with
+    only plain comment lines between them and no condition bullet or Reason
+    line separating them — that shape is always a copy-paste restatement
+    (or a stray SAFETY comment on a safe call) and never the template.
+    Intervening code lines mean two distinct unsafe sites, which is fine.
+    """
+    lines = content.split('\n')
+    header_indices = [
+        i for i, line in enumerate(lines) if SAFETY_HEADER_PATTERN.search(line)
+    ]
+    violations = []
+    for a, b in zip(header_indices, header_indices[1:]):
+        if b - a > 3:
+            continue
+        between = lines[a + 1:b]
+        only_comments = all(line.strip().startswith('//') for line in between)
+        # Separator detection is deliberately broader than
+        # CONDITION_BULLET_PATTERN: a bullet whose first token is a code span
+        # (`` // - `ptr` is valid `` ) still separates two SAFETY headers into
+        # the canonical header/bullets/reason shape and must not be flagged.
+        dash_bullet = re.compile(r'\s*//\s*[-*]\s')
+        has_separator = any(
+            CONDITION_BULLET_PATTERN.search(line)
+            or REASON_PATTERN.search(line)
+            or dash_bullet.match(line)
+            for line in between
+        )
+        if only_comments and not has_separator:
+            violations.append((
+                b + 1,
+                lines[b].strip(),
+                ["duplicate SAFETY header — merge it into the SAFETY block above "
+                 "(or drop the SAFETY prefix if the call below is safe)"],
+            ))
+    return violations
+
+
 def verify_file(filepath: Path, strict: bool = False) -> List[Tuple[int, str, List[str]]]:
     """
     Verify a single Rust file for SAFETY template completeness.
@@ -142,6 +188,8 @@ def verify_file(filepath: Path, strict: bool = False) -> List[Tuple[int, str, Li
         
         if not is_valid:
             violations.append((line_num, line_content, missing))
+    
+    violations.extend(find_adjacent_safety_duplicates(content))
     
     return violations
 


### PR DESCRIPTION
## Description

An audit pass counted 143 "duplicated SAFETY pairs"; adversarial re-review showed **134 of them are the guard's own canonical two-SAFETY template** (header / bullets / reason-SAFETY) and most of the rest are two distinct adjacent unsafe sites. Only **two** sites were real strays:

- `storage/guard.rs` — a second `SAFETY:` prefix on the parking_lot caveat note, now a plain continuation of the same block (content unchanged);
- `simd_native/dispatch/cosine.rs` — a SAFETY pair on a **safe** call (`cosine_neon` needs no unsafe), now an ordinary comment.

`verify_unsafe_safety_template.py` now closes the class: two SAFETY headers within 3 lines with **only plain comments and no bullet/Reason separator** between them fail the check. Intervening code (two distinct sites) and the canonical template — including bullets whose first token is a code span, which the historical `CONDITION_BULLET_PATTERN` does not recognize — are explicitly not flagged.

Part of the "câblage réel" plan (lot 5.1).

## Type of Change

- [x] 🔧 Refactoring (no functional changes — comments and a CI guard)

## How Has This Been Tested?

- [x] Unit tests

- New `must_refuse` vector (with its positive control) in `scripts/guards.json`; the guard-contract harness executes both states: `python3 -m unittest scripts.tests.test_guard_refusal_vectors` — Ran 8 tests, OK.
- Full-tree scan with the extended guard: the two fixed files pass; no other file trips the new rule.
- Comment-only Rust changes, but the search path is touched, so the recall gate ran: `cargo test -p velesdb-core --lib --features persistence test_recall -- --test-threads=1` — 18 passed.
- `cargo check -p velesdb-core --features persistence` — clean; `cargo fmt --all` — clean.

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

> Comment-only changes around existing `unsafe impl Send` blocks; no unsafe semantics touched.

- [x] All `unsafe {}` blocks have `// SAFETY:` comments explaining why it's sound — unchanged, and now also guarded against duplicated headers.