### PR TITLE
perf(quantization): drop the SQ8/Binary side-caches nothing ever read; document the modes honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`StorageMode::SQ8`/`Binary` stopped paying for quantization nobody
+  reads.** Every upsert into these modes ran a parallel quantization pass
+  and filled unbounded in-memory side-caches (one entry per vector) that no
+  search path ever consumed — pure CPU plus unbounded RAM (~1 byte/dim/vector
+  for SQ8) with zero effect on results, since the on-disk store and the HNSW
+  index are full-precision f32 in these modes regardless. The dead caches
+  and their fill/delete plumbing are removed; both modes are still accepted
+  and persisted, and now honestly documented as behaving like `Full`
+  (rustdoc + `docs/guides/QUANTIZATION.md`, whose "General production: SQ8"
+  recommendation is corrected). Search results are byte-identical. Wiring
+  the in-tree int8 dual-precision traversal engine into a real SQ8 backend
+  is tracked in #2112. (#2112)
+
 ## [5.2.0] - 2026-08-22
 
 ### Changed

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -3,9 +3,9 @@
 //! Read and delete operations are in `crud_read_delete.rs`.
 //! Bulk-specific methods (`upsert_bulk`, `upsert_bulk_from_raw`) are in `crud_bulk.rs`.
 //! Quantization caching helpers, secondary-index update helpers,
-//! `DedupMap`, and `QuantizationGuards` are in `crud_helpers.rs`.
+//! `DedupMap`, and the PQ cache guard are in `crud_helpers.rs`.
 
-use super::crud_helpers::{DedupMap, QuantizationGuards};
+use super::crud_helpers::DedupMap;
 use crate::collection::types::Collection;
 use crate::error::{Error, Result};
 use crate::point::Point;
@@ -311,11 +311,12 @@ impl Collection {
     ///
     /// Issue #425: For the common case (`StorageMode::Full`, no secondary
     /// indexes, empty BM25 index, no sparse vectors in the batch), Phase 2
-    /// does zero useful work. Skipping avoids `QuantizationGuards` acquisition,
+    /// does zero useful work. Skipping avoids PQ cache guard acquisition,
     /// `seen_payloads` HashMap allocation, and the per-point loop.
     fn can_skip_phase2(&self, points: &[Point], storage_mode: StorageMode) -> bool {
-        // Quantization caching is a no-op only for Full and RaBitQ modes
-        let no_quantization = matches!(storage_mode, StorageMode::Full | StorageMode::RaBitQ);
+        // PQ is the only mode with per-upsert quantization caching; every
+        // other mode (Full, RaBitQ, SQ8, Binary) does none here.
+        let no_quantization = !matches!(storage_mode, StorageMode::ProductQuantization);
         if !no_quantization {
             return false;
         }
@@ -370,25 +371,12 @@ impl Collection {
             return Ok(Vec::new());
         }
 
-        // Issue #486: Parallel quantization for SQ8/Binary — compute all
-        // quantized vectors via rayon, then batch-insert under a single
-        // write lock. PQ mode is handled sequentially (shared training state).
-        let quant_done = self.try_parallel_quantize(points, storage_mode);
+        // PQ is the only mode with per-upsert quantization work; its quantizer
+        // carries shared lazy-training state, so points run sequentially under
+        // one cache guard.
+        let mut pq_guard = super::crud_helpers::pq_cache_guard(self, storage_mode);
 
-        let mut quant_guards = if quant_done {
-            // Quantization already applied — no guards needed for SQ8/Binary
-            QuantizationGuards::acquire_pq_only(self, storage_mode)
-        } else {
-            QuantizationGuards::acquire(self, storage_mode)
-        };
-
-        self.per_point_sequential_updates(
-            points,
-            old_payloads,
-            storage_mode,
-            &mut quant_guards,
-            quant_done,
-        )
+        self.per_point_sequential_updates(points, old_payloads, &mut pq_guard)
     }
 
     /// Runs the sequential per-point loop for secondary indexes, BM25, sparse
@@ -399,9 +387,7 @@ impl Collection {
         &self,
         points: &[Point],
         old_payloads: &[Option<serde_json::Value>],
-        storage_mode: StorageMode,
-        quant_guards: &mut QuantizationGuards<'_>,
-        quant_done: bool,
+        pq_guard: &mut Option<super::crud_helpers::PqCacheGuard<'_>>,
     ) -> Result<Vec<(u64, BTreeMap<String, crate::index::sparse::SparseVector>)>> {
         let mut sparse_batch = Vec::new();
         let mut seen_payloads: HashMap<u64, Option<&serde_json::Value>> =
@@ -422,7 +408,7 @@ impl Collection {
         for (point, pre_batch_old) in points.iter().zip(old_payloads) {
             let effective_old =
                 Self::resolve_effective_old(&seen_payloads, point.id, pre_batch_old.as_ref());
-            Self::maybe_quantize(self, point, storage_mode, quant_guards, quant_done);
+            Self::maybe_quantize(self, point, pq_guard);
             self.update_secondary_indexes_on_upsert(
                 point.id,
                 effective_old,

--- a/crates/velesdb-core/src/collection/core/crud_helpers.rs
+++ b/crates/velesdb-core/src/collection/core/crud_helpers.rs
@@ -1,15 +1,11 @@
-//! Internal helpers for CRUD operations: quantization caching, secondary index
-//! updates, `DedupMap`, and `QuantizationGuards`.
+//! Internal helpers for CRUD operations: PQ quantization caching, secondary
+//! index updates, and `DedupMap`.
 
 use crate::collection::types::Collection;
 use crate::index::{JsonValue, SecondaryIndex};
 use crate::point::Point;
-use crate::quantization::{
-    BinaryQuantizedVector, PQVector, ProductQuantizer, QuantizedVector, StorageMode,
-};
+use crate::quantization::{PQVector, ProductQuantizer, StorageMode};
 use parking_lot::RwLockWriteGuard;
-#[cfg(feature = "persistence")]
-use rayon::prelude::*;
 use std::collections::HashMap;
 
 const PQ_TRAINING_SAMPLES: usize = 128;
@@ -20,37 +16,20 @@ const PQ_TRAINING_SAMPLES: usize = 128;
 /// and `write_deduped_vectors` to avoid redundant map construction (Issue #425).
 pub(super) type DedupMap = HashMap<u64, usize>;
 
-/// Write-lock guards for quantization caches, acquired once per batch.
-pub(super) struct QuantizationGuards<'a> {
-    pub(super) sq8: Option<RwLockWriteGuard<'a, HashMap<u64, QuantizedVector>>>,
-    pub(super) binary: Option<RwLockWriteGuard<'a, HashMap<u64, BinaryQuantizedVector>>>,
-    pub(super) pq: Option<RwLockWriteGuard<'a, HashMap<u64, PQVector>>>,
-}
+/// Write-lock guard over the PQ cache, acquired once per batch.
+///
+/// `ProductQuantization` is the only storage mode with per-upsert quantization
+/// work: its quantizer carries shared lazy-training state, so points are
+/// processed sequentially under one guard. (SQ8/Binary used to fill sibling
+/// caches here, but nothing ever read them — see `StorageMode`'s docs.)
+pub(super) type PqCacheGuard<'a> = RwLockWriteGuard<'a, HashMap<u64, PQVector>>;
 
-impl<'a> QuantizationGuards<'a> {
-    /// Acquires all quantization cache guards matching `mode`.
-    pub(super) fn acquire(collection: &'a Collection, mode: StorageMode) -> Self {
-        Self {
-            sq8: matches!(mode, StorageMode::SQ8).then(|| collection.storage.sq8_cache.write()),
-            binary: matches!(mode, StorageMode::Binary)
-                .then(|| collection.storage.binary_cache.write()),
-            pq: matches!(mode, StorageMode::ProductQuantization)
-                .then(|| collection.storage.pq_cache.write()),
-        }
-    }
-
-    /// Acquires only the PQ cache guard (for when SQ8/Binary were handled in parallel).
-    ///
-    /// Issue #486: After parallel quantization for SQ8/Binary, only PQ mode
-    /// still needs a guard for sequential processing.
-    pub(super) fn acquire_pq_only(collection: &'a Collection, mode: StorageMode) -> Self {
-        Self {
-            sq8: None,
-            binary: None,
-            pq: matches!(mode, StorageMode::ProductQuantization)
-                .then(|| collection.storage.pq_cache.write()),
-        }
-    }
+/// Acquires the PQ cache guard when `mode` needs it, `None` otherwise.
+pub(super) fn pq_cache_guard(
+    collection: &Collection,
+    mode: StorageMode,
+) -> Option<PqCacheGuard<'_>> {
+    matches!(mode, StorageMode::ProductQuantization).then(|| collection.storage.pq_cache.write())
 }
 
 fn auto_num_subspaces(dimension: usize) -> usize {
@@ -62,40 +41,11 @@ fn auto_num_subspaces(dimension: usize) -> usize {
 }
 
 impl Collection {
-    /// Caches a quantized representation of `point`'s vector according to `storage_mode`.
-    pub(crate) fn cache_quantized_vector(
-        &self,
-        point: &Point,
-        storage_mode: StorageMode,
-        sq8_cache: Option<&mut std::collections::HashMap<u64, QuantizedVector>>,
-        binary_cache: Option<&mut std::collections::HashMap<u64, BinaryQuantizedVector>>,
-        pq_cache: Option<&mut std::collections::HashMap<u64, PQVector>>,
-    ) {
-        match storage_mode {
-            StorageMode::SQ8 => {
-                if let Some(cache) = sq8_cache {
-                    let quantized = QuantizedVector::from_f32(&point.vector);
-                    cache.insert(point.id, quantized);
-                }
-            }
-            StorageMode::Binary => {
-                if let Some(cache) = binary_cache {
-                    let quantized = BinaryQuantizedVector::from_f32(&point.vector);
-                    cache.insert(point.id, quantized);
-                }
-            }
-            StorageMode::ProductQuantization => {
-                self.cache_pq_vector(point, pq_cache);
-            }
-            StorageMode::Full | StorageMode::RaBitQ => {}
-        }
-    }
-
-    /// Handles the Product Quantization arm of `cache_quantized_vector`.
+    /// Caches the PQ code for `point` (ProductQuantization mode only).
     ///
     /// Trains the quantizer on first `PQ_TRAINING_SAMPLES` points, then
     /// backfills and quantizes subsequent points.
-    fn cache_pq_vector(
+    pub(super) fn cache_pq_vector(
         &self,
         point: &Point,
         pq_cache: Option<&mut std::collections::HashMap<u64, PQVector>>,
@@ -220,43 +170,6 @@ impl Collection {
                     }
                 }
             }
-        }
-    }
-
-    /// Batch-quantizes SQ8 vectors in parallel and inserts into cache.
-    ///
-    /// Issue #486: `QuantizedVector::from_f32()` is a pure function (no shared
-    /// state), so the computation can run in parallel via rayon. Only the final
-    /// cache insertion requires the write lock, held briefly for a batch insert.
-    ///
-    /// Uses last-writer-wins dedup: for intra-batch duplicate IDs, only the
-    /// last occurrence's quantized vector is cached (matching the WAL dedup
-    /// semantics in `write_deduped_vectors`).
-    #[cfg(feature = "persistence")]
-    pub(super) fn batch_quantize_sq8_parallel(&self, points: &[Point]) {
-        let quantized: Vec<(u64, QuantizedVector)> = points
-            .par_iter()
-            .map(|p| (p.id, QuantizedVector::from_f32(&p.vector)))
-            .collect();
-        let mut cache = self.storage.sq8_cache.write();
-        for (id, qv) in quantized {
-            cache.insert(id, qv);
-        }
-    }
-
-    /// Batch-quantizes Binary vectors in parallel and inserts into cache.
-    ///
-    /// Issue #486: Same parallel strategy as SQ8 — `BinaryQuantizedVector::from_f32()`
-    /// is a pure function, parallelized via rayon.
-    #[cfg(feature = "persistence")]
-    pub(super) fn batch_quantize_binary_parallel(&self, points: &[Point]) {
-        let quantized: Vec<(u64, BinaryQuantizedVector)> = points
-            .par_iter()
-            .map(|p| (p.id, BinaryQuantizedVector::from_f32(&p.vector)))
-            .collect();
-        let mut cache = self.storage.binary_cache.write();
-        for (id, bqv) in quantized {
-            cache.insert(id, bqv);
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -5,11 +5,8 @@
 use crate::collection::types::Collection;
 use crate::error::Result;
 use crate::point::Point;
-use crate::quantization::StorageMode;
 use crate::storage::VectorStorage;
 use std::collections::{BTreeMap, HashMap};
-
-use super::crud_helpers::QuantizationGuards;
 
 impl Collection {
     /// Checks whether label index updates are needed for this batch.
@@ -58,24 +55,14 @@ impl Collection {
         }
     }
 
-    /// Conditionally caches a quantized vector for a single point.
+    /// Caches the PQ code for a single point when the mode carries a guard.
     pub(super) fn maybe_quantize(
         collection: &Collection,
         point: &Point,
-        storage_mode: StorageMode,
-        quant_guards: &mut QuantizationGuards<'_>,
-        quant_done: bool,
+        pq_guard: &mut Option<super::crud_helpers::PqCacheGuard<'_>>,
     ) {
-        if !quant_done {
-            let (sq8, binary, pq) = (
-                quant_guards.sq8.as_deref_mut(),
-                quant_guards.binary.as_deref_mut(),
-                quant_guards.pq.as_deref_mut(),
-            );
-            collection.cache_quantized_vector(point, storage_mode, sq8, binary, pq);
-        } else if matches!(storage_mode, StorageMode::ProductQuantization) {
-            let pq = quant_guards.pq.as_deref_mut();
-            collection.cache_quantized_vector(point, storage_mode, None, None, pq);
+        if pq_guard.is_some() {
+            collection.cache_pq_vector(point, pq_guard.as_deref_mut());
         }
     }
 
@@ -95,31 +82,6 @@ impl Collection {
             if let Some(new_val) = new {
                 label_idx.index_from_payload(*id, new_val);
             }
-        }
-    }
-
-    /// Attempts parallel quantization for SQ8/Binary modes.
-    pub(super) fn try_parallel_quantize(
-        &self,
-        points: &[Point],
-        storage_mode: StorageMode,
-    ) -> bool {
-        #[cfg(feature = "persistence")]
-        match storage_mode {
-            StorageMode::SQ8 => {
-                self.batch_quantize_sq8_parallel(points);
-                true
-            }
-            StorageMode::Binary => {
-                self.batch_quantize_binary_parallel(points);
-                true
-            }
-            _ => false,
-        }
-        #[cfg(not(feature = "persistence"))]
-        {
-            let _ = (points, storage_mode);
-            false
         }
     }
 

--- a/crates/velesdb-core/src/collection/core/crud_read_delete.rs
+++ b/crates/velesdb-core/src/collection/core/crud_read_delete.rs
@@ -271,8 +271,6 @@ impl Collection {
         // LOCK ORDER: vector_storage(2) → payload_storage(3) → caches(4) → label_index(7).
         let mut vector_storage = self.storage.vector_storage.write();
         let mut payload_storage = self.storage.payload_storage.write();
-        let mut sq8_cache = self.storage.sq8_cache.write();
-        let mut binary_cache = self.storage.binary_cache.write();
         let mut pq_cache = self.storage.pq_cache.write();
         let mut label_idx = self.graph.label_index.write();
 
@@ -293,8 +291,6 @@ impl Collection {
 
         for (&id, old_payload) in ids.iter().zip(&old_payloads) {
             self.storage.index.remove(id);
-            sq8_cache.remove(&id);
-            binary_cache.remove(&id);
             pq_cache.remove(&id);
             self.storage.text_index.remove_document(id);
             self.update_secondary_indexes_on_delete(id, old_payload.as_ref());
@@ -307,8 +303,6 @@ impl Collection {
         drop(label_idx);
         drop(vector_storage);
         drop(payload_storage);
-        drop(sq8_cache);
-        drop(binary_cache);
         drop(pq_cache);
         self.storage.config.write().point_count = point_count;
         Ok(())

--- a/crates/velesdb-core/src/collection/core/crud_tests.rs
+++ b/crates/velesdb-core/src/collection/core/crud_tests.rs
@@ -1136,158 +1136,46 @@ fn test_dedup_map_consolidation_correctness() {
     assert_eq!(coll.len(), 2, "should have 2 unique points");
 }
 
-/// Issue #425: Phase 2 must NOT skip when StorageMode is SQ8.
-///
-/// Regression: quantization caching requires per-point processing in Phase 2.
+/// SQ8/Binary storage modes are accepted and behave exactly like `Full`:
+/// vectors are stored and searched full-precision f32. The per-upsert
+/// quantized side-caches these modes used to fill were removed — nothing
+/// ever read them (see `StorageMode` docs and the tracking issue for a real
+/// int8 traversal backend). This pins the observable contract instead:
+/// upsert, search ordering, and delete all work under both modes.
 #[test]
-fn test_phase2_runs_for_sq8_storage_mode() {
-    let dir = tempfile::tempdir().unwrap();
-    let coll = Collection::create_with_options(
-        dir.path().to_path_buf(),
-        4,
-        DistanceMetric::Cosine,
-        StorageMode::SQ8,
-    )
-    .unwrap();
+fn test_sq8_and_binary_modes_behave_as_full_precision() {
+    for mode in [StorageMode::SQ8, StorageMode::Binary] {
+        let dir = tempfile::tempdir().unwrap();
+        let coll = Collection::create_with_options(
+            dir.path().to_path_buf(),
+            4,
+            DistanceMetric::Cosine,
+            mode,
+        )
+        .unwrap();
 
-    let points = vec![Point::without_payload(1, vec![1.0, 0.0, 0.0, 0.0])];
-    coll.upsert(points).unwrap();
+        coll.upsert(vec![
+            Point::without_payload(1, vec![1.0, 0.0, 0.0, 0.0]),
+            Point::without_payload(2, vec![0.0, 1.0, 0.0, 0.0]),
+            Point::without_payload(3, vec![0.9, 0.1, 0.0, 0.0]),
+        ])
+        .unwrap();
 
-    // SQ8 cache should have been populated by Phase 2
-    assert_eq!(
-        coll.storage.sq8_cache.read().len(),
-        1,
-        "SQ8 cache should be populated — Phase 2 must not skip"
-    );
-}
-
-/// Issue #486: Parallel SQ8 quantization produces correct cache entries.
-///
-/// Verifies that the parallel quantization path (rayon) populates
-/// the cache for all points and that each entry exists.
-#[test]
-fn test_parallel_sq8_quantization_correctness() {
-    let dir = tempfile::tempdir().unwrap();
-    let coll = Collection::create_with_options(
-        dir.path().to_path_buf(),
-        4,
-        DistanceMetric::Cosine,
-        StorageMode::SQ8,
-    )
-    .unwrap();
-
-    // Insert 50 points to exercise the parallel path (rayon splits work)
-    let points: Vec<Point> = (0u64..50)
-        .map(|id| {
-            #[allow(clippy::cast_precision_loss)]
-            let v = vec![id as f32 * 0.1, 0.2, 0.3, 0.4];
-            Point::without_payload(id, v)
-        })
-        .collect();
-    coll.upsert(points.clone()).unwrap();
-
-    // Verify all 50 entries are in the SQ8 cache
-    let cache = coll.storage.sq8_cache.read();
-    assert_eq!(
-        cache.len(),
-        50,
-        "all 50 points should have SQ8 cache entries"
-    );
-
-    // Verify each point has a cache entry (parallel and sequential produce the same result)
-    for p in &points {
-        assert!(
-            cache.contains_key(&p.id),
-            "SQ8 cache should contain entry for id={}",
-            p.id
-        );
-    }
-
-    // Content correctness: the parallel result must equal a fresh sequential
-    // quantization of the same input (catches all-zero / all-128 / mis-scaled
-    // regressions). QuantizedVector has no PartialEq, so compare fields.
-    for (idx, id) in [(0usize, 0u64), (49usize, 49u64)] {
-        let expected = crate::quantization::QuantizedVector::from_f32(&points[idx].vector);
-        let actual = cache.get(&id).expect("entry must exist");
+        let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 2).unwrap();
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
         assert_eq!(
-            actual.data, expected.data,
-            "SQ8 data bytes must match sequential quantization for id={id}"
+            ids,
+            vec![1, 3],
+            "{mode:?}: full-precision cosine ordering must hold"
         );
-        assert!(
-            actual.data.iter().any(|&b| b != 0),
-            "SQ8 data must not be all-zero for id={id}"
-        );
-        assert!(
-            (actual.min - expected.min).abs() < f32::EPSILON,
-            "min mismatch for id={id}"
-        );
-        assert!(
-            (actual.max - expected.max).abs() < f32::EPSILON,
-            "max mismatch for id={id}"
-        );
-    }
-}
 
-/// Issue #486: Parallel Binary quantization produces correct cache entries.
-#[test]
-fn test_parallel_binary_quantization_correctness() {
-    let dir = tempfile::tempdir().unwrap();
-    let coll = Collection::create_with_options(
-        dir.path().to_path_buf(),
-        4,
-        DistanceMetric::Cosine,
-        StorageMode::Binary,
-    )
-    .unwrap();
-
-    let points: Vec<Point> = (0u64..50)
-        .map(|id| {
-            #[allow(clippy::cast_precision_loss)]
-            let v = vec![id as f32 * 0.1 - 2.5, 0.2, -0.3, 0.4];
-            Point::without_payload(id, v)
-        })
-        .collect();
-    coll.upsert(points.clone()).unwrap();
-
-    let cache = coll.storage.binary_cache.read();
-    assert_eq!(
-        cache.len(),
-        50,
-        "all 50 points should have Binary cache entries"
-    );
-
-    for p in &points {
-        assert!(
-            cache.contains_key(&p.id),
-            "Binary cache should contain entry for id={}",
-            p.id
-        );
-    }
-
-    // Bit values must match the deterministic encoding (value >= 0.0 -> bit set),
-    // and must be paired with the correct id by the parallel path. Cover the
-    // sign-flip boundary at dim 0: id<25 -> [-,+,-,+]=0x0A, id>=25 -> [+,+,-,+]=0x0B.
-    for p in &points {
-        let expected = crate::quantization::BinaryQuantizedVector::from_f32(&p.vector);
-        let cached = cache.get(&p.id).unwrap();
+        coll.delete(&[1]).unwrap();
+        let results = coll.search(&[1.0, 0.0, 0.0, 0.0], 1).unwrap();
         assert_eq!(
-            cached.data, expected.data,
-            "binary bits for id={} must match canonical encoding (got {:?}, want {:?})",
-            p.id, cached.data, expected.data
+            results[0].point.id, 3,
+            "{mode:?}: delete must remove the point from search"
         );
     }
-    // Spot-check the absolute encoding so an all-zero/flipped-bit regression in
-    // from_f32 itself is also caught (not just self-consistency):
-    assert_eq!(
-        cache.get(&0).unwrap().data,
-        vec![0x0A],
-        "id=0 vec [-2.5,0.2,-0.3,0.4] -> 0b1010"
-    );
-    assert_eq!(
-        cache.get(&49).unwrap().data,
-        vec![0x0B],
-        "id=49 vec [+,0.2,-0.3,0.4] -> 0b1011"
-    );
 }
 
 /// Issue #486: Multi-batch upsert produces searchable results without

--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -139,8 +139,6 @@ impl Collection {
             payload_storage,
             index,
             text_index,
-            sq8_cache: Arc::new(RwLock::new(HashMap::new())),
-            binary_cache: Arc::new(RwLock::new(HashMap::new())),
             pq_cache: Arc::new(RwLock::new(HashMap::new())),
             pq_quantizer: Arc::new(RwLock::new(None)),
             pq_training_buffer: Arc::new(RwLock::new(VecDeque::new())),

--- a/crates/velesdb-core/src/collection/types.rs
+++ b/crates/velesdb-core/src/collection/types.rs
@@ -23,9 +23,7 @@ use crate::index::sparse::SparseInvertedIndex;
 use crate::index::{Bm25Index, HnswIndex, SecondaryIndex};
 #[cfg(feature = "persistence")]
 use crate::point::Point;
-use crate::quantization::{
-    BinaryQuantizedVector, PQVector, ProductQuantizer, QuantizedVector, StorageMode,
-};
+use crate::quantization::{PQVector, ProductQuantizer, StorageMode};
 use crate::storage::{LogPayloadStorage, MmapStorage, VectorStorage};
 use crate::velesql::{QueryCache, QueryPlanner};
 use parking_lot::{Mutex, RwLock};
@@ -191,7 +189,7 @@ impl Default for RuntimeLimits {
 //   3. payload_storage
 //   3b. edge_wal_lock    (see below — sometimes nested inside 3, sometimes
 //                          acquired alone)
-//   4. sq8_cache / binary_cache / pq_cache  (any order among themselves)
+//   4. pq_cache
 //   5. pq_quantizer → pq_training_buffer
 //   6. secondary_indexes
 //   7. property_index / range_index         (any order among themselves)
@@ -249,16 +247,6 @@ pub(crate) struct StorageState {
 
     /// BM25 index for full-text search.
     pub(super) text_index: Arc<Bm25Index>,
-
-    /// SQ8 quantized vectors cache (for SQ8 storage mode).
-    ///
-    /// Lock order position: **4**.
-    pub(super) sq8_cache: Arc<RwLock<HashMap<u64, QuantizedVector>>>,
-
-    /// Binary quantized vectors cache (for Binary storage mode).
-    ///
-    /// Lock order position: **4**.
-    pub(super) binary_cache: Arc<RwLock<HashMap<u64, BinaryQuantizedVector>>>,
 
     /// PQ quantized vectors cache (for ProductQuantization storage mode).
     ///

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -138,8 +138,8 @@ pub enum StorageMode {
     #[default]
     Full,
     /// Accepted and persisted, but currently behaves exactly like [`Full`]:
-    /// vectors are stored and searched full-precision f32, with no memory or
-    /// throughput gain. The SQ8 codec ([`QuantizedVector`]) and an int8
+    /// vectors are stored and searched full-precision f32 — no memory gain,
+    /// no throughput gain. The SQ8 codec ([`QuantizedVector`]) and an int8
     /// traversal engine exist in-tree; wiring them into an HNSW backend (the
     /// `RaBitQ` pattern) is tracked in issue #2112. Selecting this mode today
     /// reserves the intent without changing behavior.

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -114,22 +114,22 @@ pub const STORAGE_MODE_NAMES: &[&str] = &["full", "sq8", "binary", "pq", "rabitq
 
 /// Storage mode for vectors.
 ///
-/// # Capacity mode vs search-path mode
+/// # What each mode actually does
 ///
-/// | Mode | Kind | Collection search path |
-/// |------|------|------------------------|
-/// | `Full` | full-precision | f32 (baseline) |
-/// | `SQ8` | **Capacity Mode** | full-precision f32 (memory only, no throughput gain) |
-/// | `Binary` | **Capacity Mode** | full-precision f32 (memory only, no throughput gain) |
-/// | `ProductQuantization` | search-path mode | ADC-rescored (wired) |
-/// | `RaBitQ` | search-path mode | quantized traversal (wired end-to-end) |
+/// | Mode | Collection storage + search path |
+/// |------|----------------------------------|
+/// | `Full` | f32 (baseline) |
+/// | `SQ8` | f32 — behaves as `Full` today; int8 traversal tracked in #2112 |
+/// | `Binary` | f32 — behaves as `Full` today (use `RaBitQ` for compressed search) |
+/// | `ProductQuantization` | f32 storage + ADC-rescored search (wired) |
+/// | `RaBitQ` | quantized traversal, wired end-to-end |
 ///
-/// **Capacity Modes (`SQ8`, `Binary`)** reduce the in-memory footprint of the
-/// quantization primitives, but the collection search path stays
-/// full-precision f32 for those modes — selecting them does not gain search
-/// throughput. **Search-path modes (`RaBitQ`, `ProductQuantization`)** are the
-/// quantized paths wired into the query hot path. See
-/// `docs/guides/QUANTIZATION.md`.
+/// **Search-path modes (`RaBitQ`, `ProductQuantization`)** are the quantized
+/// paths wired into the query hot path. `SQ8` and `Binary` are accepted and
+/// persisted so the intent survives a reopen, but they change neither memory
+/// use nor throughput yet — the earlier "Capacity Mode" framing overstated
+/// them (they filled quantized side-caches that no search path ever read).
+/// See `docs/guides/QUANTIZATION.md`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -137,14 +137,20 @@ pub enum StorageMode {
     /// Full precision f32 storage (default).
     #[default]
     Full,
-    /// **Capacity Mode.** 8-bit scalar quantization for 4x memory reduction.
-    /// Reduces the quantization primitive's footprint only; the collection
-    /// search path stays full-precision f32 and gains no search throughput.
+    /// Accepted and persisted, but currently behaves exactly like [`Full`]:
+    /// vectors are stored and searched full-precision f32, with no memory or
+    /// throughput gain. The SQ8 codec ([`QuantizedVector`]) and an int8
+    /// traversal engine exist in-tree; wiring them into an HNSW backend (the
+    /// `RaBitQ` pattern) is tracked in issue #2112. Selecting this mode today
+    /// reserves the intent without changing behavior.
+    ///
+    /// [`Full`]: StorageMode::Full
     SQ8,
-    /// **Capacity Mode.** 1-bit binary quantization for 32x memory reduction.
-    /// Best for edge/IoT devices with limited RAM. Reduces footprint only; the
-    /// collection search path stays full-precision f32 and gains no search
-    /// throughput (use `RaBitQ` for a quantized search path).
+    /// Accepted and persisted, but currently behaves exactly like [`Full`] —
+    /// same status as [`SQ8`](StorageMode::SQ8). For a real quantized search
+    /// path use [`RaBitQ`](StorageMode::RaBitQ) (32x, wired end-to-end).
+    ///
+    /// [`Full`]: StorageMode::Full
     Binary,
     /// Product Quantization (PQ) for aggressive lossy compression (8x-16x
     /// typical). Search-path mode: wired into the query hot path for ADC

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -18,34 +18,36 @@ persistence behavior. The compression ratios, recall impact, and training cost
 per method are consolidated in one place:
 [Tuning Guide — When to Use Each Mode](TUNING_GUIDE.md#when-to-use-each-mode).
 
-### Capacity mode vs search-path mode
+### What each storage mode actually does
 
 The compression figures above describe the quantization **primitives**. In the
-**collection search path**, only some modes are wired up — the rest are capacity
-modes that shrink memory without changing how search runs:
+**collection search path**, only some modes are wired up:
 
-| Storage mode | Kind | Collection search path |
-|--------------|------|------------------------|
-| `full` | full-precision | f32 (baseline) |
-| `sq8` | **Capacity Mode** | full-precision f32 — memory only, no throughput gain |
-| `binary` | **Capacity Mode** | full-precision f32 — memory only, no throughput gain |
-| `pq` | search-path mode | ADC-rescored (wired) |
-| `rabitq` | search-path mode | quantized traversal (wired end-to-end) |
+| Storage mode | Collection storage + search path |
+|--------------|----------------------------------|
+| `full` | f32 (baseline) |
+| `sq8` | f32 — behaves as `full` today; int8 traversal tracked in [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112) |
+| `binary` | f32 — behaves as `full` today |
+| `pq` | f32 storage + ADC-rescored search (wired) |
+| `rabitq` | quantized traversal (wired end-to-end) |
 
-Pick `sq8`/`binary` only for the primitive-level memory savings; pick `rabitq`
-(or `pq`) when you want the quantized path in the query hot path.
+Pick `rabitq` (or `pq`) when you want a quantized query hot path. `sq8` and
+`binary` are accepted and persisted so the intent survives a reopen, but they
+currently change neither memory use nor throughput.
 
 ---
 
 ## 🚀 SQ8: 4x Compression
 
-> **Status: cache not consumed by collection search.**
-> A collection in `storage='sq8'` mode maintains a cache of SQ8-quantized
-> vectors at insertion time, but no search path reads this cache today:
-> queries run at full f32 precision. Choosing SQ8 at the collection level
-> therefore ADDS memory instead of reducing it, pending a reduced-memory
-> storage mode. The SQ8 primitives below (`QuantizedVector`, SIMD
-> distances) are, however, fully functional for direct programmatic use.
+> **Status: collection mode behaves as `full`.**
+> A collection in `storage='sq8'` mode stores and searches full-precision
+> f32 vectors. (Earlier releases also filled an SQ8 side-cache at insertion
+> time that no search path ever read — pure CPU + unbounded RAM cost — so
+> that cache was removed.) Wiring the in-tree int8 traversal engine into an
+> HNSW backend is tracked in
+> [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112). The SQ8
+> primitives below (`QuantizedVector`, SIMD distances) are fully functional
+> for direct programmatic use.
 
 Each `f32` value (4 bytes) is converted to a `u8` (1 byte):
 
@@ -84,11 +86,11 @@ println!("Memory saved: {}%",
 
 ## ⚡ Binary: 32x Compression
 
-> **Status: cache not consumed by collection search.**
-> Same as SQ8: `storage='binary'` mode fills a cache of binary vectors
-> that no search path reads (search runs at full f32 precision). For
-> effective 32x compression in the query path, use RaBitQ. The
-> `BinaryQuantizedVector` primitives remain directly usable.
+> **Status: collection mode behaves as `full`.**
+> Same as SQ8: `storage='binary'` mode stores and searches full-precision
+> f32 (its never-read insertion-time cache was removed). For effective 32x
+> compression in the query path, use RaBitQ. The `BinaryQuantizedVector`
+> primitives remain directly usable.
 
 Each `f32` value becomes **1 bit**:
 - Value ≥ 0 → 1
@@ -253,8 +255,7 @@ method) moved to the
 [Tuning Guide — When to Use Each Mode](TUNING_GUIDE.md#when-to-use-each-mode),
 the single home for those numbers. Keep in mind the wiring caveat: in the
 collection query path only **RaBitQ** and **PQ** are wired up today (see the
-status callouts above) — the SQ8/Binary modes maintain caches there that search
-does not consume yet.
+status callouts above) — the SQ8/Binary collection modes behave as `full`.
 
 ---
 
@@ -262,12 +263,12 @@ does not consume yet.
 
 | Scenario | Recommendation |
 |----------|----------------|
-| **General production** | SQ8 |
+| **General production** | f32 (default) — SQ8 adds nothing until [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112) lands |
 | **Large dataset (100K+)** | PQ m=8 + rescore |
-| **Very limited RAM** | Binary or RaBitQ |
+| **Very limited RAM** | RaBitQ |
 | **Maximum precision** | f32 (no quantization) |
 | **High compression + good recall** | RaBitQ |
-| **Fingerprints/hashes** | Binary |
+| **Fingerprints/hashes** | `BinaryQuantizedVector` primitives (direct use) |
 | **Correlated data** | PQ + OPQ |
 
 > Note: these recommendations compare the methods as such. In the collection

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -221,6 +221,14 @@ OPQ applies an orthogonal rotation to the vectors before PQ quantization. This r
 > 1000-insertion threshold) is also persisted to `rabitq.idx` on a full
 > flush, at parity with the PQ codebook.
 
+> **Resident-memory caveat:** the RaBitQ backend keeps the full-precision
+> f32 vectors in the index for exact re-ranking, with the 1-bit codes held
+> *alongside* them. The 32x figure is the size of the codes, not of the
+> resident set — today the mode buys traversal speed (32x memory-bandwidth
+> reduction in the hot loop), not a smaller RAM floor. A codes-resident
+> variant for small-RAM devices is part of
+> [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112).
+
 ### How does it work?
 
 RaBitQ combines binary compression (1 bit per dimension) with a **random orthogonal rotation** that preserves distances. Unlike naive binary quantization, the orthogonal rotation spreads the information more uniformly across all bits.
@@ -265,7 +273,7 @@ status callouts above) — the SQ8/Binary collection modes behave as `full`.
 |----------|----------------|
 | **General production** | f32 (default) — SQ8 adds nothing until [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112) lands |
 | **Large dataset (100K+)** | PQ m=8 + rescore |
-| **Very limited RAM** | RaBitQ |
+| **Very limited RAM** | f32 with modest HNSW `M` — no current mode shrinks the resident set (see [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112)) |
 | **Maximum precision** | f32 (no quantization) |
 | **High compression + good recall** | RaBitQ |
 | **Fingerprints/hashes** | `BinaryQuantizedVector` primitives (direct use) |


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Wave 3 of the `velesdb-core` architecture audit (waves 1–2: #2108, #2111). Audit finding C1, adversarially verified end-to-end before acting:

**Collections in `StorageMode::SQ8`/`Binary` paid for quantization nobody consumed.** Every upsert ran a parallel (rayon) quantization pass filling unbounded in-memory `HashMap` side-caches — one entry per vector, ~1 byte/dim/vector for SQ8 (~768 MB for 1M × 768-d) with **no eviction**. Verified consumers of those caches: the tests asserting the fill, and nothing else. The on-disk store is f32 regardless (`mmap.rs` sizes by `size_of::<f32>()`), and the HNSW backend for these modes is `Standard` full-f32 (only `RaBitQ` gets a dedicated backend). Net effect of selecting SQ8/Binary today: **more** CPU and **more** RAM than `Full`, identical results.

### The implement-vs-remove decision

Per the audit arbitration ("if there's a real value proposition, implement; otherwise clean up"), I evaluated implementing first — and found the striking part: **the int8 traversal engine already exists in-tree and is fully unwired** (`DualPrecisionHnsw` + `int8_traversal.rs`, VSAG-style dual precision, 19 tests). What's missing to wire it is a genuine feature, not plumbing: a third `HnswBackend` variant across ~50 dispatch sites, complete persistence (`DualPrecisionHnsw` has zero file I/O vs RaBitQ's 669-line `graph_io.rs`), `parallel_insert`, a training policy, and recall/perf gates on the hottest path. That design is now fully specified in **#2112** with the in-tree engine documented as the starting point. The caches removed here contribute nothing to that future (wrong layout — the backend owns its own quantized storage), so this cleanup is correct under both futures.

### What this PR does

- Removes `sq8_cache`/`binary_cache` from `StorageState`, their lifecycle init, the per-upsert fill (both the rayon batch path and the sequential arm), and the delete-path maintenance.
- `QuantizationGuards` (3-field struct) collapses into a single `Option<PqCacheGuard>` — PQ is the only mode with real per-upsert quantization work (shared lazy-training state). `try_parallel_quantize` and both `batch_quantize_*_parallel` are deleted; `can_skip_phase2` now fast-skips SQ8/Binary like Full/RaBitQ.
- Both modes stay **accepted and persisted** (existing collections reopen unchanged; the on-disk `StorageMode` tag round-trips as before). No API removal, no format change.
- Docs stop overstating: `StorageMode` rustdoc and `docs/guides/QUANTIZATION.md` now say SQ8/Binary behave as `Full` until #2112 — the guide already admitted the cache "ADDS memory instead of reducing it" yet still recommended *"General production: SQ8"*; that recommendation is corrected. The SQ8/Binary **codecs** (`QuantizedVector`, `BinaryQuantizedVector`, SIMD kernels) are untouched and remain fully usable directly.

**Search results are byte-identical by construction: nothing removed was on any read path.**

Refs #2112

## Type of Change

- [x] ⚡ Performance improvement
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

- Full core suite: **6374 passed, 0 failed** (`cargo test -p velesdb-core --features persistence -- --test-threads=1`), recall-contract gates included.
- The three tests that asserted the dead-cache fill are replaced by `test_sq8_and_binary_modes_behave_as_full_precision`, which pins the observable contract (upsert / exact search ordering / delete under both modes). Their codec-level `from_f32` assertions were duplicates of existing coverage in `quantization_tests.rs` (27 call sites).
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check` — clean.
- Dependent crates compile: `cargo check -p velesdb-server -p velesdb-cli -p velesdb-migrate`.
- Guard contract suite: **Ran 632, OK (skipped=9)** — `check-file-budgets` (no over-budget file grew), `check-feature-claims`, `check-perf-claims --no-criterion`, `check-doc-contract.sh`, all five `check-doc-freshness` guards, `check-ai-attribution` — all pass from repo root.
- `cargo fmt --all` — applied.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (rustdoc, quantization guide, CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none. Independent of #2108/#2111 except `CHANGELOG.md` (union-merge).

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Touches the upsert flow (not `hnsw`/`storage` internals), filling this in for caution:

- [x] Invariants impacted: the upsert Phase-2 contract — quantization caching happens iff the mode has a consumer, now true by construction (only PQ). Lock-order table updated (position 4 is now `pq_cache` alone).
- [x] No crash/durability semantics touched — the removed work was post-WAL, in-memory only, and consumed by nothing; delete-batch durability barriers unchanged.
- [x] Behavior pin added for both modes (upsert/search/delete); the 6374-test suite is the preservation net.
- [ ] 2-maintainer review — requesting via this PR.

## Additional Notes

Discovery worth a reviewer's attention in #2112: `RaBitQPrecisionHnsw` was built explicitly mirroring `DualPrecisionHnsw`'s API ("RF-DEDUP: Mirrors DualPrecisionHnsw"), so the backend-variant work has a proven template — the expensive missing piece is persistence.