### PR TITLE
feat(core): the vector arena can live in a file instead of the heap

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -198,6 +198,19 @@ exclude_paths:
   # non-overlapping invariants) as the pre-extraction version. Covered by
   # Miri CI.
   - "crates/velesdb-core/src/contiguous_resize.rs"
+  # File-backed vector arena (#2112 Phase B) — the third member of the
+  # ContiguousVectors family, alongside contiguous_ops.rs and
+  # contiguous_resize.rs above. Two unsafe blocks, both unavoidable:
+  # MmapMut::map_mut cannot be called safely, and addressing the data region
+  # past the reserved header needs pointer arithmetic. Both carry // SAFETY:
+  # documentation with numbered conditions, and the file passes
+  # scripts/verify_unsafe_safety_template.py --strict, which (unlike this
+  # rule) does distinguish documented from undocumented unsafe.
+  #
+  # Not covered by Miri: the interesting paths are mmap-backed and Miri cannot
+  # execute them. The equivalent heap path it can check lives in the two
+  # siblings above and is unchanged.
+  - "crates/velesdb-core/src/contiguous_file_arena.rs"
 
 # ---------------------------------------------------------------------------
 # Per-engine exclusions — targeted suppression without losing other checks

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -22,6 +22,19 @@
 //! extending the file leaves the existing pages in place, where the heap path
 //! has to `memcpy` the whole arena into a bigger block.
 //!
+//! # Byte order
+//!
+//! The mapped bytes are native-endian f32: the arena *is* the file, so no
+//! conversion happens on either side. That makes an arena file
+//! self-consistent on any target but **not portable between targets of
+//! different endianness** — it is an index-local cache, not an interchange
+//! format, and must be rebuilt rather than copied across such a boundary.
+//!
+//! Worth stating because the neighbouring `{basename}.vectors` format does
+//! the opposite: it converts explicitly (`to_le_bytes`/`from_le_bytes`), so it
+//! *is* portable. Anything that later maps that file directly inherits this
+//! constraint and must gate on `target_endian`.
+//!
 //! # Availability
 //!
 //! `persistence`-only. Without it (WASM, `--no-default-features`) there is no
@@ -40,9 +53,16 @@ use std::ptr::NonNull;
 /// satisfies the arena's 64-byte cache-line preference. The header itself
 /// occupies the first bytes of that page; the rest is reserved padding.
 ///
-/// Note this is a *layout* constant, not an alignment requirement: every SIMD
-/// kernel in this crate loads unaligned (`loadu`), so a misaligned arena would
-/// be correct but slower. The padding buys cache-line behaviour, not safety.
+/// A whole page is deliberate overkill, and the reason is soundness rather
+/// than speed. [`ContiguousVectors`] hands out `&[f32]` built with
+/// `slice::from_raw_parts`, whose contract requires the pointer to be
+/// *properly aligned* — a misaligned arena would be undefined behaviour at the
+/// first `get`, long before any SIMD ran. (The SIMD kernels themselves all
+/// load unaligned, so they would not have been the ones to complain.) Starting
+/// the data region on a page boundary keeps that requirement satisfied by
+/// construction instead of by arithmetic that a later edit could break.
+///
+/// [`ContiguousVectors`]: crate::perf_optimizations::ContiguousVectors
 pub(crate) const DATA_OFFSET: usize = 4096;
 
 /// A file mapping that owns the bytes behind a [`ContiguousVectors`] buffer.
@@ -148,12 +168,13 @@ impl FileArena {
     /// Returns [`io::ErrorKind::InvalidData`] if the mapping is somehow
     /// shorter than the header, which would mean the file was truncated
     /// underneath us.
-    // Reason: no structural fix exists — the cast is the point of the
-    // function. The alignment it warns about is *proven* here rather than
-    // assumed: an mmap base is page-aligned by the kernel and `DATA_OFFSET`
-    // is a whole page, so the result is 4096-byte aligned, far beyond f32's
-    // 4. (The arena would be sound even misaligned: every SIMD kernel in this
-    // crate loads unaligned.)
+    // Reason: no structural fix exists — producing this pointer is the whole
+    // point of the function. The alignment is *proven* rather than assumed: an
+    // mmap base is page-aligned by the kernel and `DATA_OFFSET` is a whole
+    // page, so the result is 4096-byte aligned against f32's requirement of 4.
+    // That proof is load-bearing, not decorative: the slices this pointer
+    // feeds are built with `from_raw_parts`, which requires alignment for
+    // soundness.
     #[allow(clippy::cast_ptr_alignment)]
     pub(crate) fn data_ptr(&mut self) -> io::Result<NonNull<f32>> {
         if self.map.len() < DATA_OFFSET {

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -65,7 +65,8 @@ use std::ptr::NonNull;
 /// [`ContiguousVectors`]: crate::perf_optimizations::ContiguousVectors
 pub(crate) const DATA_OFFSET: usize = 4096;
 
-/// A file mapping that owns the bytes behind a [`ContiguousVectors`] buffer.
+/// A file mapping that owns the bytes behind a
+/// [`ContiguousVectors`](crate::perf_optimizations::ContiguousVectors) buffer.
 ///
 /// # Invariants
 ///
@@ -277,6 +278,16 @@ impl FileArena {
     /// any step leaves the existing mapping — and therefore every live pointer
     /// into it — untouched. Growing never copies: the pages already written
     /// stay where they are.
+    ///
+    /// Extending the file while the old mapping is still live is the ordering
+    /// [`MmapStorage::ensure_capacity`] already uses for the same operation,
+    /// so this is the repository's established pattern rather than a new one.
+    /// Worth knowing before changing it: no CI job runs this crate's tests on
+    /// Windows — the compatibility matrix only `cargo check`s there — so the
+    /// ordering is held in common with the primary storage engine on purpose,
+    /// not validated independently here.
+    ///
+    /// [`MmapStorage::ensure_capacity`]: crate::storage::MmapStorage
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -87,7 +87,35 @@ pub(crate) struct FileArena {
     map: MmapMut,
     file: File,
     path: PathBuf,
+    /// The data-region pointer, derived once per mapping.
+    ///
+    /// Held here rather than recomputed because it is a property of the
+    /// mapping, not of a call: deriving it needs `&mut` (for `as_mut_ptr`) and
+    /// can fail, and neither belongs on an accessor that every caller uses.
+    /// `grow` re-derives it, which is the only event that can move it.
+    data: NonNull<f32>,
 }
+
+// SAFETY: `FileArena` is `Send` because everything it owns is, and the raw
+// pointer it caches addresses memory the kernel owns rather than this thread.
+// - Condition 1: `MmapMut`, `File` and `PathBuf` are all `Send`.
+// - Condition 2: `data` points into `map`, whose address is assigned by the
+//   kernel and unaffected by moving this struct, so the pointer stays valid
+//   wherever the arena goes.
+// - Condition 3: the exclusive lock taken in `from_file` means no other
+//   `FileArena` addresses the same bytes, so moving this one cannot create an
+//   alias on the receiving thread.
+// SAFETY: Moving an arena between threads leaves its mapping intact and unique.
+unsafe impl Send for FileArena {}
+// SAFETY: `FileArena` is `Sync` because shared references expose no mutation.
+// - Condition 1: `&self` reaches only `data_ptr`, `flush` and `path`; none of
+//   them writes through the mapping, and every mutating entry point
+//   (`grow`) takes `&mut self`.
+// - Condition 2: handing out the cached pointer is not itself a write — the
+//   caller's own aliasing rules govern what it does with it, exactly as for
+//   the heap backing.
+// SAFETY: Concurrent shared references to an arena cannot mutate it.
+unsafe impl Sync for FileArena {}
 
 impl FileArena {
     /// Creates (or truncates) `path` and maps `byte_len` bytes of vector data.
@@ -129,11 +157,17 @@ impl FileArena {
     fn from_file(file: File, path: PathBuf, byte_len: usize) -> io::Result<Self> {
         Self::lock_exclusive(&file, &path)?;
         let total = Self::total_len(byte_len)?;
-        if file.metadata()?.len() < total {
-            file.set_len(total)?;
+        if file.metadata()?.len() < total as u64 {
+            file.set_len(total as u64)?;
         }
-        let map = Self::map(&file, total)?;
-        Ok(Self { map, file, path })
+        let mut map = Self::map(&file, total)?;
+        let data = Self::derive_data_ptr(&mut map)?;
+        Ok(Self {
+            map,
+            file,
+            path,
+            data,
+        })
     }
 
     /// Claims the file for this arena alone.
@@ -160,29 +194,23 @@ impl FileArena {
     }
 
     /// `DATA_OFFSET + byte_len`, refusing an overflowing request.
-    fn total_len(byte_len: usize) -> io::Result<u64> {
-        let total = byte_len.checked_add(DATA_OFFSET).ok_or_else(|| {
+    ///
+    /// Deliberately `usize`: that is the width a mapping can actually have on
+    /// this target, so every internal length stays in it and the one `u64`
+    /// this type needs is produced at `set_len`'s boundary and nowhere else.
+    /// Round-tripping through `u64` would add a `u64 -> usize` conversion that
+    /// can fail and a `usize -> u64` one that never can.
+    fn total_len(byte_len: usize) -> io::Result<usize> {
+        byte_len.checked_add(DATA_OFFSET).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "vector arena size overflows usize",
-            )
-        })?;
-        u64::try_from(total).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "vector arena size overflows u64",
+                "vector arena size overflows this target's address space",
             )
         })
     }
 
-    /// Maps `total` bytes of `file` for read and write.
-    fn map(file: &File, total: u64) -> io::Result<MmapMut> {
-        let len = usize::try_from(total).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "vector arena size exceeds this target's address space",
-            )
-        })?;
+    /// Maps `len` bytes of `file` for read and write.
+    fn map(file: &File, len: usize) -> io::Result<MmapMut> {
         // SAFETY: `MmapMut::map_mut` requires a file that stays valid for the
         // mapping's lifetime and is not concurrently truncated.
         // - Condition 1: `file` is owned by the returned `FileArena`, so it
@@ -198,10 +226,18 @@ impl FileArena {
 
     /// Pointer to the first f32 of the data region.
     ///
+    /// Infallible and `&self`: the fallible derivation happens once, when the
+    /// mapping is established or re-established.
+    pub(crate) const fn data_ptr(&self) -> NonNull<f32> {
+        self.data
+    }
+
+    /// Derives the data-region pointer from a mapping.
+    ///
     /// # Errors
     ///
-    /// Returns [`io::ErrorKind::InvalidData`] if the mapping is somehow
-    /// shorter than the header, which would mean the file was truncated
+    /// Returns [`io::ErrorKind::InvalidData`] if the mapping is shorter than
+    /// the reserved header, which would mean the file was truncated
     /// underneath us.
     // Reason: no structural fix exists — producing this pointer is the whole
     // point of the function. The alignment is *proven* rather than assumed: an
@@ -211,8 +247,8 @@ impl FileArena {
     // feeds are built with `from_raw_parts`, which requires alignment for
     // soundness.
     #[allow(clippy::cast_ptr_alignment)]
-    pub(crate) fn data_ptr(&mut self) -> io::Result<NonNull<f32>> {
-        if self.map.len() < DATA_OFFSET {
+    fn derive_data_ptr(map: &mut MmapMut) -> io::Result<NonNull<f32>> {
+        if map.len() < DATA_OFFSET {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "vector arena mapping is shorter than its header",
@@ -225,7 +261,7 @@ impl FileArena {
         //   non-null and page-aligned, so the offset pointer is non-null and
         //   at least 4096-byte aligned.
         // SAFETY: Address the data region that follows the reserved header.
-        let ptr = unsafe { self.map.as_mut_ptr().add(DATA_OFFSET) };
+        let ptr = unsafe { map.as_mut_ptr().add(DATA_OFFSET) };
         NonNull::new(ptr.cast::<f32>()).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -248,11 +284,17 @@ impl FileArena {
     /// arena is unchanged and still usable.
     pub(crate) fn grow(&mut self, byte_len: usize) -> io::Result<()> {
         let total = Self::total_len(byte_len)?;
-        if self.map.len() as u64 >= total {
+        if self.map.len() >= total {
             return Ok(());
         }
-        self.file.set_len(total)?;
-        let fresh = Self::map(&self.file, total)?;
+        self.file.set_len(total as u64)?;
+        let mut fresh = Self::map(&self.file, total)?;
+        let data = Self::derive_data_ptr(&mut fresh)?;
+        // The pointer moves first: it already addresses `fresh`, whose pages
+        // survive the move into `self.map`. Assigning the map first would
+        // munmap the old region while `self.data` still named it, leaving the
+        // arena briefly holding a dangling pointer for no gain.
+        self.data = data;
         // Only now is the old mapping released.
         self.map = fresh;
         Ok(())

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -123,8 +123,11 @@ unsafe impl Sync for FileArena {}
 /// A named choice rather than a `bool` parameter, because the two callers read
 /// as opposites at the call site (`create` discards, `open` keeps) and the
 /// distinction decides whether the arena starts zeroed or starts from disk.
+///
+/// `pub(crate)` so `ContiguousVectors`' two file-backed constructors speak the
+/// same vocabulary instead of re-deriving it from a bool of their own.
 #[derive(Clone, Copy)]
-enum ExistingBytes {
+pub(crate) enum ExistingBytes {
     /// Empty the file first, so the arena starts zero-filled.
     Discard,
     /// The file's contents *are* the arena; only ever grow it.

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -118,49 +118,80 @@ unsafe impl Send for FileArena {}
 // SAFETY: Concurrent shared references to an arena cannot mutate it.
 unsafe impl Sync for FileArena {}
 
+/// What an opening arena does with the bytes the file already holds.
+///
+/// A named choice rather than a `bool` parameter, because the two callers read
+/// as opposites at the call site (`create` discards, `open` keeps) and the
+/// distinction decides whether the arena starts zeroed or starts from disk.
+#[derive(Clone, Copy)]
+enum ExistingBytes {
+    /// Empty the file first, so the arena starts zero-filled.
+    Discard,
+    /// The file's contents *are* the arena; only ever grow it.
+    Keep,
+}
+
 impl FileArena {
-    /// Creates (or truncates) `path` and maps `byte_len` bytes of vector data.
+    /// Creates `path` if absent and maps `byte_len` bytes of vector data,
+    /// discarding whatever the file held.
     ///
     /// The file is sized to `DATA_OFFSET + byte_len`. A freshly extended file
     /// reads as zeros, which is the same guarantee `alloc_zeroed` gives the
     /// anonymous backing — `insert_at` relies on it when it leaves gaps.
     ///
+    /// Note what this does **not** do: pass `truncate(true)` to `OpenOptions`.
+    /// That would empty the file at `open` time, which is before the exclusive
+    /// lock is taken, so a call destined to be refused would already have
+    /// destroyed the bytes another arena was mapping — and left that arena's
+    /// mapping addressing pages past a shrunken end of file, where a read
+    /// raises `SIGBUS`. The lock exists to prevent exactly that, so nothing
+    /// that alters the file may happen before it. Discarding is therefore a
+    /// [`ExistingBytes::Discard`] request carried through to
+    /// [`size_locked_file`](Self::size_locked_file), which runs under the lock.
+    ///
     /// # Errors
     ///
-    /// Returns any I/O error from creating, sizing, or mapping the file.
+    /// Returns any I/O error from creating, sizing, or mapping the file, and
+    /// [`io::ErrorKind::WouldBlock`] if another holder has the arena.
     pub(crate) fn create(path: &Path, byte_len: usize) -> io::Result<Self> {
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .truncate(true)
+            // Explicitly *not* at open time — see this function's doc. The
+            // discard happens under the lock instead.
+            .truncate(false)
             .open(path)?;
-        Self::from_file(file, path.to_path_buf(), byte_len)
+        Self::from_file(file, path.to_path_buf(), byte_len, ExistingBytes::Discard)
     }
 
     /// Maps an existing file whose data region already holds vector bytes.
     ///
-    /// Unlike [`create`](Self::create) this never truncates: the contents are
+    /// Unlike [`create`](Self::create) this never discards: the contents are
     /// the arena. The file is only ever grown, to `DATA_OFFSET + byte_len`.
     ///
     /// # Errors
     ///
-    /// Returns any I/O error from opening, sizing, or mapping the file.
+    /// Returns any I/O error from opening, sizing, or mapping the file, and
+    /// [`io::ErrorKind::WouldBlock`] if another holder has the arena.
     pub(crate) fn open(path: &Path, byte_len: usize) -> io::Result<Self> {
         let file = OpenOptions::new().read(true).write(true).open(path)?;
-        Self::from_file(file, path.to_path_buf(), byte_len)
+        Self::from_file(file, path.to_path_buf(), byte_len, ExistingBytes::Keep)
     }
 
-    /// Sizes `file` to hold `byte_len` data bytes and maps the whole thing.
+    /// Locks `file`, sizes it to hold `byte_len` data bytes, and maps it.
     ///
-    /// Locks before mapping: a second holder must be refused while the bytes
-    /// are still unmapped, not after two aliases already exist.
-    fn from_file(file: File, path: PathBuf, byte_len: usize) -> io::Result<Self> {
+    /// The lock comes first, and every step that can alter the file follows
+    /// it. A refused arena must leave the file exactly as it found it, because
+    /// the holder it was refused in favour of has it mapped.
+    fn from_file(
+        file: File,
+        path: PathBuf,
+        byte_len: usize,
+        existing: ExistingBytes,
+    ) -> io::Result<Self> {
         Self::lock_exclusive(&file, &path)?;
-        let total = Self::total_len(byte_len)?;
-        if file.metadata()?.len() < total as u64 {
-            file.set_len(total as u64)?;
-        }
+        let total = Self::size_locked_file(&file, byte_len, existing)?;
         let mut map = Self::map(&file, total)?;
         let data = Self::derive_data_ptr(&mut map)?;
         Ok(Self {
@@ -169,6 +200,34 @@ impl FileArena {
             path,
             data,
         })
+    }
+
+    /// Brings an already-locked file to `DATA_OFFSET + byte_len` bytes.
+    ///
+    /// Returns that total so the caller maps exactly what was sized.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from reading the file's length or resizing it.
+    fn size_locked_file(
+        file: &File,
+        byte_len: usize,
+        existing: ExistingBytes,
+    ) -> io::Result<usize> {
+        let total = Self::total_len(byte_len)?;
+        // The single `usize -> u64` conversion this type needs: every internal
+        // length is a `usize`, and only the file API speaks `u64`.
+        let total_len = total as u64;
+        if matches!(existing, ExistingBytes::Discard) {
+            // Emptying the file first is what makes the grow below hand back
+            // zeros rather than stale vectors. Safe here and nowhere earlier:
+            // the lock is held, so no other arena has these bytes mapped.
+            file.set_len(0)?;
+        }
+        if file.metadata()?.len() < total_len {
+            file.set_len(total_len)?;
+        }
+        Ok(total)
     }
 
     /// Claims the file for this arena alone.
@@ -298,7 +357,7 @@ impl FileArena {
         if self.map.len() >= total {
             return Ok(());
         }
-        self.file.set_len(total as u64)?;
+        Self::size_locked_file(&self.file, byte_len, ExistingBytes::Keep)?;
         let mut fresh = Self::map(&self.file, total)?;
         let data = Self::derive_data_ptr(&mut fresh)?;
         // The pointer moves first: it already addresses `fresh`, whose pages

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -1,0 +1,227 @@
+//! File-backed storage for a [`ContiguousVectors`] buffer.
+//!
+//! # Why this exists
+//!
+//! A quantized index keeps two representations of every vector: the codes it
+//! traverses on, and the f32 it re-ranks with. The codes are small; the f32 is
+//! not. While that f32 arena is an anonymous allocation it is **un-evictable**,
+//! so the index's resident set is `f32 + graph + codes` — larger than the
+//! unquantized index it was supposed to shrink (#2112).
+//!
+//! Backing the arena with a file makes those pages evictable: the kernel can
+//! reclaim them under pressure and fault them back in when a re-rank touches
+//! them. The resident floor becomes `codes + graph`, which is the whole point
+//! of the quantized modes on a small device.
+//!
+//! # Why the pages are the same bytes the index already persists
+//!
+//! `{basename}.vectors` was already a raw little-endian f32 blob behind a
+//! short header — the arena's own memory layout, written out one value at a
+//! time. Mapping that file instead of deserializing it into a fresh
+//! allocation removes a full copy from load and makes growth allocation-free:
+//! extending the file leaves the existing pages in place, where the heap path
+//! has to `memcpy` the whole arena into a bigger block.
+//!
+//! # Availability
+//!
+//! `persistence`-only. Without it (WASM, `--no-default-features`) there is no
+//! filesystem to map and [`ContiguousVectors`] keeps its anonymous backing;
+//! this module is not compiled at all.
+
+use memmap2::{MmapMut, MmapOptions};
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::ptr::NonNull;
+
+/// Byte offset of the f32 region inside a file-backed arena.
+///
+/// One page, so the mapped data region starts page-aligned — which also
+/// satisfies the arena's 64-byte cache-line preference. The header itself
+/// occupies the first bytes of that page; the rest is reserved padding.
+///
+/// Note this is a *layout* constant, not an alignment requirement: every SIMD
+/// kernel in this crate loads unaligned (`loadu`), so a misaligned arena would
+/// be correct but slower. The padding buys cache-line behaviour, not safety.
+pub(crate) const DATA_OFFSET: usize = 4096;
+
+/// A file mapping that owns the bytes behind a [`ContiguousVectors`] buffer.
+///
+/// # Invariants
+///
+/// - `map` is a mapping of at least `DATA_OFFSET + byte_len` bytes of `file`.
+/// - The address the mapping lives at is owned by the kernel, not stored
+///   inline in this struct, so moving a `FileArena` does **not** move the
+///   bytes. That is what makes it sound for `ContiguousVectors` to hold a
+///   `NonNull` into the mapping while also owning the `FileArena`.
+/// - `path` is kept for diagnostics and for reopening after a grow.
+pub(crate) struct FileArena {
+    map: MmapMut,
+    file: File,
+    path: PathBuf,
+}
+
+impl FileArena {
+    /// Creates (or truncates) `path` and maps `byte_len` bytes of vector data.
+    ///
+    /// The file is sized to `DATA_OFFSET + byte_len`. A freshly extended file
+    /// reads as zeros, which is the same guarantee `alloc_zeroed` gives the
+    /// anonymous backing — `insert_at` relies on it when it leaves gaps.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from creating, sizing, or mapping the file.
+    pub(crate) fn create(path: &Path, byte_len: usize) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        Self::from_file(file, path.to_path_buf(), byte_len)
+    }
+
+    /// Maps an existing file whose data region already holds vector bytes.
+    ///
+    /// Unlike [`create`](Self::create) this never truncates: the contents are
+    /// the arena. The file is only ever grown, to `DATA_OFFSET + byte_len`.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from opening, sizing, or mapping the file.
+    pub(crate) fn open(path: &Path, byte_len: usize) -> io::Result<Self> {
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
+        Self::from_file(file, path.to_path_buf(), byte_len)
+    }
+
+    /// Sizes `file` to hold `byte_len` data bytes and maps the whole thing.
+    fn from_file(file: File, path: PathBuf, byte_len: usize) -> io::Result<Self> {
+        let total = Self::total_len(byte_len)?;
+        if file.metadata()?.len() < total {
+            file.set_len(total)?;
+        }
+        let map = Self::map(&file, total)?;
+        Ok(Self { map, file, path })
+    }
+
+    /// `DATA_OFFSET + byte_len`, refusing an overflowing request.
+    fn total_len(byte_len: usize) -> io::Result<u64> {
+        let total = byte_len.checked_add(DATA_OFFSET).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vector arena size overflows usize",
+            )
+        })?;
+        u64::try_from(total).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vector arena size overflows u64",
+            )
+        })
+    }
+
+    /// Maps `total` bytes of `file` for read and write.
+    fn map(file: &File, total: u64) -> io::Result<MmapMut> {
+        let len = usize::try_from(total).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vector arena size exceeds this target's address space",
+            )
+        })?;
+        // SAFETY: `MmapMut::map_mut` requires a file that stays valid for the
+        // mapping's lifetime and is not concurrently truncated.
+        // - Condition 1: `file` is owned by the returned `FileArena`, so it
+        //   outlives every use of the mapping.
+        // - Condition 2: the file was just sized to at least `len` bytes, and
+        //   this type only ever grows it — never truncates.
+        // - Condition 3: the file is open for both read and write, which
+        //   `map_mut` requires.
+        // SAFETY: Map the arena's backing file into the address space.
+        let map = unsafe { MmapOptions::new().len(len).map_mut(file) }?;
+        Ok(map)
+    }
+
+    /// Pointer to the first f32 of the data region.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`io::ErrorKind::InvalidData`] if the mapping is somehow
+    /// shorter than the header, which would mean the file was truncated
+    /// underneath us.
+    // Reason: no structural fix exists — the cast is the point of the
+    // function. The alignment it warns about is *proven* here rather than
+    // assumed: an mmap base is page-aligned by the kernel and `DATA_OFFSET`
+    // is a whole page, so the result is 4096-byte aligned, far beyond f32's
+    // 4. (The arena would be sound even misaligned: every SIMD kernel in this
+    // crate loads unaligned.)
+    #[allow(clippy::cast_ptr_alignment)]
+    pub(crate) fn data_ptr(&mut self) -> io::Result<NonNull<f32>> {
+        if self.map.len() < DATA_OFFSET {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "vector arena mapping is shorter than its header",
+            ));
+        }
+        // SAFETY: `add` requires the result to stay inside the allocation.
+        // - Condition 1: the length check above proves `DATA_OFFSET` is within
+        //   the mapping.
+        // - Condition 2: `as_mut_ptr` returns the mapping's base, which is
+        //   non-null and page-aligned, so the offset pointer is non-null and
+        //   at least 4096-byte aligned.
+        // SAFETY: Address the data region that follows the reserved header.
+        let ptr = unsafe { self.map.as_mut_ptr().add(DATA_OFFSET) };
+        NonNull::new(ptr.cast::<f32>()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "vector arena mapping produced a null data pointer",
+            )
+        })
+    }
+
+    /// Grows the mapping so the data region holds at least `byte_len` bytes.
+    ///
+    /// Ordering is load-bearing: the file is extended and the replacement
+    /// mapping established **before** the old one is dropped, so a failure at
+    /// any step leaves the existing mapping — and therefore every live pointer
+    /// into it — untouched. Growing never copies: the pages already written
+    /// stay where they are.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from sizing or re-mapping the file. On error the
+    /// arena is unchanged and still usable.
+    pub(crate) fn grow(&mut self, byte_len: usize) -> io::Result<()> {
+        let total = Self::total_len(byte_len)?;
+        if self.map.len() as u64 >= total {
+            return Ok(());
+        }
+        self.file.set_len(total)?;
+        let fresh = Self::map(&self.file, total)?;
+        // Only now is the old mapping released.
+        self.map = fresh;
+        Ok(())
+    }
+
+    /// Flushes dirty pages to the backing file.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the underlying `msync`.
+    pub(crate) fn flush(&self) -> io::Result<()> {
+        self.map.flush()
+    }
+
+    /// The file this arena is mapped from.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::fmt::Debug for FileArena {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileArena")
+            .field("path", &self.path)
+            .field("mapped_bytes", &self.map.len())
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -74,6 +74,14 @@ pub(crate) const DATA_OFFSET: usize = 4096;
 ///   inline in this struct, so moving a `FileArena` does **not** move the
 ///   bytes. That is what makes it sound for `ContiguousVectors` to hold a
 ///   `NonNull` into the mapping while also owning the `FileArena`.
+/// - **This process holds an exclusive advisory lock on `file`, and no second
+///   `FileArena` can map the same path.** This one is not a nicety: an
+///   anonymous allocation is unique because the allocator says so, but a path
+///   is not, and two arenas over one file would be two `&mut [f32]` aliases of
+///   the same bytes — undefined behaviour that `ContiguousVectors`'
+///   `unsafe impl Send`/`Sync` would then carry across threads. The lock is
+///   what makes the uniqueness those impls assume actually true, so it is
+///   taken before the mapping and released only when `file` closes.
 /// - `path` is kept for diagnostics and for reopening after a grow.
 pub(crate) struct FileArena {
     map: MmapMut,
@@ -115,13 +123,40 @@ impl FileArena {
     }
 
     /// Sizes `file` to hold `byte_len` data bytes and maps the whole thing.
+    ///
+    /// Locks before mapping: a second holder must be refused while the bytes
+    /// are still unmapped, not after two aliases already exist.
     fn from_file(file: File, path: PathBuf, byte_len: usize) -> io::Result<Self> {
+        Self::lock_exclusive(&file, &path)?;
         let total = Self::total_len(byte_len)?;
         if file.metadata()?.len() < total {
             file.set_len(total)?;
         }
         let map = Self::map(&file, total)?;
         Ok(Self { map, file, path })
+    }
+
+    /// Claims the file for this arena alone.
+    ///
+    /// `flock` associates the lock with the open file description, so a second
+    /// `File` opened on the same path — in this process or another — is
+    /// refused rather than silently granted a second mapping.
+    ///
+    /// # Errors
+    ///
+    /// [`io::ErrorKind::WouldBlock`], naming the path, when another holder has
+    /// it. Callers surface that as a locked-resource error, not a retry.
+    fn lock_exclusive(file: &File, path: &Path) -> io::Result<()> {
+        fs2::FileExt::try_lock_exclusive(file).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::WouldBlock,
+                format!(
+                    "vector arena {} is already mapped by another holder; \
+                     mapping it twice would alias the same bytes mutably ({e})",
+                    path.display()
+                ),
+            )
+        })
     }
 
     /// `DATA_OFFSET + byte_len`, refusing an overflowing request.

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -279,3 +279,67 @@ fn a_second_arena_over_the_same_file_is_refused() {
     drop(first);
     drop(ContiguousVectors::new_file_backed(&path, 8, 16).expect("reopen after release"));
 }
+
+/// A refused second arena must not have already destroyed the first's bytes.
+///
+/// The hazard is ordering, not aliasing: `create` used to pass
+/// `truncate(true)` to `OpenOptions`, which empties the file at open time —
+/// *before* the exclusive lock is taken. A call destined to be refused had
+/// therefore already discarded the bytes the winning arena was mapping, and
+/// that arena's mapping then addressed pages past a shrunken end of file,
+/// where a read raises `SIGBUS`. The lock existed precisely to stop a second
+/// holder touching these bytes, and the truncate flag walked around it.
+///
+/// This test failed with `signal: 7, SIGBUS` before the fix, which is why it
+/// asserts on the *first* arena rather than on the refusal alone: refusing
+/// correctly while having already destroyed the file is the bug.
+#[test]
+fn a_refused_second_arena_leaves_the_first_intact() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("trunc.arena");
+    let dimension = 4;
+    let mut first = ContiguousVectors::new_file_backed(&path, dimension, 16).expect("first arena");
+    let written = fill(&mut first, 8, dimension);
+
+    let err = ContiguousVectors::new_file_backed(&path, dimension, 16)
+        .expect_err("a second mapping of the same file must be refused");
+    assert!(
+        matches!(err, crate::error::Error::DatabaseLocked(_)),
+        "expected a locked-resource error, got: {err:?}"
+    );
+
+    // Reading through the surviving mapping is the assertion: if the refused
+    // call had resized the file, this faults instead of comparing.
+    assert_contents(&first, &written);
+}
+
+/// Creating over a stale file still yields a zeroed arena.
+///
+/// Moving the discard out of `OpenOptions` and under the lock must not lose
+/// the guarantee it provided: `create` starts from zeros, never from whatever
+/// a previous, larger arena left behind.
+#[test]
+fn creating_over_an_existing_file_discards_its_contents() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("stale.arena");
+    let dimension = 4;
+
+    {
+        let mut old = ContiguousVectors::new_file_backed(&path, dimension, 64).expect("first");
+        fill(&mut old, 64, dimension);
+        old.flush_backing().expect("flush");
+    }
+
+    let mut fresh = ContiguousVectors::new_file_backed(&path, dimension, 16).expect("recreate");
+    fresh
+        .insert_at(8, &vector(dimension, 8))
+        .expect("insert_at");
+
+    for gap in [0_usize, 7] {
+        assert_eq!(
+            fresh.get(gap).expect("gap slot present"),
+            vec![0.0_f32; dimension].as_slice(),
+            "slot {gap} must be zeroed, not carried over from the old arena"
+        );
+    }
+}

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -195,3 +195,60 @@ fn reorder_moves_a_mapped_arena_onto_the_heap() {
     // wrong backing would fault or corrupt the allocator under Miri/ASan.
     drop(storage);
 }
+
+/// The mapped data pointer is f32-aligned — a soundness invariant, not a
+/// preference.
+///
+/// `ContiguousVectors` hands out `&[f32]` via `slice::from_raw_parts`, whose
+/// contract requires alignment. A misaligned arena would be undefined
+/// behaviour at the first `get`, not merely slow, so this is pinned rather
+/// than left to the arithmetic in `DATA_OFFSET`.
+#[test]
+fn mapped_data_pointer_is_aligned_for_f32_slices() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 3; // odd, so a stride bug cannot hide behind a power of two
+    let mut storage =
+        ContiguousVectors::new_file_backed(&dir.path().join("al.arena"), dimension, 16)
+            .expect("file arena");
+    fill(&mut storage, 40, dimension); // forces a re-map partway through
+
+    let addr = storage.as_flat_slice().as_ptr() as usize;
+    assert_eq!(
+        addr % std::mem::align_of::<f32>(),
+        0,
+        "data pointer {addr:#x} must satisfy from_raw_parts' alignment contract"
+    );
+    assert_eq!(
+        addr % DATA_OFFSET,
+        0,
+        "data region should start on the page boundary DATA_OFFSET promises"
+    );
+}
+
+/// An arena file is native-endian, so a round-trip through it is only
+/// meaningful on one machine.
+///
+/// Pins the constraint the module documents: the bytes are the arena, not a
+/// converted interchange form. On a little-endian target the mapped bytes
+/// therefore match `f32::to_le_bytes`; the assertion is written so it states
+/// what it depends on rather than silently assuming it.
+#[test]
+#[cfg(target_endian = "little")]
+fn arena_bytes_are_the_raw_native_representation() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("e.arena");
+    let dimension = 2;
+    let mut storage = ContiguousVectors::new_file_backed(&path, dimension, 16).expect("file arena");
+    storage.push(&[1.5_f32, -2.25]).expect("push");
+    storage.flush_backing().expect("flush");
+
+    let raw = std::fs::read(&path).expect("read arena file");
+    let data = &raw[DATA_OFFSET..DATA_OFFSET + 8];
+    let mut expected = Vec::new();
+    expected.extend_from_slice(&1.5_f32.to_le_bytes());
+    expected.extend_from_slice(&(-2.25_f32).to_le_bytes());
+    assert_eq!(
+        data, expected,
+        "the data region is the f32 values themselves, unconverted"
+    );
+}

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -267,9 +267,11 @@ fn a_second_arena_over_the_same_file_is_refused() {
 
     let err = ContiguousVectors::new_file_backed(&path, 8, 16)
         .expect_err("a second mapping of the same file must be refused");
+    // A held arena is a locked resource, not an I/O mishap: the caller can
+    // tell "someone else has this" from "the disk is full".
     assert!(
-        err.to_string().contains("already mapped"),
-        "error should explain the aliasing hazard, got: {err}"
+        matches!(err, crate::error::Error::DatabaseLocked(ref p) if p.contains("excl.arena")),
+        "a refused lock should surface as DatabaseLocked naming the path, got: {err:?}"
     );
 
     // Releasing the first frees the file for a later holder — the lock is

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -252,3 +252,28 @@ fn arena_bytes_are_the_raw_native_representation() {
         "the data region is the f32 values themselves, unconverted"
     );
 }
+
+/// A second arena over the same file is refused.
+///
+/// This is the invariant the `unsafe impl Send`/`Sync` on `ContiguousVectors`
+/// depend on. A heap arena is unique because the allocator says so; a path is
+/// not, and two mappings of one file are two `&mut [f32]` aliases of the same
+/// bytes. Enforcing it beats documenting it, so the second open fails.
+#[test]
+fn a_second_arena_over_the_same_file_is_refused() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("excl.arena");
+    let first = ContiguousVectors::new_file_backed(&path, 8, 16).expect("first arena");
+
+    let err = ContiguousVectors::new_file_backed(&path, 8, 16)
+        .expect_err("a second mapping of the same file must be refused");
+    assert!(
+        err.to_string().contains("already mapped"),
+        "error should explain the aliasing hazard, got: {err}"
+    );
+
+    // Releasing the first frees the file for a later holder — the lock is
+    // scoped to the arena's life, not to the process.
+    drop(first);
+    drop(ContiguousVectors::new_file_backed(&path, 8, 16).expect("reopen after release"));
+}

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -1,0 +1,197 @@
+//! Contracts for the file-backed vector arena (#2112 Phase B).
+//!
+//! The arena's whole claim is that it is *indistinguishable* from the
+//! anonymous one apart from where its bytes live. These tests are written as
+//! equivalence checks against a heap-backed arena wherever a behaviour is
+//! shared, and only assert file-specific facts (the backing survives growth,
+//! the bytes reach disk) where there is nothing to compare against.
+
+use crate::contiguous_file_arena::DATA_OFFSET;
+use crate::perf_optimizations::ContiguousVectors;
+use tempfile::tempdir;
+
+/// Deterministic vector so a failure names the slot, not a random seed.
+///
+/// Values are built from `u16` and widened losslessly, so the assertions
+/// compare exact floats rather than whatever a `usize as f32` cast rounded to.
+fn vector(dimension: usize, seed: usize) -> Vec<f32> {
+    (0..dimension)
+        .map(|d| {
+            let raw = u16::try_from((seed * dimension + d) % 65_536).expect("fits u16");
+            f32::from(raw)
+        })
+        .collect()
+}
+
+/// Fills `storage` with `n` vectors and returns what was written.
+fn fill(storage: &mut ContiguousVectors, n: usize, dimension: usize) -> Vec<Vec<f32>> {
+    let written: Vec<Vec<f32>> = (0..n).map(|i| vector(dimension, i)).collect();
+    for v in &written {
+        storage.push(v).expect("push");
+    }
+    written
+}
+
+/// Every slot reads back exactly what was written, in order.
+fn assert_contents(storage: &ContiguousVectors, expected: &[Vec<f32>]) {
+    assert_eq!(storage.len(), expected.len(), "vector count");
+    for (i, want) in expected.iter().enumerate() {
+        assert_eq!(
+            storage.get(i).expect("slot present"),
+            want.as_slice(),
+            "slot {i} content"
+        );
+    }
+}
+
+/// A file-backed arena stores and returns vectors like the heap one.
+#[test]
+fn file_backed_matches_heap_backed_contents() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 32;
+
+    let mut heap = ContiguousVectors::new(dimension, 16).expect("heap arena");
+    let mut mapped = ContiguousVectors::new_file_backed(&dir.path().join("a.arena"), dimension, 16)
+        .expect("file arena");
+
+    let written = fill(&mut mapped, 40, dimension);
+    for v in &written {
+        heap.push(v).expect("push");
+    }
+
+    assert_contents(&mapped, &written);
+    assert_eq!(
+        mapped.as_flat_slice(),
+        heap.as_flat_slice(),
+        "the two backings must produce byte-identical arenas"
+    );
+}
+
+/// Growth past the initial capacity must re-map without losing a byte.
+///
+/// This is the path where the two backings genuinely differ: the heap arena
+/// copies into a bigger block, the file arena extends the file and re-maps.
+/// The pointer moves in both cases, so the contents are the contract.
+#[test]
+fn growth_preserves_every_vector_across_remap() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 8;
+    let mut storage =
+        ContiguousVectors::new_file_backed(&dir.path().join("g.arena"), dimension, 16)
+            .expect("file arena");
+    assert_eq!(storage.capacity(), 16, "starts at the requested capacity");
+
+    // 500 vectors forces several doublings past the initial 16.
+    let written = fill(&mut storage, 500, dimension);
+    assert!(
+        storage.capacity() >= 500,
+        "capacity must have grown, got {}",
+        storage.capacity()
+    );
+    assert_contents(&storage, &written);
+}
+
+/// A grown arena's freshly appended range reads as zeros.
+///
+/// `insert_at` may leave gaps, and relies on the anonymous backing's
+/// `alloc_zeroed` guarantee. An extended file must offer the same.
+#[test]
+fn grown_region_is_zero_filled() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 4;
+    let mut storage =
+        ContiguousVectors::new_file_backed(&dir.path().join("z.arena"), dimension, 16)
+            .expect("file arena");
+
+    // Write far past the initial capacity, leaving every earlier slot untouched.
+    storage
+        .insert_at(200, &vector(dimension, 200))
+        .expect("insert_at");
+
+    for gap in [0_usize, 1, 99, 199] {
+        assert_eq!(
+            storage.get(gap).expect("gap slot present"),
+            vec![0.0_f32; dimension].as_slice(),
+            "slot {gap} must be zero-filled, not uninitialised"
+        );
+    }
+}
+
+/// Reopening the file yields the same vectors, without deserialization.
+#[test]
+fn reopening_the_file_recovers_the_arena() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("r.arena");
+    let dimension = 16;
+    let count = 50;
+
+    let written = {
+        let mut storage =
+            ContiguousVectors::new_file_backed(&path, dimension, 64).expect("file arena");
+        let written = fill(&mut storage, count, dimension);
+        storage.flush_backing().expect("flush");
+        written
+    };
+
+    let reopened =
+        ContiguousVectors::open_file_backed(&path, dimension, 64, count).expect("reopen");
+    assert_contents(&reopened, &written);
+}
+
+/// The data region starts a page in, so the file carries its reserved header.
+#[test]
+fn file_reserves_a_page_before_the_data_region() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("h.arena");
+    let dimension = 8;
+    let mut storage = ContiguousVectors::new_file_backed(&path, dimension, 16).expect("file arena");
+    fill(&mut storage, 16, dimension);
+    storage.flush_backing().expect("flush");
+
+    let len = std::fs::metadata(&path).expect("metadata").len();
+    let data_bytes = (16 * dimension * std::mem::size_of::<f32>()) as u64;
+    assert_eq!(
+        len,
+        DATA_OFFSET as u64 + data_bytes,
+        "file is a reserved page followed by exactly the vector bytes"
+    );
+}
+
+/// `open_file_backed` refuses a count that cannot fit the declared capacity.
+#[test]
+fn open_refuses_a_count_beyond_capacity() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("bad.arena");
+    let dimension = 4;
+    drop(ContiguousVectors::new_file_backed(&path, dimension, 16).expect("file arena"));
+
+    let err = ContiguousVectors::open_file_backed(&path, dimension, 16, 17)
+        .expect_err("count > capacity must be refused");
+    assert!(
+        err.to_string().contains("exceeds capacity"),
+        "error should name the violated bound, got: {err}"
+    );
+}
+
+/// Reordering a file-backed arena moves it onto the heap and frees the map.
+///
+/// The dangerous shape this pins: `reorder` allocates a fresh heap buffer and
+/// deallocates the old one. If the backing were not switched first, that
+/// `dealloc` would be handed a mapped pointer.
+#[test]
+fn reorder_moves_a_mapped_arena_onto_the_heap() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 4;
+    let mut storage =
+        ContiguousVectors::new_file_backed(&dir.path().join("o.arena"), dimension, 16)
+            .expect("file arena");
+    let written = fill(&mut storage, 4, dimension);
+
+    storage.reorder(&[3, 2, 1, 0]).expect("reorder");
+
+    let expected: Vec<Vec<f32>> = written.iter().rev().cloned().collect();
+    assert_contents(&storage, &expected);
+    // Dropping here exercises the heap path on a formerly mapped arena; a
+    // wrong backing would fault or corrupt the allocator under Miri/ASan.
+    drop(storage);
+}

--- a/crates/velesdb-core/src/contiguous_ops.rs
+++ b/crates/velesdb-core/src/contiguous_ops.rs
@@ -3,7 +3,7 @@
 //! Extracted from `perf_optimizations.rs` to reduce NLOC.
 //! Contains reorder permutation, dot-product batching, Drop, and free SIMD helpers.
 
-use super::perf_optimizations::ContiguousVectors;
+use super::perf_optimizations::{ArenaBacking, ContiguousVectors};
 use std::alloc::dealloc;
 use std::ptr::{self, NonNull};
 
@@ -64,16 +64,33 @@ impl ContiguousVectors {
         // Transfer ownership — guard will not free on drop
         let _ = guard.into_raw();
 
-        // Deallocate old buffer
-        let old_layout = Self::layout(self.dimension, self.capacity)?;
-        // SAFETY: self.data was allocated with old_layout, is non-null (NonNull invariant).
-        // - Condition 1: old_layout matches the allocation parameters.
-        // - Condition 2: Pointer is non-null per NonNull invariant.
-        // SAFETY: Free old buffer after data migration to reordered buffer.
-        unsafe { dealloc(self.data.as_ptr().cast::<u8>(), old_layout) };
+        self.adopt_reordered_buffer(new_ptr)
+    }
+
+    /// Installs the freshly reordered heap buffer and releases the old one.
+    ///
+    /// Reordering always lands the arena on the heap, so a file-mapped arena
+    /// changes backing here. Taking the old backing out *first* is what keeps
+    /// a mapped pointer away from `dealloc`: only a `Heap` predecessor
+    /// reaches the allocator, and a `FileMapped` one is released by dropping
+    /// it (#2112).
+    fn adopt_reordered_buffer(&mut self, new_ptr: NonNull<f32>) -> crate::error::Result<()> {
+        let previous = std::mem::replace(&mut self.backing, ArenaBacking::Heap);
+        let old_data = self.data;
+        let old_capacity = self.capacity;
 
         self.data = new_ptr;
         self.capacity = self.count;
+
+        if previous.is_heap() {
+            let old_layout = Self::layout(self.dimension, old_capacity)?;
+            // SAFETY: `old_data` was allocated with `old_layout` and is non-null
+            // (NonNull invariant).
+            // - Condition 1: the `is_heap` branch proves the allocator owns it.
+            // - Condition 2: `old_layout` matches its allocation parameters.
+            // SAFETY: Free the pre-reorder buffer now that its data has moved.
+            unsafe { dealloc(old_data.as_ptr().cast::<u8>(), old_layout) };
+        }
         Ok(())
     }
 
@@ -143,6 +160,14 @@ impl ContiguousVectors {
 
 impl Drop for ContiguousVectors {
     fn drop(&mut self) {
+        // A file-mapped arena's bytes belong to the mapping, not the
+        // allocator: releasing them is dropping `backing`, which happens on
+        // its own after this. Handing that pointer to `dealloc` would be
+        // undefined behaviour, so the backing is checked before anything else
+        // in this function touches the allocator (#2112).
+        if !self.backing.is_heap() {
+            return;
+        }
         // EPIC-032/US-002: No null check needed - NonNull guarantees non-null
         // Layout was valid at construction; it must still be valid at drop.
         let Ok(layout) = Self::layout(self.dimension, self.capacity) else {

--- a/crates/velesdb-core/src/contiguous_ops.rs
+++ b/crates/velesdb-core/src/contiguous_ops.rs
@@ -18,6 +18,24 @@ impl ContiguousVectors {
     /// position `i` after reordering. The permutation must have exactly
     /// `self.len()` elements and every index must be `< self.len()`.
     ///
+    /// # A file-backed arena is demoted to the heap
+    ///
+    /// Reordering copies into a fresh heap buffer, so an arena that was
+    /// file-mapped **stops being file-mapped here**: its mapping is released,
+    /// its exclusive lock with it, and the file is left on disk holding the
+    /// pre-reorder bytes. Two consequences a caller has to know about:
+    ///
+    /// - The pages stop being evictable, which is the property the mapped
+    ///   backing existed for (#2112). A quantized index that reorders is back
+    ///   to `f32 + graph + codes` resident.
+    /// - [`flush_backing`](Self::flush_backing) becomes a no-op that still
+    ///   returns `Ok`, because there is no longer a mapping to flush.
+    ///
+    /// This is stated rather than fixed because no production path takes a
+    /// file-backed arena yet; preserving the backing across a reorder costs a
+    /// second copy and belongs with the wiring that gives it a caller, where
+    /// it can be measured. Whoever does that wiring owns this.
+    ///
     /// # Errors
     ///
     /// Returns an error if:

--- a/crates/velesdb-core/src/contiguous_resize.rs
+++ b/crates/velesdb-core/src/contiguous_resize.rs
@@ -67,9 +67,15 @@ impl ContiguousVectors {
             return Ok(());
         }
 
+        // Matching here rather than asking `is_heap` and re-destructuring in a
+        // helper: this way the mapped branch *has* the arena, so there is no
+        // "called on a heap-backed arena" state left to report at runtime.
         #[cfg(feature = "persistence")]
-        if !self.backing.is_heap() {
-            return self.resize_file_backed(new_capacity);
+        if let crate::perf_optimizations::ArenaBacking::FileMapped(ref mut arena) = self.backing {
+            let byte_len = Self::byte_size(self.dimension, new_capacity)?;
+            self.data = Self::grow_mapped(arena, byte_len)?;
+            self.capacity = new_capacity;
+            return Ok(());
         }
 
         let old_layout = Self::layout(self.dimension, self.capacity)?;
@@ -92,7 +98,7 @@ impl ContiguousVectors {
         Ok(())
     }
 
-    /// Grows a file-backed arena by extending and re-mapping its file.
+    /// Grows a mapped arena's file and returns the pointer to its data.
     ///
     /// No copy happens: the bytes already written keep their place on disk and
     /// the kernel hands back a mapping that covers more of the same file. The
@@ -102,6 +108,11 @@ impl ContiguousVectors {
     /// The freshly appended range reads as zeros, matching the `alloc_zeroed`
     /// guarantee `insert_at` depends on when it leaves gaps.
     ///
+    /// Takes the arena rather than `&mut self` so the heap case is not
+    /// representable: there is no branch here to get wrong, and the returned
+    /// pointer is the only thing the caller has to install. Growing re-maps,
+    /// so the caller's old address is stale and this value replaces it.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::AllocationFailed`] if the file cannot be extended or
@@ -109,25 +120,16 @@ impl ContiguousVectors {
     ///
     /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
     #[cfg(feature = "persistence")]
-    fn resize_file_backed(&mut self, new_capacity: usize) -> crate::error::Result<()> {
-        use crate::perf_optimizations::ArenaBacking;
-
-        let byte_len = Self::byte_size(self.dimension, new_capacity)?;
-        let ArenaBacking::FileMapped(ref mut arena) = self.backing else {
-            return Err(crate::error::Error::Internal(
-                "resize_file_backed called on a heap-backed arena".to_string(),
-            ));
-        };
+    fn grow_mapped(
+        arena: &mut crate::contiguous_file_arena::FileArena,
+        byte_len: usize,
+    ) -> crate::error::Result<std::ptr::NonNull<f32>> {
         arena.grow(byte_len).map_err(|e| {
             crate::error::Error::AllocationFailed(format!(
                 "failed to grow the file-backed vector arena to {byte_len} bytes: {e}"
             ))
         })?;
-        // Growing re-maps, so the old address is stale; `grow` refreshed the
-        // arena's own pointer and this reads it back.
-        self.data = arena.data_ptr();
-        self.capacity = new_capacity;
-        Ok(())
+        Ok(arena.data_ptr())
     }
 
     /// Allocates a new buffer and copies existing data into it.

--- a/crates/velesdb-core/src/contiguous_resize.rs
+++ b/crates/velesdb-core/src/contiguous_resize.rs
@@ -67,6 +67,7 @@ impl ContiguousVectors {
             return Ok(());
         }
 
+        #[cfg(feature = "persistence")]
         if !self.backing.is_heap() {
             return self.resize_file_backed(new_capacity);
         }
@@ -122,36 +123,11 @@ impl ContiguousVectors {
                 "failed to grow the file-backed vector arena to {byte_len} bytes: {e}"
             ))
         })?;
-        // Re-derive the pointer: growing re-maps, so the old address is stale.
-        let data = arena.data_ptr().map_err(|e| {
-            crate::error::Error::AllocationFailed(format!(
-                "grown vector arena produced no usable data pointer: {e}"
-            ))
-        })?;
-        self.data = data;
+        // Growing re-maps, so the old address is stale; `grow` refreshed the
+        // arena's own pointer and this reads it back.
+        self.data = arena.data_ptr();
         self.capacity = new_capacity;
         Ok(())
-    }
-
-    /// Without `persistence` there is no file-backed variant to grow.
-    ///
-    /// [`ArenaBacking::Heap`] is then the only constructible backing, so this
-    /// is unreachable rather than merely unused — it exists to keep `resize`
-    /// free of `cfg` noise.
-    ///
-    /// [`ArenaBacking::Heap`]: crate::perf_optimizations::ArenaBacking::Heap
-    ///
-    /// # Errors
-    ///
-    /// Always returns [`Error::Internal`].
-    ///
-    /// [`Error::Internal`]: crate::error::Error::Internal
-    #[cfg(not(feature = "persistence"))]
-    #[allow(clippy::unnecessary_wraps)]
-    fn resize_file_backed(&mut self, _new_capacity: usize) -> crate::error::Result<()> {
-        Err(crate::error::Error::Internal(
-            "file-backed vector arenas require the persistence feature".to_string(),
-        ))
     }
 
     /// Allocates a new buffer and copies existing data into it.

--- a/crates/velesdb-core/src/contiguous_resize.rs
+++ b/crates/velesdb-core/src/contiguous_resize.rs
@@ -67,6 +67,10 @@ impl ContiguousVectors {
             return Ok(());
         }
 
+        if !self.backing.is_heap() {
+            return self.resize_file_backed(new_capacity);
+        }
+
         let old_layout = Self::layout(self.dimension, self.capacity)?;
         let new_layout = Self::layout(self.dimension, new_capacity)?;
 
@@ -85,6 +89,69 @@ impl ContiguousVectors {
         self.data = new_data;
         self.capacity = new_capacity;
         Ok(())
+    }
+
+    /// Grows a file-backed arena by extending and re-mapping its file.
+    ///
+    /// No copy happens: the bytes already written keep their place on disk and
+    /// the kernel hands back a mapping that covers more of the same file. The
+    /// heap path cannot do this — it must `memcpy` the whole arena into a
+    /// larger block — so growth is strictly cheaper here.
+    ///
+    /// The freshly appended range reads as zeros, matching the `alloc_zeroed`
+    /// guarantee `insert_at` depends on when it leaves gaps.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::AllocationFailed`] if the file cannot be extended or
+    /// re-mapped. The arena is left untouched and usable in that case.
+    ///
+    /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
+    #[cfg(feature = "persistence")]
+    fn resize_file_backed(&mut self, new_capacity: usize) -> crate::error::Result<()> {
+        use crate::perf_optimizations::ArenaBacking;
+
+        let byte_len = Self::byte_size(self.dimension, new_capacity)?;
+        let ArenaBacking::FileMapped(ref mut arena) = self.backing else {
+            return Err(crate::error::Error::Internal(
+                "resize_file_backed called on a heap-backed arena".to_string(),
+            ));
+        };
+        arena.grow(byte_len).map_err(|e| {
+            crate::error::Error::AllocationFailed(format!(
+                "failed to grow the file-backed vector arena to {byte_len} bytes: {e}"
+            ))
+        })?;
+        // Re-derive the pointer: growing re-maps, so the old address is stale.
+        let data = arena.data_ptr().map_err(|e| {
+            crate::error::Error::AllocationFailed(format!(
+                "grown vector arena produced no usable data pointer: {e}"
+            ))
+        })?;
+        self.data = data;
+        self.capacity = new_capacity;
+        Ok(())
+    }
+
+    /// Without `persistence` there is no file-backed variant to grow.
+    ///
+    /// [`ArenaBacking::Heap`] is then the only constructible backing, so this
+    /// is unreachable rather than merely unused — it exists to keep `resize`
+    /// free of `cfg` noise.
+    ///
+    /// [`ArenaBacking::Heap`]: crate::perf_optimizations::ArenaBacking::Heap
+    ///
+    /// # Errors
+    ///
+    /// Always returns [`Error::Internal`].
+    ///
+    /// [`Error::Internal`]: crate::error::Error::Internal
+    #[cfg(not(feature = "persistence"))]
+    #[allow(clippy::unnecessary_wraps)]
+    fn resize_file_backed(&mut self, _new_capacity: usize) -> crate::error::Result<()> {
+        Err(crate::error::Error::Internal(
+            "file-backed vector arenas require the persistence feature".to_string(),
+        ))
     }
 
     /// Allocates a new buffer and copies existing data into it.

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -99,6 +99,12 @@ mod config_tests;
 mod config_validation;
 /// Cross-implementation conformance harness (frozen golden reference vectors).
 pub mod conformance;
+/// File-backed storage for the vector arena (`persistence` only).
+#[cfg(feature = "persistence")]
+pub mod contiguous_file_arena;
+#[cfg(all(test, feature = "persistence"))]
+#[path = "contiguous_file_arena_tests.rs"]
+mod contiguous_file_arena_tests;
 pub mod contiguous_ops;
 mod contiguous_resize;
 pub mod distance;

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -292,7 +292,12 @@ impl ContiguousVectors {
 
     /// Flushes a file-backed arena's dirty pages to disk.
     ///
-    /// A no-op on a heap-backed arena, which has no file to reach.
+    /// A no-op on a heap-backed arena, which has no file to reach. Note that
+    /// this includes an arena that *used* to be file-backed: [`reorder`] moves
+    /// one onto the heap, after which this returns `Ok` without writing
+    /// anything. Call it before reordering, not after.
+    ///
+    /// [`reorder`]: Self::reorder
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -17,6 +17,8 @@
 //! eliminating null pointer checks and making invariants explicit. Memory is managed
 //! via RAII with `AllocGuard` for panic-safe resize operations.
 
+#[cfg(feature = "persistence")]
+use crate::contiguous_file_arena::ExistingBytes;
 use crate::validation::{validate_dimension, validate_dimension_match};
 use std::alloc::{alloc_zeroed, Layout};
 use std::fmt;
@@ -187,8 +189,9 @@ impl ContiguousVectors {
     /// them. That is what lets a quantized index hold `codes + graph`
     /// resident and page the f32 in only to re-rank (#2112).
     ///
-    /// `path` is created or truncated: the caller owns the file's lifetime.
-    /// Use [`open_file_backed`](Self::open_file_backed) to adopt a file whose
+    /// `path` is created if absent, and whatever it held is discarded — under
+    /// the arena's exclusive lock, never at open time. Use
+    /// [`open_file_backed`](Self::open_file_backed) to adopt a file whose
     /// contents are already the arena.
     ///
     /// # Errors
@@ -206,7 +209,7 @@ impl ContiguousVectors {
         dimension: usize,
         capacity: usize,
     ) -> crate::error::Result<Self> {
-        Self::file_backed(path, dimension, capacity, true)
+        Self::file_backed(path, dimension, capacity, ExistingBytes::Discard)
     }
 
     /// Adopts an existing file as the arena without truncating it.
@@ -232,7 +235,7 @@ impl ContiguousVectors {
                 "vector arena count {count} exceeds capacity {capacity}"
             )));
         }
-        let mut storage = Self::file_backed(path, dimension, capacity, false)?;
+        let mut storage = Self::file_backed(path, dimension, capacity, ExistingBytes::Keep)?;
         storage.count = count;
         Ok(storage)
     }
@@ -243,7 +246,7 @@ impl ContiguousVectors {
         path: &std::path::Path,
         dimension: usize,
         capacity: usize,
-        truncate: bool,
+        existing: ExistingBytes,
     ) -> crate::error::Result<Self> {
         use crate::contiguous_file_arena::FileArena;
 
@@ -252,10 +255,9 @@ impl ContiguousVectors {
         let byte_len = Self::byte_size(dimension, capacity)?;
         crate::alloc_guard::check_alloc_bound(byte_len)?;
 
-        let arena = if truncate {
-            FileArena::create(path, byte_len)
-        } else {
-            FileArena::open(path, byte_len)
+        let arena = match existing {
+            ExistingBytes::Discard => FileArena::create(path, byte_len),
+            ExistingBytes::Keep => FileArena::open(path, byte_len),
         }
         .map_err(|e| Self::arena_open_error(path, e))?;
         let data = arena.data_ptr();

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -101,8 +101,9 @@ impl fmt::Debug for ArenaBacking {
 //   lock before mapping and holds it for the mapping's whole life — that lock
 //   is what makes this condition true rather than hoped for.
 // - Condition 2: Mutation requires `&mut self` or lock-guarded interior access.
-// - Condition 3: `MmapMut` is itself `Send`, so the mapped variant adds no
-//   thread-affinity of its own.
+// - Condition 3: the mapped variant is `Send` on its own terms — `FileArena`
+//   carries its own justified impl next to the mapping it describes, rather
+//   than being covered by this one at a distance.
 // SAFETY: Moving ownership of this container between threads is sound.
 unsafe impl Send for ContiguousVectors {}
 // SAFETY: `ContiguousVectors` is `Sync` because shared access is read-only.
@@ -251,13 +252,13 @@ impl ContiguousVectors {
         let byte_len = Self::byte_size(dimension, capacity)?;
         crate::alloc_guard::check_alloc_bound(byte_len)?;
 
-        let mut arena = if truncate {
+        let arena = if truncate {
             FileArena::create(path, byte_len)
         } else {
             FileArena::open(path, byte_len)
         }
-        .map_err(crate::error::Error::Io)?;
-        let data = arena.data_ptr().map_err(crate::error::Error::Io)?;
+        .map_err(|e| Self::arena_open_error(path, e))?;
+        let data = arena.data_ptr();
 
         Ok(Self {
             data,
@@ -266,6 +267,25 @@ impl ContiguousVectors {
             capacity,
             backing: ArenaBacking::FileMapped(Box::new(arena)),
         })
+    }
+
+    /// Classifies a failure to open an arena file.
+    ///
+    /// A refused exclusive lock means another holder has this arena, which is
+    /// a different situation from a full disk or a missing directory and the
+    /// caller can act on it differently. Collapsing both into
+    /// [`Error::Io`] would throw that away, so the lock case is surfaced as
+    /// the same locked-resource error `Database::open` uses for its data
+    /// directory.
+    ///
+    /// [`Error::Io`]: crate::error::Error::Io
+    #[cfg(feature = "persistence")]
+    fn arena_open_error(path: &std::path::Path, error: std::io::Error) -> crate::error::Error {
+        if error.kind() == std::io::ErrorKind::WouldBlock {
+            crate::error::Error::DatabaseLocked(path.display().to_string())
+        } else {
+            crate::error::Error::Io(error)
+        }
     }
 
     /// Flushes a file-backed arena's dirty pages to disk.

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -94,14 +94,22 @@ impl fmt::Debug for ArenaBacking {
     }
 }
 
-// SAFETY: `ContiguousVectors` is `Send` because it owns its allocation.
-// - Condition 1: The backing buffer is uniquely owned by the struct.
+// SAFETY: `ContiguousVectors` is `Send` because it owns its buffer outright.
+// - Condition 1: The backing buffer is uniquely owned by the struct. For
+//   `ArenaBacking::Heap` the allocator establishes that. For `FileMapped` a
+//   path is NOT unique on its own, so `FileArena` takes an exclusive advisory
+//   lock before mapping and holds it for the mapping's whole life — that lock
+//   is what makes this condition true rather than hoped for.
 // - Condition 2: Mutation requires `&mut self` or lock-guarded interior access.
+// - Condition 3: `MmapMut` is itself `Send`, so the mapped variant adds no
+//   thread-affinity of its own.
 // SAFETY: Moving ownership of this container between threads is sound.
 unsafe impl Send for ContiguousVectors {}
 // SAFETY: `ContiguousVectors` is `Sync` because shared access is read-only.
 // - Condition 1: All writes happen through methods requiring mutable or exclusive lock access.
 // - Condition 2: Returned shared slices borrow immutably and cannot mutate internal state.
+// - Condition 3: no second mapping of the same bytes can exist to write them
+//   behind those shared references — see Condition 1 of the `Send` impl.
 // SAFETY: Concurrent shared references cannot violate aliasing rules.
 unsafe impl Sync for ContiguousVectors {}
 

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -52,6 +52,46 @@ pub struct ContiguousVectors {
     pub(crate) count: usize,
     /// Allocated capacity (number of vectors)
     pub(crate) capacity: usize,
+    /// Where `data` came from, and therefore how it must be released.
+    pub(crate) backing: ArenaBacking,
+}
+
+/// How a [`ContiguousVectors`] buffer was obtained.
+///
+/// The variant decides who frees `data` — which is why it lives next to the
+/// pointer rather than being inferred at each site. Getting this wrong means
+/// calling `dealloc` on a mapping, so the enum is the invariant.
+pub(crate) enum ArenaBacking {
+    /// `alloc_zeroed` on the arena's [`Layout`], released with `dealloc`.
+    ///
+    /// The default, and the only backing available without `persistence`.
+    Heap,
+    /// A file mapping that owns the bytes; released by dropping the mapping.
+    ///
+    /// Chosen when the index wants its f32 arena evictable rather than
+    /// resident — see [`crate::contiguous_file_arena`] for why (#2112).
+    #[cfg(feature = "persistence")]
+    FileMapped(Box<crate::contiguous_file_arena::FileArena>),
+}
+
+impl ArenaBacking {
+    /// Whether this buffer must be released with `dealloc`.
+    ///
+    /// The single place that answers "is this pointer the allocator's?", so a
+    /// new variant cannot silently fall into the deallocating branch.
+    pub(crate) const fn is_heap(&self) -> bool {
+        matches!(*self, Self::Heap)
+    }
+}
+
+impl fmt::Debug for ArenaBacking {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::Heap => f.write_str("Heap"),
+            #[cfg(feature = "persistence")]
+            Self::FileMapped(ref arena) => write!(f, "FileMapped({:?})", arena.path()),
+        }
+    }
 }
 
 // SAFETY: `ContiguousVectors` is `Send` because it owns its allocation.
@@ -71,6 +111,7 @@ impl fmt::Debug for ContiguousVectors {
             .field("dimension", &self.dimension)
             .field("count", &self.count)
             .field("capacity", &self.capacity)
+            .field("backing", &self.backing)
             .finish_non_exhaustive()
     }
 }
@@ -125,7 +166,115 @@ impl ContiguousVectors {
             dimension,
             count: 0,
             capacity,
+            backing: ArenaBacking::Heap,
         })
+    }
+
+    /// Creates a `ContiguousVectors` whose buffer is a file mapping.
+    ///
+    /// The arena behaves identically to a heap-backed one — same layout, same
+    /// accessors, same zero-fill guarantee — but its pages are evictable, so
+    /// they do not count against the resident set when nothing is touching
+    /// them. That is what lets a quantized index hold `codes + graph`
+    /// resident and page the f32 in only to re-rank (#2112).
+    ///
+    /// `path` is created or truncated: the caller owns the file's lifetime.
+    /// Use [`open_file_backed`](Self::open_file_backed) to adopt a file whose
+    /// contents are already the arena.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidDimension`] if `dimension` is out of range,
+    /// [`Error::AllocationFailed`] if the size overflows or the ceiling
+    /// rejects it, and [`Error::Io`] if the file cannot be created or mapped.
+    ///
+    /// [`Error::InvalidDimension`]: crate::error::Error::InvalidDimension
+    /// [`Error::AllocationFailed`]: crate::error::Error::AllocationFailed
+    /// [`Error::Io`]: crate::error::Error::Io
+    #[cfg(feature = "persistence")]
+    pub fn new_file_backed(
+        path: &std::path::Path,
+        dimension: usize,
+        capacity: usize,
+    ) -> crate::error::Result<Self> {
+        Self::file_backed(path, dimension, capacity, true)
+    }
+
+    /// Adopts an existing file as the arena without truncating it.
+    ///
+    /// The mapped bytes are taken as `count` already-written vectors, so this
+    /// is the load path: no deserialization, no copy, just a mapping.
+    ///
+    /// # Errors
+    ///
+    /// As [`new_file_backed`](Self::new_file_backed), plus
+    /// [`Error::Internal`] if `count` exceeds `capacity`.
+    ///
+    /// [`Error::Internal`]: crate::error::Error::Internal
+    #[cfg(feature = "persistence")]
+    pub fn open_file_backed(
+        path: &std::path::Path,
+        dimension: usize,
+        capacity: usize,
+        count: usize,
+    ) -> crate::error::Result<Self> {
+        if count > capacity {
+            return Err(crate::error::Error::Internal(format!(
+                "vector arena count {count} exceeds capacity {capacity}"
+            )));
+        }
+        let mut storage = Self::file_backed(path, dimension, capacity, false)?;
+        storage.count = count;
+        Ok(storage)
+    }
+
+    /// Shared construction for the two file-backed entry points.
+    #[cfg(feature = "persistence")]
+    fn file_backed(
+        path: &std::path::Path,
+        dimension: usize,
+        capacity: usize,
+        truncate: bool,
+    ) -> crate::error::Result<Self> {
+        use crate::contiguous_file_arena::FileArena;
+
+        validate_dimension(dimension)?;
+        let capacity = capacity.max(16);
+        let byte_len = Self::byte_size(dimension, capacity)?;
+        crate::alloc_guard::check_alloc_bound(byte_len)?;
+
+        let mut arena = if truncate {
+            FileArena::create(path, byte_len)
+        } else {
+            FileArena::open(path, byte_len)
+        }
+        .map_err(crate::error::Error::Io)?;
+        let data = arena.data_ptr().map_err(crate::error::Error::Io)?;
+
+        Ok(Self {
+            data,
+            dimension,
+            count: 0,
+            capacity,
+            backing: ArenaBacking::FileMapped(Box::new(arena)),
+        })
+    }
+
+    /// Flushes a file-backed arena's dirty pages to disk.
+    ///
+    /// A no-op on a heap-backed arena, which has no file to reach.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Io`] if the underlying `msync` fails.
+    ///
+    /// [`Error::Io`]: crate::error::Error::Io
+    pub fn flush_backing(&self) -> crate::error::Result<()> {
+        #[cfg(feature = "persistence")]
+        if let ArenaBacking::FileMapped(ref arena) = self.backing {
+            arena.flush().map_err(crate::error::Error::Io)?;
+        }
+        Ok(())
     }
 
     /// Returns the buffer size in bytes for `dimension * capacity` f32s.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → **`develop`**. ✔

## Description

First step of **#2112 Phase B**, and the B1-vs-B2 decision the issue left open.

Phase B's goal is an index whose resident set is `codes + graph`, with f32 touched only to re-rank. Today the index's f32 arena is an anonymous allocation, so the kernel cannot reclaim it: a quantized index costs `f32 + graph + codes` resident — *more* than the `Full` index it was meant to shrink. Backing that arena with a file makes the pages evictable.

**This PR lands the mechanism only. No production path chooses it yet**, so behaviour is unchanged everywhere; wiring it into the quantized backends is the next PR.

### The decision: B1

The issue recommended B1 (file-backed arena) over B2 (rerank reads the collection mmap) as "minimal coupling". Reading the code turned up a stronger reason: **the on-disk format is already this memory layout.** `{basename}.vectors` is a raw little-endian f32 blob behind a 16-byte header — the arena, serialised one value at a time. The bytes on disk and the bytes in memory can be the same bytes.

And a property neither design anticipated: **growth stops copying.** The heap path must `memcpy` the whole arena into a larger block. Extending a file leaves the written pages where they are and re-maps.

### What the change is

`ContiguousVectors` gains an `ArenaBacking` recording where its buffer came from and therefore who releases it. That enum is the invariant, not a convenience: **four sites** allocate or free this pointer — `new`, `resize`, `reorder`, `Drop` — and handing a mapping to `dealloc` is undefined behaviour. The question *"is this the allocator's?"* now has one answer-site instead of four assumptions.

Deliberately unchanged: the heap path, byte for byte. `persistence` gates the file variant, so WASM and `--no-default-features` keep the only backing they can have and the module is not compiled there at all.

---

## What self-review found, in the order it found it

Four passes over my own diff. Each found something the previous one had shipped.

### 1. A claim in my own justification was false

The first commit argued the arena "would be sound even misaligned, since every SIMD kernel loads unaligned". `ContiguousVectors` hands out `&[f32]` through `slice::from_raw_parts` at five sites, and that contract requires a *properly aligned* pointer — a misaligned arena is UB at the first `get`, before any SIMD runs. The SIMD survey was accurate but answered the wrong question, and made a soundness requirement look optional; it would have invited a later edit to shrink `DATA_OFFSET` believing only throughput was at stake. Corrected in the doc and the clippy justification, pinned by a test at an odd dimension across a re-map.

The same pass found an unstated constraint: an arena file is **native-endian** — the bytes *are* the arena. Fine for an index-local, rebuildable cache, and worth recording because the neighbouring `.vectors` format does the opposite (explicit `to_le_bytes`, hence portable). **Anything that later maps that file directly must gate on `target_endian`.**

That re-sequenced the remaining work: mapping `.vectors` directly is no longer the next step, because it would trade a portable format for a native-endian one.

### 2. Uniqueness was assumed, not enforced

`ContiguousVectors`' `unsafe impl Send`/`Sync` state as their first condition that the backing buffer is *uniquely owned*. A heap allocation makes that true by construction — the allocator hands the block to exactly one owner. **A path does not.** Two arenas opened on one file would each believe they owned the bytes, giving two `&mut [f32]` aliases, and those very impls would then carry the aliases across threads.

So the file backing weakened an invariant its own safety comments rested on, while the comments still read as a proof. `FileArena` now takes an exclusive advisory lock (`fs2`, bound to the open file description) inside the single construction funnel — before the mapping exists, rather than after two aliases already do.

### 3. Idiomatic-Rust pass — six fixes, none silenced

Asking not "is it sound?" but "is this what Rust expects of it?":

- **`total_len` returned `u64`**, forcing every caller through a fallible `u64 -> usize` conversion back to the width a mapping actually has. It returns `usize`; the one `u64` this type needs exists at the file API's boundary and nowhere else.
- **`data_ptr` took `&mut self` and could fail on every call**, though the pointer is a property of the mapping, not of the call. Derived once when the mapping is established, cached, read back through an infallible `const fn data_ptr(&self)`.
- **Caching it made `FileArena` `!Send`** — which `ContiguousVectors`' blanket `unsafe impl` had been covering *at a distance*, without justifying. Caught by `clippy::non_send_fields_in_send_ty`. The fix is not an `allow`: `FileArena` carries its own `Send`/`Sync` next to the mapping it argues about, and the container delegates.
- **`grow` replaced the mapping before the pointer**, so `self.data` named a `munmap`ped region for one statement. Never dereferenced, so not UB — but a dangling pointer held for no gain. The pointer moves first.
- **A refused lock surfaced as a generic `Error::Io`.** It is now `Error::DatabaseLocked` naming the path — the same locked-resource error `Database::open` uses — and the test asserts the *kind*, not the message text.
- **Two intra-doc links did not resolve**, so rustdoc rendered them as literal text.

### 4. The lock had a hole in it — SIGBUS

The most serious finding, and it was in the fix from pass 2.

`create` passed `truncate(true)` to `OpenOptions`, so the file was emptied **at open time — before `from_file` took the lock**. A second arena destined to be refused had therefore already destroyed the bytes the first was mapping, and the first's mapping then addressed pages past a shrunken end of file. The refusal was correct and came too late to matter.

Written as a test before being fixed, to avoid arguing from theory:

```
signal: 7, SIGBUS: access to undefined memory
```

The invariant the code now states and keeps: **the lock comes first, and every step able to alter the file follows it.** Discarding is no longer an open flag but an `ExistingBytes` request carried into a new `size_locked_file`, which runs under the lock. `grow` routes through the same helper, so sizing has one implementation and the `usize -> u64` conversion exists in exactly one place. `truncate(false)` is spelled out at the open site — what `clippy::suspicious_open_options` asks for, and the honest answer rather than something to allow away.

Carrying that outward through the callers found two more impossible states worth deleting:

- `resize` asked `is_heap()` and then called a helper that re-destructured `self.backing` and returned `Error::Internal` on the arm the caller had already excluded — an untestable branch outliving whatever made it look necessary. `resize` now matches once, so the mapped branch *holds* the arena and the helper takes that arena instead of `&mut self`: the heap case is not representable.
- `file_backed` took `truncate: bool`, the same boolean trap the arena's constructors had just stopped using. `ExistingBytes` is `pub(crate)` and both layers speak it, so the call sites read `Discard`/`Keep` and the `if` becomes a match the compiler will check if a third case appears.

---

## Two things stated rather than fixed

**`reorder` demotes a mapped arena to the heap.** It copies into a fresh heap buffer and drops the mapping, so the pages stop being evictable — the one property this backing exists for — and `flush_backing` afterwards returns `Ok` without writing anything. The second is the worse of the two: a flush that silently succeeds having done nothing reads as durability the caller does not have. Both are now documented on the public methods. Preserving the backing costs a second copy and no production path takes a file-backed arena yet, so there is nothing to measure that cost against; it belongs with the wiring that gives it a caller, and the doc says so plainly enough that the wiring cannot miss it.

**Windows is unverified.** `grow` extends the file while the old mapping is live — the platform-sensitive step. This is the ordering `MmapStorage::ensure_capacity` already uses for the same operation, so the arena holds it in common with the primary storage engine rather than inventing one. Worth stating because it is not checkable here: the compatibility matrix runs `cargo check` on Windows, not `cargo test`, so **no CI job anywhere executes this crate's tests on Windows.** That gap is pre-existing and wider than this PR.

Refs #2112 (Phase B, step 1 of 3)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests

Twelve tests, written as **equivalence against a heap arena** wherever the behaviour is shared, and asserting file-specific facts only where there is nothing to compare against:

- byte-identical contents and flat slice vs a heap arena fed the same vectors;
- growth across several re-maps preserving every vector;
- the zero-fill `insert_at` depends on, on a freshly extended file;
- reopen-without-deserialising;
- the reserved page (file length is exactly `DATA_OFFSET + data`);
- a refused over-capacity count;
- `reorder` moving a mapped arena onto the heap — the shape that would otherwise hand a mapping to `dealloc`;
- the f32 alignment invariant, at an odd dimension across a re-map;
- the raw native byte representation (`#[cfg(target_endian = "little")]`, so the test states its own dependency);
- a second arena over the same path refused with `Error::DatabaseLocked`, and released when the first is dropped;
- **the refused second arena leaves the first readable** — the SIGBUS reproducer;
- **creating over a larger stale file still yields a zeroed arena** — the guarantee the open flag used to provide, now owed by the locked path.

Gates and checks:

- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- `cargo build -p velesdb-core --no-default-features` — compiles (the module is absent there).
- The existing `contiguous`/`perf_optimizations` suites pass unchanged.
- `verify_unsafe_safety_template.py --strict` over the changed production files — 0 violations. Worth noting: thanks to #2115 this gate now genuinely inspects files, and this is the first PR whose new `unsafe` blocks it has actually read.
- `check-todo-annotations.py` — clean; `check-file-budgets.py` — baseline unchanged.
- `reorder_copy` reached CCN 9 with the backing switch inline (Gate 5 is ≤ 8) and was **split rather than allowed**; `lizard -C 8 -L 50` reports no threshold exceeded across all touched files.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (module docs carry the why, the byte-order constraint, the availability rule, the lock ordering, and the reorder demotion)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none

## Unsafe Code Checklist

- [x] All `unsafe {}` blocks have `// SAFETY:` comments explaining why it's sound — each with numbered conditions, including the two `unsafe impl`s `FileArena` carries for itself
- [x] No undefined behavior possible with valid inputs — alignment is satisfied by construction (page-aligned base + whole-page offset) and pinned by a test; uniqueness is enforced by an exclusive lock, and nothing that alters the file now runs before that lock is held
- [x] Edge cases tested (empty, boundary values, alignment) — zero-fill on a grown region, over-capacity refusal, odd dimension, alignment across a re-map, a refused second holder, a refused holder that must not have already truncated
- [ ] Miri: not run here. The interesting paths are `mmap`-backed, which Miri cannot execute; the heap path it *can* check is unchanged by this PR.

## High-Risk Change Checklist

Touches audited `unsafe` memory management, so filling this in:

- [x] Invariants impacted: (a) who releases `data` — now carried by `ArenaBacking` rather than assumed at four sites; (b) the arena pointer is f32-aligned, which `from_raw_parts` requires for soundness; (c) the zero-fill guarantee `insert_at` relies on, now also owed by a freshly extended file; (d) a mapping's address is kernel-owned, so moving a `FileArena` does not move the bytes — what makes the cached `NonNull` sound; (e) unique ownership of the backing bytes, which a path cannot provide by construction, an exclusive lock now enforces, and no earlier step may pre-empt.
- [x] Crash/durability semantics: `grow` establishes the new mapping before releasing the old, so a failure leaves the arena usable; `flush_backing` exposes `msync` for callers that need durability, with its post-reorder no-op documented. No existing persistence format is touched.
- [x] Concurrency/lifecycle tests: `Drop` on a formerly mapped arena is exercised by the reorder test; growth across re-maps by the growth test; the exclusion invariant by two tests — that a second holder is refused, and that being refused costs the first holder nothing.
- [ ] 2-maintainer review — requesting via this PR.

## Additional Notes

The arena file is deliberately **not** wired to any persistence flow yet. It is index-local and rebuildable by construction, which is what makes its native-endian layout acceptable; if a later change makes it the persisted form, that property has to be re-examined, and the module doc says so.