### PR TITLE
perf(column-store): intern each string once — Arc&lt;str&gt; shared between both StringTable maps

### DIFF
--- a/crates/velesdb-core/src/column_store/string_table.rs
+++ b/crates/velesdb-core/src/column_store/string_table.rs
@@ -6,17 +6,24 @@
 //! The `intern()` method debug-asserts this limit (physically unreachable:
 //! 4 billion interned strings would require terabytes of RAM).
 
+use std::sync::Arc;
+
 use rustc_hash::FxHashMap;
 
 use super::types::StringId;
 
 /// String interning table for fast string comparisons.
+///
+/// Both maps share one `Arc<str>` per interned string — an interning table
+/// that stored every string twice (map key + vec entry) would defeat half
+/// its own point. `Arc<str>` rather than `Rc<str>` because `ColumnStore`
+/// must stay `Send`/`Sync`.
 #[derive(Debug, Default)]
 pub struct StringTable {
     /// String to ID mapping
-    string_to_id: FxHashMap<String, StringId>,
+    string_to_id: FxHashMap<Arc<str>, StringId>,
     /// ID to string mapping (for retrieval)
-    id_to_string: Vec<String>,
+    id_to_string: Vec<Arc<str>>,
 }
 
 impl StringTable {
@@ -43,15 +50,16 @@ impl StringTable {
         );
         #[allow(clippy::cast_possible_truncation)] // Bounds checked above
         let id = StringId(len as u32);
-        self.id_to_string.push(s.to_string());
-        self.string_to_id.insert(s.to_string(), id);
+        let shared: Arc<str> = Arc::from(s);
+        self.id_to_string.push(Arc::clone(&shared));
+        self.string_to_id.insert(shared, id);
         id
     }
 
     /// Gets the string for an ID.
     #[must_use]
     pub fn get(&self, id: StringId) -> Option<&str> {
-        self.id_to_string.get(id.0 as usize).map(String::as_str)
+        self.id_to_string.get(id.0 as usize).map(AsRef::as_ref)
     }
 
     /// Gets the ID for a string without interning.


### PR DESCRIPTION
## Description

First half of #2076, extracted as its own PR because it is small, isolated, and immediately profitable.

`StringTable` — the ColumnStore's interning dictionary — stored **every interned string twice**: one `String` as the `FxHashMap` key, and a second identical `String` in the `id → string` `Vec`. An interning table that duplicates its own dictionary defeats half its purpose.

Both sides now share a single `Arc<str>` allocation per interned string:

- halves the table's string payload (and drops one allocation per `intern` call);
- `&str` lookups keep working through the std `Borrow<str>` impl for `Arc<str>`;
- the public `get()` / `get_id()` signatures are unchanged (`Option<&str>` / `Option<StringId>`) — fields were already private, so this is not a semver-visible change;
- `Arc` rather than `Rc` because `ColumnStore` must stay `Send`/`Sync`.

`StringTable` is not serialized (rebuilt in memory), so no on-disk format is involved.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5352 passed, 0 failed**; `column_store` subset 175/175
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features `-Dwarnings` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The second half of #2076 — the `Option<T>` → values + validity-bitmap column layout — stays on the issue: it is an Arrow-interop enabler and belongs to a product milestone, not a drive-by diff.
