### PR TITLE
fix(streaming): implement the documented age-based merge trigger; stop segment_count from claiming a fallback that does not exist

### DIFF
--- a/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
@@ -27,7 +27,11 @@ pub struct AsyncIndexBuilderConfig {
     #[serde(default = "default_merge_threshold")]
     pub merge_threshold: usize,
 
-    /// Number of segments for parallel construction (default: `num_cpus`).
+    /// Reserved — parsed but not yet wired. Flushes currently go through
+    /// `HnswIndex::insert_batch_parallel`, which parallelizes on the global
+    /// rayon pool with no segment notion; this knob changes nothing today.
+    /// Wiring it belongs to the pipeline integration tracked under
+    /// issue #488 Task 4 (the same one gating this whole builder).
     #[serde(default)]
     pub segment_count: Option<usize>,
 }

--- a/crates/velesdb-core/src/collection/streaming/deferred.rs
+++ b/crates/velesdb-core/src/collection/streaming/deferred.rs
@@ -30,7 +30,9 @@ use crate::distance::DistanceMetric;
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -68,6 +70,11 @@ pub struct DeferredIndexerConfig {
 
     /// Maximum age (milliseconds) of the oldest buffered vector before a
     /// time-based merge is triggered.
+    ///
+    /// The age is checked at write time (`push`/`extend`) and by
+    /// [`DeferredIndexer::should_merge`] — there is no background timer, so
+    /// an expired buffer merges on the next write or explicit check, not
+    /// spontaneously. `0` makes every write signal a merge.
     #[serde(default = "default_max_buffer_age_ms")]
     pub max_buffer_age_ms: u64,
 }
@@ -108,7 +115,18 @@ pub struct DeferredIndexer {
 
     /// Configuration (immutable after construction).
     config: DeferredIndexerConfig,
+
+    /// Millisecond timestamp (relative to `epoch`) of the first push since
+    /// the last drain; [`AGE_EMPTY`] when the buffer holds no epoch-tracked
+    /// entries. Lock-free: the common push path is one relaxed load.
+    first_push_millis: AtomicU64,
+
+    /// Time origin for `first_push_millis`.
+    epoch: Instant,
 }
+
+/// Sentinel for `first_push_millis`: no first-push timestamp recorded.
+const AGE_EMPTY: u64 = u64::MAX;
 
 impl DeferredIndexer {
     /// Creates a new `DeferredIndexer` with the given configuration.
@@ -122,7 +140,43 @@ impl DeferredIndexer {
             swap_lock: Mutex::new(()),
             deleted_ids: RwLock::new(FxHashSet::default()),
             config,
+            first_push_millis: AtomicU64::new(AGE_EMPTY),
+            epoch: Instant::now(),
         }
+    }
+
+    /// Records the first-push timestamp if none is recorded yet.
+    ///
+    /// One relaxed load in the steady state (timestamp already set); the CAS
+    /// runs only on the first push after a drain. Losing the race to another
+    /// first pusher is fine — either timestamp is a valid buffer birth time.
+    #[inline]
+    fn note_push_time(&self) {
+        if self.first_push_millis.load(Ordering::Relaxed) == AGE_EMPTY {
+            #[allow(clippy::cast_possible_truncation)]
+            // Reason: millis since indexer creation; u64 covers 584M years.
+            let now = self.epoch.elapsed().as_millis() as u64;
+            let _ = self.first_push_millis.compare_exchange(
+                AGE_EMPTY,
+                now,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+        }
+    }
+
+    /// Returns `true` if the oldest buffered entry has exceeded
+    /// `max_buffer_age_ms`. `false` when the buffer is age-empty.
+    #[inline]
+    fn buffer_expired(&self) -> bool {
+        let first = self.first_push_millis.load(Ordering::Relaxed);
+        if first == AGE_EMPTY {
+            return false;
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        // Reason: same clock domain as note_push_time.
+        let now = self.epoch.elapsed().as_millis() as u64;
+        now.saturating_sub(first) >= self.config.max_buffer_age_ms
     }
 
     /// Whether deferred indexing is enabled.
@@ -157,7 +211,8 @@ impl DeferredIndexer {
         }
         self.ensure_buffer_active();
         self.buffer.push(id, vector);
-        self.buffer.len() >= self.config.merge_threshold
+        self.note_push_time();
+        self.buffer.len() >= self.config.merge_threshold || self.buffer_expired()
     }
 
     /// Batch-pushes vectors into the write buffer.
@@ -170,7 +225,8 @@ impl DeferredIndexer {
         }
         self.ensure_buffer_active();
         self.buffer.extend(entries);
-        self.buffer.len() >= self.config.merge_threshold
+        self.note_push_time();
+        self.buffer.len() >= self.config.merge_threshold || self.buffer_expired()
     }
 
     /// Marks `id` as deleted, removing it from the buffer.
@@ -255,6 +311,7 @@ impl DeferredIndexer {
     pub fn swap_and_drain(&self) -> Vec<(u64, Vec<f32>)> {
         let _guard = self.swap_lock.lock();
         let drained = self.buffer.deactivate_and_drain();
+        self.first_push_millis.store(AGE_EMPTY, Ordering::Relaxed);
         self.deleted_ids.write().clear();
         // Re-activate the buffer so pushes between drain and next merge
         // are not silently dropped (fixes TOCTOU race with concurrent push).
@@ -271,7 +328,7 @@ impl DeferredIndexer {
     /// Returns `true` if the buffer has reached `merge_threshold`.
     #[must_use]
     pub fn should_merge(&self) -> bool {
-        self.buffer.len() >= self.config.merge_threshold
+        self.buffer.len() >= self.config.merge_threshold || self.buffer_expired()
     }
 
     /// Returns `true` if deferred indexing is enabled and the buffer has
@@ -288,6 +345,7 @@ impl DeferredIndexer {
     pub fn drain_all(&self) -> Vec<(u64, Vec<f32>)> {
         let _guard = self.swap_lock.lock();
         let all = self.buffer.deactivate_and_drain();
+        self.first_push_millis.store(AGE_EMPTY, Ordering::Relaxed);
         self.deleted_ids.write().clear();
         all
     }
@@ -343,6 +401,36 @@ mod tests {
         idx.push(1, vec![1.0, 0.0, 0.0]);
         idx.push(2, vec![0.0, 1.0, 0.0]);
         assert_eq!(idx.pending_count(), 2);
+    }
+
+    #[test]
+    fn age_zero_makes_every_write_signal_a_merge() {
+        let indexer = DeferredIndexer::new(DeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: 1_000,
+            max_buffer_age_ms: 0,
+        });
+        // Far below the count threshold: only the age trigger can fire.
+        assert!(indexer.push(1, vec![0.0; 4]));
+        assert!(indexer.should_merge());
+        // Draining clears the age stamp; an empty buffer never reports
+        // expiry on its own.
+        let drained = indexer.swap_and_drain();
+        assert_eq!(drained.len(), 1);
+        assert!(!indexer.should_merge());
+    }
+
+    #[test]
+    fn unexpired_buffer_below_threshold_does_not_merge() {
+        let indexer = DeferredIndexer::new(DeferredIndexerConfig {
+            enabled: true,
+            merge_threshold: 1_000,
+            // One hour: cannot expire within the test.
+            max_buffer_age_ms: 3_600_000,
+        });
+        assert!(!indexer.push(1, vec![0.0; 4]));
+        assert!(!indexer.extend(vec![(2, vec![0.0; 4])]));
+        assert!(!indexer.should_merge());
     }
 
     #[test]

--- a/crates/velesdb-mobile/src/types.rs
+++ b/crates/velesdb-mobile/src/types.rs
@@ -472,7 +472,9 @@ pub struct MobileDeferredIndexerConfig {
     pub enabled: bool,
     /// Number of buffered points before a merge is triggered.
     pub merge_threshold: u64,
-    /// Maximum buffer age in milliseconds before a forced merge.
+    /// Maximum buffer age in milliseconds before a forced merge. Checked
+    /// at write time (no background timer): an expired buffer merges on
+    /// the next write. `0` makes every write trigger a merge.
     pub max_buffer_age_ms: u64,
 }
 
@@ -494,7 +496,9 @@ impl From<MobileDeferredIndexerConfig>
 pub struct MobileAsyncIndexBuilderConfig {
     /// Number of buffered points before a segment merge is triggered.
     pub merge_threshold: u64,
-    /// Number of parallel segments; `None` falls back to the CPU count.
+    /// Reserved — parsed but not yet wired (core issue #488 Task 4):
+    /// flushes parallelize on the global thread pool and this knob
+    /// changes nothing today.
     pub segment_count: Option<u32>,
 }
 


### PR DESCRIPTION
## Description

Audit finding: two streaming config fields were deserialized across three crates (core, python, mobile) with **zero read sites** — the `wal_batch` disease, but one of them was a broken *behavioral promise*, not just dead surface.

**`max_buffer_age_ms` documented a time-based merge that never happened.** The merge decision was `len >= merge_threshold` only, so a slow-filling deferred buffer never flushed on time, in all three bindings, despite the field being documented and settable everywhere. The trigger now exists:

- `push`/`extend`/`should_merge` also report a merge when the oldest buffered entry has exceeded the configured age;
- the first-push timestamp is a lock-free `AtomicU64` — one relaxed load on the steady-state push path, a CAS only on the first push after a drain; both drain paths reset it;
- semantics documented honestly: the age is **checked at write time** — no background timer, so an expired buffer merges on the next write, and `0` makes every write signal a merge;
- two deterministic tests (no sleeps) pin the age-zero trigger, the drain reset, and the unexpired case.

**`segment_count` claimed "`None` falls back to the CPU count"** — but flushes go through `insert_batch_parallel` on the global rayon pool; there is no segment notion at all, and the whole `AsyncIndexBuilder` is gated on the pipeline integration tracked under issue #488 Task 4. The core and mobile docs now mark the knob reserved and inert instead of describing behavior that does not exist. (No runtime warning here, unlike `[wal_batch]`: the entire builder is dormant, so there is no active path to warn from.)

## Type of Change

- [x] 🐛 Bug fix (documented behavior did not exist)

## How Has This Been Tested?

- [x] Unit tests

- Full lib suite: **5356 passed, 0 failed**; `deferred` 31/31, `streaming` 102/102
- `velesdb-mobile` compiles against the updated docs
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features `-Dwarnings` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Third PR from the final wiring audit (#2084 CSR, #2085 property maintenance).
