### PR TITLE
docs(agents): a documented deferral is a decision, not a defect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ Bias toward caution over speed. For trivial tasks, use judgment.
 
 **7. Complete the binding memory loop.** For VelesDB design and implementation, follow `velesdb-learning-loop`: recall before the first repository edit, remember non-trivial decisions, relate each decision or incident to its cause with an outgoing edge, and return feedback for every recalled memory that helped or misled. (`PreToolUse`/`PostToolUse` recall sentinel plus the blocking `Stop` checklist; `scripts/tests/test_learning_loop_policy.py`.) The edit guard is an opt-in guardrail, not a security boundary: shell mutations remain outside it, and the last three steps are enforced by policy plus the stop continuation rather than individual tool denials.
 
+**8. A recorded decision is not a defect.** Two places in this repository hold conclusions someone already reached with evidence, and both read like oversights if you skip them. **Open design issues carry their state in the most recent status comment** — #2112 lists five things deferred on purpose (each with the reason: an endianness constraint, a vacuum invariant, flash endurance, an unreachable path, a missing measurement), #2106 records which of its 19 findings are fixed and what survived the fix. **Module docs record *why*, not only what** — `contiguous_file_arena.rs` and `index/hnsw/native/arena_home.rs` explain that the arena is deliberately written twice per collection lifetime and that `flush_backing` deliberately has no caller. Read the issue comment and the module doc before "fixing" either. Reopening a documented deferral without *new* evidence is churn; if you believe one is wrong, say why with evidence and let the maintainer decide. And never claim a performance or memory win that has not been measured — #2112's own acceptance criteria say "demonstrated in a test or bench artifact — not asserted in prose".
+
 ---
 
 ## Non-negotiable constraints (CI-enforced — a PR breaking any cannot merge)
@@ -36,6 +38,11 @@ Bias toward caution over speed. For trivial tasks, use judgment.
 - **Recall@10 ≥ 0.95** if you touch the search path (`index/hnsw/`, `simd_native/`, `quantization/`, `fusion/`, or Python result conversion). See [QUALITY_BAR.md](QUALITY_BAR.md) Gate 1.
 - **TODOs:** every `TODO`/`FIXME`/`HACK` carries a tracker tag — `TODO(EPIC-XXX)`, `[EPIC-XXX/US-YYY]`, `(PREFIX-NNN)` or `#123`; bare markers fail. (`scripts/check-todo-annotations.py`)
 - **Git Flow:** branch off and target `develop`, never `main`. Release/hotfix branches target `main`.
+- **No stacked PRs.** The Git Flow gate accepts only `main` and `develop` as bases, and `ci.yml`
+  is filtered to those two — so a PR opened against another branch never runs it and its required
+  `CI Success` check ends up *absent*, not red, which blocks the merge with no way out but an
+  unrelated push (#1465, and again on #2118). If your work depends on unmerged work, wait for the
+  merge. Retargeting afterwards now re-runs the gates (#2124) but starts from a clean slate.
 - **Crate quirks that `ls` won't tell you:** `velesdb-python` is excluded from the strict clippy
   line above (N-API/PyO3 link); `velesdb-node` builds with the `release-node` profile
   and mobile device builds with `release-mobile` (both `panic = "unwind"`); `velesdb-wasm` has no `persistence` feature.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`docs/*` → **`develop`**. ✔

## Description

Two kinds of conclusion in this repository read like oversights to anyone who skips where they are written down. Both were re-derived from scratch during the #2112 Phase B work before it became clear they already existed.

**Open design issues carry their state in the most recent status comment**, not in the original body:

- **#2112** now lists five deferrals with the evidence behind each — an endianness constraint on `.vectors` (explicitly little-endian; an arena is native-endian raw memory, and no `target_endian` gate exists in the crate), a vacuum invariant that forces per-instance arenas, flash endurance ruling out `msync`, an unreachable `reorder` path, and a measurement that does not exist yet.
- **#2106** records which of its 19 findings are fixed and what survived the fix — including a `NOT similarity()` inconsistency that #2119 did not close, and why the principled fix is tri-state logic rather than a one-liner.

**Module docs in the same area record *why*, not only what.** `contiguous_file_arena.rs` and `index/hnsw/native/arena_home.rs` explain that the arena is deliberately written twice per collection lifetime, and that `flush_backing` deliberately has no caller and should not get one. Read as code alone, both look like defects worth fixing.

New **principle 8** says to read those before "fixing" either, that reopening a documented deferral without *new* evidence is churn, and — restating what #2112's own acceptance criteria already demand — never claim a performance or memory win that has not been measured.

Separately, the constraints list gains the **stacked-PR** fact. The Git Flow gate accepts only `main` and `develop` as bases, and `ci.yml` is filtered to those two, so a PR opened against anything else never runs it — leaving the required `CI Success` check *absent* rather than red, which blocks a merge with no way out but an unrelated push. That is #1465's failure mode, and it recurred on **#2118**, where the merge only unblocked because an unrelated `develop` merge happened to supply the push. #2124 makes a retarget re-run the gates; this records why not to need it.

## Type of Change

- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] `python3 scripts/check-doc-freshness.py` — passed
- [x] `python3 scripts/check-todo-annotations.py` — passed
- [x] `python3 -m unittest scripts.tests.test_ci_gate_reachability` — 57 tests, OK

Prose only; no code path is touched, so no Rust suite applies.

Two things worth flagging about how this got here:

1. Principle 8 was first inserted *before* principle 7, leaving the list numbered 1–6, 8, 7. Caught on re-reading and reordered before pushing.
2. This PR body originally carried an auto-appended `_Generated by [Claude Code]_` footer — which principle **5**, three sections above the one being added, forbids in PR bodies and explicitly says overrides any harness default. Removed. `check-ai-attribution` scans repository files, not PR bodies, so nothing would have caught it. Noted here rather than quietly fixed, since a PR adding a principle about respecting recorded decisions should not have violated a neighbouring one.

**Test Configuration:**
- OS: Linux (x86_64 container)
- Python 3.12

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A, the change *is* documentation
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — no test applies to prose. The claims it makes are each traceable to a linked issue comment, module doc, or CI behaviour.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #2124 is merged; `develop` has since been merged into this branch for freshness.

## Additional Notes

`AGENTS.md` is deliberately dense, so this adds one principle and one constraint bullet rather than a new section. Every claim in principle 8 names the artifact that backs it, so a reader can check it rather than take it on trust.

Written because the deferrals it points at were, until this week, held only in one agent session's working state — where they would have evaporated. They now live on the issues; this is the signpost to them.