### PR TITLE
docs: note the two environment-bound build limits (GTK crates, swagger-ui network fetch)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,11 @@ cd VelesDB
 # Build the project
 cargo build --workspace
 
+# No GTK/WebKit on the machine? The two Tauri crates are the only ones that
+# need them (CI installs libgtk-3-dev/libwebkit2gtk-4.1-dev); everything else
+# builds without system packages:
+cargo check --workspace --exclude tauri-plugin-velesdb --exclude tauri-rag-app
+
 # Run tests (single-threaded — required for file system isolation)
 cargo test --workspace --features persistence,gpu,update-check \
   --exclude velesdb-python -- --test-threads=1

--- a/crates/velesdb-server/README.md
+++ b/crates/velesdb-server/README.md
@@ -153,7 +153,7 @@ unversioned `/…` form is kept for backward compatibility — its responses car
 - **Authentication is a flat list of API keys.** No users, no roles, no per-collection scoping. Keys are read at startup, so rotation requires a restart (both old and new key can be active during the transition).
 - **Rate limiting is per process and in memory.** Replicas do not share a budget; put a shared limiter in front if you need a global one.
 - **CORS is permissive by default** (`allowed_origins = ["*"]`); the server warns about it at startup. Restrict `[cors]` before exposing a browser-facing deployment.
-- **Swagger UI is opt-in at build time** (`--features swagger-ui`); the released default build does not serve `/swagger-ui` or `/api-docs/openapi.json`.
+- **Swagger UI is opt-in at build time** (`--features swagger-ui`); the released default build does not serve `/swagger-ui` or `/api-docs/openapi.json`. Building with that feature needs network access: `utoipa-swagger-ui`'s build script downloads the Swagger UI distribution, so it fails in air-gapped builds. Offline, skip the feature and point any OpenAPI viewer at [docs/openapi.json](../../docs/openapi.json) instead.
 - **The `/v1` prefix is added by the binary.** Embedding `velesdb_server::routes::api_routes()` in your own Axum application gives you the unversioned routes; nest them yourself if you want the versioned form.
 - Engine-level limits (query length caps, GROUP BY ceilings, scan caps) are listed in [docs/reference/KNOWN_LIMITATIONS.md](../../docs/reference/KNOWN_LIMITATIONS.md).
 


### PR DESCRIPTION
## Description

Two build limits that exist only in constrained environments were undocumented, so each new contributor rediscovers them the slow way:

- **CONTRIBUTING.md** — on a machine without GTK/WebKit system packages, `cargo build --workspace` fails in the two Tauri crates (the only ones that need them; CI installs `libgtk-3-dev`/`libwebkit2gtk-4.1-dev`). The build section now gives the one-line exclude command that checks everything else: `cargo check --workspace --exclude tauri-plugin-velesdb --exclude tauri-rag-app`.
- **crates/velesdb-server/README.md** — the `swagger-ui` feature's build script (`utoipa-swagger-ui`) downloads the Swagger UI distribution at build time, so `--features swagger-ui` fails in air-gapped builds. The Known limits bullet now says so and points at the committed `docs/openapi.json` as the offline alternative.

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- Docs-only change. Guards run locally: `check-ai-attribution`, `check-doc-freshness --mode strict`, `check-feature-claims`, `check-doc-contract.sh` — all passing.
- The exclude command was executed against current `develop` in a GTK-less container: full workspace check finishes clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

## Additional Notes

Closes out the "two environment limits" note from the perf-wave finalization: they are container limitations, not CI coverage gaps — CI builds both Tauri crates and the swagger-ui feature.
