### PR TITLE
perf(core): drop the per-read fstat; memoize MATCH payload reads per query

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs
@@ -77,6 +77,9 @@ impl Collection {
             metric,
             vector_guard: &vector_storage,
             payload_guard: &payload_storage,
+            payload_memo: crate::collection::search::query::match_exec::PayloadMemo::new(
+                &payload_storage,
+            ),
         };
         let ids = vector_storage.ids();
         let mut graph_cache = GraphMatchEvalCache::default();

--- a/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/aggregation/mod.rs
@@ -230,6 +230,9 @@ impl Collection {
             metric,
             vector_guard: &vector_storage,
             payload_guard: &payload_storage,
+            payload_memo: crate::collection::search::query::match_exec::PayloadMemo::new(
+                &payload_storage,
+            ),
         };
         let ids: Vec<u64> = vector_storage.ids();
 

--- a/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/expand.rs
@@ -199,7 +199,7 @@ impl Collection {
         let Some(node) = walk.pattern.nodes.get(rel_idx + 1) else {
             return Ok(());
         };
-        if !Self::node_matches_bound_pattern(node_id, node, walk.ctx.guards.payload_guard) {
+        if !Self::node_matches_bound_pattern(node_id, node, &walk.ctx.guards.payload_memo) {
             return Ok(());
         }
         let inserted = Self::bind_node_alias(walk.bindings, node, node_id);
@@ -244,7 +244,7 @@ impl Collection {
             walk.edge_bindings,
             walk.edge_paths,
             &walk.ctx.match_clause.return_clause,
-            walk.ctx.guards.payload_guard,
+            &walk.ctx.guards.payload_memo,
         );
         walk.ctx.all_results.push(result);
         Ok(())

--- a/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/mod.rs
@@ -23,7 +23,7 @@ use crate::collection::types::Collection;
 use crate::distance::DistanceMetric;
 use crate::error::{Error, Result};
 use crate::guardrails::QueryContext;
-use crate::storage::{LogPayloadStorage, MmapStorage};
+use crate::storage::{LogPayloadStorage, MmapStorage, PayloadStorage as _};
 use crate::velesql::{GraphPattern, MatchClause};
 use std::collections::{HashMap, HashSet};
 
@@ -51,6 +51,58 @@ pub(in crate::collection::search::query) struct MatchStorageGuards<'a> {
     pub(in crate::collection::search::query) vector_guard: &'a MmapStorage,
     /// `payload_storage` read guard (rank 3).
     pub(in crate::collection::search::query) payload_guard: &'a LogPayloadStorage,
+    /// Query-lifetime payload memo over `payload_guard` (see [`PayloadMemo`]).
+    pub(in crate::collection::search::query) payload_memo: PayloadMemo<'a>,
+}
+
+/// Query-lifetime memo of payload reads during MATCH traversal.
+///
+/// A k-hop pattern re-reads the same node payload once per hop candidacy
+/// check, once per WHERE leaf, and once per RETURN item — each a positional
+/// disk read plus a full JSON deserialize. Bindings repeat across those
+/// stages, so one memoized `Arc` per node id turns the repeats into pointer
+/// clones.
+///
+/// Deliberately NOT used by the start-node full scan: that pass touches every
+/// candidate id exactly once, so caching it would grow the memo to the
+/// collection size for zero reuse. The memo fills from the ids traversal
+/// actually binds, which bounds it by the visited-binding set.
+///
+/// `RefCell` is sound here: MATCH traversal is single-threaded per query (the
+/// guards bundle is `!Sync` by construction and never crosses threads).
+pub(in crate::collection::search::query) struct PayloadMemo<'a> {
+    storage: &'a LogPayloadStorage,
+    cache:
+        std::cell::RefCell<rustc_hash::FxHashMap<u64, Option<std::sync::Arc<serde_json::Value>>>>,
+}
+
+impl<'a> PayloadMemo<'a> {
+    pub(in crate::collection::search::query) fn new(storage: &'a LogPayloadStorage) -> Self {
+        Self {
+            storage,
+            cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+        }
+    }
+
+    /// Returns the payload for `id`, reading and deserializing at most once
+    /// per query. `None` (absent payload) is memoized too — repeat probes of
+    /// payload-less nodes are as common as hits during traversal.
+    pub(in crate::collection::search::query) fn get(
+        &self,
+        id: u64,
+    ) -> Option<std::sync::Arc<serde_json::Value>> {
+        if let Some(hit) = self.cache.borrow().get(&id) {
+            return hit.clone();
+        }
+        let loaded = self
+            .storage
+            .retrieve(id)
+            .ok()
+            .flatten()
+            .map(std::sync::Arc::new);
+        self.cache.borrow_mut().insert(id, loaded.clone());
+        loaded
+    }
 }
 
 /// Result of a MATCH query traversal.
@@ -294,6 +346,7 @@ impl Collection {
             metric,
             vector_guard: &vector_guard,
             payload_guard: &payload_guard,
+            payload_memo: PayloadMemo::new(&payload_guard),
         };
         self.execute_match_with_guards(match_clause, params, ctx, &guards)
     }
@@ -459,7 +512,7 @@ impl Collection {
                 &HashMap::new(),
                 &HashMap::new(),
                 &ctx.match_clause.return_clause,
-                ctx.guards.payload_guard,
+                &ctx.guards.payload_memo,
             );
             ctx.all_results.push(result);
         }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/similarity.rs
@@ -14,7 +14,7 @@ use crate::collection::expiry::{is_payload_expired, now_unix_secs};
 use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::SearchResult;
-use crate::storage::{LogPayloadStorage, PayloadStorage, VectorStorage};
+use crate::storage::{PayloadStorage, VectorStorage};
 use crate::validation::validate_dimension_match;
 use std::collections::HashMap;
 
@@ -24,7 +24,7 @@ struct ProjectionCtx<'a> {
     edge_bindings: &'a HashMap<String, u64>,
     edge_paths: &'a HashMap<String, Vec<u64>>,
     score: Option<f32>,
-    payload_guard: &'a LogPayloadStorage,
+    memo: &'a super::PayloadMemo<'a>,
 }
 
 /// Output key of a RETURN item: its `AS` alias, or the raw expression.
@@ -47,13 +47,13 @@ impl Collection {
     /// per-node lock acquisitions during traversal. `edge_bindings` maps
     /// relationship aliases to traversed edge ids so `RETURN r.prop`
     /// projects the EDGE's property (audit 2026-06 F).
-    pub(crate) fn project_properties(
+    pub(in crate::collection::search::query) fn project_properties(
         &self,
         bindings: &HashMap<String, u64>,
         edge_bindings: &HashMap<String, u64>,
         edge_paths: &HashMap<String, Vec<u64>>,
         return_clause: &crate::velesql::ReturnClause,
-        payload_guard: &LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
     ) -> HashMap<String, serde_json::Value> {
         self.project_properties_with_score(
             bindings,
@@ -61,7 +61,7 @@ impl Collection {
             edge_paths,
             return_clause,
             None,
-            payload_guard,
+            memo,
         )
     }
 
@@ -71,21 +71,21 @@ impl Collection {
     /// When `score` is `Some`, `RETURN similarity()` injects it into the
     /// projected map. All other variants work identically to
     /// [`project_properties`].
-    pub(crate) fn project_properties_with_score(
+    pub(in crate::collection::search::query) fn project_properties_with_score(
         &self,
         bindings: &HashMap<String, u64>,
         edge_bindings: &HashMap<String, u64>,
         edge_paths: &HashMap<String, Vec<u64>>,
         return_clause: &crate::velesql::ReturnClause,
         score: Option<f32>,
-        payload_guard: &LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
     ) -> HashMap<String, serde_json::Value> {
         let ctx = ProjectionCtx {
             bindings,
             edge_bindings,
             edge_paths,
             score,
-            payload_guard,
+            memo,
         };
         let mut projected = HashMap::new();
         for item in &return_clause.items {
@@ -103,7 +103,7 @@ impl Collection {
     ) {
         match parse_projection_item(&item.expression) {
             ProjectionItem::Wildcard => {
-                Self::project_wildcard(ctx.bindings, ctx.payload_guard, projected);
+                Self::project_wildcard(ctx.bindings, ctx.memo, projected);
             }
             ProjectionItem::FunctionCall(name) => {
                 if let ("similarity", Some(s)) = (name, ctx.score) {
@@ -122,7 +122,7 @@ impl Collection {
                 if let Some(edge_ids) = ctx.edge_paths.get(alias) {
                     projected.insert(projection_key(item), serde_json::json!(edge_ids));
                 } else {
-                    Self::project_bare_alias(alias, ctx.bindings, ctx.payload_guard, projected);
+                    Self::project_bare_alias(alias, ctx.bindings, ctx.memo, projected);
                 }
             }
         }
@@ -145,14 +145,7 @@ impl Collection {
         } else if let Some(edge_ids) = ctx.edge_paths.get(alias) {
             self.project_edge_path_property(edge_ids, property, item, projected);
         } else {
-            Self::project_property_path(
-                alias,
-                property,
-                item,
-                ctx.bindings,
-                ctx.payload_guard,
-                projected,
-            );
+            Self::project_property_path(alias, property, item, ctx.bindings, ctx.memo, projected);
         }
     }
 
@@ -201,11 +194,11 @@ impl Collection {
     /// Projects ALL properties from ALL bound nodes into the result (RETURN *).
     fn project_wildcard(
         bindings: &HashMap<String, u64>,
-        payload_storage: &crate::storage::LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
         projected: &mut HashMap<String, serde_json::Value>,
     ) {
         for (alias, &node_id) in bindings {
-            Self::project_all_node_properties(alias, node_id, payload_storage, projected);
+            Self::project_all_node_properties(alias, node_id, memo, projected);
         }
     }
 
@@ -214,10 +207,10 @@ impl Collection {
     fn project_all_node_properties(
         alias: &str,
         node_id: u64,
-        payload_storage: &crate::storage::LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
         projected: &mut HashMap<String, serde_json::Value>,
     ) {
-        let Ok(Some(payload)) = payload_storage.retrieve(node_id) else {
+        let Some(payload) = memo.get(node_id) else {
             return;
         };
         if let Some(map) = payload.as_object() {
@@ -233,13 +226,13 @@ impl Collection {
         property: &str,
         item: &crate::velesql::ReturnItem,
         bindings: &HashMap<String, u64>,
-        payload_storage: &crate::storage::LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
         projected: &mut HashMap<String, serde_json::Value>,
     ) {
         let Some(&node_id) = bindings.get(alias) else {
             return;
         };
-        let Ok(Some(payload)) = payload_storage.retrieve(node_id) else {
+        let Some(payload) = memo.get(node_id) else {
             return;
         };
         let Some(payload_map) = payload.as_object() else {
@@ -254,13 +247,13 @@ impl Collection {
     fn project_bare_alias(
         alias: &str,
         bindings: &HashMap<String, u64>,
-        payload_storage: &crate::storage::LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
         projected: &mut HashMap<String, serde_json::Value>,
     ) {
         let Some(&node_id) = bindings.get(alias) else {
             return;
         };
-        Self::project_all_node_properties(alias, node_id, payload_storage, projected);
+        Self::project_all_node_properties(alias, node_id, memo, projected);
     }
 
     /// Gets a nested property from a JSON object (EPIC-058 US-007).
@@ -335,12 +328,13 @@ impl Collection {
         // reversed here. See .investigation/http-deadlock-2026-07-22/.
         let vector_storage = self.storage.vector_storage.read();
         let payload_guard = self.storage.payload_storage.read();
+        let memo = super::PayloadMemo::new(&payload_guard);
         let higher_is_better = metric.higher_is_better();
 
         let mut scored_results = self.score_match_results(
             results,
             &vector_storage,
-            &payload_guard,
+            &memo,
             match_clause,
             query_vector,
             expected_dimension,
@@ -379,7 +373,7 @@ impl Collection {
         &self,
         results: Vec<MatchResult>,
         vector_storage: &crate::storage::MmapStorage,
-        payload_guard: &LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
         match_clause: &crate::velesql::MatchClause,
         query_vector: &[f32],
         expected_dimension: usize,
@@ -409,7 +403,7 @@ impl Collection {
                         &result.edge_paths,
                         &match_clause.return_clause,
                         Some(score),
-                        payload_guard,
+                        memo,
                     );
                     scored_results.push(result);
                 }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/start_nodes.rs
@@ -164,12 +164,7 @@ impl Collection {
             return true;
         }
         let payload_opt = payload_storage.retrieve(id).ok().flatten();
-        if !node.labels.is_empty() && !Self::node_matches_labels(payload_opt.as_ref(), &node.labels)
-        {
-            return false;
-        }
-        node.properties.is_empty()
-            || Self::node_matches_properties(payload_opt.as_ref(), &node.properties)
+        Self::payload_matches_pattern(payload_opt.as_ref(), node)
     }
 
     /// Returns true if a bound node satisfies its pattern.
@@ -179,13 +174,29 @@ impl Collection {
     pub(super) fn node_matches_bound_pattern(
         id: u64,
         node: &NodePattern,
-        payload_storage: &crate::storage::LogPayloadStorage,
+        memo: &super::PayloadMemo<'_>,
     ) -> bool {
         if node.collection.is_some() {
             return true;
         }
         let needs_payload = !node.properties.is_empty() || !node.labels.is_empty();
-        Self::node_matches_pattern(id, node, needs_payload, payload_storage)
+        if !needs_payload {
+            return true;
+        }
+        // Bound-node checks repeat per hop candidacy: read through the memo.
+        let payload_opt = memo.get(id);
+        Self::payload_matches_pattern(payload_opt.as_deref(), node)
+    }
+
+    /// Label + property check against an already-loaded payload.
+    fn payload_matches_pattern(
+        payload_opt: Option<&serde_json::Value>,
+        node: &NodePattern,
+    ) -> bool {
+        if !node.labels.is_empty() && !Self::node_matches_labels(payload_opt, &node.labels) {
+            return false;
+        }
+        node.properties.is_empty() || Self::node_matches_properties(payload_opt, &node.properties)
     }
 
     /// Builds a `(node_id, bindings)` pair for a start node.

--- a/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/vector_first.rs
@@ -95,6 +95,7 @@ impl Collection {
             metric,
             vector_guard: &vector_guard,
             payload_guard: &payload_guard,
+            payload_memo: super::PayloadMemo::new(&payload_guard),
         };
         let mut results = Vec::new();
         let mut examined = 0u64;
@@ -163,7 +164,7 @@ impl Collection {
             &mr.edge_paths,
             &match_clause.return_clause,
             Some(candidate.score),
-            guards.payload_guard,
+            &guards.payload_memo,
         );
         Ok(Some(mr))
     }

--- a/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_exec/where_eval.rs
@@ -9,7 +9,7 @@ use crate::collection::graph::GraphEdge;
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::filter;
-use crate::storage::{PayloadStorage, VectorStorage};
+use crate::storage::VectorStorage;
 use std::collections::HashMap;
 
 /// Applies an ordering comparison operator to an `Ord` pair.
@@ -289,8 +289,7 @@ impl Collection {
 
         let target_id = resolve_target_id(&cmp.column, ctx.bindings, ctx.node_id);
 
-        let Some(target_payload) = ctx.guards.payload_guard.retrieve(target_id).ok().flatten()
-        else {
+        let Some(target_payload) = ctx.guards.payload_memo.get(target_id) else {
             return Ok(false);
         };
 
@@ -353,7 +352,7 @@ impl Collection {
             resolve_target_id(col, ctx.bindings, ctx.node_id)
         });
 
-        let Some(payload) = ctx.guards.payload_guard.retrieve(target_id).ok().flatten() else {
+        let Some(payload) = ctx.guards.payload_memo.get(target_id) else {
             return Ok(false);
         };
 

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -497,7 +497,12 @@ impl PayloadStorage for LogPayloadStorage {
         // runs fully outside the lock.
         let payload_bytes = {
             let reader = self.reader.read();
-            let file_len = reader.metadata()?.len();
+            // `write_offset` is the tracked WAL length: every append advances
+            // it under the write path's lock and every entry lives strictly
+            // below it, so it is a valid out-of-bounds guard for positional
+            // reads — without paying a `metadata()` (fstat) syscall on every
+            // single payload hydration.
+            let file_len = *self.write_offset.read();
             read_length_prefixed_payload(&reader, offset, file_len)?
         };
 


### PR DESCRIPTION
## Description

Tier-S findings converged on by 3 of the 4 audit domains — two compounding costs on every payload hydration:

- **One `fstat` syscall per payload read.** `LogPayloadStorage::retrieve` called `reader.metadata()` on every read, purely as an out-of-bounds guard for the positional read. The WAL length is already tracked in-process (`write_offset` advances under the write path's lock; every entry lives strictly below it), so the guard now reads the atomic. A k=100 hydration drops from 100 fstat + 200 pread to 200 pread — and this benefits **every** consumer (search, filters, aggregations, JOIN, MATCH), not just one path.

- **MATCH re-read the same payload 5–10× per binding.** Once per hop candidacy check, once per WHERE leaf, once per RETURN item — each a positional disk read plus a full JSON deserialize. `MatchStorageGuards` now carries a `PayloadMemo`: one `Arc<Value>` per node id for the query's lifetime, absent payloads memoized too. The start-node full scan deliberately bypasses the memo (single pass over every candidate — caching it would grow the memo to collection size for zero reuse); the memo fills from the ids traversal actually binds, bounding it by the visited-binding set. `RefCell` is sound: MATCH execution is single-threaded per query, and the bundle being `!Sync` makes the **compiler** enforce that claim.

The projection chain (`ProjectionCtx` + helpers) reads through the memo; the post-traversal similarity scoring pass builds its own memo over its locally-held guard.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full lib suite: **5367 passed, 0 failed** (isolated rerun after a contention flake from two concurrent suites)
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Third PR of the Tier-S wave (after #2058 cosine kernel, #2059 WAL batching).
