### PR TITLE
perf(core): JOIN moves left rows instead of deep-cloning them; grouped indexed build side

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/join.rs
+++ b/crates/velesdb-core/src/collection/search/query/join.rs
@@ -132,13 +132,13 @@ pub fn extract_join_keys(results: &[SearchResult], condition: &JoinCondition) ->
 /// - the target `ColumnStore` has no primary key,
 /// - the JOIN column does not match the target primary key.
 pub fn execute_join(
-    results: &[SearchResult],
+    results: Vec<SearchResult>,
     join: &JoinClause,
     column_store: &ColumnStore,
     row_budget: usize,
 ) -> Result<Vec<JoinedResult>> {
     let condition = validate_join_condition(join, column_store)?;
-    let join_keys = extract_join_keys(results, &condition);
+    let join_keys = extract_join_keys(&results, &condition);
 
     if join_keys.is_empty() {
         return Ok(Vec::new());
@@ -147,17 +147,22 @@ pub fn execute_join(
     let batch_size = adaptive_batch_size(join_keys.len());
     let null_row_data = build_null_row_data(column_store);
 
-    let mut matched_left_indices = vec![false; results.len()];
+    // Move-out slots: this is a primary-key join, so `join_keys` carries at
+    // most one entry per left row and every match consumes its slot with
+    // `take()` — the pre-fix shape deep-cloned the whole SearchResult
+    // (vector included: ~3 KB per row at 768 dims) for every joined row.
+    // Whatever remains `Some` afterwards is exactly the unmatched-left set,
+    // which retires the separate `matched_left_indices` bookkeeping.
+    let mut slots: Vec<Option<SearchResult>> = results.into_iter().map(Some).collect();
     let mut matched_right_pks: HashSet<i64> = HashSet::with_capacity(join_keys.len());
 
     let mut joined_results = process_join_batches(
-        results,
+        &mut slots,
         &join_keys,
         batch_size,
         join.join_type,
         column_store,
         &null_row_data,
-        &mut matched_left_indices,
         &mut matched_right_pks,
         row_budget,
     );
@@ -177,13 +182,7 @@ pub fn execute_join(
     if joined_results.len() < row_budget
         && matches!(join.join_type, JoinType::Left | JoinType::Full)
     {
-        append_unmatched_left_rows(
-            results,
-            &matched_left_indices,
-            &null_row_data,
-            &mut joined_results,
-            row_budget,
-        );
+        append_unmatched_left_rows(&mut slots, &null_row_data, &mut joined_results, row_budget);
     }
 
     Ok(joined_results)
@@ -219,13 +218,12 @@ fn validate_join_condition(join: &JoinClause, column_store: &ColumnStore) -> Res
 /// Processes join key batches, merging matching rows with search results.
 #[allow(clippy::too_many_arguments)]
 fn process_join_batches(
-    results: &[SearchResult],
+    slots: &mut [Option<SearchResult>],
     join_keys: &[(usize, i64)],
     batch_size: usize,
     join_type: JoinType,
     column_store: &ColumnStore,
     null_row_data: &HashMap<String, serde_json::Value>,
-    matched_left_indices: &mut [bool],
     matched_right_pks: &mut HashSet<i64>,
     row_budget: usize,
 ) -> Vec<JoinedResult> {
@@ -243,18 +241,14 @@ fn process_join_batches(
                 break;
             }
             if let Some(column_data) = row_map.get(pk) {
-                joined_results.push(JoinedResult::new(
-                    results[*result_idx].clone(),
-                    column_data.clone(),
-                ));
-                matched_left_indices[*result_idx] = true;
-                matched_right_pks.insert(*pk);
+                if let Some(left) = slots[*result_idx].take() {
+                    joined_results.push(JoinedResult::new(left, column_data.clone()));
+                    matched_right_pks.insert(*pk);
+                }
             } else if matches!(join_type, JoinType::Left | JoinType::Full) {
-                joined_results.push(JoinedResult::new(
-                    results[*result_idx].clone(),
-                    null_row_data.clone(),
-                ));
-                matched_left_indices[*result_idx] = true;
+                if let Some(left) = slots[*result_idx].take() {
+                    joined_results.push(JoinedResult::new(left, null_row_data.clone()));
+                }
             }
         }
     }
@@ -295,21 +289,17 @@ fn append_unmatched_right_rows(
 
 /// Appends unmatched left-side rows for LEFT/FULL JOINs.
 fn append_unmatched_left_rows(
-    results: &[SearchResult],
-    matched_left_indices: &[bool],
+    slots: &mut [Option<SearchResult>],
     null_row_data: &HashMap<String, serde_json::Value>,
     joined_results: &mut Vec<JoinedResult>,
     row_budget: usize,
 ) {
-    for (idx, left_result) in results.iter().enumerate() {
+    for slot in slots.iter_mut() {
         if joined_results.len() >= row_budget {
             break;
         }
-        if !matched_left_indices[idx] {
-            joined_results.push(JoinedResult::new(
-                left_result.clone(),
-                null_row_data.clone(),
-            ));
+        if let Some(left) = slot.take() {
+            joined_results.push(JoinedResult::new(left, null_row_data.clone()));
         }
     }
 }

--- a/crates/velesdb-core/src/collection/search/query/join_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/join_tests.rs
@@ -134,7 +134,7 @@ fn test_execute_join_basic() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
 
     assert_eq!(joined.len(), 3);
     assert!(joined[0].column_data.contains_key("price"));
@@ -157,7 +157,7 @@ fn test_execute_join_inner_skips_missing() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
 }
 
@@ -167,7 +167,7 @@ fn test_joined_to_search_results() {
     let column_store = make_column_store();
     let join = make_join_clause();
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     let search_results = joined_to_search_results(joined);
 
     assert_eq!(search_results.len(), 1);
@@ -303,7 +303,7 @@ fn test_execute_join_validates_pk_column() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &wrong_join, &column_store, NO_LIMIT);
+    let joined = execute_join(results.clone(), &wrong_join, &column_store, NO_LIMIT);
     assert!(
         joined.is_err(),
         "JOIN on non-PK column must return an error"
@@ -332,7 +332,7 @@ fn test_execute_join_correct_pk_column_works() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &correct_join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &correct_join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 1);
 }
 
@@ -353,7 +353,7 @@ fn test_execute_join_using_single_column_supported() {
         using_columns: Some(vec!["product_id".to_string()]),
     };
 
-    let joined = execute_join(&results, &using_join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &using_join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
     assert!(joined[0].column_data.contains_key("price"));
 }
@@ -374,7 +374,7 @@ fn test_execute_join_using_rejects_multi_column() {
         using_columns: Some(vec!["product_id".to_string(), "region_id".to_string()]),
     };
 
-    let joined = execute_join(&results, &using_join, &column_store, NO_LIMIT);
+    let joined = execute_join(results.clone(), &using_join, &column_store, NO_LIMIT);
     assert!(
         joined.is_err(),
         "USING with multiple columns must return an error"
@@ -402,7 +402,7 @@ fn test_execute_left_join_keeps_unmatched_left_rows() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 2);
     assert!(joined[0].column_data.contains_key("price"));
     assert_eq!(
@@ -432,7 +432,7 @@ fn test_execute_right_join_includes_unmatched_right_rows() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 3);
 }
 
@@ -457,7 +457,7 @@ fn test_execute_full_join_combines_left_and_right_unmatched() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(joined.len(), 4);
     let null_join_count = joined
         .iter()
@@ -512,7 +512,7 @@ fn test_execute_right_join_respects_row_budget() {
     };
 
     // Budget 5: 1 matched row + 4 unmatched-right rows, NOT all 10_000.
-    let joined = execute_join(&results, &join, &column_store, 5).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, 5).unwrap();
     assert_eq!(joined.len(), 5, "RIGHT join must stop at the row budget");
 
     // The matched row (pk=1) is emitted first.
@@ -520,7 +520,7 @@ fn test_execute_right_join_respects_row_budget() {
     assert!(joined[0].column_data.contains_key("price"));
 
     // Unbounded run returns every right row (regression guard on correctness).
-    let full = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let full = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(full.len(), 10_000);
 }
 
@@ -550,9 +550,9 @@ fn test_execute_left_join_respects_row_budget() {
         using_columns: None,
     };
 
-    let joined = execute_join(&results, &join, &column_store, 7).unwrap();
+    let joined = execute_join(results.clone(), &join, &column_store, 7).unwrap();
     assert_eq!(joined.len(), 7, "LEFT join must stop at the row budget");
 
-    let full = execute_join(&results, &join, &column_store, NO_LIMIT).unwrap();
+    let full = execute_join(results.clone(), &join, &column_store, NO_LIMIT).unwrap();
     assert_eq!(full.len(), 50);
 }

--- a/crates/velesdb-core/src/database/query_engine.rs
+++ b/crates/velesdb-core/src/database/query_engine.rs
@@ -821,7 +821,7 @@ impl Database {
             None => base_collection.execute_query(&single_query, params)?,
         };
         for join in &query.select.joins {
-            results = self.execute_single_join(&results, join, &pushed, row_budget)?;
+            results = self.execute_single_join(results, join, &pushed, row_budget)?;
         }
 
         // Apply post-join filters: cross-source predicates that reference

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -289,7 +289,7 @@ impl Database {
 
         // Phase 3: emit — one merged row per (left row, match), budget-bounded.
         let mut output = Vec::new();
-        'rows: for (left, key) in results.into_iter().zip(keys) {
+        for (left, key) in results.into_iter().zip(keys) {
             if output.len() >= row_budget {
                 break;
             }
@@ -303,36 +303,47 @@ impl Database {
                 }
                 continue;
             };
-            let rights: Vec<&crate::Point> = match_ids
-                .iter()
-                .filter_map(|id| point_map.get(id))
-                .collect();
-            let Some((last_right, head_rights)) = rights.split_last() else {
-                // Matches existed but none hydrated — the row vanishes,
-                // exactly as the per-row `get` loop emitted nothing here.
-                continue;
-            };
-            let score = left.score;
-            for right_point in head_rights {
-                if output.len() >= row_budget {
-                    continue 'rows;
-                }
-                output.push(SearchResult::new(
-                    Self::merge_payloads(&left.point, right_point),
-                    score,
-                ));
-            }
+            Self::emit_indexed_rows(left, match_ids, &point_map, row_budget, &mut output);
+        }
+        output
+    }
+
+    /// Emits the merged rows of one left row's match list, budget-bounded.
+    ///
+    /// The final row of a key takes the left point by move — the 1:1 common
+    /// case therefore never clones the vector. A match list whose ids all
+    /// failed to hydrate emits nothing, exactly as the per-row `get` loop
+    /// behaved.
+    fn emit_indexed_rows(
+        left: SearchResult,
+        match_ids: &[u64],
+        point_map: &std::collections::HashMap<u64, crate::Point>,
+        row_budget: usize,
+        output: &mut Vec<SearchResult>,
+    ) {
+        let rights: Vec<&crate::Point> = match_ids
+            .iter()
+            .filter_map(|id| point_map.get(id))
+            .collect();
+        let Some((last_right, head_rights)) = rights.split_last() else {
+            return;
+        };
+        let score = left.score;
+        for right_point in head_rights {
             if output.len() >= row_budget {
-                continue;
+                return;
             }
-            // The final row of a key takes the left point by move — the
-            // 1:1 common case therefore never clones the vector.
+            output.push(SearchResult::new(
+                Self::merge_payloads(&left.point, right_point),
+                score,
+            ));
+        }
+        if output.len() < row_budget {
             output.push(SearchResult::new(
                 Self::merge_payloads_owned(left.point, last_right),
                 score,
             ));
         }
-        output
     }
 
     /// Returns the JOIN-side `ColumnStore` for `collection`, rebuilding only

--- a/crates/velesdb-core/src/database/query_join.rs
+++ b/crates/velesdb-core/src/database/query_join.rs
@@ -34,7 +34,7 @@ impl Database {
     ///
     /// This avoids building a full `ColumnStore` when the join key is the primary key.
     pub(super) fn execute_lookup_join(
-        results: &[SearchResult],
+        results: Vec<SearchResult>,
         join: &crate::velesql::JoinClause,
         collection: &crate::collection::Collection,
     ) -> Vec<SearchResult> {
@@ -51,30 +51,46 @@ impl Database {
         let mut output = Vec::with_capacity(results.len());
         for left in results {
             if let Some(right_point) = point_map.get(&left.point.id) {
-                let merged = Self::merge_payloads(&left.point, right_point);
-                output.push(SearchResult::new(merged, left.score));
+                let score = left.score;
+                let merged = Self::merge_payloads_owned(left.point, right_point);
+                output.push(SearchResult::new(merged, score));
             } else if matches!(join.join_type, crate::velesql::JoinType::Left) {
-                output.push(left.clone());
+                output.push(left);
             }
         }
         output
     }
 
     /// Merges payloads from left and right points into a single point.
+    ///
+    /// Borrowing variant for callers that emit several rows from one left
+    /// point (the indexed 1:N path); the by-value twin below moves the left
+    /// point — vector included — instead of cloning it.
     pub(super) fn merge_payloads(left: &crate::Point, right: &crate::Point) -> crate::Point {
+        Self::merge_payloads_owned(left.clone(), right)
+    }
+
+    /// By-value twin of [`Self::merge_payloads`]: consumes the left point so
+    /// its vector is moved, not copied.
+    pub(super) fn merge_payloads_owned(
+        mut left: crate::Point,
+        right: &crate::Point,
+    ) -> crate::Point {
         let mut payload = left
             .payload
-            .as_ref()
-            .and_then(|p| p.as_object().cloned())
+            .take()
+            .and_then(|p| match p {
+                serde_json::Value::Object(map) => Some(map),
+                _ => None,
+            })
             .unwrap_or_default();
         if let Some(right_obj) = right.payload.as_ref().and_then(|p| p.as_object()) {
             for (k, v) in right_obj {
                 payload.insert(k.clone(), v.clone());
             }
         }
-        let mut merged = left.clone();
-        merged.payload = Some(serde_json::Value::Object(payload));
-        merged
+        left.payload = Some(serde_json::Value::Object(payload));
+        left
     }
 
     /// Rebuilds a WHERE clause excluding conditions that were pushed down.
@@ -128,7 +144,7 @@ impl Database {
     /// stores. It never drops rows within the requested window.
     pub(super) fn execute_single_join(
         &self,
-        results: &[SearchResult],
+        results: Vec<SearchResult>,
         join: &crate::velesql::JoinClause,
         pushed: &[crate::velesql::Condition],
         row_budget: usize,
@@ -138,12 +154,13 @@ impl Database {
         if Self::is_lookup_join_eligible(join) && pushed.is_empty() {
             return Ok(Self::execute_lookup_join(results, join, &join_collection));
         }
-        if pushed.is_empty() {
-            if let Some(output) =
-                Self::try_indexed_join(results, join, &join_collection, row_budget)
-            {
-                return Ok(output);
-            }
+        if pushed.is_empty() && Self::indexed_join_eligible(join, &join_collection) {
+            return Ok(Self::execute_indexed_join(
+                results,
+                join,
+                &join_collection,
+                row_budget,
+            ));
         }
 
         let column_store = if pushed.is_empty() {
@@ -167,88 +184,155 @@ impl Database {
     /// Answers an Inner/Left JOIN from a secondary index on the join-side
     /// column, avoiding the per-query `ColumnStore` materialization.
     ///
-    /// Returns `None` when the shape is not eligible, falling through to the
-    /// `ColumnStore` path: Right/Full joins need the unmatched join-side rows
-    /// that only a full enumeration can produce, `id` is already served by
-    /// the lookup fast path, and a column that is neither `id` nor indexed
-    /// reaches that path's actionable error. Unlike the PK paths a non-PK
-    /// key may match several join-side points; one merged row is emitted per
-    /// (left row, match) pair, bounded by `row_budget`.
-    fn try_indexed_join(
-        results: &[SearchResult],
+    /// Eligibility mirrors the pre-grouped shape: Right/Full joins need the
+    /// unmatched join-side rows only a full enumeration can produce, `id` is
+    /// already served by the lookup fast path, and a column that is neither
+    /// `id` nor indexed falls through to the `ColumnStore` path.
+    fn indexed_join_eligible(
+        join: &crate::velesql::JoinClause,
+        collection: &crate::collection::Collection,
+    ) -> bool {
+        use crate::velesql::JoinType;
+        if !matches!(join.join_type, JoinType::Inner | JoinType::Left) {
+            return false;
+        }
+        let Some(condition) = crate::collection::search::query::join::resolve_join_condition(join)
+        else {
+            return false;
+        };
+        let index_column = &condition.left.column;
+        index_column != "id" && collection.indexed_field_names().contains(index_column)
+    }
+
+    /// Build side of the indexed join: one `secondary_index_lookup` per
+    /// DISTINCT key, then one batched hydration over the deduplicated match
+    /// ids — the hash-join build the per-left-row shape never had.
+    #[allow(clippy::type_complexity)] // Reason: internal pair of build-side maps, named at the single call site
+    fn indexed_join_build_side(
+        collection: &crate::collection::Collection,
+        keys: &[Option<crate::index::JsonValue>],
+        index_column: &str,
+    ) -> (
+        std::collections::BTreeMap<crate::index::JsonValue, Vec<u64>>,
+        std::collections::HashMap<u64, crate::Point>,
+    ) {
+        let mut key_matches: std::collections::BTreeMap<crate::index::JsonValue, Vec<u64>> =
+            std::collections::BTreeMap::new();
+        for key in keys.iter().flatten() {
+            if !key_matches.contains_key(key) {
+                let ids = collection
+                    .secondary_index_lookup(index_column, key)
+                    .unwrap_or_default();
+                key_matches.insert(key.clone(), ids);
+            }
+        }
+        let all_ids: Vec<u64> = {
+            let mut seen = std::collections::HashSet::new();
+            key_matches
+                .values()
+                .flatten()
+                .copied()
+                .filter(|id| seen.insert(*id))
+                .collect()
+        };
+        let point_map: std::collections::HashMap<u64, crate::Point> = collection
+            .get(&all_ids)
+            .into_iter()
+            .flatten()
+            .map(|p| (p.id, p))
+            .collect();
+        (key_matches, point_map)
+    }
+
+    /// Executes the indexed non-PK join in three grouped phases.
+    ///
+    /// The per-left-row shape issued one `secondary_index_lookup` and one
+    /// storage `get` PER LEFT ROW, re-hydrating the same join-side points
+    /// once per left row sharing a key (10k left rows on one hot key = 10k
+    /// identical fetches). Phases: (1) resolve each left row's join key
+    /// once; (2) one index lookup per DISTINCT key and one batched
+    /// hydration over the deduplicated match ids — a proper hash-join build
+    /// side; (3) emit, moving each left row into its final match and
+    /// cloning only for the extra rows of a 1:N key.
+    fn execute_indexed_join(
+        results: Vec<SearchResult>,
         join: &crate::velesql::JoinClause,
         collection: &crate::collection::Collection,
         row_budget: usize,
-    ) -> Option<Vec<SearchResult>> {
-        use crate::velesql::JoinType;
-        if !matches!(join.join_type, JoinType::Inner | JoinType::Left) {
-            return None;
-        }
-        let condition = crate::collection::search::query::join::resolve_join_condition(join)?;
-        let index_column = condition.left.column.clone();
-        if index_column == "id" || !collection.indexed_field_names().contains(&index_column) {
-            return None;
-        }
+    ) -> Vec<SearchResult> {
+        // Eligibility was checked by `indexed_join_eligible`.
+        let Some(condition) = crate::collection::search::query::join::resolve_join_condition(join)
+        else {
+            return Vec::new();
+        };
+        let index_column = &condition.left.column;
+        let source_column = &condition.right.column;
 
+        // Phase 1: one key per left row (same payload->key conversion as
+        // index maintenance, with the `id` fallback the PK extractor honours).
+        let keys: Vec<Option<crate::index::JsonValue>> = results
+            .iter()
+            .map(|left| {
+                left.point
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get(source_column).cloned())
+                    .or_else(|| (source_column == "id").then(|| serde_json::json!(left.point.id)))
+                    .as_ref()
+                    .and_then(crate::index::JsonValue::from_json)
+            })
+            .collect();
+
+        // Phase 2: build side — one lookup per distinct key, one batched get.
+        let (key_matches, point_map) =
+            Self::indexed_join_build_side(collection, &keys, index_column);
+
+        // Phase 3: emit — one merged row per (left row, match), budget-bounded.
         let mut output = Vec::new();
-        for left in results {
+        'rows: for (left, key) in results.into_iter().zip(keys) {
             if output.len() >= row_budget {
                 break;
             }
-            Self::append_indexed_matches(
-                collection,
-                left,
-                &index_column,
-                &condition.right.column,
-                join.join_type,
-                row_budget,
-                &mut output,
-            );
-        }
-        Some(output)
-    }
-
-    /// Appends the join output rows for one left-side result: every indexed
-    /// match merged left-over-right, or the bare left row for an unmatched
-    /// LEFT JOIN. The source key uses the same payload→key conversion as
-    /// index maintenance (`JsonValue::from_json`), with the `id` fallback the
-    /// PK key extractor also honours.
-    fn append_indexed_matches(
-        collection: &crate::collection::Collection,
-        left: &SearchResult,
-        index_column: &str,
-        source_column: &str,
-        join_type: crate::velesql::JoinType,
-        row_budget: usize,
-        output: &mut Vec<SearchResult>,
-    ) {
-        let source_value = left
-            .point
-            .payload
-            .as_ref()
-            .and_then(|p| p.get(source_column).cloned())
-            .or_else(|| (source_column == "id").then(|| serde_json::json!(left.point.id)));
-        let matches = source_value
-            .as_ref()
-            .and_then(crate::index::JsonValue::from_json)
-            .and_then(|key| collection.secondary_index_lookup(index_column, &key))
-            .unwrap_or_default();
-
-        if matches.is_empty() {
-            if matches!(join_type, crate::velesql::JoinType::Left) {
-                output.push(left.clone());
+            let matches = key
+                .as_ref()
+                .and_then(|k| key_matches.get(k))
+                .filter(|ids| !ids.is_empty());
+            let Some(match_ids) = matches else {
+                if matches!(join.join_type, crate::velesql::JoinType::Left) {
+                    output.push(left);
+                }
+                continue;
+            };
+            let rights: Vec<&crate::Point> = match_ids
+                .iter()
+                .filter_map(|id| point_map.get(id))
+                .collect();
+            let Some((last_right, head_rights)) = rights.split_last() else {
+                // Matches existed but none hydrated — the row vanishes,
+                // exactly as the per-row `get` loop emitted nothing here.
+                continue;
+            };
+            let score = left.score;
+            for right_point in head_rights {
+                if output.len() >= row_budget {
+                    continue 'rows;
+                }
+                output.push(SearchResult::new(
+                    Self::merge_payloads(&left.point, right_point),
+                    score,
+                ));
             }
-            return;
-        }
-        for right_point in collection.get(&matches).into_iter().flatten() {
             if output.len() >= row_budget {
-                return;
+                continue;
             }
+            // The final row of a key takes the left point by move — the
+            // 1:1 common case therefore never clones the vector.
             output.push(SearchResult::new(
-                Self::merge_payloads(&left.point, &right_point),
-                left.score,
+                Self::merge_payloads_owned(left.point, last_right),
+                score,
             ));
         }
+        output
     }
 
     /// Returns the JOIN-side `ColumnStore` for `collection`, rebuilding only


### PR DESCRIPTION
## Description

Tier-A findings from the graph/join audit: **every joined row deep-cloned its left `SearchResult` — vector included** (~3 KB memcpy per row at 768 dims), and the indexed non-PK join issued one index lookup plus one storage fetch **per left row**.

- **The PK `ColumnStore` join is 1:1 by construction** (`extract_join_keys` emits at most one key per left row), so the join chain now consumes its input: `execute_single_join` and `execute_join` take `Vec<SearchResult>`, the batch processor moves each left row out of an `Option` slot with `take()`, and whatever remains `Some` **is** the unmatched-left set — which retires the separate `matched_left_indices` bookkeeping. The multi-join loop in the query engine re-binds the moved `Vec` per join instead of re-borrowing (each surviving row was previously re-cloned once per join in the chain).
- **The lookup join moves too**: `merge_payloads_owned` consumes the left point (vector moved, not copied); the borrowing `merge_payloads` remains for 1:N call sites and delegates to it.
- **The indexed non-PK join runs in three grouped phases**: one key per left row; ONE `secondary_index_lookup` per DISTINCT key plus ONE batched hydration over deduplicated match ids (a real hash-join build side); then emission — each left row is moved into its final match row and cloned only for the extra rows of a 1:N key. 10k left rows sharing one hot key previously performed 10k identical lookups and hydrations.

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5367 passed, 0 failed**
- `join` subset: 98/98 (re-run after merging latest `develop`)
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Fifth PR of the Tier-A wave. The Tier-S wave (#2058–#2062) is now fully merged. Branch already carries the latest `develop` for the freshness gate.
