### PR TITLE
feat(core): serve Inner/Left JOINs from a secondary index on the join column

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/join.rs
+++ b/crates/velesdb-core/src/collection/search/query/join.rs
@@ -322,7 +322,7 @@ fn append_unmatched_left_rows(
 ///
 /// `USING` with multiple columns is currently not supported because execution
 /// path relies on a single primary key lookup.
-fn resolve_join_condition(join: &JoinClause) -> Option<JoinCondition> {
+pub(crate) fn resolve_join_condition(join: &JoinClause) -> Option<JoinCondition> {
     if let Some(condition) = &join.condition {
         return Some(normalize_join_condition(condition, join));
     }

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -168,7 +168,7 @@ impl Database {
     /// column, avoiding the per-query `ColumnStore` materialization.
     ///
     /// Returns `None` when the shape is not eligible, falling through to the
-    /// ColumnStore path: Right/Full joins need the unmatched join-side rows
+    /// `ColumnStore` path: Right/Full joins need the unmatched join-side rows
     /// that only a full enumeration can produce, `id` is already served by
     /// the lookup fast path, and a column that is neither `id` nor indexed
     /// reaches that path's actionable error. Unlike the PK paths a non-PK

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -138,6 +138,13 @@ impl Database {
         if Self::is_lookup_join_eligible(join) && pushed.is_empty() {
             return Ok(Self::execute_lookup_join(results, join, &join_collection));
         }
+        if pushed.is_empty() {
+            if let Some(output) =
+                Self::try_indexed_join(results, join, &join_collection, row_budget)
+            {
+                return Ok(output);
+            }
+        }
 
         let column_store = if pushed.is_empty() {
             self.cached_join_column_store(&join.table, &join_collection)?
@@ -155,6 +162,93 @@ impl Database {
             row_budget,
         )?;
         Ok(crate::collection::search::query::join::joined_to_search_results(joined))
+    }
+
+    /// Answers an Inner/Left JOIN from a secondary index on the join-side
+    /// column, avoiding the per-query `ColumnStore` materialization.
+    ///
+    /// Returns `None` when the shape is not eligible, falling through to the
+    /// ColumnStore path: Right/Full joins need the unmatched join-side rows
+    /// that only a full enumeration can produce, `id` is already served by
+    /// the lookup fast path, and a column that is neither `id` nor indexed
+    /// reaches that path's actionable error. Unlike the PK paths a non-PK
+    /// key may match several join-side points; one merged row is emitted per
+    /// (left row, match) pair, bounded by `row_budget`.
+    fn try_indexed_join(
+        results: &[SearchResult],
+        join: &crate::velesql::JoinClause,
+        collection: &crate::collection::Collection,
+        row_budget: usize,
+    ) -> Option<Vec<SearchResult>> {
+        use crate::velesql::JoinType;
+        if !matches!(join.join_type, JoinType::Inner | JoinType::Left) {
+            return None;
+        }
+        let condition = crate::collection::search::query::join::resolve_join_condition(join)?;
+        let index_column = condition.left.column.clone();
+        if index_column == "id" || !collection.indexed_field_names().contains(&index_column) {
+            return None;
+        }
+
+        let mut output = Vec::new();
+        for left in results {
+            if output.len() >= row_budget {
+                break;
+            }
+            Self::append_indexed_matches(
+                collection,
+                left,
+                &index_column,
+                &condition.right.column,
+                join.join_type,
+                row_budget,
+                &mut output,
+            );
+        }
+        Some(output)
+    }
+
+    /// Appends the join output rows for one left-side result: every indexed
+    /// match merged left-over-right, or the bare left row for an unmatched
+    /// LEFT JOIN. The source key uses the same payload→key conversion as
+    /// index maintenance (`JsonValue::from_json`), with the `id` fallback the
+    /// PK key extractor also honours.
+    fn append_indexed_matches(
+        collection: &crate::collection::Collection,
+        left: &SearchResult,
+        index_column: &str,
+        source_column: &str,
+        join_type: crate::velesql::JoinType,
+        row_budget: usize,
+        output: &mut Vec<SearchResult>,
+    ) {
+        let source_value = left
+            .point
+            .payload
+            .as_ref()
+            .and_then(|p| p.get(source_column).cloned())
+            .or_else(|| (source_column == "id").then(|| serde_json::json!(left.point.id)));
+        let matches = source_value
+            .as_ref()
+            .and_then(crate::index::JsonValue::from_json)
+            .and_then(|key| collection.secondary_index_lookup(index_column, &key))
+            .unwrap_or_default();
+
+        if matches.is_empty() {
+            if matches!(join_type, crate::velesql::JoinType::Left) {
+                output.push(left.clone());
+            }
+            return;
+        }
+        for right_point in collection.get(&matches).into_iter().flatten() {
+            if output.len() >= row_budget {
+                return;
+            }
+            output.push(SearchResult::new(
+                Self::merge_payloads(&left.point, &right_point),
+                left.score,
+            ));
+        }
     }
 
     /// Returns the JOIN-side `ColumnStore` for `collection`, rebuilding only

--- a/crates/velesdb-core/src/database/query_join_tests.rs
+++ b/crates/velesdb-core/src/database/query_join_tests.rs
@@ -114,3 +114,125 @@ fn ttl_points_disable_caching() {
         "TTL-carrying builds must not populate the cache"
     );
 }
+
+// =========================================================================
+// Indexed non-PK JOIN — served from a secondary index, no ColumnStore
+// =========================================================================
+
+fn run_sql(db: &Database, sql: &str) -> crate::Result<Vec<crate::SearchResult>> {
+    let query =
+        crate::velesql::Parser::parse(sql).map_err(|e| crate::Error::Query(e.to_string()))?;
+    db.execute_query(&query, &std::collections::HashMap::new())
+}
+
+/// products(id, sku) JOIN inventory ON inventory.sku = products.sku, with a
+/// secondary index on inventory.sku. One product sku matches TWO inventory
+/// rows — a shape the PK-only path cannot express.
+fn seed_indexed_join_fixtures(db: &Database) {
+    db.create_collection("products", 4, DistanceMetric::Cosine)
+        .unwrap();
+    db.create_collection("inventory", 4, DistanceMetric::Cosine)
+        .unwrap();
+    let products = db.resolve_collection("products").unwrap();
+    products
+        .upsert([
+            Point::new(
+                1,
+                vec![1.0, 0.0, 0.0, 0.0],
+                Some(serde_json::json!({"sku": "a"})),
+            ),
+            Point::new(
+                2,
+                vec![0.0, 1.0, 0.0, 0.0],
+                Some(serde_json::json!({"sku": "zz"})),
+            ),
+        ])
+        .unwrap();
+    let inventory = db.resolve_collection("inventory").unwrap();
+    inventory
+        .upsert([
+            Point::new(
+                10,
+                vec![0.0; 4],
+                Some(serde_json::json!({"sku": "a", "wh": "paris"})),
+            ),
+            Point::new(
+                11,
+                vec![0.0; 4],
+                Some(serde_json::json!({"sku": "a", "wh": "lyon"})),
+            ),
+            Point::new(
+                12,
+                vec![0.0; 4],
+                Some(serde_json::json!({"sku": "b", "wh": "nice"})),
+            ),
+        ])
+        .unwrap();
+    inventory.create_index("sku").unwrap();
+}
+
+#[test]
+fn indexed_inner_join_emits_one_row_per_match() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    seed_indexed_join_fixtures(&db);
+
+    let rows = run_sql(
+        &db,
+        "SELECT * FROM products JOIN inventory ON inventory.sku = products.sku LIMIT 10",
+    )
+    .unwrap();
+    // sku "a" matches two inventory rows; sku "zz" matches none (INNER drops it).
+    assert_eq!(rows.len(), 2, "one merged row per indexed match");
+    let mut warehouses: Vec<String> = rows
+        .iter()
+        .filter_map(|r| {
+            r.point
+                .payload
+                .as_ref()?
+                .get("wh")?
+                .as_str()
+                .map(String::from)
+        })
+        .collect();
+    warehouses.sort();
+    assert_eq!(warehouses, ["lyon", "paris"]);
+}
+
+#[test]
+fn indexed_left_join_keeps_unmatched_left_rows() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    seed_indexed_join_fixtures(&db);
+
+    let rows = run_sql(
+        &db,
+        "SELECT * FROM products LEFT JOIN inventory ON inventory.sku = products.sku LIMIT 10",
+    )
+    .unwrap();
+    // Two matches for "a" plus the bare unmatched "zz" row.
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().any(|r| {
+        let p = r.point.payload.as_ref().unwrap();
+        p.get("sku").and_then(|v| v.as_str()) == Some("zz") && p.get("wh").is_none()
+    }));
+}
+
+/// The reject contract is untouched: a non-PK join column WITHOUT a
+/// secondary index still fails with the actionable primary-key error.
+#[test]
+fn unindexed_non_pk_join_column_still_rejected() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+    seed_indexed_join_fixtures(&db);
+
+    let err = run_sql(
+        &db,
+        "SELECT * FROM products JOIN inventory ON inventory.wh = products.sku LIMIT 10",
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("requires primary key"),
+        "got: {err}"
+    );
+}

--- a/crates/velesdb-core/src/database/query_join_tests.rs
+++ b/crates/velesdb-core/src/database/query_join_tests.rs
@@ -125,8 +125,8 @@ fn run_sql(db: &Database, sql: &str) -> crate::Result<Vec<crate::SearchResult>> 
     db.execute_query(&query, &std::collections::HashMap::new())
 }
 
-/// products(id, sku) JOIN inventory ON inventory.sku = products.sku, with a
-/// secondary index on inventory.sku. One product sku matches TWO inventory
+/// `products(id, sku) JOIN inventory ON inventory.sku = products.sku`, with
+/// a secondary index on `inventory.sku`. One product sku matches TWO inventory
 /// rows — a shape the PK-only path cannot express.
 fn seed_indexed_join_fixtures(db: &Database) {
     db.create_collection("products", 4, DistanceMetric::Cosine)

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -276,11 +276,16 @@ FROM <table1> [[AS] <alias1>]
 | Right | `RIGHT JOIN` or `RIGHT OUTER JOIN` | All right rows; unmatched left side gets `NULL`s | Fully executed (`join.rs:155-162`) |
 | Full | `FULL JOIN` or `FULL OUTER JOIN` | All rows from both sides with `NULL`s on the unmatched side | Fully executed (`join.rs:155-171`) |
 
-> **Constraint:** all four JOIN types require the join column to be the
-> right-side collection's column-store **primary key**. The executor
-> rejects `JOIN ... ON other_col = ...` at runtime with
+> **Constraint:** the join column must be either the right-side
+> collection's column-store **primary key**, or — for **INNER** and
+> **LEFT** joins only — a payload field covered by a **secondary index**
+> (`create_index`; string, number or boolean keys). An indexed non-PK key
+> may match several right-side points: one merged row is emitted per
+> match. RIGHT and FULL joins, and any non-PK column without a secondary
+> index, are rejected at runtime with
 > `"JOIN on table 'T' requires primary key 'PK', got 'other_col'"`
-> (see `validate_join_condition` in `join.rs:177-201`).
+> (see `validate_join_condition` in `join.rs` and
+> `Database::try_indexed_join` in `database/query_join.rs`).
 
 ### ON Condition
 
@@ -353,6 +358,8 @@ WHERE inventory.stock > 0
 ```
 
 **Lookup Join**: When the JOIN condition references the primary key (`id`) on both sides and no pushdown filters apply, the engine uses direct `collection.get()` lookups instead of building a full ColumnStore, achieving O(K) instead of O(N) retrieval.
+
+**Indexed Join**: When the join-side column carries a secondary index (and the join is INNER or LEFT, with no pushdown filters), the engine resolves matches through the index — `secondary_index_lookup` per left row — instead of materializing the ColumnStore, and emits one merged row per indexed match.
 
 ```sql
 -- Uses optimized lookup path (both sides reference id)


### PR DESCRIPTION
## Description

The JOIN executor only accepted the column-store **primary key** as join column; everything else was rejected at runtime. This PR adds an indexed path (`Database::try_indexed_join`, `database/query_join.rs`):

- When the join-side column carries a **B-tree secondary index** and the join is **INNER or LEFT** (no pushdown filters), matches are resolved through `secondary_index_lookup` per left row — **no ColumnStore materialization at all**.
- Key conversion is the **exact one index maintenance uses** (`JsonValue::from_json`: string / number / bool), with the `id` fallback the PK key extractor also honours — so a key that indexed will match, and nothing else will.
- A non-PK key may match several join-side points: one merged row is emitted per (left row, match) pair, bounded by `row_budget` — semantics the PK-only paths could not express.
- The join condition goes through the existing `resolve_join_condition` normalization (join-table column on the left, `USING(col)` included), now `pub(crate)` — reused, not duplicated.
- **Right/Full joins** (which need the unmatched join-side rows only a full enumeration produces) and **unindexed non-PK columns** keep the prior path and its actionable `requires primary key` error — pinned by the reject-conformance suite, which passes unchanged.

`docs/VELESQL_SPEC.md`'s JOIN constraint and execution-strategy sections are updated in the same PR. Part of the "câblage réel" plan (lot 4.2).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Three new tests in `database/query_join_tests.rs` drive the full SQL path (`Parser::parse` → `execute_query`): an indexed inner join emitting one row per match (2 matches for one key), a LEFT join keeping the unmatched left row bare, and the unindexed non-PK regression still rejected with `requires primary key`.

- `cargo test -p velesdb-core --lib --features persistence join -- --test-threads=1` — 98 passed
- `cargo test -p velesdb-core --features persistence --test bdd velesql_reject -- --test-threads=1` — 11 passed (reject contract intact)
- `cargo test -p velesdb-core --features persistence --test pushdown_join_e2e_tests -- --test-threads=1` — 14 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `RUSTFLAGS=-Dwarnings cargo check -p velesdb-core --no-default-features` — clean
- `bash scripts/check-doc-contract.sh` + the five doc-freshness guards — pass

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Secondary-index key types are string/number/boolean (the B-tree's own limit), stated in the spec. The indexed path deliberately declines when pushdown conditions apply — those filter the join side and belong to the filtered-ColumnStore path.