### PR TITLE
fix(ci): a run whose jobs all skip must not cancel the run doing the work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,27 @@ on:
   workflow_dispatch:
 
 # Annuler les runs précédents pour la même branche/PR
+#
+# `cancel-in-progress` carries the *same predicate as every job's guard*, and
+# that is the whole point: a run whose jobs all skip must not be allowed to
+# cancel a run whose jobs are doing the work. Without this, editing a PR's
+# title or body while CI is running killed that CI and replaced it with an
+# all-skipped run — and because branch protection accepts a `skipped` required
+# check, `CI Success` then reported green with nothing having run. That is
+# #1465's hole (a required check that does not reflect any actual work) reached
+# through a far more common door than the retarget `edited` was added for. Hit
+# in production on PR #2125: run 4312 (`synchronize`) was cancelled 28s in by
+# run 4313 (`edited`, a body edit), which skipped all 27 guarded jobs.
+#
+# Keeping the predicate character-identical to the job guard is deliberate —
+# two spellings of "this run is a no-op" is how the two drift apart and the
+# hole reopens. Pinned by scripts/tests/test_ci_gate_reachability.py.
+#
+# A no-op run does not cancel; it queues behind the real run and finishes in
+# seconds. A real run still cancels whatever is stale, no-op or not.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
 
 permissions:
   contents: read

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1246,10 +1246,6 @@ class DiffScopedGateReachabilityTests(unittest.TestCase):
                     )
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 # ---------------------------------------------------------------------------
 # Retargeting a PR must re-run the gates
 # ---------------------------------------------------------------------------
@@ -1397,3 +1393,88 @@ class RetargetGuardParserTests(unittest.TestCase):
             f"  alpha:\n    name: A\n    steps:\n      - if: {self.GUARD}\n        run: true\n"
         )
         self.assertEqual(jobs_with_guard(text), ([], ["alpha"]))
+
+
+# ---------------------------------------------------------------------------
+# A run that does nothing must not cancel a run that does something
+# ---------------------------------------------------------------------------
+
+CANCEL_IN_PROGRESS_RE = re.compile(r"^\s*cancel-in-progress:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def cancel_in_progress(text: str) -> str:
+    """The workflow-level `cancel-in-progress:` value, verbatim."""
+    match = CANCEL_IN_PROGRESS_RE.search(text)
+    return "" if match is None else match.group(1)
+
+
+class NoOpRunCannotCancelRealCiTests(unittest.TestCase):
+    """The guard makes a title edit cheap; this keeps it from making CI absent.
+
+    `edited` fires on every title and body edit, and every job guards against
+    it — so such a run skips all 27 of them. It still joins the concurrency
+    group, though, and with an unconditional `cancel-in-progress: true` it
+    *cancelled the real run it arrived behind*, leaving an all-skipped run in
+    its place. Branch protection accepts a `skipped` required check, so
+    `CI Success` then reported green having run nothing: #1465's hole (a
+    required check that reflects no actual work) reached through a much more
+    common door than the retarget this trigger was added for.
+
+    Seen in production on PR #2125 — run 4312 (`synchronize`) cancelled 28
+    seconds in by run 4313, a body edit.
+    """
+
+    def setUp(self) -> None:
+        self.ci = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_a_no_op_run_does_not_cancel_the_run_it_arrives_behind(self) -> None:
+        value = cancel_in_progress(self.ci)
+        self.assertTrue(value, "ci.yml declares no `cancel-in-progress:` — parser or workflow broke")
+        self.assertNotEqual(
+            value,
+            "true",
+            "an unconditional `cancel-in-progress` lets a title/body edit — whose jobs all "
+            "skip — cancel the real CI run and stand in for it. Branch protection accepts "
+            "the resulting skipped check, so `CI Success` goes green having run nothing.",
+        )
+        self.assertRegex(
+            value,
+            RETARGET_GUARD_RE,
+            "`cancel-in-progress` must carry the same predicate as the job guard: a run may "
+            "cancel another only when it is not itself a no-op.",
+        )
+
+    def test_the_predicate_is_spelled_the_same_as_the_job_guard(self) -> None:
+        """Two spellings of \"this run is a no-op\" is how the two drift apart."""
+        guard_in_cancel = RETARGET_GUARD_RE.search(cancel_in_progress(self.ci))
+        self.assertIsNotNone(guard_in_cancel)
+        block = self.ci[self.ci.index("\n  ci-success:") :].split("\n    steps:", 1)[0]
+        guard_in_job = RETARGET_GUARD_RE.search(block)
+        self.assertIsNotNone(guard_in_job)
+        self.assertEqual(
+            guard_in_cancel.group(0),
+            guard_in_job.group(0),
+            "the concurrency predicate and the job guard must be character-identical, so "
+            "editing one and not the other cannot silently reopen the hole",
+        )
+
+
+class CancelInProgressParserTests(unittest.TestCase):
+    """RED-then-GREEN on synthetic text, per this module's parser contract."""
+
+    def test_parser_reads_a_literal_and_an_expression(self) -> None:
+        self.assertEqual(
+            cancel_in_progress("concurrency:\n  group: g\n  cancel-in-progress: true\n"),
+            "true",
+        )
+        self.assertEqual(
+            cancel_in_progress("concurrency:\n  group: g\n  cancel-in-progress: ${{ a != b }}\n"),
+            "${{ a != b }}",
+        )
+
+    def test_parser_reports_absence_rather_than_guessing(self) -> None:
+        self.assertEqual(cancel_in_progress("concurrency:\n  group: g\n"), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → **targets `develop`**. ✅

## Description

#2124 added `edited` to `ci.yml`'s `pull_request` types, because retargeting a PR is the only thing a base change emits, and guarded every job so that the title and body edits sharing that trigger cost nothing. The guard works. The concurrency block does not.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true          # unconditional
```

A no-op `edited` run joins that group and **cancels whatever real run it arrives behind**, standing in for it with 27 skipped jobs. Branch protection accepts a `skipped` required check, so `CI Success` then reports green having run nothing — a required check that reflects no actual work. That is #1465's hole, reached through a far more common door than the retarget the trigger was added for: editing a description while CI is running is enough.

Seen in production on #2125:

| Run | Created | Event | Outcome |
|---|---|---|---|
| 4312 | 10:57:19 | `synchronize` | **cancelled** |
| 4313 | 10:57:47 | `edited` (body edit) | 27 jobs skipped → run "success" |

The only job that survived was `mcp-doc-contract`, the one deliberately exempt from the guard — which is what made the cause unambiguous.

### The fix

`cancel-in-progress` now carries the guard's predicate, character for character:

```yaml
cancel-in-progress: ${{ github.event.action != 'edited' || github.event.changes.base != null }}
```

Reusing the *spelling* rather than restating the idea in a group key is the point: two ways of saying "this run is a no-op" is how the two drift apart and the hole reopens. A test asserts they stay identical.

Semantics: a no-op run no longer cancels — it queues behind the real run and finishes in seconds. A real run still cancels whatever is stale, no-op or not.

### Also in this diff

This suite's `if __name__ == "__main__": unittest.main()` block had sat mid-module since before #2124. CI invokes the module (`python3 -m unittest`) and was unaffected, but running the file directly executed `unittest.main()` before the last two classes were defined and reported **OK on 57 of 65 tests** — silently dropping the entire retarget-guard suite. Moved to the end of the file; 69 either way now.

Fixes the regression introduced by #2124.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

Two new assertions in `scripts/tests/test_ci_gate_reachability.py`, **both confirmed RED against the unconditional value before the fix**:

- `test_a_no_op_run_does_not_cancel_the_run_it_arrives_behind` — `cancel-in-progress` must not be the bare literal `true`, and must carry the guard predicate.
- `test_the_predicate_is_spelled_the_same_as_the_job_guard` — the concurrency predicate and `ci-success`'s guard must be character-identical.

Plus `CancelInProgressParserTests`, RED-then-GREEN on synthetic text per this module's parser contract (literal, expression, and absence).

```
# with the fix reverted
FAILED (failures=2)

# with the fix
python3 -m unittest scripts.tests.test_ci_gate_reachability   → Ran 69 tests, OK
python3 scripts/tests/test_ci_gate_reachability.py            → Ran 69 tests, OK
```

Also run clean: the 27 other `scripts/tests/` gate suites, `check-ai-attribution.py`, `check-file-budgets.py`, and a `yaml.safe_load` of `ci.yml` (29 jobs, types and group intact).

**Test Configuration:**
- OS: Ubuntu (Linux 6.18)
- Rust version: n/a — no Rust code in this diff

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — the `concurrency:` comment records the failure mode and why the predicate is duplicated verbatim
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #2124 is on `develop`

## Unsafe Code Checklist

Not applicable — no `unsafe` code in this diff.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD path is touched. The risk here is CI-integrity, which the two new tests pin.

## Additional Notes

Worth knowing for review: with this merged, a PR whose description is edited mid-run keeps its running CI. Before it, that PR could reach a mergeable state with zero jobs having executed.

An assistant-attribution footer was appended to this body automatically on creation. It is removed here: `AGENTS.md` principle 5 forbids such attribution in PR bodies and says so in terms that override any tooling default. Noted rather than quietly fixed, since the same slip happened on #2112 and #2106.
