### PR TITLE
fix(config): stop [wal_batch] from promising group commit it does not deliver

### DIFF
--- a/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
+++ b/crates/tauri-plugin-velesdb/examples/production-config/velesdb.toml
@@ -76,8 +76,9 @@ auto_quantization = true
 auto_quantization_threshold = 10000
 
 [wal_batch]
-# WAL group commit: trades durability latency for write throughput. Off by
-# default. Worth enabling for bulk ingestion, less so for interactive writes.
+# RESERVED — parsed but not yet wired (issue #2078): enabling it changes
+# nothing today, and the engine logs a warning if you do. Batch writes
+# already pay one durability barrier per call.
 enabled = false
 commit_delay_us = 100
 max_batch_size = 128

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -263,8 +263,16 @@ const fn default_max_batch_size() -> usize {
 
 /// Configuration for WAL group commit batching.
 ///
-/// When enabled, multiple concurrent writes are batched into a single
-/// `sync_all()` call, amortizing the fsync cost across the batch.
+/// **Reserved — parsed but not yet wired.** Setting `enabled = true` changes
+/// nothing today: no group commit occurs, and every write keeps its own
+/// durability barrier (batch APIs already amortize to one barrier per call).
+/// [`VelesConfig::validate`] logs a warning when the flag is set so a config
+/// cannot promise behavior the engine does not deliver. Wiring the
+/// `WalBatcher` (or removing this section) is tracked in issue #2078 — the
+/// decision needs a multi-writer measurement, not a default.
+///
+/// When wired, group commit would batch multiple concurrent writes into a
+/// single `sync_all()` call, amortizing the fsync cost across the batch.
 ///
 /// # Example (TOML)
 ///

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -83,7 +83,22 @@ impl VelesConfig {
         self.validate_limits()?;
         self.validate_server()?;
         self.validate_storage()?;
-        self.validate_logging()
+        self.validate_logging()?;
+        self.warn_inert_wal_batch();
+        Ok(())
+    }
+
+    /// `[wal_batch]` is parsed but not wired (issue #2078): warn — rather
+    /// than reject — when a config enables it, so existing files keep
+    /// loading while no deployment silently believes it has group commit.
+    fn warn_inert_wal_batch(&self) {
+        if self.wal_batch.enabled {
+            tracing::warn!(
+                "[wal_batch] enabled = true is parsed but not yet wired: no group \
+                 commit occurs and every write keeps its own durability barrier \
+                 (see issue #2078)"
+            );
+        }
     }
 
     fn validate_search(&self) -> Result<(), ConfigError> {

--- a/crates/velesdb-mobile/examples/velesdb.toml
+++ b/crates/velesdb-mobile/examples/velesdb.toml
@@ -87,8 +87,9 @@ auto_quantization = true
 auto_quantization_threshold = 10000
 
 [wal_batch]
-# Group commit. Off by default: it trades durability latency for throughput,
-# which rarely pays on a device that can be killed by the OS at any moment.
+# RESERVED — parsed but not yet wired (issue #2078): enabling it changes
+# nothing today, and the engine logs a warning if you do. Batch writes
+# already pay one durability barrier per call.
 enabled = false
 commit_delay_us = 100
 max_batch_size = 128


### PR DESCRIPTION
## Description

Interim honesty step for #2078. The `[wal_batch]` section is parsed end to end — core config, CLI, mobile, tauri plugin — and documented as WAL group commit, but **nothing consumes it**: enabling it changes no behavior, and every write keeps its own durability barrier. A public config surface that silently does nothing is the worst kind of dead code — worse than the unwired PDX machinery the Tier-S wave removed, because this one is visible from outside.

This PR deliberately does **not** decide between wiring the `WalBatcher` and removing the section — #2078's bar (a multi-writer measurement on `velesdb-server`) still stands. Until then:

- `validate()` logs a `tracing` warning when `enabled = true` — **warn, not reject**, so existing config files keep loading unchanged; an existing test (`from_toml` with `enabled = true`) already pins that acceptance.
- `WalBatchConfig`'s rustdoc states the section is **reserved and inert** and points at #2078; the future behavior description is kept, clearly marked as "when wired".
- Both example TOMLs stop describing the flag as functional. The tauri production-config example actively *recommended enabling* the no-op ("Worth enabling for bulk ingestion") — that line is gone.

## Type of Change

- [x] 🐛 Bug fix (documentation/config surface promised behavior the engine does not deliver)

## How Has This Been Tested?

- [x] Unit tests

- `config` subset: 119/119 (includes the pre-existing acceptance test for `enabled = true`)
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features `-Dwarnings` — clean
- Guards: `check-doc-freshness --mode strict`, `check-feature-claims` — passing

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

When #2078 resolves, this warning either disappears (section wired, opt-in, documented durability contract) or the whole section goes through a deprecation cycle (accept-and-warn → removal in the next major).
