### PR TITLE
perf(core): top-k partial sorts on brute-force paths; decorate plain ORDER BY fields

### DIFF
--- a/crates/velesdb-core/src/collection/search/query/ordering.rs
+++ b/crates/velesdb-core/src/collection/search/query/ordering.rs
@@ -125,6 +125,34 @@ impl Collection {
         let similarity_scores_map = self.precompute_similarity_scores(results, order_by, params)?;
         let higher_is_better = self.storage.config.read().metric.higher_is_better();
 
+        // Decorate-then-sort for plain payload fields: resolve each row's
+        // key ONCE instead of re-walking the (BTreeMap-backed) payload JSON
+        // inside the comparator — O(n) resolutions where the comparator paid
+        // O(n log n) x2. LET-bound and builtin-score fields keep the
+        // per-comparison path: they read per-row f32 contexts, not payload
+        // JSON, so there is nothing to decorate.
+        let field_keys: Vec<Option<Vec<Option<&serde_json::Value>>>> = order_by
+            .iter()
+            .map(|ob| match &ob.expr {
+                crate::velesql::OrderByExpr::Field(field_name)
+                    if per_result_let.is_empty() && !is_builtin_score_variable(field_name) =>
+                {
+                    Some(
+                        results
+                            .iter()
+                            .map(|r| {
+                                r.point
+                                    .payload
+                                    .as_ref()
+                                    .and_then(|p| get_nested_payload(p, field_name))
+                            })
+                            .collect(),
+                    )
+                }
+                _ => None,
+            })
+            .collect();
+
         let mut indices: Vec<usize> = (0..results.len()).collect();
         indices.sort_unstable_by(|&i, &j| {
             Self::compare_by_order_columns(
@@ -135,6 +163,7 @@ impl Collection {
                 &similarity_scores_map,
                 higher_is_better,
                 per_result_let,
+                &field_keys,
             )
             // Deterministic tie-break: rows whose ORDER BY keys are all equal are
             // ordered by ascending point id, regardless of ASC/DESC on the keys.
@@ -233,6 +262,7 @@ impl Collection {
 
     /// Compares two result indices across all ORDER BY columns.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // Reason: internal comparator; the decorated keys ride alongside the raw inputs
     fn compare_by_order_columns(
         i: usize,
         j: usize,
@@ -241,6 +271,7 @@ impl Collection {
         similarity_scores: &std::collections::HashMap<usize, Vec<f32>>,
         higher_is_better: bool,
         per_result_let: &[Vec<(String, f32)>],
+        field_keys: &[Option<Vec<Option<&serde_json::Value>>>],
     ) -> Ordering {
         use crate::velesql::OrderByExpr;
         for (idx, ob) in order_by.iter().enumerate() {
@@ -249,7 +280,10 @@ impl Collection {
                     .get(&idx)
                     .map_or(Ordering::Equal, |scores| scores[i].total_cmp(&scores[j])),
                 OrderByExpr::Field(field_name) => {
-                    Self::compare_field_expr(field_name, i, j, results, per_result_let)
+                    match field_keys.get(idx).and_then(Option::as_ref) {
+                        Some(keys) => compare_json_values(keys[i], keys[j]),
+                        None => Self::compare_field_expr(field_name, i, j, results, per_result_let),
+                    }
                 }
                 OrderByExpr::Aggregate(_) => Ordering::Equal,
                 // Design: Arithmetic ORDER BY uses direct numeric ordering without

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -195,6 +195,26 @@ impl DistanceMetric {
             results.sort_unstable_by(|a, b| a.score.total_cmp(&b.score));
         }
     }
+
+    /// Top-k twin of [`Self::sort_scored_results`]: O(n + k log k) partial
+    /// select + sort instead of a full O(n log n) sort, for callers that
+    /// truncate to `k` anyway — the bitmap brute-force scan hands this the
+    /// whole allowed set, which can be a large fraction of the collection.
+    ///
+    /// Gated with the `index` module its helper lives in (its callers are
+    /// the persistence-gated HNSW paths).
+    #[cfg(feature = "persistence")]
+    pub(crate) fn top_k_scored_results(
+        self,
+        results: &mut Vec<crate::scored_result::ScoredResult>,
+        k: usize,
+    ) {
+        if self.higher_is_better() {
+            crate::index::top_k_partial_sort(results, k, |a, b| b.score.total_cmp(&a.score));
+        } else {
+            crate::index::top_k_partial_sort(results, k, |a, b| a.score.total_cmp(&b.score));
+        }
+    }
 }
 
 impl FromStr for DistanceMetric {

--- a/crates/velesdb-core/src/index/hnsw/index/brute_force.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/brute_force.rs
@@ -48,8 +48,7 @@ impl HnswIndex {
             // RoaringBitmap — consistent with HNSW+bitmap path (search.rs).
             self.score_overflow_ids(query, vectors, &mut scored);
 
-            self.metric.sort_scored_results(&mut scored);
-            scored.truncate(k);
+            self.metric.top_k_scored_results(&mut scored, k);
             scored
         });
 

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -210,8 +210,7 @@ impl HnswIndex {
             }
         }
 
-        self.metric.sort_scored_results(&mut results);
-        results.truncate(k);
+        self.metric.top_k_scored_results(&mut results, k);
         Ok(results)
     }
 


### PR DESCRIPTION
## Description

Two Tier-A "O(n log n) where O(n + k log k) suffices" shapes:

- **The bitmap brute-force scan and the bitmap under-fill retry fully sorted their candidate sets** (potentially a large fraction of the collection — the pre-filter-exact strategy routes here at low selectivity, and the retry path stacks up to 10k + 10k candidates), then truncated to k. `DistanceMetric::top_k_scored_results` is the top-k twin of `sort_scored_results` — `select_nth_unstable` + truncate + sort of the k survivors, same comparator, persistence-gated with the module its helper lives in.
- **`ORDER BY <payload.field>` re-walked the (BTreeMap-backed) payload JSON inside the comparator**: two `get_nested_payload` calls — each a dotted split plus string-compare chains — per comparison, O(n log n) times. Plain payload fields are now **decorated once per row** before the sort (one `Vec<Option<&Value>>` per Field column); the comparator reads the precomputed refs. LET-bound and builtin-score fields keep the per-comparison path unchanged — they read per-row f32 contexts, not payload JSON, so there is nothing to decorate.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5352 passed, 0 failed** (post-#2062 baseline)
- Search path touched → recall gate: `test_recall` **18/18**; `order` subset 171/171
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features check — clean (the new method is persistence-gated like its callers)

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Seventh and final planned PR of the Tier-A wave (#2063 merged; #2064–#2068 in CI).
