### PR TITLE
feat(core): cost GraphMatch from the ANALYZE graph view instead of a 0.5 constant

### DIFF
--- a/crates/velesdb-core/src/collection/stats/mod.rs
+++ b/crates/velesdb-core/src/collection/stats/mod.rs
@@ -164,7 +164,6 @@ pub(crate) mod selectivity_defaults {
     pub(crate) const NEGATION: f64 = 0.9;
     /// Floor applied under conjunction/negation so an over-confident
     /// estimate never predicts zero rows.
-    #[cfg(feature = "persistence")]
     pub(crate) const FLOOR: f64 = 0.01;
 }
 

--- a/crates/velesdb-core/src/velesql/cost_estimator/mod.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/mod.rs
@@ -361,7 +361,7 @@ impl<'a> CostEstimator<'a> {
             Condition::Match(_) | Condition::Contains(_) | Condition::GeoDistance(_) => 0.1,
             Condition::ContainsText(_) => 0.05,
             Condition::GeoBbox(_) => 0.2,
-            Condition::GraphMatch(_) => 0.5,
+            Condition::GraphMatch(gm) => self.estimate_graph_match_selectivity(gm),
             Condition::And(left, right) => {
                 self.estimate_condition_selectivity(left)
                     * self.estimate_condition_selectivity(right)
@@ -378,6 +378,46 @@ impl<'a> CostEstimator<'a> {
             | Condition::SparseVectorSearch(_)
             | Condition::Similarity(_) => 1.0,
         }
+    }
+
+    /// Estimates the anchor fraction of a graph pattern from the `ANALYZE`
+    /// graph view; the historical `0.5` constant when no graph statistics
+    /// exist (never-analyzed collection, stats persisted before 5.2.0).
+    ///
+    /// Per hop: a typed hop keeps roughly `avg_degree × label_selectivity`
+    /// of the nodes (expected count of matching out-edges, capped at 1); an
+    /// untyped hop only requires *some* edge, ≈ `min(1, avg_degree)`. A
+    /// variable-length hop `*lo..hi` contributes `lo` mandatory hops — and
+    /// none when `lo == 0`, since the pattern then matches without any edge.
+    /// Hops multiply (independence approximation), clamped to
+    /// `[FLOOR, 0.5]`: the estimate only ever *tightens* the historical
+    /// constant, never loosens it, so an optimistic graph view cannot make
+    /// a graph predicate look cheaper to post-filter than before.
+    fn estimate_graph_match_selectivity(
+        &self,
+        gm: &crate::velesql::ast::GraphMatchPredicate,
+    ) -> f64 {
+        const GRAPH_MATCH_DEFAULT: f64 = 0.5;
+        let Some(graph) = self.stats.graph_stats.as_ref() else {
+            return GRAPH_MATCH_DEFAULT;
+        };
+        if graph.total_nodes == 0 {
+            return GRAPH_MATCH_DEFAULT;
+        }
+        let mut selectivity = 1.0_f64;
+        for rel in &gm.pattern.relationships {
+            let per_hop = if rel.types.is_empty() {
+                graph.avg_degree.min(1.0)
+            } else {
+                (graph.avg_degree * graph.label_selectivity).min(1.0)
+            };
+            let mandatory_hops = rel.range.map_or(1, |(lo, _)| lo);
+            selectivity *= per_hop.powi(i32::try_from(mandatory_hops).unwrap_or(i32::MAX));
+        }
+        selectivity.clamp(
+            crate::collection::stats::selectivity_defaults::FLOOR,
+            GRAPH_MATCH_DEFAULT,
+        )
     }
 
     /// Estimates selectivity for a `Comparison` condition using histogram data.

--- a/crates/velesdb-core/src/velesql/cost_estimator/selectivity_method_tests.rs
+++ b/crates/velesdb-core/src/velesql/cost_estimator/selectivity_method_tests.rs
@@ -290,3 +290,91 @@ fn backward_compat_selectivity_value_unchanged() {
         "method-aware and legacy paths must agree: new={sel_new} old={sel_old}"
     );
 }
+
+// =========================================================================
+// GraphMatch selectivity — ANALYZE graph view instead of the 0.5 constant
+// =========================================================================
+
+fn graph_match(types: Vec<&str>, range: Option<(u32, u32)>) -> Condition {
+    use crate::velesql::graph_pattern::{
+        Direction, GraphPattern, NodePattern, RelationshipPattern,
+    };
+    let mut rel = RelationshipPattern::new(Direction::Outgoing);
+    rel.types = types.into_iter().map(String::from).collect();
+    rel.range = range;
+    Condition::GraphMatch(crate::velesql::ast::GraphMatchPredicate {
+        pattern: GraphPattern {
+            name: None,
+            nodes: vec![NodePattern::new(), NodePattern::new()],
+            relationships: vec![rel],
+        },
+    })
+}
+
+fn stats_with_graph(avg_degree: f64, label_count: usize) -> CollectionStats {
+    let mut s = CollectionStats::new();
+    s.total_points = 1_000;
+    s.row_count = 1_000;
+    s.graph_stats = Some(crate::velesql::match_planner::MatchGraphStats {
+        total_nodes: 1_000,
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        // Reason: test fixture; degree is a small positive constant.
+        total_edges: (avg_degree * 1_000.0) as usize,
+        avg_degree,
+        label_count,
+        label_selectivity: if label_count > 0 {
+            1.0 / label_count as f64
+        } else {
+            1.0
+        },
+    });
+    s
+}
+
+#[test]
+fn graph_match_without_graph_stats_keeps_the_historical_constant() {
+    let stats = CollectionStats::new();
+    let est = CostEstimator::new(&stats);
+    let sel = est.estimate_condition_selectivity(&graph_match(vec!["WROTE"], None));
+    assert!((sel - 0.5).abs() < f64::EPSILON);
+}
+
+#[test]
+fn typed_hop_on_a_sparse_labeled_graph_tightens_the_estimate() {
+    // avg_degree 2, 50 edge labels: one typed hop keeps ~2/50 = 0.04.
+    let stats = stats_with_graph(2.0, 50);
+    let est = CostEstimator::new(&stats);
+    let sel = est.estimate_condition_selectivity(&graph_match(vec!["WROTE"], None));
+    assert!(sel < 0.05, "expected a tight estimate, got {sel}");
+    assert!(sel >= 0.01, "estimate must respect the floor, got {sel}");
+}
+
+#[test]
+fn graph_estimate_never_exceeds_the_historical_constant() {
+    // Dense graph, single label: raw estimate would be ~min(1, 8*1) = 1.0.
+    let stats = stats_with_graph(8.0, 1);
+    let est = CostEstimator::new(&stats);
+    let sel = est.estimate_condition_selectivity(&graph_match(vec!["LINK"], None));
+    assert!(
+        (sel - 0.5).abs() < f64::EPSILON,
+        "cap at the historical 0.5, got {sel}"
+    );
+}
+
+#[test]
+fn optional_variable_length_hop_contributes_nothing() {
+    // `*0..3`: zero mandatory hops — the pattern matches without any edge.
+    let stats = stats_with_graph(2.0, 50);
+    let est = CostEstimator::new(&stats);
+    let sel = est.estimate_condition_selectivity(&graph_match(vec!["WROTE"], Some((0, 3))));
+    assert!((sel - 0.5).abs() < f64::EPSILON, "got {sel}");
+}
+
+#[test]
+fn mandatory_variable_length_hops_multiply() {
+    // `*2..3` on a 0.04-per-hop graph: 0.04^2 = 0.0016 -> floored at 0.01.
+    let stats = stats_with_graph(2.0, 50);
+    let est = CostEstimator::new(&stats);
+    let sel = est.estimate_condition_selectivity(&graph_match(vec!["WROTE"], Some((2, 3))));
+    assert!((sel - 0.01).abs() < f64::EPSILON, "got {sel}");
+}


### PR DESCRIPTION
## Description

The CBO priced every graph predicate at a hardcoded `0.5` selectivity (`cost_estimator/mod.rs`), so it could never justify a graph-first plan however selective the pattern. This PR makes `estimate_condition_selectivity` read the `ANALYZE` graph view (`CollectionStats::graph_stats`, in place since #2043):

- a **typed hop** keeps ≈ `avg_degree × label_selectivity` of the nodes (expected matching out-edges, capped at 1);
- an **untyped hop** only requires some edge: `min(1, avg_degree)`;
- a **variable-length hop** `*lo..hi` contributes its `lo` mandatory hops — and none when `lo == 0`, since the pattern then matches without any edge;
- hops multiply (independence approximation), clamped to **`[FLOOR, 0.5]`**: the estimate only ever *tightens* the historical constant, never loosens it, so an optimistic graph view cannot make a graph predicate look cheaper to post-filter than before.

Collections without graph stats (never analyzed, stats persisted before 5.2.0) keep the exact prior behaviour. Part of the "câblage réel" plan (lot 1.3).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests

Five tests pin the model in `selectivity_method_tests.rs`: no-stats keeps 0.5; a sparse labeled graph (degree 2, 50 labels) tightens to 0.04; a dense single-label graph is capped at 0.5; `*0..3` contributes nothing; `*2..3` multiplies and hits the floor.

- `cargo test -p velesdb-core --lib --features persistence selectivity_method -- --test-threads=1` — 21 passed
- `cargo test -p velesdb-core --lib --features persistence cbo -- --test-threads=1` — 5 passed
- `cargo test -p velesdb-core --lib --features persistence test_recall -- --test-threads=1` — 18 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `RUSTFLAGS=-Dwarnings cargo check -p velesdb-core --no-default-features` — clean (the shared `FLOOR` constant is un-gated: the cost estimator is its new always-compiled consumer)

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

A criterion A/B on a NEAR+MATCH corpus where graph-first wins is deliberately out of scope here — the estimator is designed so its only possible effect versus today is a *lower* graph selectivity, which the existing CBO tests and the recall gate cover.