### PR TITLE
feat(core): EXPLAIN ANALYZE reports the filter strategy the executor ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **EXPLAIN ANALYZE now reports the filter strategy the executor actually
+  ran** (`actual_stats.executed_filter_strategy`), recorded at the dispatch
+  site itself — not re-derived — through a probe shared between the query
+  context and the search options (an atomic slot, so the vector leg of the
+  CBO `Parallel` strategy, which runs on a rayon worker, records correctly).
+  Present for single SELECTs that went through the filtered vector-search
+  dispatch (including the new `PreFilterExact` brute-force branch); omitted
+  for MATCH, compound queries, and arms where pre/post-filter does not
+  apply. Unlike the plan's `filter_strategy` (an estimate), this is ground
+  truth: comparing the two surfaces plan/execution divergence — e.g. the
+  no-override path runs the bitmap even at 90 % selectivity where the
+  override path post-filters. Serde-defaulted: stats persisted by older
+  versions load unchanged.
+
 - **Deterministic cost-crossover harness** (`tests/cost_crossover.rs`, nightly
   `cost-crossover` CI job): measures the *work* (single-pair distance
   evaluations, via a new `internal-bench`-gated counter) and the exact recall

--- a/crates/velesdb-core/src/api_types/responses_explain.rs
+++ b/crates/velesdb-core/src/api_types/responses_explain.rs
@@ -79,6 +79,13 @@ pub struct ActualStatsResponse {
     /// approximations (a lower bound), not exact measured counts. Always `false`
     /// for non-graph queries, where both counters are 0.
     pub traversal_counters_approximate: bool,
+    /// Filter strategy the executor actually ran, recorded at the dispatch
+    /// site (see `FilterStrategy::as_str`). Present for single SELECTs that
+    /// went through the filtered vector-search dispatch; absent for MATCH,
+    /// compound queries, and arms where pre/post-filter does not apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(nullable))]
+    pub executed_filter_strategy: Option<String>,
 }
 
 #[cfg(feature = "persistence")]
@@ -93,6 +100,7 @@ impl From<&crate::velesql::ActualStats> for ActualStatsResponse {
             // Graph traversal counters are only present (and only approximate)
             // when a MATCH query actually walked the graph (backlog #26).
             traversal_counters_approximate: s.nodes_visited > 0 || s.edges_traversed > 0,
+            executed_filter_strategy: s.executed_filter_strategy.map(|f| f.as_str().to_string()),
         }
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -197,12 +197,47 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
         client_id: &str,
     ) -> Result<Vec<SearchResult>> {
+        self.execute_query_traced(query, params, client_id)
+            .map(|(results, _)| results)
+    }
+
+    /// Executes a single (non-compound) query, storing the executor's ran
+    /// filter strategy into the caller's slot. Used by the Database-level
+    /// EXPLAIN ANALYZE counted path, whose probe travels through the JOIN
+    /// resolution machinery down to this base-collection call.
+    pub(crate) fn execute_query_probed(
+        &self,
+        query: &crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        slot: &std::sync::Arc<std::sync::atomic::AtomicU8>,
+    ) -> Result<Vec<SearchResult>> {
+        let (results, strategy) = self.execute_query_traced(query, params, "default")?;
+        if let Some(strategy) = strategy {
+            slot.store(
+                crate::guardrails::encode_filter_strategy(strategy),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+        Ok(results)
+    }
+
+    /// Like [`execute_query_with_client`](Self::execute_query_with_client),
+    /// additionally returning the filter strategy the executor actually ran
+    /// (recorded through the query context's probe — `None` when the query
+    /// did not go through the filtered vector-search dispatch, e.g. MATCH).
+    /// Consumed by EXPLAIN ANALYZE at both the Collection and Database level.
+    pub(crate) fn execute_query_traced(
+        &self,
+        query: &crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        client_id: &str,
+    ) -> Result<(Vec<SearchResult>, Option<crate::velesql::FilterStrategy>)> {
         // Phase 1: Pre-checks and context setup.
         let ctx = self.prepare_query_context(query, client_id)?;
 
         // MATCH queries take a completely separate path (no extraction needed).
         if let Some(results) = self.try_dispatch_match(query, params, &ctx)? {
-            return Ok(results);
+            return Ok((results, None));
         }
 
         // Resolve scalar WHERE parameters once so every downstream conversion
@@ -212,7 +247,8 @@ impl Collection {
         let query = resolved_query.as_ref().unwrap_or(query);
 
         // Phase 2-3: SELECT extraction, early-return, dispatch, and finalization.
-        self.execute_select_pipeline(query, params, &ctx)
+        let results = self.execute_select_pipeline(query, params, &ctx)?;
+        Ok((results, ctx.executed_filter_strategy()))
     }
 
     /// Runs the full SELECT pipeline: extraction, early-return check, dispatch,

--- a/crates/velesdb-core/src/collection/search/query/options.rs
+++ b/crates/velesdb-core/src/collection/search/query/options.rs
@@ -20,6 +20,13 @@ pub(crate) struct QuerySearchOptions {
     pub force_rerank: Option<bool>,
     /// Fusion clause from `USING FUSION (...)`.
     pub fusion_clause: Option<crate::velesql::FusionClause>,
+    /// EXPLAIN ANALYZE out-channel: the executor records which filter
+    /// strategy it actually ran into this slot (shared with the query's
+    /// [`QueryContext`](crate::guardrails::QueryContext)). `None` outside
+    /// the pipeline (raw search entry points) — recording is then a no-op.
+    /// An `Arc` atomic, not a thread-local: the vector leg of the CBO
+    /// `Parallel` strategy runs on a rayon worker thread.
+    pub executed_strategy_probe: Option<std::sync::Arc<std::sync::atomic::AtomicU8>>,
 }
 
 impl QuerySearchOptions {
@@ -44,6 +51,30 @@ impl QuerySearchOptions {
             ef_search,
             force_rerank,
             fusion_clause: None,
+            executed_strategy_probe: None,
+        }
+    }
+
+    /// Attaches the query context's executed-strategy slot, so the filtered
+    /// vector-search dispatch can report which shape it ran to EXPLAIN
+    /// ANALYZE.
+    #[must_use]
+    pub(crate) fn with_executed_strategy_probe(
+        mut self,
+        ctx: &crate::guardrails::QueryContext,
+    ) -> Self {
+        self.executed_strategy_probe = Some(ctx.executed_strategy_slot());
+        self
+    }
+
+    /// Records the filter strategy the executor is about to run. No-op when
+    /// no probe is attached (raw search entry points).
+    pub(crate) fn record_executed_strategy(&self, strategy: crate::velesql::FilterStrategy) {
+        if let Some(probe) = &self.executed_strategy_probe {
+            probe.store(
+                crate::guardrails::encode_filter_strategy(strategy),
+                std::sync::atomic::Ordering::Relaxed,
+            );
         }
     }
 

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -50,7 +50,12 @@ impl Collection {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<(Vec<SearchResult>, u64, u64)> {
+    ) -> Result<(
+        Vec<SearchResult>,
+        u64,
+        u64,
+        Option<crate::velesql::FilterStrategy>,
+    )> {
         // Only a standalone MATCH query carries traversal counters. Run it
         // through the same context + dispatch as execute_query, then read the
         // counters the executor recorded into the query context. is_match_query
@@ -64,9 +69,17 @@ impl Collection {
                 results,
                 ctx.traversal_nodes_visited(),
                 ctx.traversal_edges_traversed(),
+                None,
             ));
         }
-        Ok((self.execute_query(query, params)?, 0, 0))
+        // Single SELECT: the traced core also reports which filter strategy
+        // the executor ran. Compound queries execute several selects — a
+        // single reported strategy would be ambiguous, so they report none.
+        if query.compound.is_none() {
+            let (results, strategy) = self.execute_query_traced(query, params, "default")?;
+            return Ok((results, 0, 0, strategy));
+        }
+        Ok((self.execute_query(query, params)?, 0, 0, None))
     }
 
     /// Computes the effective `(limit, fetch_limit)` from a SELECT statement.
@@ -389,8 +402,10 @@ impl Collection {
         let plan = QueryPlan::from_query_with_all_stats(query, &indexed, None, Some(&match_stats));
 
         let start = std::time::Instant::now();
-        let (results, nodes, edges) = self.execute_query_counted(query, params)?;
-        let stats = ActualStats::from_counted(results.len() as u64, start.elapsed(), nodes, edges);
+        let (results, nodes, edges, executed_strategy) =
+            self.execute_query_counted(query, params)?;
+        let stats = ActualStats::from_counted(results.len() as u64, start.elapsed(), nodes, edges)
+            .with_executed_filter_strategy(executed_strategy);
         let node_stats = build_leaf_node_stats(&plan.root, stats.actual_rows, stats.actual_time_ms);
         let mut output = ExplainOutput::with_stats(plan, stats, node_stats);
 

--- a/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
+++ b/crates/velesdb-core/src/collection/search/query/select_dispatch.rs
@@ -198,7 +198,7 @@ impl Collection {
         params: &std::collections::HashMap<String, serde_json::Value>,
         extracted: &ExtractedComponents,
         limit: usize,
-        _ctx: &crate::guardrails::QueryContext,
+        ctx: &crate::guardrails::QueryContext,
     ) -> Result<Vec<SearchResult>> {
         let has_graph_predicates = !extracted.graph_match_predicates.is_empty();
         let skip_metadata_prefilter_for_graph_or = has_graph_predicates
@@ -208,7 +208,8 @@ impl Collection {
                 .is_some_and(Self::condition_contains_or);
         let execution_limit = main_select_execution_limit(stmt, extracted, limit);
         let search_opts = super::QuerySearchOptions::from_with_clause(stmt.with_clause.as_ref())
-            .with_fusion(stmt.fusion_clause.clone());
+            .with_fusion(stmt.fusion_clause.clone())
+            .with_executed_strategy_probe(ctx);
         let (cbo_strategy, cbo_over_fetch) =
             self.compute_cbo_strategy(stmt, extracted.filter_condition.as_ref(), limit);
 

--- a/crates/velesdb-core/src/collection/search/query/with_options_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/with_options_tests.rs
@@ -530,6 +530,7 @@ fn test_search_with_filter_and_opts_applies_quality() {
         ef_search: None,
         force_rerank: None,
         fusion_clause: None,
+        executed_strategy_probe: None,
     };
     // This method must exist and apply quality-aware search + filter.
     let results = col

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -526,6 +526,29 @@ impl Collection {
         k: usize,
         filter: &crate::filter::Filter,
     ) -> Result<Vec<SearchResult>> {
+        self.search_with_filter_impl(query, k, filter, None)
+    }
+
+    /// Like [`search_with_filter`](Self::search_with_filter), recording the
+    /// executed filter strategy into the options' EXPLAIN ANALYZE probe.
+    /// Taken by the quality-aware dispatch when no quality override applies.
+    pub(crate) fn search_with_filter_recorded(
+        &self,
+        query: &[f32],
+        k: usize,
+        filter: &crate::filter::Filter,
+        opts: &crate::collection::search::query::QuerySearchOptions,
+    ) -> Result<Vec<SearchResult>> {
+        self.search_with_filter_impl(query, k, filter, Some(opts))
+    }
+
+    fn search_with_filter_impl(
+        &self,
+        query: &[f32],
+        k: usize,
+        filter: &crate::filter::Filter,
+        opts: Option<&crate::collection::search::query::QuerySearchOptions>,
+    ) -> Result<Vec<SearchResult>> {
         let metric = self.validate_query_and_read_metric(query)?;
         let higher_is_better = metric.higher_is_better();
 
@@ -536,7 +559,7 @@ impl Collection {
 
         // Attempt bitmap pre-filter from secondary indexes.
         let index_results =
-            self.search_with_optional_bitmap(query, k, candidates_k, filter, metric);
+            self.search_with_optional_bitmap(query, k, candidates_k, filter, metric, opts);
 
         Ok(self.filter_and_hydrate(index_results, filter, k, higher_is_better))
     }
@@ -549,8 +572,12 @@ impl Collection {
         candidates_k: usize,
         filter: &crate::filter::Filter,
         metric: DistanceMetric,
+        opts: Option<&crate::collection::search::query::QuerySearchOptions>,
     ) -> Vec<ScoredResult> {
         if let Some(bitmap) = self.build_prefilter_bitmap(filter) {
+            if let Some(opts) = opts {
+                opts.record_executed_strategy(crate::velesql::FilterStrategy::PreFilter);
+            }
             let ef_search = candidates_k.max(k * 10);
             let results = self.storage.index.search_hnsw_only_filtered(
                 query,
@@ -559,6 +586,9 @@ impl Collection {
                 &bitmap,
             );
             return self.merge_delta(results, query, candidates_k, metric);
+        }
+        if let Some(opts) = opts {
+            opts.record_executed_strategy(crate::velesql::FilterStrategy::PostFilter);
         }
         self.search_ids_with_adc_if_pq(query, candidates_k)
     }

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -33,7 +33,7 @@ impl Collection {
         opts: &crate::collection::search::query::QuerySearchOptions,
     ) -> Result<Vec<SearchResult>> {
         if !opts.has_quality_overrides() {
-            return self.search_with_filter(query, k, filter);
+            return self.search_with_filter_recorded(query, k, filter, opts);
         }
 
         let config = self.storage.config.read();
@@ -50,11 +50,18 @@ impl Collection {
         self.enforce_perfect_mode_limit(quality)?;
 
         let index_results = match self.build_prefilter_bitmap(filter) {
-            Some(bitmap) if bitmap.is_empty() => return Ok(Vec::new()),
-            Some(bitmap) => {
-                self.search_with_bitmap_strategy(query, k, filter, quality, metric, &bitmap)?
+            Some(bitmap) if bitmap.is_empty() => {
+                // The bitmap answers the query exactly: nothing matches.
+                opts.record_executed_strategy(FilterStrategy::PreFilterExact);
+                return Ok(Vec::new());
             }
-            None => self.search_post_filter(query, k, filter, quality, metric)?,
+            Some(bitmap) => {
+                self.search_with_bitmap_strategy(query, k, filter, quality, metric, &bitmap, opts)?
+            }
+            None => {
+                opts.record_executed_strategy(FilterStrategy::PostFilter);
+                self.search_post_filter(query, k, filter, quality, metric)?
+            }
         };
 
         // The full re-match inside `filter_and_hydrate` is deliberate even on
@@ -65,6 +72,7 @@ impl Collection {
     }
 
     /// Dispatches to full-scan, HNSW+bitmap, or post-filter based on selectivity.
+    #[allow(clippy::too_many_arguments)] // Reason: dispatch bundle mirrors the query's full shape.
     fn search_with_bitmap_strategy(
         &self,
         query: &[f32],
@@ -73,11 +81,14 @@ impl Collection {
         quality: crate::SearchQuality,
         metric: crate::DistanceMetric,
         bitmap: &roaring::RoaringBitmap,
+        opts: &crate::collection::search::query::QuerySearchOptions,
     ) -> Result<Vec<ScoredResult>> {
         let selectivity =
             super::vector::estimate_real_selectivity(bitmap, self.storage.index.len());
 
-        match decide_filter_strategy(selectivity, FilterDecisionMode::Exact, None) {
+        let strategy = decide_filter_strategy(selectivity, FilterDecisionMode::Exact, None);
+        opts.record_executed_strategy(strategy);
+        match strategy {
             FilterStrategy::PostFilter => {
                 self.search_post_filter(query, k, filter, quality, metric)
             }

--- a/crates/velesdb-core/src/collection/search/vector_tests.rs
+++ b/crates/velesdb-core/src/collection/search/vector_tests.rs
@@ -318,6 +318,7 @@ fn test_search_with_filter_and_opts_bitmap_empty_returns_empty() {
         ef_search: None,
         force_rerank: None,
         fusion_clause: None,
+        executed_strategy_probe: None,
     };
     let results = col
         .search_with_filter_and_opts(&[0.5, 0.5, 0.5, 0.5], 10, &filter, &opts)
@@ -344,6 +345,7 @@ fn test_search_with_filter_and_opts_no_bitmap_falls_back_to_post_filter() {
         ef_search: None,
         force_rerank: None,
         fusion_clause: None,
+        executed_strategy_probe: None,
     };
     let results = col
         .search_with_filter_and_opts(&[0.5, 0.5, 0.5, 0.5], 5, &filter, &opts)
@@ -393,6 +395,7 @@ fn test_filtered_perfect_search_over_cap_is_rejected() {
         ef_search: None,
         force_rerank: None,
         fusion_clause: None,
+        executed_strategy_probe: None,
     };
 
     let err = col

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -19,6 +19,11 @@ use crate::observer::DatabaseObserver;
 use crate::simd_dispatch;
 use crate::{ColumnStore, Error, Result};
 
+/// Shared out-slot for the executed filter strategy, threaded from the
+/// EXPLAIN ANALYZE counted path down to the base collection's query pipeline.
+/// Encoding is `guardrails`' (0 = unset).
+pub(crate) type StrategyProbeSlot = std::sync::Arc<std::sync::atomic::AtomicU8>;
+
 mod admin_executor;
 mod collection_ops;
 mod cross_collection;

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -326,8 +326,10 @@ impl Database {
 
         let plan = self.explain_query(query)?;
         let start = std::time::Instant::now();
-        let (results, nodes, edges) = self.execute_query_counted(query, params)?;
-        let stats = ActualStats::from_counted(results.len() as u64, start.elapsed(), nodes, edges);
+        let (results, nodes, edges, executed_strategy) =
+            self.execute_query_counted(query, params)?;
+        let stats = ActualStats::from_counted(results.len() as u64, start.elapsed(), nodes, edges)
+            .with_executed_filter_strategy(executed_strategy);
         let node_stats = crate::velesql::build_leaf_node_stats(
             &plan.root,
             stats.actual_rows,
@@ -371,7 +373,7 @@ impl Database {
         // (via deref coercion on `&gated`) keeps the timing in one place rather
         // than duplicated across the borrowed / owned arms.
         let gated = self.read_gate(query)?;
-        self.execute_query_timed(&gated, params)
+        self.execute_query_timed(&gated, params, None)
     }
 
     /// Executes the resolved (post-gate) query and fires the `on_query`
@@ -392,12 +394,13 @@ impl Database {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
+        probe: Option<&crate::database::StrategyProbeSlot>,
     ) -> Result<Vec<SearchResult>> {
         let Some(observer) = self.observer.as_ref() else {
-            return self.execute_query_inner(query, params); // zero-overhead fast path
+            return self.execute_query_inner(query, params, probe); // zero-overhead fast path
         };
         let started = std::time::Instant::now();
-        let results = self.execute_query_inner(query, params)?;
+        let results = self.execute_query_inner(query, params, probe)?;
         let duration_us = u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX);
         observer.on_query(query.select.from.as_str(), duration_us);
         Ok(results)
@@ -529,6 +532,7 @@ impl Database {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
+        probe: Option<&crate::database::StrategyProbeSlot>,
     ) -> Result<Vec<SearchResult>> {
         if let Some(results) = self.dispatch_non_select(query, params)? {
             return Ok(results);
@@ -543,7 +547,7 @@ impl Database {
         let pre_exec_key = self.build_plan_key(query);
         let is_cached = self.compiled_plan_cache.contains(&pre_exec_key);
 
-        let results = self.execute_select_query(query, params)?;
+        let results = self.execute_select_query(query, params, probe)?;
 
         // Populate cache on miss (CACHE-02).
         //
@@ -616,7 +620,7 @@ impl Database {
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<(Vec<SearchResult>, u64, u64)> {
         let coll = self.resolve_match_collection(query, params)?;
-        let (mut results, nodes_visited, edges_traversed) =
+        let (mut results, nodes_visited, edges_traversed, _strategy) =
             coll.execute_query_counted(query, params)?;
         // Cross-collection enrichment: if any node pattern has a @collection
         // annotation, look up payloads from those collections and merge them
@@ -635,16 +639,36 @@ impl Database {
         &self,
         query: &Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<(Vec<SearchResult>, u64, u64)> {
+    ) -> Result<(
+        Vec<SearchResult>,
+        u64,
+        u64,
+        Option<crate::velesql::FilterStrategy>,
+    )> {
         if query.is_match_query() {
             // Apply the read-path gate before the MATCH executor. The non-EXPLAIN
             // MATCH path is gated inside `execute_query`; this counted path (used
             // by EXPLAIN ANALYZE) routes straight to `execute_match_routed`, so
             // without this it would let EXPLAIN ANALYZE MATCH bypass governance.
             let gated = self.read_gate(query)?;
-            return self.execute_match_routed(&gated, params);
+            let (results, nodes, edges) = self.execute_match_routed(&gated, params)?;
+            return Ok((results, nodes, edges, None));
         }
-        Ok((self.execute_query(query, params)?, 0, 0))
+        // Same pre-steps as execute_query (subquery resolution, validation,
+        // read gate, telemetry) with a probe threaded to the base-collection
+        // call so EXPLAIN ANALYZE reports the strategy the executor ran.
+        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
+            return self.execute_query_counted(&rewritten, params);
+        }
+        crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
+        let gated = self.read_gate(query)?;
+        let slot: crate::database::StrategyProbeSlot =
+            std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
+        let results = self.execute_query_timed(&gated, params, Some(&slot))?;
+        let strategy = crate::guardrails::decode_filter_strategy(
+            slot.load(std::sync::atomic::Ordering::Relaxed),
+        );
+        Ok((results, 0, 0, strategy))
     }
 
     /// Executes the SELECT portion of a query, resolving JOINs if present.
@@ -652,6 +676,7 @@ impl Database {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
+        probe: Option<&crate::database::StrategyProbeSlot>,
     ) -> Result<Vec<SearchResult>> {
         // EPIC-040 US-006: For compound queries, strip LIMIT from each operand so
         // the set operation sees the full result sets.  The final LIMIT is applied
@@ -660,11 +685,13 @@ impl Database {
         const COMPOUND_LIMIT: usize = 100_000;
         let compound_limit = Some(COMPOUND_LIMIT as u64); // 100_000 fits u64 exactly.
         let left_results = if query.compound.is_some() {
+            // Compound queries execute several selects; a single reported
+            // strategy would be ambiguous, so the probe stays untouched.
             let mut left_query = query.clone();
             left_query.select.limit = compound_limit;
-            self.execute_single_select(&left_query, params)?
+            self.execute_single_select(&left_query, params, None)?
         } else {
-            return self.execute_single_select(query, params);
+            return self.execute_single_select(query, params, probe);
         };
 
         // compound is guaranteed Some here (non-compound returns above).
@@ -673,7 +700,7 @@ impl Database {
             for (operator, right_select) in &compound.operations {
                 let mut right_query = crate::velesql::Query::new_select(right_select.clone());
                 right_query.select.limit = compound_limit;
-                let right_results = self.execute_single_select(&right_query, params)?;
+                let right_results = self.execute_single_select(&right_query, params, None)?;
                 accumulated = crate::collection::search::query::set_operations::apply_set_operation(
                     accumulated,
                     right_results,
@@ -764,6 +791,7 @@ impl Database {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
+        probe: Option<&crate::database::StrategyProbeSlot>,
     ) -> Result<Vec<SearchResult>> {
         let base_collection = self.resolve_collection(&query.select.from)?;
 
@@ -771,7 +799,10 @@ impl Database {
         single_query.compound = None;
 
         if single_query.select.joins.is_empty() {
-            return base_collection.execute_query(&single_query, params);
+            return match probe {
+                Some(slot) => base_collection.execute_query_probed(&single_query, params, slot),
+                None => base_collection.execute_query(&single_query, params),
+            };
         }
 
         let analysis = Self::prepare_join_pushdown(&mut single_query, params)?;
@@ -779,7 +810,10 @@ impl Database {
 
         let row_budget = Self::join_row_budget(&query.select, &analysis);
 
-        let mut results = base_collection.execute_query(&single_query, params)?;
+        let mut results = match probe {
+            Some(slot) => base_collection.execute_query_probed(&single_query, params, slot)?,
+            None => base_collection.execute_query(&single_query, params)?,
+        };
         for join in &query.select.joins {
             results = self.execute_single_join(&results, join, &pushed, row_budget)?;
         }

--- a/crates/velesdb-core/src/guardrails/context.rs
+++ b/crates/velesdb-core/src/guardrails/context.rs
@@ -8,7 +8,8 @@
 // - Used for timeout checking and logging, not precise calculations
 #![allow(clippy::cast_possible_truncation)]
 
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use super::limits::{GuardRailViolation, QueryLimits};
@@ -30,6 +31,41 @@ pub struct QueryContext {
     traversal_nodes_visited: AtomicU64,
     /// Graph edges traversed during MATCH traversal (for EXPLAIN ANALYZE).
     traversal_edges_traversed: AtomicU64,
+    /// Filter strategy the executor actually ran (for EXPLAIN ANALYZE).
+    ///
+    /// `Arc` so the query pipeline can hand the slot to the search options,
+    /// which flow through every dispatch path — including the vector leg of
+    /// the CBO `Parallel` strategy, which runs on a rayon worker thread
+    /// (a thread-local channel would silently lose that leg's record).
+    /// Encoding: 0 = unset, then `FilterStrategy` per
+    /// [`encode_filter_strategy`].
+    executed_filter_strategy: Arc<AtomicU8>,
+}
+
+/// Encodes a [`FilterStrategy`](crate::velesql::FilterStrategy) into the
+/// atomic slot representation (0 is reserved for "unset").
+pub(crate) fn encode_filter_strategy(strategy: crate::velesql::FilterStrategy) -> u8 {
+    use crate::velesql::FilterStrategy as F;
+    match strategy {
+        // `None` maps to the "unset" encoding: recording it is a no-op read
+        // back as absent. A future variant added to the (non-exhaustive)
+        // enum fails compilation here, forcing an explicit encoding choice.
+        F::None => 0,
+        F::PreFilter => 1,
+        F::PreFilterExact => 2,
+        F::PostFilter => 3,
+    }
+}
+
+/// Decodes the atomic slot representation back into a strategy.
+pub(crate) fn decode_filter_strategy(raw: u8) -> Option<crate::velesql::FilterStrategy> {
+    use crate::velesql::FilterStrategy as F;
+    match raw {
+        1 => Some(F::PreFilter),
+        2 => Some(F::PreFilterExact),
+        3 => Some(F::PostFilter),
+        _ => None,
+    }
 }
 
 impl QueryContext {
@@ -44,7 +80,23 @@ impl QueryContext {
             memory_used: AtomicUsize::new(0),
             traversal_nodes_visited: AtomicU64::new(0),
             traversal_edges_traversed: AtomicU64::new(0),
+            executed_filter_strategy: Arc::new(AtomicU8::new(0)),
         }
+    }
+
+    /// Returns the shared slot the executor records the ran filter strategy
+    /// into. Handed to the search options at pipeline entry; read back by
+    /// EXPLAIN ANALYZE via [`executed_filter_strategy`](Self::executed_filter_strategy).
+    #[must_use]
+    pub(crate) fn executed_strategy_slot(&self) -> Arc<AtomicU8> {
+        Arc::clone(&self.executed_filter_strategy)
+    }
+
+    /// Returns the filter strategy the executor recorded for this query, if
+    /// the query went through the filtered vector-search dispatch.
+    #[must_use]
+    pub(crate) fn executed_filter_strategy(&self) -> Option<crate::velesql::FilterStrategy> {
+        decode_filter_strategy(self.executed_filter_strategy.load(Ordering::Relaxed))
     }
 
     /// Checks if the query has timed out (US-001).

--- a/crates/velesdb-core/src/guardrails/mod.rs
+++ b/crates/velesdb-core/src/guardrails/mod.rs
@@ -9,6 +9,7 @@
 //! - **Circuit Breaker**: Auto-disable on repeated failures (US-006)
 
 mod context;
+pub(crate) use context::{decode_filter_strategy, encode_filter_strategy};
 mod limits;
 mod resilience;
 #[cfg(test)]

--- a/crates/velesdb-core/src/velesql/explain/types.rs
+++ b/crates/velesdb-core/src/velesql/explain/types.rs
@@ -337,6 +337,14 @@ pub struct ActualStats {
     /// VectorFirst per-candidate BFS edges, undercounted by the `limit(1)`
     /// frontier; Parallel sums both legs). 0 for non-graph queries.
     pub edges_traversed: u64,
+    /// Filter strategy the executor actually ran, recorded at the dispatch
+    /// site itself — so this cannot drift from execution the way a re-derived
+    /// estimate could. Present for single SELECTs that went through the
+    /// filtered vector-search dispatch (under the CBO `Parallel` strategy it
+    /// describes the vector leg); `None` for MATCH, compound queries, and
+    /// arms where the pre/post-filter notion does not apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub executed_filter_strategy: Option<FilterStrategy>,
 }
 
 impl ActualStats {
@@ -356,7 +364,15 @@ impl ActualStats {
             loops: 1,
             nodes_visited,
             edges_traversed,
+            executed_filter_strategy: None,
         }
+    }
+
+    /// Attaches the filter strategy the executor recorded for this query.
+    #[must_use]
+    pub fn with_executed_filter_strategy(mut self, strategy: Option<FilterStrategy>) -> Self {
+        self.executed_filter_strategy = strategy;
+        self
     }
 }
 

--- a/crates/velesdb-core/tests/explain_executed_strategy.rs
+++ b/crates/velesdb-core/tests/explain_executed_strategy.rs
@@ -1,0 +1,158 @@
+#![cfg(all(test, feature = "persistence"))]
+//! EXPLAIN ANALYZE reports the filter strategy the executor *actually ran*.
+//!
+//! The value is recorded at the dispatch site itself (lot 3.2a), so these
+//! tests pin the ground truth against corpora whose selectivities are exact
+//! by construction:
+//!
+//! - `<= 1%` with quality overrides → exact brute-force scan (`PreFilterExact`);
+//! - mid selectivity → bitmap-constrained HNSW (`PreFilter`);
+//! - `> 80%` with quality overrides → `PostFilter`;
+//! - `> 80%` WITHOUT overrides → still `PreFilter`: the no-override path
+//!   always runs the bitmap when one exists — precisely the plan/execution
+//!   divergence this field exists to surface;
+//! - MATCH and compound queries report nothing.
+
+#![allow(clippy::cast_precision_loss)]
+
+use serde_json::json;
+use std::collections::HashMap;
+use tempfile::TempDir;
+use velesdb_core::velesql::{FilterStrategy, Parser};
+use velesdb_core::{Database, DistanceMetric, Point};
+
+const N: u64 = 1_000;
+const DIM: usize = 16;
+
+/// Builds a database with one collection: three indexed tag fields whose
+/// `"y"` population is an id prefix (exact selectivities 1%, 10%, 90%).
+fn setup() -> (Database, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let db = Database::open(dir.path()).expect("open database");
+    db.create_collection("docs", DIM, DistanceMetric::Cosine)
+        .expect("create collection");
+    let collection = db.get_vector_collection("docs").expect("get collection");
+
+    for field in ["b_rare", "b_mid", "b_wide"] {
+        collection.create_index(field).expect("create index");
+    }
+
+    let points: Vec<Point> = (0..N)
+        .map(|id| {
+            let payload = json!({
+                "b_rare": if id < N / 100 { "y" } else { "n" },  // 1%
+                "b_mid": if id < N / 10 { "y" } else { "n" },    // 10%
+                "b_wide": if id < N * 9 / 10 { "y" } else { "n" }, // 90%
+            });
+            let mut vector: Vec<f32> = (0..DIM)
+                .map(|d| ((id as f32) * 0.13 + (d as f32) * 0.07).cos())
+                .collect();
+            let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+            for x in &mut vector {
+                *x /= norm;
+            }
+            Point::new(id, vector, Some(payload))
+        })
+        .collect();
+    collection.upsert(points).expect("upsert");
+    (db, dir)
+}
+
+fn query_params() -> HashMap<String, serde_json::Value> {
+    let v: Vec<f32> = (0..DIM).map(|d| (d as f32 * 0.1).sin()).collect();
+    let mut params = HashMap::new();
+    params.insert("v".to_string(), json!(v));
+    params
+}
+
+/// Runs EXPLAIN ANALYZE through the Database facade and returns the
+/// executed strategy the response carries.
+fn analyzed_strategy(db: &Database, sql: &str) -> Option<FilterStrategy> {
+    let query = Parser::parse(sql).expect("parse");
+    let output = db
+        .explain_analyze_query(&query, &query_params())
+        .expect("explain analyze");
+    let stats = output.actual_stats.expect("ANALYZE carries actual stats");
+    stats.executed_filter_strategy
+}
+
+#[test]
+fn reports_exact_scan_for_rare_band_with_overrides() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND b_rare = 'y' LIMIT 5 WITH (mode='balanced')",
+    );
+    assert_eq!(strategy, Some(FilterStrategy::PreFilterExact));
+}
+
+#[test]
+fn reports_bitmap_prefilter_for_mid_band_with_overrides() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND b_mid = 'y' LIMIT 5 WITH (mode='balanced')",
+    );
+    assert_eq!(strategy, Some(FilterStrategy::PreFilter));
+}
+
+#[test]
+fn reports_post_filter_for_wide_band_with_overrides() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND b_wide = 'y' LIMIT 5 WITH (mode='balanced')",
+    );
+    assert_eq!(strategy, Some(FilterStrategy::PostFilter));
+}
+
+/// The divergence this field exists to surface: without quality overrides
+/// the executor always runs the bitmap when one exists — even at 90%
+/// selectivity, where the override path post-filters.
+#[test]
+fn no_override_path_runs_bitmap_even_on_wide_band() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND b_wide = 'y' LIMIT 5",
+    );
+    assert_eq!(strategy, Some(FilterStrategy::PreFilter));
+}
+
+#[test]
+fn pure_near_reports_nothing() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(&db, "SELECT * FROM docs WHERE vector NEAR $v LIMIT 5");
+    assert_eq!(strategy, None, "no filter → no pre/post-filter notion");
+}
+
+#[test]
+fn compound_query_reports_nothing() {
+    let (db, _dir) = setup();
+    let strategy = analyzed_strategy(
+        &db,
+        "SELECT * FROM docs WHERE vector NEAR $v AND b_mid = 'y' LIMIT 5 \
+         UNION SELECT * FROM docs WHERE vector NEAR $v AND b_rare = 'y' LIMIT 5",
+    );
+    assert_eq!(
+        strategy, None,
+        "several selects → a single strategy would be ambiguous"
+    );
+}
+
+/// Stats persisted by older versions (no such field) must load unchanged,
+/// and a `None` strategy must not appear in the serialized JSON.
+#[test]
+fn actual_stats_serde_is_backward_compatible() {
+    let legacy =
+        r#"{"actual_rows":3,"actual_time_ms":1.5,"loops":1,"nodes_visited":0,"edges_traversed":0}"#;
+    let stats: velesdb_core::velesql::ActualStats =
+        serde_json::from_str(legacy).expect("legacy JSON must deserialize");
+    assert_eq!(stats.executed_filter_strategy, None);
+
+    let round = serde_json::to_string(&stats).expect("serialize");
+    assert!(
+        !round.contains("executed_filter_strategy"),
+        "None must stay absent from the wire"
+    );
+}

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2077,6 +2077,7 @@ The result includes the estimated plan (identical to `EXPLAIN`) plus:
 | `nodes_visited` | u64 | For MATCH queries, an approximate (best-effort, lower-bound) graph-traversal node count (start nodes examined + nodes reached by following edges); 0 for non-MATCH queries |
 | `edges_traversed` | u64 | For MATCH queries, an approximate (best-effort, lower-bound) count of edges followed during traversal; 0 for non-MATCH queries |
 | `traversal_counters_approximate` | bool | `true` when `nodes_visited` / `edges_traversed` are strategy-dependent approximations (a lower bound), not exact measured counts; `false` for non-graph queries where both counters are 0. |
+| `executed_filter_strategy` | string \| absent | The filter strategy the executor **actually ran**, recorded at the dispatch site itself (`"pre-filtering (high selectivity)"`, `"pre-filtering (exact, brute-force scan)"`, or `"post-filtering (low selectivity)"`). Present for single SELECTs that went through the filtered vector-search dispatch — under the CBO `Parallel` strategy it describes the vector leg. **Omitted** for MATCH, compound queries, and arms where the pre/post-filter notion does not apply. Unlike the plan's `filter_strategy` (an estimate), this is ground truth: comparing the two surfaces plan/execution divergence. |
 
 > **Note:** `nodes_visited` / `edges_traversed` are an **approximate, best-effort
 > lower bound** on the graph traversal across all MATCH strategies — not exact

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3408,6 +3408,13 @@
             "description": "Approximate number of edges traversed during MATCH graph traversal.\nSee `traversal_counters_approximate`; 0 for non-graph queries.",
             "minimum": 0
           },
+          "executed_filter_strategy": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Filter strategy the executor actually ran, recorded at the dispatch\nsite (see `FilterStrategy::as_str`). Present for single SELECTs that\nwent through the filtered vector-search dispatch; absent for MATCH,\ncompound queries, and arms where pre/post-filter does not apply."
+          },
           "loops": {
             "type": "integer",
             "format": "int64",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2259,6 +2259,15 @@ components:
             Approximate number of edges traversed during MATCH graph traversal.
             See `traversal_counters_approximate`; 0 for non-graph queries.
           minimum: 0
+        executed_filter_strategy:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Filter strategy the executor actually ran, recorded at the dispatch
+            site (see `FilterStrategy::as_str`). Present for single SELECTs that
+            went through the filtered vector-search dispatch; absent for MATCH,
+            compound queries, and arms where pre/post-filter does not apply.
         loops:
           type: integer
           format: int64


### PR DESCRIPTION
## Description

The plan's `filter_strategy` is an estimate; nothing surfaced what the executor actually did, so plan/execution divergence was invisible. EXPLAIN ANALYZE now carries the ran strategy, **recorded at the dispatch site itself** — not re-derived, so it cannot drift from execution (lot 3.2, observability half):

- `guardrails::QueryContext` gains an atomic executed-strategy slot (the `add_traversal` idiom); the pipeline clones it into `QuerySearchOptions`, which by design flows through every dispatch path — **including the vector leg of the CBO `Parallel` strategy on a rayon worker**, where a thread-local channel would silently lose the record (this is why the channel is a shared atomic, adversarial review of the design).
- The filtered vector-search dispatch records at each branch: the three exact-mode shapes (`PostFilter` / `PreFilterExact` / bitmap `PreFilter`), the empty-bitmap short-circuit, and the no-override fallback (bitmap → `PreFilter`, none → `PostFilter`).
- **`ActualStats.executed_filter_strategy`** (serde-defaulted, absent when `None`): present for single SELECTs through the filtered dispatch; `None` for MATCH, compound queries, and arms where pre/post-filter does not apply. Surfaced at **both** EXPLAIN ANALYZE levels: the Collection facade via a shared `execute_query_traced` core (`execute_query_with_client` is now a thin wrapper — zero gate duplication), and the Database facade via a probe threaded through JOIN resolution to the base-collection call, replaying exactly the same pre-steps as `execute_query` (subquery resolution, validation, read gate, telemetry).
- REST `ActualStatsResponse` and `docs/VELESQL_SPEC.md` expose the field with the `FilterStrategy::as_str` wording.

First ground truth surfaced by the new tests: **without quality overrides the executor runs the bitmap even at 90 % selectivity**, where the override path post-filters — exactly the plan/execution divergence this field exists to make visible (and a measured input, alongside #2054's crossover table, to the threshold-convergence half of lot 3.2, which stays gated on measurements).

## Type of Change

- [x] ✨ New feature (observability; zero change to query results or dispatch)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Seven integration tests (`tests/explain_executed_strategy.rs`) pin the ground truth on exact-selectivity bands (1 % → `PreFilterExact`, 10 % → `PreFilter`, 90 % + overrides → `PostFilter`, 90 % without overrides → `PreFilter`), the `None` cases (pure NEAR, compound), and serde backward-compat (legacy JSON loads; `None` stays absent from the wire).

- `cargo test -p velesdb-core --features persistence --test explain_executed_strategy -- --test-threads=1` — 7 passed
- `cargo test -p velesdb-core --lib --features persistence query -- --test-threads=1` — 743 passed
- `cargo test -p velesdb-core --lib --features persistence filter -- --test-threads=1` — 319 passed
- `cargo test -p velesdb-core --lib --features persistence explain -- --test-threads=1` — 86 passed
- Search path touched (`vector.rs`/`vector_filter.rs`) → recall gate: `test_recall` — 18 passed
- `cargo test -p velesdb-core --features persistence --test bdd explain -- --test-threads=1` — 34 passed; `bitmap_prefilter_integration` — passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean (CI-exact flags)
- `RUSTFLAGS="-Dwarnings" cargo check -p velesdb-core --no-default-features --tests` — clean
- `bash scripts/check-doc-contract.sh` — pass

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Under the CBO `Parallel` strategy the reported value describes the vector leg (documented). GraphFirst, similarity, sparse and fused arms report nothing: the pre/post-filter notion does not apply there. Changing any dispatch threshold stays out of scope — that is the convergence half of lot 3.2, now fed by both this field and #2054's deterministic work counts.