### PR TITLE
fix(core): metric-calculation correctness wave — score semantics, SIMD cosine, RaBitQ estimator, storage percentiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Jaccard scores come back as similarities on every HNSW path.** The
+  HNSW score transform passed the engine's `1 - jaccard` traversal
+  distance through while the metric is declared higher-is-better, so the
+  bitmap-filtered, brute-force-parallel, dual-precision/RaBitQ rerank and
+  delta-merge paths ranked the *worst* candidates first and disagreed
+  with the exact path on the same query. (#2100)
+
+- **The GraphFirst filtered scan stopped clamping every metric into
+  [-1, 1].** Euclidean/Hamming distances and raw dot products beyond 1
+  collapsed into an artificial 1.0 tie (arbitrary top-k, meaningless
+  score) and the clamp never removed the NaN it claimed to guard; NaN
+  scores now map to the metric's worst key instead. (#2101)
+
+- **Score-level fusion honors score polarity.** Average, Maximum,
+  Weighted and RSF fused Euclidean/Hamming distance branches as if
+  higher were better — inverted or degenerate fused rankings across
+  multi-query, `NEAR_FUSED`, hybrid dense+sparse and dense+text. Branch
+  polarity is now declared via `fusion::ScoreDirection`, derived from
+  the metric. (#2102)
+
+- **SIMD cosine no longer zeroes small-magnitude vectors.** The shared
+  finish step guarded on the *product* of squared norms against
+  `EPSILON²`, so vectors with norms around 3.4e-4 scored 0.0 on
+  AVX2/AVX-512/NEON while the scalar path returned the true cosine.
+  (#2103)
+
+- **The RaBitQ estimator is de-biased by the arcsine law.** The
+  symmetric binary inner product satisfies `E[ip] = 1 - 2θ/π`, not
+  `cos θ`; using it raw overestimated every non-zero angle's distance
+  (+15% at 60°) and distorted cross-norm ranking. (#2104)
+
+- **Storage latency percentiles use nearest-rank.** The floor-based
+  target reported 1µs for any window where `count × p < 100` — a single
+  500ms mmap resize was invisible to the P99 monitoring it exists for.
+  (#2105)
+
 ## [5.2.0] - 2026-08-22
 
 ### Changed

--- a/crates/velesdb-core/src/collection/search/batch.rs
+++ b/crates/velesdb-core/src/collection/search/batch.rs
@@ -193,7 +193,8 @@ impl Collection {
     ///
     /// # Returns
     ///
-    /// Vector of `SearchResult` sorted by fused score descending.
+    /// Vector of `SearchResult` sorted best-first (descending fused score for
+    /// similarity metrics, ascending fused distance for Euclidean/Hamming).
     ///
     /// # Errors
     ///
@@ -215,8 +216,11 @@ impl Collection {
         let batch_results = self.search_and_merge_delta(vectors, overfetch_k, metric)?;
         let filtered = self.apply_pre_fusion_filter(batch_results, filter);
 
+        // Every branch carries this collection's metric scores, so score-level
+        // strategies must honor the metric's polarity (#2102).
+        let directions = vec![metric.score_direction(); filtered.len()];
         let fused = fusion
-            .fuse(filtered)
+            .fuse_with_directions(filtered, &directions)
             .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
 
         Ok(self.hydrate_fused_results(&fused, top_k))
@@ -360,8 +364,10 @@ impl Collection {
 
         let batch_results = self.search_and_merge_delta(vectors, overfetch_k, metric)?;
 
+        // Same polarity contract as `multi_query_search` (#2102).
+        let directions = vec![metric.score_direction(); batch_results.len()];
         let fused = fusion
-            .fuse(batch_results)
+            .fuse_with_directions(batch_results, &directions)
             .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
 
         Ok(fused.into_iter().take(top_k).collect())

--- a/crates/velesdb-core/src/collection/search/batch_tests.rs
+++ b/crates/velesdb-core/src/collection/search/batch_tests.rs
@@ -185,3 +185,72 @@ fn test_batch_with_filters_respects_per_call_k() {
         "k=5 should return more results than k=2"
     );
 }
+
+// -----------------------------------------------------------------------
+// Regression (#2102): multi-query fusion on a distance metric must rank
+// the NEAREST documents first. Pre-fix, score-level strategies fused raw
+// Euclidean distances as if higher were better and returned the farthest.
+// -----------------------------------------------------------------------
+
+fn setup_euclidean_collection() -> (tempfile::TempDir, Collection) {
+    use crate::distance::DistanceMetric;
+    let dir = tempfile::tempdir().expect("test: tempdir");
+    let col = Collection::create(
+        std::path::PathBuf::from(dir.path()),
+        2,
+        DistanceMetric::Euclidean,
+    )
+    .expect("test: collection");
+    col.upsert(vec![
+        make_point_with_payload(1, vec![0.1, 0.0], serde_json::json!({})),
+        make_point_with_payload(2, vec![5.0, 0.0], serde_json::json!({})),
+        make_point_with_payload(3, vec![9.0, 0.0], serde_json::json!({})),
+    ])
+    .expect("test: upsert");
+    (dir, col)
+}
+
+#[test]
+fn test_multi_query_euclidean_maximum_ranks_nearest_first() {
+    let (_dir, col) = setup_euclidean_collection();
+    let q1: Vec<f32> = vec![0.0, 0.0];
+    let q2: Vec<f32> = vec![0.2, 0.0];
+    let queries: Vec<&[f32]> = vec![&q1, &q2];
+
+    let results = col
+        .multi_query_search(&queries, 3, crate::fusion::FusionStrategy::Maximum, None)
+        .expect("test: multi query");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 2, 3],
+        "nearest-first order for Euclidean fusion, got scores {:?}",
+        results.iter().map(|r| r.score).collect::<Vec<_>>()
+    );
+    // "Best" per doc across queries is its SMALLEST distance, in metric units.
+    assert!(
+        (results[0].score - 0.1).abs() < 1e-5,
+        "doc1 best distance is 0.1 from both queries, got {}",
+        results[0].score
+    );
+}
+
+#[test]
+fn test_multi_query_euclidean_average_ranks_nearest_first() {
+    let (_dir, col) = setup_euclidean_collection();
+    let q1: Vec<f32> = vec![0.0, 0.0];
+    let queries: Vec<&[f32]> = vec![&q1];
+
+    let results = col
+        .multi_query_search(&queries, 3, crate::fusion::FusionStrategy::Average, None)
+        .expect("test: multi query");
+
+    let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+    assert_eq!(ids, vec![1, 2, 3], "ascending average distance");
+    assert!(
+        results.windows(2).all(|w| w[0].score <= w[1].score),
+        "scores must ascend in metric units: {:?}",
+        results.iter().map(|r| r.score).collect::<Vec<_>>()
+    );
+}

--- a/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
+++ b/crates/velesdb-core/src/collection/search/query/hybrid_sparse.rs
@@ -493,8 +493,15 @@ impl Collection {
             .map(|sd| (sd.doc_id, sd.score))
             .collect();
 
+        // Dense scores carry the collection metric's polarity (distances for
+        // Euclidean/Hamming); sparse scores are always higher-is-better
+        // relevance. Score-level strategies must align them (#2102).
+        let directions = [
+            self.storage.config.read().metric.score_direction(),
+            crate::fusion::ScoreDirection::HigherIsBetter,
+        ];
         let fused = strategy
-            .fuse(vec![dense_results, sparse_tuples])
+            .fuse_with_directions(vec![dense_results, sparse_tuples], &directions)
             .map_err(|e| Error::Config(format!("Fusion error: {e}")))?;
 
         Ok(self.resolve_fused_results(&fused, limit))

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -554,8 +554,11 @@ impl Collection {
     ///
     /// # SecDev
     ///
-    /// All cosine scores are clamped to `[-1.0, 1.0]` to prevent silent NaN propagation
-    /// from zero-norm vectors.
+    /// A NaN score (corrupt or NaN-bearing stored vector) is mapped to the
+    /// metric's worst key so it can never outrank a real result. Scores are
+    /// otherwise reported verbatim: Euclidean/Hamming distances and raw dot
+    /// products legitimately exceed 1, and cosine is already clamped inside
+    /// `DistanceMetric::calculate`.
     pub(crate) fn scan_and_score_by_vector(
         &self,
         metadata_filter: &crate::filter::Filter,
@@ -606,11 +609,22 @@ impl Collection {
             );
         }
 
+        // Regression (#2101): this used to clamp every metric into [-1, 1],
+        // which collapsed all Euclidean/Hamming distances > 1 and all raw dot
+        // products > 1 into an artificial tie at 1.0 (arbitrary top-k), while
+        // not even removing NaN — clamp() propagates it. Only NaN needs
+        // guarding, with the metric-appropriate worst key (same convention as
+        // `similarity_scores_for_field`).
+        let worst = if higher_is_better {
+            f32::NEG_INFINITY
+        } else {
+            f32::INFINITY
+        };
         let mut topk = super::bounded_top_k::BoundedTopK::new(limit, higher_is_better);
         for mut r in scan.results {
             // Exact distance computation using the stored vector.
-            // Clamp is mandatory (SecDev) to guard against NaN from zero-norm vectors.
-            r.score = metric.calculate(&r.point.vector, query).clamp(-1.0, 1.0);
+            let raw = metric.calculate(&r.point.vector, query);
+            r.score = if raw.is_nan() { worst } else { raw };
             topk.offer(r);
         }
 

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
@@ -19,3 +19,122 @@ fn test_not_similarity_guard_rejects_above_ceiling() {
         "error should explain the scan-limit rejection, got: {msg}"
     );
 }
+
+// ============================================================================
+// Regression (#2101): the GraphFirst exact-rescoring scan clamped every
+// metric's score into [-1, 1]. Euclidean/Hamming distances > 1 and raw dot
+// products > 1 all collapsed to an artificial 1.0 tie, so the "top-k" was
+// insertion-order arbitrary and the user-visible score meaningless. The
+// clamp also failed its stated purpose: clamp() propagates NaN.
+// ============================================================================
+
+#[cfg(feature = "persistence")]
+mod scan_score_semantics {
+    use crate::collection::Collection;
+    use crate::distance::DistanceMetric;
+    use crate::filter::{Condition, Filter};
+    use crate::point::Point;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn tagged_point(id: u64, vector: Vec<f32>) -> Point {
+        Point {
+            id,
+            vector,
+            payload: Some(serde_json::json!({"cat": "a"})),
+            sparse_vectors: None,
+        }
+    }
+
+    fn setup(metric: DistanceMetric, points: Vec<Point>) -> (TempDir, Collection) {
+        let dir = tempfile::tempdir().expect("test: tempdir");
+        let col =
+            Collection::create(PathBuf::from(dir.path()), 2, metric).expect("test: collection");
+        col.upsert(points).expect("test: upsert");
+        (dir, col)
+    }
+
+    fn cat_filter() -> Filter {
+        Filter::new(Condition::Eq {
+            field: "cat".into(),
+            value: serde_json::json!("a"),
+        })
+    }
+
+    /// Euclidean distances above 1 must be reported verbatim and ranked
+    /// ascending — pre-fix all three clamped to 1.0 (total tie).
+    #[test]
+    fn test_scan_score_euclidean_distances_above_one_not_clamped() {
+        let (_dir, col) = setup(
+            DistanceMetric::Euclidean,
+            vec![
+                tagged_point(1, vec![7.0, 0.0]),
+                tagged_point(2, vec![3.0, 0.0]),
+                tagged_point(3, vec![10.0, 0.0]),
+            ],
+        );
+
+        let results = col.scan_and_score_by_vector(&cat_filter(), &[0.0, 0.0], 3);
+
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(ids, vec![2, 1, 3], "ascending true distance 3 < 7 < 10");
+        for (result, want) in results.iter().zip([3.0f32, 7.0, 10.0]) {
+            assert!(
+                (result.score - want).abs() < 1e-5,
+                "id {} score {} != true distance {want}",
+                result.point.id,
+                result.score
+            );
+        }
+    }
+
+    /// Raw dot products above 1 must be reported verbatim and ranked
+    /// descending — pre-fix both clamped to 1.0.
+    #[test]
+    fn test_scan_score_dot_product_above_one_not_clamped() {
+        let (_dir, col) = setup(
+            DistanceMetric::DotProduct,
+            vec![
+                tagged_point(1, vec![2.0, 0.0]),
+                tagged_point(2, vec![5.0, 3.0]),
+            ],
+        );
+
+        let results = col.scan_and_score_by_vector(&cat_filter(), &[1.0, 0.0], 2);
+
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(ids, vec![2, 1], "descending raw dot 5.0 > 2.0");
+        assert!(
+            (results[0].score - 5.0).abs() < 1e-5,
+            "raw dot 5.0 must survive, got {}",
+            results[0].score
+        );
+    }
+
+    /// A NaN-bearing stored vector must sort last (worst key), never first —
+    /// the old clamp let NaN through into the top-k comparator.
+    #[test]
+    fn test_scan_score_nan_vector_sorts_last() {
+        let (_dir, col) = setup(
+            DistanceMetric::Euclidean,
+            vec![
+                tagged_point(1, vec![3.0, 0.0]),
+                tagged_point(2, vec![f32::NAN, 0.0]),
+                tagged_point(3, vec![7.0, 0.0]),
+            ],
+        );
+
+        let results = col.scan_and_score_by_vector(&cat_filter(), &[0.0, 0.0], 3);
+
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        assert_eq!(
+            ids,
+            vec![1, 3, 2],
+            "NaN point must rank after every finite distance"
+        );
+        assert!(
+            results[2].score.is_infinite(),
+            "NaN maps to the metric's worst key (INFINITY for distances)"
+        );
+    }
+}

--- a/crates/velesdb-core/src/collection/search/text_fusion.rs
+++ b/crates/velesdb-core/src/collection/search/text_fusion.rs
@@ -115,7 +115,8 @@ impl Collection {
         let (vector_scored, text_stream) =
             self.anchored_hybrid_streams(vector_query, text_query, anchor_ids, overfetch_k)?;
         let vector_stream: ScoreStream = vector_scored.iter().map(|sr| (sr.id, sr.score)).collect();
-        let fused = fuse_streams(strategy, vector_stream, text_stream)?;
+        let direction = self.storage.config.read().metric.score_direction();
+        let fused = fuse_streams(strategy, vector_stream, direction, text_stream)?;
         Ok(self.resolve_fused_results(&fused, k))
     }
 
@@ -149,7 +150,8 @@ impl Collection {
         let candidate_k = k.saturating_mul(2).max(k + 10);
         let (vector_stream, text_stream) =
             self.hybrid_score_streams(vector_query, text_query, candidate_k)?;
-        let fused = fuse_streams(strategy, vector_stream, text_stream)?;
+        let direction = self.storage.config.read().metric.score_direction();
+        let fused = fuse_streams(strategy, vector_stream, direction, text_stream)?;
         let resolved = self.resolve_fused_results(&fused, fused.len());
         Ok(apply_post_filter(resolved, filter, k))
     }
@@ -184,16 +186,26 @@ fn cast_weight(w: f64) -> f32 {
 
 /// Fuses two `(id, score)` streams via `strategy`, returning an empty list when
 /// both inputs are empty (so callers resolve a uniform result set).
+///
+/// `vector_direction` is the collection metric's polarity: Euclidean/Hamming
+/// vector scores are distances and must be declared lower-is-better so
+/// score-level strategies do not invert them against the always
+/// higher-is-better BM25 stream (#2102).
 fn fuse_streams(
     strategy: &FusionStrategy,
     vector_stream: ScoreStream,
+    vector_direction: crate::fusion::ScoreDirection,
     text_stream: ScoreStream,
 ) -> Result<ScoreStream> {
     if vector_stream.is_empty() && text_stream.is_empty() {
         return Ok(Vec::new());
     }
+    let directions = [
+        vector_direction,
+        crate::fusion::ScoreDirection::HigherIsBetter,
+    ];
     strategy
-        .fuse(vec![vector_stream, text_stream])
+        .fuse_with_directions(vec![vector_stream, text_stream], &directions)
         .map_err(|e| Error::Config(format!("Fusion error: {e}")))
 }
 

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -159,6 +159,19 @@ impl DistanceMetric {
         }
     }
 
+    /// Returns this metric's score polarity for fusion
+    /// ([`ScoreDirection`](crate::fusion::ScoreDirection)).
+    ///
+    /// Derived from [`Self::higher_is_better`] so the two can never drift.
+    #[must_use]
+    pub const fn score_direction(&self) -> crate::fusion::ScoreDirection {
+        if self.higher_is_better() {
+            crate::fusion::ScoreDirection::HigherIsBetter
+        } else {
+            crate::fusion::ScoreDirection::LowerIsBetter
+        }
+    }
+
     /// Sorts search results by distance/similarity according to the metric.
     ///
     /// - **Similarity metrics** (`Cosine`, `DotProduct`, `Jaccard`): sorts descending (higher = better)

--- a/crates/velesdb-core/src/fusion/mod.rs
+++ b/crates/velesdb-core/src/fusion/mod.rs
@@ -26,6 +26,6 @@ mod strategy;
 mod strategy_tests;
 
 pub use strategy::{
-    min_max_normalize, FusionError, FusionStrategy, DEFAULT_WEIGHTED_AVG_WEIGHT,
+    min_max_normalize, FusionError, FusionStrategy, ScoreDirection, DEFAULT_WEIGHTED_AVG_WEIGHT,
     DEFAULT_WEIGHTED_HIT_WEIGHT, DEFAULT_WEIGHTED_MAX_WEIGHT,
 };

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -296,7 +296,9 @@ impl FusionStrategy {
         let mut fused = self.fuse(results)?;
 
         let all_lower = !directions.is_empty()
-            && directions.iter().all(|d| *d == ScoreDirection::LowerIsBetter);
+            && directions
+                .iter()
+                .all(|d| *d == ScoreDirection::LowerIsBetter);
         if all_lower && self.preserves_score_space() {
             // Restore metric units; descending negated order is ascending
             // distance, so the list stays best-first.
@@ -314,10 +316,7 @@ impl FusionStrategy {
 
     /// True for strategies whose output stays in the input score space.
     fn preserves_score_space(&self) -> bool {
-        matches!(
-            self,
-            Self::Average | Self::Maximum | Self::Weighted { .. }
-        )
+        matches!(self, Self::Average | Self::Maximum | Self::Weighted { .. })
     }
 
     /// Fuses results from multiple queries into a single ranked list.

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -25,6 +25,13 @@ pub enum FusionError {
         /// Number of branches passed to fuse.
         branches: usize,
     },
+    /// Direction slice length does not match the number of result branches.
+    DirectionCountMismatch {
+        /// Number of directions provided.
+        directions: usize,
+        /// Number of branches passed to fuse.
+        branches: usize,
+    },
 }
 
 impl std::fmt::Display for FusionError {
@@ -40,11 +47,34 @@ impl std::fmt::Display for FusionError {
                 f,
                 "WeightedRRF requires one weight per branch: {weights} weights for {branches} branches",
             ),
+            Self::DirectionCountMismatch {
+                directions,
+                branches,
+            } => write!(
+                f,
+                "fuse_with_directions requires one direction per branch: {directions} directions for {branches} branches",
+            ),
         }
     }
 }
 
 impl std::error::Error for FusionError {}
+
+/// Polarity of a branch's raw scores.
+///
+/// Score-level fusion (average, maximum, weighted, relative-score) is only
+/// meaningful when every branch agrees on which end of the scale is "better".
+/// Distance metrics (Euclidean, Hamming) produce lower-is-better streams, so
+/// they must be declared as such — fusing them as if higher were better
+/// silently inverts the ranking (#2102).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScoreDirection {
+    /// Similarity-like scores: higher is better (`Cosine`, `DotProduct`,
+    /// `Jaccard`, BM25/text relevance).
+    HigherIsBetter,
+    /// Distance-like scores: lower is better (`Euclidean`, `Hamming`).
+    LowerIsBetter,
+}
 
 /// Canonical default weight for the average-score component of
 /// [`FusionStrategy::Weighted`] when a caller does not supply explicit
@@ -213,12 +243,91 @@ impl FusionStrategy {
         }
     }
 
+    /// Fuses branches whose raw scores may not all be higher-is-better.
+    ///
+    /// `directions[i]` declares the polarity of `results[i]`. Lower-is-better
+    /// branches are negated on the way in — an order-preserving map into
+    /// higher-is-better space — so every strategy combines and ranks them
+    /// correctly. When **all** branches are lower-is-better and the strategy
+    /// preserves the input score space (`Average`, `Maximum`, `Weighted`),
+    /// the fused scores are negated back so the output stays in the metric's
+    /// own units (best first, ascending). Rank-based strategies (`RRF`,
+    /// `WeightedRRF`) only consume the best-first order, and `RelativeScore`
+    /// outputs normalized `[0, 1]` similarities; neither is negated back.
+    ///
+    /// # Arguments
+    ///
+    /// * `results` - One branch per entry, each `(document_id, raw_score)`
+    ///   sorted best-first.
+    /// * `directions` - The polarity of each branch, same length as `results`.
+    ///
+    /// # Returns
+    ///
+    /// A single best-first `(document_id, fused_score)` list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FusionError::DirectionCountMismatch`] if `directions.len()`
+    /// differs from `results.len()`, plus any error [`Self::fuse`] returns.
+    pub fn fuse_with_directions(
+        &self,
+        mut results: Vec<Vec<(u64, f32)>>,
+        directions: &[ScoreDirection],
+    ) -> Result<Vec<(u64, f32)>, FusionError> {
+        if directions.len() != results.len() {
+            return Err(FusionError::DirectionCountMismatch {
+                directions: directions.len(),
+                branches: results.len(),
+            });
+        }
+        if self.is_rank_based() {
+            // Rank-based strategies consume the best-first order only; the
+            // raw score values (and thus their polarity) never enter the math.
+            return self.fuse(results);
+        }
+
+        for (branch, direction) in results.iter_mut().zip(directions) {
+            if *direction == ScoreDirection::LowerIsBetter {
+                for entry in branch.iter_mut() {
+                    entry.1 = -entry.1;
+                }
+            }
+        }
+        let mut fused = self.fuse(results)?;
+
+        let all_lower = !directions.is_empty()
+            && directions.iter().all(|d| *d == ScoreDirection::LowerIsBetter);
+        if all_lower && self.preserves_score_space() {
+            // Restore metric units; descending negated order is ascending
+            // distance, so the list stays best-first.
+            for entry in &mut fused {
+                entry.1 = -entry.1;
+            }
+        }
+        Ok(fused)
+    }
+
+    /// True for strategies that rank purely by input order, ignoring raw scores.
+    fn is_rank_based(&self) -> bool {
+        matches!(self, Self::RRF { .. } | Self::WeightedRRF { .. })
+    }
+
+    /// True for strategies whose output stays in the input score space.
+    fn preserves_score_space(&self) -> bool {
+        matches!(
+            self,
+            Self::Average | Self::Maximum | Self::Weighted { .. }
+        )
+    }
+
     /// Fuses results from multiple queries into a single ranked list.
     ///
     /// # Arguments
     ///
     /// * `results` - Vec of search results, one per query. Each inner Vec
     ///   contains `(document_id, score)` tuples, assumed sorted by score descending.
+    ///   Raw scores are combined as **higher-is-better**; for distance-metric
+    ///   branches use [`Self::fuse_with_directions`] instead.
     ///
     /// # Returns
     ///

--- a/crates/velesdb-core/src/fusion/strategy_tests.rs
+++ b/crates/velesdb-core/src/fusion/strategy_tests.rs
@@ -1,9 +1,132 @@
 //! Tests for `FusionStrategy` implementations.
 
 use super::strategy::{
-    min_max_normalize, FusionError, FusionStrategy, DEFAULT_WEIGHTED_AVG_WEIGHT,
+    min_max_normalize, FusionError, FusionStrategy, ScoreDirection, DEFAULT_WEIGHTED_AVG_WEIGHT,
     DEFAULT_WEIGHTED_HIT_WEIGHT, DEFAULT_WEIGHTED_MAX_WEIGHT,
 };
+
+// =============================================================================
+// Regression (#2102): score-level strategies must honor branch polarity.
+// Pre-fix every strategy assumed higher-is-better, so Euclidean/Hamming
+// distance branches were fused and sorted inverted (farthest first).
+// =============================================================================
+
+/// Two Euclidean-distance branches (best-first ascending). doc1 is the near
+/// document in both; doc2 is far in both.
+fn distance_branches() -> Vec<Vec<(u64, f32)>> {
+    vec![
+        vec![(1, 0.1), (2, 3.0)],
+        vec![(1, 0.2), (2, 2.9)],
+    ]
+}
+
+fn all_lower(n: usize) -> Vec<ScoreDirection> {
+    vec![ScoreDirection::LowerIsBetter; n]
+}
+
+#[test]
+fn test_directed_maximum_lower_is_better_keeps_nearest_first() {
+    let fused = FusionStrategy::Maximum
+        .fuse_with_directions(distance_branches(), &all_lower(2))
+        .expect("fuse");
+
+    // "Maximum" = best score per doc = the SMALLEST distance; nearest first.
+    assert_eq!(fused[0].0, 1, "nearest doc must rank first, got {fused:?}");
+    assert!(
+        (fused[0].1 - 0.1).abs() < 1e-6,
+        "doc1 keeps its best (smallest) distance, got {}",
+        fused[0].1
+    );
+    assert!(
+        (fused[1].1 - 2.9).abs() < 1e-6,
+        "doc2 keeps its best (smallest) distance, got {}",
+        fused[1].1
+    );
+}
+
+#[test]
+fn test_directed_average_lower_is_better_ascending_metric_units() {
+    let fused = FusionStrategy::Average
+        .fuse_with_directions(distance_branches(), &all_lower(2))
+        .expect("fuse");
+
+    assert_eq!(fused[0].0, 1, "smallest average distance first");
+    assert!(
+        (fused[0].1 - 0.15).abs() < 1e-6,
+        "average stays in metric units (0.15), got {}",
+        fused[0].1
+    );
+    assert!((fused[1].1 - 2.95).abs() < 1e-6);
+}
+
+#[test]
+fn test_directed_relative_score_inverts_distance_branch() {
+    // Dense = Euclidean distances (lower better), sparse = BM25 (higher
+    // better). doc1 wins both branches outright; pre-fix min-max gave the
+    // NEAREST dense doc the WORST normalized score and doc1/doc2 tied.
+    let dense = vec![(1, 0.1), (2, 5.0)];
+    let sparse = vec![(1, 9.0), (2, 1.0)];
+    let strategy = FusionStrategy::RelativeScore {
+        dense_weight: 0.5,
+        sparse_weight: 0.5,
+    };
+
+    let fused = strategy
+        .fuse_with_directions(
+            vec![dense, sparse],
+            &[ScoreDirection::LowerIsBetter, ScoreDirection::HigherIsBetter],
+        )
+        .expect("fuse");
+
+    assert_eq!(fused[0].0, 1, "doc winning both branches must rank first");
+    assert!(
+        (fused[0].1 - 1.0).abs() < 1e-6,
+        "doc1 normalizes to 1.0 in both branches, got {}",
+        fused[0].1
+    );
+    assert!(
+        fused[1].1.abs() < 1e-6,
+        "doc2 normalizes to 0.0 in both branches, got {}",
+        fused[1].1
+    );
+}
+
+#[test]
+fn test_directed_rank_based_ignores_polarity() {
+    // RRF consumes best-first order only: identical output either way.
+    let with_dirs = FusionStrategy::rrf_default()
+        .fuse_with_directions(distance_branches(), &all_lower(2))
+        .expect("fuse");
+    let plain = FusionStrategy::rrf_default()
+        .fuse(distance_branches())
+        .expect("fuse");
+    assert_eq!(with_dirs, plain);
+    assert_eq!(with_dirs[0].0, 1, "best-ranked doc first");
+}
+
+#[test]
+fn test_directed_higher_is_better_matches_plain_fuse() {
+    let branches = vec![vec![(1, 0.9), (2, 0.4)], vec![(1, 0.8), (2, 0.5)]];
+    let with_dirs = FusionStrategy::Average
+        .fuse_with_directions(branches.clone(), &[ScoreDirection::HigherIsBetter; 2])
+        .expect("fuse");
+    let plain = FusionStrategy::Average.fuse(branches).expect("fuse");
+    assert_eq!(with_dirs, plain);
+}
+
+#[test]
+fn test_directed_direction_count_mismatch_rejected() {
+    let err = FusionStrategy::Average
+        .fuse_with_directions(distance_branches(), &all_lower(1))
+        .expect_err("mismatched direction count must be rejected");
+    assert!(matches!(
+        err,
+        FusionError::DirectionCountMismatch {
+            directions: 1,
+            branches: 2
+        }
+    ));
+}
 
 // =============================================================================
 // Canonical `Weighted` default constants (issue #1545: single-source the

--- a/crates/velesdb-core/src/fusion/strategy_tests.rs
+++ b/crates/velesdb-core/src/fusion/strategy_tests.rs
@@ -14,10 +14,7 @@ use super::strategy::{
 /// Two Euclidean-distance branches (best-first ascending). doc1 is the near
 /// document in both; doc2 is far in both.
 fn distance_branches() -> Vec<Vec<(u64, f32)>> {
-    vec![
-        vec![(1, 0.1), (2, 3.0)],
-        vec![(1, 0.2), (2, 2.9)],
-    ]
+    vec![vec![(1, 0.1), (2, 3.0)], vec![(1, 0.2), (2, 2.9)]]
 }
 
 fn all_lower(n: usize) -> Vec<ScoreDirection> {
@@ -74,7 +71,10 @@ fn test_directed_relative_score_inverts_distance_branch() {
     let fused = strategy
         .fuse_with_directions(
             vec![dense, sparse],
-            &[ScoreDirection::LowerIsBetter, ScoreDirection::HigherIsBetter],
+            &[
+                ScoreDirection::LowerIsBetter,
+                ScoreDirection::HigherIsBetter,
+            ],
         )
         .expect("fuse");
 

--- a/crates/velesdb-core/src/index/hnsw/index_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index_tests.rs
@@ -1539,6 +1539,66 @@ fn test_brute_force_buffered_repeated_calls_stable() {
 }
 
 // =========================================================================
+// Regression (#2100): Jaccard is declared a similarity by higher_is_better,
+// so transform_score must return `1 - engine_distance` (the similarity),
+// exactly like Cosine. Pre-fix it passed the raw `1 - jaccard` distance
+// through, so every descending sort/top-k over HNSW scores ranked the
+// WORST candidates first and user-visible scores were inverted.
+// =========================================================================
+
+/// Dim-4 Jaccard fixture with hand-computed similarities against
+/// q=[1,1,0,0]: id1=1.0 (identical), id2=0.5 (Σmin/Σmax=1/2), id3=0.0.
+fn jaccard_fixture() -> (HnswIndex, Vec<f32>) {
+    let index = HnswIndex::new(4, DistanceMetric::Jaccard).unwrap();
+    index.insert(1, &[1.0, 1.0, 0.0, 0.0]);
+    index.insert(2, &[1.0, 0.0, 0.0, 0.0]);
+    index.insert(3, &[0.0, 0.0, 1.0, 1.0]);
+    (index, vec![1.0, 1.0, 0.0, 0.0])
+}
+
+#[test]
+fn test_jaccard_hnsw_scores_are_similarities() {
+    let (index, query) = jaccard_fixture();
+    let results = index.search(&query, 3);
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(
+        results[0].id, 1,
+        "exact match must rank first, got {results:?}"
+    );
+    // Scores must be the Jaccard SIMILARITY (1.0, 0.5, 0.0), not the
+    // internal 1-sim traversal distance (0.0, 0.5, 1.0).
+    for (result, want) in results.iter().zip([1.0f32, 0.5, 0.0]) {
+        assert!(
+            (result.score - want).abs() < 1e-6,
+            "id {} score {} != similarity {want}",
+            result.id,
+            result.score
+        );
+    }
+}
+
+#[test]
+fn test_jaccard_bitmap_filtered_search_keeps_best_not_worst() {
+    let (index, query) = jaccard_fixture();
+    let allowed: roaring::RoaringBitmap = [1u32, 2, 3].into_iter().collect();
+
+    let results = index
+        .search_with_quality_and_bitmap(&query, 1, SearchQuality::Balanced, &allowed)
+        .unwrap();
+
+    // Pre-fix, the descending top-k over raw distances kept id3 (the
+    // completely dissimilar vector) and dropped the exact match.
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, 1, "top-1 must be the exact match");
+    assert!(
+        (results[0].score - 1.0).abs() < 1e-6,
+        "exact match must score similarity 1.0, got {}",
+        results[0].score
+    );
+}
+
+// =========================================================================
 // Stress Tests
 // =========================================================================
 

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -371,16 +371,22 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     /// - **Euclidean**: `sqrt(raw_distance)` — the search loop stores squared L2
     ///   to skip redundant sqrt during traversal; this restores the actual
     ///   Euclidean distance for user-visible scores.
-    /// - **Hamming**/**Jaccard**: raw distance (lower is better)
+    /// - **Hamming**: raw distance (lower is better)
+    /// - **Jaccard**: `(1.0 - distance).clamp(0.0, 1.0)` — the engine traverses
+    ///   on `1 - jaccard`, but `DistanceMetric::higher_is_better()` declares
+    ///   Jaccard a similarity, so every downstream sort/top-k/merge expects
+    ///   the similarity back (same contract as Cosine).
     /// - **DotProduct**: `-distance` (negated for consistency)
     #[must_use]
     pub fn transform_score(&self, raw_distance: f32) -> f32 {
         match self.distance.metric() {
-            DistanceMetric::Cosine => (1.0 - raw_distance).clamp(0.0, 1.0),
+            DistanceMetric::Cosine | DistanceMetric::Jaccard => {
+                (1.0 - raw_distance).clamp(0.0, 1.0)
+            }
             // Reason: CachedSimdDistance stores squared L2 during HNSW traversal
             // to avoid per-comparison sqrt. Apply sqrt here on the final k results.
             DistanceMetric::Euclidean => raw_distance.sqrt(),
-            DistanceMetric::Hamming | DistanceMetric::Jaccard => raw_distance,
+            DistanceMetric::Hamming => raw_distance,
             DistanceMetric::DotProduct => -raw_distance,
         }
     }

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -18,13 +18,18 @@ use serde::{Deserialize, Serialize};
 
 /// Scalar correction factors for a `RaBitQ`-encoded vector.
 ///
-/// These values are needed to apply the affine correction during distance estimation.
+/// `vector_norm` restores the metric scale during distance estimation.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct RaBitQCorrection {
     /// L2 norm of the centered vector before binarization.
     pub vector_norm: f32,
     /// Inner product between the binary reconstruction (`±1/√D` scaled) and the
-    /// rotated normalized vector. Measures quantization quality; closer to 1.0 is better.
+    /// rotated normalized vector. Measures quantization quality; closer to 1.0
+    /// is better. NOT consumed by the current symmetric (query-binarized)
+    /// estimator, whose de-bias is the arcsine-law transform in
+    /// [`RaBitQIndex::distance_from_prepared_slice`]; it is the per-vector
+    /// rescale the paper's asymmetric estimator (real-valued query) divides
+    /// by, kept in the persisted format for that upgrade path (#2104).
     pub quantization_ip: f32,
 }
 
@@ -213,8 +218,19 @@ impl RaBitQIndex {
     ) -> f32 {
         let ip_binary = xor_popcount_ip(&pq.bits, bits, pq.num_words, self.dimension);
 
+        // De-bias the symmetric binary inner product (#2104). Both sides are
+        // binarized here, so per coordinate of a random rotation the sign
+        // agreement probability is 1 - θ/π, giving E[ip_binary] = 1 - 2θ/π —
+        // NOT cos θ. Using ip_binary directly overestimates every non-zero
+        // angle's distance by a norm-dependent amount, distorting candidate
+        // ranking (e.g. θ = 60°: ip_binary ≈ 1/3 where cos θ = 0.5). Invert
+        // the map: cos θ = cos(π/2 · (1 - ip_binary)) = sin(π/2 · ip_binary).
+        // The transform is monotone on [-1, 1], so same-norm ordering is
+        // preserved while cross-norm comparisons become unbiased.
+        let cos_est = (std::f32::consts::FRAC_PI_2 * ip_binary).sin();
+
         let v_norm = correction.vector_norm;
-        let estimated_ip = pq.norm * v_norm * ip_binary;
+        let estimated_ip = pq.norm * v_norm * cos_est;
         let l2_sq = v_norm.mul_add(v_norm, pq.norm_sq) - 2.0 * estimated_ip;
         l2_sq.max(0.0).sqrt()
     }

--- a/crates/velesdb-core/src/quantization/rabitq_tests.rs
+++ b/crates/velesdb-core/src/quantization/rabitq_tests.rs
@@ -726,3 +726,81 @@ fn rabitq_load_rejects_rotation_length_mismatch() {
     let err = RaBitQIndex::load(dir.path()).expect_err("corrupt rotation length must fail to load");
     assert!(matches!(err, Error::IndexCorrupted(_)), "got {err:?}");
 }
+
+// =============================================================================
+// Regression (#2104): the symmetric (query-binarized) estimator must de-bias
+// the binary inner product. For a random rotation, per-coordinate sign
+// agreement follows the arcsine law (E[agreement] = 1/2 + arcsin(cosθ)/π),
+// so E[ip_binary] = 1 - 2θ/π — not cosθ. Using ip_binary as cosθ
+// overestimated every non-zero angle's distance by a norm-dependent amount.
+// =============================================================================
+
+/// Deterministic unit vector orthogonalized against `q` (Gram-Schmidt).
+#[cfg(feature = "persistence")]
+fn unit_orthogonal_to(q: &[f32], seed: u64) -> Vec<f32> {
+    use rand::{RngExt, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mut u: Vec<f32> = (0..q.len()).map(|_| rng.random::<f32>() * 2.0 - 1.0).collect();
+    let dot: f32 = u.iter().zip(q.iter()).map(|(a, b)| a * b).sum();
+    for (ui, qi) in u.iter_mut().zip(q.iter()) {
+        *ui -= dot * qi;
+    }
+    let norm: f32 = u.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in &mut u {
+        *x /= norm;
+    }
+    u
+}
+
+/// At θ = 60° between unit vectors the true L2 distance is exactly 1.0.
+/// The pre-fix estimator used ip_binary ≈ 1/3 as cosθ, reporting
+/// sqrt(2 - 2/3) ≈ 1.155 — a systematic +15% bias no averaging removes.
+/// The arcsine-law transform recovers cosθ = sin(π/2 · 1/3) ≈ 0.5.
+#[cfg(feature = "persistence")]
+#[test]
+fn rabitq_estimator_unbiased_at_sixty_degrees() {
+    let dim = 256;
+    // A trained rotation over throwaway vectors provides the random
+    // orthogonal rotation the arcsine law assumes; force a zero centroid so
+    // vector geometry (angles/norms) is exactly as constructed.
+    let filler: Vec<Vec<f32>> = (0..8)
+        .map(|s| unit_orthogonal_to(&vec![1.0; dim], 900 + s))
+        .collect();
+    let mut index = RaBitQIndex::train(&filler, 7).unwrap();
+    index.centroid = vec![0.0; dim];
+
+    // Query: deterministic unit vector.
+    let mut q = vec![0.0f32; dim];
+    for (i, x) in q.iter_mut().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let v = (i as f32 * 0.7).sin() + 0.1;
+        *x = v;
+    }
+    let qn: f32 = q.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in &mut q {
+        *x /= qn;
+    }
+
+    // Candidates at exactly 60°: v = 0.5 q + (√3/2) u with u ⊥ q, ‖v‖ = 1.
+    let n_candidates: u64 = 32;
+    let mut total = 0.0f64;
+    for s in 0..n_candidates {
+        let u = unit_orthogonal_to(&q, 1_000 + s);
+        let v: Vec<f32> = q
+            .iter()
+            .zip(u.iter())
+            .map(|(&qi, &ui)| 3.0f32.sqrt().mul_add(ui / 2.0, 0.5 * qi))
+            .collect();
+        let encoded = index.encode(&v).unwrap();
+        total += f64::from(index.distance(&q, &encoded));
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let mean_estimate = total / n_candidates as f64;
+
+    // True distance is 1.0; binary-estimator noise at dim 256 averages out
+    // over 32 candidates, but the pre-fix +15% bias would not.
+    assert!(
+        (mean_estimate - 1.0).abs() < 0.05,
+        "mean estimated distance at 60° must be ~1.0 (unbiased), got {mean_estimate:.4}"
+    );
+}

--- a/crates/velesdb-core/src/quantization/rabitq_tests.rs
+++ b/crates/velesdb-core/src/quantization/rabitq_tests.rs
@@ -740,7 +740,9 @@ fn rabitq_load_rejects_rotation_length_mismatch() {
 fn unit_orthogonal_to(q: &[f32], seed: u64) -> Vec<f32> {
     use rand::{RngExt, SeedableRng};
     let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
-    let mut u: Vec<f32> = (0..q.len()).map(|_| rng.random::<f32>() * 2.0 - 1.0).collect();
+    let mut u: Vec<f32> = (0..q.len())
+        .map(|_| rng.random::<f32>() * 2.0 - 1.0)
+        .collect();
     let dot: f32 = u.iter().zip(q.iter()).map(|(a, b)| a * b).sum();
     for (ui, qi) in u.iter_mut().zip(q.iter()) {
         *ui -= dot * qi;

--- a/crates/velesdb-core/src/simd_native/cosine_fused_tests.rs
+++ b/crates/velesdb-core/src/simd_native/cosine_fused_tests.rs
@@ -98,6 +98,36 @@ fn test_fused_cosine_zero_vectors() {
 }
 
 #[test]
+fn test_fused_cosine_small_magnitude_vectors() {
+    // Regression (#2103): the SIMD finish step guarded on the *product* of
+    // squared norms (< EPSILON²), zeroing out legitimate vectors with norms
+    // around 3.4e-4 while the scalar fallback returned the true cosine. The
+    // result then flipped between 1.0 and 0.0 with dimension and CPU features.
+    for magnitude in [1e-3f32, 1e-4, 1e-5] {
+        // Cover the scalar fallback (dim < 4/8) and every SIMD kernel width,
+        // including tail-exercising odd dims.
+        for size in [3usize, 4, 7, 8, 15, 16, 17, 64, 100, 768] {
+            let a: Vec<f32> = vec![magnitude; size];
+            let result = cosine_similarity_native(&a, &a);
+            assert!(
+                (result - 1.0).abs() < 1e-3,
+                "identical vectors of magnitude {magnitude} at dim {size} \
+                 must have cosine ~1.0, got {result}"
+            );
+        }
+    }
+
+    // Anti-parallel small vectors must stay -1.0, not collapse to 0.0.
+    let a = vec![1e-4f32; 16];
+    let b: Vec<f32> = a.iter().map(|x| -x).collect();
+    let result = cosine_similarity_native(&a, &b);
+    assert!(
+        (result + 1.0).abs() < 1e-3,
+        "opposite small-magnitude vectors must have cosine ~-1.0, got {result}"
+    );
+}
+
+#[test]
 fn test_fused_cosine_opposite_vectors() {
     // Opposite vectors should have cosine = -1.0
     let a: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];

--- a/crates/velesdb-core/src/simd_native/scalar.rs
+++ b/crates/velesdb-core/src/simd_native/scalar.rs
@@ -52,13 +52,22 @@ pub fn fast_rsqrt(x: f32) -> f32 {
 #[inline]
 #[must_use]
 pub(crate) fn cosine_finish_fast(dot: f32, norm_a_sq: f32, norm_b_sq: f32) -> f32 {
-    // Guard: both norms must be significant for meaningful cosine
-    let denom_sq = norm_a_sq * norm_b_sq;
-    if denom_sq < f32::EPSILON * f32::EPSILON {
+    // Zero-norm guard on the operands, matching `cosine_scalar`. Guarding the
+    // product instead would zero out legitimate small-magnitude vectors: with
+    // ‖a‖ = ‖b‖ ≈ 3.4e-4 the product already dips under EPSILON² while the
+    // true cosine is well defined (and the scalar fallback returns it).
+    if norm_a_sq == 0.0 || norm_b_sq == 0.0 {
         return 0.0;
     }
-    // 1 sqrt + 1 div instead of 2 sqrt + 1 mul + 1 div (~3 cycles saved)
-    (dot / denom_sq.sqrt()).clamp(-1.0, 1.0)
+    let denom_sq = norm_a_sq * norm_b_sq;
+    if denom_sq > f32::MIN_POSITIVE {
+        // 1 sqrt + 1 div instead of 2 sqrt + 1 mul + 1 div (~3 cycles saved)
+        (dot / denom_sq.sqrt()).clamp(-1.0, 1.0)
+    } else {
+        // The product underflowed (or is subnormal): fall back to the exact
+        // two-sqrt form, which keeps the denominator representable.
+        (dot / (norm_a_sq.sqrt() * norm_b_sq.sqrt())).clamp(-1.0, 1.0)
+    }
 }
 
 /// Fast cosine similarity using Newton-Raphson rsqrt.

--- a/crates/velesdb-core/src/storage/histogram.rs
+++ b/crates/velesdb-core/src/storage/histogram.rs
@@ -128,10 +128,10 @@ impl LockFreeHistogram {
         self.sum.load(Ordering::Relaxed) / count
     }
 
-    /// Returns an approximate percentile value (0-100).
+    /// Returns an approximate percentile value (0-100), nearest-rank method.
     ///
-    /// Uses linear interpolation within buckets for accuracy.
-    /// Result is capped by the actual max value recorded.
+    /// Resolution is the log2 bucket midpoint, capped by the actual max
+    /// value recorded.
     #[must_use]
     pub fn percentile(&self, p: u8) -> u64 {
         let total = self.count.load(Ordering::Relaxed);
@@ -141,8 +141,13 @@ impl LockFreeHistogram {
 
         let max_val = self.max();
 
+        // Nearest-rank: the smallest sample whose cumulative count reaches
+        // ceil(total * p / 100), never below rank 1. A floor here (the old
+        // formula) yields target 0 whenever total * p < 100, which made the
+        // very first bucket "reach" it and reported 1µs for every low-count
+        // window — exactly where rare slow events live.
         #[allow(clippy::cast_possible_truncation)]
-        let target = (u128::from(total) * u128::from(p.min(100)) / 100) as u64;
+        let target = ((u128::from(total) * u128::from(p.min(100))).div_ceil(100) as u64).max(1);
         let mut cumulative = 0u64;
 
         for (i, bucket) in self.buckets.iter().enumerate() {

--- a/crates/velesdb-core/src/storage/metrics_tests.rs
+++ b/crates/velesdb-core/src/storage/metrics_tests.rs
@@ -119,16 +119,19 @@ fn test_latency_stats_single_sample() {
     assert_eq!(stats.count, 1);
     assert_eq!(stats.min_us, 500);
     assert_eq!(stats.max_us, 500);
-    // PERF-001: single-sample edge case. percentile target = count*p/100 rounds
-    // down to 0, so bucket 0 immediately satisfies the cumulative check and the
-    // value is capped to value_for_bucket(0) = 1µs. Guards this approximation.
+    // Regression (#2105): nearest-rank with a minimum rank of 1 must land on
+    // the sample's own bucket. The old floor-based target rounded to 0, so
+    // bucket 0 satisfied the cumulative check immediately and a single 500µs
+    // resize was reported as 1µs — blinding the P99 monitoring exactly in the
+    // low-count windows where rare slow events live. 500µs falls in the log2
+    // bucket [256, 512), whose midpoint 384 is the reported approximation.
     assert_eq!(
-        stats.p50_us, 1,
-        "single-sample P50 collapses to bucket 0 (1µs)"
+        stats.p50_us, 384,
+        "single-sample P50 must land in the sample's bucket (midpoint 384µs)"
     );
     assert_eq!(
-        stats.p99_us, 1,
-        "single-sample P99 collapses to bucket 0 (1µs)"
+        stats.p99_us, 384,
+        "single-sample P99 must land in the sample's bucket (midpoint 384µs)"
     );
 }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

End-to-end audit of every metric calculation in core (distance kernels scalar/AVX2/AVX-512/NEON, HNSW score transforms, fusion, quantization, observability metrics — bindings excluded) surfaced six confirmed bugs, each fixed here in its own commit with a regression test that fails on the pre-fix code:

1. **Jaccard `transform_score` inversion** — the HNSW engine traverses on `1 - jaccard` but the transform passed that raw distance through while `higher_is_better()` declares Jaccard a similarity; every descending sort/top-k/merge over HNSW scores ranked the *worst* candidates first (bitmap-filtered search, brute-force parallel, dual-precision/RaBitQ rerank, delta merge), and the two filter strategies disagreed on the same query. Jaccard now shares Cosine's `(1.0 - raw).clamp(0.0, 1.0)`.
2. **GraphFirst filtered scan clamped every metric into `[-1, 1]`** — Euclidean/Hamming/DotProduct values beyond 1 collapsed into an artificial 1.0 tie (arbitrary top-k, meaningless user score), and the `Parallel` strategy compared those clamped values against unclamped HNSW distances. The clamp also failed its stated purpose: `clamp()` propagates NaN. Scores are now verbatim; NaN maps to the metric's worst key (the `similarity_scores_for_field` convention).
3. **Score-level fusion was polarity-blind** — Average/Maximum/Weighted/RSF assumed higher-is-better while the dense branch feeds raw metric scores (distances for Euclidean/Hamming): inverted or degenerate fused rankings across multi-query, `NEAR_FUSED`, hybrid dense+sparse, and dense+text. New `fusion::ScoreDirection` + `FusionStrategy::fuse_with_directions` negates lower-is-better branches in (order-preserving) and back out for score-space strategies, so fused scores stay in metric units, best-first. `DistanceMetric::score_direction()` derives from `higher_is_better()` so the two cannot drift. RRF/WeightedRRF (rank-based) unchanged.
4. **`cosine_finish_fast` epsilon guard** — every SIMD cosine kernel returned 0.0 whenever `norm_a² · norm_b² < EPSILON²`, reachable at norms ≈ 3.4e-4: identical small-magnitude vectors scored as orthogonal, flipping with dimension and CPU features vs the scalar path. Guard now matches `cosine_scalar` (operand norms), with a two-sqrt fallback when the product underflows.
5. **RaBitQ estimator bias** — the symmetric (query-binarized) estimator used the raw binary inner product as `cos θ`, but under a random rotation sign agreement follows the arcsine law: `E[ip_binary] = 1 - 2θ/π`. Every non-zero angle's distance was overestimated (+15.1% measured at 60°), distorting cross-norm ranking. Fixed with the inverse map `cos θ = sin(π/2 · ip_binary)` (monotone, one `sinf` next to the existing sqrt). `quantization_ip`'s doc was corrected — it belongs to the paper's asymmetric estimator and is kept in the persisted format for that upgrade path rather than breaking the on-disk layout.
6. **`LockFreeHistogram::percentile` collapse** — floor-based rank target reported 1µs for any window where `count × p < 100` (a single 500ms mmap resize was invisible to the P99 monitoring). Nearest-rank `ceil` with minimum rank 1; the test pinning the collapsed value now pins the correct bucket.

Fixes #2100
Fixes #2101
Fixes #2102
Fixes #2103
Fixes #2104
Fixes #2105

**Overlap note:** commit 1's `transform_score` hunk is byte-identical to open PR #2096 (same finding, item A1 of #2095). The two PRs carry complementary regression tests. If #2096 lands first, this branch rebases trivially (the Jaccard commit reduces to its extra tests); happy to do the refresh either way.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

Every fix landed test-first: each new regression test was run against the pre-fix code and observed failing (the RaBitQ bias test fails pre-fix with mean distance 1.1511 vs the true 1.0), then passing post-fix.

- Full core suite: **6391 passed, 0 failed** (`cargo test -p velesdb-core --features persistence -- --test-threads=1`), including the recall-contract gates (`balanced ≥ 0.95`, `accurate ≥ 0.99`, `perfect = 1.0`, multimetric variants) and all RaBitQ/PQ recall floors.
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean
- `cargo test --doc --package velesdb-core` — 50 passed
- `cargo fmt --all` — applied
- Guard suite: `python3 -m unittest discover -s scripts/tests` — **Ran 632, OK (skipped=9)**; `check_prod_unwraps`, `check-todo-annotations`, `check-version-sync`, `check-feature-claims`, `check-perf-claims --no-criterion`, `check-promise-contract`, `check-ai-attribution`, `check-doc-contract.sh` — all pass.
- Not runnable in this container: workspace-wide clippy including `tauri-plugin-velesdb` and `cargo check --no-default-features` (both hit missing system GTK/`gdk-sys` headers, unrelated to the diff); wasm-pack. CI covers these.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG + corrected doc comments that misdescribed behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none (see the #2096 overlap note)

## Unsafe Code Checklist

Skipped — no `unsafe` code touched (`cosine_finish_fast` is the safe finish helper consumed by the kernels; the `undocumented_unsafe_blocks` lint pass is clean).

## High-Risk Change Checklist

Touches `hnsw` and SIMD-adjacent code, so filling this in:

- [x] Invariants impacted: (a) `transform_score` output must match `higher_is_better()`/`calculate()` semantics for every metric — Jaccard was the violating variant; (b) score-level fusion is only meaningful when branch polarity is aligned — now encoded in the `ScoreDirection` type rather than prose; (c) `cosine_finish_fast` must agree with `cosine_scalar` on the zero-norm guard; (d) RaBitQ estimated distances share the metric space of exact rescoring (monotone transform, sqrt after, unchanged).
- [x] No crash/durability semantics touched — pure scoring/aggregation math; no persistence format change (RaBitQ corrections keep their serialized layout).
- [x] Regression tests added per affected path: Jaccard bitmap-filtered top-k + score pins, filtered-scan Euclidean/DotProduct/NaN ordering, directed-fusion unit tests + Euclidean multi-query integration tests, small-magnitude cosine across scalar/SIMD widths, RaBitQ 60° bias statistic, single-sample percentile.
- [ ] 2-maintainer review — requesting via this PR.

## Additional Notes

Companion issue #2106 batches the minor findings from the same audit (SIMD pointer-probe UB hygiene, AVX-512-without-AVX2 dispatch gate, cosine `[0,1]` vs `[-1,1]` range divergence, `CpuDistance` reference-impl semantics, tail-coverage test gaps). Deliberately out of scope here to keep this PR reviewable; each is file:line-documented in the issue.