### PR TITLE
perf(core): defer vector hydration to survivors; stream candidate scans

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/execution_paths.rs
+++ b/crates/velesdb-core/src/collection/search/query/execution_paths.rs
@@ -452,8 +452,11 @@ impl Collection {
         if bitmap.is_empty() {
             return Some(Vec::new());
         }
-        let candidate_ids: Vec<u64> = bitmap.iter().map(u64::from).collect();
-        if self.prefer_candidate_scan(candidate_ids.len(), execution_limit, Some(cond)) {
+        // Route on bitmap.len() (O(1)) — the id vector is only materialized
+        // once the candidate scan is actually chosen.
+        let candidate_count = usize::try_from(bitmap.len()).unwrap_or(usize::MAX);
+        if self.prefer_candidate_scan(candidate_count, execution_limit, Some(cond)) {
+            let candidate_ids: Vec<u64> = bitmap.iter().map(u64::from).collect();
             return Some(self.scan_ids_with_filter(&candidate_ids, filter, execution_limit));
         }
         // Too many bitmap hits — fall through to scan with early exit
@@ -552,24 +555,16 @@ impl Collection {
         Some(text_results.iter().map(|(id, _)| *id).collect())
     }
 
-    /// Scans a candidate ID list, returning up to `limit` points that match the filter.
+    /// Scans a candidate ID list, returning up to `limit` points that match
+    /// the filter. Delegates to `scan_ids_with_filter` — this body was a
+    /// duplicate that had also kept a per-candidate payload deep clone.
     fn collect_matching_points(
         &self,
         candidate_ids: &[u64],
         filter: &crate::filter::Filter,
         limit: usize,
     ) -> Vec<SearchResult> {
-        let mut results = Vec::new();
-        for point in self.get(candidate_ids).into_iter().flatten() {
-            let payload = point.payload.clone().unwrap_or(serde_json::Value::Null);
-            if filter.matches(&payload) {
-                results.push(SearchResult::new(point, 1.0));
-                if results.len() >= limit {
-                    break;
-                }
-            }
-        }
-        results
+        self.scan_ids_with_filter(candidate_ids, filter, limit)
     }
 
     /// Recursively extracts the first LIKE pattern from a condition tree.

--- a/crates/velesdb-core/src/collection/search/query/metadata_query.rs
+++ b/crates/velesdb-core/src/collection/search/query/metadata_query.rs
@@ -81,16 +81,26 @@ impl Collection {
         filter: &crate::filter::Filter,
         execution_limit: usize,
     ) -> Vec<SearchResult> {
+        /// Hydration chunk: large enough to amortize the storage guards,
+        /// small enough that an early exit at the limit leaves most of a
+        /// broad candidate list (bitmap prefilters routinely hand over
+        /// thousands of ids) un-hydrated.
+        const SCAN_CHUNK: usize = 256;
+
         let mut results = Vec::new();
-        for point in self.get(ids).into_iter().flatten() {
-            // `matches` only borrows the payload; pass a reference instead of
-            // deep-cloning the JSON per candidate. A missing payload is treated
-            // as `Null` (unchanged semantics). The borrow ends before `point`
-            // is moved into the result below.
-            if filter.matches(point.payload.as_ref().unwrap_or(&serde_json::Value::Null)) {
-                results.push(SearchResult::new(point, 1.0));
-                if results.len() >= execution_limit {
-                    break;
+        // Hydrate lazily, chunk by chunk: `self.get(ids)` up front paid
+        // N preads + N JSON parses + N vector copies before the first
+        // filter check, so the early exit below only ever saved filter
+        // work, never the dominant hydration cost.
+        'chunks: for chunk in ids.chunks(SCAN_CHUNK) {
+            for point in self.get(chunk).into_iter().flatten() {
+                // `matches` only borrows the payload; a missing payload is
+                // treated as `Null` (unchanged semantics).
+                if filter.matches(point.payload.as_ref().unwrap_or(&serde_json::Value::Null)) {
+                    results.push(SearchResult::new(point, 1.0));
+                    if results.len() >= execution_limit {
+                        break 'chunks;
+                    }
                 }
             }
         }

--- a/crates/velesdb-core/src/collection/search/resolve.rs
+++ b/crates/velesdb-core/src/collection/search/resolve.rs
@@ -79,44 +79,43 @@ pub(crate) fn resolve_scored_results(
 ///
 /// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 pub(crate) fn sort_results_by_metric(results: &mut [SearchResult], higher_is_better: bool) {
-    results.sort_unstable_by(|a, b| {
-        if higher_is_better {
-            // Descending: NaN treated as worst (placed at the end).
-            // partial_cmp returns None for NaN; the unwrap_or arms put any NaN
-            // result after all finite scores, preserving result quality when a
-            // score is accidentally NaN (e.g. zero-norm vector in SIMD path).
-            b.score.partial_cmp(&a.score).unwrap_or_else(|| {
-                match (a.score.is_nan(), b.score.is_nan()) {
-                    (true, false) => std::cmp::Ordering::Greater,
-                    (false, true) => std::cmp::Ordering::Less,
-                    _ => std::cmp::Ordering::Equal,
-                }
+    results.sort_unstable_by(|a, b| metric_score_order(a.score, b.score, higher_is_better));
+}
+
+/// Sorts `(id, score, payload)` candidates with the same ordering as
+/// [`sort_results_by_metric`] — the deferred-hydration filter path ranks
+/// candidates before any vector is read, so it sorts triples, not results.
+pub(crate) fn sort_scored_ids_by_metric<P>(entries: &mut [(u64, f32, P)], higher_is_better: bool) {
+    entries.sort_unstable_by(|a, b| metric_score_order(a.1, b.1, higher_is_better));
+}
+
+/// Shared score ordering for the metric direction.
+///
+/// - `higher_is_better = true`: descending; NaN treated as worst (placed at
+///   the end). `partial_cmp` returns `None` for NaN; the fallback arms put
+///   any NaN result after all finite scores, preserving result quality when
+///   a score is accidentally NaN (e.g. zero-norm vector in SIMD path).
+/// - `higher_is_better = false`: ascending (lower distance = better);
+///   `total_cmp` gives a true total order and NaN sorts after +inf, so NaN
+///   distances end up last (worst).
+fn metric_score_order(a: f32, b: f32, higher_is_better: bool) -> std::cmp::Ordering {
+    if higher_is_better {
+        b.partial_cmp(&a)
+            .unwrap_or_else(|| match (a.is_nan(), b.is_nan()) {
+                (true, false) => std::cmp::Ordering::Greater,
+                (false, true) => std::cmp::Ordering::Less,
+                _ => std::cmp::Ordering::Equal,
             })
-        } else {
-            // Ascending (lower distance = better): total_cmp gives a true total
-            // order; NaN sorts after +∞, so NaN distances end up last (worst).
-            a.score.total_cmp(&b.score)
-        }
-    });
+    } else {
+        a.total_cmp(&b)
+    }
 }
 
 /// Sorts `ScoredResult` values by score according to metric direction.
 ///
 /// Uses unstable sort: equal-score tie-breaking order is irrelevant for ranking.
 pub(crate) fn sort_scored_by_metric(results: &mut [ScoredResult], higher_is_better: bool) {
-    results.sort_unstable_by(|a, b| {
-        if higher_is_better {
-            b.score.partial_cmp(&a.score).unwrap_or_else(|| {
-                match (a.score.is_nan(), b.score.is_nan()) {
-                    (true, false) => std::cmp::Ordering::Greater,
-                    (false, true) => std::cmp::Ordering::Less,
-                    _ => std::cmp::Ordering::Equal,
-                }
-            })
-        } else {
-            a.score.total_cmp(&b.score)
-        }
-    });
+    results.sort_unstable_by(|a, b| metric_score_order(a.score, b.score, higher_is_better));
 }
 
 /// Sorts `SearchResult` values by score descending (higher scores first).

--- a/crates/velesdb-core/src/collection/search/vector_filter.rs
+++ b/crates/velesdb-core/src/collection/search/vector_filter.rs
@@ -142,7 +142,11 @@ impl Collection {
         let payload_storage = self.storage.payload_storage.read();
         let now_secs = now_unix_secs();
 
-        let mut results: Vec<SearchResult> = index_results
+        // Phase 1 — filter on payloads only. The pre-fix shape hydrated the
+        // vector of EVERY candidate that passed the filter (the oversampled
+        // budget reaches 10 000), then threw all but k away: up to ~60 MB of
+        // vector copies per 1536-dim query to keep 10.
+        let mut passing: Vec<(u64, f32, Option<serde_json::Value>)> = index_results
             .into_iter()
             .filter_map(|sr| {
                 let payload = payload_storage.retrieve(sr.id).ok().flatten();
@@ -155,24 +159,33 @@ impl Collection {
                     Some(p) => filter.matches(p),
                     None => filter.matches(&serde_json::Value::Null),
                 };
-                if !matches {
-                    return None;
-                }
-                let vector = vector_storage.retrieve(sr.id).ok().flatten()?;
-                Some(SearchResult::new(
-                    crate::point::Point {
-                        id: sr.id,
-                        vector,
-                        payload,
-                        sparse_vectors: None,
-                    },
-                    sr.score,
-                ))
+                matches.then_some((sr.id, sr.score, payload))
             })
             .collect();
 
-        resolve::sort_results_by_metric(&mut results, higher_is_better);
-        results.truncate(k);
+        resolve::sort_scored_ids_by_metric(&mut passing, higher_is_better);
+
+        // Phase 2 — hydrate vectors in sorted order until k results stand. A
+        // candidate whose vector is missing is skipped and the next one takes
+        // its place, exactly as the eager filter_map dropped it pre-truncate.
+        let mut results: Vec<SearchResult> = Vec::with_capacity(k.min(passing.len()));
+        for (id, score, payload) in passing {
+            if results.len() >= k {
+                break;
+            }
+            let Some(vector) = vector_storage.retrieve(id).ok().flatten() else {
+                continue;
+            };
+            results.push(SearchResult::new(
+                crate::point::Point {
+                    id,
+                    vector,
+                    payload,
+                    sparse_vectors: None,
+                },
+                score,
+            ));
+        }
         super::vector::tag_vector_component_scores(&mut results);
         results
     }


### PR DESCRIPTION
## Description

Tier-A findings on the filtered-search path, all of the shape *"pay for every candidate what only the survivors need"*:

- **`filter_and_hydrate` retrieved the FULL vector of every candidate that passed the metadata filter** — the oversampled budget reaches 10 000 candidates, so a k=10 query on 1536-dim vectors could copy ~60 MB to keep 10. It now filters on payloads alone, ranks the passing `(id, score, payload)` triples with the same metric ordering (shared `metric_score_order`, which also deduplicates the two hand-rolled comparator copies in `resolve.rs`), and hydrates vectors in sorted order until k stand. A candidate with a missing vector is skipped and the next takes its place — exactly as the eager `filter_map` dropped it pre-truncate.
- **Candidate-id scans hydrated ALL ids up front** (`self.get(ids)` builds every `Point` — preads, JSON parses, vector copies — before the first filter check), so the early exit at the limit only ever saved filter work. `scan_ids_with_filter` now hydrates in chunks of 256 with a real early exit, and `collect_matching_points` — a duplicate body that had also kept a per-candidate payload deep clone — now delegates to it.
- **The bitmap prefilter materialized the full candidate id vector before deciding whether to candidate-scan at all**; the decision now reads `bitmap.len()` (O(1)) and the vector is built only when the scan is actually chosen.

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring (comparator dedup, scan-path dedup)

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5367 passed, 0 failed**
- Search path touched → recall gate: `test_recall` **18/18**
- `filter` subset re-run after merging latest `develop` (319 passed)
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Third PR of the Tier-A wave. Branch already carries the latest `develop` (post #2058/#2059/#2060) for the freshness gate.
