### PR TITLE
ci: re-run the gates when a pull request is retargeted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,24 @@ on:
     # so leaving `types:` implicit here would have silently narrowed it: a
     # draft turned "ready" with no new commit would never be re-governed.
     # Pinned by scripts/tests/test_ci_gate_reachability.py.
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `edited` is here for exactly one reason: **retargeting a PR**. Changing
+    # a PR's base emits `edited` and nothing else — no `synchronize`, no
+    # `reopened` — so without it a PR retargeted onto develop never gets a CI
+    # run at all, and `CI Success` (a required check) is simply absent. That
+    # is the #1465 failure mode again: not red, *missing*, which blocks the
+    # merge with no way out but an unrelated push. Hit in production on
+    # PR #2118, opened against a feature branch and retargeted here.
+    #
+    # `edited` also fires on every title and body edit, which must NOT cost a
+    # full CI run — so every job in this workflow carries a guard admitting
+    # `edited` only when `changes.base` is present. `ci-success` carries it
+    # too, and that is load-bearing: it asserts `result == 'success'` for each
+    # of its needs, so leaving it unguarded while its needs skipped would turn
+    # every title edit red. All jobs skipping together yields a `skipped`
+    # check-run, which branch protection accepts.
+    #
+    # Pinned by scripts/tests/test_ci_gate_reachability.py.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   # Manual trigger so coverage can be refreshed on demand (e.g. after a
   # config-only commit to main that skipped the path-filtered CI, leaving the
   # Codacy coverage badge stale).
@@ -83,6 +100,7 @@ jobs:
   # ===========================================================================
   lint:
     name: Lint & Format
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -457,6 +475,7 @@ jobs:
   # ===========================================================================
   test:
     name: Tests
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -568,6 +587,7 @@ jobs:
   # ===========================================================================
   security:
     name: Security Audit
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -596,6 +616,7 @@ jobs:
   # ===========================================================================
   hygiene:
     name: Hygiene (typos, taplo, machete)
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -637,6 +658,7 @@ jobs:
   # `cargo check` runs are the cost this gate is allowed to have.
   memory-feature-matrix:
     name: Memory Feature Matrix
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -664,6 +686,7 @@ jobs:
 
   wasm-check:
     name: WASM Build Check
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -720,6 +743,7 @@ jobs:
   # ===========================================================================
   openapi-drift:
     name: OpenAPI Drift Check
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -768,6 +792,12 @@ jobs:
   #
   # No toolchain, no build: pure Python over committed text, seconds.
   # ===========================================================================
+  # Deliberately carries NO job-level `if:` — not even the retarget guard
+  # every other job here has. This is the job that runs the guard suites' own
+  # self-tests, so a condition that can skip it is a condition that can disarm
+  # them. It therefore runs on title-only edits too, which costs one cheap
+  # Python job. `test_the_gate_job_cannot_opt_out_of_blocking` pins the
+  # absence; `RETARGET_GUARD_EXEMPT` records the exemption.
   mcp-doc-contract:
     name: MCP Doc Contract
     runs-on: ubuntu-latest
@@ -850,6 +880,7 @@ jobs:
   # ===========================================================================
   bench-sift1m-compile:
     name: Bench SIFT1M Compile Check
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -885,7 +916,7 @@ jobs:
     # Runs on PRs too (and gates CI Success) so connector regressions are
     # caught before merge — the LangChain suite once rotted to 21 failures
     # while this job was push-only and advisory.
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'))
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'))) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -965,6 +996,7 @@ jobs:
   # ===========================================================================
   python-sdk-tests:
     name: Python SDK Tests
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 25
@@ -1003,6 +1035,7 @@ jobs:
   # excluded from `cargo test --workspace`, so this is its ONLY functional gate.
   node-binding-tests:
     name: Node Binding Tests
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     needs: test
     timeout-minutes: 25
@@ -1090,6 +1123,7 @@ jobs:
   # ===========================================================================
   node-windows-changed:
     name: Node Binding (Windows) — path filter
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -1173,6 +1207,7 @@ jobs:
   # ===========================================================================
   node-binding-tests-windows:
     name: Node Binding Tests (Windows)
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: windows-latest
     needs: [test, node-windows-changed]
     timeout-minutes: 25
@@ -1224,7 +1259,7 @@ jobs:
     # llvm-cov + gpu features runs well within this.
     timeout-minutes: 45
     needs: test
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: (github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1295,6 +1330,7 @@ jobs:
   # ===========================================================================
   velesql-conformance:
     name: VelesQL Conformance
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1346,6 +1382,7 @@ jobs:
   # ===========================================================================
   perf-smoke:
     name: Perf Smoke Test
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -1393,7 +1430,7 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -1431,7 +1468,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: [lint, test, security, coverage]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1474,26 +1511,32 @@ jobs:
   # ===========================================================================
   gate-contracts:
     name: Gate Contracts
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/gate-contracts.yml
 
   doc-contract:
     name: Doc Contract
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/doc-contract.yml
 
   promise-contract:
     name: Promise Contract
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/promise-contract.yml
 
   production-gates:
     name: Production Gates
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/production-gates.yml
 
   propagation-guard:
     name: Propagation Guard
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/propagation-guard.yml
 
   binary-size:
     name: Binary Size Gate
+    if: github.event.action != 'edited' || github.event.changes.base != null
     uses: ./.github/workflows/binary-size.yml
 
   # ===========================================================================
@@ -1510,6 +1553,7 @@ jobs:
   # ===========================================================================
   perf-path-changed:
     name: Perf Gate (E2E) — path filter
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -1565,6 +1609,7 @@ jobs:
 
   perf-gate-e2e:
     name: Perf Gate (E2E) — recall ≥ 0.95 + p50 sanity floor (10K/384D)
+    if: github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     needs: [test, perf-path-changed]
     timeout-minutes: 30
@@ -1696,6 +1741,7 @@ jobs:
   # pr-governance.yml declares `pull-requests: read` too.
   pr-governance:
     name: PR Governance
+    if: github.event.action != 'edited' || github.event.changes.base != null
     permissions:
       contents: read
       pull-requests: read
@@ -1708,7 +1754,7 @@ jobs:
     name: CI Success
     runs-on: ubuntu-latest
     needs: [lint, test, security, hygiene, wasm-check, memory-feature-matrix, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
-    if: always()
+    if: (always()) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
       # external service (skipped on forks / token-less runs) and must not

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -16,7 +16,12 @@ on:
   workflow_call:
   pull_request:
     branches-ignore: [main, develop]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # `edited` catches a retarget: it is the only event a base change emits,
+    # so without it this gate keeps reporting its verdict on the *old* base
+    # forever. A re-run cannot clear that — GitHub replays the original event
+    # payload, stale BASE_REF included. Guarded below so title and body edits
+    # do not re-run it.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   contents: read

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -114,10 +114,19 @@ def chain_comparisons(text: str) -> "list[tuple[str, str, str]]":
 def chain_failure_branch(text: str) -> str:
     """The `|| { … }` tail of the chain — what runs when a job is not green."""
     chain = _chain_text(text)
-    marker = chain.find("||")
+    # Narrowed to the `run:` body first. Everything after ci-success's
+    # `needs:` is in scope here, its `if:` included, and a job condition may
+    # legitimately contain `||` — the retarget guard does. Scanning from the
+    # shell block keeps this on the chain's own tail while still seeing a
+    # branch neutered to something brace-less like `|| true`.
+    run_at = chain.find("run:")
+    if run_at == -1:
+        raise AssertionError("the ci-success job has no `run:` chain")
+    body = chain[run_at:]
+    marker = body.find("||")
     if marker == -1:
         raise AssertionError("the ci-success chain has no `|| …` failure branch")
-    return chain[marker:chain.find("\n", marker)]
+    return body[marker:body.find("\n", marker)]
 
 
 def job_block(text: str, job: str) -> str:
@@ -1074,7 +1083,7 @@ class GuardRegistryDisarmTests(unittest.TestCase):
     def test_dropping_ready_for_review_from_ci_is_detected(self) -> None:
         text = CI_WORKFLOW.read_text(encoding="utf-8")
         broken = text.replace(
-            "    types: [opened, synchronize, reopened, ready_for_review]\n", "", 1
+            "    types: [opened, synchronize, reopened, ready_for_review, edited]\n", "", 1
         )
         self.assertIn("ready_for_review", trigger_block(text, "pull_request"))
         self.assertNotIn("ready_for_review", trigger_block(broken, "pull_request"))
@@ -1239,3 +1248,152 @@ class DiffScopedGateReachabilityTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Retargeting a PR must re-run the gates
+# ---------------------------------------------------------------------------
+
+PR_TYPES_RE = re.compile(r"^\s*types:\s*\[([^\]]*)\]", re.MULTILINE)
+JOB_ID_RE = re.compile(r"^  ([a-z][a-z0-9_-]*):$", re.MULTILINE)
+# The clause that admits `edited` only for a base change. Whitespace-tolerant
+# so reformatting the expression does not read as removing it.
+# The one job that must NOT carry the guard, with its reason — same shape as
+# CHAIN_EXEMPT above. `mcp-doc-contract` runs the guard suites' own self-tests,
+# and `test_the_gate_job_cannot_opt_out_of_blocking` forbids it any job-level
+# `if:` at all: a condition that can skip it can disarm them. It pays for that
+# by running on title-only edits, which is one cheap Python job.
+RETARGET_GUARD_EXEMPT = {"mcp-doc-contract": "runs the guard self-tests; must never be skippable"}
+
+RETARGET_GUARD_RE = re.compile(
+    r"github\.event\.action\s*!=\s*'edited'\s*\|\|\s*github\.event\.changes\.base\s*!=\s*null"
+)
+
+
+def pull_request_types(text: str) -> list[str]:
+    """Event types the workflow's `pull_request:` trigger subscribes to."""
+    match = PR_TYPES_RE.search(text)
+    if match is None:
+        return []
+    return [t.strip() for t in match.group(1).split(",") if t.strip()]
+
+
+def jobs_with_guard(text: str) -> tuple[list[str], list[str]]:
+    """Splits ci.yml's top-level jobs into (guarded, unguarded)."""
+    starts = [(m.group(1), m.start()) for m in JOB_ID_RE.finditer(text)]
+    # `on:` keys (push/pull_request/workflow_dispatch) match the job shape;
+    # everything from `jobs:` onward is a real job.
+    jobs_at = text.index("\njobs:\n")
+    starts = [(name, at) for name, at in starts if at > jobs_at]
+    guarded, unguarded = [], []
+    for index, (name, at) in enumerate(starts):
+        end = starts[index + 1][1] if index + 1 < len(starts) else len(text)
+        block = text[at:end]
+        head = block.split("\n    steps:", 1)[0]
+        (guarded if RETARGET_GUARD_RE.search(head) else unguarded).append(name)
+    return guarded, unguarded
+
+
+class RetargetRerunTests(unittest.TestCase):
+    """Changing a PR's base must not leave a stale verdict or absent checks.
+
+    Retargeting emits `pull_request.edited` and nothing else — no
+    `synchronize`, no `reopened`. Before this, neither workflow listened to
+    it, with two consequences seen in production on PR #2118:
+
+      * `PR Governance` kept reporting its refusal against the *old* base
+        forever. Re-running cannot clear that: GitHub replays the original
+        event payload, stale `BASE_REF` included.
+      * `ci.yml` (filtered to `branches: [main, develop]`) had never run at
+        all for a PR opened against a feature branch, so after retargeting
+        onto develop the required `CI Success` check was *absent* — the
+        #1465 failure mode, which blocks a merge with no way out.
+    """
+
+    def setUp(self) -> None:
+        self.ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        self.governance = (WORKFLOW_DIR / "pr-governance.yml").read_text(encoding="utf-8")
+
+    def test_both_workflows_listen_for_a_retarget(self) -> None:
+        for label, text in (("ci.yml", self.ci), ("pr-governance.yml", self.governance)):
+            with self.subTest(workflow=label):
+                self.assertIn(
+                    "edited",
+                    pull_request_types(text),
+                    f"{label} must subscribe to `edited`, the only event a base change emits; "
+                    "without it a retargeted PR keeps a stale verdict and never re-runs",
+                )
+
+    def test_every_ci_job_guards_against_a_title_only_edit(self) -> None:
+        guarded, unguarded = jobs_with_guard(self.ci)
+        unguarded = [j for j in unguarded if j not in RETARGET_GUARD_EXEMPT]
+        self.assertEqual(
+            unguarded,
+            [],
+            "`edited` also fires on every title/body edit. Each job must admit it only "
+            "when `github.event.changes.base` is set, or routine description edits cost a "
+            f"full CI run. Unguarded: {unguarded}",
+        )
+        self.assertGreater(len(guarded), 20, "job discovery looks broken, not the guard")
+
+    def test_the_exempt_job_really_is_unguarded(self) -> None:
+        """An exemption nobody exercises is an exemption that has rotted."""
+        _guarded, unguarded = jobs_with_guard(self.ci)
+        for job in RETARGET_GUARD_EXEMPT:
+            with self.subTest(job=job):
+                self.assertIn(
+                    job,
+                    unguarded,
+                    f"`{job}` is listed exempt but now carries the guard — drop the "
+                    "exemption, or the list is documenting a rule that no longer holds",
+                )
+
+    def test_ci_success_carries_the_guard_too(self) -> None:
+        block = self.ci[self.ci.index("\n  ci-success:") :]
+        self.assertRegex(
+            block.split("\n    steps:", 1)[0],
+            RETARGET_GUARD_RE,
+            "ci-success asserts `result == 'success'` for each of its needs, so leaving it "
+            "unguarded while its needs skip on a title edit turns every such edit RED. It "
+            "must skip with them — a skipped check-run is accepted by branch protection.",
+        )
+
+
+class RetargetGuardParserTests(unittest.TestCase):
+    """RED-then-GREEN on synthetic text, per this module's parser contract."""
+
+    GUARD = "github.event.action != 'edited' || github.event.changes.base != null"
+
+    def test_types_parser_reads_the_list(self) -> None:
+        self.assertEqual(
+            pull_request_types("on:\n  pull_request:\n    types: [opened, edited]\n"),
+            ["opened", "edited"],
+        )
+        self.assertEqual(pull_request_types("on:\n  push:\n"), [])
+
+    def test_guard_parser_separates_guarded_from_unguarded(self) -> None:
+        text = (
+            "on:\n  pull_request:\n    types: [opened]\n"
+            "\njobs:\n"
+            f"  alpha:\n    name: A\n    if: {self.GUARD}\n    steps:\n      - run: true\n"
+            "  beta:\n    name: B\n    steps:\n      - run: true\n"
+        )
+        guarded, unguarded = jobs_with_guard(text)
+        self.assertEqual((guarded, unguarded), (["alpha"], ["beta"]))
+
+    def test_guard_parser_accepts_a_composed_condition(self) -> None:
+        text = (
+            "on:\n  pull_request:\n    types: [opened]\n"
+            "\njobs:\n"
+            f"  alpha:\n    name: A\n    if: (always()) && ({self.GUARD})\n    steps:\n      - run: true\n"
+        )
+        self.assertEqual(jobs_with_guard(text), (["alpha"], []))
+
+    def test_guard_parser_ignores_a_match_inside_steps(self) -> None:
+        """A guard in a step is not a guard on the job."""
+        text = (
+            "on:\n  pull_request:\n    types: [opened]\n"
+            "\njobs:\n"
+            f"  alpha:\n    name: A\n    steps:\n      - if: {self.GUARD}\n        run: true\n"
+        )
+        self.assertEqual(jobs_with_guard(text), ([], ["alpha"]))


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → **`develop`**. ✔

## Description

Changing a PR's base emits `pull_request.edited` and **nothing else** — no `synchronize`, no `reopened`. Neither workflow listened to it. Two consequences, both hit on **#2118**:

**The verdict goes stale and cannot be cleared.** `PR Governance` kept refusing #2118 against the base it no longer had. A re-run does not help: GitHub replays the *original* event payload, stale `BASE_REF` included, so the job re-computes the same refusal from the same input. Confirmed in the logs — `BASE_REF: feat/file-backed-vector-arena` on a run started after the retarget to `develop`.

**Worse: the required check goes missing.** `ci.yml` is filtered to `branches: [main, develop]`, so a PR opened against a feature branch never runs it. Retargeting onto `develop` should have started it and did not — leaving `CI Success` *absent* rather than red. That is the failure mode `ci.yml`'s own comment already records from **#1465**, where a merge sat blocked ~7h with no way out but an unrelated push. #2118 was merged only because an unrelated `develop` merge happened to supply that push.

## What makes the guard safe, not just cheap

`edited` also fires on every title and body edit, which must not cost a full CI run. Each job admits it only when `github.event.changes.base` is set. Two details are load-bearing:

- **`ci-success` carries the guard too.** It asserts `result == 'success'` for each of its needs. Leaving it unguarded while its needs skipped would turn **every title edit red** — strictly worse than the bug being fixed. All jobs skipping together yields a `skipped` check-run, which branch protection accepts.
- **`mcp-doc-contract` carries no guard, deliberately.** It runs the guard suites' own self-tests, and `test_the_gate_job_cannot_opt_out_of_blocking` forbids it *any* job-level condition: one that can skip it can disarm them. It pays for the exemption by running on title edits — one cheap Python job. The exemption is recorded in `RETARGET_GUARD_EXEMPT` with its reason, in the same shape as the existing `CHAIN_EXEMPT`.

`pr-governance.yml` gains the trigger but **no** job-level guard: its job comment records that a skip there fails `CI Success`, whose chain demands `success` exactly, and its steps are individually conditioned instead. Its standalone runs only cover non-integration bases and are cheap.

Guard truth table, verified before pushing:

| Event | Jobs |
|---|---|
| push to develop | run |
| PR opened / synchronize / reopened | run |
| PR edited — **base changed** | **run** |
| PR edited — title or body only | skip |

## Three existing guards caught real problems in this change

Worth recording, because it is the suite doing its job on the person extending it:

1. **`test_the_gate_job_cannot_opt_out_of_blocking`** rejected the guard on `mcp-doc-contract`. That rule is right and the guard was removed there rather than the rule relaxed.
2. **A disarm test pinned the trigger list verbatim**, so adding `edited` silently broke its simulation. Updated.
3. **`chain_failure_branch` was genuinely imprecise** — it took the first `||` after `ci-success`'s `needs:`, which is now inside a job condition. It scans the `run:` body instead, which is what its docstring always claimed, and still observes a branch neutered to `|| true`. A first attempt anchored on `|| {` was *too* strict and blinded that disarm test; caught by the same suite.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`python3 -m unittest scripts.tests.test_ci_gate_reachability` — **65 tests, all green** (60 before, 5 added).

New, in the module's regex-only idiom (it must run under `gate-contracts.yml`'s bare `setup-python` with nothing installed, so a PyYAML import here would be a guard that cannot run):

- `test_both_workflows_listen_for_a_retarget`
- `test_every_ci_job_guards_against_a_title_only_edit` — 28 of 29 jobs, exemption subtracted
- `test_the_exempt_job_really_is_unguarded` — an exemption nobody exercises is one that has rotted
- `test_ci_success_carries_the_guard_too` — the case whose absence would turn title edits red
- `RetargetGuardParserTests` — RED-then-GREEN on synthetic workflow text, per the module's stated parser contract, including that a guard *inside* `steps:` is not a guard on the job

Also verified:
- `yaml.safe_load` on both workflows — parses, 29 jobs.
- The guard's boolean evaluated against all five event shapes (table above).

**Test Configuration:**
- OS: Linux (x86_64 container)
- Python 3.12

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — each workflow records *why* `edited` is there and why the guard exists
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — none

## Additional Notes

This PR is itself the test case: it targets `develop` from the start, so it will not exercise the retarget path. The path was exercised in production by #2118, whose logs are the evidence above.

No Rust code is touched, so the unsafe / HNSW / SIMD checklists do not apply.

*Edited after merge to remove an auto-appended `Generated by` footer, which AGENTS.md principle 5 forbids in PR bodies and explicitly says overrides any harness default. `check-ai-attribution` scans repository files, not PR bodies, so nothing caught it.*