### PR TITLE
perf(core): hoist per-query invariants out of the WHERE similarity row loop

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/multi_vector.rs
+++ b/crates/velesdb-core/src/collection/search/query/multi_vector.rs
@@ -41,6 +41,31 @@ impl Collection {
 
         // Named vector from payload JSON field
         let payload_storage = self.storage.payload_storage.read();
+        Self::vector_from_payload_field(&payload_storage, point_id, field)
+    }
+
+    /// Guard-parameterized twin of [`Self::get_vector_for_field`] for the
+    /// `field == "vector"` = false case: scan loops hoist the storage guards
+    /// once instead of re-acquiring them per candidate row.
+    pub(crate) fn get_vector_for_field_in(
+        vector_storage: &crate::storage::MmapStorage,
+        payload_storage: &crate::storage::LogPayloadStorage,
+        point_id: u64,
+        field: &str,
+    ) -> Result<Option<Vec<f32>>> {
+        if field == "vector" {
+            return Ok(vector_storage.retrieve(point_id)?);
+        }
+        Self::vector_from_payload_field(payload_storage, point_id, field)
+    }
+
+    /// Reads a named vector from a payload JSON field through an
+    /// already-held payload guard.
+    fn vector_from_payload_field(
+        payload_storage: &crate::storage::LogPayloadStorage,
+        point_id: u64,
+        field: &str,
+    ) -> Result<Option<Vec<f32>>> {
         let Some(payload) = payload_storage.retrieve(point_id)? else {
             return Ok(None);
         };

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -28,6 +28,14 @@ pub(crate) struct TrackedScan {
 }
 
 /// Inverted-similarity threshold bundle for the NOT-similarity scan.
+/// Per-scan invariants for the NOT-similarity loop, hoisted once.
+struct NotSimilarityScanCtx<'a> {
+    vector_storage: &'a crate::storage::MmapStorage,
+    payload_storage: &'a crate::storage::LogPayloadStorage,
+    metric: crate::distance::DistanceMetric,
+    now_secs: u64,
+}
+
 struct NotSimilarityThreshold {
     op: crate::velesql::CompareOp,
     value: f32,
@@ -151,13 +159,28 @@ impl Collection {
             value: threshold_f32,
             higher_is_better,
         };
+        // Hoist the per-row invariants: the metric snapshot, the expiry
+        // clock, and both storage guards (vector rank 2 before payload rank
+        // 3, decree order). The per-candidate helper previously acquired
+        // three locks and called SystemTime::now() for every scanned row.
+        let metric = self.storage.config.read().metric;
+        let now_secs = now_unix_secs();
+        let vector_storage = self.storage.vector_storage.read();
+        let payload_storage = self.storage.payload_storage.read();
+        let scan = NotSimilarityScanCtx {
+            vector_storage: &vector_storage,
+            payload_storage: &payload_storage,
+            metric,
+            now_secs,
+        };
         for id in all_ids {
-            if let Some(result) = self.eval_not_similarity_candidate(
+            if let Some(result) = Self::eval_not_similarity_candidate(
                 id,
                 &sim_field,
                 &sim_vec,
                 &threshold,
                 filter.as_ref(),
+                &scan,
             ) {
                 results.push(result);
                 if results.len() >= limit {
@@ -173,15 +196,24 @@ impl Collection {
     /// hydrated result when it passes both the inverted similarity threshold
     /// and the metadata filter.
     fn eval_not_similarity_candidate(
-        &self,
         id: u64,
         sim_field: &str,
         sim_vec: &[f32],
         threshold: &NotSimilarityThreshold,
         filter: Option<&crate::filter::Filter>,
+        scan: &NotSimilarityScanCtx<'_>,
     ) -> Option<SearchResult> {
-        let vector = self.retrieve_vector_for_scan(id, sim_field)?;
-        let score = self.compute_metric_score(&vector, sim_vec);
+        let vector = Self::retrieve_vector_for_scan_in(
+            scan.vector_storage,
+            scan.payload_storage,
+            id,
+            sim_field,
+        )?;
+        let score = if vector.len() == sim_vec.len() && !vector.is_empty() {
+            scan.metric.calculate(&vector, sim_vec)
+        } else {
+            0.0
+        };
         if Self::compare_similarity(
             score,
             threshold.value,
@@ -190,14 +222,8 @@ impl Collection {
         ) {
             return None; // excluded by the NOT-similarity threshold
         }
-        let payload = self
-            .storage
-            .payload_storage
-            .read()
-            .retrieve(id)
-            .ok()
-            .flatten();
-        if is_payload_expired(payload.as_ref(), now_unix_secs()) {
+        let payload = scan.payload_storage.retrieve(id).ok().flatten();
+        if is_payload_expired(payload.as_ref(), scan.now_secs) {
             return None;
         }
         if !Self::passes_metadata_filter(filter, payload.as_ref()) {
@@ -228,8 +254,13 @@ impl Collection {
     }
 
     /// Retrieves a vector for a given field, logging warnings on failure.
-    fn retrieve_vector_for_scan(&self, id: u64, field: &str) -> Option<Vec<f32>> {
-        match self.get_vector_for_field(id, field) {
+    fn retrieve_vector_for_scan_in(
+        vector_storage: &crate::storage::MmapStorage,
+        payload_storage: &crate::storage::LogPayloadStorage,
+        id: u64,
+        field: &str,
+    ) -> Option<Vec<f32>> {
+        match Self::get_vector_for_field_in(vector_storage, payload_storage, id, field) {
             Ok(Some(v)) => Some(v),
             Ok(None) => None,
             Err(e) => {

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -22,6 +22,15 @@ pub(crate) struct GraphMatchEvalCache {
     /// every row of a single evaluation, so pointer identity is a stable key
     /// and lets us build each leaf `Filter` exactly once instead of per row.
     filters: Vec<(usize, crate::filter::Filter)>,
+    /// Resolved query vectors for `similarity()` leaves, keyed the same way
+    /// (leaf pointer): `resolve_vector` cloned the literal (or re-parsed the
+    /// `$param` JSON) for EVERY candidate row — a 3 KB alloc+copy per row at
+    /// 768 dims. The vector is invariant across the evaluation.
+    similarity_vectors: Vec<(usize, Vec<f32>)>,
+    /// Metric snapshot for similarity comparisons: `evaluate_similarity` took
+    /// the `config` read lock TWICE per row (once inside
+    /// `compute_metric_score`, once for the threshold direction).
+    metric: Option<crate::distance::DistanceMetric>,
 }
 
 impl GraphMatchEvalCache {
@@ -59,6 +68,35 @@ impl GraphMatchEvalCache {
         self.filters.push((key, filter));
         let idx = self.filters.len() - 1;
         &self.filters[idx].1
+    }
+
+    /// Returns the resolved query vector for a `similarity()` leaf, resolving
+    /// it exactly once per evaluation (same pointer-keyed scheme as
+    /// [`Self::metadata_filter`]).
+    fn similarity_query_vector(
+        &mut self,
+        sim: &crate::velesql::SimilarityCondition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
+    ) -> Result<&[f32]> {
+        let key = std::ptr::from_ref(sim) as usize;
+        if let Some(idx) = self.similarity_vectors.iter().position(|(k, _)| *k == key) {
+            return Ok(&self.similarity_vectors[idx].1);
+        }
+        let resolved = Collection::resolve_vector(&sim.vector, params)?;
+        self.similarity_vectors.push((key, resolved));
+        let idx = self.similarity_vectors.len() - 1;
+        Ok(&self.similarity_vectors[idx].1)
+    }
+
+    /// Returns the collection's metric, reading the `config` lock at most
+    /// once per evaluation (the per-row path read it twice per candidate).
+    fn metric_snapshot(&mut self, collection: &Collection) -> crate::distance::DistanceMetric {
+        if let Some(metric) = self.metric {
+            return metric;
+        }
+        let metric = collection.storage.config.read().metric;
+        self.metric = Some(metric);
+        metric
     }
 
     /// Test seam (#904): number of distinct metadata-leaf `Filter`s built.
@@ -233,7 +271,9 @@ impl Collection {
             Condition::Or(left, right) => self.eval_short_circuit_or(left, right, ctx, graph_cache),
             Condition::Not(inner) => self.eval_condition(inner, ctx, graph_cache).map(|v| !v),
             Condition::Group(inner) => self.eval_condition(inner, ctx, graph_cache),
-            Condition::Similarity(sim) => self.evaluate_similarity(sim, ctx.vector, ctx.params),
+            Condition::Similarity(sim) => {
+                self.evaluate_similarity(sim, ctx.vector, ctx.params, graph_cache)
+            }
             Condition::VectorSearch(_) | Condition::VectorFusedSearch(_) => Ok(true),
             // #904: reuse the per-query cached `Filter` for this metadata leaf
             // instead of rebuilding it (and cloning the AST) on every row.
@@ -278,13 +318,22 @@ impl Collection {
         sim: &crate::velesql::SimilarityCondition,
         vector: Option<&[f32]>,
         params: &std::collections::HashMap<String, serde_json::Value>,
+        graph_cache: &mut GraphMatchEvalCache,
     ) -> Result<bool> {
         let Some(record_vector) = vector else {
             return Ok(false);
         };
-        let query_vec = Self::resolve_vector(&sim.vector, params)?;
-        let score = self.compute_metric_score(record_vector, &query_vec);
-        let metric = self.storage.config.read().metric;
+        // Per-query invariants come from the eval cache: the resolved query
+        // vector (was one alloc+copy or `$param` re-parse per row) and the
+        // metric snapshot (was TWO `config` read-lock acquisitions per row —
+        // one inside `compute_metric_score`, one for the direction).
+        let metric = graph_cache.metric_snapshot(self);
+        let query_vec = graph_cache.similarity_query_vector(sim, params)?;
+        let score = if record_vector.len() == query_vec.len() && !record_vector.is_empty() {
+            metric.calculate(record_vector, query_vec)
+        } else {
+            0.0
+        };
         #[allow(clippy::cast_possible_truncation)]
         // Reason: similarity thresholds are approximate floating bounds.
         let threshold = sim.threshold as f32;


### PR DESCRIPTION
## Description

Tier-A findings: two row-loop shapes re-derived per candidate what is invariant across the whole evaluation.

- **`WHERE similarity()` re-resolved the query vector for EVERY row** (a clone of the literal or a full JSON re-parse of the `$param` — 3 KB alloc+copy per row at 768 dims) and took the `config` read lock **twice per row** (once inside `compute_metric_score`, once for the threshold direction). Both now live in `GraphMatchEvalCache` next to the #904 leaf-filter cache, with the same pointer-keyed scheme: one resolution and one lock read per query.
- **The NOT-similarity full scan acquired three locks per scanned row** (vector storage inside `get_vector_for_field`, config inside `compute_metric_score`, payload for the expiry check) and called `SystemTime::now()` per row. The loop now hoists the metric snapshot, the expiry clock, and both storage guards (vector rank 2 before payload rank 3, decree order) into a `NotSimilarityScanCtx`, with a guard-parameterized twin of `get_vector_for_field` so multi-vector fields read through the held guards.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5367 passed, 0 failed**
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Fourth PR of the Tier-A wave. **Examined and deferred**: pre-splitting dotted filter paths (audit item) — `split('.')` allocates nothing and the per-row cost is dominated by the BTreeMap string probes; restructuring the public `Condition` AST for that is churn without a measurement behind it.
