### PR TITLE
test(core): track the real vectors→columnar order in the PDX rebuild; state the Neighbors rank as a reservation

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking.rs
@@ -81,13 +81,18 @@ pub(crate) enum LockRank {
     GpuVectorsSnapshot = crate::lock_rank::LockRank::GPU_VECTORS_SNAPSHOT.ordinal(),
     /// `vectors` RwLock — rank 10 (acquired first among the core HNSW locks)
     Vectors = crate::lock_rank::LockRank::VECTORS.ordinal(),
-    /// `columnar` RwLock — rank 15 (PDX block-columnar layout)
-    #[allow(dead_code)] // Reason: PDX columnar lock rank — used when PDX search is wired
+    /// `columnar` RwLock — rank 15 (PDX block-columnar layout).
+    ///
+    /// Tracked at its single acquisition site, the PDX layout rebuild in
+    /// `reorder.rs` (vectors → columnar); PDX search readers, when wired,
+    /// inherit the tracked order.
     Columnar = crate::lock_rank::LockRank::COLUMNAR.ordinal(),
     /// `layers` RwLock — rank 20 (acquired after vectors/columnar)
     Layers = crate::lock_rank::LockRank::LAYERS.ordinal(),
-    /// Per-node neighbor lists — rank 30 (acquired last)
-    #[allow(dead_code)] // Reason: Neighbor-level lock rank — reserved for fine-grained locking
+    /// Per-node neighbor lists — rank 30 (acquired last).
+    // Reason: pure reservation — no per-node neighbor lock exists yet, so
+    // there is nothing to track; the rank pins the slot in the global order.
+    #[allow(dead_code)]
     Neighbors = crate::lock_rank::LockRank::NEIGHBORS.ordinal(),
 }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/locking_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/locking_tests.rs
@@ -39,3 +39,31 @@ fn nested_acquire_in_declared_order_reports_both_held() {
     assert!(!holds_lock(LockRank::GpuVectorsSnapshot));
     assert!(!holds_lock(LockRank::Vectors));
 }
+
+#[test]
+fn columnar_after_vectors_is_the_tracked_pdx_rebuild_order() {
+    // Mirrors reorder::build_columnar_layout: vectors (10) then columnar (15).
+    record_lock_acquire(LockRank::Vectors);
+    record_lock_acquire(LockRank::Columnar);
+
+    assert!(holds_lock(LockRank::Vectors));
+    assert!(holds_lock(LockRank::Columnar));
+
+    record_lock_release(LockRank::Columnar);
+    record_lock_release(LockRank::Vectors);
+    assert!(!holds_lock(LockRank::Columnar));
+    assert!(!holds_lock(LockRank::Vectors));
+}
+
+#[test]
+fn vectors_after_columnar_counts_a_violation() {
+    let before = HNSW_COUNTERS.snapshot().invariant_violation_total;
+    record_lock_acquire(LockRank::Columnar);
+    record_lock_acquire(LockRank::Vectors); // wrong order: 10 while holding 15
+    record_lock_release(LockRank::Vectors);
+    record_lock_release(LockRank::Columnar);
+    assert!(
+        HNSW_COUNTERS.snapshot().invariant_violation_total > before,
+        "acquiring Vectors while holding Columnar must be flagged"
+    );
+}

--- a/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
@@ -146,11 +146,20 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// This transposes row-major vectors into 64-vector blocks where each
     /// dimension is contiguous, enabling SIMD-parallel distance computation.
     fn build_columnar_layout(&self) {
+        use super::locking::{record_lock_acquire, record_lock_release, LockRank};
+        // The only current two-lock site touching `columnar`: vectors (10)
+        // then columnar (15), tracked so a future PDX reader taking the
+        // locks the other way round trips the debug tracker immediately.
+        record_lock_acquire(LockRank::Vectors);
         let vectors_guard = self.vectors.read();
         if let Some(vectors) = vectors_guard.as_ref() {
             let pdx = super::super::columnar_vectors::ColumnarVectors::from_contiguous(vectors);
+            record_lock_acquire(LockRank::Columnar);
             *self.columnar.write() = Some(pdx);
+            record_lock_release(LockRank::Columnar);
         }
+        drop(vectors_guard);
+        record_lock_release(LockRank::Vectors);
     }
 
     /// Builds a reverse mapping: `result[old_id] = new_id`.

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -247,6 +247,13 @@ fn test_graph_parallel_insert_search_integrity() {
     use std::sync::Arc;
     use std::thread;
 
+    // The safety counters are process-global: snapshot before, compare after,
+    // so tests that legitimately exercise the violation detector cannot fail
+    // this one through the shared counter.
+    let violations_before = super::graph::safety_counters::HNSW_COUNTERS
+        .snapshot()
+        .invariant_violation_total;
+
     let engine = CpuDistance::new(DistanceMetric::Euclidean);
     let hnsw = Arc::new(NativeHnsw::new(engine, 16, 100, 500));
 
@@ -297,10 +304,10 @@ fn test_graph_parallel_insert_search_integrity() {
     // Deterministic: 50 pre-pop + 200 parallel = 250
     assert_eq!(hnsw.len(), 250, "All inserts must be reflected in count");
 
-    // Safety counters check
+    // Safety counters check: this test must not have added violations
     let snapshot = super::graph::safety_counters::HNSW_COUNTERS.snapshot();
     assert_eq!(
-        snapshot.invariant_violation_total, 0,
+        snapshot.invariant_violation_total, violations_before,
         "No lock-order violations during parallel graph operations"
     );
 }

--- a/crates/velesdb-core/src/index/hnsw/native/tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/tests.rs
@@ -488,6 +488,13 @@ fn test_concurrent_insert_search_correctness() {
     use std::sync::Arc;
     use std::thread;
 
+    // The safety counters are process-global: snapshot before, compare after,
+    // so tests that legitimately exercise the violation detector (e.g. the
+    // locking tests) cannot fail this one through the shared counter.
+    let violations_before = super::graph::safety_counters::HNSW_COUNTERS
+        .snapshot()
+        .invariant_violation_total;
+
     let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 32);
     let hnsw = Arc::new(NativeHnsw::new(engine, 16, 100, 1000));
 
@@ -557,10 +564,10 @@ fn test_concurrent_insert_search_correctness() {
         "Should have at least 100 initial + 200 inserted, got {final_count}"
     );
 
-    // Safety counters: no invariant violations
+    // Safety counters: this test must not have added invariant violations
     let snapshot = super::graph::safety_counters::HNSW_COUNTERS.snapshot();
     assert_eq!(
-        snapshot.invariant_violation_total, 0,
+        snapshot.invariant_violation_total, violations_before,
         "Concurrent insert+search must not trigger lock-order violations"
     );
 }
@@ -634,6 +641,11 @@ fn test_hnsw_no_deadlock_during_parallel_insert_search() {
     use std::sync::Arc;
     use std::thread;
 
+    // Global-counter delta (see test_concurrent_insert_search_correctness).
+    let violations_before = super::graph::safety_counters::HNSW_COUNTERS
+        .snapshot()
+        .invariant_violation_total;
+
     let engine = CachedSimdDistance::new(DistanceMetric::Cosine, 64);
     let hnsw = Arc::new(NativeHnsw::new(engine, 16, 100, 500));
 
@@ -689,10 +701,10 @@ fn test_hnsw_no_deadlock_during_parallel_insert_search() {
         "Should have at least initial 100 vectors, got {final_count}"
     );
 
-    // Verify safety counters are accessible and no invariant violations
+    // Verify safety counters are accessible and this test added no violations
     let snapshot = super::graph::safety_counters::HNSW_COUNTERS.snapshot();
     assert_eq!(
-        snapshot.invariant_violation_total, 0,
+        snapshot.invariant_violation_total, violations_before,
         "No lock-order violations should occur with correct lock ordering"
     );
 }
@@ -982,6 +994,9 @@ fn test_prenormalized_search_distances_are_consistent() {
 
 #[test]
 fn test_safety_counters_accessible_after_operations() {
+    // Global-counter deltas (see test_concurrent_insert_search_correctness).
+    let before = super::graph::safety_counters::HNSW_COUNTERS.snapshot();
+
     let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 32);
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
@@ -998,12 +1013,12 @@ fn test_safety_counters_accessible_after_operations() {
 
     // No invariant violations expected with correct lock ordering
     assert_eq!(
-        snapshot.invariant_violation_total, 0,
+        snapshot.invariant_violation_total, before.invariant_violation_total,
         "Correct lock ordering should produce zero violations"
     );
-    // Corruption counter should be zero for normal operations
+    // Corruption counter should not move for normal operations
     assert_eq!(
-        snapshot.corruption_detected_total, 0,
+        snapshot.corruption_detected_total, before.corruption_detected_total,
         "Normal operations should not trigger corruption signals"
     );
 }


### PR DESCRIPTION
## Description

Two lock ranks of the HNSW debug tracker (`graph/locking.rs`) were declared but never tracked. Adversarial review split them into a real gap and a non-gap:

- **`Columnar` — real, now wired.** The `columnar` RwLock has exactly one acquisition site: the PDX layout rebuild (`reorder.rs::build_columnar_layout`), which holds `vectors` (rank 10) while taking `columnar` (rank 15). That site is now instrumented with `record_lock_acquire/release`, so the day a PDX search reader takes the locks the other way round, the debug tracker flags it immediately. The rank's `#[allow(dead_code)]` is gone; its doc states where it is tracked.
- **`Neighbors` — a reservation, now stated as one.** No per-node neighbor lock exists in the code at all, so there is nothing to track; instrumenting it would be decoration. Its comment now says plainly that the rank pins the slot in the global order for future fine-grained locking (docs describe what the code enforces — AGENTS.md §6).

Part of the "câblage réel" plan (lot 5.4), scoped down by the adversarial pass.

## Type of Change

- [x] 🔧 Refactoring (debug-only instrumentation + tests; no release-build behavior change)

## How Has This Been Tested?

- [x] Unit tests

Two new tests in `locking_tests.rs`: the vectors→columnar order (mirroring the rebuild) reports both held and no violation; the inverted order increments the invariant-violation counter.

- `cargo test -p velesdb-core --lib --features persistence locking -- --test-threads=1` — 8 passed
- `cargo test -p velesdb-core --lib --features persistence reorder -- --test-threads=1` — 5 passed
- Search path touched (`index/hnsw/`) → recall gate: `test_recall` — **18 passed**
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `RUSTFLAGS=-Dwarnings cargo check -p velesdb-core --no-default-features` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches `index/hnsw/` (reorder path) — instrumentation only, debug builds only (`record_lock_acquire` is a no-op in release).

- [x] I listed the invariants impacted — none in release; in debug, the tracked order is exactly the one the code already follows.
- [x] I added/updated tests for concurrency where applicable — order + violation tests.