### PR TITLE
fix(search): hybrid dense+sparse filter binds both branches and reaches the REST endpoint; REST weighted defaults rejoin the #1545 canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The hybrid dense+sparse metadata filter now binds BOTH branches — and
+  the REST endpoint finally reads it at all.** Two layered defects: the
+  server's `/search` hybrid dense+sparse path never read the request's
+  `filter` (silently returning unfiltered fused results), and even when a
+  filter reached core's `execute_both_branches` (the VelesQL hybrid path),
+  only the sparse branch applied it — dense-only candidates the filter
+  excludes leaked into fusion. The dense branch now routes through the
+  filtered dense search (bitmap pre-filter + oversampling), the facade
+  gains `hybrid_sparse_search_filtered`, and the server wires the request
+  filter through it. A facade test pins that no fused result can carry an
+  excluded point.
+
+- **The REST weighted-fusion defaults rejoin the #1545 canon.** The REST
+  surface froze the pre-#1545 weights (0.5/0.3/0.2) in two places — the
+  `api_types` serde defaults and the server's strategy parser — while
+  every other surface used the canonical 0.6/0.3/0.1 from core's fusion
+  module. Both now derive from the canonical constants; a weightless
+  `strategy: "weighted"` REST request behaves like the same request on
+  every other surface. Behavioral change for REST clients that relied on
+  the forked defaults: pass explicit weights to keep the old blend.
+
 - **The bitmap under-fill retry explored nothing.** It doubled
   `candidates_k` at the same `ef`, but the graph's result heap is bounded
   by `ef`, so the retry re-ran the identical traversal and returned the

--- a/crates/velesdb-core/src/api_types/mod.rs
+++ b/crates/velesdb-core/src/api_types/mod.rs
@@ -66,21 +66,29 @@ pub const fn default_rrf_k() -> u32 {
 }
 
 /// Default average weight for weighted fusion.
+///
+/// Derived from [`crate::fusion::DEFAULT_WEIGHTED_AVG_WEIGHT`] — the fusion
+/// module is the single source of truth for these defaults (#1545); this
+/// wrapper exists only because serde `default` needs a function path. The
+/// REST surface previously froze the pre-#1545 values (0.5/0.3/0.2) here,
+/// forking the default fusion behavior from every other surface.
 #[must_use]
 pub const fn default_avg_weight() -> f32 {
-    0.5
+    crate::fusion::DEFAULT_WEIGHTED_AVG_WEIGHT
 }
 
 /// Default max weight for weighted fusion.
+/// See [`default_avg_weight`] for the single-source rationale.
 #[must_use]
 pub const fn default_max_weight() -> f32 {
-    0.3
+    crate::fusion::DEFAULT_WEIGHTED_MAX_WEIGHT
 }
 
 /// Default hit weight for weighted fusion.
+/// See [`default_avg_weight`] for the single-source rationale.
 #[must_use]
 pub const fn default_hit_weight() -> f32 {
-    0.2
+    crate::fusion::DEFAULT_WEIGHTED_HIT_WEIGHT
 }
 
 /// Default dense weight for relative score fusion.

--- a/crates/velesdb-core/src/api_types/tests.rs
+++ b/crates/velesdb-core/src/api_types/tests.rs
@@ -162,9 +162,12 @@ fn deserialize_multi_query_search_request_defaults() {
     assert_eq!(req.top_k, 10);
     assert_eq!(req.strategy, "rrf");
     assert_eq!(req.rrf_k, 60);
-    assert!((req.avg_weight - 0.5).abs() < f32::EPSILON);
+    // Canonical #1545 defaults — this surface shipped the pre-#1545 fork
+    // (0.5/0.3/0.2) until the serde defaults were re-derived from
+    // crate::fusion's constants.
+    assert!((req.avg_weight - 0.6).abs() < f32::EPSILON);
     assert!((req.max_weight - 0.3).abs() < f32::EPSILON);
-    assert!((req.hit_weight - 0.2).abs() < f32::EPSILON);
+    assert!((req.hit_weight - 0.1).abs() < f32::EPSILON);
 }
 
 #[test]
@@ -459,9 +462,11 @@ fn test_velesql_contract_version() {
 
 #[test]
 fn test_default_fusion_weights() {
-    assert!((default_avg_weight() - 0.5).abs() < f32::EPSILON);
+    // Values pinned to the #1545 canon; the derivation itself is pinned by
+    // weighted_fusion_defaults_are_the_canonical_constants below.
+    assert!((default_avg_weight() - 0.6).abs() < f32::EPSILON);
     assert!((default_max_weight() - 0.3).abs() < f32::EPSILON);
-    assert!((default_hit_weight() - 0.2).abs() < f32::EPSILON);
+    assert!((default_hit_weight() - 0.1).abs() < f32::EPSILON);
 }
 
 // ============================================================================
@@ -918,4 +923,25 @@ fn scroll_request_cursor_accepts_null() {
     let input = json!({});
     let req: ScrollRequest = serde_json::from_value(input).unwrap();
     assert_eq!(req.cursor, None);
+}
+
+/// The REST weighted-fusion serde defaults must be the fusion module's
+/// canonical constants (#1545) — this surface previously froze the
+/// pre-#1545 literals 0.5/0.3/0.2, forking the default behavior of a
+/// weightless `weighted` request from every other surface. Double pin:
+/// the derivation AND the canonical values.
+#[test]
+fn weighted_fusion_defaults_are_the_canonical_constants() {
+    assert!(
+        (default_avg_weight() - crate::fusion::DEFAULT_WEIGHTED_AVG_WEIGHT).abs() < f32::EPSILON
+    );
+    assert!(
+        (default_max_weight() - crate::fusion::DEFAULT_WEIGHTED_MAX_WEIGHT).abs() < f32::EPSILON
+    );
+    assert!(
+        (default_hit_weight() - crate::fusion::DEFAULT_WEIGHTED_HIT_WEIGHT).abs() < f32::EPSILON
+    );
+    assert!((default_avg_weight() - 0.6).abs() < f32::EPSILON);
+    assert!((default_max_weight() - 0.3).abs() < f32::EPSILON);
+    assert!((default_hit_weight() - 0.1).abs() < f32::EPSILON);
 }

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -371,11 +371,23 @@ impl Collection {
             // sparse_indexes(9) when filtering is needed.
             let (dense, sparse) = rayon::join(
                 || {
-                    self.search_ids(dense_vector, candidate_k)
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(Into::into)
-                        .collect()
+                    // The metadata filter bounds BOTH branches. The dense
+                    // branch previously ignored it entirely (only sparse
+                    // filtered), so dense-only candidates the filter
+                    // excludes leaked into fusion.
+                    if let Some(filter) = metadata_filter {
+                        self.search_with_filter(dense_vector, candidate_k, filter)
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|r| (r.point.id, r.score))
+                            .collect()
+                    } else {
+                        self.search_ids(dense_vector, candidate_k)
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(Into::into)
+                            .collect()
+                    }
                 },
                 || {
                     if let Some(filter) = metadata_filter {
@@ -406,12 +418,20 @@ impl Collection {
         #[cfg(not(feature = "persistence"))]
         {
             // Sequential fallback (no rayon).
-            let dense: Vec<(u64, f32)> = self
-                .search_ids(dense_vector, candidate_k)
-                .unwrap_or_default()
-                .into_iter()
-                .map(Into::into)
-                .collect();
+            // Same both-branches contract as the rayon variant above.
+            let dense: Vec<(u64, f32)> = if let Some(filter) = metadata_filter {
+                self.search_with_filter(dense_vector, candidate_k, filter)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|r| (r.point.id, r.score))
+                    .collect()
+            } else {
+                self.search_ids(dense_vector, candidate_k)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect()
+            };
             let sparse = if let Some(filter) = metadata_filter {
                 // LOCK ORDER: payload_storage(3) before sparse_indexes(9).
                 let payload_storage = self.storage.payload_storage.read();

--- a/crates/velesdb-core/src/collection/vector_collection/search.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search.rs
@@ -311,6 +311,35 @@ impl VectorCollection {
         index_name: &str,
         strategy: &crate::fusion::FusionStrategy,
     ) -> Result<Vec<SearchResult>> {
+        self.hybrid_sparse_search_filtered(
+            dense_vector,
+            sparse_query,
+            k,
+            index_name,
+            strategy,
+            None,
+        )
+    }
+
+    /// [`Self::hybrid_sparse_search`] with an optional metadata filter.
+    ///
+    /// The filter applies to **both** branches before fusion (dense
+    /// pre-filter, sparse post-filter — see `execute_both_branches`), so a
+    /// fused result never surfaces a point the filter excludes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if dense or sparse search fails, or fusion errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn hybrid_sparse_search_filtered(
+        &self,
+        dense_vector: &[f32],
+        sparse_query: &crate::index::sparse::SparseVector,
+        k: usize,
+        index_name: &str,
+        strategy: &crate::fusion::FusionStrategy,
+        filter: Option<&crate::filter::Filter>,
+    ) -> Result<Vec<SearchResult>> {
         let candidate_k = k.saturating_mul(2).max(k + 10);
 
         let (dense_results, sparse_results) = self.inner.execute_both_branches(
@@ -318,7 +347,7 @@ impl VectorCollection {
             sparse_query,
             index_name,
             candidate_k,
-            None,
+            filter,
         );
 
         if dense_results.is_empty() && sparse_results.is_empty() {

--- a/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
@@ -463,3 +463,95 @@ fn test_stream_insert_without_enable_returns_not_configured() {
         "expected NotConfigured, got: {err}"
     );
 }
+
+// ─── hybrid_sparse_search_filtered() ─────────────────────────────────────────
+
+/// Seeds points that carry BOTH a dense vector and a default-index sparse
+/// vector, split across two `cat` values, so the filtered hybrid path has
+/// something to exclude on each branch.
+fn seed_sparse_points(coll: &VectorCollection) {
+    use std::collections::BTreeMap;
+    let mut points = Vec::new();
+    for i in 0u64..8 {
+        #[allow(clippy::cast_precision_loss)]
+        let fi = i as f32;
+        let mut sparse = BTreeMap::new();
+        sparse.insert(
+            String::new(), // default sparse index
+            crate::index::sparse::SparseVector::new(vec![(10, 1.0 + fi), (20, 0.5)]),
+        );
+        points.push(Point {
+            id: i,
+            vector: vec![fi / 8.0, 0.5, 0.3, 0.1],
+            payload: Some(json!({"cat": if i % 2 == 0 { "a" } else { "b" }})),
+            sparse_vectors: Some(sparse),
+        });
+    }
+    coll.upsert(points).unwrap();
+}
+
+/// The metadata filter must bound BOTH branches: no fused result may carry a
+/// point the filter excludes. This pins the defect where the server's hybrid
+/// dense+sparse path never read the request filter.
+#[test]
+fn hybrid_sparse_search_filtered_excludes_filtered_points() {
+    let (coll, _dir) = create_test_vc();
+    seed_sparse_points(&coll);
+
+    let filter = Filter::new(Condition::eq("cat", "a"));
+    let sparse_q = crate::index::sparse::SparseVector::new(vec![(10, 1.0)]);
+    let strategy = crate::fusion::FusionStrategy::rrf_default();
+
+    let filtered = coll
+        .hybrid_sparse_search_filtered(
+            &[0.5, 0.5, 0.3, 0.1],
+            &sparse_q,
+            8,
+            "",
+            &strategy,
+            Some(&filter),
+        )
+        .unwrap();
+    assert!(!filtered.is_empty(), "filtered hybrid search found nothing");
+    for r in &filtered {
+        assert_eq!(
+            r.point.payload.as_ref().unwrap()["cat"],
+            "a",
+            "point {} leaked through the hybrid filter",
+            r.point.id
+        );
+    }
+
+    // Without a filter the excluded category is reachable — proving the
+    // assertion above tested the filter, not the corpus.
+    let unfiltered = coll
+        .hybrid_sparse_search_filtered(&[0.5, 0.5, 0.3, 0.1], &sparse_q, 8, "", &strategy, None)
+        .unwrap();
+    assert!(
+        unfiltered
+            .iter()
+            .any(|r| r.point.payload.as_ref().unwrap()["cat"] == "b"),
+        "corpus setup broken: cat=b never surfaces even unfiltered"
+    );
+}
+
+/// The unfiltered method must stay exactly the filtered method with `None` —
+/// pins the delegation so the two paths cannot drift.
+#[test]
+fn hybrid_sparse_search_is_filtered_with_none() {
+    let (coll, _dir) = create_test_vc();
+    seed_sparse_points(&coll);
+
+    let sparse_q = crate::index::sparse::SparseVector::new(vec![(10, 1.0)]);
+    let strategy = crate::fusion::FusionStrategy::rrf_default();
+
+    let plain = coll
+        .hybrid_sparse_search(&[0.5, 0.5, 0.3, 0.1], &sparse_q, 5, "", &strategy)
+        .unwrap();
+    let none = coll
+        .hybrid_sparse_search_filtered(&[0.5, 0.5, 0.3, 0.1], &sparse_q, 5, "", &strategy, None)
+        .unwrap();
+    let a: Vec<u64> = plain.iter().map(|r| r.point.id).collect();
+    let b: Vec<u64> = none.iter().map(|r| r.point.id).collect();
+    assert_eq!(a, b);
+}

--- a/crates/velesdb-server/src/handlers/search/parse_fusion_strategy_tests.rs
+++ b/crates/velesdb-server/src/handlers/search/parse_fusion_strategy_tests.rs
@@ -63,9 +63,11 @@ fn test_weighted_with_defaults() {
             max_weight,
             hit_weight,
         } => {
-            assert!((avg_weight - 0.5).abs() < f32::EPSILON);
-            assert!((max_weight - 0.3).abs() < f32::EPSILON);
-            assert!((hit_weight - 0.2).abs() < f32::EPSILON);
+            // Canonical #1545 defaults, sourced from core's fusion consts —
+            // this arm shipped the pre-#1545 fork (0.5/0.3/0.2) until then.
+            assert!((avg_weight - velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT).abs() < f32::EPSILON);
+            assert!((max_weight - velesdb_core::DEFAULT_WEIGHTED_MAX_WEIGHT).abs() < f32::EPSILON);
+            assert!((hit_weight - velesdb_core::DEFAULT_WEIGHTED_HIT_WEIGHT).abs() < f32::EPSILON);
         }
         other => panic!("expected Weighted, got {other:?}"),
     }

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -206,9 +206,12 @@ pub(crate) fn parse_fusion_strategy(
         "average" | "avg" => Ok(velesdb_core::FusionStrategy::Average),
         "maximum" | "max" => Ok(velesdb_core::FusionStrategy::Maximum),
         "weighted" => Ok(velesdb_core::FusionStrategy::Weighted {
-            avg_weight: f.avg_w.unwrap_or(0.5),
-            max_weight: f.max_w.unwrap_or(0.3),
-            hit_weight: f.hit_w.unwrap_or(0.2),
+            // Canonical defaults from core's fusion module (#1545) — this
+            // arm previously froze the pre-#1545 literals 0.5/0.3/0.2,
+            // forking the REST default from every other surface.
+            avg_weight: f.avg_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT),
+            max_weight: f.max_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_MAX_WEIGHT),
+            hit_weight: f.hit_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_HIT_WEIGHT),
         }),
         other => Err((
             StatusCode::BAD_REQUEST,
@@ -464,20 +467,28 @@ fn execute_hybrid_sparse(
         return Err((StatusCode::BAD_REQUEST, Json(error)).into_response());
     }
     let strategy = parse_fusion_strategy(req.fusion.as_ref())?;
-    // Gate the read (CORE-2): hybrid dense+sparse has no metadata-filter leaf,
-    // so a scope decision fails closed rather than running unfiltered.
+    // The request's metadata filter applies to BOTH branches (dense pre-filter
+    // + sparse post-filter) inside core; it was previously never read on this
+    // path, silently returning unfiltered hybrid results.
+    let filter = match req.filter {
+        Some(ref filter_json) => Some(parse_filter_or_400(filter_json, &state.onboarding_metrics)?),
+        None => None,
+    };
+    // Gate the read (CORE-2): the gate is consulted without a filter leaf, so
+    // a scope decision still fails closed rather than running under-scoped.
     match state.db.authorize_read(
         name,
         velesdb_core::observer::QueryOperationKind::HybridSearch,
         None,
         None,
     ) {
-        Ok(None) => Ok(collection.hybrid_sparse_search(
+        Ok(None) => Ok(collection.hybrid_sparse_search_filtered(
             &req.vector,
             sparse_query,
             req.top_k,
             index_name,
             &strategy,
+            filter.as_ref(),
         )),
         Ok(Some(_)) => Ok(Err(velesdb_core::Error::Config(
             "scope narrowing is not supported for hybrid dense+sparse search".to_string(),


### PR DESCRIPTION
## Description

Pre-release batch, first PR — the two highest-impact correctness findings from the adversarially-verified parity audit, both on the hybrid search contract.

**1. The hybrid dense+sparse metadata filter — two layered defects.**
- The server's `/search` hybrid dense+sparse path **never read the request's `filter`**: core exposes filtered variants, the handler called the unfiltered one, silently returning unfiltered fused results.
- Deeper (caught by this PR's own new test during development): even when a filter reached core's `execute_both_branches` — the VelesQL hybrid path — **only the sparse branch applied it**. The dense branch called `search_ids` with no filter in both cfg variants, so dense-only candidates the filter excludes leaked into fusion.

The dense branch now routes through the filtered dense search (bitmap pre-filter + oversampling via `search_with_filter`), the `VectorCollection` facade gains `hybrid_sparse_search_filtered` (the unfiltered method delegates with `None`, pinned by a drift test), and the server parses `req.filter` and wires it through. The CORE-2 scope gate keeps its fail-closed behavior unchanged. A facade test pins that **no fused result can carry a point the filter excludes**, plus the corpus-sanity counter-check that the excluded category does surface unfiltered.

**2. The REST weighted-fusion default fork.** The REST surface froze the pre-#1545 weights (0.5/0.3/0.2) in two places — the `api_types` serde defaults and the server's strategy parser — while core's fusion module (which declares itself the single source of truth) and every other surface use the canonical 0.6/0.3/0.1. Both sites now derive from `DEFAULT_WEIGHTED_{AVG,MAX,HIT}_WEIGHT`; a new test pins both the derivation and the values, and the three tests that pinned the fork are updated to pin the canon.

⚠️ **Behavioral change for REST clients** that relied on the forked defaults of a weightless `strategy: "weighted"` request: pass explicit weights to keep the old blend. Flagged in the CHANGELOG.

## Type of Change

- [x] 🐛 Bug fix

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Core lib: **5359 passed, 0 failed** (includes the 2 new facade filter tests + the canonical-constants pin)
- Server lib: 156/156; server `api_integration`: 87/87
- `cargo clippy … -- -D warnings -D clippy::pedantic` (CI-exact, core + server), `cargo fmt --check`, no-default-features `-Dwarnings` — clean
- The remaining server integration targets could not be **linked** in this container (session disk allowance — `LLVM ERROR: No space left on device`, not a code failure); CI covers them.

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Pre-release batch for v5.2.0 (option A). Second PR (TS SDK `sparseVector` drop on REST upsert) follows; the 54-finding triage issue lands alongside.
