### PR TITLE
perf(hnsw): resume the adaptive escalation instead of restarting; widen ef on the bitmap under-fill retry

### DIFF
--- a/.github/workflows/quality-deep.yml
+++ b/.github/workflows/quality-deep.yml
@@ -132,6 +132,8 @@ jobs:
         run: |
           cargo test -p velesdb-core --features persistence,internal-bench \
             --test cost_crossover -- --test-threads=1 --nocapture
+          cargo test -p velesdb-core --features persistence,internal-bench \
+            --test adaptive_resume_evals -- --test-threads=1 --nocapture
 
   # ===========================================================================
   # Loom Concurrency Tests - Détecte deadlocks et data races

--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -430,6 +430,10 @@ harness = false
 name = "pq_recall_multidist"
 harness = false
 
+[[test]]
+name = "adaptive_resume_evals"
+required-features = ["internal-bench"]
+
 [[bench]]
 name = "scalability_quick"
 harness = false

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -86,9 +86,19 @@ impl HnswIndex {
     ) -> Vec<ScoredResult> {
         let inner = self.inner.read();
         let neighbours = inner.search_auto(query, k, ef_search);
+        self.map_graph_results(&inner, &neighbours)
+    }
 
+    /// Maps raw graph results `(node_id, raw_dist)` to user-facing
+    /// [`ScoredResult`]s: internal index -> external ID via the mappings,
+    /// raw distance -> metric score via `transform_score`.
+    fn map_graph_results(
+        &self,
+        inner: &crate::index::hnsw::native_inner::NativeHnswInner,
+        neighbours: &[(usize, f32)],
+    ) -> Vec<ScoredResult> {
         let mut results: Vec<ScoredResult> = Vec::with_capacity(neighbours.len());
-        for &(node_id, raw_dist) in &neighbours {
+        for &(node_id, raw_dist) in neighbours {
             if let Some(id) = self.mappings.get_id(node_id) {
                 let score = inner.transform_score(raw_dist);
                 results.push(ScoredResult::new(id, score));
@@ -196,11 +206,18 @@ impl HnswIndex {
             self.search_hnsw_only_filtered(query, candidates_k, ef_search, allowed_ids);
 
         // Adaptive retry: if too few results survived the bitmap filter,
-        // double the candidate pool and retry once to find more matches.
+        // double the candidate pool AND the ef budget, then retry once.
+        // `ef_search` bounds the graph's result heap, so it is the knob that
+        // actually deepens exploration: `candidates_k` beyond `ef` only
+        // raises a truncation limit the heap never reaches. (A retry at the
+        // same ef re-runs the identical traversal and returns the same
+        // candidate set — the pre-fix behavior, which made this retry pure
+        // cost.)
         if results.len() < k && candidates_k < 10_000 {
             let retry_k = (candidates_k.saturating_mul(2)).min(10_000);
+            let retry_ef = (ef_search.saturating_mul(2)).min(10_000);
             let retry_results =
-                self.search_hnsw_only_filtered(query, retry_k, ef_search, allowed_ids);
+                self.search_hnsw_only_filtered(query, retry_k, retry_ef, allowed_ids);
             // Merge retry results, deduplicating by ID
             let existing_ids: rustc_hash::FxHashSet<u64> = results.iter().map(|r| r.id).collect();
             for r in retry_results {
@@ -385,8 +402,12 @@ impl HnswIndex {
     /// Two-phase adaptive search that starts with a low ef and escalates if needed.
     ///
     /// Phase 1: search with `min_ef`. If the result spread (max_dist / min_dist)
-    /// indicates a hard query (scattered results), re-search with doubled ef.
-    /// This saves 2-4x latency on easy queries while maintaining recall on hard ones.
+    /// indicates a hard query (scattered results), widen ef to `2 * min_ef` and
+    /// **resume** the phase-1 traversal (visited set and frontier carried over)
+    /// rather than re-searching from scratch — restart remains only for the
+    /// GPU/RaBitQ paths, which keep no CPU-side state. This saves 2-4x latency
+    /// on easy queries and roughly a third of the distance evaluations on
+    /// escalated ones.
     fn search_adaptive(
         &self,
         query: &[f32],
@@ -394,8 +415,14 @@ impl HnswIndex {
         min_ef: usize,
         max_ef: usize,
     ) -> Vec<ScoredResult> {
-        // Phase 1: fast search with min_ef
-        let results = self.search_hnsw_only(query, k, min_ef);
+        // Phase 1: fast search with min_ef, keeping the traversal state so an
+        // escalation resumes the search instead of restarting it (#2077).
+        // One read guard spans both phases: re-locking through
+        // `search_hnsw_only` would be a recursive `read()` on a parking_lot
+        // `RwLock`, which can deadlock behind a queued writer.
+        let inner = self.inner.read();
+        let (neighbours, resume) = inner.search_resumable(query, k, min_ef);
+        let results = self.map_graph_results(&inner, &neighbours);
         if results.len() < 2 {
             return results;
         }
@@ -422,13 +449,24 @@ impl HnswIndex {
             return results;
         }
 
-        // Phase 2: re-search with doubled ef (capped at max_ef)
+        // Phase 2: widen ef (capped at max_ef)
         let escalated_ef = (min_ef * 2).min(max_ef);
         if escalated_ef <= min_ef {
             return results;
         }
 
-        self.search_hnsw_only(query, k, escalated_ef)
+        // Resume the phase-1 traversal when it kept state (Standard backend,
+        // CPU path): the visited set and frontier carry over, so the widened
+        // pass pays only the marginal exploration instead of ef1 + ef2 from
+        // scratch. GPU and RaBitQ phase-1 searches return no state and
+        // restart, exactly as before. See `ResumableSearch` for what a
+        // resumed pass does not reconsider (recall sits between single-pass
+        // ef1 and ef2; the `adaptive_resume_evals` harness pins the trade).
+        let escalated = match resume {
+            Some(r) => inner.resume_search(r, query, k, escalated_ef),
+            None => inner.search_auto(query, k, escalated_ef),
+        };
+        self.map_graph_results(&inner, &escalated)
     }
 
     /// Sets the index to searching mode after bulk insertions.

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -3390,3 +3390,145 @@ fn test_with_params_propagates_alpha_to_native_graph() {
         "alpha 1.5 must propagate to native graph, got {actual}"
     );
 }
+
+// =========================================================================
+// Resumable adaptive escalation + bitmap under-fill retry (#2077)
+// =========================================================================
+
+/// Deterministic pseudo-random unit vector for the resume/retry tests.
+fn resume_test_vector(dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut v: Vec<f32> = (0..dim)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state as f64 / u64::MAX as f64) as f32 - 0.5
+        })
+        .collect();
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in &mut v {
+        *x /= norm;
+    }
+    v
+}
+
+/// The bitmap under-fill retry must widen `ef`, not just `candidates_k`:
+/// the graph's result heap is bounded by `ef`, so a same-ef retry re-runs
+/// the identical traversal and returns the identical candidate set. This
+/// test pins both halves of that statement.
+#[test]
+fn bitmap_underfill_retry_widens_ef_and_finds_more_matches() {
+    const DIM: usize = 64;
+    const N: u64 = 1_500;
+    const K: usize = 20;
+
+    let index = HnswIndex::new(DIM, DistanceMetric::Cosine).unwrap();
+    for id in 0..N {
+        index.insert(id, &resume_test_vector(DIM, id + 1));
+    }
+    let query = resume_test_vector(DIM, 987_654_321);
+
+    // Exact cosine ranking of all ids against the query.
+    let mut ranked: Vec<(u64, f32)> = (0..N)
+        .map(|id| {
+            let v = resume_test_vector(DIM, id + 1);
+            let dot: f32 = query.iter().zip(&v).map(|(a, b)| a * b).sum();
+            (id, dot)
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+    // Allow only a mid-far band: mostly outside the base-ef candidate set,
+    // reachable when the traversal digs deeper.
+    let allowed: Vec<u64> = ranked[300..380].iter().map(|&(id, _)| id).collect();
+    let mut bitmap = roaring::RoaringBitmap::new();
+    for &id in &allowed {
+        bitmap.insert(u32::try_from(id).unwrap());
+    }
+
+    let quality = SearchQuality::Balanced;
+    let ef = quality.ef_search_for_scale(K, index.len());
+    let candidates_k = K.saturating_mul(4).max(ef);
+
+    // Mechanism pin: doubling candidates_k at the SAME ef returns the exact
+    // same survivor set — candidates_k beyond ef only raises a truncation
+    // limit the ef-bounded heap never reaches.
+    let base = index.search_hnsw_only_filtered(&query, candidates_k, ef, &bitmap);
+    let same_ef_double_k = index.search_hnsw_only_filtered(&query, candidates_k * 2, ef, &bitmap);
+    let base_ids: Vec<u64> = base.iter().map(|r| r.id).collect();
+    let double_k_ids: Vec<u64> = same_ef_double_k.iter().map(|r| r.id).collect();
+    assert_eq!(
+        base_ids, double_k_ids,
+        "same-ef retry must be a no-op: candidates_k is not the exploration knob"
+    );
+
+    // The band is chosen so the base pass under-fills — otherwise the retry
+    // (the code under test) never runs.
+    assert!(
+        base.len() < K,
+        "test setup: base pass must under-fill (got {} >= K={K})",
+        base.len()
+    );
+
+    // Fix pin: the full path (base + widened-ef retry) surfaces strictly
+    // more allowed matches than the base pass alone.
+    let full = index
+        .search_with_quality_and_bitmap(&query, K, quality, &bitmap)
+        .unwrap();
+    assert!(
+        full.len() > base.len(),
+        "widened-ef retry must find more allowed matches (base {}, full {})",
+        base.len(),
+        full.len()
+    );
+}
+
+/// Repeated adaptive searches must be bit-identical: the resumed traversal
+/// hands its pooled heaps and visited set back on drop, so any pool
+/// pollution (a visited set returned uncleared, a heap kept warm with stale
+/// entries) would show up as run-to-run drift here.
+#[test]
+fn adaptive_resume_is_deterministic_across_pool_reuse() {
+    const DIM: usize = 128;
+    const N: u64 = 1_200;
+    const K: usize = 10;
+
+    let index = HnswIndex::new(DIM, DistanceMetric::Cosine).unwrap();
+    // A tight 4-vector pocket around a distinct direction plus random
+    // background: the pocket dominates the top of the result list while the
+    // background trails far behind, which drives the spread heuristic over
+    // its escalation threshold.
+    let pocket_dir = resume_test_vector(DIM, 42);
+    for id in 0..4u64 {
+        let mut v = pocket_dir.clone();
+        let noise = resume_test_vector(DIM, 1_000 + id);
+        for (x, n) in v.iter_mut().zip(&noise) {
+            *x += 0.05 * n;
+        }
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in &mut v {
+            *x /= norm;
+        }
+        index.insert(id, &v);
+    }
+    for id in 4..N {
+        index.insert(id, &resume_test_vector(DIM, id + 1));
+    }
+
+    let quality = SearchQuality::Adaptive {
+        min_ef: 32,
+        max_ef: 64,
+    };
+    let first = index.search_with_quality(&pocket_dir, K, quality).unwrap();
+    assert!(!first.is_empty());
+    for _ in 0..50 {
+        let run = index.search_with_quality(&pocket_dir, K, quality).unwrap();
+        let first_ids: Vec<u64> = first.iter().map(|r| r.id).collect();
+        let run_ids: Vec<u64> = run.iter().map(|r| r.id).collect();
+        assert_eq!(
+            first_ids, run_ids,
+            "adaptive resume drifted across pooled reuse"
+        );
+    }
+}

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -15,6 +15,7 @@ mod neighbors;
 mod reorder;
 pub(crate) mod safety_counters;
 mod search;
+pub(crate) use search::ResumableSearch;
 mod search_pipeline;
 mod search_pools;
 mod search_state;

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search.rs
@@ -38,6 +38,34 @@ thread_local! {
     static PROBE_RNG: Cell<u64> = const { Cell::new(0) };
 }
 
+/// Resumable handle over a completed layer-0 traversal.
+///
+/// Produced by [`NativeHnsw::search_resumable`] and consumed by
+/// [`NativeHnsw::resume_search`]. Dropping it without resuming returns the
+/// pooled heaps and visited set through [`SearchState`]'s `Drop`.
+///
+/// # What a resumed traversal does not reconsider
+///
+/// Resuming continues best-first expansion from the phase-1 frontier
+/// (`candidates`) under a widened `ef`. Two classes of phase-1 nodes are
+/// permanently out of reach:
+///
+/// - neighbors gathered during phase 1 whose distance failed the phase-1
+///   admission test — the visited mark happens at gather time (exactly as
+///   in hnswlib), so they can never be re-gathered, and no heap entry was
+///   created for them;
+/// - the single candidate popped by the terminating iteration of phase 1.
+///
+/// A resumed search therefore explores a subset of what a from-scratch
+/// search at the widened `ef` would explore: its recall sits between
+/// single-pass `ef1` and single-pass `ef2`. The `adaptive_resume_evals`
+/// harness pins both sides of that trade — distance evaluations saved and
+/// recall parity against the from-scratch escalation — on a deterministic
+/// corpus.
+pub struct ResumableSearch {
+    state: SearchState,
+}
+
 impl<D: DistanceEngine> NativeHnsw<D> {
     /// Searches for k nearest neighbors.
     ///
@@ -239,6 +267,108 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     // Layer-level search helpers
     // =========================================================================
 
+    /// Phase-1 search that keeps its traversal state for a possible escalation.
+    ///
+    /// Runs the same descent and layer-0 traversal as [`Self::search`], but
+    /// returns the sorted top-k **and** a live [`ResumableSearch`] handle
+    /// instead of consuming the state. Pass the handle to
+    /// [`Self::resume_search`] to widen the `ef` budget without restarting
+    /// the traversal; drop it to release the pooled structures unchanged.
+    #[must_use]
+    pub(in crate::index::hnsw) fn search_resumable(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> (Vec<(NodeId, f32)>, Option<ResumableSearch>) {
+        let prepared_query = self.prepare_query(query);
+        let outcome = self.search_resumable_prepared(&prepared_query, k, ef_search);
+        Self::recycle_cow(prepared_query);
+        outcome
+    }
+
+    /// [`Self::search_resumable`] on an already-prepared query vector.
+    ///
+    /// Mirrors [`Self::search_prepared`] / [`Self::search_multi_entry_prepared`]
+    /// (greedy upper-layer descent, adaptive probe count, layer-0 traversal)
+    /// but keeps the [`SearchState`] alive inside the returned handle.
+    fn search_resumable_prepared(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> (Vec<(NodeId, f32)>, Option<ResumableSearch>) {
+        let ep = self.entry_point.load(Ordering::Acquire);
+        if ep == NO_ENTRY_POINT {
+            return (Vec::new(), None);
+        }
+
+        let max_layer = self.max_layer.load(Ordering::Relaxed);
+        let mut current_ep = ep;
+        for layer_idx in (1..=max_layer).rev() {
+            current_ep = self.search_layer_single(query, current_ep, layer_idx);
+        }
+
+        let count = self.count.load(Ordering::Relaxed);
+        let probes = self.adaptive_num_probes(count, ef_search, k);
+
+        let mut state = SearchState::new(count);
+        if probes > 1 {
+            let entry_points = Self::gather_multi_entry_points(current_ep, count, probes);
+            self.run_layer_search(
+                query,
+                &entry_points,
+                ef_search,
+                0,
+                self.stagnation_limit,
+                &mut state,
+            );
+        } else {
+            self.run_layer_search(
+                query,
+                &[current_ep],
+                ef_search,
+                0,
+                self.stagnation_limit,
+                &mut state,
+            );
+        }
+
+        let results = state.peek_sorted_results(Some(k));
+        (results, Some(ResumableSearch { state }))
+    }
+
+    /// Continues a phase-1 traversal under a widened `ef` budget.
+    ///
+    /// `query` must be the same vector passed to [`Self::search_resumable`];
+    /// it is re-prepared here (one normalization pass for cosine) so the
+    /// handle neither borrows nor owns the phase-1 buffer. See
+    /// [`ResumableSearch`] for what a resumed traversal does and does not
+    /// reconsider.
+    #[must_use]
+    pub(in crate::index::hnsw) fn resume_search(
+        &self,
+        resume: ResumableSearch,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> Vec<(NodeId, f32)> {
+        let ResumableSearch { mut state } = resume;
+        // The widened budget deserves fresh stagnation chances: phase 1 may
+        // have stopped on the stagnation limit rather than the distance bound.
+        state.stagnation_count = 0;
+        let prepared_query = self.prepare_query(query);
+        self.continue_layer_search(
+            &prepared_query,
+            &mut state,
+            ef_search,
+            0,
+            self.stagnation_limit,
+        );
+        Self::recycle_cow(prepared_query);
+        state.into_sorted_results(Some(k))
+    }
+
     /// F-04 optimization: acquires both vectors and layers read locks once
     /// before the greedy descent loop, avoiding repeated lock cycles per hop.
     ///
@@ -389,7 +519,23 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     ) -> Vec<(NodeId, f32)> {
         let capacity_hint = self.count.load(Ordering::Relaxed);
         let mut state = SearchState::new(capacity_hint);
+        self.run_layer_search(query, entry_points, ef, layer, stagnation_limit, &mut state);
+        state.into_sorted_results(result_limit)
+    }
 
+    /// Seeds `state` with `entry_points` and runs the layer traversal loop.
+    ///
+    /// Factored out of [`Self::search_layer`] so the resumable-search path
+    /// can run the identical traversal while retaining the state.
+    fn run_layer_search(
+        &self,
+        query: &[f32],
+        entry_points: &[NodeId],
+        ef: usize,
+        layer: usize,
+        stagnation_limit: usize,
+        state: &mut SearchState,
+    ) {
         self.with_vectors_and_layers_read(|vectors, layers| {
             let use_prefetch = should_prefetch(vectors.dimension());
 
@@ -415,15 +561,44 @@ impl<D: DistanceEngine> NativeHnsw<D> {
                 query,
                 vectors,
                 layers,
-                &mut state,
+                state,
                 ef,
                 layer,
                 stagnation_limit,
                 use_prefetch,
             );
         });
+    }
 
-        state.into_sorted_results(result_limit)
+    /// Re-enters the layer traversal loop with an existing state.
+    ///
+    /// No entry-point seeding: `state.candidates` already holds the frontier
+    /// left by the previous pass, and `state.results` its admitted set. With
+    /// a widened `ef`, [`SearchState::should_terminate`] does not fire until
+    /// the result set grows past the new budget, so the loop continues the
+    /// best-first expansion exactly where the previous pass stopped.
+    fn continue_layer_search(
+        &self,
+        query: &[f32],
+        state: &mut SearchState,
+        ef: usize,
+        layer: usize,
+        stagnation_limit: usize,
+    ) {
+        self.with_vectors_and_layers_read(|vectors, layers| {
+            let use_prefetch = should_prefetch(vectors.dimension());
+            Self::dispatch_layer_search(
+                &self.distance,
+                query,
+                vectors,
+                layers,
+                state,
+                ef,
+                layer,
+                stagnation_limit,
+                use_prefetch,
+            );
+        });
     }
 
     /// Dispatches layer search to the pipelined or sequential path.

--- a/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/search_state.rs
@@ -99,6 +99,24 @@ impl SearchState {
         }
     }
 
+    /// Non-destructive sorted snapshot of the current result set.
+    ///
+    /// Used by the resumable-search path to publish phase-1 results while
+    /// the heaps and visited set stay alive for a possible escalation.
+    /// Copies at most `ef` entries and applies the same partial sort as
+    /// [`Self::into_sorted_results`].
+    pub(super) fn peek_sorted_results(&self, limit: Option<usize>) -> Vec<(NodeId, f32)> {
+        let mut result_vec: Vec<(NodeId, f32)> =
+            self.results.iter().map(|&(d, n)| (n, d.0)).collect();
+        let cmp = |a: &(NodeId, f32), b: &(NodeId, f32)| a.1.total_cmp(&b.1);
+        if let Some(k) = limit {
+            crate::index::top_k_partial_sort(&mut result_vec, k, cmp);
+        } else {
+            result_vec.sort_by(cmp);
+        }
+        result_vec
+    }
+
     /// Consumes the state and returns results sorted by distance ascending.
     ///
     /// When `limit` is `Some(k)`, uses partial sort (`select_nth_unstable_by`)

--- a/crates/velesdb-core/src/index/hnsw/native/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/mod.rs
@@ -51,6 +51,7 @@ mod search;
 pub use backend_adapter::{NativeHnswBackend, NativeNeighbour};
 pub use distance::{CachedSimdDistance, CpuDistance, DistanceEngine};
 pub use dual_precision::{DualPrecisionConfig, DualPrecisionHnsw};
+pub(crate) use graph::ResumableSearch;
 pub use graph::{NativeHnsw, DEFAULT_ALPHA, NO_ENTRY_POINT};
 // Re-exported so sibling modules (notably `crate::gpu::gpu_csr` and its
 // tests) can document and assert the caller contract of rebuilders that

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -10,9 +10,18 @@
 #![allow(clippy::cast_precision_loss)]
 
 use super::native::rabitq_precision::RaBitQPrecisionHnsw;
-use super::native::{CachedSimdDistance, NativeHnsw, NativeNeighbour, DEFAULT_ALPHA};
+use super::native::{
+    CachedSimdDistance, NativeHnsw, NativeNeighbour, ResumableSearch, DEFAULT_ALPHA,
+};
 use crate::distance::DistanceMetric;
 use std::path::Path;
+
+/// Opaque resume handle for an escalatable CPU search on the Standard backend.
+///
+/// Wraps the graph-level [`ResumableSearch`] so callers above the backend
+/// dispatch hold it without seeing graph internals. Dropping it releases the
+/// pooled traversal structures.
+pub struct SearchResume(ResumableSearch);
 
 /// Backend selector for the native HNSW index.
 ///
@@ -257,21 +266,90 @@ impl NativeHnswInner {
     /// is not yet implemented).
     #[must_use]
     pub fn search_auto(&self, query: &[f32], k: usize, ef_search: usize) -> Vec<(usize, f32)> {
+        if let Some(results) = self.try_gpu_route(query, k, ef_search) {
+            return results;
+        }
+        self.search(query, k, ef_search)
+    }
+
+    /// GPU routing policy shared by [`Self::search_auto`] and
+    /// [`Self::search_resumable`]: attempts device layer-0 traversal when the
+    /// Standard backend crosses the GPU threshold. `None` means "take the CPU
+    /// path" — either the feature is off, the backend/scale does not qualify,
+    /// or the GPU attempt failed and search falls through.
+    ///
+    /// `query.len()` is authoritative for the index dimension: a query of
+    /// wrong length would fail distance evaluation anyway.
+    #[allow(unused_variables)] // Reason: parameters unused when `gpu` is off
+    fn try_gpu_route(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> Option<Vec<(usize, f32)>> {
         #[cfg(feature = "gpu")]
-        {
-            if let HnswBackend::Standard(hnsw) = &self.backend {
-                // `query.len()` is authoritative for the index dimension: a query
-                // of wrong length would fail distance evaluation anyway.
-                if crate::gpu::should_traverse_gpu(hnsw.len(), query.len()) {
-                    if let Some(results) = self.search_gpu(query, k, ef_search) {
-                        return results;
-                    }
-                    // GPU failed — fall through to CPU
+        if let HnswBackend::Standard(hnsw) = &self.backend {
+            if crate::gpu::should_traverse_gpu(hnsw.len(), query.len()) {
+                if let Some(results) = self.search_gpu(query, k, ef_search) {
+                    return Some(results);
                 }
+                // GPU failed — fall through to CPU
             }
         }
+        None
+    }
 
-        self.search(query, k, ef_search)
+    /// Phase-1 search that keeps its traversal state for a possible escalation.
+    ///
+    /// Same GPU/backend dispatch as [`Self::search_auto`], with one addition:
+    /// on the Standard-backend CPU path the graph traversal state is returned
+    /// as a [`SearchResume`] handle, so an escalating caller can widen the
+    /// `ef` budget via [`Self::resume_search`] instead of restarting.
+    ///
+    /// Paths with no CPU-side state to resume return `None` and keep their
+    /// pre-change escalation behavior (restart):
+    /// - GPU layer-0 traversal (state lives on the device);
+    /// - the `RaBitQ` backend (its binary-quantized search loop owns no
+    ///   [`ResumableSearch`]).
+    #[must_use]
+    pub fn search_resumable(
+        &self,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> (Vec<(usize, f32)>, Option<SearchResume>) {
+        if let Some(results) = self.try_gpu_route(query, k, ef_search) {
+            // GPU traversal keeps no CPU-side state to resume.
+            return (results, None);
+        }
+
+        match &self.backend {
+            HnswBackend::Standard(hnsw) => {
+                let (results, resume) = hnsw.search_resumable(query, k, ef_search);
+                (results, resume.map(SearchResume))
+            }
+            HnswBackend::RaBitQ(rabitq) => (rabitq.search(query, k, ef_search), None),
+        }
+    }
+
+    /// Continues a [`Self::search_resumable`] traversal under a widened `ef`.
+    ///
+    /// `query` must be the same vector passed to `search_resumable`.
+    #[must_use]
+    pub fn resume_search(
+        &self,
+        resume: SearchResume,
+        query: &[f32],
+        k: usize,
+        ef_search: usize,
+    ) -> Vec<(usize, f32)> {
+        match &self.backend {
+            HnswBackend::Standard(hnsw) => hnsw.resume_search(resume.0, query, k, ef_search),
+            // Unreachable in practice: `SearchResume` is only handed out for
+            // the Standard backend. Kept total so a future backend cannot
+            // silently drop the escalation.
+            HnswBackend::RaBitQ(rabitq) => rabitq.search(query, k, ef_search),
+        }
     }
 
     /// Attempts GPU-accelerated search on the Standard backend.

--- a/crates/velesdb-core/tests/adaptive_resume_evals.rs
+++ b/crates/velesdb-core/tests/adaptive_resume_evals.rs
@@ -1,0 +1,219 @@
+//! Deterministic A/B harness for the resumable adaptive escalation (#2077).
+//!
+//! Requires `--features internal-bench` (registered with `required-features`
+//! in `Cargo.toml`, run by the `quality-deep` workflow next to
+//! `cost_crossover`). Uses the process-global distance-evaluation counter,
+//! which is bit-for-bit reproducible for a deterministic corpus — a work
+//! measure usable on shared CI runners where wall-clock is noise.
+//!
+//! What is measured, per hard query:
+//!
+//! - `E_resume`  — evals of `Adaptive { min_ef, max_ef: 2*min_ef }`, the
+//!   production path: phase 1 at `min_ef`, then a **resumed** escalation.
+//! - `E_phase1`  — evals of `Adaptive { min_ef, max_ef: min_ef }`: the same
+//!   phase 1 with escalation structurally disabled (`escalated_ef <= min_ef`
+//!   returns phase-1 results).
+//! - `E_restart` — evals of `Adaptive { 2*min_ef, 2*min_ef }`: a single
+//!   from-scratch pass at the escalated budget — what phase 2 cost before
+//!   the resume existed.
+//!
+//! The pre-change escalation cost was `E_phase1 + E_restart`. The harness
+//! asserts the resumed path saves a meaningful fraction of that, and that
+//! its recall (against exact ground truth) stays at parity with the
+//! from-scratch escalation.
+
+use velesdb_core::internal_bench::{hnsw_distance_evals, reset_hnsw_distance_evals};
+use velesdb_core::{DistanceMetric, HnswIndex, SearchQuality, VectorIndex};
+
+const DIM: usize = 256;
+const N: u64 = 3_000;
+const K: usize = 10;
+const NQ: u64 = 40;
+const MIN_EF: usize = 32;
+const POCKET: u64 = 4;
+
+/// XORshift64-based deterministic unit vector.
+fn unit_vector(dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1;
+    let mut v: Vec<f32> = (0..dim)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+            let x = (state as f64 / u64::MAX as f64) as f32 - 0.5;
+            x
+        })
+        .collect();
+    normalize(&mut v);
+    v
+}
+
+fn normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in v {
+        *x /= norm;
+    }
+}
+
+/// Query direction for hard query `q`.
+fn query_dir(q: u64) -> Vec<f32> {
+    unit_vector(DIM, 7_000_000 + q)
+}
+
+/// Builds the corpus: for each query, a tight `POCKET`-vector pocket around
+/// its direction (ids `q*POCKET..q*POCKET+POCKET`), then random background.
+/// Pockets smaller than `K` force the tail of every top-`K` into the far
+/// background, which drives the spread heuristic over its escalation
+/// threshold on every query.
+fn build_index() -> HnswIndex {
+    let index = HnswIndex::new(DIM, DistanceMetric::Cosine).unwrap();
+    for q in 0..NQ {
+        let dir = query_dir(q);
+        for p in 0..POCKET {
+            let mut v = dir.clone();
+            let noise = unit_vector(DIM, 9_000_000 + q * POCKET + p);
+            for (x, n) in v.iter_mut().zip(&noise) {
+                *x += 0.05 * n;
+            }
+            normalize(&mut v);
+            index.insert(q * POCKET + p, &v);
+        }
+    }
+    for id in NQ * POCKET..N {
+        index.insert(id, &unit_vector(DIM, id + 1));
+    }
+    index
+}
+
+/// Exact top-`K` ids by brute-force cosine (vectors regenerated from seeds).
+fn ground_truth(query: &[f32]) -> Vec<u64> {
+    let mut scored: Vec<(u64, f32)> = (0..N)
+        .map(|id| {
+            let v = corpus_vector(id);
+            let dot: f32 = query.iter().zip(&v).map(|(a, b)| a * b).sum();
+            (id, dot)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.1.total_cmp(&a.1));
+    scored.truncate(K);
+    scored.into_iter().map(|(id, _)| id).collect()
+}
+
+/// Regenerates the corpus vector for `id` exactly as `build_index` inserted it.
+fn corpus_vector(id: u64) -> Vec<f32> {
+    if id < NQ * POCKET {
+        let q = id / POCKET;
+        let p = id % POCKET;
+        let mut v = query_dir(q);
+        let noise = unit_vector(DIM, 9_000_000 + q * POCKET + p);
+        for (x, n) in v.iter_mut().zip(&noise) {
+            *x += 0.05 * n;
+        }
+        normalize(&mut v);
+        v
+    } else {
+        unit_vector(DIM, id + 1)
+    }
+}
+
+fn hits(results: &[velesdb_core::ScoredResult], truth: &[u64]) -> usize {
+    results.iter().filter(|r| truth.contains(&r.id)).count()
+}
+
+fn measured_search(
+    index: &HnswIndex,
+    query: &[f32],
+    quality: SearchQuality,
+) -> (Vec<velesdb_core::ScoredResult>, u64) {
+    reset_hnsw_distance_evals();
+    let results = index.search_with_quality(query, K, quality).unwrap();
+    (results, hnsw_distance_evals())
+}
+
+#[test]
+fn resumed_escalation_saves_evals_at_recall_parity() {
+    let index = build_index();
+
+    let resume_q = SearchQuality::Adaptive {
+        min_ef: MIN_EF,
+        max_ef: MIN_EF * 2,
+    };
+    let phase1_q = SearchQuality::Adaptive {
+        min_ef: MIN_EF,
+        max_ef: MIN_EF,
+    };
+    let restart_q = SearchQuality::Adaptive {
+        min_ef: MIN_EF * 2,
+        max_ef: MIN_EF * 2,
+    };
+
+    let mut sum_resume = 0u64;
+    let mut sum_old = 0u64;
+    let mut escalated_queries = 0u64;
+    let mut hits_resume = 0usize;
+    let mut hits_restart = 0usize;
+    let mut hits_max = 0usize;
+
+    for q in 0..NQ {
+        let query = query_dir(q);
+        let truth = ground_truth(&query);
+
+        let (r_resume, e_resume) = measured_search(&index, &query, resume_q);
+        let (_r_phase1, e_phase1) = measured_search(&index, &query, phase1_q);
+        let (r_restart, e_restart) = measured_search(&index, &query, restart_q);
+
+        // Determinism: the counter and the ids must reproduce exactly.
+        let (r_resume2, e_resume2) = measured_search(&index, &query, resume_q);
+        assert_eq!(
+            e_resume, e_resume2,
+            "eval count drifted between runs (q={q})"
+        );
+        let ids: Vec<u64> = r_resume.iter().map(|r| r.id).collect();
+        let ids2: Vec<u64> = r_resume2.iter().map(|r| r.id).collect();
+        assert_eq!(ids, ids2, "result ids drifted between runs (q={q})");
+
+        if e_resume > e_phase1 {
+            escalated_queries += 1;
+        }
+        sum_resume += e_resume;
+        sum_old += e_phase1 + e_restart;
+        hits_resume += hits(&r_resume, &truth);
+        hits_restart += hits(&r_restart, &truth);
+        hits_max += K;
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    {
+        eprintln!(
+            "adaptive resume A/B over {NQ} hard queries (k={K}, min_ef={MIN_EF}):\n\
+             escalated: {escalated_queries}/{NQ}\n\
+             evals: resume={sum_resume}  old(phase1+restart)={sum_old}  saved={:.1}%\n\
+             hits@{K}: resume={hits_resume}  restart={hits_restart}  (max {hits_max})",
+            100.0 * (1.0 - sum_resume as f64 / sum_old as f64),
+        );
+    }
+
+    // The corpus must actually exercise the escalation path.
+    assert!(
+        escalated_queries * 4 >= NQ * 3,
+        "corpus failed to trigger escalation: {escalated_queries}/{NQ} queries escalated"
+    );
+
+    // Work: the resumed escalation must beat the old restart total by a
+    // clear margin (expected ~1/3 saved; asserted conservatively at 10%).
+    assert!(
+        sum_resume * 10 <= sum_old * 9,
+        "resume saved too little: resume={sum_resume} evals vs old restart total={sum_old}"
+    );
+
+    // Recall parity with the from-scratch escalation: a resumed pass cannot
+    // reconsider phase-1's pruned-visited nodes, so allow a 2% absolute
+    // slack of the total expected hits — measured headroom is far smaller,
+    // but the bound must not flake if the corpus generator shifts.
+    let slack = hits_max / 50; // 2%
+    assert!(
+        hits_resume + slack >= hits_restart,
+        "resumed escalation lost recall beyond slack: resume {hits_resume}, restart {hits_restart} (of {hits_max})"
+    );
+}


### PR DESCRIPTION
## Description

Closes #2077 — the issue's validation bar (recall gates unchanged, eval-count A/B on escalated queries, pool-return behavior preserved) is met in full below. Also fixes a deeper defect found on the bitmap path while implementing it.

**1. Resumable adaptive escalation.** `search_adaptive` phase 2 discarded the phase-1 traversal and re-ran from scratch — `ef1 + 2·ef1` total work where the marginal exploration suffices, on the default AutoTune route. The layer-0 `SearchState` (visited set, frontier, result heap) now survives phase 1 inside an opaque `ResumableSearch` handle, and phase 2 re-enters the same best-first loop (`dispatch_layer_search`) under the widened `ef` — the hot loops themselves are untouched. GPU and RaBitQ phase-1 searches keep no CPU-side state and restart exactly as before. One read guard spans both phases: a recursive parking_lot `read()` can deadlock behind a queued writer.

The semantic trade is documented, not hidden: a resumed pass cannot reconsider nodes *visited-and-pruned* during phase 1 (the visited mark lands at gather time, exactly as in hnswlib), so its recall sits between single-pass ef1 and single-pass ef2. The new deterministic harness pins both sides:

```
adaptive resume A/B over 40 hard queries (k=10, min_ef=32):
escalated: 40/40
evals: resume=81665  old(phase1+restart)=111865  saved=27.0%
hits@10: resume=400  restart=400  (max 400)
```

**2. Bitmap under-fill retry was a no-op.** The retry doubled `candidates_k` at the *same* `ef` — but the graph's result heap is bounded by `ef`, and `candidates_k >= ef` always holds on that path, so the retry re-ran the identical traversal and returned the identical candidate set: 2× the cost, zero new results. The retry now doubles `ef` as well. A regression test pins **both** halves: same-ef-double-k returns the exact same ids (the old mechanism), and the widened-ef retry surfaces strictly more allowed matches.

Dropping the handle without resuming returns the pooled heaps/visited set through `SearchState`'s existing `Drop`; a 50-iteration determinism test pins pool hygiene across reuse. `BitVecVisited` grows on demand, so inserts landing between the two phases are safe.

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🐛 Bug fix (bitmap retry explored nothing new)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full lib suite: **5354 passed, 0 failed** (includes the 2 new in-src tests)
- Recall subset: 56/56; `recall_validation` + `read_gate_recall_regression` targets green
- New `adaptive_resume_evals` harness (deterministic eval-count A/B, `internal-bench`): wired into the `quality-deep` workflow next to `cost_crossover`
- `cargo clippy … --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` (CI-exact, gpu included), `cargo fmt --check`, no-default-features `-Dwarnings` — clean
- Guards: `check-ai-attribution`, `check_prod_unwraps`, `check-inline-tests` — passing

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

- Touches `hnsw` search paths: no `unsafe` added; the existing `SAFETY:`-documented blocks are moved verbatim inside the `run_layer_search` extraction, not modified. Recall gates and the eval harness bound the behavior change; heap/pool lifecycle is pinned by the determinism test.

## Additional Notes

One deliberate non-goal: the *bitmap-filtered* retry restarts rather than resumes. That path now explores meaningfully (the ef fix above — a strict improvement over the pre-change no-op), fires only on selective filters, and threading traversal state through `search_hnsw_only_filtered` would double the resume plumbing surface. If it ever shows up in profiles, it deserves its own small issue; nothing tracks it today by design.