### PR TITLE
fix(hnsw): Jaccard transform_score stops inverting the metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HNSW `Jaccard` search scores no longer invert the metric.**
+  `DistanceMetric::higher_is_better()` and `DistanceMetric::calculate()` both
+  treat Jaccard as a similarity (like Cosine), but `transform_score` passed
+  the internal `1.0 - similarity` graph-traversal distance straight through
+  instead of inverting it back — the HNSW-only search path reported the
+  complement of what the brute-force/rerank path reported for the same
+  query. Jaccard now shares Cosine's `(1.0 - raw).clamp(0.0, 1.0)` transform;
+  a regression test pins both paths agreeing on score for the same vectors.
+  (parity audit #2095)
+
 - **TS SDK: REST `upsert`/`upsertBatch` no longer drop `sparseVector`.**
   The REST backend sent only `{id, vector, payload}` while the server
   accepts `sparse_vector` and the streaming backend always forwarded it —

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -1579,6 +1579,37 @@ fn test_concurrent_search_stress() {
     }
 }
 
+/// Regression: `Jaccard` is a similarity metric
+/// (`DistanceMetric::higher_is_better() == true`, same as Cosine), but
+/// `transform_score` used to pass the internal `1.0 - similarity` graph
+/// distance straight through instead of inverting it back. That made the
+/// HNSW-only path (`search`, via `transform_score`) report the complement
+/// of what the rerank path (`compute_distance`, via
+/// `jaccard_similarity_native` directly) reports for the exact same query —
+/// caught by the 2026-08-21 parity audit. Both paths must now agree.
+#[test]
+fn test_jaccard_hnsw_and_rerank_paths_agree_on_score() {
+    let index = HnswIndex::new(8, DistanceMetric::Jaccard).unwrap();
+    let target = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+    index.insert(1, &target);
+    index.insert(2, &[0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]);
+
+    let hnsw_only = index.search(&target, 1);
+    let hnsw_score = hnsw_only[0].score;
+    let rerank_score = index.compute_distance(&target, &target);
+
+    assert!(
+        hnsw_score > 0.9,
+        "Jaccard is a similarity metric: the exact self-match must score \
+         near 1.0 via the HNSW-only path, got {hnsw_score}"
+    );
+    assert!(
+        (hnsw_score - rerank_score).abs() < 1e-5,
+        "HNSW-only score ({hnsw_score}) and rerank-path score \
+         ({rerank_score}) must agree for the same query/vector pair"
+    );
+}
+
 #[test]
 fn test_all_distance_metrics_search_with_rerank() {
     for metric in [

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -371,16 +371,25 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     /// - **Euclidean**: `sqrt(raw_distance)` — the search loop stores squared L2
     ///   to skip redundant sqrt during traversal; this restores the actual
     ///   Euclidean distance for user-visible scores.
-    /// - **Hamming**/**Jaccard**: raw distance (lower is better)
+    /// - **Hamming**: raw distance (lower is better)
+    /// - **Jaccard**: `(1.0 - distance).clamp(0.0, 1.0)` (similarity in `[0,1]`) —
+    ///   `CachedSimdDistance` stores `1.0 - jaccard_similarity` during HNSW
+    ///   traversal (a real distance a graph search can minimize); this restores
+    ///   the similarity that `DistanceMetric::higher_is_better()` and
+    ///   `DistanceMetric::calculate()` both declare for Jaccard, so HNSW-path
+    ///   scores agree with brute-force/rerank-path scores instead of being
+    ///   each other's complement.
     /// - **DotProduct**: `-distance` (negated for consistency)
     #[must_use]
     pub fn transform_score(&self, raw_distance: f32) -> f32 {
         match self.distance.metric() {
-            DistanceMetric::Cosine => (1.0 - raw_distance).clamp(0.0, 1.0),
+            DistanceMetric::Cosine | DistanceMetric::Jaccard => {
+                (1.0 - raw_distance).clamp(0.0, 1.0)
+            }
             // Reason: CachedSimdDistance stores squared L2 during HNSW traversal
             // to avoid per-comparison sqrt. Apply sqrt here on the final k results.
             DistanceMetric::Euclidean => raw_distance.sqrt(),
-            DistanceMetric::Hamming | DistanceMetric::Jaccard => raw_distance,
+            DistanceMetric::Hamming => raw_distance,
             DistanceMetric::DotProduct => -raw_distance,
         }
     }

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -140,6 +140,23 @@ fn test_transform_score_dot_product() {
     assert!((hnsw.transform_score(0.5) - (-0.5)).abs() < f32::EPSILON);
 }
 
+#[test]
+fn test_transform_score_jaccard() {
+    let engine = CachedSimdDistance::new(DistanceMetric::Jaccard, 32);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+
+    // Jaccard is a similarity metric (DistanceMetric::higher_is_better() ==
+    // true), same as Cosine. `CachedSimdDistance` stores `1.0 - similarity`
+    // as the graph-traversal distance, so transform_score must invert it
+    // back to similarity — not pass it through as a raw distance (which
+    // would return the complement and disagree with the rerank path's
+    // `jaccard_similarity_native`, a regression caught by the 2026-08-21
+    // parity audit).
+    assert!((hnsw.transform_score(0.3) - 0.7).abs() < f32::EPSILON);
+    assert!((hnsw.transform_score(1.5) - 0.0).abs() < f32::EPSILON); // clamped
+    assert!((hnsw.transform_score(0.0) - 1.0).abs() < f32::EPSILON); // exact match
+}
+
 // =========================================================================
 // TDD Tests: file_dump and file_load
 // =========================================================================


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

> **Superseded by #2108.** The production hunk in `backend_adapter.rs` is character-for-character identical there (only the doc wording differs), and #2108 additionally covers the five other metric-semantics findings from the same audit. This branch is `dirty` against `develop` and will stay conflicted with #2108. Keeping it open serves nothing — close it once #2108 lands.

## Description

Parity-audit finding A1 (#2095), the one flagged &#34;intra-core!&#34; — the same query returns incomparable scores depending on which core search path answers it, for `DistanceMetric::Jaccard`.

`DistanceMetric::higher_is_better()` and `DistanceMetric::calculate()` both treat Jaccard as a similarity metric, exactly like Cosine (`distance_semantics_tests.rs` pins this contract explicitly). Internally, `CachedSimdDistance` stores `1.0 - jaccard_similarity` as the HNSW graph-traversal distance — same trick used for Cosine — so the graph can minimize it like every other metric. `transform_score` is the step that converts that internal distance back to the user-visible metric score on the final k results. For Cosine it does `(1.0 - raw).clamp(0.0, 1.0)`; for Jaccard it just returned `raw_distance` unchanged, i.e. `1.0 - similarity` — the complement of what the metric is documented and everywhere else assumed to return.

Concretely: `HnswIndex::search`/`search_with_quality` (the HNSW-only path, via `transform_score`) reported `1 - similarity` for a Jaccard collection, while `HnswIndex::compute_distance` (the brute-force/rerank path, calling `jaccard_similarity_native` directly) reported `similarity` for the exact same query and vectors — an exact match scored ~0.0 on one path and ~1.0 on the other.

Fixes # (no dedicated issue yet — tracked as item A1 under the umbrella issue #2095)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- `test_transform_score_jaccard` (new) pins the corrected transform&#39;s output directly, mirroring the existing `test_transform_score_cosine`.
- `test_jaccard_hnsw_and_rerank_paths_agree_on_score` (new) is an end-to-end regression: inserts vectors into a real `HnswIndex`, asserts the HNSW-only `search()` path and the rerank-path `compute_distance()` now agree on score for the same query/vector pair (they were exact complements before the fix).
- Full `index::hnsw::` suite: **538 passed, 0 failed** (`cargo test -p velesdb-core --lib --features persistence -- --test-threads=1 index::hnsw::`)
- `cargo clippy -p velesdb-core --lib --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean
- `cargo fmt --all -- --check` — clean

**Test Configuration:**
- OS: Linux (x86_64)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Touches `hnsw`, so filling this in:

- [x] Invariant impacted: `transform_score`&#39;s contract that its output matches `DistanceMetric::higher_is_better()`/`calculate()` semantics for every metric — Jaccard was the one variant violating it.
- [x] No crash/durability semantics touched — this is a pure scoring transform on already-computed distances, no persistence format change (nothing here is serialized).
- [x] Regression test added for the specific score-agreement invariant (`test_jaccard_hnsw_and_rerank_paths_agree_on_score`).
- [ ] 2-maintainer review — requesting via this PR.

## Additional Notes

Scope is intentionally limited to core Jaccard scoring, the one item in A1 that&#39;s a same-crate bug rather than a cross-binding drift (WASM&#39;s Cosine range divergence and the rest of A1 are separate, larger items best triaged individually per #2095&#39;s own note that &#34;each needs its own issue&#34;).
