### PR TITLE
fix(guardrails): reproduce and fix the CircuitBreaker ABBA deadlock, gate the lint that was hiding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The circuit breaker could deadlock the whole service under load.**
+  `check()` held `opened_at` (read) while asking for `state` (write) and
+  `record_failure()` held `state` (write) while asking for `opened_at`
+  (write) — opposite orders on two paths the query pipeline calls on every
+  request, so an open breaker under concurrent traffic could wedge both.
+  The two values now live under one lock, which makes the conflicting order
+  unrepresentable; `clippy::significant_drop_in_scrutinee` is promoted to
+  `deny` so the shape cannot return, and the 17 other guards that spanned a
+  `match`/`if let`/`for` expression (including two held across a disk write
+  in `flush_secondary_indexes`, and the collection-cache lookups whose disk
+  fallback takes the same map for write) are bound before the expression.
+  (#2109, #2110)
+
 ## [5.2.0] - 2026-08-22
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,10 +170,16 @@ struct_field_names = "allow"
 # Clippy set to allow since Codacy is the hard gate for this metric.
 too_many_lines = "allow"
 
+# Lock-guard lifetime. NOT a style preference: a guard living to the end of a
+# `match`/`if let`/`for` expression is how the CircuitBreaker ABBA deadlock
+# (#2109) reached production, so `in_scrutinee` is a hard gate. `tightening`
+# stays off for now — 192 sites, contention rather than deadlock; tracked in
+# #2110 and to be enabled the same way once that backlog is drained.
+significant_drop_in_scrutinee = "deny"
+significant_drop_tightening = "allow"
+
 # Code style preferences (no bug risk)
 ptr_as_ptr = "allow"
-significant_drop_tightening = "allow"
-significant_drop_in_scrutinee = "allow"
 set_contains_or_insert = "allow"
 useless_let_if_seq = "allow"
 manual_assert = "allow"

--- a/crates/tauri-plugin-velesdb/src/state.rs
+++ b/crates/tauri-plugin-velesdb/src/state.rs
@@ -81,8 +81,12 @@ impl StateInner {
     /// inner [`Arc<Database>`] and is dropped before the handle is returned, so
     /// no state lock is ever held across a core operation.
     fn db_handle(&self) -> Result<Arc<Database>> {
-        if let Some(db) = self.db.read().as_ref() {
-            return Ok(Arc::clone(db));
+        // Bound before the `if let`: inside the scrutinee the guard would live
+        // to the end of the expression, contradicting the scoping this doc
+        // comment promises — and `open()` below takes `db` for write.
+        let cached = self.db.read().as_ref().map(Arc::clone);
+        if let Some(db) = cached {
+            return Ok(db);
         }
         self.open()?;
         let db_guard = self.db.read();
@@ -101,7 +105,10 @@ impl StateInner {
     /// the database. Every later call takes the read lock just long enough to
     /// clone the existing [`Arc`].
     fn memory_handle(&self) -> Result<Arc<AgentMemory>> {
-        if let Some(existing) = self.memory.read().clone() {
+        // Bound for the same reason as `db_handle`: the `memory` write lock is
+        // taken further down this function.
+        let cached = self.memory.read().clone();
+        if let Some(existing) = cached {
             return Ok(existing);
         }
         let db = self.db_handle()?;

--- a/crates/velesdb-core/src/collection/auto_reindex/mod.rs
+++ b/crates/velesdb-core/src/collection/auto_reindex/mod.rs
@@ -207,9 +207,12 @@ impl AutoReindexManager {
         dimension: usize,
     ) -> bool {
         // Check cooldown
-        if let Some(last) = *self.last_reindex_timestamp.read() {
-            let config = self.config.read();
-            if last.elapsed() < config.cooldown {
+        // Bound: the `if let` guard would stay alive while `config` is taken,
+        // nesting two locks that no declared rank orders.
+        let last_reindex = *self.last_reindex_timestamp.read();
+        if let Some(last) = last_reindex {
+            let cooldown = self.config.read().cooldown;
+            if last.elapsed() < cooldown {
                 return false;
             }
         }

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -406,7 +406,9 @@ impl Collection {
             .ids()
             .into_iter()
             .collect();
-        for id in self.storage.payload_storage.read().ids() {
+        // Bound so `payload_storage` (lock-order 3) is not held across the loop.
+        let payload_ids = self.storage.payload_storage.read().ids();
+        for id in payload_ids {
             ids.insert(id);
         }
         ids.into_iter().collect()

--- a/crates/velesdb-core/src/collection/core/flush.rs
+++ b/crates/velesdb-core/src/collection/core/flush.rs
@@ -287,12 +287,14 @@ impl Collection {
             .swap(false, Ordering::AcqRel)
         {
             let property_index_path = self.storage.path.join("property_index.bin");
-            if let Err(e) = self
+            // Bound: the `if let` would keep the index read guard alive for the
+            // whole expression, blocking writers for the duration of a disk write.
+            let saved = self
                 .graph
                 .property_index
                 .read()
-                .save_to_file(&property_index_path)
-            {
+                .save_to_file(&property_index_path);
+            if let Err(e) = saved {
                 // Re-mark so the next flush retries the write.
                 self.graph
                     .property_index_dirty
@@ -303,12 +305,13 @@ impl Collection {
 
         if self.graph.range_index_dirty.swap(false, Ordering::AcqRel) {
             let range_index_path = self.storage.path.join("range_index.bin");
-            if let Err(e) = self
+            // Bound for the same reason as `property_index` above.
+            let saved = self
                 .graph
                 .range_index
                 .read()
-                .save_to_file(&range_index_path)
-            {
+                .save_to_file(&range_index_path);
+            if let Err(e) = saved {
                 self.graph.range_index_dirty.store(true, Ordering::Release);
                 return Err(e.into());
             }

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -211,14 +211,9 @@ impl Collection {
     /// Returns `Error::SchemaValidation` if any label in `_labels` is not
     /// declared in the strict schema.
     fn validate_node_labels_against_schema(&self, payload: &serde_json::Value) -> Result<()> {
-        // `config` is lock-order position 1 (outermost); bind the clone so the
-        // guard does not span the validation loop below.
-        let declared = self.storage.config.read().graph_schema.clone();
-        let schema = match declared {
-            Some(s) if !s.is_schemaless() => s,
-            _ => return Ok(()),
+        let Some(schema) = self.non_schemaless_graph_schema() else {
+            return Ok(());
         };
-
         for label in extract_labels(payload) {
             schema.validate_node_type(&label)?;
         }
@@ -233,6 +228,7 @@ impl Collection {
     /// schema after the payload guard would invert the documented
     /// acquisition order to 3 → 1 (see LOCK ORDERING in
     /// `collection/types.rs`).
+    /// The clone is bound first so the `config` guard dies with that statement.
     fn non_schemaless_graph_schema(&self) -> Option<GraphSchema> {
         let declared = self.storage.config.read().graph_schema.clone();
         match declared {

--- a/crates/velesdb-core/src/collection/core/graph_api.rs
+++ b/crates/velesdb-core/src/collection/core/graph_api.rs
@@ -211,7 +211,10 @@ impl Collection {
     /// Returns `Error::SchemaValidation` if any label in `_labels` is not
     /// declared in the strict schema.
     fn validate_node_labels_against_schema(&self, payload: &serde_json::Value) -> Result<()> {
-        let schema = match self.storage.config.read().graph_schema.clone() {
+        // `config` is lock-order position 1 (outermost); bind the clone so the
+        // guard does not span the validation loop below.
+        let declared = self.storage.config.read().graph_schema.clone();
+        let schema = match declared {
             Some(s) if !s.is_schemaless() => s,
             _ => return Ok(()),
         };
@@ -231,7 +234,8 @@ impl Collection {
     /// acquisition order to 3 → 1 (see LOCK ORDERING in
     /// `collection/types.rs`).
     fn non_schemaless_graph_schema(&self) -> Option<GraphSchema> {
-        match self.storage.config.read().graph_schema.clone() {
+        let declared = self.storage.config.read().graph_schema.clone();
+        match declared {
             Some(s) if !s.is_schemaless() => Some(s),
             _ => None,
         }

--- a/crates/velesdb-core/src/database/graph_ops.rs
+++ b/crates/velesdb-core/src/database/graph_ops.rs
@@ -108,7 +108,10 @@ impl Database {
     /// Returns `None` if the collection does not exist on disk.
     #[must_use]
     pub fn get_graph_collection(&self, name: &str) -> Option<GraphCollection> {
-        if let Some(c) = self.graph_colls.read().get(name).cloned() {
+        // Bound before the `if let` — see `get_vector_collection`: the disk
+        // fallback takes `graph_colls` for WRITE.
+        let cached = self.graph_colls.read().get(name).cloned();
+        if let Some(c) = cached {
             return Some(c);
         }
         self.open_graph_collection_from_disk(name)

--- a/crates/velesdb-core/src/database/metadata_ops.rs
+++ b/crates/velesdb-core/src/database/metadata_ops.rs
@@ -38,7 +38,10 @@ impl Database {
     /// Returns `None` if the collection does not exist on disk.
     #[must_use]
     pub fn get_metadata_collection(&self, name: &str) -> Option<MetadataCollection> {
-        if let Some(c) = self.metadata_colls.read().get(name).cloned() {
+        // Bound before the `if let` — see `get_vector_collection`: the disk
+        // fallback takes `metadata_colls` for WRITE.
+        let cached = self.metadata_colls.read().get(name).cloned();
+        if let Some(c) = cached {
             return Some(c);
         }
         self.open_metadata_collection_from_disk(name)

--- a/crates/velesdb-core/src/database/stats.rs
+++ b/crates/velesdb-core/src/database/stats.rs
@@ -53,7 +53,9 @@ impl Database {
     ) -> Result<Option<crate::collection::stats::CollectionStats>> {
         crate::validation::validate_collection_name(name)?;
 
-        if let Some(stats) = self.collection_stats.read().get(name).cloned() {
+        // Bound before the `if let` so the guard does not span the disk read below.
+        let cached = self.collection_stats.read().get(name).cloned();
+        if let Some(stats) = cached {
             return Ok(Some(stats));
         }
 

--- a/crates/velesdb-core/src/database/vector_ops.rs
+++ b/crates/velesdb-core/src/database/vector_ops.rs
@@ -165,7 +165,12 @@ impl Database {
     /// Returns `None` if the collection does not exist on disk.
     #[must_use]
     pub fn get_vector_collection(&self, name: &str) -> Option<VectorCollection> {
-        if let Some(c) = self.vector_colls.read().get(name).cloned() {
+        // Bound before the `if let`: the guard would otherwise stay alive for
+        // the whole expression, and the disk fallback below takes `vector_colls`
+        // for WRITE — one refactor away from a self-deadlock on a non-reentrant
+        // `parking_lot` lock.
+        let cached = self.vector_colls.read().get(name).cloned();
+        if let Some(c) = cached {
             return Some(c);
         }
         self.open_vector_collection_from_disk(name)

--- a/crates/velesdb-core/src/guardrails/resilience.rs
+++ b/crates/velesdb-core/src/guardrails/resilience.rs
@@ -181,19 +181,34 @@ pub enum CircuitState {
     HalfOpen,
 }
 
+/// Transition state and the instant the breaker opened, under one lock.
+///
+/// These two values are a single state machine: `opened_at` is only
+/// meaningful while `state` is [`CircuitState::Open`], and every transition
+/// reads or writes both. Holding them in separate locks made the acquisition
+/// order differ per method — `check` took `opened_at` then `state`, while
+/// `record_failure` took `state` then `opened_at` — an ABBA deadlock between
+/// two paths the query pipeline calls on every request. Fusing them removes
+/// the ordering question instead of documenting it.
+#[derive(Debug, Clone, Copy)]
+struct CircuitCore {
+    /// Current state.
+    state: CircuitState,
+    /// Time when the circuit opened; `Some` exactly while `state` is `Open`.
+    opened_at: Option<Instant>,
+}
+
 /// Circuit breaker for automatic failure protection (EPIC-048 US-006).
 #[derive(Debug)]
 pub struct CircuitBreaker {
-    /// Current state.
-    state: parking_lot::RwLock<CircuitState>,
+    /// State machine (transition state + open instant) under a single lock.
+    core: parking_lot::RwLock<CircuitCore>,
     /// Consecutive failure count.
     failure_count: AtomicU64,
     /// Failure threshold before opening.
     failure_threshold: u32,
     /// Recovery time in seconds.
     recovery_seconds: u64,
-    /// Time when circuit was opened.
-    opened_at: parking_lot::RwLock<Option<Instant>>,
 }
 
 impl CircuitBreaker {
@@ -201,11 +216,13 @@ impl CircuitBreaker {
     #[must_use]
     pub fn new(failure_threshold: u32, recovery_seconds: u64) -> Self {
         Self {
-            state: parking_lot::RwLock::new(CircuitState::Closed),
+            core: parking_lot::RwLock::new(CircuitCore {
+                state: CircuitState::Closed,
+                opened_at: None,
+            }),
             failure_count: AtomicU64::new(0),
             failure_threshold,
             recovery_seconds,
-            opened_at: parking_lot::RwLock::new(None),
         }
     }
 
@@ -216,34 +233,46 @@ impl CircuitBreaker {
     /// Returns [`GuardRailViolation::CircuitOpen`] when the breaker is open and
     /// recovery time has not elapsed.
     pub fn check(&self) -> Result<(), GuardRailViolation> {
-        let state = *self.state.read();
-        match state {
-            CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
-            CircuitState::Open => {
-                // Check if recovery time has passed
-                if let Some(opened_at) = *self.opened_at.read() {
-                    let elapsed = opened_at.elapsed().as_secs();
-                    if elapsed >= self.recovery_seconds {
-                        // Transition to half-open
-                        *self.state.write() = CircuitState::HalfOpen;
-                        return Ok(());
-                    }
-                    return Err(GuardRailViolation::CircuitOpen {
-                        recovery_in_seconds: self.recovery_seconds.saturating_sub(elapsed),
-                    });
-                }
-                // Should not happen, but allow request
-                Ok(())
-            }
+        // One read, copied out: the guard dies at the end of this statement,
+        // so no lock is held while the transition below takes the write lock.
+        let core = *self.core.read();
+        if core.state != CircuitState::Open {
+            return Ok(());
         }
+        // `opened_at` is `Some` for every `Open` state the transitions produce;
+        // a `None` here would mean a corrupt state machine, so allow the request
+        // rather than reject traffic on an invariant we cannot repair.
+        let Some(opened_at) = core.opened_at else {
+            return Ok(());
+        };
+
+        let elapsed = opened_at.elapsed().as_secs();
+        if elapsed < self.recovery_seconds {
+            return Err(GuardRailViolation::CircuitOpen {
+                recovery_in_seconds: self.recovery_seconds.saturating_sub(elapsed),
+            });
+        }
+
+        // Transition to half-open. The read guard was released above, so
+        // re-check the state: another thread may have moved the breaker in
+        // between (this is a probe transition, not a lost update).
+        let mut core = self.core.write();
+        if core.state == CircuitState::Open {
+            core.state = CircuitState::HalfOpen;
+        }
+        Ok(())
     }
 
     /// Records a successful request.
     pub fn record_success(&self) {
         self.failure_count.store(0, Ordering::Relaxed);
-        let mut state = self.state.write();
-        if *state == CircuitState::HalfOpen {
-            *state = CircuitState::Closed;
+        let mut core = self.core.write();
+        if core.state == CircuitState::HalfOpen {
+            core.state = CircuitState::Closed;
+            // Keeps `opened_at.is_some() == (state == Open)` true. Unobservable
+            // on its own (it is only read while `Open`), but the invariant is
+            // now the type's, so it is upheld at every transition.
+            core.opened_at = None;
         }
     }
 
@@ -253,19 +282,19 @@ impl CircuitBreaker {
         // window. Without this, a thread could compute count >= threshold, be preempted, and
         // then resume after the circuit has already gone through Open → HalfOpen — incorrectly
         // resetting opened_at and extending the recovery window.
-        let mut state = self.state.write();
+        let mut core = self.core.write();
         let count = self.failure_count.fetch_add(1, Ordering::Relaxed) + 1;
         if count >= u64::from(self.failure_threshold)
-            && (*state == CircuitState::Closed || *state == CircuitState::HalfOpen)
+            && (core.state == CircuitState::Closed || core.state == CircuitState::HalfOpen)
         {
-            *state = CircuitState::Open;
-            *self.opened_at.write() = Some(Instant::now());
+            core.state = CircuitState::Open;
+            core.opened_at = Some(Instant::now());
         }
     }
 
     /// Returns the current state.
     #[must_use]
     pub fn state(&self) -> CircuitState {
-        *self.state.read()
+        self.core.read().state
     }
 }

--- a/crates/velesdb-core/src/guardrails/resilience_tests.rs
+++ b/crates/velesdb-core/src/guardrails/resilience_tests.rs
@@ -203,3 +203,59 @@ fn circuit_halfopen_failure_reopens() {
     cb.record_failure();
     assert_eq!(cb.state(), CircuitState::Open);
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression: CircuitBreaker lock-order (ABBA deadlock)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `check()` and `record_failure()` used to take the breaker's two locks in
+/// opposite orders — `check` held `opened_at` (read) while asking for `state`
+/// (write), `record_failure` held `state` (write) while asking for `opened_at`
+/// (write). Both are called on every query by the pipeline, so a breaker that
+/// is `Open` under concurrent load could deadlock: each thread holds what the
+/// other waits for.
+///
+/// The two values now live under one lock, so the ordering cannot conflict.
+/// This test hammers both paths from several threads and fails on a watchdog
+/// timeout rather than hanging the suite if the ordering is ever reintroduced.
+#[test]
+fn circuit_breaker_concurrent_check_and_failure_make_progress() {
+    use std::sync::mpsc;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    // threshold 1 + recovery 0 keeps the breaker cycling through the exact
+    // transition that used to nest the locks (Open -> HalfOpen in `check`,
+    // -> Open again in `record_failure`).
+    let cb = Arc::new(CircuitBreaker::new(1, 0));
+    cb.record_failure();
+    assert_eq!(cb.state(), CircuitState::Open, "precondition: breaker open");
+
+    let (tx, rx) = mpsc::channel();
+    let mut handles = Vec::new();
+    for t in 0..4 {
+        let cb = Arc::clone(&cb);
+        let tx = tx.clone();
+        handles.push(thread::spawn(move || {
+            for _ in 0..2_000 {
+                if t % 2 == 0 {
+                    let _ = cb.check();
+                } else {
+                    cb.record_failure();
+                }
+            }
+            // Only reached if no thread is wedged on a lock.
+            let _ = tx.send(t);
+        }));
+    }
+    drop(tx);
+
+    for _ in 0..4 {
+        rx.recv_timeout(Duration::from_secs(30))
+            .expect("circuit breaker deadlocked: a worker never finished (lock-order regression)");
+    }
+    for h in handles {
+        h.join().expect("worker panicked");
+    }
+}

--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -402,7 +402,10 @@ impl Bm25Index {
             return Some(existing);
         }
 
-        let allocated = if let Some(recycled) = self.free_doc_ids.write().pop() {
+        // Bound: the `if let` would hold the `free_doc_ids` WRITE guard across
+        // the `else` branch, which takes a second write lock (`next_doc_id`).
+        let recycled = self.free_doc_ids.write().pop();
+        let allocated = if let Some(recycled) = recycled {
             recycled
         } else {
             let mut next = self.next_doc_id.write();

--- a/crates/velesdb-core/src/index/hnsw/index/batch.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/batch.rs
@@ -142,7 +142,10 @@ impl HnswIndex {
             .map(|(idx, vec)| (*vec, *idx))
             .collect();
 
-        let assigned_ids = match self.inner.read().parallel_insert(&refs_for_hnsw) {
+        // Bound so the graph read guard is released before `rollback_batch`
+        // touches `mappings`.
+        let inserted = self.inner.read().parallel_insert(&refs_for_hnsw);
+        let assigned_ids = match inserted {
             Ok(ids) => ids,
             Err(e) => {
                 tracing::error!("insert_batch_parallel: parallel_insert failed: {e}");

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -133,7 +133,10 @@ impl HnswIndex {
         vector: &[f32],
         result: &UpsertResult,
     ) -> bool {
-        let assigned_id = match self.inner.read().insert((vector, result.idx)) {
+        // Bound so the graph read guard is released before the rollback path
+        // touches `mappings`.
+        let inserted = self.inner.read().insert((vector, result.idx));
+        let assigned_id = match inserted {
             Ok(id) => id,
             Err(e) => {
                 self.rollback_upsert(id, result);

--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -208,7 +208,10 @@ impl HnswIndex {
         }
         let new_inner = new_inner.promote_to_rabitq(self.dimension);
         #[cfg(feature = "persistence")]
-        if let Some(rabitq) = self.inner.read().rabitq_quantizer() {
+        // Bound: the guard would otherwise be held across the full re-encode
+        // pass in `install_trained_rabitq`.
+        let carried = self.inner.read().rabitq_quantizer();
+        if let Some(rabitq) = carried {
             // Single encode pass with the carried-over quantizer; an
             // untrained collection stays untrained (no state change).
             new_inner

--- a/crates/velesdb-core/src/index/hnsw/native_index.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_index.rs
@@ -206,7 +206,9 @@ impl NativeHnswIndex {
 
         let result = self.upsert_mapping(id);
 
-        if let Err(e) = self.inner.read().insert((vector, result.idx)) {
+        // Bound so the graph read guard is released before the rollback.
+        let inserted = self.inner.read().insert((vector, result.idx));
+        if let Err(e) = inserted {
             self.rollback_upsert(id, &result);
             return Err(e);
         }
@@ -242,7 +244,9 @@ impl NativeHnswIndex {
             rollback_info.push((*id, result));
         }
 
-        let assigned_ids = match self.inner.read().parallel_insert(&data) {
+        // Bound so the graph read guard is released before `rollback_batch`.
+        let inserted = self.inner.read().parallel_insert(&data);
+        let assigned_ids = match inserted {
             Ok(ids) => ids,
             Err(e) => {
                 // RF-DEDUP #448 Group D — reverse-order rollback shared with

--- a/crates/velesdb-core/tests/read_gate_scope_composition.rs
+++ b/crates/velesdb-core/tests/read_gate_scope_composition.rs
@@ -72,7 +72,8 @@ impl ScopingObserver {
 
 impl DatabaseObserver for ScopingObserver {
     fn on_query_request(&self, _ctx: &QueryAccessContext) -> velesdb_core::Result<AccessDecision> {
-        match self.scope.read().clone() {
+        let scoped = self.scope.read().clone();
+        match scoped {
             None => Ok(AccessDecision::Allow),
             Some(cond) => {
                 // `AccessScope` is `#[non_exhaustive]`; construct via Default

--- a/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
+++ b/crates/velesdb-memory/src/mutation/catchup_tests/replay_tests.rs
@@ -356,7 +356,8 @@ impl Embedder for ReplayBlockingEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
         let mut blocked = self.gate.0.lock();
         if *blocked {
-            if let Some(entered) = self.entered.lock().take() {
+            let entered_guard = self.entered.lock().take();
+            if let Some(entered) = entered_guard {
                 let _ = entered.send(());
             }
             while *blocked {
@@ -375,7 +376,8 @@ impl Embedder for BlockingEmbedder {
     fn embed(&self, _text: &str) -> Result<Vec<f32>, EmbedError> {
         let mut blocked = self.gate.0.lock();
         if *blocked {
-            if let Some(entered) = self.entered.lock().take() {
+            let entered_guard = self.entered.lock().take();
+            if let Some(entered) = entered_guard {
                 let _ = entered.send(());
             }
             while *blocked {

--- a/crates/velesdb-memory/src/storage_tests.rs
+++ b/crates/velesdb-memory/src/storage_tests.rs
@@ -16,7 +16,8 @@ struct RecordingObserver {
 
 impl MutationObserver for RecordingObserver {
     fn before_mutation(&self, key: DirtyKey) -> Result<(), MemoryError> {
-        if let Some(message) = self.failure.lock().clone() {
+        let failure = self.failure.lock().clone();
+        if let Some(message) = failure {
             return Err(MemoryError::MigrationCapture(message));
         }
         self.keys.lock().push(key);


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

The workspace had `clippy::significant_drop_in_scrutinee` and `significant_drop_tightening` set to `allow` under the heading *"Code style preferences (no bug risk)"*. Baselining them (per `AGENTS.md` rule 9 — baseline before gating) returned **210 hits**, and one of them was a reproducible production deadlock.

**1. The `CircuitBreaker` could wedge the whole service (#2109).** Its two locks are taken in opposite orders:

- `check()` holds `opened_at` (read, alive to the end of the `if let` expression) then requests `state` (write) — `resilience.rs:224→228`
- `record_failure()` holds `state` (write) then requests `opened_at` (write) — `:256→262`

Both run on every query (`record_failure` is wired into the pipeline's `inspect_err`, `check` gates admission), so an **open** breaker under concurrent load can hang both paths — precisely when the breaker exists to protect the service. `parking_lot` locks are non-reentrant and writer-preferring, which widens the window rather than narrowing it.

Fixed by fusing `state` and `opened_at` into a single `RwLock`. They are one state machine — `opened_at` is only meaningful while `Open`, every transition touches both — so one lock makes the conflicting order **unrepresentable** instead of documented (rule 6: the invariant belongs to the compiler, not to prose). Side benefit: the `(state, opened_at)` pair is no longer read non-atomically.

**2. Nineteen other guards outliving their last use** (17 in core, 3 in `velesdb-memory` test doubles, 2 in `tauri-plugin-velesdb`). Each is now bound to a local before the expression. The ones that were doing real work under a guard:

- `flush_secondary_indexes` held the property/range index **read guards across a `save_to_file()` disk write**, blocking writers for the duration.
- `get_vector_collection` / `get_graph_collection` / `get_metadata_collection` — and `tauri-plugin-velesdb`'s `db_handle` / `memory_handle` — hold their map/state for **read** inside the `if let` scrutinee, while the fallback path takes **the same lock for write**. Safe today only because the fallback sits *after* the expression; moving that call into an `else` is an instant self-deadlock. `db_handle`'s doc comment already promised the guard was "dropped before the handle is returned" — the binding makes that true.
- HNSW insert paths held the graph read guard while the rollback path touched `mappings`; `auto_reindex` nested `config` under the timestamp guard; `bm25` held `free_doc_ids` (write) while taking `next_doc_id` (write); `graph_api` held `config` (lock-order position 1, the outermost) across a schema-validation loop.

**3. The gate.** `significant_drop_in_scrutinee` goes from `allow` to **`deny`**, and the config comment stops filing this family under "no bug risk". `significant_drop_tightening` (192 sites, contention rather than deadlock) stays off with an honest note and a tracking issue.

Fixes #2109
Refs #2110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Refactoring (no functional changes) — items 2 and 3

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

`circuit_breaker_concurrent_check_and_failure_make_progress` drives 4 threads through `check()` / `record_failure()` on an open breaker (2 000 iterations each) and joins through a watchdog channel:

- **pre-fix: wedges**, the 30 s `recv_timeout` fires → `circuit breaker deadlocked: a worker never finished (lock-order regression)`
- **post-fix: passes in 0.39 s**

The watchdog is deliberate — a deadlock test that simply hangs would stall CI instead of reporting a failure.

- Full core suite: **6377 passed, 0 failed** (`cargo test -p velesdb-core --features persistence -- --test-threads=1`), recall-contract gates included.
- `velesdb-memory` lib suite: **779 passed, 0 failed**.
- Per-crate `cargo clippy --all-targets` across **every** workspace member: zero `significant_drop_in_scrutinee` hits.
- `cargo clippy -p velesdb-core --lib --bins … -D clippy::undocumented_unsafe_blocks` — clean
- `cargo test --doc --package velesdb-core` — 50 passed
- Guard contract suite: `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` — **Ran 632, OK (skipped=9)**, `check-file-budgets` included.
- `cargo fmt --all` — applied

**Not runnable in this container:** `tauri-plugin-velesdb` does not build here (missing system GTK for `gdk-sys`), so its two sites were located by inspection and fixed to the same shape as the seventeen in core — CI covers the compile.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG + the lint-config comment that mislabeled this family)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none. Independent of #2108 (no shared files apart from `CHANGELOG.md`, union-merge).

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Touches `hnsw` and lock ordering, so filling this in:

- [x] Invariants impacted: (a) the breaker's `(state, opened_at)` pair is now atomic and `opened_at.is_some() == (state == Open)` is upheld at every transition; (b) no lock guard outlives the expression that produced it — now compiler-enforced rather than reviewed.
- [x] No crash/durability semantics touched. `flush_secondary_indexes` keeps its retry-on-error `dirty` re-marking; the guard is simply released before the `if let`, and the value tested is the same `Result`.
- [x] Concurrency test added (the watchdog stress test above); every rewrite in item 2 binds exactly the value the scrutinee produced, so the 6377-test core suite and the 779-test memory suite are the behavior-preservation net.
- [ ] 2-maintainer review — requesting via this PR.

## Additional Notes

Two method notes for reviewers, both of which cost a CI cycle here and are worth recording:

1. Passing `-A warnings -W clippy::significant_drop_tightening` on the command line reports **0 hits** — the `[workspace.lints]` table's `--allow` wins. The lints must be toggled in `Cargo.toml` to be measured. That is likely why this family stayed invisible; #2110 records it.
2. `check-file-budgets` froze `graph_api.rs` at 1021 lines and its policy is that an over-budget file only ever shrinks. Rather than bump the baseline, `validate_node_labels_against_schema` now calls the `non_schemaless_graph_schema` helper it was duplicating inline, which removes the duplication and lands the file back at exactly 1021.

This is wave 2 of the `velesdb-core` architecture audit (wave 1 = the metric-correctness PR #2108).