### PR TITLE
fix(config): warn when the four inert engine sections are set; deprecate the helper nothing calls

### DIFF
--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -87,6 +87,13 @@ impl SearchMode {
 }
 
 /// Search configuration section.
+///
+/// **Reserved — parsed and validated, not yet applied.** Only `[limits]`
+/// reaches the engine today; [`VelesConfig::validate`] warns when this
+/// section deviates from its defaults so a config cannot silently promise
+/// behavior the engine does not deliver. Wiring these values as engine
+/// defaults is tracked in issue #2087. Per-query runtime overrides
+/// (`WITH (ef_search = N)`) are a separate, working mechanism.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SearchConfig {
@@ -112,6 +119,13 @@ impl Default for SearchConfig {
 }
 
 /// HNSW index configuration section.
+///
+/// **Reserved — parsed and validated, not yet applied.** Only `[limits]`
+/// reaches the engine today; [`VelesConfig::validate`] warns when this
+/// section deviates from its defaults so a config cannot silently promise
+/// behavior the engine does not deliver. Wiring these values as engine
+/// defaults is tracked in issue #2087. Per-query runtime overrides
+/// (`WITH (ef_search = N)`) are a separate, working mechanism.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct HnswConfig {
@@ -134,6 +148,12 @@ pub mod server {
     use serde::{Deserialize, Serialize};
 
     /// Storage configuration section.
+    ///
+    /// **Reserved — parsed and validated, not yet applied.** Only
+    /// `[limits]` reaches the engine today; `VelesConfig::validate` warns
+    /// when this section deviates from its defaults. Wiring is tracked in
+    /// issue #2087 (`data_dir` in particular conflicts with the path passed
+    /// to `Database::open` and may go through deprecation instead).
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(default)]
     pub struct StorageConfig {
@@ -473,6 +493,11 @@ impl VelesConfig {
     // Validation is in config_validation.rs
 
     /// Returns the effective `ef_search` value.
+    #[deprecated(
+        since = "5.2.0",
+        note = "never read by the engine — [search] is not applied (issue #2087); \
+                query-time WITH (ef_search = N) is the working override"
+    )]
     #[must_use]
     pub fn effective_ef_search(&self) -> usize {
         self.search

--- a/crates/velesdb-core/src/config_tests.rs
+++ b/crates/velesdb-core/src/config_tests.rs
@@ -60,6 +60,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Reason: pins the deprecated helper until its removal (issue #2087)
     fn test_config_effective_ef_search_from_mode() {
         // Arrange
         let config = VelesConfig::default();
@@ -72,6 +73,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Reason: pins the deprecated helper until its removal (issue #2087)
     fn test_config_effective_ef_search_override() {
         // Arrange
         let mut config = VelesConfig::default();

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -85,7 +85,53 @@ impl VelesConfig {
         self.validate_storage()?;
         self.validate_logging()?;
         self.warn_inert_wal_batch();
+        self.warn_inert_engine_sections();
         Ok(())
+    }
+
+    /// The `[search]`, `[hnsw]`, `[storage]` and `[quantization]` sections
+    /// are parsed and validated but not yet applied — only `[limits]`
+    /// reaches the engine (issue #2087). Warn — rather than reject — when a
+    /// config sets any of them away from its defaults, so existing files
+    /// keep loading while no deployment silently believes those knobs work.
+    ///
+    /// Serde-value comparison instead of `PartialEq` derives: the sections
+    /// carry enums and nested types, and this runs once per config load.
+    fn warn_inert_engine_sections(&self) {
+        fn deviates<T: serde::Serialize>(actual: &T, default: &T) -> bool {
+            match (serde_json::to_value(actual), serde_json::to_value(default)) {
+                (Ok(a), Ok(d)) => a != d,
+                _ => false,
+            }
+        }
+
+        let mut inert: Vec<&str> = Vec::new();
+        if deviates(&self.search, &crate::config::SearchConfig::default()) {
+            inert.push("[search]");
+        }
+        if deviates(&self.hnsw, &crate::config::HnswConfig::default()) {
+            inert.push("[hnsw]");
+        }
+        if deviates(
+            &self.storage,
+            &crate::config::server::StorageConfig::default(),
+        ) {
+            inert.push("[storage]");
+        }
+        if deviates(
+            &self.quantization,
+            &crate::config_quantization::QuantizationConfig::default(),
+        ) {
+            inert.push("[quantization]");
+        }
+        if !inert.is_empty() {
+            tracing::warn!(
+                sections = inert.join(", "),
+                "these config sections are parsed and validated but not yet \
+                 applied by the engine — only [limits] is; see issue #2087. \
+                 Query-time WITH (...) overrides are unaffected."
+            );
+        }
     }
 
     /// `[wal_batch]` is parsed but not wired (issue #2078): warn — rather

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -45,6 +45,13 @@ To point at a file anywhere else, pass it explicitly:
 | `velesdb-server` | `--config <path>` | `VELESDB_CONFIG` |
 | `velesdb` (CLI) | `--config <path>` (global — REPL and every one-shot command) | `VELESDB_CONFIG` |
 
+> **Reserved sections (issue #2087).** Of the engine sections below, only
+> `[limits]` is applied by the engine today. `[search]`, `[hnsw]`,
+> `[storage]` and `[quantization]` are parsed and validated but not yet
+> wired — setting them away from their defaults logs a warning at load.
+> Query-time overrides (`WITH (ef_search = N)`) are a separate, working
+> mechanism, as are per-collection creation options.
+
 Both binaries can load the **same** file, but only the *engine* sections —
 `[search]`, `[hnsw]`, `[storage]`, `[limits]`, `[quantization]`,
 `[wal_batch]` — reach `VelesConfig` and, via


### PR DESCRIPTION
## Description

Audit finding — the `[wal_batch]` disease at scale: `[search]`, `[hnsw]`, `[storage]` and `[quantization]` are parsed **and validated** (hand-written range rules reject invalid values) but no behavior reads them. The only `VelesConfig` section the engine applies is `[limits]` (`database/collection_ops.rs`, `collection/types.rs`, `search/vector.rs`). A config that rejects a bad `ef_search` while ignoring a good one signals harder than silence that the knob works — and `docs/guides/CONFIGURATION.md` documents all four at length, env-var table included.

This PR does **not** wire them — that is a design (precedence chain query-override → collection option → config default; and some knobs may be unwirable, e.g. `storage.data_dir` conflicts with the path passed to `Database::open`). The design and validation bar live in the new issue #2087. Until it resolves:

- `validate()` logs **one** warning listing the sections a config sets away from their defaults (serde-value comparison, once per load; a defaults-only file stays silent);
- the four section structs and the configuration guide carry a reserved-section banner; both point out that query-time `WITH (...)` overrides are a separate, working mechanism;
- `VelesConfig::effective_ef_search` — zero callers workspace-wide (the CLI hit is a different type's homonym) — is `#[deprecated]` toward removal at the next major; its two pinning tests `allow(deprecated)`.

## Type of Change

- [x] 🐛 Bug fix (config surface promised behavior the engine does not deliver)

## How Has This Been Tested?

- [x] Unit tests

- `config` subset: 119/119
- `velesdb-python` compiles (it round-trips `quantization` options)
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact), `cargo fmt --check`, no-default-features `-Dwarnings` — clean
- Guards: `check-doc-freshness --mode strict`, `check-feature-claims` — passing

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Fourth PR from the final wiring audit (#2084 CSR, #2085 property maintenance, #2086 streaming). Closes nothing: #2087 stays open as the wiring tracker.
