### PR TITLE
perf(core): wire the pre-normalized cosine kernel into production HNSW

### DIFF
--- a/crates/velesdb-core/src/collection/core/recovery.rs
+++ b/crates/velesdb-core/src/collection/core/recovery.rs
@@ -269,10 +269,13 @@ fn remove_orphan_ids(vector_storage: &Arc<RwLock<MmapStorage>>, index: &Arc<Hnsw
 /// is compared to the storage bytes; on mismatch the storage value is
 /// re-upserted into the index (tombstoning the stale graph node).
 ///
-/// The byte comparison is exact: the graph stores vectors verbatim (the
-/// production distance engine is not pre-normalized), so an indexed vector
-/// that survived the crash is bit-identical to its storage copy. An id
-/// whose graph slot is missing is treated as stale.
+/// The byte comparison is exact up to the cosine normalization invariant:
+/// for cosine the graph stores unit-norm vectors (pre-normalized engine),
+/// so the storage copy is normalized with the same SIMD kernel before
+/// comparing — same input bytes through the same function yield the same
+/// output bytes, so a vector that survived the crash still compares
+/// bit-identical. Other metrics store vectors verbatim and compare raw. An
+/// id whose graph slot is missing is treated as stale.
 #[cfg(feature = "persistence")]
 fn reindex_stale_wal_ids(
     vector_storage: &Arc<RwLock<MmapStorage>>,
@@ -288,7 +291,10 @@ fn reindex_stale_wal_ids(
             continue; // Not indexed (deleted id — already handled by pass 2).
         };
         match storage.retrieve(id) {
-            Ok(Some(v)) if v.len() == dimension => {
+            Ok(Some(mut v)) if v.len() == dimension => {
+                if index.metric() == crate::DistanceMetric::Cosine {
+                    crate::simd_native::normalize_inplace_native(&mut v);
+                }
                 let matches = inner.with_contiguous_vectors(|vectors| {
                     vectors
                         .get(idx)

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -1224,9 +1224,11 @@ fn test_unit_vs_batch_parity_cosine_production_engine() {
     let n = 300;
     let vectors = parity_vectors(n, dim);
 
-    // Production configuration: CachedSimdDistance::new — NOT pre-normalized.
+    // Production configuration: CachedSimdDistance::new_prenormalized —
+    // cosine vectors are unit-norm in graph storage (recovery pass 3
+    // normalizes the storage copy before its byte comparison to match).
     let unit = NativeHnsw::new(
-        CachedSimdDistance::new(DistanceMetric::Cosine, dim),
+        CachedSimdDistance::new_prenormalized(DistanceMetric::Cosine, dim),
         16,
         100,
         n,
@@ -1236,7 +1238,7 @@ fn test_unit_vs_batch_parity_cosine_production_engine() {
     }
 
     let batch = NativeHnsw::new(
-        CachedSimdDistance::new(DistanceMetric::Cosine, dim),
+        CachedSimdDistance::new_prenormalized(DistanceMetric::Cosine, dim),
         16,
         100,
         n,
@@ -1249,13 +1251,16 @@ fn test_unit_vs_batch_parity_cosine_production_engine() {
     batch.parallel_insert(&data).expect("batch insert");
     assert_eq!(batch.len(), n);
 
-    // Production cosine stores vectors VERBATIM (recovery pass 3 relies on
-    // byte-exact equality between graph storage and vector storage).
+    // Production cosine stores vectors UNIT-NORM: batch and unit insert paths
+    // must produce byte-identical normalized storage (recovery pass 3
+    // normalizes the WAL storage copy with the same kernel before comparing).
     for id in [0, n / 2, n - 1] {
+        let mut expected = vectors[id].clone();
+        crate::simd_native::normalize_inplace_native(&mut expected);
         assert_eq!(
             stored_vector(&batch, id),
-            vectors[id],
-            "production cosine batch path must store vectors verbatim (id={id})"
+            expected,
+            "production cosine batch path must store unit-norm vectors (id={id})"
         );
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/distance.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/distance.rs
@@ -157,7 +157,11 @@ impl DistanceEngine for CachedSimdDistance {
         crate::index::hnsw::eval_count::record_eval();
         match self.metric {
             DistanceMetric::Cosine if self.pre_normalized => {
-                1.0 - self.engine.cosine_similarity(a, b).clamp(-1.0, 1.0)
+                // Both sides are unit-norm (enforced at insert and load), so
+                // cosine reduces to a single dot-product chain: no norm
+                // accumulators, no sqrt, no divide. The clamp absorbs FP
+                // drift so the distance stays in [0, 2] like the exact arm.
+                1.0 - self.engine.dot_product(a, b).clamp(-1.0, 1.0)
             }
             DistanceMetric::Cosine => 1.0 - self.engine.cosine_similarity(a, b),
             // Reason: Returns squared L2 (no sqrt) because HNSW traversal only

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -244,7 +244,34 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     /// Returns `io::Error` if file operations fail or data is corrupted.
     pub fn file_load(path: &Path, basename: &str, distance: D) -> std::io::Result<Self> {
         let vectors_path = path.join(format!("{basename}.vectors"));
-        let (vectors, count) = Self::load_vectors_file(&vectors_path)?;
+        let (mut vectors, count) = Self::load_vectors_file(&vectors_path)?;
+
+        // Indexes written before the pre-normalized cosine engine store raw
+        // vectors. Cosine is scale-invariant, so normalizing here never
+        // changes any result, and it (re-)establishes the unit-norm invariant
+        // the fast dot-product arm relies on.
+        //
+        // The epsilon gate keeps save/load roundtrips bit-identical: a file
+        // written by the pre-normalized engine holds vectors whose norm is 1
+        // within f32 renormalization noise (~sqrt(dim) * 2^-24), and blindly
+        // re-normalizing those would drift the stored bytes by 1 ulp per
+        // cycle. Legacy raw vectors sit far outside the gate and get their
+        // one-time normalization; a legacy vector the user already stored
+        // unit-norm within 1e-5 is left as-is, bounding its dot-vs-cosine
+        // error at the same 1e-5 — below f32 ranking noise.
+        if distance.is_pre_normalized() && distance.metric() == crate::DistanceMetric::Cosine {
+            const UNIT_NORM_EPS: f32 = 1e-5;
+            if let Some(storage) = vectors.as_mut() {
+                for i in 0..storage.len() {
+                    if let Some(v) = storage.get_mut(i) {
+                        let n = crate::simd_native::norm_native(v);
+                        if n > 0.0 && (n - 1.0).abs() > UNIT_NORM_EPS {
+                            crate::simd_native::normalize_inplace_native(v);
+                        }
+                    }
+                }
+            }
+        }
 
         let graph_path = path.join(format!("{basename}.graph"));
         let graph = Self::load_graph_file(&graph_path, count)?;

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision.rs
@@ -491,13 +491,17 @@ impl<D: DistanceEngine> RaBitQPrecisionHnsw<D> {
         candidate_ids: &[NodeId],
         k: usize,
     ) -> Vec<(NodeId, f32)> {
+        // Stored cosine vectors are unit-norm (pre-normalized engine), so the
+        // query must be normalized the same way before exact re-ranking —
+        // `prepare_query` is a zero-cost pass-through for every other metric.
+        let prepared = self.inner.prepare_query(query);
         let vectors_guard = self.inner.vectors.read();
         let mut reranked: Vec<(NodeId, f32)> = if let Some(vectors) = vectors_guard.as_ref() {
             candidate_ids
                 .iter()
                 .filter_map(|&node_id| {
                     let vec = vectors.get(node_id)?;
-                    let raw_dist = self.inner.compute_distance(query, vec);
+                    let raw_dist = self.inner.compute_distance(&prepared, vec);
                     let final_dist = self.inner.transform_score(raw_dist);
                     Some((node_id, final_dist))
                 })

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -91,7 +91,7 @@ impl NativeHnswInner {
         alpha: f32,
     ) -> crate::error::Result<Self> {
         let backend = if matches!(storage_mode, crate::StorageMode::RaBitQ) {
-            let distance = CachedSimdDistance::new(metric, dimension);
+            let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
             let rabitq = RaBitQPrecisionHnsw::new_with_alpha(
                 distance,
                 dimension,
@@ -102,7 +102,7 @@ impl NativeHnswInner {
             )?;
             HnswBackend::RaBitQ(Box::new(rabitq))
         } else {
-            let distance = CachedSimdDistance::new(metric, dimension);
+            let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
             let inner = if dimension > 0 {
                 NativeHnsw::new_with_dimension_and_alpha(
                     distance,
@@ -188,7 +188,7 @@ impl NativeHnswInner {
     pub fn promote_to_rabitq(self, dimension: usize) -> Self {
         match self.backend {
             HnswBackend::Standard(inner) => {
-                let distance = CachedSimdDistance::new(self.metric, dimension);
+                let distance = CachedSimdDistance::new_prenormalized(self.metric, dimension);
                 Self {
                     backend: HnswBackend::RaBitQ(Box::new(RaBitQPrecisionHnsw::from_inner(
                         inner, distance, dimension,
@@ -420,13 +420,13 @@ impl NativeHnswInner {
         dimension: usize,
         storage_mode: crate::StorageMode,
     ) -> std::io::Result<Self> {
-        let distance = CachedSimdDistance::new(metric, dimension);
+        let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
         let inner = NativeHnsw::file_load(path, basename, distance)?;
 
         let backend = if matches!(storage_mode, crate::StorageMode::RaBitQ) {
             // Wrap loaded graph in RaBitQ backend.
             // The quantizer is NOT trained yet — it trains lazily from new inserts.
-            let distance = CachedSimdDistance::new(metric, dimension);
+            let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
             let rabitq = RaBitQPrecisionHnsw::from_inner(inner, distance, dimension);
             HnswBackend::RaBitQ(Box::new(rabitq))
         } else {


### PR DESCRIPTION
## Description

Tier-S finding from the four-domain perf audit: **the entire cosine pre-normalization machinery existed and was tested — but no production path used it.** Insert-time in-place normalization, query normalization in `prepare_query`, the `new_prenormalized` constructor: all built, all dormant. Every one of the ~`ef × M` node visits per cosine query paid three FMA accumulator chains plus a `sqrt` and a divide (full cosine formula) instead of one dot-product chain (~3× the FLOPs on the hottest function in the system).

- All five `CachedSimdDistance` construction sites now use `new_prenormalized`; the pre-normalized arm computes `1 - dot(a, b).clamp(-1, 1)`.
- **RaBitQ exact re-ranking** prepares (normalizes) the query before `inner.compute_distance` — the one path that fed a raw query to the pre-normalized engine. Coarse quantized ranking is scale-invariant in the query; brute-force and GPU paths use the full cosine formula — no other path needed changes.
- **Legacy on-disk indexes**: `file_load` re-establishes the unit-norm invariant (cosine is scale-invariant, results cannot change), behind an epsilon gate that leaves already-normalized files bitwise untouched — save/load roundtrips stay bit-identical (`hnsw_dedup_parity_tests` pins this).
- **Recovery pass 3** normalizes the WAL storage copy with the same SIMD kernel before its byte comparison, so surviving vectors still compare bit-identical and WAL-touched cosine ids are not spuriously re-upserted.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full lib suite: **5367 passed, 0 failed** (includes all recall gates)
- `crash_recovery_tests` (15), `wal_recovery_e2e_tests` (5), `recall_validation`, `hnsw_dedup_parity_tests` (7 — bitwise save/load roundtrip), `read_gate_recall_regression` — all green
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

First PR of the Tier-S optimization wave (7 planned). The production-config parity test that previously documented "NOT pre-normalized" now pins the pre-normalized configuration and asserts unit-norm graph storage.
