### PR TITLE
perf(graph): node property maintenance stops paying for indexes that do not exist

### DIFF
--- a/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
+++ b/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
@@ -77,12 +77,18 @@ impl Collection {
         // Populate composite indexes
         {
             let mut composite_mgr = self.graph.composite_index_manager.write();
-            for label in &labels {
+            // Composite indexes are DDL-created and usually absent; the owned
+            // props map (String key + Value clone per property) is only worth
+            // building when at least one index exists — and once, not once
+            // per label.
+            if !composite_mgr.is_empty() {
                 let props_map: HashMap<String, Value> = properties
                     .iter()
                     .map(|&(k, v)| (k.to_string(), v.clone()))
                     .collect();
-                composite_mgr.on_add_node(label, node_id, &props_map);
+                for label in &labels {
+                    composite_mgr.on_add_node(label, node_id, &props_map);
+                }
             }
         }
     }
@@ -110,12 +116,15 @@ impl Collection {
 
         {
             let mut composite_mgr = self.graph.composite_index_manager.write();
-            for label in &labels {
+            // Same guard as the add path: no composite index, no owned map.
+            if !composite_mgr.is_empty() {
                 let props_map: HashMap<String, Value> = properties
                     .iter()
                     .map(|&(k, v)| (k.to_string(), v.clone()))
                     .collect();
-                composite_mgr.on_remove_node(label, node_id, &props_map);
+                for label in &labels {
+                    composite_mgr.on_remove_node(label, node_id, &props_map);
+                }
             }
         }
     }

--- a/crates/velesdb-core/src/collection/graph/property_index/composite.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/composite.rs
@@ -232,6 +232,15 @@ impl CompositeIndexManager {
             .collect()
     }
 
+    /// Returns `true` when no composite index exists.
+    ///
+    /// The per-node maintenance wiring uses this to skip building its
+    /// owned property map when there is nothing to maintain.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.indexes.is_empty()
+    }
+
     /// Lists all index names.
     #[must_use]
     #[allow(dead_code)] // Reason: Public API — used by tests and future DDL SHOW INDEXES handler

--- a/crates/velesdb-core/src/collection/graph/property_index/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/property_index/mod.rs
@@ -96,6 +96,14 @@ impl PropertyIndex {
     /// Uses `RoaringBitmap` internally which only supports u32 IDs.
     /// Returns `false` if `node_id > u32::MAX` to prevent data corruption.
     pub fn insert(&mut self, label: &str, property: &str, value: &Value, node_id: u64) -> bool {
+        // Resolve the index BEFORE the id-range check: an unindexed property
+        // is a silent no-op (the maintenance hooks call this for every
+        // property), and the u32 warning should only fire when an existing
+        // index actually failed to take the node.
+        let key = make_label_prop_key(label, property);
+        let Some(value_map) = self.indexes.get_mut(&key) else {
+            return false;
+        };
         let Some(safe_id) = safe_bitmap_id(node_id) else {
             tracing::warn!(
                 node_id = node_id,
@@ -108,14 +116,9 @@ impl PropertyIndex {
             return false;
         };
 
-        let key = make_label_prop_key(label, property);
-        if let Some(value_map) = self.indexes.get_mut(&key) {
-            let value_key = value.to_string();
-            value_map.entry(value_key).or_default().insert(safe_id);
-            true
-        } else {
-            false
-        }
+        let value_key = value.to_string();
+        value_map.entry(value_key).or_default().insert(safe_id);
+        true
     }
 
     /// Remove a node from the index.
@@ -147,6 +150,9 @@ impl PropertyIndex {
     /// Returns `Some(&RoaringBitmap)` with matching node IDs (empty if no matches).
     #[must_use]
     pub fn lookup(&self, label: &str, property: &str, value: &Value) -> Option<&RoaringBitmap> {
+        if self.indexes.is_empty() {
+            return None;
+        }
         let key = make_label_prop_key(label, property);
         self.indexes
             .get(&key)
@@ -200,10 +206,14 @@ impl PropertyIndex {
     ///
     /// Indexes all properties that have an active index.
     pub fn on_add_node(&mut self, label: &str, node_id: u64, properties: &HashMap<String, Value>) {
+        if self.indexes.is_empty() {
+            return;
+        }
         for (prop_name, value) in properties {
-            if self.has_index(label, prop_name) {
-                self.insert(label, prop_name, value, node_id);
-            }
+            // No `has_index` pre-check: `insert` already no-ops on an
+            // unindexed property, and the pre-check doubled the key
+            // allocations for every property of every node.
+            self.insert(label, prop_name, value, node_id);
         }
     }
 
@@ -216,10 +226,13 @@ impl PropertyIndex {
         node_id: u64,
         properties: &HashMap<String, Value>,
     ) {
+        if self.indexes.is_empty() {
+            return;
+        }
         for (prop_name, value) in properties {
-            if self.has_index(label, prop_name) {
-                self.remove(label, prop_name, value, node_id);
-            }
+            // Same rationale as `on_add_node`: `remove` no-ops when the
+            // index is absent.
+            self.remove(label, prop_name, value, node_id);
         }
     }
 
@@ -234,6 +247,9 @@ impl PropertyIndex {
         old_value: &Value,
         new_value: &Value,
     ) {
+        if self.indexes.is_empty() {
+            return;
+        }
         if self.has_index(label, property) {
             self.remove(label, property, old_value, node_id);
             self.insert(label, property, new_value, node_id);


### PR DESCRIPTION
## Description

Audit finding on the per-node index-maintenance path: **a node with 8 properties and zero indexes still paid ~16 String allocations (plus Value clones) on the way in.** Three fixes, none touching the serialized index format:

- **Composite wiring built an owned props map per label, unconditionally.** `index_node_properties`/`deindex_node_properties` cloned every property (String key + `Value`) once *per label* of every node — even with zero composite indexes, which is the default (they are DDL-created). The map is now built once per node, and only when the manager holds at least one index (new `CompositeIndexManager::is_empty`).
- **`PropertyIndex` hooks double-allocated their keys.** `on_add_node`/`on_remove_node` pre-checked `has_index` (one `(String, String)` pair) then called `insert`/`remove` (a second pair) — but both operations already no-op on an unindexed property, so the pre-check bought nothing. Dropped; the hooks and `lookup` also short-circuit on an empty index map, making the no-indexes case allocation-free.
- **The u32-range warning fired for unindexed properties.** `insert` resolved `safe_bitmap_id` before the index lookup, so a node with an id above `u32::MAX` logged one warning per property, indexed or not. The index resolves first now; the warning fires only when an existing index actually failed to take the node.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5354 passed, 0 failed**; `property_index` 49/49, `composite` 13/13, `index_management` 46/46
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features `-Dwarnings` — clean
- The on-disk `property_index.bin` format is untouched (key types unchanged; only probe order and guards moved)

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Second PR from the final interning/wiring audit (#2084 was first). One candidate fix was considered and rejected during implementation: probing `graph_range_indexes` with a borrowed key — its key is a formatted `"label.property"` `String`, so the allocation is inherent to the key shape; restructuring that map is part of the structural follow-ups, not this diff.
