### PR TITLE
refactor(core): type the executed-strategy channel; share the counted pre-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The executed-strategy channel is now a typed cell.** The
+  `Arc<AtomicU8>` probe introduced with `executed_filter_strategy` spread
+  its raw `u8` encoding across three modules; it is now
+  `guardrails::ExecutedStrategyCell`, whose encoding is a private detail —
+  callers only `record` a `FilterStrategy` and `get` an `Option` back. The
+  counted (EXPLAIN ANALYZE) executions also return a named
+  `CountedExecution` struct instead of a 4-tuple, and the Database-level
+  counted path shares its pre-flight (`execute_query_gated`: subquery
+  resolution, validation, read gate, timed execution) with the plain path
+  instead of replaying a copy — the two can no longer drift. The executor's
+  dispatch match is spelled out with no wildcard arm: a future
+  `FilterStrategy` variant fails compilation at every site that must choose,
+  instead of silently falling into a default. No behavior change.
+
 ### Added
 
 - **EXPLAIN ANALYZE now reports the filter strategy the executor actually

--- a/crates/velesdb-core/src/collection/search/query/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/mod.rs
@@ -102,6 +102,20 @@ pub use join::{execute_join, JoinedResult, JOIN_ROW_CEILING};
 
 // Re-export types from options.rs so sibling submodules can use `super::*`.
 pub(crate) use options::QuerySearchOptions;
+
+/// Outcome of a counted (EXPLAIN ANALYZE) execution: the results plus the
+/// execution facts the plain path discards — graph-traversal counters and
+/// the filter strategy the executor actually ran.
+pub(crate) struct CountedExecution {
+    /// Query results, as `execute_query` would return them.
+    pub(crate) results: Vec<crate::point::SearchResult>,
+    /// Approximate MATCH traversal node count (0 for non-MATCH).
+    pub(crate) nodes_visited: u64,
+    /// Approximate MATCH traversal edge count (0 for non-MATCH).
+    pub(crate) edges_traversed: u64,
+    /// Strategy the filtered vector-search dispatch recorded, if any.
+    pub(crate) executed_filter_strategy: Option<crate::velesql::FilterStrategy>,
+}
 pub(in crate::collection::search::query) use options::{
     ExtractedComponents, QueryFinalizationContext, MAX_LIMIT,
 };
@@ -209,14 +223,11 @@ impl Collection {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
-        slot: &std::sync::Arc<std::sync::atomic::AtomicU8>,
+        slot: &crate::guardrails::ExecutedStrategyCell,
     ) -> Result<Vec<SearchResult>> {
         let (results, strategy) = self.execute_query_traced(query, params, "default")?;
         if let Some(strategy) = strategy {
-            slot.store(
-                crate::guardrails::encode_filter_strategy(strategy),
-                std::sync::atomic::Ordering::Relaxed,
-            );
+            slot.record(strategy);
         }
         Ok(results)
     }

--- a/crates/velesdb-core/src/collection/search/query/options.rs
+++ b/crates/velesdb-core/src/collection/search/query/options.rs
@@ -21,12 +21,12 @@ pub(crate) struct QuerySearchOptions {
     /// Fusion clause from `USING FUSION (...)`.
     pub fusion_clause: Option<crate::velesql::FusionClause>,
     /// EXPLAIN ANALYZE out-channel: the executor records which filter
-    /// strategy it actually ran into this slot (shared with the query's
+    /// strategy it actually ran into this cell (shared with the query's
     /// [`QueryContext`](crate::guardrails::QueryContext)). `None` outside
     /// the pipeline (raw search entry points) — recording is then a no-op.
-    /// An `Arc` atomic, not a thread-local: the vector leg of the CBO
+    /// A shared atomic cell, not a thread-local: the vector leg of the CBO
     /// `Parallel` strategy runs on a rayon worker thread.
-    pub executed_strategy_probe: Option<std::sync::Arc<std::sync::atomic::AtomicU8>>,
+    pub executed_strategy_probe: Option<std::sync::Arc<crate::guardrails::ExecutedStrategyCell>>,
 }
 
 impl QuerySearchOptions {
@@ -71,10 +71,7 @@ impl QuerySearchOptions {
     /// no probe is attached (raw search entry points).
     pub(crate) fn record_executed_strategy(&self, strategy: crate::velesql::FilterStrategy) {
         if let Some(probe) = &self.executed_strategy_probe {
-            probe.store(
-                crate::guardrails::encode_filter_strategy(strategy),
-                std::sync::atomic::Ordering::Relaxed,
-            );
+            probe.record(strategy);
         }
     }
 

--- a/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
+++ b/crates/velesdb-core/src/collection/search/query/query_pipeline.rs
@@ -6,6 +6,7 @@
 
 use super::options::{ExtractedComponents, QueryFinalizationContext, MAX_LIMIT};
 use super::vector_group_by;
+use super::CountedExecution;
 use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
@@ -50,12 +51,7 @@ impl Collection {
         &self,
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
-    ) -> Result<(
-        Vec<SearchResult>,
-        u64,
-        u64,
-        Option<crate::velesql::FilterStrategy>,
-    )> {
+    ) -> Result<CountedExecution> {
         // Only a standalone MATCH query carries traversal counters. Run it
         // through the same context + dispatch as execute_query, then read the
         // counters the executor recorded into the query context. is_match_query
@@ -65,21 +61,31 @@ impl Collection {
             let results = self
                 .try_dispatch_match(query, params, &ctx)?
                 .unwrap_or_default();
-            return Ok((
+            return Ok(CountedExecution {
+                nodes_visited: ctx.traversal_nodes_visited(),
+                edges_traversed: ctx.traversal_edges_traversed(),
+                executed_filter_strategy: None,
                 results,
-                ctx.traversal_nodes_visited(),
-                ctx.traversal_edges_traversed(),
-                None,
-            ));
+            });
         }
         // Single SELECT: the traced core also reports which filter strategy
         // the executor ran. Compound queries execute several selects — a
         // single reported strategy would be ambiguous, so they report none.
         if query.compound.is_none() {
             let (results, strategy) = self.execute_query_traced(query, params, "default")?;
-            return Ok((results, 0, 0, strategy));
+            return Ok(CountedExecution {
+                results,
+                nodes_visited: 0,
+                edges_traversed: 0,
+                executed_filter_strategy: strategy,
+            });
         }
-        Ok((self.execute_query(query, params)?, 0, 0, None))
+        Ok(CountedExecution {
+            results: self.execute_query(query, params)?,
+            nodes_visited: 0,
+            edges_traversed: 0,
+            executed_filter_strategy: None,
+        })
     }
 
     /// Computes the effective `(limit, fetch_limit)` from a SELECT statement.
@@ -402,10 +408,14 @@ impl Collection {
         let plan = QueryPlan::from_query_with_all_stats(query, &indexed, None, Some(&match_stats));
 
         let start = std::time::Instant::now();
-        let (results, nodes, edges, executed_strategy) =
-            self.execute_query_counted(query, params)?;
-        let stats = ActualStats::from_counted(results.len() as u64, start.elapsed(), nodes, edges)
-            .with_executed_filter_strategy(executed_strategy);
+        let counted = self.execute_query_counted(query, params)?;
+        let stats = ActualStats::from_counted(
+            counted.results.len() as u64,
+            start.elapsed(),
+            counted.nodes_visited,
+            counted.edges_traversed,
+        )
+        .with_executed_filter_strategy(counted.executed_filter_strategy);
         let node_stats = build_leaf_node_stats(&plan.root, stats.actual_rows, stats.actual_time_ms);
         let mut output = ExplainOutput::with_stats(plan, stats, node_stats);
 

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -96,10 +96,11 @@ impl Collection {
                 let results = self.storage.index.full_scan_with_bitmap(query, k, bitmap)?;
                 Ok(self.merge_delta(results, query, k, metric))
             }
-            // `PreFilter` — and, defensively, any future variant the
-            // non-exhaustive enum grows that Exact mode does not emit —
-            // runs HNSW constrained by the bitmap with an oversampled k.
-            _ => {
+            // Exact mode never emits `None`; if it ever did, the bitmap
+            // path below is the shape that ran. Spelled out (no wildcard)
+            // so a future `FilterStrategy` variant fails compilation here
+            // and forces an explicit dispatch choice.
+            FilterStrategy::PreFilter | FilterStrategy::None => {
                 let candidates_k = compute_oversampled_k(k, filter, Some(&self.get_stats()));
                 let results = self.storage.index.search_with_quality_and_bitmap(
                     query,

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -19,10 +19,9 @@ use crate::observer::DatabaseObserver;
 use crate::simd_dispatch;
 use crate::{ColumnStore, Error, Result};
 
-/// Shared out-slot for the executed filter strategy, threaded from the
+/// Shared out-cell for the executed filter strategy, threaded from the
 /// EXPLAIN ANALYZE counted path down to the base collection's query pipeline.
-/// Encoding is `guardrails`' (0 = unset).
-pub(crate) type StrategyProbeSlot = std::sync::Arc<std::sync::atomic::AtomicU8>;
+pub(crate) type StrategyProbeSlot = std::sync::Arc<crate::guardrails::ExecutedStrategyCell>;
 
 mod admin_executor;
 mod collection_ops;

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -352,14 +352,6 @@ impl Database {
         query: &crate::velesql::Query,
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<Vec<SearchResult>> {
-        // Resolve scalar subqueries (EPIC-039) into literals *before* validation
-        // so the validator and every downstream path see a subquery-free AST.
-        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
-            return self.execute_query(&rewritten, params);
-        }
-
-        crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
-
         // Requirement 1: read-path control-plane gate. Fires exactly once here
         // at the `Database` facade for read paths (SELECT + MATCH). Compound /
         // JOIN sub-executions re-enter `execute_single_select`, not
@@ -372,8 +364,26 @@ impl Database {
         // after the data-plane op completes. Resolving the `Cow` to a `&Query`
         // (via deref coercion on `&gated`) keeps the timing in one place rather
         // than duplicated across the borrowed / owned arms.
+        self.execute_query_gated(query, params, None)
+    }
+
+    /// Shared pre-flight + execution used by both the plain path and the
+    /// EXPLAIN ANALYZE counted path, so the two can never drift: scalar
+    /// subquery resolution, validation, the read-path gate, then the timed
+    /// execution — with an optional executed-strategy probe threaded to the
+    /// base-collection call.
+    fn execute_query_gated(
+        &self,
+        query: &crate::velesql::Query,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+        probe: Option<&crate::database::StrategyProbeSlot>,
+    ) -> Result<Vec<SearchResult>> {
+        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
+            return self.execute_query_gated(&rewritten, params, probe);
+        }
+        crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
         let gated = self.read_gate(query)?;
-        self.execute_query_timed(&gated, params, None)
+        self.execute_query_timed(&gated, params, probe)
     }
 
     /// Executes the resolved (post-gate) query and fires the `on_query`
@@ -620,8 +630,12 @@ impl Database {
         params: &std::collections::HashMap<String, serde_json::Value>,
     ) -> Result<(Vec<SearchResult>, u64, u64)> {
         let coll = self.resolve_match_collection(query, params)?;
-        let (mut results, nodes_visited, edges_traversed, _strategy) =
-            coll.execute_query_counted(query, params)?;
+        let counted = coll.execute_query_counted(query, params)?;
+        let (mut results, nodes_visited, edges_traversed) = (
+            counted.results,
+            counted.nodes_visited,
+            counted.edges_traversed,
+        );
         // Cross-collection enrichment: if any node pattern has a @collection
         // annotation, look up payloads from those collections and merge them
         // into the projected fields.
@@ -654,21 +668,13 @@ impl Database {
             let (results, nodes, edges) = self.execute_match_routed(&gated, params)?;
             return Ok((results, nodes, edges, None));
         }
-        // Same pre-steps as execute_query (subquery resolution, validation,
-        // read gate, telemetry) with a probe threaded to the base-collection
-        // call so EXPLAIN ANALYZE reports the strategy the executor ran.
-        if let Some(rewritten) = self.resolve_subqueries(query, params)? {
-            return self.execute_query_counted(&rewritten, params);
-        }
-        crate::velesql::QueryValidator::validate(query).map_err(|e| Error::Query(e.to_string()))?;
-        let gated = self.read_gate(query)?;
+        // The exact pre-steps of execute_query (shared execute_query_gated
+        // inner — the two paths cannot drift), with a probe threaded to the
+        // base-collection call so EXPLAIN ANALYZE reports the ran strategy.
         let slot: crate::database::StrategyProbeSlot =
-            std::sync::Arc::new(std::sync::atomic::AtomicU8::new(0));
-        let results = self.execute_query_timed(&gated, params, Some(&slot))?;
-        let strategy = crate::guardrails::decode_filter_strategy(
-            slot.load(std::sync::atomic::Ordering::Relaxed),
-        );
-        Ok((results, 0, 0, strategy))
+            std::sync::Arc::new(crate::guardrails::ExecutedStrategyCell::default());
+        let results = self.execute_query_gated(query, params, Some(&slot))?;
+        Ok((results, 0, 0, slot.get()))
     }
 
     /// Executes the SELECT portion of a query, resolving JOINs if present.

--- a/crates/velesdb-core/src/guardrails/context.rs
+++ b/crates/velesdb-core/src/guardrails/context.rs
@@ -33,38 +33,49 @@ pub struct QueryContext {
     traversal_edges_traversed: AtomicU64,
     /// Filter strategy the executor actually ran (for EXPLAIN ANALYZE).
     ///
-    /// `Arc` so the query pipeline can hand the slot to the search options,
+    /// `Arc` so the query pipeline can hand the cell to the search options,
     /// which flow through every dispatch path — including the vector leg of
     /// the CBO `Parallel` strategy, which runs on a rayon worker thread
     /// (a thread-local channel would silently lose that leg's record).
-    /// Encoding: 0 = unset, then `FilterStrategy` per
-    /// [`encode_filter_strategy`].
-    executed_filter_strategy: Arc<AtomicU8>,
+    executed_filter_strategy: Arc<ExecutedStrategyCell>,
 }
 
-/// Encodes a [`FilterStrategy`](crate::velesql::FilterStrategy) into the
-/// atomic slot representation (0 is reserved for "unset").
-pub(crate) fn encode_filter_strategy(strategy: crate::velesql::FilterStrategy) -> u8 {
-    use crate::velesql::FilterStrategy as F;
-    match strategy {
-        // `None` maps to the "unset" encoding: recording it is a no-op read
-        // back as absent. A future variant added to the (non-exhaustive)
-        // enum fails compilation here, forcing an explicit encoding choice.
-        F::None => 0,
-        F::PreFilter => 1,
-        F::PreFilterExact => 2,
-        F::PostFilter => 3,
+/// Shared cell the executor records the ran filter strategy into.
+///
+/// The atomic encoding (0 = unset) is a private detail of this type: callers
+/// only ever [`record`](Self::record) a [`FilterStrategy`] and
+/// [`get`](Self::get) an `Option` back. Relaxed ordering is sufficient — the
+/// only cross-thread hand-off (a rayon `join` leg recording before the join
+/// point returns) is ordered by the join itself.
+#[derive(Debug, Default)]
+pub(crate) struct ExecutedStrategyCell(AtomicU8);
+
+impl ExecutedStrategyCell {
+    /// Records the strategy the executor is about to run.
+    pub(crate) fn record(&self, strategy: crate::velesql::FilterStrategy) {
+        use crate::velesql::FilterStrategy as F;
+        let raw = match strategy {
+            // `None` maps to the "unset" encoding: recording it is a no-op
+            // read back as absent. A future variant added to the
+            // (non-exhaustive) enum fails compilation here, forcing an
+            // explicit encoding choice.
+            F::None => 0,
+            F::PreFilter => 1,
+            F::PreFilterExact => 2,
+            F::PostFilter => 3,
+        };
+        self.0.store(raw, Ordering::Relaxed);
     }
-}
 
-/// Decodes the atomic slot representation back into a strategy.
-pub(crate) fn decode_filter_strategy(raw: u8) -> Option<crate::velesql::FilterStrategy> {
-    use crate::velesql::FilterStrategy as F;
-    match raw {
-        1 => Some(F::PreFilter),
-        2 => Some(F::PreFilterExact),
-        3 => Some(F::PostFilter),
-        _ => None,
+    /// Returns the recorded strategy, if any query dispatch recorded one.
+    pub(crate) fn get(&self) -> Option<crate::velesql::FilterStrategy> {
+        use crate::velesql::FilterStrategy as F;
+        match self.0.load(Ordering::Relaxed) {
+            1 => Some(F::PreFilter),
+            2 => Some(F::PreFilterExact),
+            3 => Some(F::PostFilter),
+            _ => None,
+        }
     }
 }
 
@@ -80,15 +91,15 @@ impl QueryContext {
             memory_used: AtomicUsize::new(0),
             traversal_nodes_visited: AtomicU64::new(0),
             traversal_edges_traversed: AtomicU64::new(0),
-            executed_filter_strategy: Arc::new(AtomicU8::new(0)),
+            executed_filter_strategy: Arc::new(ExecutedStrategyCell::default()),
         }
     }
 
-    /// Returns the shared slot the executor records the ran filter strategy
+    /// Returns the shared cell the executor records the ran filter strategy
     /// into. Handed to the search options at pipeline entry; read back by
     /// EXPLAIN ANALYZE via [`executed_filter_strategy`](Self::executed_filter_strategy).
     #[must_use]
-    pub(crate) fn executed_strategy_slot(&self) -> Arc<AtomicU8> {
+    pub(crate) fn executed_strategy_slot(&self) -> Arc<ExecutedStrategyCell> {
         Arc::clone(&self.executed_filter_strategy)
     }
 
@@ -96,7 +107,7 @@ impl QueryContext {
     /// the query went through the filtered vector-search dispatch.
     #[must_use]
     pub(crate) fn executed_filter_strategy(&self) -> Option<crate::velesql::FilterStrategy> {
-        decode_filter_strategy(self.executed_filter_strategy.load(Ordering::Relaxed))
+        self.executed_filter_strategy.get()
     }
 
     /// Checks if the query has timed out (US-001).

--- a/crates/velesdb-core/src/guardrails/mod.rs
+++ b/crates/velesdb-core/src/guardrails/mod.rs
@@ -9,7 +9,7 @@
 //! - **Circuit Breaker**: Auto-disable on repeated failures (US-006)
 
 mod context;
-pub(crate) use context::{decode_filter_strategy, encode_filter_strategy};
+pub(crate) use context::ExecutedStrategyCell;
 mod limits;
 mod resilience;
 #[cfg(test)]


### PR DESCRIPTION
## Description

Post-merge adversarial review of the `executed_filter_strategy` work (#2055) sustained three code-shape findings, fixed here with **zero behavior change**:

- **The `Arc<AtomicU8>` probe spread its raw `u8` encoding across three modules.** It is now `guardrails::ExecutedStrategyCell`: the encoding is a private detail of the cell — callers only `record()` a `FilterStrategy` and `get()` an `Option` back — and a future enum variant fails compilation inside the cell instead of silently mapping to a number.
- **The counted (EXPLAIN ANALYZE) executions return a named `CountedExecution` struct** instead of a positional 4-tuple, at both the Collection and Database level.
- **The Database counted path replayed a copy of `execute_query`'s pre-flight** (subquery resolution, validation, read gate). Both now call one shared `execute_query_gated` inner — the two paths cannot drift.
- **The executor's dispatch match spells out its arms with no wildcard**: a future `FilterStrategy` variant fails compilation at every site that must choose a shape, instead of falling into a default.

## Type of Change

- [x] 🔧 Refactoring (no functional change)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- `cargo test -p velesdb-core --features persistence --test explain_executed_strategy -- --test-threads=1` — 7 passed (the ground-truth suite pins every recorded value)
- `cargo test -p velesdb-core --lib --features persistence query -- --test-threads=1` — 743 passed; `filter` — 319; `explain` — 86
- Search path touched → recall gate: `test_recall` — 18 passed
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean (CI-exact flags)
- `RUSTFLAGS="-Dwarnings" cargo check -p velesdb-core --no-default-features --tests` — clean
- `cargo fmt --check` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Same review pass also re-ran the full lib suite on clean `develop` (5367 passed, 0 failed) and produced #2056 (second corpus geometry for the crossover harness). One finding was examined and deliberately **not** executed: moving the dispatch thresholds out of `velesql::explain` into a neutral module — the placement is a documented choice from #2053 (the plan-time and exact-mode brains share one file on purpose), and churning it again would be motion, not improvement.