### PR TITLE
perf(core): prebuilt roaring buckets in the secondary index; ordered AND fold

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/crud_helpers.rs
@@ -202,10 +202,8 @@ impl Collection {
         match index {
             SecondaryIndex::BTree(tree) => {
                 let mut tree = tree.write();
-                let ids = tree.entry(key).or_default();
-                if !ids.contains(&id) {
-                    ids.push(id);
-                }
+                // Set semantics: no O(k) contains() scan per insert.
+                tree.entry(key).or_default().insert(id);
             }
         }
     }
@@ -216,7 +214,7 @@ impl Collection {
             SecondaryIndex::BTree(tree) => {
                 let mut tree = tree.write();
                 if let Some(ids) = tree.get_mut(key) {
-                    ids.retain(|existing| *existing != id);
+                    ids.remove(id);
                     if ids.is_empty() {
                         tree.remove(key);
                     }

--- a/crates/velesdb-core/src/collection/core/index_management.rs
+++ b/crates/velesdb-core/src/collection/core/index_management.rs
@@ -105,13 +105,6 @@ impl Collection {
         for id in ids {
             Self::backfill_single_payload(&*payload_storage, id, field_name, &mut tree_guard);
         }
-        // Deduplicate each bucket in one O(k log k) pass rather than checking
-        // contains() per-insertion (was O(k) per insert → O(k²) total for a
-        // bucket of k IDs, e.g. low-cardinality fields like status/category).
-        for ids_vec in tree_guard.values_mut() {
-            ids_vec.sort_unstable();
-            ids_vec.dedup();
-        }
         if !is_new {
             tracing::debug!(
                 field = field_name,
@@ -127,12 +120,12 @@ impl Collection {
         payload_storage: &dyn crate::storage::PayloadStorage,
         id: u64,
         field_name: &str,
-        tree_guard: &mut std::collections::BTreeMap<JsonValue, Vec<u64>>,
+        tree_guard: &mut std::collections::BTreeMap<JsonValue, crate::index::secondary::IdSet>,
     ) {
         if let Ok(Some(payload)) = payload_storage.retrieve(id) {
             if let Some(val) = payload.get(field_name) {
                 if let Some(key) = JsonValue::from_json(val) {
-                    tree_guard.entry(key).or_default().push(id);
+                    tree_guard.entry(key).or_default().insert(id);
                 }
             }
         }
@@ -323,7 +316,10 @@ impl Collection {
         let indexes = self.query.secondary_indexes.read();
         let index = indexes.get(field_name)?;
         match index {
-            SecondaryIndex::BTree(tree) => tree.read().get(value).cloned(),
+            SecondaryIndex::BTree(tree) => tree
+                .read()
+                .get(value)
+                .map(crate::index::secondary::IdSet::to_vec),
         }
     }
 
@@ -481,16 +477,25 @@ impl Collection {
         indexes: &SecondaryIndexMap,
         conditions: &[crate::filter::Condition],
     ) -> Option<roaring::RoaringBitmap> {
-        let mut result: Option<roaring::RoaringBitmap> = None;
-        for cond in conditions {
-            if let Some(bm) = Self::bitmap_from_condition(indexes, cond) {
-                result = Some(match result {
-                    Some(existing) => existing & &bm,
-                    None => bm,
-                });
+        // Children that cannot be pre-filtered are skipped: for AND that
+        // yields a superset bitmap, which the post-filter narrows — same
+        // contract as before. Intersect smallest-first and in place: the
+        // AST-order fold allocated a fresh bitmap per child and could grind
+        // a 10-row Eq child against a million-row range child first.
+        let mut bitmaps: Vec<roaring::RoaringBitmap> = conditions
+            .iter()
+            .filter_map(|cond| Self::bitmap_from_condition(indexes, cond))
+            .collect();
+        bitmaps.sort_unstable_by_key(roaring::RoaringBitmap::len);
+        let mut iter = bitmaps.into_iter();
+        let mut result = iter.next()?;
+        for bm in iter {
+            result &= &bm;
+            if result.is_empty() {
+                break;
             }
         }
-        result
+        Some(result)
     }
 
     /// Unions bitmaps from OR-ed conditions.

--- a/crates/velesdb-core/src/collection/core/index_management_tests.rs
+++ b/crates/velesdb-core/src/collection/core/index_management_tests.rs
@@ -214,7 +214,7 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 5, 10],
+                    vec![1, 5, 10].into(),
                 );
             }
         }
@@ -250,14 +250,14 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 5, 10, 20],
+                    vec![1, 5, 10, 20].into(),
                 );
             }
             if let Some(crate::index::SecondaryIndex::BTree(tree)) = indexes.get("status") {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("active".to_string()),
-                    vec![5, 10, 30],
+                    vec![5, 10, 30].into(),
                 );
             }
         }
@@ -302,7 +302,7 @@ mod tests {
             for (price, id) in [(10, 1u64), (20, 2), (30, 3), (40, 4), (50, 5)] {
                 t.insert(
                     crate::index::JsonValue::Number(F64Key::from(f64::from(price))),
-                    vec![id],
+                    vec![id].into(),
                 );
             }
         }
@@ -496,11 +496,11 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 5],
+                    vec![1, 5].into(),
                 );
                 t.insert(
                     crate::index::JsonValue::String("science".to_string()),
-                    vec![3, 7],
+                    vec![3, 7].into(),
                 );
             }
         }
@@ -546,7 +546,7 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 5],
+                    vec![1, 5].into(),
                 );
             }
         }
@@ -606,11 +606,11 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 5, 10],
+                    vec![1, 5, 10].into(),
                 );
                 t.insert(
                     crate::index::JsonValue::String("science".to_string()),
-                    vec![2, 7],
+                    vec![2, 7].into(),
                 );
             }
         }
@@ -649,7 +649,7 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, 2, 3, 4, 5],
+                    vec![1, 2, 3, 4, 5].into(),
                 );
             }
         }
@@ -711,13 +711,16 @@ mod tests {
             let mut t = tree.write();
             t.insert(
                 crate::index::JsonValue::String("tech".to_string()),
-                vec![1, 5, 10],
+                vec![1, 5, 10].into(),
             );
             t.insert(
                 crate::index::JsonValue::String("science".to_string()),
-                vec![2, 7],
+                vec![2, 7].into(),
             );
-            t.insert(crate::index::JsonValue::String("art".to_string()), vec![3]);
+            t.insert(
+                crate::index::JsonValue::String("art".to_string()),
+                vec![3].into(),
+            );
         }
     }
 
@@ -871,7 +874,7 @@ mod tests {
                 let mut t = tree.write();
                 t.insert(
                     crate::index::JsonValue::String("tech".to_string()),
-                    vec![1, large_id, 5],
+                    vec![1, large_id, 5].into(),
                 );
             }
         }

--- a/crates/velesdb-core/src/index/secondary/bitmap_tests.rs
+++ b/crates/velesdb-core/src/index/secondary/bitmap_tests.rs
@@ -1,8 +1,8 @@
-//! Tests for `SecondaryIndex::to_bitmap` and `ids_to_bitmap`.
+//! Tests for `SecondaryIndex::to_bitmap` over `IdSet` buckets.
 
 #[cfg(test)]
 mod tests {
-    use crate::index::secondary::{JsonValue, SecondaryIndex};
+    use crate::index::secondary::{IdSet, JsonValue, SecondaryIndex};
     use parking_lot::RwLock;
     use std::collections::BTreeMap;
 
@@ -10,7 +10,11 @@ mod tests {
     fn make_btree_index(entries: Vec<(JsonValue, Vec<u64>)>) -> SecondaryIndex {
         let mut tree = BTreeMap::new();
         for (key, ids) in entries {
-            tree.insert(key, ids);
+            let mut set = IdSet::default();
+            for id in ids {
+                set.insert(id);
+            }
+            tree.insert(key, set);
         }
         SecondaryIndex::BTree(RwLock::new(tree))
     }

--- a/crates/velesdb-core/src/index/secondary/mod.rs
+++ b/crates/velesdb-core/src/index/secondary/mod.rs
@@ -98,11 +98,86 @@ impl JsonValue {
     }
 }
 
+/// One equal-key bucket of a secondary index.
+///
+/// The common case lives in a prebuilt [`roaring::RoaringBitmap`], so
+/// pre-filter reads are bitmap clones and unions instead of one roaring
+/// insert per id per query (the pre-fix shape rebuilt a 500k-row range
+/// bitmap on every execution). Ids above `u32::MAX` — unrepresentable in
+/// roaring — live in the sorted `overflow` side list; its non-emptiness is
+/// exactly the "incomplete bitmap" condition that [`SecondaryIndex::to_bitmap`]
+/// reports as `None`. Insert/remove are set operations, so buckets need no
+/// dedup or sort passes and iteration is ascending by construction
+/// (every overflow id exceeds every bitmap id).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct IdSet {
+    bitmap: roaring::RoaringBitmap,
+    overflow: Vec<u64>,
+}
+
+impl IdSet {
+    pub(crate) fn insert(&mut self, id: u64) {
+        match u32::try_from(id) {
+            Ok(id32) => {
+                self.bitmap.insert(id32);
+            }
+            Err(_) => {
+                if let Err(pos) = self.overflow.binary_search(&id) {
+                    self.overflow.insert(pos, id);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn remove(&mut self, id: u64) {
+        match u32::try_from(id) {
+            Ok(id32) => {
+                self.bitmap.remove(id32);
+            }
+            Err(_) => {
+                if let Ok(pos) = self.overflow.binary_search(&id) {
+                    self.overflow.remove(pos);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.bitmap.is_empty() && self.overflow.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        usize::try_from(self.bitmap.len()).unwrap_or(usize::MAX) + self.overflow.len()
+    }
+
+    /// Ascending-id iteration: every overflow id exceeds every bitmap id.
+    fn iter_ascending(&self) -> impl Iterator<Item = u64> + '_ {
+        self.bitmap
+            .iter()
+            .map(u64::from)
+            .chain(self.overflow.iter().copied())
+    }
+
+    pub(crate) fn to_vec(&self) -> Vec<u64> {
+        self.iter_ascending().collect()
+    }
+}
+
+impl From<Vec<u64>> for IdSet {
+    fn from(ids: Vec<u64>) -> Self {
+        let mut set = Self::default();
+        for id in ids {
+            set.insert(id);
+        }
+        set
+    }
+}
+
 /// Secondary index implementation.
 #[derive(Debug)]
 pub(crate) enum SecondaryIndex {
-    /// B-tree index mapping JSON primitive values to point IDs.
-    BTree(RwLock<BTreeMap<JsonValue, Vec<u64>>>),
+    /// B-tree index mapping JSON primitive values to id sets.
+    BTree(RwLock<BTreeMap<JsonValue, IdSet>>),
 }
 
 impl SecondaryIndex {
@@ -120,7 +195,8 @@ impl SecondaryIndex {
             Self::BTree(tree) => {
                 let guard = tree.read();
                 match guard.get(value) {
-                    Some(ids) => ids_to_bitmap(ids),
+                    Some(ids) if ids.overflow.is_empty() => Some(ids.bitmap.clone()),
+                    Some(_) => None,
                     None => Some(roaring::RoaringBitmap::new()),
                 }
             }
@@ -145,9 +221,10 @@ impl SecondaryIndex {
                 let guard = tree.read();
                 let mut bm = roaring::RoaringBitmap::new();
                 for ids in guard.range((from, to)).map(|(_, v)| v) {
-                    for &id in ids {
-                        bm.insert(u32::try_from(id).ok()?);
+                    if !ids.overflow.is_empty() {
+                        return None;
                     }
+                    bm |= &ids.bitmap;
                 }
                 Some(bm)
             }
@@ -194,7 +271,7 @@ impl SecondaryIndex {
     ) -> Option<Vec<u64>> {
         let Self::BTree(tree) = self;
         let guard = tree.read();
-        let covered: usize = guard.values().map(Vec::len).sum();
+        let covered: usize = guard.values().map(IdSet::len).sum();
         if covered != point_count {
             return None;
         }
@@ -222,7 +299,7 @@ impl SecondaryIndex {
     ) -> Option<Vec<u64>> {
         let Self::BTree(tree) = self;
         let guard = tree.read();
-        let covered: usize = guard.values().map(Vec::len).sum();
+        let covered: usize = guard.values().map(IdSet::len).sum();
         if covered != point_count {
             return None;
         }
@@ -234,9 +311,9 @@ impl SecondaryIndex {
 /// collecting up to `limit` point IDs, ascending by ID within each equal-key
 /// bucket. The caller holds the read guard so the coverage check and the walk
 /// stay atomic.
-fn walk_ordered(tree: &BTreeMap<JsonValue, Vec<u64>>, descending: bool, limit: usize) -> Vec<u64> {
+fn walk_ordered(tree: &BTreeMap<JsonValue, IdSet>, descending: bool, limit: usize) -> Vec<u64> {
     let mut out: Vec<u64> = Vec::new();
-    let mut collect = |buckets: &mut dyn Iterator<Item = &Vec<u64>>| {
+    let mut collect = |buckets: &mut dyn Iterator<Item = &IdSet>| {
         for ids in buckets {
             if out.len() >= limit {
                 break;
@@ -258,19 +335,17 @@ fn walk_ordered(tree: &BTreeMap<JsonValue, Vec<u64>>, descending: bool, limit: u
 /// bucket and the result holds complete leading buckets — never a partial one,
 /// which a multi-key secondary sort requires.
 fn walk_whole_buckets(
-    tree: &BTreeMap<JsonValue, Vec<u64>>,
+    tree: &BTreeMap<JsonValue, IdSet>,
     descending: bool,
     min_rows: usize,
 ) -> Vec<u64> {
     let mut out: Vec<u64> = Vec::new();
-    let mut absorb = |buckets: &mut dyn Iterator<Item = &Vec<u64>>| {
+    let mut absorb = |buckets: &mut dyn Iterator<Item = &IdSet>| {
         for ids in buckets {
             if out.len() >= min_rows {
                 break;
             }
-            let mut bucket = ids.clone();
-            bucket.sort_unstable();
-            out.extend(bucket);
+            out.extend(ids.iter_ascending());
         }
     };
     if descending {
@@ -281,29 +356,13 @@ fn walk_whole_buckets(
     out
 }
 
-/// Appends `ids` (sorted ascending for determinism) to `out`, stopping once
-/// `out` reaches `limit`.
-fn push_bucket_capped(ids: &[u64], limit: usize, out: &mut Vec<u64>) {
-    let mut bucket = ids.to_vec();
-    bucket.sort_unstable();
-    for id in bucket {
+/// Appends `ids` (ascending by construction) to `out`, stopping once `out`
+/// reaches `limit`.
+fn push_bucket_capped(ids: &IdSet, limit: usize, out: &mut Vec<u64>) {
+    for id in ids.iter_ascending() {
         if out.len() >= limit {
             return;
         }
         out.push(id);
     }
-}
-
-/// Converts a slice of `u64` point IDs into a [`RoaringBitmap`].
-///
-/// `RoaringBitmap` stores `u32` values. Returns `None` if any ID exceeds
-/// [`u32::MAX`]: the bitmap would silently omit that ID, so callers that fetch
-/// only the bitmap's IDs (e.g. the JOIN pre-filter) would drop a real match.
-/// Signalling `None` forces those callers to fall back to a full scan.
-fn ids_to_bitmap(ids: &[u64]) -> Option<roaring::RoaringBitmap> {
-    let mut bm = roaring::RoaringBitmap::new();
-    for &id in ids {
-        bm.insert(u32::try_from(id).ok()?);
-    }
-    Some(bm)
 }

--- a/crates/velesdb-core/src/index/secondary/ordered_ids_tests.rs
+++ b/crates/velesdb-core/src/index/secondary/ordered_ids_tests.rs
@@ -1,20 +1,29 @@
 //! Unit tests for [`SecondaryIndex::ordered_ids`] — the ordered-iteration
 //! primitive for index-backed `ORDER BY <field> LIMIT k` top-k (B001 follow-up).
 
-use super::{F64Key, JsonValue, SecondaryIndex};
+use super::{F64Key, IdSet, JsonValue, SecondaryIndex};
 use parking_lot::RwLock;
 use std::collections::BTreeMap;
+
+/// Builds an `IdSet` bucket from ids given in any order.
+fn set(ids: &[u64]) -> IdSet {
+    let mut out = IdSet::default();
+    for &id in ids {
+        out.insert(id);
+    }
+    out
+}
 
 /// Mixed-type fixture. Key order is Bool < Number < String (the `JsonValue`
 /// `Ord`), and the `Number(1.0)` bucket holds IDs out of order on purpose so
 /// the within-bucket ascending-ID sort is exercised.
 fn fixture() -> SecondaryIndex {
-    let mut map: BTreeMap<JsonValue, Vec<u64>> = BTreeMap::new();
-    map.insert(JsonValue::Bool(false), vec![5]);
-    map.insert(JsonValue::Bool(true), vec![3]);
-    map.insert(JsonValue::Number(F64Key::from(1.0)), vec![10, 2]);
-    map.insert(JsonValue::Number(F64Key::from(2.0)), vec![7]);
-    map.insert(JsonValue::String("a".to_string()), vec![8]);
+    let mut map: BTreeMap<JsonValue, IdSet> = BTreeMap::new();
+    map.insert(JsonValue::Bool(false), set(&[5]));
+    map.insert(JsonValue::Bool(true), set(&[3]));
+    map.insert(JsonValue::Number(F64Key::from(1.0)), set(&[10, 2]));
+    map.insert(JsonValue::Number(F64Key::from(2.0)), set(&[7]));
+    map.insert(JsonValue::String("a".to_string()), set(&[8]));
     SecondaryIndex::BTree(RwLock::new(map))
 }
 
@@ -52,10 +61,10 @@ fn empty_index_returns_empty() {
 
 #[test]
 fn single_key_many_ids_emits_all_sorted() {
-    let mut map: BTreeMap<JsonValue, Vec<u64>> = BTreeMap::new();
+    let mut map: BTreeMap<JsonValue, IdSet> = BTreeMap::new();
     map.insert(
         JsonValue::Number(F64Key::from(42.0)),
-        vec![9, 1, 4, 1_000_000_000_000],
+        set(&[9, 1, 4, 1_000_000_000_000]),
     );
     let idx = SecondaryIndex::BTree(RwLock::new(map));
     assert_eq!(


### PR DESCRIPTION
## Description

Tier-A finding from the query/filter audit: the secondary index stored `BTreeMap<JsonValue, Vec<u64>>` and **rebuilt every pre-filter bitmap from scratch on every query** — `to_bitmap` re-inserted each id of the bucket, and a `WHERE ts > X` range covering 500k rows performed 500k roaring inserts per execution, before any vector work. Inserts also paid an O(k) `contains()` scan per id, and backfill needed a sort+dedup sweep over every bucket.

Buckets are now `IdSet`: a **prebuilt `RoaringBitmap`** plus a sorted overflow side list for ids above `u32::MAX` (unrepresentable in roaring):

- `to_bitmap` is a bitmap clone (memcpy) — or `None` exactly when overflow is non-empty, the same incomplete-result contract as before;
- `range_bitmap` is a vectorized union (`bm |= &bucket.bitmap`) per bucket;
- insert/remove are set operations: no `contains()` scan, no dedup pass, and ordered walks emit ascending ids **by construction** (every overflow id exceeds every bitmap id), so the walk helpers drop their per-bucket sort copies;
- `bitmap_from_and` intersects **in place and smallest-first** with early exit on empty, instead of allocating a fresh bitmap per child in AST order — a 10-row Eq child now bounds the fold before a million-row range child is ever touched. Skipped (non-prefilterable) children still yield a superset the post-filter narrows, as before.

**No persistence impact**: secondary indexes are rebuilt from payloads at open (`restore_secondary_indexes_from_config`); nothing serializes the bucket type.

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full lib suite: **5367 passed, 0 failed**
- `secondary_index_persistence` 13/13 — green
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Second PR of the Tier-A wave (#2063 was first). Tier-S is fully authored (#2058 merged; #2059–#2062 in CI).
