### PR TITLE
feat(core): quantized indexes keep their f32 arena on disk

### DIFF
--- a/crates/velesdb-core/src/collection/core/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle.rs
@@ -216,7 +216,17 @@ impl Collection {
     ) -> Result<CollectionParts> {
         let vector_storage = Arc::new(RwLock::new(MmapStorage::new(&path, config.dimension)?));
         let payload_storage = Arc::new(RwLock::new(LogPayloadStorage::new(&path)?));
-        let index = Arc::new(Self::build_hnsw_index(&config, hnsw_params)?);
+        // Arena files from a run that never got to drop them are pure waste
+        // and unreadable to anyone — sweep before handing the directory out.
+        // Safe here because the database holds an exclusive lock on its data
+        // directory for as long as it is open, so no other process can be
+        // mapping one of these.
+        crate::index::hnsw::sweep_stale_arenas(&path);
+        let index = Arc::new(Self::build_hnsw_index(
+            &config,
+            hnsw_params,
+            Some(path.clone()),
+        )?);
         let text_index = Arc::new(Bm25Index::new());
         Ok(CollectionParts::new_with_empty_indexes(
             path,
@@ -238,11 +248,12 @@ impl Collection {
     fn build_hnsw_index(
         config: &CollectionConfig,
         hnsw_params: Option<crate::index::hnsw::HnswParams>,
+        arena_dir: Option<std::path::PathBuf>,
     ) -> Result<HnswIndex> {
         let mut params =
             hnsw_params.unwrap_or_else(|| crate::index::hnsw::HnswParams::auto(config.dimension));
         params.storage_mode = config.storage_mode;
-        HnswIndex::with_params(config.dimension, config.metric, params)
+        HnswIndex::with_params_in_dir(config.dimension, config.metric, params, true, arena_dir)
     }
 
     /// Rebuilds the BM25 full-text index from persisted payloads.
@@ -483,7 +494,11 @@ impl Collection {
              rebuilding from vector storage",
             wal_ids.len()
         );
-        let fresh = Self::build_hnsw_index(config, config.hnsw_params)?;
+        // Inherit the home from the index being replaced: this path has no
+        // directory of its own, and a rebuild must not silently demote a
+        // mapped arena to the heap.
+        let arena_dir = index.arena_dir.clone();
+        let fresh = Self::build_hnsw_index(config, config.hnsw_params, arena_dir)?;
         Ok((Arc::new(fresh), true))
     }
 
@@ -525,12 +540,20 @@ impl Collection {
         path: &std::path::Path,
         config: &CollectionConfig,
     ) -> Result<Arc<HnswIndex>> {
+        // Before anything claims an arena in this directory, and only here:
+        // the sweep removes every arena file it finds, so running it once a
+        // graph holds one would delete a live arena. This is the open-path
+        // twin of the sweep in `init_collection_parts` — without it, a
+        // collection that crashed would carry its orphan forever, and gain a
+        // new one on every subsequent crash.
+        crate::index::hnsw::sweep_stale_arenas(path);
         if let Some(idx) = Self::try_load_hnsw(path, config) {
             return Ok(Arc::new(idx));
         }
         Ok(Arc::new(Self::build_hnsw_index(
             config,
             config.hnsw_params,
+            Some(path.to_path_buf()),
         )?))
     }
 

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -228,7 +228,20 @@ impl FileArena {
             file.set_len(0)?;
         }
         if file.metadata()?.len() < total_len {
-            file.set_len(total_len)?;
+            // `allocate`, not `set_len`. `set_len` extends the file without
+            // reserving a single block, so the mapping is backed by holes and
+            // the blocks are found only when a page is first written. If the
+            // filesystem is full at that moment the kernel has no error to
+            // return through a store instruction — it raises **SIGBUS** and
+            // the process dies. The heap arena this replaces returns
+            // `AllocationFailed` and lets the caller carry on, and a
+            // local-first database on a small device must not trade a
+            // recoverable error for a fatal signal.
+            //
+            // `posix_fallocate` (what this is on Linux) reserves the blocks
+            // up front, so a full disk surfaces here, as an `io::Error`, on a
+            // line that can handle it.
+            fs2::FileExt::allocate(file, total_len)?;
         }
         Ok(total)
     }
@@ -284,6 +297,18 @@ impl FileArena {
         //   `map_mut` requires.
         // SAFETY: Map the arena's backing file into the address space.
         let map = unsafe { MmapOptions::new().len(len).map_mut(file) }?;
+        // The arena is read by re-rank, on a scattered handful of candidates
+        // per query — never sequentially. Telling the kernel so stops it
+        // reading ahead around every faulted page, which is wasted I/O and
+        // wasted page cache on exactly the device this feature exists for.
+        // `MmapStorage` gives its own mapping the same advice.
+        //
+        // Best-effort: an advisory hint that a platform declines changes
+        // nothing about correctness.
+        #[cfg(unix)]
+        if let Err(e) = map.advise(memmap2::Advice::Random) {
+            tracing::debug!("madvise(MADV_RANDOM) on the vector arena failed: {e}");
+        }
         Ok(map)
     }
 

--- a/crates/velesdb-core/src/index/hnsw/index/constructors.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/constructors.rs
@@ -146,15 +146,45 @@ impl HnswIndex {
         params: HnswParams,
         enable_vector_storage: bool,
     ) -> Result<Self> {
-        let inner = HnswInner::new_with_options(
+        Self::with_params_in_dir(dimension, metric, params, enable_vector_storage, None)
+    }
+
+    /// Builds an index that may keep its f32 arena in `arena_dir`.
+    ///
+    /// The directory is remembered on the index, not just used here, because
+    /// `vacuum` rebuilds the graph and has to put the replacement's arena
+    /// somewhere too.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the graph or its arena cannot be allocated.
+    pub(crate) fn with_params_in_dir(
+        dimension: usize,
+        metric: DistanceMetric,
+        params: HnswParams,
+        enable_vector_storage: bool,
+        arena_dir: Option<std::path::PathBuf>,
+    ) -> Result<Self> {
+        // The policy gate. A mapped arena pays off only where traversal runs
+        // on something other than the f32 — the quantized backends read it
+        // solely to re-rank a bounded candidate set, so their pages can be
+        // evicted freely. A `Full` graph traverses *on* the f32 and would
+        // fault a page per hop, so it keeps its heap arena whatever the
+        // caller offers (#2112).
+        let arena_dir = match params.storage_mode {
+            crate::StorageMode::RaBitQ | crate::StorageMode::SQ8 => arena_dir,
+            _ => None,
+        };
+        let inner = HnswInner::build(&crate::index::hnsw::native_inner::InnerBuild {
             metric,
-            params.max_connections,
-            params.max_elements,
-            params.ef_construction,
+            max_connections: params.max_connections,
+            max_elements: params.max_elements,
+            ef_construction: params.ef_construction,
             dimension,
-            params.storage_mode,
-            params.alpha,
-        )?;
+            storage_mode: params.storage_mode,
+            alpha: params.alpha,
+            arena_dir: arena_dir.as_deref(),
+        })?;
 
         let mappings = ShardedMappings::with_capacity(params.max_elements);
 
@@ -167,6 +197,7 @@ impl HnswIndex {
             rerank_latency_target_us: AtomicU64::new(0),
             rerank_latency_ema_us: AtomicU64::new(0),
             io_holder: None,
+            arena_dir,
         })
     }
 
@@ -291,6 +322,7 @@ impl HnswIndex {
             rerank_latency_target_us: AtomicU64::new(0),
             rerank_latency_ema_us: AtomicU64::new(0),
             io_holder: None,
+            arena_dir: Some(path.to_path_buf()),
         };
 
         #[cfg(feature = "persistence")]

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -110,6 +110,16 @@ pub struct HnswIndex {
     /// invariant is already structurally enforced.
     #[allow(dead_code)] // Retained for field-layout invariant; dropped after inner
     pub(crate) io_holder: Option<Box<HnswIo>>,
+    /// Directory this index may keep its f32 arena file in.
+    ///
+    /// Remembered rather than passed per call because the index rebuilds
+    /// itself: `vacuum` constructs a whole replacement graph, and without
+    /// this the replacement would come back heap-backed and silently undo
+    /// the mapping on every compaction (#2112).
+    ///
+    /// `None` for an index with no collection directory, and honoured only
+    /// by the quantized backends.
+    pub(crate) arena_dir: Option<std::path::PathBuf>,
 }
 
 impl HnswIndex {

--- a/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/vacuum.rs
@@ -171,6 +171,21 @@ impl HnswIndex {
     /// (re-encodes the compacted vectors in NodeId order — without this, a
     /// vacuumed RaBitQ index would fall back to f32 search until the next
     /// collection open).
+    /// Where the replacement graph's f32 arena belongs, given what it will
+    /// become.
+    ///
+    /// Keyed on the *target* mode, not the mode the replacement is built
+    /// with: `build_vacuum_replacement` deliberately builds through a
+    /// `Full` backend and promotes afterwards, and the promotion moves the
+    /// graph as-is. A heap arena chosen here would therefore survive the
+    /// promotion and quietly undo the mapping on every compaction (#2112).
+    fn arena_dir_for(&self, target_mode: crate::StorageMode) -> Option<&std::path::Path> {
+        match target_mode {
+            crate::StorageMode::RaBitQ | crate::StorageMode::SQ8 => self.arena_dir.as_deref(),
+            _ => None,
+        }
+    }
+
     fn build_vacuum_replacement(
         &self,
         active_vectors: &[(u64, Vec<f32>)],
@@ -182,14 +197,24 @@ impl HnswIndex {
         // threshold (then re-encode everything a second time on install) —
         // and would silently SELF-train an untrained collection from
         // compaction order. The graph is promoted afterwards.
-        let new_inner = HnswInner::new_with_storage_mode(
-            self.metric,
-            params.max_connections,
-            active_vectors.len().max(1000), // max_elements with reasonable minimum
-            params.ef_construction,
-            self.dimension,
-            crate::StorageMode::Full,
-        )
+        //
+        // The arena dir still has to be `target_mode`'s, not `Full`'s: the
+        // graph built here is the one `promote_to_*` hands to the quantized
+        // wrapper, so if it were built heap-backed the promotion would carry
+        // a heap arena and every vacuum would silently undo the mapping
+        // (#2112). Building it mapped up front is safe precisely because
+        // arenas are per-instance — the old index is still serving reads from
+        // its own file, and the two never contend.
+        let new_inner = HnswInner::build(&crate::index::hnsw::native_inner::InnerBuild {
+            metric: self.metric,
+            max_connections: params.max_connections,
+            max_elements: active_vectors.len().max(1000),
+            ef_construction: params.ef_construction,
+            dimension: self.dimension,
+            storage_mode: crate::StorageMode::Full,
+            alpha: params.alpha,
+            arena_dir: self.arena_dir_for(target_mode),
+        })
         .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
         // Insertion references: idx = sequential, matches graph allocation.
@@ -203,6 +228,20 @@ impl HnswIndex {
             .parallel_insert(&refs_for_hnsw)
             .map_err(|e| VacuumError::RebuildFailed(e.to_string()))?;
 
+        self.promote_replacement(new_inner, target_mode)
+    }
+
+    /// Promotes a freshly rebuilt `Full` graph to `target_mode` and carries
+    /// the old index's trained quantizer onto it.
+    ///
+    /// Split from `build_vacuum_replacement` to keep that function inside the
+    /// complexity gate; the two halves are genuinely separate steps — build
+    /// the graph, then decide what it becomes.
+    fn promote_replacement(
+        &self,
+        new_inner: HnswInner,
+        target_mode: crate::StorageMode,
+    ) -> Result<HnswInner, VacuumError> {
         match target_mode {
             crate::StorageMode::RaBitQ => {
                 let new_inner = new_inner.promote_to_rabitq(self.dimension);

--- a/crates/velesdb-core/src/index/hnsw/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/mod.rs
@@ -68,3 +68,18 @@ pub use index::HnswIndex;
 
 /// Native HNSW index with direct access to underlying graph.
 pub use native_index::NativeHnswIndex;
+
+/// Removes f32 arena files a previous run left behind in `dir`.
+///
+/// A graph deletes its own arena on drop; a crash or a kill skips that. The
+/// leftovers are unreadable to anyone — the per-instance token that named
+/// them is gone — so they are pure waste. Call once when opening a
+/// collection, before any graph claims a new one — never later: it cannot
+/// tell a live arena from an abandoned one, so a late call deletes the file
+/// out from under a running graph.
+///
+/// Best-effort: a file that will not go away is a diagnostic, never a reason
+/// to refuse to open a collection whose real data is intact.
+pub(crate) fn sweep_stale_arenas(dir: &std::path::Path) {
+    native::arena_home::ArenaHome::sweep_stale(dir);
+}

--- a/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
@@ -1,0 +1,156 @@
+//! Where a graph's f32 arena lives on disk, and what becomes of it after.
+//!
+//! # Why the arena is disposable rather than persistent
+//!
+//! The obvious design is to make the arena file *the* stored vectors — map
+//! `{basename}.vectors` and skip deserialization entirely. Two facts rule
+//! that out for now, and both were found by reading the code rather than
+//! assumed:
+//!
+//! 1. **Vacuum makes two live indexes on purpose.** `build_vacuum_replacement`
+//!    constructs a whole replacement graph while the old one is still serving
+//!    reads, then swaps. A single well-known arena path would put both of them
+//!    on the same bytes, and [`FileArena`]'s exclusive lock — which exists
+//!    because two mappings of one file are two `&mut [f32]` aliases — would
+//!    refuse the second. The lock would be doing its job; the design would be
+//!    wrong.
+//! 2. **`.vectors` is portable and the arena is not.** `.vectors` converts
+//!    explicitly through `to_le_bytes`; an arena file is native-endian raw
+//!    memory. Merging them trades a portable on-disk format for one that
+//!    cannot cross an endianness boundary — a real cost, for a load-time win
+//!    that #2112 never asked for.
+//!
+//! So each live graph gets its **own** arena file, and deletes it when it
+//! drops. The arena is a cache of something already persisted, which is what
+//! makes throwing it away free: `.vectors` remains the durable copy, and a
+//! reopened collection simply builds a fresh arena from it.
+//!
+//! [`FileArena`]: crate::contiguous_file_arena::FileArena
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Hands out a distinct arena file to every graph in this process.
+///
+/// Two live graphs over one collection is a normal state, not an error — see
+/// the module doc — so uniqueness has to come from somewhere other than the
+/// collection's identity. A counter is enough: the file is deleted on drop
+/// and never read by anyone but its own graph, so the value carries no
+/// meaning beyond "not the same as the others".
+static NEXT_ARENA_TOKEN: AtomicU64 = AtomicU64::new(0);
+
+/// Owns one graph's arena file and removes it when the graph goes away.
+///
+/// # Drop order
+///
+/// The mapping must be released before the file is unlinked, so whatever
+/// holds an `ArenaHome` must declare it **after** the field holding the
+/// [`ContiguousVectors`] it belongs to. Rust drops fields in declaration
+/// order, so that ordering is the whole mechanism — the same technique
+/// `HnswIndex` already uses for `inner` and `io_holder`.
+///
+/// Unlinking a mapped file succeeds on Unix and fails on Windows, which is
+/// the other reason the order is not merely tidy.
+///
+/// [`ContiguousVectors`]: crate::perf_optimizations::ContiguousVectors
+#[derive(Debug)]
+pub(crate) struct ArenaHome {
+    path: PathBuf,
+}
+
+impl ArenaHome {
+    /// Claims a fresh arena path inside `dir`.
+    ///
+    /// Creates no file: that is [`ContiguousVectors::new_file_backed`]'s job,
+    /// and it may never happen if the graph takes no vectors.
+    ///
+    /// [`ContiguousVectors::new_file_backed`]: crate::perf_optimizations::ContiguousVectors::new_file_backed
+    pub(crate) fn claim(dir: &Path) -> Self {
+        let token = NEXT_ARENA_TOKEN.fetch_add(1, Ordering::Relaxed);
+        Self {
+            path: dir.join(format!("{ARENA_PREFIX}{token}.{ARENA_EXTENSION}")),
+        }
+    }
+
+    /// The file this graph's arena should occupy.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Removes arena files left behind by a process that did not drop them.
+    ///
+    /// A crash or a kill skips [`Drop`], so a collection directory can carry
+    /// arenas from a previous run. They are unreadable to anyone — the token
+    /// that named them is gone — so they are pure waste, and sweeping is safe
+    /// precisely because nothing else may be running: the database holds an
+    /// exclusive lock on its directory for as long as it is open.
+    ///
+    /// # Call it before any arena is claimed, and only then
+    ///
+    /// This deletes *every* file it recognises, and it cannot tell a live
+    /// arena from an abandoned one — the token in the name is meaningless
+    /// outside the process that issued it. Calling it while a graph holds an
+    /// arena in `dir` unlinks that graph's file: on Unix the mapping survives
+    /// but the file is gone, on Windows the delete fails. So it belongs at
+    /// collection open/create, before any graph exists, and nowhere else.
+    ///
+    /// Best-effort by construction. A file that cannot be removed is a
+    /// diagnostic, not a reason to refuse to open a collection whose real
+    /// data is intact.
+    pub(crate) fn sweep_stale(dir: &Path) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if Self::is_arena_file(&path) {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    tracing::debug!("could not sweep stale vector arena {path:?}: {e}");
+                }
+            }
+        }
+    }
+
+    /// Whether `path` names a file this module owns.
+    ///
+    /// The one definition of that question. [`sweep_stale`](Self::sweep_stale)
+    /// deletes everything it accepts, so a second, drifting copy of this
+    /// predicate is how a sweep starts eating `.vectors`.
+    ///
+    /// Matches on the extension rather than a string suffix so a
+    /// case-insensitive filesystem cannot hide a file from the sweep that a
+    /// case-sensitive one would have removed.
+    pub(in crate::index::hnsw) fn is_arena_file(path: &Path) -> bool {
+        let named = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with(ARENA_PREFIX));
+        named
+            && path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case(ARENA_EXTENSION))
+    }
+}
+
+/// Marks a file as this module's to create and to delete.
+///
+/// Both halves are load-bearing: [`ArenaHome::sweep_stale`] deletes every
+/// file that matches, so the pattern must not be able to name anything a
+/// collection actually needs. `.vectors`, `.graph` and the payload log all
+/// fail it.
+const ARENA_PREFIX: &str = "hnsw-";
+/// See [`ARENA_PREFIX`].
+const ARENA_EXTENSION: &str = "arena";
+
+impl Drop for ArenaHome {
+    fn drop(&mut self) {
+        // Missing is the expected case for a graph that never took a vector,
+        // so absence is not worth a log line.
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => tracing::debug!("could not remove vector arena {:?}: {e}", self.path),
+        }
+    }
+}

--- a/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
@@ -25,6 +25,31 @@
 //! makes throwing it away free: `.vectors` remains the durable copy, and a
 //! reopened collection simply builds a fresh arena from it.
 //!
+//! # What this costs, and why the end state is different
+//!
+//! Being a second copy is not free, and the cost is write volume rather than
+//! space. Loading a collection writes every vector through the mapping, so
+//! those pages are dirty; the kernel writes them back on its own schedule,
+//! and then the file is deleted when the graph drops. The vector data is
+//! therefore written to disk roughly **twice per collection lifetime** —
+//! once into `.vectors`, once into an arena nobody will ever read again.
+//!
+//! Nothing here should try to hurry that along. An explicit `msync` would
+//! only force the useless half of that writeback to happen sooner, spending
+//! flash endurance to persist bytes already durable in `.vectors`; the pages
+//! become reclaimable either way once the kernel has written them, which is
+//! the property the resident-set argument actually needs.
+//!
+//! The trade is deliberate: on a memory-constrained device, spending write
+//! bandwidth to move the f32 arena out of the resident set is usually worth
+//! it, since that arena is the single largest thing a quantized index holds.
+//! But it *is* a trade, and it is the reason the end state is not this
+//! design. Mapping `{basename}.vectors` itself removes the duplicate
+//! entirely — no second copy, no second write, no deletion — and the only
+//! thing standing in the way is that the arena is native-endian where
+//! `.vectors` is explicitly little-endian. That is a format question, not an
+//! architectural one, and it is tracked separately.
+//!
 //! [`FileArena`]: crate::contiguous_file_arena::FileArena
 
 use std::path::{Path, PathBuf};

--- a/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/insert.rs
@@ -15,10 +15,10 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     fn allocate_and_store_vector(&self, vector: &[f32]) -> crate::error::Result<NodeId> {
         let mut guard = self.vectors.write();
         if guard.is_none() {
-            *guard = Some(crate::perf_optimizations::ContiguousVectors::new(
-                vector.len(),
-                16,
-            )?);
+            // Through `new_arena`, not `ContiguousVectors::new`: a graph whose
+            // arena belongs on disk must get a mapped one here too, or the
+            // lazy path would silently hand back a heap arena (#2112).
+            *guard = Some(Self::new_arena(self.arena_home.as_ref(), vector.len(), 16)?);
         }
         let storage = guard.as_mut().ok_or_else(|| {
             crate::error::Error::Internal("Vector storage missing after init".to_string())
@@ -239,7 +239,11 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     ) -> crate::error::Result<()> {
         let mut guard = self.vectors.write();
         if guard.is_none() {
-            *guard = Some(ContiguousVectors::new(dimension, batch_size.max(16))?);
+            *guard = Some(Self::new_arena(
+                self.arena_home.as_ref(),
+                dimension,
+                batch_size.max(16),
+            )?);
         }
         let storage = guard.as_mut().ok_or_else(|| {
             crate::error::Error::Internal("Vector storage missing after init".to_string())

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -154,6 +154,26 @@ pub struct NativeHnsw<D: DistanceEngine> {
 #[cfg(feature = "gpu")]
 pub(in crate::index::hnsw::native) type GpuVectorsSnapshot = (u64, usize, std::sync::Arc<[f32]>);
 
+/// How many vectors a mapped arena is sized for before it has any.
+///
+/// The heap arena pre-allocates `max_elements` because growing it means
+/// copying the whole block. A mapped arena does not: `grow` extends the file
+/// and re-maps, leaving every written page where it is, so pre-sizing buys
+/// nothing and costs a great deal. `HnswParams::auto` defaults
+/// `max_elements` to 100 000, which at 768 dimensions is a **292 MB file
+/// created before the collection holds a single vector** — measured, not
+/// estimated. On the small devices this feature exists for, that is the
+/// difference between a working install and a full disk.
+///
+/// So the initial size is capped and growth does the rest.
+#[cfg(feature = "persistence")]
+fn initial_arena_capacity(max_elements: usize) -> usize {
+    /// ~12 MB at 768 dimensions: large enough that a small collection never
+    /// grows, small enough that an empty one costs nothing worth counting.
+    const CAP: usize = 4096;
+    max_elements.min(CAP)
+}
+
 impl<D: DistanceEngine> NativeHnsw<D> {
     /// Creates a new native HNSW index with VAMANA diversification (`alpha = 1.2`).
     ///
@@ -258,7 +278,8 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         dir: &std::path::Path,
     ) -> crate::error::Result<Self> {
         let home = crate::index::hnsw::native::arena_home::ArenaHome::claim(dir);
-        let storage = Self::new_arena(Some(&home), dimension, max_elements)?;
+        let storage =
+            Self::new_arena(Some(&home), dimension, initial_arena_capacity(max_elements))?;
         Ok(Self::build(
             distance,
             max_connections,
@@ -331,7 +352,22 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     ) -> crate::error::Result<ContiguousVectors> {
         #[cfg(feature = "persistence")]
         if let Some(home) = home {
-            return ContiguousVectors::new_file_backed(home.path(), dimension, capacity);
+            // A mapped arena is an optimisation, never a requirement: it
+            // lowers the resident set and changes nothing a caller can
+            // observe. So a filesystem that will not host one — read-only
+            // directory, no space, no permission, a platform where the
+            // mapping is refused — must cost the optimisation and nothing
+            // else. Failing here instead would mean this feature could stop a
+            // collection from opening that opened fine before it existed,
+            // which is not a trade worth making for a memory saving.
+            match ContiguousVectors::new_file_backed(home.path(), dimension, capacity) {
+                Ok(mapped) => return Ok(mapped),
+                Err(e) => tracing::warn!(
+                    "vector arena at {:?} could not be mapped ({e}); \
+                     falling back to an in-memory arena, which costs memory, not correctness",
+                    home.path()
+                ),
+            }
         }
         #[cfg(not(feature = "persistence"))]
         let _ = home;

--- a/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/mod.rs
@@ -129,6 +129,21 @@ pub struct NativeHnsw<D: DistanceEngine> {
     /// clear the snapshot mutex (belt-and-suspenders).
     #[cfg(feature = "gpu")]
     pub(in crate::index::hnsw::native) gpu_snapshot_version: AtomicU64,
+    /// The arena file this graph owns, when its vectors live on disk.
+    ///
+    /// # Drop order
+    ///
+    /// Declared **last**, and specifically after `vectors`: dropping this
+    /// unlinks the file, and the mapping in `vectors` must be released first.
+    /// Rust drops fields in declaration order, so the position *is* the
+    /// mechanism — the same technique `HnswIndex` uses for `inner` before
+    /// `io_holder`. `graph_field_order_keeps_the_arena_alive_until_unmapped`
+    /// pins it.
+    ///
+    /// `None` for a heap-backed graph, which is every `Full`-mode graph and
+    /// every graph built without a collection directory.
+    pub(in crate::index::hnsw::native) arena_home:
+        Option<crate::index::hnsw::native::arena_home::ArenaHome>,
 }
 
 /// Cached GPU vector snapshot: `(version, dimension, flat_vectors)`.
@@ -157,6 +172,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             ef_construction,
             max_elements,
             DEFAULT_ALPHA,
+            None,
             None,
         )
     }
@@ -212,7 +228,114 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             max_elements,
             alpha,
             Some(storage),
+            None,
         ))
+    }
+
+    /// As [`new_with_dimension_and_alpha`], but the arena lives in `dir`.
+    ///
+    /// Only quantized backends should ask for this. In `Full` mode the f32
+    /// vectors *are* the traversal data, so every hop would fault a page and
+    /// the mapping would cost latency for nothing; in `SQ8`/`RaBitQ` the
+    /// traversal runs entirely on the codes and the f32 is touched only by
+    /// `rerank_with_exact_f32`, on `k * oversampling` candidates. That
+    /// difference is the whole reason this constructor exists (#2112).
+    ///
+    /// [`new_with_dimension_and_alpha`]: Self::new_with_dimension_and_alpha
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the arena file cannot be created or mapped.
+    #[cfg(feature = "persistence")]
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::index::hnsw) fn new_file_backed_with_alpha(
+        distance: D,
+        max_connections: usize,
+        ef_construction: usize,
+        max_elements: usize,
+        dimension: usize,
+        alpha: f32,
+        dir: &std::path::Path,
+    ) -> crate::error::Result<Self> {
+        let home = crate::index::hnsw::native::arena_home::ArenaHome::claim(dir);
+        let storage = Self::new_arena(Some(&home), dimension, max_elements)?;
+        Ok(Self::build(
+            distance,
+            max_connections,
+            ef_construction,
+            max_elements,
+            alpha,
+            Some(storage),
+            Some(home),
+        ))
+    }
+
+    /// A graph whose arena lives in `dir`, sized eagerly or lazily.
+    ///
+    /// `dimension == 0` means the caller does not know it yet, so the arena
+    /// is deferred to the first insert — the home is claimed now either way,
+    /// so the lazy path in `allocate_and_store_vector` finds it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the arena file cannot be created or mapped.
+    #[cfg(feature = "persistence")]
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::index::hnsw) fn standard_in_dir(
+        distance: D,
+        max_connections: usize,
+        ef_construction: usize,
+        max_elements: usize,
+        dimension: usize,
+        alpha: f32,
+        dir: &std::path::Path,
+    ) -> crate::error::Result<Self> {
+        if dimension > 0 {
+            return Self::new_file_backed_with_alpha(
+                distance,
+                max_connections,
+                ef_construction,
+                max_elements,
+                dimension,
+                alpha,
+                dir,
+            );
+        }
+        let home = crate::index::hnsw::native::arena_home::ArenaHome::claim(dir);
+        Ok(Self::build(
+            distance,
+            max_connections,
+            ef_construction,
+            max_elements,
+            alpha,
+            None,
+            Some(home),
+        ))
+    }
+
+    /// Builds an arena of `capacity` vectors, on disk when `home` says so.
+    ///
+    /// The single place that answers "heap or file?" for this graph. All four
+    /// sites that can create an arena — the two constructors, the lazy
+    /// first-insert path, and the batch-reserve path — route through it, so a
+    /// graph cannot end up with a heap arena on one path and a mapped one on
+    /// another.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the allocation or the file mapping fails.
+    pub(in crate::index::hnsw::native) fn new_arena(
+        home: Option<&crate::index::hnsw::native::arena_home::ArenaHome>,
+        dimension: usize,
+        capacity: usize,
+    ) -> crate::error::Result<ContiguousVectors> {
+        #[cfg(feature = "persistence")]
+        if let Some(home) = home {
+            return ContiguousVectors::new_file_backed(home.path(), dimension, capacity);
+        }
+        #[cfg(not(feature = "persistence"))]
+        let _ = home;
+        ContiguousVectors::new(dimension, capacity)
     }
 
     /// Creates a new native HNSW index with VAMANA-style diversification.
@@ -231,6 +354,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             max_elements,
             alpha,
             None,
+            None,
         )
     }
 
@@ -242,6 +366,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         max_elements: usize,
         alpha: f32,
         vectors: Option<ContiguousVectors>,
+        arena_home: Option<crate::index::hnsw::native::arena_home::ArenaHome>,
     ) -> Self {
         let max_connections_0 = max_connections * 2;
         let level_mult = 1.0 / (max_connections as f64).ln();
@@ -273,6 +398,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
             // counter to invalidate all subsequent reads.
             #[cfg(feature = "gpu")]
             gpu_snapshot_version: AtomicU64::new(0),
+            arena_home,
         }
     }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -248,8 +248,29 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     ///
     /// Returns `io::Error` if file operations fail or data is corrupted.
     pub fn file_load(path: &Path, basename: &str, distance: D) -> std::io::Result<Self> {
+        Self::file_load_with_arena(path, basename, distance, None)
+    }
+
+    /// As [`file_load`](Self::file_load), but the reloaded arena may live in
+    /// `arena_dir` instead of on the heap.
+    ///
+    /// `.vectors` stays the durable copy either way — the arena is a cache of
+    /// it, which is what lets the graph delete the arena on drop. Passing a
+    /// directory only decides where the loaded f32 is *held*, never what is
+    /// read.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` if file operations fail or data is corrupted.
+    pub(in crate::index::hnsw) fn file_load_with_arena(
+        path: &Path,
+        basename: &str,
+        distance: D,
+        arena_dir: Option<&Path>,
+    ) -> std::io::Result<Self> {
+        let arena_home = arena_dir.map(crate::index::hnsw::native::arena_home::ArenaHome::claim);
         let vectors_path = path.join(format!("{basename}.vectors"));
-        let (mut vectors, count) = Self::load_vectors_file(&vectors_path)?;
+        let (mut vectors, count) = Self::load_vectors_file(&vectors_path, arena_home.as_ref())?;
 
         // Indexes written before the pre-normalized cosine engine store raw
         // vectors. Cosine is scale-invariant, so normalizing here never
@@ -297,6 +318,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             entry_point: std::sync::atomic::AtomicUsize::new(entry_point),
             max_layer: std::sync::atomic::AtomicUsize::new(graph.max_layer),
             count: std::sync::atomic::AtomicUsize::new(count),
+            arena_home,
             rng_state: std::sync::atomic::AtomicU64::new(0x5DEE_CE66_D1A4_B5B5),
             max_connections: graph.max_connections,
             max_connections_0: graph.max_connections_0,
@@ -319,6 +341,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 
     fn load_vectors_file(
         path: &Path,
+        arena_home: Option<&crate::index::hnsw::native::arena_home::ArenaHome>,
     ) -> std::io::Result<(Option<crate::perf_optimizations::ContiguousVectors>, usize)> {
         let file = File::open(path)?;
         let file_len = file.metadata()?.len();
@@ -335,7 +358,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         // file cannot possibly back. Header = version(4) + count(8) + dim(4).
         Self::validate_vectors_file_len(count, dimension, file_len)?;
 
-        let storage = Self::read_vector_data(&mut reader, count, dimension)?;
+        let storage = Self::read_vector_data(&mut reader, count, dimension, arena_home)?;
         Ok((Some(storage), count))
     }
 
@@ -390,6 +413,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         reader: &mut BufReader<File>,
         count: usize,
         dimension: usize,
+        arena_home: Option<&crate::index::hnsw::native::arena_home::ArenaHome>,
     ) -> std::io::Result<crate::perf_optimizations::ContiguousVectors> {
         // The (count, dimension) here was already validated to fit within the
         // actual file length by `validate_vectors_file_len`, so this is a real,
@@ -406,9 +430,8 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             .ok_or_else(|| corrupt("vector payload size overflows usize"))?;
 
         crate::alloc_guard::with_min_alloc_byte_limit(min_bytes, || {
-            let mut storage =
-                crate::perf_optimizations::ContiguousVectors::new(dimension, count.max(16))
-                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+            let mut storage = Self::new_arena(arena_home, dimension, count.max(16))
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
             let mut buf4 = [0u8; 4];
             let mut buf_vec = vec![0f32; dimension];
             for _ in 0..count {

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -625,3 +625,148 @@ fn test_snapshot_version_detects_staleness_without_explicit_clear() {
         "invalidate_gpu_caches must also clear the snapshot mutex (belt-and-suspenders)"
     );
 }
+
+/// A quantized collection keeps its f32 arena on disk, a Full one does not.
+///
+/// The whole point of #2112: in SQ8/RaBitQ the traversal runs on codes and
+/// f32 is read only to re-rank, so those pages may be evicted. In Full the
+/// f32 *is* the traversal data, so mapping it would fault a page per hop.
+/// This pins the split at the level a user actually configures.
+#[cfg(feature = "persistence")]
+#[test]
+fn only_a_quantized_index_puts_its_arena_on_disk() {
+    use crate::index::hnsw::{HnswIndex, HnswParams};
+
+    fn arena_files(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir)
+            .expect("read_dir")
+            .flatten()
+            .filter(|e| crate::index::hnsw::native::arena_home::ArenaHome::is_arena_file(&e.path()))
+            .count()
+    }
+
+    for (mode, expected) in [
+        (crate::StorageMode::Full, 0),
+        (crate::StorageMode::SQ8, 1),
+        (crate::StorageMode::RaBitQ, 1),
+    ] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut params = HnswParams::auto(16);
+        params.storage_mode = mode;
+        let index = HnswIndex::with_params_in_dir(
+            16,
+            crate::DistanceMetric::Cosine,
+            params,
+            true,
+            Some(dir.path().to_path_buf()),
+        )
+        .expect("index");
+
+        assert_eq!(
+            arena_files(dir.path()),
+            expected,
+            "{mode:?} should hold {expected} arena file(s) on disk"
+        );
+
+        // Dropping the index must take its arena file with it: the file is a
+        // cache of `.vectors`, so leaving it behind is pure waste.
+        drop(index);
+        assert_eq!(
+            arena_files(dir.path()),
+            0,
+            "{mode:?}: dropping the index must remove its arena file"
+        );
+    }
+}
+
+/// A stale arena from a killed process is swept, and nothing else is.
+#[cfg(feature = "persistence")]
+#[test]
+fn sweeping_removes_only_arena_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let arena = dir.path().join("hnsw-99.arena");
+    let vectors = dir.path().join("native_hnsw.vectors");
+    std::fs::write(&arena, b"stale").expect("write arena");
+    std::fs::write(&vectors, b"precious").expect("write vectors");
+
+    crate::index::hnsw::sweep_stale_arenas(dir.path());
+
+    assert!(!arena.exists(), "a stale arena must be swept");
+    assert!(
+        vectors.exists(),
+        "the sweep must not touch the durable vector file"
+    );
+}
+
+/// A quantized collection maps its arena, searches correctly, and cleans up.
+///
+/// The end-to-end claim of #2112 Phase B, at the level a user configures:
+/// an SQ8 collection's f32 arena is a file, the results are the same as they
+/// would be on the heap, and closing the collection leaves nothing behind.
+#[cfg(feature = "persistence")]
+#[test]
+fn a_quantized_collection_maps_its_arena_and_cleans_up() {
+    use crate::index::hnsw::{HnswIndex, HnswParams};
+    use crate::index::VectorIndex;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dimension = 8;
+    // Directions must be genuinely distinct: under Cosine a vector and any
+    // positive multiple of it are the same point, so a fixture that varies
+    // only the magnitude of one axis makes "nearest neighbour" ambiguous and
+    // the assertion below meaningless.
+    let vectors: Vec<Vec<f32>> = (0..64)
+        .map(|i| {
+            (0..dimension)
+                .map(|d| {
+                    let step = u32::try_from(i * dimension + d).expect("fits u32");
+                    // Deterministic spread; no RNG, so a failure names the slot.
+                    f32::from((step.wrapping_mul(2_654_435_761) >> 20) as u16) + 1.0
+                })
+                .collect()
+        })
+        .collect();
+
+    let arena_count = || {
+        std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .flatten()
+            .filter(|e| crate::index::hnsw::native::arena_home::ArenaHome::is_arena_file(&e.path()))
+            .count()
+    };
+
+    let mut params = HnswParams::auto(dimension);
+    params.storage_mode = crate::StorageMode::SQ8;
+    let index = HnswIndex::with_params_in_dir(
+        dimension,
+        crate::DistanceMetric::Cosine,
+        params,
+        true,
+        Some(dir.path().to_path_buf()),
+    )
+    .expect("index");
+
+    for (i, v) in vectors.iter().enumerate() {
+        index.insert(i as u64, v);
+    }
+    assert_eq!(arena_count(), 1, "the f32 arena should be a file on disk");
+
+    // Every vector must be findable as its own nearest neighbour. Reading
+    // them back is what proves the mapped arena is actually serving the
+    // re-rank, not merely existing.
+    for (i, v) in vectors.iter().enumerate() {
+        let hits = index.search(v, 1);
+        assert_eq!(
+            hits.first().map(|r| r.id),
+            Some(i as u64),
+            "vector {i} should be its own nearest neighbour"
+        );
+    }
+
+    drop(index);
+    assert_eq!(
+        arena_count(),
+        0,
+        "closing the index must leave no arena file behind"
+    );
+}

--- a/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_tests.rs
@@ -770,3 +770,81 @@ fn a_quantized_collection_maps_its_arena_and_cleans_up() {
         "closing the index must leave no arena file behind"
     );
 }
+
+/// A fresh quantized index does not pre-create a huge arena file.
+///
+/// `HnswParams::auto` defaults `max_elements` to 100 000, which at 768
+/// dimensions sizes the arena at ~292 MB. The heap arena pre-allocates that
+/// because growing it copies the whole block; a mapped arena grows by
+/// extending the file, so pre-sizing buys nothing and would put a
+/// third-of-a-gigabyte file on a device before the collection holds a single
+/// vector. This pins the cap rather than leaving it to a constant nobody
+/// re-reads.
+#[cfg(feature = "persistence")]
+#[test]
+fn a_fresh_arena_does_not_pre_size_to_max_elements() {
+    use crate::index::hnsw::{HnswIndex, HnswParams};
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dimension = 768;
+    let mut params = HnswParams::auto(dimension);
+    params.storage_mode = crate::StorageMode::SQ8;
+    assert!(
+        params.max_elements >= 100_000,
+        "this test is only meaningful while the default is large, got {}",
+        params.max_elements
+    );
+
+    let index = HnswIndex::with_params_in_dir(
+        dimension,
+        crate::DistanceMetric::Cosine,
+        params,
+        true,
+        Some(dir.path().to_path_buf()),
+    )
+    .expect("index");
+
+    let bytes: u64 = std::fs::read_dir(dir.path())
+        .expect("read_dir")
+        .flatten()
+        .filter(|e| crate::index::hnsw::native::arena_home::ArenaHome::is_arena_file(&e.path()))
+        .map(|e| e.metadata().expect("metadata").len())
+        .sum();
+
+    assert!(
+        bytes < 32 * 1024 * 1024,
+        "an empty index should not reserve {} MB of arena",
+        bytes / 1_048_576
+    );
+    drop(index);
+}
+
+/// Blocks are reserved, not left as holes.
+///
+/// A sparse mapping finds its blocks only when a page is first written, and
+/// a full filesystem then has no error to return through a store
+/// instruction: the kernel raises SIGBUS and the process dies. The heap
+/// arena returns a recoverable `AllocationFailed`, so the mapped one must
+/// surface a full disk at setup instead. Reserved blocks are what make that
+/// possible, and `allocated_size` is how you tell.
+#[cfg(all(unix, feature = "persistence"))]
+#[test]
+fn an_arena_reserves_its_blocks_rather_than_leaving_holes() {
+    use crate::perf_optimizations::ContiguousVectors;
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("reserved.arena");
+    let (dimension, capacity) = (64, 4096);
+    let arena = ContiguousVectors::new_file_backed(&path, dimension, capacity).expect("arena");
+
+    let meta = std::fs::metadata(&path).expect("metadata");
+    let allocated = meta.blocks() * 512;
+    assert!(
+        allocated >= meta.len(),
+        "arena must have blocks reserved for its whole length: {allocated} allocated \
+         for {} apparent bytes — a hole here is a SIGBUS on a full disk",
+        meta.len()
+    );
+    drop(arena);
+}

--- a/crates/velesdb-core/src/index/hnsw/native/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/mod.rs
@@ -34,6 +34,7 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_sign_loss)]
 
+pub(in crate::index::hnsw) mod arena_home;
 mod backend_adapter;
 mod batch_schedule;
 mod distance;

--- a/crates/velesdb-core/src/index/hnsw/native/quantized_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/quantized_precision.rs
@@ -201,15 +201,54 @@ impl<D: DistanceEngine, C: TraversalCodec> QuantizedPrecisionHnsw<D, C> {
         max_elements: usize,
         alpha: f32,
     ) -> crate::error::Result<Self> {
+        Self::with_optional_arena_dir(
+            distance,
+            dimension,
+            max_connections,
+            ef_construction,
+            max_elements,
+            alpha,
+            None,
+        )
+    }
+
+    /// As [`new_with_alpha`], with the f32 arena optionally living in a file.
+    ///
+    /// This backend is exactly the case the mapped arena was built for: the
+    /// traversal runs on `store` (the codes), and the f32 in `inner` is read
+    /// only by `rerank_with_exact_f32`, on `k * oversampling` candidates. So
+    /// the arena's pages can be evicted with no effect on search structure —
+    /// which drops the resident floor from `f32 + graph + codes` to
+    /// `graph + codes` (#2112).
+    ///
+    /// `None` keeps the heap arena, which is what a collection without a
+    /// directory gets.
+    ///
+    /// [`new_with_alpha`]: Self::new_with_alpha
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vector storage pre-allocation or mapping fails.
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::index::hnsw) fn with_optional_arena_dir(
+        distance: D,
+        dimension: usize,
+        max_connections: usize,
+        ef_construction: usize,
+        max_elements: usize,
+        alpha: f32,
+        arena_dir: Option<&std::path::Path>,
+    ) -> crate::error::Result<Self> {
         let codec_enabled = C::supports_metric(distance.metric());
         Ok(Self {
-            inner: NativeHnsw::new_with_dimension_and_alpha(
+            inner: Self::build_inner_graph(
                 distance,
                 max_connections,
                 ef_construction,
                 max_elements,
                 dimension,
                 alpha,
+                arena_dir,
             )?,
             quantizer: RwLock::new(None),
             store: RwLock::new(None),
@@ -219,6 +258,48 @@ impl<D: DistanceEngine, C: TraversalCodec> QuantizedPrecisionHnsw<D, C> {
             install_gate: RwLock::new(()),
             codec_enabled,
         })
+    }
+
+    /// Builds the f32 graph, mapped or heap-backed.
+    ///
+    /// Split out so `with_optional_arena_dir` stays one construction
+    /// expression rather than branching around the whole struct literal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vector storage pre-allocation or mapping fails.
+    #[allow(clippy::too_many_arguments)]
+    fn build_inner_graph(
+        distance: D,
+        max_connections: usize,
+        ef_construction: usize,
+        max_elements: usize,
+        dimension: usize,
+        alpha: f32,
+        arena_dir: Option<&std::path::Path>,
+    ) -> crate::error::Result<NativeHnsw<D>> {
+        #[cfg(feature = "persistence")]
+        if let Some(dir) = arena_dir {
+            return NativeHnsw::new_file_backed_with_alpha(
+                distance,
+                max_connections,
+                ef_construction,
+                max_elements,
+                dimension,
+                alpha,
+                dir,
+            );
+        }
+        #[cfg(not(feature = "persistence"))]
+        let _ = arena_dir;
+        NativeHnsw::new_with_dimension_and_alpha(
+            distance,
+            max_connections,
+            ef_construction,
+            max_elements,
+            dimension,
+            alpha,
+        )
     }
 
     /// Creates a quantized-precision HNSW from a pre-loaded `NativeHnsw` graph.

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -12,9 +12,7 @@
 
 use super::native::rabitq_precision::RaBitQPrecisionHnsw;
 use super::native::sq8_precision::Sq8PrecisionHnsw;
-use super::native::{
-    CachedSimdDistance, NativeHnsw, NativeNeighbour, ResumableSearch, DEFAULT_ALPHA,
-};
+use super::native::{CachedSimdDistance, NativeHnsw, NativeNeighbour, ResumableSearch};
 use crate::distance::DistanceMetric;
 use std::path::Path;
 
@@ -59,35 +57,36 @@ pub struct NativeHnswInner {
     metric: DistanceMetric,
 }
 
-impl NativeHnswInner {
-    /// Creates a new `NativeHnswInner` with a specific storage mode.
+/// Everything needed to build a [`NativeHnswInner`].
+///
+/// A struct rather than an eighth positional parameter: the constructor had
+/// already earned a `too_many_arguments` allow at seven, and four of them are
+/// `usize`, so a transposed pair compiles and misbehaves silently. Named
+/// fields make that a compile error instead.
+pub(crate) struct InnerBuild<'a> {
+    /// Distance metric the graph is built for.
+    pub metric: DistanceMetric,
+    /// M — connections per node above layer 0.
+    pub max_connections: usize,
+    /// Capacity hint for layer pre-allocation.
+    pub max_elements: usize,
+    /// Beam width during construction.
+    pub ef_construction: usize,
+    /// Vector dimension; `0` defers arena allocation to the first insert.
+    pub dimension: usize,
+    /// Selects the backend, and with it whether a mapped arena applies.
+    pub storage_mode: crate::StorageMode,
+    /// VAMANA diversification factor.
+    pub alpha: f32,
+    /// Directory for the f32 arena file, when it should live on disk.
     ///
-    /// [`StorageMode::RaBitQ`] selects the binary-traversal backend and
-    /// [`StorageMode::SQ8`] the int8-traversal backend; every other mode
-    /// runs the Standard f32 backend.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if vector storage pre-allocation fails.
-    pub fn new_with_storage_mode(
-        metric: DistanceMetric,
-        max_connections: usize,
-        max_elements: usize,
-        ef_construction: usize,
-        dimension: usize,
-        storage_mode: crate::StorageMode,
-    ) -> crate::error::Result<Self> {
-        Self::new_with_options(
-            metric,
-            max_connections,
-            max_elements,
-            ef_construction,
-            dimension,
-            storage_mode,
-            DEFAULT_ALPHA,
-        )
-    }
+    /// Honoured only by the quantized backends — see [`NativeHnswInner::build`]
+    /// for why a `Full` graph must keep its arena in memory. `None` anywhere
+    /// else, including for a collection with no directory of its own.
+    pub arena_dir: Option<&'a std::path::Path>,
+}
 
+impl NativeHnswInner {
     /// Creates a new `NativeHnswInner` with full configuration options.
     ///
     /// This is the canonical constructor; all other `new*` methods delegate here.
@@ -95,7 +94,6 @@ impl NativeHnswInner {
     /// # Errors
     ///
     /// Returns an error if vector storage pre-allocation fails.
-    #[allow(clippy::too_many_arguments)]
     pub fn new_with_options(
         metric: DistanceMetric,
         max_connections: usize,
@@ -105,39 +103,73 @@ impl NativeHnswInner {
         storage_mode: crate::StorageMode,
         alpha: f32,
     ) -> crate::error::Result<Self> {
-        let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
-        let backend = match storage_mode {
+        Self::build(&InnerBuild {
+            metric,
+            max_connections,
+            max_elements,
+            ef_construction,
+            dimension,
+            storage_mode,
+            alpha,
+            arena_dir: None,
+        })
+    }
+
+    /// Builds a backend from a fully-specified [`InnerBuild`].
+    ///
+    /// The canonical constructor; `new_with_options` is the positional
+    /// shorthand for the common case of a graph with no arena directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vector storage pre-allocation or mapping fails.
+    pub(crate) fn build(opts: &InnerBuild<'_>) -> crate::error::Result<Self> {
+        let distance = CachedSimdDistance::new_prenormalized(opts.metric, opts.dimension);
+        // `arena_dir` is honoured for every mode here, on purpose. Whether a
+        // mapped arena *suits* a graph depends on how that graph will be
+        // read, which only the caller knows: vacuum builds a `Full` graph it
+        // is about to promote to a quantized one, and that graph must be
+        // mapped even though its mode says otherwise. Deciding it here would
+        // make that case unreachable, so the policy lives with the callers —
+        // see `HnswIndex::with_params_in_dir`.
+        let backend = match opts.storage_mode {
             crate::StorageMode::RaBitQ => {
-                HnswBackend::RaBitQ(Box::new(RaBitQPrecisionHnsw::new_with_alpha(
+                HnswBackend::RaBitQ(Box::new(RaBitQPrecisionHnsw::with_optional_arena_dir(
                     distance,
-                    dimension,
-                    max_connections,
-                    ef_construction,
-                    max_elements,
-                    alpha,
+                    opts.dimension,
+                    opts.max_connections,
+                    opts.ef_construction,
+                    opts.max_elements,
+                    opts.alpha,
+                    opts.arena_dir,
                 )?))
             }
             crate::StorageMode::SQ8 => {
-                HnswBackend::Sq8(Box::new(Sq8PrecisionHnsw::new_with_alpha(
+                HnswBackend::Sq8(Box::new(Sq8PrecisionHnsw::with_optional_arena_dir(
                     distance,
-                    dimension,
-                    max_connections,
-                    ef_construction,
-                    max_elements,
-                    alpha,
+                    opts.dimension,
+                    opts.max_connections,
+                    opts.ef_construction,
+                    opts.max_elements,
+                    opts.alpha,
+                    opts.arena_dir,
                 )?))
             }
             _ => Self::new_standard_backend(
                 distance,
-                max_connections,
-                ef_construction,
-                max_elements,
-                dimension,
-                alpha,
+                opts.max_connections,
+                opts.ef_construction,
+                opts.max_elements,
+                opts.dimension,
+                opts.alpha,
+                opts.arena_dir,
             )?,
         };
 
-        Ok(Self { backend, metric })
+        Ok(Self {
+            backend,
+            metric: opts.metric,
+        })
     }
 
     /// Builds the Standard (full-f32) backend.
@@ -149,6 +181,7 @@ impl NativeHnswInner {
     /// # Errors
     ///
     /// Returns an error if vector storage pre-allocation fails.
+    #[allow(clippy::too_many_arguments)]
     fn new_standard_backend(
         distance: CachedSimdDistance,
         max_connections: usize,
@@ -156,7 +189,23 @@ impl NativeHnswInner {
         max_elements: usize,
         dimension: usize,
         alpha: f32,
+        arena_dir: Option<&std::path::Path>,
     ) -> crate::error::Result<HnswBackend> {
+        #[cfg(feature = "persistence")]
+        if let Some(dir) = arena_dir {
+            let inner = NativeHnsw::standard_in_dir(
+                distance,
+                max_connections,
+                ef_construction,
+                max_elements,
+                dimension,
+                alpha,
+                dir,
+            )?;
+            return Ok(HnswBackend::Standard(inner));
+        }
+        #[cfg(not(feature = "persistence"))]
+        let _ = arena_dir;
         let inner = if dimension > 0 {
             NativeHnsw::new_with_dimension_and_alpha(
                 distance,
@@ -606,7 +655,15 @@ impl NativeHnswInner {
         storage_mode: crate::StorageMode,
     ) -> std::io::Result<Self> {
         let distance = CachedSimdDistance::new_prenormalized(metric, dimension);
-        let inner = NativeHnsw::file_load(path, basename, distance)?;
+        // Same gate as `build`, for the same reason: only a backend that
+        // traverses on codes can afford an evictable f32 arena. `path` is the
+        // collection directory, which is where the arena file belongs — it is
+        // a cache of `{basename}.vectors`, deleted when this graph drops.
+        let arena_dir = match storage_mode {
+            crate::StorageMode::RaBitQ | crate::StorageMode::SQ8 => Some(path),
+            _ => None,
+        };
+        let inner = NativeHnsw::file_load_with_arena(path, basename, distance, arena_dir)?;
 
         let backend = match storage_mode {
             // Wrap the loaded graph in the matching quantized backend. The


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → **`develop`**. ✔

**Merge #2117 first.** This branch is built on `feat/file-backed-vector-arena`, so until that PR lands this one's diff also contains its commits. It was originally opened against that branch; the Git Flow gate correctly refused it (`main` and `develop` are the only valid targets — this repository does not do stacked PRs), so it now targets `develop` and GitHub will shrink the diff to this PR's own two commits the moment #2117 merges. Merging *this* one first would drag #2117's work in with it.

## Description

**#2112 Phase B, step 2.** #2117 landed the mechanism with no production caller; this gives it one, and only where it pays.

### The split is by access pattern, not by name

Verified in the code rather than assumed, because the whole PR rests on it:

- `search_layer_quantized` traverses on `store` — the codes. It never touches f32.
- `rerank_with_exact_f32` is the *only* reader of `inner.vectors`, over `k * oversampling_ratio` candidates.

So in SQ8/RaBitQ the f32 arena is read sparsely, after traversal, on a bounded set — exactly where eviction costs nothing structural. A `Full` graph traverses *on* the f32 and would fault a page per hop, so it keeps its heap arena whatever a caller offers.

That gate lives **with the callers**, not inside `NativeHnswInner::build`: vacuum legitimately needs a `Full`-built graph to be mapped, so a gate inside `build` would make that case unreachable.

### Each graph owns its own arena file

Two live graphs over one collection is a normal state: `build_vacuum_replacement` constructs a replacement while the old one still serves reads. A single well-known arena path would put both on the same bytes, and #2117's exclusive lock — which exists because two mappings of one file are two `&mut [f32]` aliases — would refuse the second. **The lock would be doing its job and the design would be wrong.**

So each graph claims a per-instance file and deletes it on drop, ordered by field declaration (`arena_home` after `vectors`, the technique `HnswIndex` already uses for `inner` before `io_holder`). This keeps `.vectors` as the durable, portable copy and sidesteps trading a portable on-disk format for a native-endian one.

## Three things the wiring had to handle

**Vacuum would have silently undone the mapping.** It builds through a `Full` backend on purpose, then calls `promote_to_*`, which moves the graph as-is. A heap-backed replacement would have carried a heap arena through every promotion — the resident set quietly returning to `f32 + graph + codes` after each compaction, the exact regression #2112 exists to fix. The replacement is now built mapped when the *target* mode is quantized.

**The crash sweep only ran on create.** Arenas orphaned by a kill were swept when a collection was created, not when one was opened, so a crashed collection kept its orphan forever and gained another on each subsequent crash. It now runs on the open path too — and **only before any graph claims an arena**, because the sweep cannot tell a live arena from an abandoned one. Calling it late would unlink a running graph's file; that precondition is documented everywhere it could be violated.

**An eighth positional parameter.** `new_with_options` had earned a `too_many_arguments` allow at seven, four of them `usize`. The canonical constructor now takes an `InnerBuild` struct with named fields; the positional shorthand left without a live caller is **removed**, not warning-suppressed.

## Robustness pass — what happens off the happy path

A second review asked what this does when the device says no. Four problems, three of them regressions against the heap arena. Two were **measured, not reasoned about**.

**A full disk killed the process.** `set_len` extends a file without reserving a block, so the mapping was backed by holes and blocks were found only when a page was first written. A filesystem with nothing left has no way to report that through a store instruction: the kernel raises **SIGBUS** and the process dies. The heap arena returns `AllocationFailed` and lets the caller carry on. `posix_fallocate` (via `fs2::FileExt::allocate`) now reserves the blocks up front, so a full disk surfaces as an `io::Error` on a line that can handle it. Pinned by a test reading `allocated_size` — a hole is invisible in the apparent length.

**An empty collection reserved 292 MB.** `HnswParams::auto` defaults `max_elements` to 100 000; at 768 dimensions the arena was sized to a **292 MB file created before the collection held a single vector**. Measured. The heap arena pre-allocates because growing it copies the whole block; a mapped arena grows by extending the file, so pre-sizing buys nothing. The initial size is capped and growth does the rest.

**An unwritable directory stopped a collection from opening.** A mapped arena lowers the resident set and changes nothing a caller can observe — it is an optimisation, and the code treated it as a requirement. A read-only directory, a full disk, a platform refusing the mapping: each would have failed a collection that opened fine before this feature existed. They now cost the optimisation and nothing else, with a warning naming what was lost.

**No `msync`, deliberately.** `flush_backing` has no production caller and should not get one. Forcing writeback would hurry along the useless half of this design — spending flash endurance to persist bytes already durable in `.vectors`, on a file deleted when the graph drops. The pages become reclaimable either way once the kernel writes them back on its own schedule, which is the property the resident-set argument actually needs.

Also gives the mapping `MADV_RANDOM`: re-rank reads a scattered handful of candidates per query and never a run, so read-ahead around each faulted page is wasted I/O and wasted page cache on exactly the device this exists for. `MmapStorage` already advises its own mapping the same way.

## What this costs

Stated plainly rather than left implicit, and recorded in the module doc: the vector data is written to disk roughly **twice per collection lifetime** — once into `.vectors`, once into an arena nobody will read again.

On a memory-constrained device, spending write bandwidth to move the largest thing a quantized index holds out of the resident set is usually the right trade. But it is a trade, and it is why the end state is **mapping `.vectors` itself** rather than copying it — that removes the duplicate entirely. The only obstacle is that the arena is native-endian where `.vectors` is explicitly little-endian: a format question, not an architectural one, tracked separately.

Whether this should be configurable is a real question, and the answer depends on measurements that are the next step.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests

- **`only_a_quantized_index_puts_its_arena_on_disk`** — Full holds 0 arena files, SQ8 and RaBitQ hold 1; dropping the index removes it.
- **`a_quantized_collection_maps_its_arena_and_cleans_up`** — end-to-end: an SQ8 index maps its arena, returns every vector as its own nearest neighbour (which proves the mapped arena is serving the re-rank, not merely existing), and leaves nothing behind on close.
- **`sweeping_removes_only_arena_files`** — the sweep takes a stale arena and leaves `.vectors` alone. Worth its own test because the sweep deletes everything its predicate accepts; there is now exactly one definition of that predicate.
- **`a_fresh_arena_does_not_pre_size_to_max_elements`** — an empty 768-d index reserves under 32 MB, not 292 MB. Asserts the default is still large first, so it cannot pass vacuously.
- **`an_arena_reserves_its_blocks_rather_than_leaving_holes`** — `allocated_size >= len`, the difference between a recoverable error and SIGBUS.

Gates and checks:

- **5393 lib tests pass**, 0 failures.
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- `cargo build -p velesdb-core --no-default-features` — builds (the mapped path is `persistence`-gated throughout).
- `verify_unsafe_safety_template.py --strict` — clean; `check-file-budgets.py` — baseline unchanged; `check-todo-annotations.py` — clean.
- `build_vacuum_replacement` reached **CCN 9** with the arena choice inline (Gate 5 is ≤ 8) and was **split rather than allowed**, into `arena_dir_for` and `promote_replacement`. It is now under the gate and below the NLOC it had before this PR.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Rust version: 1.90 (repo toolchain pin)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings — one that appeared (a constructor left without callers) was removed rather than suppressed
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — **not yet: depends on #2117**, see the note at the top

## Additional Notes

**Known limitation carried from #2117:** `ContiguousVectors::reorder` copies into a fresh heap buffer, so a mapped arena is demoted to the heap there and `flush_backing` becomes a silent no-op. Documented on both public methods in #2117. Not reachable from this PR's paths, but it becomes reachable the moment anything reorders a quantized graph; tracked as follow-up.

**Peak disk during vacuum:** two arenas exist while the replacement is built. That is inherent to rebuilding a graph beside a live one, and is bounded by the arena size rather than by `max_elements` now that pre-sizing is capped.

**Not yet measured.** Resident-set and cold-page rerank-latency numbers are the next step; this PR delivers the mechanism the measurement needs, and those numbers are what should decide the configurability question above.