### PR TITLE
refactor(core): back the runtime filter selectivity with ANALYZE statistics

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
+++ b/crates/velesdb-core/src/collection/search/query/graph_prefilter.rs
@@ -154,7 +154,11 @@ impl Collection {
         let candidates_k = metadata_filter
             .as_ref()
             .map_or(limit, |f| {
-                super::super::vector_filter::compute_oversampled_k(limit, f)
+                super::super::vector_filter::compute_oversampled_k(
+                    limit,
+                    f,
+                    Some(&self.get_stats()),
+                )
             })
             .min(super::MAX_LIMIT);
         let index_results = self.storage.index.search_with_quality_and_bitmap(

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -533,7 +533,10 @@ impl Collection {
         let metric = self.validate_query_and_read_metric(query)?;
         let higher_is_better = metric.higher_is_better();
 
-        let candidates_k = super::vector_filter::compute_oversampled_k(k, filter);
+        // Raw search path: no stats handle threaded here, and get_stats() may
+        // trigger a full analyze() on a cold cache — keep the structure-only
+        // estimate so this path's cost profile is unchanged.
+        let candidates_k = super::vector_filter::compute_oversampled_k(k, filter, None);
 
         // Attempt bitmap pre-filter from secondary indexes.
         let index_results =

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -90,7 +90,7 @@ impl Collection {
             return Ok(self.merge_delta(results, query, k, metric));
         }
 
-        let candidates_k = compute_oversampled_k(k, filter);
+        let candidates_k = compute_oversampled_k(k, filter, Some(&self.get_stats()));
         let results = self.storage.index.search_with_quality_and_bitmap(
             query,
             candidates_k,
@@ -109,7 +109,7 @@ impl Collection {
         quality: crate::SearchQuality,
         metric: crate::DistanceMetric,
     ) -> Result<Vec<ScoredResult>> {
-        let candidates_k = compute_oversampled_k(k, filter);
+        let candidates_k = compute_oversampled_k(k, filter, Some(&self.get_stats()));
         let index_results = self
             .storage
             .index
@@ -194,12 +194,21 @@ const OVERSAMPLE_CAP: f64 = 10_000.0;
 /// huge `k` (e.g. LIMIT close to `MAX_LIMIT`) get at most 10_000 candidates
 /// instead of panicking — `f64::clamp` asserts `min <= max`, and an
 /// unbounded lower bound of `k + 10` used to violate that for large `k`.
-pub(super) fn compute_oversampled_k(k: usize, filter: &crate::filter::Filter) -> usize {
+pub(super) fn compute_oversampled_k(
+    k: usize,
+    filter: &crate::filter::Filter,
+    stats: Option<&crate::collection::stats::CollectionStats>,
+) -> usize {
     // Clamp to a tiny positive value so that a zero-selectivity filter (e.g. empty
     // IN clause) never produces NaN (0.0/0.0 when k=0) or Inf (k>0/0.0). Both would
     // be handled by the clamp below, but NaN→usize is implementation-defined (LLVM
     // saturates to 0, giving zero candidates instead of the minimum sensible count).
-    let selectivity = estimate_filter_selectivity(filter).max(1e-9);
+    let selectivity = stats
+        .map_or_else(
+            || estimate_filter_selectivity(filter),
+            |s| s.estimate_runtime_filter_selectivity(filter),
+        )
+        .max(1e-9);
     #[allow(clippy::cast_precision_loss)]
     let k_f64 = k as f64;
     #[allow(clippy::cast_precision_loss)]
@@ -214,10 +223,15 @@ fn estimate_filter_selectivity(filter: &crate::filter::Filter) -> f64 {
     estimate_condition_selectivity(&filter.condition)
 }
 
+/// Structure-only fallback used when no [`CollectionStats`] is available
+/// (raw search paths). Constants come from the shared
+/// [`selectivity_defaults`](crate::collection::stats::selectivity_defaults)
+/// table so this path cannot drift from the stats-backed one.
 fn estimate_condition_selectivity(cond: &crate::filter::Condition) -> f64 {
+    use crate::collection::stats::selectivity_defaults as d;
     use crate::filter::Condition;
     match cond {
-        Condition::Eq { .. } | Condition::IsNull { .. } => 0.1,
+        Condition::Eq { .. } | Condition::IsNull { .. } => d::EQ,
         Condition::Gt { .. }
         | Condition::Gte { .. }
         | Condition::Lt { .. }
@@ -229,23 +243,25 @@ fn estimate_condition_selectivity(cond: &crate::filter::Condition) -> f64 {
         | Condition::ArrayContainsAny { .. }
         | Condition::ArrayContainsAll { .. }
         | Condition::GeoDistance { .. }
-        | Condition::GeoBbox { .. } => 0.3,
+        | Condition::GeoBbox { .. } => d::RANGE,
         Condition::In { values, .. } => {
             #[allow(clippy::cast_precision_loss)]
-            let sel = values.len() as f64 * 0.05;
-            sel.min(0.8)
+            let sel = values.len() as f64 * d::IN_PER_VALUE;
+            sel.min(d::IN_CAP)
         }
-        Condition::Neq { .. } | Condition::IsNotNull { .. } => 0.9,
+        Condition::Neq { .. } | Condition::IsNotNull { .. } => d::NEGATION,
         Condition::And { conditions } => conditions
             .iter()
             .map(estimate_condition_selectivity)
             .product::<f64>()
-            .max(0.01),
+            .max(d::FLOOR),
         Condition::Or { conditions } => conditions
             .iter()
             .map(estimate_condition_selectivity)
             .sum::<f64>()
             .min(1.0),
-        Condition::Not { condition } => (1.0 - estimate_condition_selectivity(condition)).max(0.01),
+        Condition::Not { condition } => {
+            (1.0 - estimate_condition_selectivity(condition)).max(d::FLOOR)
+        }
     }
 }

--- a/crates/velesdb-core/src/collection/search/vector_filter_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter_tests.rs
@@ -17,15 +17,15 @@ fn eq_filter() -> Filter {
 #[test]
 fn test_compute_oversampled_k_never_panics_at_max_limit() {
     let k = 100_000;
-    let candidates = compute_oversampled_k(k, &eq_filter());
+    let candidates = compute_oversampled_k(k, &eq_filter(), None);
     assert_eq!(candidates, 10_000, "budget saturates at the 10_000 cap");
 }
 
 /// Exact boundary: at k = 9_990 the lower bound (k + 10) equals the cap.
 #[test]
 fn test_compute_oversampled_k_boundary_at_cap() {
-    assert_eq!(compute_oversampled_k(9_990, &eq_filter()), 10_000);
-    assert_eq!(compute_oversampled_k(10_000, &eq_filter()), 10_000);
+    assert_eq!(compute_oversampled_k(9_990, &eq_filter(), None), 10_000);
+    assert_eq!(compute_oversampled_k(10_000, &eq_filter(), None), 10_000);
 }
 
 /// Nominal: small k keeps the selectivity-driven oversampling
@@ -33,9 +33,9 @@ fn test_compute_oversampled_k_boundary_at_cap() {
 #[test]
 fn test_compute_oversampled_k_small_k_unchanged() {
     // selectivity(Eq) = 0.1 -> 100 / 0.1 = 1000.
-    assert_eq!(compute_oversampled_k(100, &eq_filter()), 1_000);
+    assert_eq!(compute_oversampled_k(100, &eq_filter(), None), 1_000);
     // 5 / 0.1 = 50, above the lower bound (15).
-    assert_eq!(compute_oversampled_k(5, &eq_filter()), 50);
+    assert_eq!(compute_oversampled_k(5, &eq_filter(), None), 50);
 }
 
 /// `WITH (ef_search = N)` must honor the exact budget verbatim, not snap to a

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -114,8 +114,8 @@ impl CollectionStats {
                 return 1.0 / col_stats.distinct_count as f64;
             }
         }
-        // Default: assume 10% selectivity if unknown
-        0.1
+        // Default: shared structural fallback for an unknown column.
+        selectivity_defaults::EQ
     }
 
     /// Returns the histogram for a column, checking both `column_stats` and `field_stats`.
@@ -138,6 +138,133 @@ impl CollectionStats {
                 .duration_since(std::time::UNIX_EPOCH)
                 .map_or(0, |d| d.as_millis() as u64),
         );
+    }
+}
+
+/// Shared structural fallback selectivities.
+///
+/// Single source for the constants used when no histogram or cardinality
+/// data can answer — consumed by both the plan-time AST estimator
+/// (`velesql::cost_estimator`) and the runtime filter estimator below, so
+/// the two paths cannot drift apart silently.
+pub(crate) mod selectivity_defaults {
+    /// Equality / IS NULL with no statistics.
+    pub(crate) const EQ: f64 = 0.1;
+    /// Range, pattern and containment predicates with no statistics.
+    pub(crate) const RANGE: f64 = 0.3;
+    /// Per-value contribution of an IN list.
+    pub(crate) const IN_PER_VALUE: f64 = 0.05;
+    /// Cap on an IN list's total selectivity.
+    pub(crate) const IN_CAP: f64 = 0.8;
+    /// Negative predicates (`!=`, IS NOT NULL).
+    pub(crate) const NEGATION: f64 = 0.9;
+    /// Floor applied under conjunction/negation so an over-confident
+    /// estimate never predicts zero rows.
+    pub(crate) const FLOOR: f64 = 0.01;
+}
+
+impl CollectionStats {
+    /// Estimates the fraction of rows matching a runtime metadata filter.
+    ///
+    /// Histogram-backed where `ANALYZE` has produced one for the field,
+    /// cardinality-backed otherwise, and falling back to the same
+    /// structural constants as the plan-time estimator. Runtime mirror of
+    /// `CostEstimator::estimate_condition_selectivity`, which speaks the
+    /// AST `Condition` — this one speaks `crate::filter::Condition`.
+    #[must_use]
+    pub(crate) fn estimate_runtime_filter_selectivity(&self, filter: &crate::Filter) -> f64 {
+        self.estimate_runtime_condition_selectivity(&filter.condition)
+    }
+
+    pub(crate) fn estimate_runtime_condition_selectivity(
+        &self,
+        cond: &crate::filter::Condition,
+    ) -> f64 {
+        use crate::filter::Condition as C;
+        use selectivity_defaults as d;
+        match cond {
+            C::Eq { field, value } => self.runtime_eq_selectivity(field, value),
+            C::Neq { field, value } => {
+                (1.0 - self.runtime_eq_selectivity(field, value)).clamp(d::FLOOR, 1.0)
+            }
+            C::Gt { field, value } => self.runtime_lt_complement(field, value, true),
+            C::Gte { field, value } => self.runtime_lt_complement(field, value, false),
+            C::Lt { field, value } => self.runtime_lt_selectivity(field, value, false),
+            C::Lte { field, value } => self.runtime_lt_selectivity(field, value, true),
+            C::In { field, values } => {
+                let sum: f64 = values
+                    .iter()
+                    .map(|v| self.runtime_eq_selectivity(field, v))
+                    .sum();
+                sum.min(d::IN_CAP)
+            }
+            C::IsNull { field } => self.runtime_null_ratio(field),
+            C::IsNotNull { field } => (1.0 - self.runtime_null_ratio(field)).clamp(d::FLOOR, 1.0),
+            C::And { conditions } => conditions
+                .iter()
+                .map(|c| self.estimate_runtime_condition_selectivity(c))
+                .product::<f64>()
+                .max(d::FLOOR),
+            C::Or { conditions } => conditions
+                .iter()
+                .map(|c| self.estimate_runtime_condition_selectivity(c))
+                .sum::<f64>()
+                .min(1.0),
+            C::Not { condition } => {
+                (1.0 - self.estimate_runtime_condition_selectivity(condition)).max(d::FLOOR)
+            }
+            C::Contains { .. }
+            | C::Like { .. }
+            | C::ILike { .. }
+            | C::ArrayContains { .. }
+            | C::ArrayContainsAny { .. }
+            | C::ArrayContainsAll { .. }
+            | C::GeoDistance { .. }
+            | C::GeoBbox { .. } => d::RANGE,
+        }
+    }
+
+    /// Histogram equality estimate, then cardinality, then the shared default.
+    fn runtime_eq_selectivity(&self, field: &str, value: &serde_json::Value) -> f64 {
+        if let (Some(hist), Some(v)) = (self.get_column_histogram(field), value.as_f64()) {
+            return hist.estimate_eq_selectivity(v).clamp(0.0, 1.0);
+        }
+        self.estimate_selectivity(field)
+    }
+
+    /// Histogram `<` / `<=` estimate; `RANGE` fallback without one.
+    fn runtime_lt_selectivity(
+        &self,
+        field: &str,
+        value: &serde_json::Value,
+        inclusive: bool,
+    ) -> f64 {
+        if let (Some(hist), Some(v)) = (self.get_column_histogram(field), value.as_f64()) {
+            let bound = if inclusive { next_after(v) } else { v };
+            return hist.estimate_lt_selectivity(bound).clamp(0.0, 1.0);
+        }
+        selectivity_defaults::RANGE
+    }
+
+    /// Histogram `>` / `>=` as the complement of `<=` / `<`.
+    fn runtime_lt_complement(&self, field: &str, value: &serde_json::Value, strict: bool) -> f64 {
+        if let (Some(hist), Some(v)) = (self.get_column_histogram(field), value.as_f64()) {
+            let bound = if strict { next_after(v) } else { v };
+            return (1.0 - hist.estimate_lt_selectivity(bound)).clamp(0.0, 1.0);
+        }
+        selectivity_defaults::RANGE
+    }
+
+    /// Observed null ratio for a field; `EQ` default when never analyzed.
+    fn runtime_null_ratio(&self, field: &str) -> f64 {
+        self.field_stats
+            .get(field)
+            .or_else(|| self.column_stats.get(field))
+            .map_or(selectivity_defaults::EQ, |s| {
+                #[allow(clippy::cast_precision_loss)]
+                let ratio = s.null_count as f64 / self.total_points.max(1) as f64;
+                ratio.clamp(0.0, 1.0)
+            })
     }
 }
 

--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -151,18 +151,24 @@ pub(crate) mod selectivity_defaults {
     /// Equality / IS NULL with no statistics.
     pub(crate) const EQ: f64 = 0.1;
     /// Range, pattern and containment predicates with no statistics.
+    #[cfg(feature = "persistence")]
     pub(crate) const RANGE: f64 = 0.3;
     /// Per-value contribution of an IN list.
+    #[cfg(feature = "persistence")]
     pub(crate) const IN_PER_VALUE: f64 = 0.05;
     /// Cap on an IN list's total selectivity.
+    #[cfg(feature = "persistence")]
     pub(crate) const IN_CAP: f64 = 0.8;
     /// Negative predicates (`!=`, IS NOT NULL).
+    #[cfg(feature = "persistence")]
     pub(crate) const NEGATION: f64 = 0.9;
     /// Floor applied under conjunction/negation so an over-confident
     /// estimate never predicts zero rows.
+    #[cfg(feature = "persistence")]
     pub(crate) const FLOOR: f64 = 0.01;
 }
 
+#[cfg(feature = "persistence")]
 impl CollectionStats {
     /// Estimates the fraction of rows matching a runtime metadata filter.
     ///

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -794,4 +794,109 @@ fn graph_stats_roundtrips_through_serde() {
     let json = serde_json::to_string(&stats).unwrap();
     let back: CollectionStats = serde_json::from_str(&json).unwrap();
     assert_eq!(back.graph_stats, stats.graph_stats);
+// Runtime filter selectivity — the stats-backed mirror of the AST estimator
+// =========================================================================
+
+fn stats_with_price_histogram() -> CollectionStats {
+    let mut stats = CollectionStats::new();
+    stats.total_points = 100;
+    let builder = HistogramBuilder::new(4);
+    let mut values: Vec<f64> = (0..100).map(f64::from).collect();
+    let hist = builder.build(&mut values);
+    let mut col = ColumnStats::new("price").with_distinct_count(100);
+    col.histogram = Some(hist);
+    stats.column_stats.insert("price".to_string(), col);
+    stats
+}
+
+#[test]
+fn runtime_eq_uses_the_histogram_when_present() {
+    let stats = stats_with_price_histogram();
+    let cond = crate::filter::Condition::Eq {
+        field: "price".to_string(),
+        value: serde_json::json!(50),
+    };
+    let sel = stats.estimate_runtime_condition_selectivity(&cond);
+    // 100 distinct uniform values: histogram equality is ~1/100, far from
+    // the 0.1 structural default.
+    assert!(sel < 0.05, "expected histogram-backed estimate, got {sel}");
+}
+
+#[test]
+fn runtime_range_uses_the_histogram_when_present() {
+    let stats = stats_with_price_histogram();
+    let cond = crate::filter::Condition::Lt {
+        field: "price".to_string(),
+        value: serde_json::json!(25),
+    };
+    let sel = stats.estimate_runtime_condition_selectivity(&cond);
+    assert!(
+        (sel - 0.25).abs() < 0.1,
+        "uniform 0..100: P(x < 25) should be near 0.25, got {sel}"
+    );
+}
+
+#[test]
+fn runtime_unknown_column_falls_back_to_shared_defaults() {
+    let stats = CollectionStats::new();
+    let eq = crate::filter::Condition::Eq {
+        field: "missing".to_string(),
+        value: serde_json::json!("x"),
+    };
+    let range = crate::filter::Condition::Gt {
+        field: "missing".to_string(),
+        value: serde_json::json!(1),
+    };
+    assert!(
+        (stats.estimate_runtime_condition_selectivity(&eq) - selectivity_defaults::EQ).abs()
+            < f64::EPSILON
+    );
+    assert!(
+        (stats.estimate_runtime_condition_selectivity(&range) - selectivity_defaults::RANGE).abs()
+            < f64::EPSILON
+    );
+}
+
+/// Drift test (single-source constants): without histograms, the runtime
+/// estimator's equality answer must equal the AST estimator's fallback for
+/// the same column — both resolve through `CollectionStats::estimate_selectivity`.
+#[test]
+fn runtime_and_ast_estimators_agree_without_histograms() {
+    let mut stats = CollectionStats::new();
+    stats.total_points = 100;
+    stats.column_stats.insert(
+        "cat".to_string(),
+        ColumnStats::new("cat").with_distinct_count(4),
+    );
+    stats.row_count = 100;
+
+    let runtime = stats.estimate_runtime_condition_selectivity(&crate::filter::Condition::Eq {
+        field: "cat".to_string(),
+        value: serde_json::json!("a"),
+    });
+    // AST path: Comparison Eq falls back to estimate_selectivity("cat") when
+    // no histogram exists (cost_estimator delegates to the same method).
+    let ast_fallback = stats.estimate_selectivity("cat");
+    assert!(
+        (runtime - ast_fallback).abs() < f64::EPSILON,
+        "runtime {runtime} vs ast fallback {ast_fallback}"
+    );
+}
+
+#[test]
+fn runtime_boolean_combinators_recurse() {
+    let stats = CollectionStats::new();
+    let eq = crate::filter::Condition::Eq {
+        field: "a".to_string(),
+        value: serde_json::json!(1),
+    };
+    let and = crate::filter::Condition::And {
+        conditions: vec![eq.clone(), eq.clone()],
+    };
+    let not = crate::filter::Condition::Not {
+        condition: Box::new(eq.clone()),
+    };
+    let base = stats.estimate_runtime_condition_selectivity(&eq);
+    assert!((stats.estimate_runtime_condition_selectivity(&and) - base * base).abs() < 1e-9);
+    assert!((stats.estimate_runtime_condition_selectivity(&not) - (1.0 - base)).abs() < 1e-9);
 }

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -794,6 +794,9 @@ fn graph_stats_roundtrips_through_serde() {
     let json = serde_json::to_string(&stats).unwrap();
     let back: CollectionStats = serde_json::from_str(&json).unwrap();
     assert_eq!(back.graph_stats, stats.graph_stats);
+}
+
+// =========================================================================
 // Runtime filter selectivity — the stats-backed mirror of the AST estimator
 // =========================================================================
 


### PR DESCRIPTION
## Description

The over-fetch sizing for filtered vector search guessed selectivity from filter structure alone (`Eq=0.1`, ranges `=0.3`, …, `vector_filter.rs`) while the plan-time CBO estimated the same predicates from real histograms (`cost_estimator`) — two estimators, two constant tables, no shared source.

- `CollectionStats` gains the runtime mirror, `estimate_runtime_condition_selectivity` (speaking `crate::filter::Condition`): histogram-backed equality and range estimates, cardinality fallback, null-ratio for `IS NULL`, same combinator algebra.
- One shared `selectivity_defaults` table now feeds **both** the structural fallback and `CollectionStats::estimate_selectivity` — the constants exist once, with a **drift test** asserting the AST and runtime answers agree when no histogram exists.
- `compute_oversampled_k(k, filter, stats: Option<&CollectionStats>)`: the VelesQL execution paths (bitmap, post-filter, anchored graph prefilter) pass the warm 30 s-TTL stats handle (`select_dispatch` already calls `get_stats()` per query, so the cache is hot); the raw `search_with_filter` path deliberately passes `None` — its cost profile is unchanged, documented in place.
- The strategy decision itself (`search_with_bitmap_strategy`, real bitmap selectivity) is untouched.

Part of the "câblage réel" plan (lots 1.1 + 1.2) from the unified-engine audit.

## Type of Change

- [x] 🔧 Refactoring (no functional changes on the raw path; stats-informed over-fetch on the VelesQL path)

## How Has This Been Tested?

- [x] Unit tests

- New: histogram-backed Eq deviates from the structural default on a 100-distinct uniform column; `Lt 25` on uniform 0..100 estimates ≈0.25; unknown columns fall back to the shared defaults; AST↔runtime drift test; combinator recursion.
- Legacy `compute_oversampled_k` tests updated to the `None` arm — numeric expectations unchanged (anti-regression).
- Search path touched → recall gate: `cargo test -p velesdb-core --lib --features persistence test_recall -- --test-threads=1` — **18 passed**.
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `cargo check -p velesdb-core --no-default-features` — clean; `cargo fmt --all` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches the filtered-search over-fetch sizing (not hnsw internals/storage/Drop/unsafe/SIMD dispatch).

- [x] I listed the invariants impacted by this change — over-fetch stays clamped to `[min(k+10, 10_000), 10_000]`; the exact-brute-force and post-filter strategy thresholds are unchanged.
- [x] I added/updated tests for the affected paths; the recall gate is green.