### PR TITLE
test(core): measure the cost crossover on a second, isotropic corpus geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The cost-crossover harness measures two corpus geometries.** The original
+  closed-form trigonometric corpus lies on a smooth 1-D curve — a degenerate
+  distribution an HNSW graph finds unusually easy, so its numbers alone could
+  flatter the index. A seeded isotropic corpus (inline xorshift64*, no RNG
+  dependency, so the sequence can never change under a dependency bump) now
+  runs the same band table; every exact law must hold on both. First
+  measured correction: on the isotropic corpus the bitmap path's work
+  advantage over post-filter at 50–80 % selectivity collapses (≈4 % instead
+  of ≈36 %), and at 5 % selectivity bitmap-HNSW costs nearly 2× the
+  post-filter — the oversampling budget `k/selectivity` dominates. The
+  threshold-convergence work must weigh both geometries.
+
 - **EXPLAIN ANALYZE now reports the filter strategy the executor actually
   ran** (`actual_stats.executed_filter_strategy`), recorded at the dispatch
   site itself — not re-derived — through a probe shared between the query

--- a/crates/velesdb-core/src/index/hnsw/eval_count.rs
+++ b/crates/velesdb-core/src/index/hnsw/eval_count.rs
@@ -17,6 +17,11 @@
 //! wall-clock benchmarks are noise. Block-columnar (PDX) kernels compute
 //! distances in blocks without passing through these entry points, so for
 //! paths that engage them the counter is a lower bound.
+//!
+//! Corollary: with `internal-bench` enabled, the relaxed atomic increment
+//! sits inside the distance hot loop — wall-clock measured under this
+//! feature is NOT a benchmark of the real engine. Count with this feature;
+//! time without it.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/crates/velesdb-core/tests/cost_crossover.rs
+++ b/crates/velesdb-core/tests/cost_crossover.rs
@@ -98,11 +98,45 @@ const BANDS: &[Band] = &[
     }, // 95% → post-filter
 ];
 
-/// Deterministic, normalized vector for a point id (closed form, no RNG).
-fn vector_for(id: u64) -> Vec<f32> {
-    let mut v: Vec<f32> = (0..DIM)
-        .map(|d| ((id as f32) * 0.13 + (d as f32) * 0.07).cos())
-        .collect();
+/// Corpus geometry. The closed-form trigonometric corpus lies on a smooth
+/// 1-D curve — a degenerate distribution an HNSW graph finds unusually easy,
+/// so its numbers alone could flatter the index. The seeded corpus draws
+/// isotropic-ish vectors from an inline xorshift64* stream (no external RNG
+/// crate, so the sequence can never change under a dependency bump): every
+/// law must hold on BOTH geometries for the table to be trusted.
+#[derive(Clone, Copy, Debug)]
+enum Geometry {
+    ClosedForm,
+    Seeded,
+}
+
+const GEOMETRIES: &[Geometry] = &[Geometry::ClosedForm, Geometry::Seeded];
+
+impl Geometry {
+    fn name(self) -> &'static str {
+        match self {
+            Self::ClosedForm => "closed_form",
+            Self::Seeded => "seeded_xorshift",
+        }
+    }
+}
+
+/// Inline xorshift64* step — deterministic forever, dependency-free.
+fn xorshift64star(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x >> 12;
+    x ^= x << 25;
+    x ^= x >> 27;
+    *state = x;
+    x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+}
+
+/// Uniform-ish f32 in [-1, 1) from the stream.
+fn unit_f32(state: &mut u64) -> f32 {
+    ((xorshift64star(state) >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+}
+
+fn normalize(mut v: Vec<f32>) -> Vec<f32> {
     let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
         for x in &mut v {
@@ -112,23 +146,37 @@ fn vector_for(id: u64) -> Vec<f32> {
     v
 }
 
-/// Deterministic, normalized query vector for a query index.
-fn query_for(q: usize) -> Vec<f32> {
-    let mut v: Vec<f32> = (0..DIM)
-        .map(|d| ((q as f32) * 0.31 + (d as f32) * 0.11).sin())
-        .collect();
-    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for x in &mut v {
-            *x /= norm;
+/// Deterministic, normalized vector for a point id under a geometry.
+fn vector_for(geometry: Geometry, id: u64) -> Vec<f32> {
+    let v: Vec<f32> = match geometry {
+        Geometry::ClosedForm => (0..DIM)
+            .map(|d| ((id as f32) * 0.13 + (d as f32) * 0.07).cos())
+            .collect(),
+        Geometry::Seeded => {
+            let mut state = id ^ 0x9E37_79B9_7F4A_7C15 | 1;
+            (0..DIM).map(|_| unit_f32(&mut state)).collect()
         }
-    }
-    v
+    };
+    normalize(v)
+}
+
+/// Deterministic, normalized query vector for a query index under a geometry.
+fn query_for(geometry: Geometry, q: usize) -> Vec<f32> {
+    let v: Vec<f32> = match geometry {
+        Geometry::ClosedForm => (0..DIM)
+            .map(|d| ((q as f32) * 0.31 + (d as f32) * 0.11).sin())
+            .collect(),
+        Geometry::Seeded => {
+            let mut state = (q as u64) ^ 0xD1B5_4A32_D192_ED03 | 1;
+            (0..DIM).map(|_| unit_f32(&mut state)).collect()
+        }
+    };
+    normalize(v)
 }
 
 /// Builds the corpus: every band field is an indexed boolean-like tag whose
 /// `"y"` population is the id prefix `0..count`.
-fn setup() -> (VectorCollection, TempDir) {
+fn setup(geometry: Geometry) -> (VectorCollection, TempDir) {
     let dir = TempDir::new().expect("temp dir");
     let collection = VectorCollection::create(
         dir.path().join("crossover"),
@@ -151,7 +199,11 @@ fn setup() -> (VectorCollection, TempDir) {
                 payload.insert(band.field.to_string(), json!(value));
             }
             payload.insert("seq".to_string(), json!(id));
-            Point::new(id, vector_for(id), Some(serde_json::Value::Object(payload)))
+            Point::new(
+                id,
+                vector_for(geometry, id),
+                Some(serde_json::Value::Object(payload)),
+            )
         })
         .collect();
 
@@ -165,9 +217,9 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 }
 
 /// Exact top-k ids among the band's population for one query (ground truth).
-fn ground_truth(band: &Band, query: &[f32]) -> Vec<u64> {
+fn ground_truth(geometry: Geometry, band: &Band, query: &[f32]) -> Vec<u64> {
     let mut scored: Vec<(u64, f32)> = (0..band.count)
-        .map(|id| (id, cosine(query, &vector_for(id))))
+        .map(|id| (id, cosine(query, &vector_for(geometry, id))))
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(K);
@@ -176,7 +228,7 @@ fn ground_truth(band: &Band, query: &[f32]) -> Vec<u64> {
 
 /// Runs one batch of the band's filtered query through the quality-aware
 /// dispatch; returns (distance evals for the batch, mean recall@K).
-fn run_batch(collection: &VectorCollection, band: &Band) -> (u64, f64) {
+fn run_batch(geometry: Geometry, collection: &VectorCollection, band: &Band) -> (u64, f64) {
     let sql = format!(
         "SELECT * FROM crossover WHERE vector NEAR $v AND {} = '{}' LIMIT {K} WITH (mode='balanced')",
         band.field, band.value
@@ -184,13 +236,13 @@ fn run_batch(collection: &VectorCollection, band: &Band) -> (u64, f64) {
     let mut recall_sum = 0.0_f64;
     reset_hnsw_distance_evals();
     for q in 0..QUERIES {
-        let query = query_for(q);
+        let query = query_for(geometry, q);
         let mut params = HashMap::new();
         params.insert("v".to_string(), json!(query));
         let results = collection
             .execute_query_str(&sql, &params)
             .expect("filtered query");
-        let truth = ground_truth(band, &query);
+        let truth = ground_truth(geometry, band, &query);
         let got: std::collections::HashSet<u64> = results.iter().map(|r| r.point.id).collect();
         let hit = truth.iter().filter(|id| got.contains(id)).count();
         recall_sum += hit as f64 / truth.len().max(1) as f64;
@@ -200,12 +252,20 @@ fn run_batch(collection: &VectorCollection, band: &Band) -> (u64, f64) {
 
 #[test]
 fn cost_crossover_work_table_is_deterministic_and_lawful() {
-    let (collection, _dir) = setup();
+    for &geometry in GEOMETRIES {
+        crossover_table_for(geometry);
+    }
+}
+
+/// Runs the full band table under one corpus geometry and asserts the exact
+/// laws; the laws are geometry-independent, the numbers are not.
+fn crossover_table_for(geometry: Geometry) {
+    let (collection, _dir) = setup(geometry);
 
     let mut rows = Vec::new();
     for band in BANDS {
-        let (evals_a, recall_a) = run_batch(&collection, band);
-        let (evals_b, recall_b) = run_batch(&collection, band);
+        let (evals_a, recall_a) = run_batch(geometry, &collection, band);
+        let (evals_b, recall_b) = run_batch(geometry, &collection, band);
 
         // Determinism: two identical batches over an immutable collection
         // must do bit-for-bit identical work and return identical recall.
@@ -230,6 +290,7 @@ fn cost_crossover_work_table_is_deterministic_and_lawful() {
         println!(
             "{}",
             json!({
+                "geometry": geometry.name(),
                 "band": band.field,
                 "selectivity": selectivity,
                 "matching": band.count,


### PR DESCRIPTION
## Description

Adversarial review of the freshly merged harness (#2054) sustained one methodological objection: the closed-form trigonometric corpus lies on a smooth 1-D curve — a degenerate distribution an HNSW graph finds unusually easy, so its numbers alone could flatter the index. This PR makes the harness measure **two geometries** and demands every exact law hold on both:

- A **seeded isotropic corpus** joins the closed-form one: inline xorshift64* (dependency-free, so the byte-for-byte sequence can never change under a crate bump), normalized vectors, same exact-by-construction selectivity bands.
- The JSON table now carries a `geometry` field; all assertions (in-process determinism, scan work = bitmap cardinality × queries with recall exactly 1.0, post-filter work independent of selectivity, strict 0.8 boundary) run per geometry.
- `eval_count` docs now state the corollary explicitly: **wall-clock measured under `internal-bench` is not a benchmark** — the counter's relaxed increment sits inside the distance hot loop. Count with the feature; time without it.

**First measured correction — and it changes the story the closed-form table told:**

| selectivity | shape | closed-form (evals/q) | isotropic (evals/q) |
|---|---|---|---|
| 0.5 % / 1 % | exact scan | 40 / 80 | 40 / 80 (law: = bitmap cardinality) |
| 5 % | bitmap-HNSW | 662 | **5684** (≈2× the post-filter cost) |
| 50 % / 80 % | bitmap-HNSW | 331 | 2842 |
| 90 % / 95 % | post-filter | 451 | 2962 |

On realistic geometry the bitmap path's advantage at 50–80 % collapses from ≈36 % to ≈4 %, and at 5 % the `k/selectivity` oversampling budget makes bitmap-HNSW nearly **twice** as expensive as post-filter. The threshold-convergence work must weigh both tables (and the i9 wall-clock when it lands).

## Type of Change

- [x] 🔧 Refactoring (harness + docs only; no shipped-code change)

## How Has This Been Tested?

- [x] Integration tests

- `cargo test -p velesdb-core --features persistence,internal-bench --test cost_crossover -- --test-threads=1` — 1 passed (both geometries, all exact laws)
- `cargo clippy -p velesdb-core --all-targets --features persistence,internal-bench -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean (CI-exact flags)
- `cargo fmt --check` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Cross-commit observation the harness itself surfaced: the closed-form counts shifted by −3 evals/batch on every HNSW band versus the table measured on pre-#2053 develop (e.g. 451.5 → 451.125/query), recall unchanged. In-process determinism holds exactly; the nightly table exists precisely to make such sub-0.1 % cross-commit shifts visible rather than anecdotal.