### PR TITLE
test(core): unbreak the no-default test build and extend nightly Miri to the manual-allocation core

### DIFF
--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -92,6 +92,15 @@ jobs:
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
 
+      # ContiguousVectors / AllocGuard - manual allocation, raw pointers, resize
+      - name: Miri - contiguous vectors & alloc guard
+        run: |
+          cargo miri test --no-default-features \
+            -p velesdb-core --lib -- \
+            perf_optimizations alloc_guard contiguous_resize --test-threads=1
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
+
   # ===========================================================================
   # Loom Concurrency Tests - Détecte deadlocks et data races
   # ===========================================================================

--- a/crates/velesdb-core/src/collection/stats/tests.rs
+++ b/crates/velesdb-core/src/collection/stats/tests.rs
@@ -798,8 +798,11 @@ fn graph_stats_roundtrips_through_serde() {
 
 // =========================================================================
 // Runtime filter selectivity — the stats-backed mirror of the AST estimator
+// (persistence-gated like the methods under test: `cargo miri test
+// --no-default-features` compiles this file too, and must keep compiling)
 // =========================================================================
 
+#[cfg(feature = "persistence")]
 fn stats_with_price_histogram() -> CollectionStats {
     let mut stats = CollectionStats::new();
     stats.total_points = 100;
@@ -812,6 +815,7 @@ fn stats_with_price_histogram() -> CollectionStats {
     stats
 }
 
+#[cfg(feature = "persistence")]
 #[test]
 fn runtime_eq_uses_the_histogram_when_present() {
     let stats = stats_with_price_histogram();
@@ -825,6 +829,7 @@ fn runtime_eq_uses_the_histogram_when_present() {
     assert!(sel < 0.05, "expected histogram-backed estimate, got {sel}");
 }
 
+#[cfg(feature = "persistence")]
 #[test]
 fn runtime_range_uses_the_histogram_when_present() {
     let stats = stats_with_price_histogram();
@@ -839,6 +844,7 @@ fn runtime_range_uses_the_histogram_when_present() {
     );
 }
 
+#[cfg(feature = "persistence")]
 #[test]
 fn runtime_unknown_column_falls_back_to_shared_defaults() {
     let stats = CollectionStats::new();
@@ -863,6 +869,7 @@ fn runtime_unknown_column_falls_back_to_shared_defaults() {
 /// Drift test (single-source constants): without histograms, the runtime
 /// estimator's equality answer must equal the AST estimator's fallback for
 /// the same column — both resolve through `CollectionStats::estimate_selectivity`.
+#[cfg(feature = "persistence")]
 #[test]
 fn runtime_and_ast_estimators_agree_without_histograms() {
     let mut stats = CollectionStats::new();
@@ -886,6 +893,7 @@ fn runtime_and_ast_estimators_agree_without_histograms() {
     );
 }
 
+#[cfg(feature = "persistence")]
 #[test]
 fn runtime_boolean_combinators_recurse() {
     let stats = CollectionStats::new();

--- a/crates/velesdb-core/tests/graph_bounded_reads.rs
+++ b/crates/velesdb-core/tests/graph_bounded_reads.rs
@@ -19,6 +19,8 @@
 //! edge buffer (`degree × size_of::<GraphEdge>()`). A meter that failed to
 //! see that much would fail the control rather than green-light the claim.
 
+#![cfg(feature = "persistence")]
+
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/velesdb-core/tests/label_index_log_noise.rs
+++ b/crates/velesdb-core/tests/label_index_log_noise.rs
@@ -23,6 +23,8 @@
 //! installed once — sequential phases inside one test keep every count
 //! attributable.
 
+#![cfg(feature = "persistence")]
+
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 


### PR DESCRIPTION
## Description

Two halves, ordered so the second is honest (lot 5.2 of the "câblage réel" plan):

1. **The nightly Miri job's build was broken by #2046.** The runtime-selectivity tests call persistence-gated methods (`estimate_runtime_filter_selectivity` & co.) but were not themselves gated, so `cargo check -p velesdb-core --no-default-features --tests` — the compile the nightly Miri steps perform — stopped compiling. The six tests (`stats_with_price_histogram` + the five `runtime_*` tests) are now behind `#[cfg(feature = "persistence")]`, and the two integration tests that always required persistence without saying so (`graph_bounded_reads.rs`, `label_index_log_noise.rs`) got the crate-level `#[cfg(feature = "persistence")]` they were missing.

2. **Miri now covers the densest manually-managed unsafe surface.** A new nightly step runs the `perf_optimizations` / `alloc_guard` / `contiguous_resize` filters (`--lib`, `-Zmiri-disable-isolation -Zmiri-symbolic-alignment-check`) — `ContiguousVectors`' manual allocation, raw-pointer resize paths, and the alloc-guard accounting. The step mirrors the exact local command, which passes today: **64 tests, zero Miri diagnostics**. mmap-backed storage stays out of Miri's reach (foreign syscalls), as before.

## Type of Change

- [x] 🔧 Refactoring (test gating + CI coverage; no shipped-code changes)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

- `MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-symbolic-alignment-check" cargo +nightly miri test --no-default-features -p velesdb-core --lib -- perf_optimizations alloc_guard contiguous_resize --test-threads=1` — **64 passed, 0 diagnostics** (the exact command the new CI step runs)
- `RUSTFLAGS="-Dwarnings" cargo check -p velesdb-core --no-default-features --tests` — compiles again (was broken)
- `cargo test -p velesdb-core --lib --features persistence stats -- --test-threads=1` — the gated tests still run and pass under persistence
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — 0 warnings (pedantic)
- `cargo fmt --check` — clean; workflow YAML parses

**Test Configuration:**
- OS: Linux (x86_64)
- Rust: 1.90 (repo pin) for stable checks; nightly + Miri for the UB pass

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

A second Miri pass over the HNSW graph internals (`--features persistence -- index::hnsw::native::graph::`) is running locally; if it comes back clean it lands as a follow-up commit on this PR with its own mirrored CI step.