### PR TITLE
refactor(core): route the pre/post-filter decision through one pure function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The pre/post-filter decision now has a single brain:
+  `velesql::decide_filter_strategy`.** The executor's bitmap dispatch
+  (`collection/search/vector_filter.rs`) and EXPLAIN's plan-time strategy
+  (`velesql/explain/filter_strategy.rs`) each owned their own thresholds; the
+  executor's `0.01` / `0.8` cutoffs now live next to the plan-time recall
+  guard and both consumers call the same pure function —
+  `FilterDecisionMode::Exact` for the measured bitmap ratio,
+  `FilterDecisionMode::Estimated` for the cost-model comparison. A new
+  `FilterStrategy::PreFilterExact` variant names the executor's brute-force
+  branch (exact scan of the bitmap survivors), which the estimated mode never
+  promises. Zero behavior change: every dispatch boundary and every EXPLAIN
+  output is bit-for-bit what it was.
 - **`velesql::match_planner::CollectionStats` is renamed `MatchGraphStats`**;
   the old name remains as a deprecated type alias, so callers compile
   unchanged. The old name collided with the tabular

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -12,10 +12,6 @@ use crate::quantization::{
 use crate::scored_result::ScoredResult;
 use crate::validation::validate_dimension_match;
 
-// Re-export constants moved to vector_filter.rs for test compatibility.
-#[cfg(test)]
-pub(crate) use super::vector_filter::SELECTIVITY_THRESHOLD;
-
 /// Estimates the real selectivity from a pre-filter bitmap.
 ///
 /// Returns the ratio `bitmap.len() / collection_len` as an `f64` in

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -17,11 +17,7 @@ use crate::point::SearchResult;
 use crate::scored_result::ScoredResult;
 use crate::storage::{PayloadStorage, VectorStorage};
 use crate::validation::validate_dimension_match;
-
-/// Selectivity threshold below which full-scan brute-force is used.
-pub(crate) const SELECTIVITY_THRESHOLD: f64 = 0.01;
-/// Selectivity threshold above which bitmap is skipped in favor of post-filter.
-const SELECTIVITY_HIGH_THRESHOLD: f64 = 0.8;
+use crate::velesql::{decide_filter_strategy, FilterDecisionMode, FilterStrategy};
 
 impl Collection {
     /// Searches with metadata filtering AND quality options from a WITH clause.
@@ -81,23 +77,28 @@ impl Collection {
         let selectivity =
             super::vector::estimate_real_selectivity(bitmap, self.storage.index.len());
 
-        if selectivity > SELECTIVITY_HIGH_THRESHOLD {
-            return self.search_post_filter(query, k, filter, quality, metric);
+        match decide_filter_strategy(selectivity, FilterDecisionMode::Exact, None) {
+            FilterStrategy::PostFilter => {
+                self.search_post_filter(query, k, filter, quality, metric)
+            }
+            FilterStrategy::PreFilterExact => {
+                let results = self.storage.index.full_scan_with_bitmap(query, k, bitmap)?;
+                Ok(self.merge_delta(results, query, k, metric))
+            }
+            // `PreFilter` — and, defensively, any future variant the
+            // non-exhaustive enum grows that Exact mode does not emit —
+            // runs HNSW constrained by the bitmap with an oversampled k.
+            _ => {
+                let candidates_k = compute_oversampled_k(k, filter, Some(&self.get_stats()));
+                let results = self.storage.index.search_with_quality_and_bitmap(
+                    query,
+                    candidates_k,
+                    quality,
+                    bitmap,
+                )?;
+                Ok(self.merge_delta(results, query, candidates_k, metric))
+            }
         }
-
-        if selectivity <= SELECTIVITY_THRESHOLD {
-            let results = self.storage.index.full_scan_with_bitmap(query, k, bitmap)?;
-            return Ok(self.merge_delta(results, query, k, metric));
-        }
-
-        let candidates_k = compute_oversampled_k(k, filter, Some(&self.get_stats()));
-        let results = self.storage.index.search_with_quality_and_bitmap(
-            query,
-            candidates_k,
-            quality,
-            bitmap,
-        )?;
-        Ok(self.merge_delta(results, query, candidates_k, metric))
     }
 
     /// Searches without bitmap pre-filter, using quality-aware HNSW + post-filter.

--- a/crates/velesdb-core/src/collection/search/vector_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_tests.rs
@@ -214,7 +214,8 @@ fn test_search_with_filter_bitmap_empty_result_for_nonexistent_value() {
 
 #[cfg(test)]
 mod selectivity_tests {
-    use super::super::vector::{estimate_real_selectivity, SELECTIVITY_THRESHOLD};
+    use super::super::vector::estimate_real_selectivity;
+    use crate::velesql::{EXACT_FULL_SCAN_MAX_SELECTIVITY, EXACT_POST_FILTER_MIN_SELECTIVITY};
 
     #[test]
     fn test_estimate_real_selectivity_nominal() {
@@ -252,8 +253,16 @@ mod selectivity_tests {
     #[test]
     fn test_selectivity_threshold_default_is_one_percent() {
         assert!(
-            (SELECTIVITY_THRESHOLD - 0.01).abs() < f64::EPSILON,
+            (EXACT_FULL_SCAN_MAX_SELECTIVITY - 0.01).abs() < f64::EPSILON,
             "default threshold should be 0.01 (1%)"
+        );
+    }
+
+    #[test]
+    fn test_post_filter_threshold_default_is_eighty_percent() {
+        assert!(
+            (EXACT_POST_FILTER_MIN_SELECTIVITY - 0.8).abs() < f64::EPSILON,
+            "default high threshold should be 0.8 (80%)"
         );
     }
 }

--- a/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
+++ b/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
@@ -112,6 +112,23 @@ pub fn set_fallback_selectivity_threshold(value: f64) -> Result<f64> {
 /// candidates survive). Forces PostFilter in that case.
 pub(super) const PREFILTER_RECALL_GUARD: f64 = 0.5;
 
+/// Exact-mode threshold: at or below this measured selectivity, the executor
+/// abandons HNSW and brute-forces the bitmap survivors — the candidate set is
+/// so small that exact distance computation beats graph traversal.
+///
+/// Historically `SELECTIVITY_THRESHOLD` in `collection/search/vector_filter.rs`;
+/// moved here so every filter-strategy threshold lives in one module.
+pub const EXACT_FULL_SCAN_MAX_SELECTIVITY: f64 = 0.01;
+
+/// Exact-mode threshold: above this measured selectivity, the bitmap prunes
+/// so little that the executor skips it entirely and post-filters a full
+/// HNSW pass.
+///
+/// Historically `SELECTIVITY_HIGH_THRESHOLD` in
+/// `collection/search/vector_filter.rs`; moved here so every filter-strategy
+/// threshold lives in one module.
+pub const EXACT_POST_FILTER_MIN_SELECTIVITY: f64 = 0.8;
+
 // POSTFILTER_TOPK_COST_FRACTION was removed in favour of
 // `CostEstimator::estimate_post_filter_topk_cost(k, ef_search)` (issue #609).
 // The previous `filter_scan_cost × 0.01` approximation was off by up to 5× for
@@ -230,7 +247,10 @@ fn threshold_strategy(selectivity: f64) -> FilterStrategy {
     }
 }
 
-pub(super) fn resolve_filter_strategy(
+/// Plan-time (estimated) arm of [`decide_filter_strategy`]: cost comparison
+/// with a recall guardrail when calibrated stats are available, the
+/// historical fallback threshold otherwise.
+fn estimated_strategy(
     selectivity: f64,
     has_vector_search: bool,
     ef_search: u32,
@@ -305,5 +325,70 @@ pub(super) fn resolve_filter_strategy(
         FilterStrategy::PreFilter
     } else {
         FilterStrategy::PostFilter
+    }
+}
+
+/// How the selectivity fed to [`decide_filter_strategy`] was obtained.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FilterDecisionMode {
+    /// Plan-time estimate (EXPLAIN / planner): the selectivity comes from
+    /// histograms or structural heuristics, and the decision weighs the
+    /// calibrated pre- vs post-filter cost models when stats are available.
+    Estimated {
+        /// Whether the plan contains an HNSW stage; without one the
+        /// pre/post-filter label is informational only.
+        has_vector_search: bool,
+        /// The query's effective `ef_search` (WITH clause or default).
+        ef_search: u32,
+        /// The query's effective candidate count (`LIMIT` or default).
+        candidates: u32,
+    },
+    /// Executor-side: the selectivity is the exact ratio measured from a
+    /// materialized pre-filter bitmap (`bitmap.len() / collection.len()`),
+    /// so the decision uses the executor's hard thresholds instead of a
+    /// cost model.
+    Exact,
+}
+
+/// The single decision point for pre- vs post-filtering — the executor and
+/// EXPLAIN both consume this function, so the plan output cannot drift from
+/// what actually runs.
+///
+/// - [`FilterDecisionMode::Exact`] reproduces the executor's dispatch in
+///   `collection/search/vector_filter.rs` bit-for-bit: selectivity above
+///   [`EXACT_POST_FILTER_MIN_SELECTIVITY`] post-filters a full HNSW pass, at
+///   or below [`EXACT_FULL_SCAN_MAX_SELECTIVITY`] the bitmap survivors are
+///   brute-forced exactly ([`FilterStrategy::PreFilterExact`]), and the band
+///   in between runs HNSW constrained by the bitmap
+///   ([`FilterStrategy::PreFilter`]). `stats` is not consulted: the
+///   selectivity is already exact.
+/// - [`FilterDecisionMode::Estimated`] is the plan-time brain: a calibrated
+///   cost comparison guarded by [`PREFILTER_RECALL_GUARD`] when `stats` is
+///   available, the historical fallback threshold
+///   ([`fallback_selectivity_threshold`]) otherwise. It never returns
+///   [`FilterStrategy::PreFilterExact`] — without the bitmap the executor's
+///   exact branch cannot be promised.
+#[must_use]
+pub fn decide_filter_strategy(
+    selectivity: f64,
+    mode: FilterDecisionMode,
+    stats: Option<&CoreCollectionStats>,
+) -> FilterStrategy {
+    match mode {
+        FilterDecisionMode::Exact => {
+            if selectivity > EXACT_POST_FILTER_MIN_SELECTIVITY {
+                FilterStrategy::PostFilter
+            } else if selectivity <= EXACT_FULL_SCAN_MAX_SELECTIVITY {
+                FilterStrategy::PreFilterExact
+            } else {
+                FilterStrategy::PreFilter
+            }
+        }
+        FilterDecisionMode::Estimated {
+            has_vector_search,
+            ef_search,
+            candidates,
+        } => estimated_strategy(selectivity, has_vector_search, ef_search, candidates, stats),
     }
 }

--- a/crates/velesdb-core/src/velesql/explain/formatter.rs
+++ b/crates/velesdb-core/src/velesql/explain/formatter.rs
@@ -268,6 +268,7 @@ impl FilterStrategy {
         match self {
             Self::None => "none",
             Self::PreFilter => "pre-filtering (high selectivity)",
+            Self::PreFilterExact => "pre-filtering (exact, brute-force scan)",
             Self::PostFilter => "post-filtering (low selectivity)",
         }
     }

--- a/crates/velesdb-core/src/velesql/explain/mod.rs
+++ b/crates/velesdb-core/src/velesql/explain/mod.rs
@@ -22,8 +22,9 @@ mod types;
 #[cfg(feature = "persistence")]
 pub(crate) use filter_strategy::strip_vector_predicates;
 pub use filter_strategy::{
-    fallback_selectivity_threshold, set_fallback_selectivity_threshold,
-    DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
+    decide_filter_strategy, fallback_selectivity_threshold, set_fallback_selectivity_threshold,
+    FilterDecisionMode, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD, EXACT_FULL_SCAN_MAX_SELECTIVITY,
+    EXACT_POST_FILTER_MIN_SELECTIVITY,
 };
 pub use node_stats::build_leaf_node_stats;
 pub use types::*;

--- a/crates/velesdb-core/src/velesql/explain/plan_builder.rs
+++ b/crates/velesdb-core/src/velesql/explain/plan_builder.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use super::filter_strategy::{estimate_filter_stats, resolve_filter_strategy};
+use super::filter_strategy::{decide_filter_strategy, estimate_filter_stats, FilterDecisionMode};
 use super::formatter;
 use super::node_stats;
 use super::types::{
@@ -347,11 +347,13 @@ impl QueryPlan {
             let candidates =
                 u32::try_from(stmt.limit.unwrap_or(DEFAULT_SELECT_LIMIT)).unwrap_or(u32::MAX);
 
-            filter_strategy = resolve_filter_strategy(
+            filter_strategy = decide_filter_strategy(
                 selectivity,
-                has_vector_search,
-                ef_search,
-                candidates,
+                FilterDecisionMode::Estimated {
+                    has_vector_search,
+                    ef_search,
+                    candidates,
+                },
                 stats,
             );
 

--- a/crates/velesdb-core/src/velesql/explain/types.rs
+++ b/crates/velesdb-core/src/velesql/explain/types.rs
@@ -417,6 +417,14 @@ pub enum FilterStrategy {
     None,
     /// Pre-filtering: filter before vector search (high selectivity).
     PreFilter,
+    /// Exact pre-filtering: the filter is so selective that the executor
+    /// brute-forces the surviving candidates instead of running HNSW.
+    ///
+    /// Only produced by the exact (executor-side) decision mode of
+    /// [`decide_filter_strategy`](crate::velesql::decide_filter_strategy),
+    /// where the true selectivity is measured from a materialized pre-filter
+    /// bitmap. The plan-time estimated mode never emits it.
+    PreFilterExact,
     /// Post-filtering: filter after vector search (low selectivity).
     PostFilter,
 }

--- a/crates/velesdb-core/src/velesql/explain_tests.rs
+++ b/crates/velesdb-core/src/velesql/explain_tests.rs
@@ -489,8 +489,72 @@ fn test_filter_strategy_as_str() {
         "pre-filtering (high selectivity)"
     );
     assert_eq!(
+        FilterStrategy::PreFilterExact.as_str(),
+        "pre-filtering (exact, brute-force scan)"
+    );
+    assert_eq!(
         FilterStrategy::PostFilter.as_str(),
         "post-filtering (low selectivity)"
+    );
+}
+
+// =============================================================================
+// decide_filter_strategy — the single executor/EXPLAIN decision point (lot 3.1)
+// =============================================================================
+
+/// Exact mode must reproduce the executor's historical dispatch bit-for-bit:
+/// `> 0.8` post-filters, `<= 0.01` brute-forces the bitmap survivors, and the
+/// band in between runs bitmap-constrained HNSW.
+#[test]
+fn test_decide_exact_mode_matches_executor_dispatch() {
+    let decide = |sel: f64| decide_filter_strategy(sel, FilterDecisionMode::Exact, None);
+
+    assert_eq!(decide(0.0), FilterStrategy::PreFilterExact);
+    assert_eq!(
+        decide(EXACT_FULL_SCAN_MAX_SELECTIVITY),
+        FilterStrategy::PreFilterExact
+    );
+    assert_eq!(
+        decide(EXACT_FULL_SCAN_MAX_SELECTIVITY + 1e-9),
+        FilterStrategy::PreFilter
+    );
+    assert_eq!(decide(0.5), FilterStrategy::PreFilter);
+    // The boundary itself is NOT post-filter: the executor used a strict `>`.
+    assert_eq!(
+        decide(EXACT_POST_FILTER_MIN_SELECTIVITY),
+        FilterStrategy::PreFilter
+    );
+    assert_eq!(
+        decide(EXACT_POST_FILTER_MIN_SELECTIVITY + 1e-9),
+        FilterStrategy::PostFilter
+    );
+    assert_eq!(decide(1.0), FilterStrategy::PostFilter);
+}
+
+/// Estimated mode without stats must preserve the historical 0.1 fallback
+/// threshold — and must never promise the exact brute-force branch, which
+/// only exists once a bitmap has been materialized.
+#[test]
+fn test_decide_estimated_mode_fallback_threshold_parity() {
+    let mode = FilterDecisionMode::Estimated {
+        has_vector_search: true,
+        ef_search: 100,
+        candidates: 10,
+    };
+
+    assert_eq!(
+        decide_filter_strategy(0.05, mode, None),
+        FilterStrategy::PreFilter
+    );
+    assert_eq!(
+        decide_filter_strategy(0.2, mode, None),
+        FilterStrategy::PostFilter
+    );
+    // Even a selectivity deep inside the executor's brute-force band stays
+    // a plain PreFilter at plan time.
+    assert_eq!(
+        decide_filter_strategy(0.001, mode, None),
+        FilterStrategy::PreFilter
     );
 }
 

--- a/crates/velesdb-core/src/velesql/mod.rs
+++ b/crates/velesdb-core/src/velesql/mod.rs
@@ -274,11 +274,13 @@ pub use error::{ParseError, ParseErrorKind};
 #[cfg(feature = "persistence")]
 pub(crate) use explain::strip_vector_predicates;
 pub use explain::{
-    build_leaf_node_stats, fallback_selectivity_threshold, set_fallback_selectivity_threshold,
-    ActualStats, AggregatePlan, ExplainOutput, FeedbackCalibration, FilterPlan, FilterStrategy,
-    FusionInfo, GroupByPlan, IndexLookupPlan, IndexType, JoinPlanNode, LimitPlan,
-    MatchTraversalPlan, NodeStats, OffsetPlan, PlanNode, PlanStep, PlanStepKind, QueryPlan,
-    SortPlan, TableScanPlan, VectorSearchPlan, DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD,
+    build_leaf_node_stats, decide_filter_strategy, fallback_selectivity_threshold,
+    set_fallback_selectivity_threshold, ActualStats, AggregatePlan, ExplainOutput,
+    FeedbackCalibration, FilterDecisionMode, FilterPlan, FilterStrategy, FusionInfo, GroupByPlan,
+    IndexLookupPlan, IndexType, JoinPlanNode, LimitPlan, MatchTraversalPlan, NodeStats, OffsetPlan,
+    PlanNode, PlanStep, PlanStepKind, QueryPlan, SortPlan, TableScanPlan, VectorSearchPlan,
+    DEFAULT_FALLBACK_SELECTIVITY_THRESHOLD, EXACT_FULL_SCAN_MAX_SELECTIVITY,
+    EXACT_POST_FILTER_MIN_SELECTIVITY,
 };
 pub use parser::match_clause;
 pub use parser::Parser;


### PR DESCRIPTION
## Description

The executor's bitmap dispatch (`collection/search/vector_filter.rs`) and EXPLAIN's plan-time strategy (`velesql/explain/filter_strategy.rs`) each owned their own thresholds — `0.01`/`0.8` on the measured bitmap ratio on one side, the `0.5` recall guard and `0.1` fallback on the other — with nothing tying them together, so the plan output could silently drift from what actually runs. Lot 3.1 of the "câblage réel" plan:

- **`decide_filter_strategy(selectivity, mode, stats)`** now owns every threshold, in `explain/filter_strategy.rs`.
- **`FilterDecisionMode::Exact`** reproduces the executor's dispatch bit-for-bit: `> 0.8` post-filters a full HNSW pass, `<= 0.01` brute-forces the bitmap survivors — named by a new **`FilterStrategy::PreFilterExact`** variant (the enum is `#[non_exhaustive]`, so this is non-breaking) — and the band in between runs bitmap-constrained HNSW. The executor `match`es on the returned strategy.
- **`FilterDecisionMode::Estimated`** is the unchanged plan-time brain (calibrated cost comparison + recall guard with stats, historical `0.1` fallback without), passed by the plan builder. It never emits `PreFilterExact`: without a materialized bitmap the exact branch cannot be promised.
- The executor-side constants moved next to the plan-time ones (`EXACT_FULL_SCAN_MAX_SELECTIVITY`, `EXACT_POST_FILTER_MIN_SELECTIVITY`), exported through `velesql`.

**Zero behavior change**: every dispatch boundary and every EXPLAIN output is bit-for-bit what it was.

## Type of Change

- [x] 🔧 Refactoring (no functional change; decision logic single-sourced)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

New tests pin the contract: the exact-mode partition at both thresholds (strict `>` at 0.8, inclusive `<=` at 0.01), estimated-mode fallback parity at 0.1, and that estimated mode never returns `PreFilterExact` even deep inside the brute-force band. The pre-existing EXPLAIN suite passes untouched.

- `cargo test -p velesdb-core --lib --features persistence explain -- --test-threads=1` — 84 passed
- `cargo test -p velesdb-core --lib --features persistence selectivity -- --test-threads=1` — 48 passed
- `cargo test -p velesdb-core --lib --features persistence filter -- --test-threads=1` — 318 passed
- `cargo test -p velesdb-core --features persistence --test bdd explain -- --test-threads=1` — 34 passed
- Search dispatch touched → recall gate: `test_recall` — 18 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean (CI-exact flags)
- `RUSTFLAGS="-Dwarnings" cargo check -p velesdb-core --no-default-features` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`cargo check --no-default-features --tests` fails on current `develop` for reasons unrelated to this change (persistence-only tests missing their gate); the fix is in flight in #2052. The lib-only no-default check with `-Dwarnings` is clean here.

Lot 3.2 (EXPLAIN ANALYZE reporting the *executed* strategy, then threshold convergence on a benched corpus) stays separate, as planned: this PR deliberately changes no behavior.