### PR TITLE
perf(core): one durability barrier per batch on every WAL write path

### DIFF
--- a/crates/velesdb-core/src/collection/core/bm25_durability_tests.rs
+++ b/crates/velesdb-core/src/collection/core/bm25_durability_tests.rs
@@ -365,12 +365,15 @@ fn empty_batch_does_not_touch_the_wal() {
     assert!(!wal_path(&dir).exists(), "no WAL file for an empty batch");
 }
 
-/// The single-document path keeps its per-call durability contract.
+/// `upsert` keeps its per-call durability contract at ONE barrier per call.
 ///
-/// The fix batches the BULK path; it must not silently weaken `upsert`, whose
-/// callers get one durability barrier per call.
+/// The contract callers rely on is "everything this call acknowledged is
+/// durable when it returns" — nothing is acknowledged between the points of
+/// one call, so per-document barriers bought no guarantee, only N-1 extra
+/// fsyncs (#1797). The whole batch now rides a single `wal_append_batch`
+/// barrier, same as `upsert_bulk`.
 #[test]
-fn single_document_path_keeps_its_contract() {
+fn upsert_call_gets_one_durability_barrier() {
     let dir = tempfile::tempdir().expect("temp dir");
     let col = Collection::create(PathBuf::from(dir.path()), DIM, DistanceMetric::Cosine)
         .expect("created");
@@ -379,9 +382,8 @@ fn single_document_path_keeps_its_contract() {
     res.expect("upsert");
 
     assert_eq!(
-        counts.syncs, 3,
-        "the single-document path still fsyncs per document; batching the bulk \
-         path must not have changed it"
+        counts.syncs, 1,
+        "one durability barrier covers the whole upsert call's BM25 batch"
     );
 }
 

--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -295,7 +295,7 @@ impl Collection {
     ///
     /// Points with `Some(payload)` get their text indexed; points with
     /// `None` payload get their stale BM25 entry removed. Mirrors the
-    /// contract of `update_text_index` in `crud.rs`.
+    /// contract of `bulk_update_text_index` in `crud_indexing.rs`.
     ///
     /// Issue #389: each mutation is appended to the BM25 WAL BEFORE it
     /// is applied in-memory so that a crash between the two replays
@@ -308,19 +308,29 @@ impl Collection {
         payloads: Option<&[Option<serde_json::Value>]>,
     ) -> Result<()> {
         let Some(ps) = payloads else { return Ok(()) };
+        let mut adds: Vec<(u64, String)> = Vec::new();
+        let mut removes: Vec<u64> = Vec::new();
         for (i, opt) in ps.iter().enumerate() {
             if let Some(payload) = opt {
                 let text = Self::extract_text_from_payload(payload);
                 if !text.is_empty() {
-                    #[cfg(feature = "persistence")]
-                    self.append_bm25_wal_add(ids[i], &text)?;
-                    self.storage.text_index.add_document(ids[i], &text);
+                    adds.push((ids[i], text));
                 }
             } else {
-                #[cfg(feature = "persistence")]
-                self.append_bm25_wal_remove(ids[i])?;
-                self.storage.text_index.remove_document(ids[i]);
+                removes.push(ids[i]);
             }
+        }
+        if adds.is_empty() && removes.is_empty() {
+            return Ok(());
+        }
+        // One WAL barrier for the whole batch (WAL-before-apply preserved:
+        // the in-memory index is only touched after the batch is durable).
+        self.append_text_batch_to_wal(&adds, &removes)?;
+        for (id, text) in &adds {
+            self.storage.text_index.add_document(*id, text);
+        }
+        for id in &removes {
+            self.storage.text_index.remove_document(*id);
         }
         Ok(())
     }

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -267,14 +267,21 @@ impl Collection {
             .filter(|&(i, p)| dedup_map.get(&p.id) == Some(&i) && p.payload.is_some())
             .filter_map(|(_, p)| p.payload.as_ref().map(|pl| (p.id, pl)))
             .collect();
-        storage.store_batch(&deduped)?;
+        // Deferred: the caller (`write_and_flush_payloads`) ends with
+        // `flush()`, which applies the configured durability barrier once for
+        // stores and tombstones together — `store_batch` + per-id `delete`
+        // here would fsync 1 + N_DELETED times for the same guarantee.
+        storage.store_batch_deferred(&deduped)?;
 
-        // Delete IDs whose final occurrence has payload=None
-        for (i, p) in points.iter().enumerate() {
-            if dedup_map.get(&p.id) == Some(&i) && p.payload.is_none() {
-                storage.delete(p.id)?;
-            }
-        }
+        // Delete IDs whose final occurrence has payload=None — one batched
+        // tombstone append instead of one barrier per id.
+        let final_deletes: Vec<u64> = points
+            .iter()
+            .enumerate()
+            .filter(|&(i, p)| dedup_map.get(&p.id) == Some(&i) && p.payload.is_none())
+            .map(|(_, p)| p.id)
+            .collect();
+        storage.delete_batch(&final_deletes)?;
         Ok(())
     }
 
@@ -401,6 +408,14 @@ impl Collection {
             HashMap::with_capacity(points.len());
         let skip_bm25 =
             self.storage.text_index.is_empty() && !points.iter().any(|p| p.payload.is_some());
+        // Issue #389 + #1797: WAL-before-apply at BATCH granularity — one
+        // durability barrier for the whole batch's BM25 mutations instead of
+        // one open + fsync per point. Payloads were already stored and
+        // flushed by `batch_store_all`, so the BM25 WAL never leads payload
+        // durability. A failure propagates with the in-memory index untouched.
+        if !skip_bm25 {
+            self.bulk_update_text_index(points)?;
+        }
         let needs_label_updates = Self::needs_label_updates(points, old_payloads);
         let mut label_updates = Self::alloc_label_buffer(needs_label_updates, points.len());
 
@@ -413,11 +428,6 @@ impl Collection {
                 effective_old,
                 point.payload.as_ref(),
             );
-            if !skip_bm25 {
-                // Issue #389: WAL-before-apply — failure propagates so
-                // in-memory BM25 and on-disk WAL never diverge.
-                self.update_text_index(point)?;
-            }
             Self::collect_sparse_vectors(point, &mut sparse_batch);
             if needs_label_updates {
                 label_updates.push((point.id, effective_old.cloned(), point.payload.clone()));
@@ -465,6 +475,11 @@ impl Collection {
         payload_storage.flush()?;
         drop(payload_storage);
 
+        // Issue #389 + #1797: one BM25 WAL barrier for the whole batch,
+        // sequenced after the payload flush so the BM25 WAL never leads
+        // payload durability — the same envelope as the vector upsert path.
+        self.bulk_update_text_index(&points)?;
+
         // config(1) only — payload_storage(3) and label_index(7) both released above.
         self.storage.config.write().point_count = point_count;
 
@@ -489,14 +504,32 @@ impl Collection {
         payload_storage: &mut LogPayloadStorage,
         label_idx: &mut crate::collection::graph::LabelIndex,
     ) -> Result<()> {
+        // Pass 1: resolve the old payload each occurrence would have seen in
+        // the sequential loop. Intra-batch duplicates observe the previous
+        // occurrence's payload (via `seen`), not the pre-batch value, exactly
+        // as the per-point store-then-retrieve interleaving behaved.
+        let mut seen: HashMap<u64, Option<serde_json::Value>> =
+            HashMap::with_capacity(points.len());
+        let mut effective_olds: Vec<Option<serde_json::Value>> = Vec::with_capacity(points.len());
         for point in points {
-            let old_payload = payload_storage.retrieve(point.id).ok().flatten();
-            if let Some(payload) = &point.payload {
-                payload_storage.store(point.id, payload)?;
-            } else {
-                payload_storage.delete(point.id)?;
-            }
-            self.update_text_index(point)?;
+            let old_payload = match seen.get(&point.id) {
+                Some(prev) => prev.clone(),
+                None => payload_storage.retrieve(point.id).ok().flatten(),
+            };
+            effective_olds.push(old_payload);
+            seen.insert(point.id, point.payload.clone());
+        }
+
+        // Pass 2: payload writes, last-writer-wins deduped, buffered under
+        // the caller's single `flush()` barrier — the per-point `store` +
+        // `delete` calls each carried their own fsync (#1797 shape) for the
+        // same end state and the same durability point (return of
+        // `upsert_metadata`).
+        let dedup_map = Self::build_dedup_map(points);
+        Self::write_deduped_payloads(points, payload_storage, &dedup_map)?;
+
+        // Pass 3: in-memory index maintenance, per occurrence, in order.
+        for (point, old_payload) in points.iter().zip(&effective_olds) {
             self.update_secondary_indexes_on_upsert(
                 point.id,
                 old_payload.as_ref(),

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -137,32 +137,12 @@ impl Collection {
 
     /// Updates the BM25 text index for a single point (WAL-then-apply).
     ///
-    /// Issue #389: appends the mutation to `bm25.wal` BEFORE calling
-    /// `add_document` / `remove_document` on the in-memory index so
-    /// that a crash between the two replays the mutation on next
-    /// open. WAL append errors propagate; the in-memory mutation is
-    /// skipped so in-memory and WAL state never diverge.
-    pub(super) fn update_text_index(&self, point: &Point) -> Result<()> {
-        if let Some(payload) = &point.payload {
-            let text = Self::extract_text_from_payload(payload);
-            if !text.is_empty() {
-                #[cfg(feature = "persistence")]
-                self.append_bm25_wal_add(point.id, &text)?;
-                self.storage.text_index.add_document(point.id, &text);
-            }
-        } else {
-            #[cfg(feature = "persistence")]
-            self.append_bm25_wal_remove(point.id)?;
-            self.storage.text_index.remove_document(point.id);
-        }
-        Ok(())
-    }
-
     /// Applies the BM25 side of a whole batch under ONE durability barrier.
     ///
-    /// The batched counterpart of [`Self::update_text_index`]. Calling that per
-    /// point is what cost one `open` and one `fsync` PER DOCUMENT (#1797); here
-    /// every frame goes into a single `wal_append_batch` call.
+    /// The single upsert, metadata upsert, and bulk-import paths all route
+    /// here: a per-point WAL append cost one `open` and one `fsync` PER
+    /// DOCUMENT (#1797); every frame goes into a single `wal_append_batch`
+    /// call instead.
     ///
     /// # The three cases a mixed batch contains
     ///
@@ -171,7 +151,7 @@ impl Collection {
     ///
     /// * payload carrying text → an `Add` frame;
     /// * payload with NO text  → nothing at all, no WAL entry (empty text is
-    ///   not indexed, matching [`Self::update_text_index`]);
+    ///   not indexed — an empty extraction never was);
     /// * no payload at all     → a `Remove` frame, preserving delete semantics.
     ///
     /// # Ordering
@@ -228,7 +208,11 @@ impl Collection {
     /// Non-persistence builds have no on-disk WAL, so this is a no-op there and
     /// the caller proceeds straight to the in-memory update.
     #[allow(clippy::unused_self)] // Reason: needs `self.storage.path` under `persistence`.
-    fn append_text_batch_to_wal(&self, adds: &[(u64, String)], removes: &[u64]) -> Result<()> {
+    pub(super) fn append_text_batch_to_wal(
+        &self,
+        adds: &[(u64, String)],
+        removes: &[u64],
+    ) -> Result<()> {
         #[cfg(feature = "persistence")]
         {
             use crate::index::bm25_persistence_wal::{wal_append_batch, wal_path_for_bm25, WalOp};
@@ -249,32 +233,12 @@ impl Collection {
         Ok(())
     }
 
-    /// Appends an `add_document` mutation to the BM25 WAL.
-    ///
-    /// Feature-gated — non-persistence builds have no on-disk WAL.
-    /// Callers already gate on `feature = "persistence"` when they
-    /// need crash-safety ordering.
-    #[cfg(feature = "persistence")]
-    #[inline]
-    pub(super) fn append_bm25_wal_add(&self, id: u64, text: &str) -> Result<()> {
-        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.storage.path);
-        crate::index::bm25_persistence_wal::wal_append_add_document(&wal_path, id, text)
-    }
-
-    /// Appends a `remove_document` mutation to the BM25 WAL.
-    #[cfg(feature = "persistence")]
-    #[inline]
-    pub(super) fn append_bm25_wal_remove(&self, id: u64) -> Result<()> {
-        let wal_path = crate::index::bm25_persistence_wal::wal_path_for_bm25(&self.storage.path);
-        crate::index::bm25_persistence_wal::wal_append_remove_document(&wal_path, id)
-    }
-
     /// Appends `remove_document` mutations for a whole batch to the BM25 WAL
     /// under ONE durability barrier.
     ///
-    /// Batched counterpart of [`Self::append_bm25_wal_remove`]: calling that
-    /// in a loop pays one `open` + one fsync PER ID (the #1797 failure mode,
-    /// resurfacing on the delete path — finding C3). The frames are identical
+    /// Calling a single-frame append in a loop pays one `open` + one fsync
+    /// PER ID (the #1797 failure mode, resurfacing on the delete path —
+    /// finding C3). The frames are identical
     /// to N sequential appends; only the syscall count differs. Callers keep
     /// WAL-before-apply at batch granularity: let this return `Ok` first,
     /// then remove the documents from the in-memory index.
@@ -309,23 +273,40 @@ impl Collection {
     where
         I: IntoIterator<Item = (&'a str, u64, &'a crate::index::sparse::SparseVector)>,
     {
-        // Cache wal_path across consecutive entries sharing the same index name
-        // so callers that yield entries grouped by name (e.g. apply_sparse_batch_bulk)
-        // retain the O(N_NAMES) path-resolution cost of the pre-refactor code
-        // rather than paying O(N_ENTRIES). Mixed-name callers degrade gracefully
-        // to one resolution per entry, matching the original per-triple cost.
-        let mut cached: Option<(&'a str, std::path::PathBuf)> = None;
+        // Group consecutive entries sharing the same index name into one
+        // `wal_append_upsert_batch` call: one `open` and one fsync per run
+        // instead of per entry (#1797 shape). Callers yield entries grouped
+        // by name (e.g. `apply_sparse_batch_bulk`), so a batch touching K
+        // index names pays exactly K barriers. Mixed-name callers degrade
+        // gracefully to one barrier per run boundary.
+        let mut run_name: Option<&'a str> = None;
+        let mut run: Vec<(u64, &'a crate::index::sparse::SparseVector)> = Vec::new();
         for (name, point_id, sv) in entries {
-            if cached.as_ref().map(|(cached_name, _)| *cached_name) != Some(name) {
-                let wal_path =
-                    crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
-                cached = Some((name, wal_path));
+            if run_name != Some(name) {
+                if let Some(prev) = run_name.take() {
+                    self.flush_sparse_wal_run(prev, &run)?;
+                    run.clear();
+                }
+                run_name = Some(name);
             }
-            let Some((_, wal_path)) = cached.as_ref() else {
-                continue;
-            };
-            crate::index::sparse::persistence::wal_append_upsert(wal_path, point_id, sv)?;
+            run.push((point_id, sv));
         }
+        if let Some(prev) = run_name {
+            self.flush_sparse_wal_run(prev, &run)?;
+        }
+        Ok(())
+    }
+
+    /// Writes one same-name run of sparse upserts under a single WAL barrier.
+    #[cfg(feature = "persistence")]
+    fn flush_sparse_wal_run(
+        &self,
+        name: &str,
+        run: &[(u64, &crate::index::sparse::SparseVector)],
+    ) -> Result<()> {
+        let wal_path =
+            crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
+        crate::index::sparse::persistence::wal_append_upsert_batch(&wal_path, run)?;
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -339,12 +339,13 @@ impl Collection {
         let indexes = self.query.sparse_indexes.write();
         #[cfg(feature = "persistence")]
         {
+            // One barrier per index name instead of one per (name, id): the
+            // nested single-append loop cost N_NAMES x N_IDS fsyncs, all held
+            // under the exclusive `sparse_indexes` guard above.
             for name in indexes.keys() {
                 let wal_path =
                     crate::index::sparse::persistence::wal_path_for_name(&self.storage.path, name);
-                for &id in ids {
-                    crate::index::sparse::persistence::wal_append_delete(&wal_path, id)?;
-                }
+                crate::index::sparse::persistence::wal_append_delete_batch(&wal_path, ids)?;
             }
         }
         for idx in indexes.values() {

--- a/crates/velesdb-core/src/index/bm25_persistence_wal.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence_wal.rs
@@ -69,6 +69,8 @@ pub(crate) fn wal_path_for_bm25(dir: &Path) -> PathBuf {
 /// written, or if the text is too large to encode in a `u32`-prefixed
 /// entry.
 #[inline]
+#[cfg(test)] // Production paths batch through `wal_append_batch`; the
+             // single-frame writer remains as the replay tests' reference encoder.
 pub(crate) fn wal_append_add_document(wal_path: &Path, id: u64, text: &str) -> Result<()> {
     let text_bytes = text.as_bytes();
     let text_len = encode_text_len(text_bytes)?;
@@ -215,6 +217,7 @@ fn write_op_frame(w: &mut std::io::BufWriter<std::fs::File>, op: WalOp<'_>) -> R
 /// Returns [`Error::Index`] if the WAL file cannot be opened or
 /// written.
 #[inline]
+#[cfg(test)] // See `wal_append_add_document` — reference encoder for tests.
 pub(crate) fn wal_append_remove_document(wal_path: &Path, id: u64) -> Result<()> {
     let body_len = u32::try_from(REMOVE_ENTRY_HEADER)
         .map_err(|_| Error::Index("BM25 WAL: remove header too large".to_string()))?;

--- a/crates/velesdb-core/src/index/sparse/persistence.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence.rs
@@ -36,7 +36,10 @@ use crate::error::{Error, Result};
 use crate::storage::atomic_write::{atomic_write, atomic_write_with};
 
 // Re-export WAL operations for backward compatibility.
-pub use super::persistence_wal::{wal_append_delete, wal_append_upsert, wal_replay};
+pub use super::persistence_wal::{
+    wal_append_delete, wal_append_delete_batch, wal_append_upsert, wal_append_upsert_batch,
+    wal_replay,
+};
 
 // WAL constants are in persistence_wal.rs
 

--- a/crates/velesdb-core/src/index/sparse/persistence_wal.rs
+++ b/crates/velesdb-core/src/index/sparse/persistence_wal.rs
@@ -52,6 +52,56 @@ pub(super) fn read_le_f32(data: &[u8], pos: usize, context: &str) -> Result<f32>
 // WAL write operations
 // ---------------------------------------------------------------------------
 
+/// Appends a batch of upsert entries under ONE open + ONE durability barrier.
+///
+/// The batched counterpart of [`wal_append_upsert`]: calling that in a loop
+/// costs one `open` and one fsync PER ENTRY; here every frame is buffered
+/// through a single writer and `flush_wal` runs once at the end. Frame
+/// encoding is byte-identical to the single-entry path, so replay cannot
+/// tell them apart. An empty batch writes nothing and never opens the file.
+///
+/// # Errors
+///
+/// Returns an error if the WAL file cannot be opened or written. Entries
+/// buffered before the error are only durable up to the last completed
+/// `flush_wal`, exactly like a crash between single-entry appends.
+pub fn wal_append_upsert_batch(wal_path: &Path, entries: &[(u64, &SparseVector)]) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let mut w = open_wal_writer(wal_path)?;
+    for (point_id, vector) in entries {
+        #[allow(clippy::cast_possible_truncation)] // nnz bounded by sparse vector dimension count
+        let nnz = vector.nnz() as u32;
+        let total_len = compute_upsert_entry_len(nnz)?;
+        write_upsert_header(&mut w, total_len, *point_id, nnz)?;
+        write_term_value_pairs(&mut w, &vector.indices, &vector.values)?;
+    }
+    flush_wal(&mut w, wal_path)
+}
+
+/// Appends a batch of delete entries under ONE open + ONE durability barrier.
+///
+/// The batched counterpart of [`wal_append_delete`], with the same frame
+/// encoding; see [`wal_append_upsert_batch`] for the batching contract.
+///
+/// # Errors
+///
+/// Returns an error if the WAL file cannot be opened or written.
+pub fn wal_append_delete_batch(wal_path: &Path, ids: &[u64]) -> Result<()> {
+    if ids.is_empty() {
+        return Ok(());
+    }
+    let total_len: u32 = 1 + 8;
+    let mut w = open_wal_writer(wal_path)?;
+    for &point_id in ids {
+        wal_write(&mut w, &total_len.to_le_bytes())?;
+        wal_write(&mut w, &[WAL_OP_DELETE])?;
+        wal_write(&mut w, &point_id.to_le_bytes())?;
+    }
+    flush_wal(&mut w, wal_path)
+}
+
 /// Appends an upsert entry to the sparse WAL.
 ///
 /// # Errors


### PR DESCRIPTION
## Description

Tier-S findings from the storage/concurrency perf audit: four write paths paid **one `open` + one fsync per item** where the durability guarantee callers actually rely on — *everything acknowledged by the call is durable when it returns* — needs exactly **one barrier per call**:

- **`upsert()` BM25**: routed through the per-point WAL path even though the batch API existed and `upsert_bulk` already used it — a 1000-point text batch cost 1000 opens + 1000 fsyncs. Both `upsert()` and `upsert_metadata()` now call `bulk_update_text_index`, sequenced **after** the payload flush so the BM25 WAL never leads payload durability (same envelope as `upsert_bulk`). `bulk_import`'s raw path batches the same way. Dead single-point helpers removed; the single-frame encoders survive `cfg(test)`-gated as the replay tests' reference.
- **Sparse WAL**: had no batch writers at all. `wal_append_upsert_batch` / `wal_append_delete_batch` write N frames under one open + one `flush_wal`, **byte-identical to N single appends for replay**. The upsert path groups same-name runs (K barriers for K index names); the delete path drops its N_NAMES × N_IDS fsync nest — previously held under the exclusive `sparse_indexes` guard, blocking every sparse query for the duration.
- **`upsert_metadata`**: stored payloads one-at-a-time (one fsync each) under two write locks. Now resolves per-occurrence old payloads first (intra-batch duplicate semantics preserved via a seen-map, exactly as the sequential interleaving behaved), then writes one deferred store batch + one tombstone batch under the caller's single `flush()` barrier.
- **Vector upsert payload tail**: per-id tombstone fsync → `delete_batch`.

The BM25 durability contract test pinned the old per-document fsync count; its own doc comment stated the real contract ("one durability barrier per call"), which the assertion now matches.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full lib suite: **5367 passed, 0 failed** (includes all BM25/sparse durability suites)
- `crash_recovery_tests` (15), `wal_recovery_e2e_tests` (5), `secondary_index_persistence` (13) — green
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Second PR of the Tier-S wave. Deliberately **not** wired here: the dormant `WalBatcher` group-commit front (cross-caller amortization) — that changes single-op latency semantics and deserves its own PR with its own bench; the batch APIs above capture the O(N)→O(1) win without touching them.
