### PR TITLE
fix(ts-sdk): REST upsert/upsertBatch forward sparseVector instead of silently dropping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TS SDK: REST `upsert`/`upsertBatch` no longer drop `sparseVector`.**
+  The REST backend sent only `{id, vector, payload}` while the server
+  accepts `sparse_vector` and the streaming backend always forwarded it —
+  a sparse-carrying upsert silently produced an empty sparse index and
+  degraded hybrid search. Both paths now forward it; wire-body tests pin
+  the contract.
+
 - **The bitmap under-fill retry explored nothing.** It doubled
   `candidates_k` at the same `ef`, but the graph's result heap is bounded
   by `ef`, so the retry re-ran the identical traversal and returned the

--- a/sdks/typescript/src/backends/crud-backend.ts
+++ b/sdks/typescript/src/backends/crud-backend.ts
@@ -216,10 +216,18 @@ export async function upsert(
   const restId = parseRestPointId(doc.id);
   const vector = toNumberArray(doc.vector);
 
+  // sparseVector must reach the wire: the server accepts `sparse_vector`
+  // on upsert, and dropping it silently produced an empty sparse index and
+  // degraded hybrid search (the streaming backend always forwarded it).
+  const point: Record<string, unknown> = { id: restId, vector, payload: doc.payload };
+  if (doc.sparseVector) {
+    point.sparse_vector = sparseVectorToRestFormat(doc.sparseVector);
+  }
+
   const response = await transport.requestJson(
     'POST',
     `${collectionPath(collection)}/points`,
-    { points: [{ id: restId, vector, payload: doc.payload }] }
+    { points: [point] }
   );
   throwOnError(response, `Collection '${collection}'`);
 }
@@ -229,11 +237,18 @@ export async function upsertBatch(
   collection: string,
   docs: VectorDocument[]
 ): Promise<void> {
-  const vectors = docs.map(doc => ({
-    id: parseRestPointId(doc.id),
-    vector: toNumberArray(doc.vector),
-    payload: doc.payload,
-  }));
+  const vectors = docs.map(doc => {
+    // Same wire contract as single upsert: forward sparseVector when present.
+    const point: Record<string, unknown> = {
+      id: parseRestPointId(doc.id),
+      vector: toNumberArray(doc.vector),
+      payload: doc.payload,
+    };
+    if (doc.sparseVector) {
+      point.sparse_vector = sparseVectorToRestFormat(doc.sparseVector);
+    }
+    return point;
+  });
 
   const response = await transport.requestJson(
     'POST',

--- a/sdks/typescript/tests/rest-backend.test.ts
+++ b/sdks/typescript/tests/rest-backend.test.ts
@@ -270,6 +270,63 @@ describe('RestBackend', () => {
       );
     });
 
+    it('forwards sparseVector as sparse_vector on upsert', async () => {
+      // Pinned defect: the REST upsert silently dropped sparseVector while
+      // the server accepts it and the streaming backend forwarded it —
+      // producing an empty sparse index and degraded hybrid search.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await backend.upsert('test', {
+        id: 1,
+        vector: [1.0, 0.0],
+        payload: { title: 'Test' },
+        sparseVector: { 10: 0.5, 42: 1.25 },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/collections/test/points',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            points: [{
+              id: 1,
+              vector: [1.0, 0.0],
+              payload: { title: 'Test' },
+              sparse_vector: { '10': 0.5, '42': 1.25 },
+            }],
+          }),
+        })
+      );
+    });
+
+    it('forwards sparseVector per point on upsertBatch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      await backend.upsertBatch('test', [
+        { id: 1, vector: [1.0, 0.0], sparseVector: { 7: 2.0 } },
+        { id: 2, vector: [0.0, 1.0] },
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/collections/test/points',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            points: [
+              { id: 1, vector: [1.0, 0.0], sparse_vector: { '7': 2.0 } },
+              { id: 2, vector: [0.0, 1.0] },
+            ],
+          }),
+        })
+      );
+    });
+
     it('should search vectors', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,


### PR DESCRIPTION
## Description

Pre-release batch, second PR — parity-audit finding, adversarially confirmed.

The TS SDK's REST backend sent only `{id, vector, payload}` on `upsert`/`upsertBatch`: `VectorDocument` documents `sparseVector`, the server accepts `sparse_vector` on upsert (`convert_sparse_inputs`), and the **streaming backend always forwarded it** — so a sparse-carrying upsert through the plain REST path silently produced an **empty sparse index and degraded hybrid search**, with no error anywhere in the chain.

Both paths now build the wire point through one shape and attach `sparse_vector` via the existing `sparseVectorToRestFormat` when the document carries one, mirroring the streaming backend exactly.

## Type of Change

- [x] 🐛 Bug fix

## How Has This Been Tested?

- [x] Unit tests

- `vitest`: **929 passed (37 files)** — includes two new wire-body tests pinning the forwarding (single upsert, and a batch mixing sparse and non-sparse points); the pre-existing exact-body tests pin that sparse-less requests stay byte-identical.
- `eslint src` — clean.

**Test Configuration:**
- OS: Linux (x86_64), Node v22

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Pre-release batch for v5.2.0 (option A), alongside #2093. The triage issue for the remaining audit findings follows.
