### PR TITLE
perf(quantization): measure the resident set instead of claiming it

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -164,6 +164,11 @@ name = "profile_batch_insert"
 path = "examples/profile_batch_insert.rs"
 required-features = ["persistence"]
 
+[[example]]
+name = "resident_set"
+path = "examples/resident_set.rs"
+required-features = ["persistence"]
+
 [[test]]
 name = "scale_recall_100k"
 required-features = ["persistence"]

--- a/crates/velesdb-core/examples/resident_set.rs
+++ b/crates/velesdb-core/examples/resident_set.rs
@@ -1,0 +1,321 @@
+//! Measures what a quantized index actually costs in un-evictable RAM.
+//!
+//! #2112 asks for the resident set of a 100 000 × 768-d SQ8 index to be
+//! `codes + graph`, "demonstrated in a test or bench artifact — not asserted
+//! in prose", plus the cold-page re-rank cost that evictability buys. This is
+//! that artifact.
+//!
+//! # Why `VmRSS` is the wrong number
+//!
+//! A mapped file's pages count toward `VmRSS` for as long as they are
+//! resident, so an index whose f32 arena is file-backed reports the *same*
+//! `VmRSS` as one whose arena is on the heap — right up until memory pressure
+//! arrives. Reading `VmRSS` and concluding "no saving" would be wrong, and
+//! waiting for pressure would measure the host, not the change.
+//!
+//! What changed is which *kind* of page holds the f32, and Linux reports that
+//! directly in `/proc/self/status`:
+//!
+//! - `RssAnon` — anonymous pages, reclaimable only by swapping. The
+//!   edge/IoT device this feature targets usually has no swap, so this is the
+//!   floor that decides whether the process fits at all.
+//! - `RssFile` — file-backed pages, reclaimable by dropping them, because
+//!   the file already holds their contents.
+//!
+//! The file-backed arena moves `N × D × 4` bytes from the first to the
+//! second. That is the whole claim, and it is a difference this program reads
+//! rather than infers.
+//!
+//! # One mode per process, always
+//!
+//! The first collection built in a process absorbs every one-time cost the
+//! process pays — thread pools, allocator arenas, lazy statics. Measured back
+//! to back in one run, `Full` charged +310 MiB of `RssAnon` for a 14.6 MiB
+//! arena while `SQ8` charged +16 MiB, and almost all of that gap was the
+//! order, not the mode. So this program measures **one** mode per invocation
+//! and the comparison is made between runs.
+//!
+//! # The two halves are measured at different levels, on purpose
+//!
+//! **Resident set** goes through `Database`, the real production path: only a
+//! collection owns the directory that makes its arena file-backed, and a
+//! number measured anywhere else would not be the number a user pays.
+//!
+//! **Cold-page cost** goes through `ContiguousVectors` directly. Evicting a
+//! live collection's arena would need a public API whose only caller is this
+//! program, and the page-fault cost is a property of the arena, not of the
+//! graph above it — isolating it removes traversal noise from a figure that
+//! is meant to be about I/O. What a re-rank does to the arena is read `k`
+//! scattered vectors, which is exactly what the cold loop below times.
+//!
+//! # Two kinds of cold
+//!
+//! `MADV_DONTNEED` drops the *process's* pages, but the file's contents can
+//! still sit in the page cache, so the next touch is a minor fault — cheap,
+//! and not what evictability costs. Reclaim under real pressure takes the page
+//! cache too, and the next touch is a disk read. Both are reported: the minor
+//! fault is the floor, the post-`POSIX_FADV_DONTNEED` figure is what an
+//! edge device without swap actually pays.
+//!
+//! # Usage
+//!
+//! ```text
+//! cargo run --release --example resident_set --features persistence -- <mode> [N] [D]
+//! ```
+//!
+//! `mode` is `full`, `sq8`, or `cold`, and only one runs per invocation — see
+//! above for why. `N` and `D` default to the configuration #2112 names, so the
+//! three runs behind the published tables are `-- full`, `-- sq8` and
+//! `-- cold`. Linux only: no other platform
+//! exposes the anonymous/file split, and reporting `VmRSS` alone would be
+//! reporting the very number this program exists to reject.
+
+fn main() {
+    #[cfg(all(target_os = "linux", feature = "persistence"))]
+    linux::run();
+    #[cfg(not(all(target_os = "linux", feature = "persistence")))]
+    eprintln!(
+        "resident_set needs Linux (for the RssAnon/RssFile split) and \
+         --features persistence (for the file-backed arena)."
+    );
+}
+
+#[cfg(all(target_os = "linux", feature = "persistence"))]
+mod linux {
+    use std::time::{Duration, Instant};
+    use velesdb_core::perf_optimizations::ContiguousVectors;
+    use velesdb_core::{Database, DistanceMetric, Point, StorageMode};
+
+    /// The split that decides whether an index fits on a small device.
+    #[derive(Clone, Copy)]
+    struct Rss {
+        anon_kb: u64,
+        file_kb: u64,
+    }
+
+    impl Rss {
+        fn read() -> Self {
+            let status = std::fs::read_to_string("/proc/self/status")
+                .expect("Linux always exposes /proc/self/status");
+            Self {
+                anon_kb: field(&status, "RssAnon:"),
+                file_kb: field(&status, "RssFile:"),
+            }
+        }
+    }
+
+    /// Pulls one `kB` field out of `/proc/self/status`.
+    fn field(status: &str, key: &str) -> u64 {
+        status
+            .lines()
+            .find_map(|l| l.strip_prefix(key))
+            .and_then(|v| v.split_whitespace().next())
+            .and_then(|v| v.parse().ok())
+            .unwrap_or_else(|| panic!("{key} missing from /proc/self/status"))
+    }
+
+    /// kB, as `/proc` reports it, to MiB.
+    ///
+    /// The cast is lossy above 2^53 kB — eight petabytes of resident memory,
+    /// which no reading here will reach.
+    #[allow(clippy::cast_precision_loss)]
+    fn mib(kb: u64) -> f64 {
+        kb as f64 / 1024.0
+    }
+
+    /// Deterministic vectors: reproducible runs, and no RNG in the measurement.
+    ///
+    /// The cast is exact: the modulo bounds the value below 1000, well inside
+    /// an f32 mantissa.
+    #[allow(clippy::cast_precision_loss)]
+    fn vector(seed: usize, dimension: usize) -> Vec<f32> {
+        (0..dimension)
+            .map(|d| ((seed * 31 + d * 17) % 1000) as f32 / 1000.0 - 0.5)
+            .collect()
+    }
+
+    /// Builds one collection and reports what it added to each kind of RSS.
+    ///
+    /// Hands the database back so the caller can hold it: dropping it would
+    /// release the arena and make the reading describe memory nobody holds.
+    fn build(
+        label: &str,
+        mode: StorageMode,
+        count: usize,
+        dimension: usize,
+    ) -> (Database, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("a writable temp dir");
+        let before = Rss::read();
+        let db = Database::open(dir.path()).expect("database opens");
+        db.create_vector_collection_with_options("bench", dimension, DistanceMetric::Cosine, mode)
+            .expect("collection creates");
+        let coll = db
+            .get_vector_collection("bench")
+            .expect("the collection just created");
+
+        let started = Instant::now();
+        for chunk in (0..count).step_by(1_000) {
+            let points: Vec<Point> = (chunk..(chunk + 1_000).min(count))
+                .map(|i| Point::without_payload(i as u64, vector(i, dimension)))
+                .collect();
+            coll.upsert(points).expect("upsert succeeds");
+        }
+        let after = Rss::read();
+
+        println!(
+            "{label:<28} {:>6.1}s   RssAnon +{:>8.1} MiB   RssFile +{:>8.1} MiB",
+            started.elapsed().as_secs_f64(),
+            mib(after.anon_kb.saturating_sub(before.anon_kb)),
+            mib(after.file_kb.saturating_sub(before.file_kb)),
+        );
+        (db, dir)
+    }
+
+    /// Median — robust to the one slow sample a shared runner always produces.
+    fn median(mut samples: Vec<Duration>) -> Duration {
+        samples.sort_unstable();
+        samples[samples.len() / 2]
+    }
+
+    /// Times `rounds` re-rank-shaped reads: `k` scattered vectors each.
+    ///
+    /// Every element is summed, not just the first. A vector is `D × 4` bytes
+    /// — 3 KiB at 768 dims — so it straddles one or two pages, and a re-rank
+    /// computing a distance touches all of them. Reading only `v[0]` would
+    /// fault a single page per vector and undercount the very thing this
+    /// measures. `black_box` keeps the sum from being optimised away.
+    fn time_scattered_reads(
+        arena: &ContiguousVectors,
+        count: usize,
+        k: usize,
+        rounds: usize,
+    ) -> Duration {
+        let samples: Vec<Duration> = (0..rounds)
+            .map(|r| {
+                let started = Instant::now();
+                for i in 0..k {
+                    // A stride coprime with `count` visits a different scatter
+                    // each round without repeating within one.
+                    let idx = (r * 7919 + i * 104_729) % count;
+                    let v = arena.get(idx).expect("index in range");
+                    std::hint::black_box(v.iter().sum::<f32>());
+                }
+                started.elapsed()
+            })
+            .collect();
+        median(samples)
+    }
+
+    /// The cast is lossy only past 2^53 bytes of arena, which would need more
+    /// vectors than the address space holds.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn run() {
+        let args: Vec<String> = std::env::args().collect();
+        let mode_arg = args.get(1).map_or("sq8", String::as_str);
+        let count: usize = args.get(2).and_then(|a| a.parse().ok()).unwrap_or(100_000);
+        let dimension: usize = args.get(3).and_then(|a| a.parse().ok()).unwrap_or(768);
+        let f32_mib = (count * dimension * 4) as f64 / (1024.0 * 1024.0);
+
+        let (mode, label) = match mode_arg {
+            "full" => (StorageMode::Full, "Full (heap arena)"),
+            "sq8" => (StorageMode::SQ8, "SQ8 (file-backed arena)"),
+            "cold" => {
+                cold_page_cost(count, dimension);
+                return;
+            }
+            other => {
+                eprintln!("unknown mode {other:?}; expected full | sq8 | cold");
+                std::process::exit(2);
+            }
+        };
+
+        println!("Resident set — {count} × {dimension}-d");
+        println!(
+            "f32 arena {f32_mib:.1} MiB · SQ8 codes {:.1} MiB\n",
+            f32_mib / 4.0
+        );
+
+        let (db, _dir) = build(label, mode, count, dimension);
+        // Alive to here: the reading above describes memory that must still be
+        // held for it to mean anything.
+        drop(db);
+    }
+
+    /// The honest price of evictability, isolated from graph traversal.
+    fn cold_page_cost(count: usize, dimension: usize) {
+        const K: usize = 100;
+        const ROUNDS: usize = 50;
+
+        let dir = tempfile::tempdir().expect("a writable temp dir");
+        let path = dir.path().join("arena.bin");
+        let mut arena = ContiguousVectors::new_file_backed(&path, dimension, count)
+            .expect("a file-backed arena");
+        for i in 0..count {
+            arena.push(&vector(i, dimension)).expect("push succeeds");
+        }
+
+        println!("Cold-page re-rank cost — {K} scattered vectors, median of {ROUNDS} rounds");
+        let warm = time_scattered_reads(&arena, count, K, ROUNDS);
+        report("warm", warm, warm);
+
+        // Minor fault: the process loses its pages, the page cache keeps them.
+        let before = Rss::read();
+        arena.evict_backing().expect("eviction succeeds");
+        let after = Rss::read();
+        println!(
+            "  dropped{:>9.1} MiB of RssFile",
+            mib(before.file_kb.saturating_sub(after.file_kb)),
+        );
+        report(
+            "minor",
+            time_scattered_reads(&arena, count, K, ROUNDS),
+            warm,
+        );
+
+        // Major fault: take the page cache too, which is what reclaim under
+        // real memory pressure does. The arena was flushed by `evict_backing`,
+        // so these pages are clean and the kernel can drop them.
+        arena.evict_backing().expect("eviction succeeds");
+        drop_page_cache(&path);
+        report(
+            "major",
+            time_scattered_reads(&arena, count, K, ROUNDS),
+            warm,
+        );
+    }
+
+    /// Prints one latency line against the warm baseline.
+    fn report(label: &str, measured: Duration, warm: Duration) {
+        let ms = measured.as_secs_f64() * 1e3;
+        if label == "warm" {
+            println!("  {label:<7}{ms:>9.3} ms");
+        } else {
+            println!(
+                "  {label:<7}{ms:>9.3} ms   ({:.1}× warm, +{:.3} ms)",
+                measured.as_secs_f64() / warm.as_secs_f64().max(f64::MIN_POSITIVE),
+                ms - warm.as_secs_f64() * 1e3,
+            );
+        }
+    }
+
+    /// Evicts a file's clean pages from the page cache.
+    ///
+    /// Best-effort and deliberately quiet: this only sharpens the measurement,
+    /// and a kernel that declines leaves the `major` row equal to `minor`,
+    /// which is visible in the output rather than hidden.
+    fn drop_page_cache(path: &std::path::Path) {
+        use std::os::unix::io::AsRawFd;
+        let Ok(file) = std::fs::File::open(path) else {
+            return;
+        };
+        // SAFETY: `posix_fadvise` over a file descriptor this function owns
+        // and keeps alive for the call.
+        // - Condition 1: `file` is open and its fd valid until it drops below.
+        // - Condition 2: offset 0 / len 0 means "the whole file"; `DONTNEED`
+        //   only drops clean page-cache pages, so no data can be lost.
+        // SAFETY: Take the page cache too, so the next touch is a real read.
+        unsafe {
+            libc::posix_fadvise(file.as_raw_fd(), 0, 0, libc::POSIX_FADV_DONTNEED);
+        }
+    }
+}

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -109,8 +109,10 @@ pub(crate) struct FileArena {
 // SAFETY: Moving an arena between threads leaves its mapping intact and unique.
 unsafe impl Send for FileArena {}
 // SAFETY: `FileArena` is `Sync` because shared references expose no mutation.
-// - Condition 1: `&self` reaches only `data_ptr`, `flush` and `path`; none of
-//   them writes through the mapping, and every mutating entry point
+// - Condition 1: `&self` reaches only `data_ptr`, `flush`, `evict` and
+//   `path`. None writes through the mapping: `evict` discards resident pages
+//   and the next read re-faults the same bytes from the page cache, which is
+//   not a mutation any reader can observe. Every mutating entry point
 //   (`grow`) takes `&mut self`.
 // - Condition 2: handing out the cached pointer is not itself a write — the
 //   caller's own aliasing rules govern what it does with it, exactly as for
@@ -410,6 +412,58 @@ impl FileArena {
     /// The file this arena is mapped from.
     pub(crate) fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Drops this arena's resident pages, keeping its contents.
+    ///
+    /// This is what makes the evictability claim *testable*. The arena exists
+    /// so the kernel **can** reclaim these pages under memory pressure, and
+    /// the only honest way to measure what a reclaim costs is to cause one on
+    /// demand rather than wait for pressure a benchmark host does not have.
+    ///
+    /// # Why the flush, and what it is not for
+    ///
+    /// It is **not** for correctness. On Linux the pages of a `MAP_SHARED`
+    /// mapping *are* the file's page-cache pages, and the kernel never drops a
+    /// dirty one without writing it back — so `MADV_DONTNEED` cannot lose a
+    /// write, flush or no flush. That was checked rather than assumed: with
+    /// the flush removed, `evicting_preserves_every_vector` still passes.
+    ///
+    /// It is for **determinism**. A caller that wants genuinely cold pages
+    /// follows this with `POSIX_FADV_DONTNEED` on the file, which only drops
+    /// *clean* page-cache pages. Without the flush, how much gets dropped
+    /// depends on whether the kernel's writeback happened to have run — which
+    /// turns a measurement into a coin flip. Measured both ways at 100 000 ×
+    /// 768: 8.2 ms cold with the flush, 6.9 ms without, the difference being
+    /// pages writeback had not yet reached.
+    ///
+    /// The module doc argues against `msync` on the *routine* path, for flash
+    /// endurance. This is not that path: nothing in a query calls it.
+    ///
+    /// # Errors
+    ///
+    /// Returns any I/O error from the flush. A declined `madvise` is *not* an
+    /// error: eviction is advisory, a kernel that refuses leaves the pages
+    /// resident, and the arena reads correctly either way.
+    pub(crate) fn evict(&self) -> io::Result<()> {
+        self.flush()?;
+        #[cfg(unix)]
+        // SAFETY: `MADV_DONTNEED` over this arena's own mapping.
+        // - Condition 1: the range is `self.map`, so it stays mapped for as
+        //   long as `self` lives; the call cannot reach memory the arena does
+        //   not own.
+        // - Condition 2: discarded pages are repopulated from the file's
+        //   page cache, which holds every write made through this mapping, so
+        //   each `&[f32]` derived from it reads back what it read before.
+        // SAFETY: Reclaim the arena's resident pages so a cold re-rank can be
+        // measured rather than asserted.
+        if let Err(e) = unsafe {
+            self.map
+                .unchecked_advise(memmap2::UncheckedAdvice::DontNeed)
+        } {
+            tracing::debug!("madvise(MADV_DONTNEED) on the vector arena declined: {e}");
+        }
+        Ok(())
     }
 }
 

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -343,3 +343,57 @@ fn creating_over_an_existing_file_discards_its_contents() {
         );
     }
 }
+
+/// Eviction must not change a single vector.
+///
+/// The property callers depend on: dropping the resident pages is invisible
+/// to anyone reading the arena. Everything above `ContiguousVectors` treats a
+/// mapped arena as memory, and a re-rank that scored against re-faulted pages
+/// holding anything other than the original vectors would return wrong
+/// neighbours with no error anywhere.
+///
+/// Note what this does *not* pin. It passes with `evict`'s flush removed,
+/// which was checked: on Linux the mapping's pages are the file's page-cache
+/// pages, so `MADV_DONTNEED` cannot lose a write. The flush is there to make
+/// a subsequent page-cache drop deterministic, not to keep this test green.
+///
+/// Sized to span many pages — a single-page arena would pass on luck.
+#[test]
+fn evicting_preserves_every_vector() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("evict.arena");
+    let dimension = 128;
+    let count = 512; // 256 KiB — 64 pages, well past a single-page fluke.
+
+    let mut arena = ContiguousVectors::new_file_backed(&path, dimension, count).expect("create");
+    let written = fill(&mut arena, count, dimension);
+
+    arena.evict_backing().expect("eviction succeeds");
+
+    for (i, expected) in written.iter().enumerate() {
+        assert_eq!(
+            arena.get(i).expect("slot present"),
+            expected.as_slice(),
+            "vector {i} changed across an evict; the flush before MADV_DONTNEED is missing \
+             or ineffective, and a re-rank would score against wrong vectors"
+        );
+    }
+}
+
+/// Eviction is a no-op on a heap arena, not an error.
+///
+/// The measurement path calls this on whatever arena it is handed. A heap
+/// arena has no file to drop pages to, and that asymmetry is the feature —
+/// it must not surface as a failure.
+#[test]
+fn evicting_a_heap_arena_is_a_no_op() {
+    let dimension = 8;
+    let mut arena = ContiguousVectors::new(dimension, 16).expect("heap arena");
+    let written = fill(&mut arena, 16, dimension);
+
+    arena.evict_backing().expect("a heap arena reports success");
+
+    for (i, expected) in written.iter().enumerate() {
+        assert_eq!(arena.get(i).expect("slot present"), expected.as_slice());
+    }
+}

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -312,6 +312,33 @@ impl ContiguousVectors {
         Ok(())
     }
 
+    /// Drops a file-backed arena's resident pages, keeping its contents.
+    ///
+    /// A no-op on a heap-backed arena, which has nothing evictable to drop —
+    /// that asymmetry *is* the feature, and this method is how it gets
+    /// measured instead of asserted (#2112). Eviction is transparent: the
+    /// vectors read back unchanged either way. It flushes before discarding,
+    /// which is about making a later page-cache drop deterministic rather
+    /// than about correctness — `FileArena::evict` carries the measurements
+    /// behind that distinction.
+    ///
+    /// This exists for measurement, not for the search path. Nothing in a
+    /// query should call it: evicting pages a re-rank is about to fault back
+    /// in buys nothing and costs two I/Os.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Io`] if the flush that precedes the discard fails.
+    ///
+    /// [`Error::Io`]: crate::error::Error::Io
+    pub fn evict_backing(&self) -> crate::error::Result<()> {
+        #[cfg(feature = "persistence")]
+        if let ArenaBacking::FileMapped(ref arena) = self.backing {
+            arena.evict().map_err(crate::error::Error::Io)?;
+        }
+        Ok(())
+    }
+
     /// Returns the buffer size in bytes for `dimension * capacity` f32s.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/quantization/mod.rs
+++ b/crates/velesdb-core/src/quantization/mod.rs
@@ -127,11 +127,14 @@ pub const STORAGE_MODE_NAMES: &[&str] = &["full", "sq8", "binary", "pq", "rabitq
 ///
 /// **Search-path modes (`RaBitQ`, `SQ8`, `ProductQuantization`)** are the
 /// quantized paths wired into the query hot path. All of them keep the f32
-/// vectors resident for exact re-ranking, so none of them shrinks the
-/// resident-memory floor — the codes are additive (see the resident-memory
-/// note in `docs/guides/QUANTIZATION.md`). `Binary` is accepted and
-/// persisted so the intent survives a reopen, but changes neither memory
-/// use nor the search path today.
+/// vectors for exact re-ranking, so total resident memory is not reduced —
+/// for `RaBitQ` and `SQ8` it rises, since the codes are additive. What those
+/// two shrink is the *un-evictable* floor: their f32 lives in a file-backed
+/// arena the kernel can reclaim. Measured at 100 000 x 768-d, anonymous RSS
+/// falls 61% (385 -> 150 MiB) while total RSS rises 11%. See the measured
+/// tables in `docs/guides/QUANTIZATION.md`. `Binary` is accepted and persisted so
+/// the intent survives a reopen, but changes neither memory use nor the
+/// search path today.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
@@ -146,8 +149,11 @@ pub enum StorageMode {
     /// type=sq8`) and persists to `sq8.idx`; traversal engages at 10 000+
     /// vectors, below which search stays exact f32. On other metrics (int8
     /// L2 cannot preserve their ordering) the collection behaves as
-    /// [`Full`]. Resident memory is NOT reduced: f32 vectors stay resident
-    /// for re-ranking and the codes are additive.
+    /// [`Full`]. The f32 kept for re-ranking sits in a file-backed arena, so
+    /// it is evictable rather than pinned. Measured at 100 000 x 768-d against
+    /// [`Full`]: anonymous RSS 385 -> 150 MiB (-61%), total RSS +11% because
+    /// the codes are additive, and the first re-rank after a reclaim pays
+    /// 8-10 ms per 100 candidates.
     ///
     /// [`Full`]: StorageMode::Full
     SQ8,

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -2289,9 +2289,12 @@ CREATE METADATA COLLECTION tags
 | `rabitq` | search-path mode | quantized traversal (wired end-to-end) |
 
 Choose `rabitq`, `sq8` (Euclidean/Cosine) or `pq` (via `TRAIN QUANTIZER`)
-for a quantized search path. All quantized paths keep the f32 vectors
-resident for exact re-ranking, so none of them shrinks the resident-memory
-floor.
+for a quantized search path. All quantized paths keep the f32 vectors for
+exact re-ranking, so total resident memory does not shrink — for `rabitq`
+and `sq8` it rises, because the codes are additive. What `rabitq` and `sq8`
+do shrink is the *un-evictable* share: their f32 sits in a file-backed arena
+the kernel can reclaim. Measured at 100 000 x 768-d, anonymous RSS falls 61%
+while total RSS rises 11%. See `docs/guides/QUANTIZATION.md`.
 
 #### Schema Type Names
 

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -53,11 +53,16 @@ reopen, but currently changes neither memory use nor the search path — use
 > metrics whose ordering int8 L2 cannot preserve (DotProduct, Hamming,
 > Jaccard), search stays exact f32.
 
-> **Resident-memory caveat:** same as RaBitQ below — the f32 vectors stay
-> resident for exact re-ranking and the 1-byte codes are held *alongside*
-> them. The 4x figure is the size of the codes, not of the resident set. A
-> codes-resident variant for small-RAM devices is part of
-> [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112).
+> **What the 4x figure is, and what it is not:** it is the size of the
+> codes. The f32 vectors are still there — exact re-ranking needs them — but
+> since [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112) they
+> live in a file-backed arena rather than an anonymous allocation, so the
+> kernel can reclaim them. Measured at 100 000 x 768-d: **anonymous RSS falls
+> from 385 MiB to 150 MiB**, a 61% cut in the memory a device without swap
+> cannot get back. Total RSS *rises* 11% over `Full` — the f32 moves rather
+> than disappears, and the codes are additive on top. The trade is more total
+> memory for less un-evictable memory. See
+> [Measured resident set](#measured-resident-set) below.
 
 Each `f32` value (4 bytes) is converted to a `u8` (1 byte):
 
@@ -231,13 +236,15 @@ OPQ applies an orthogonal rotation to the vectors before PQ quantization. This r
 > 1000-insertion threshold) is also persisted to `rabitq.idx` on a full
 > flush, at parity with the PQ codebook.
 
-> **Resident-memory caveat:** the RaBitQ backend keeps the full-precision
-> f32 vectors in the index for exact re-ranking, with the 1-bit codes held
-> *alongside* them. The 32x figure is the size of the codes, not of the
-> resident set — today the mode buys traversal speed (32x memory-bandwidth
-> reduction in the hot loop), not a smaller RAM floor. A codes-resident
-> variant for small-RAM devices is part of
-> [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112).
+> **What the 32x figure is, and what it is not:** it is the size of the
+> codes. The backend keeps the full-precision f32 for exact re-ranking, with
+> the 1-bit codes alongside. Since
+> [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112) that f32
+> sits in a file-backed arena, so it is evictable rather than pinned; the mode
+> buys both traversal speed (32x memory-bandwidth reduction in the hot loop)
+> and a lower un-evictable floor. The measurement below was taken on SQ8; the
+> arena is shared by both quantized backends, so RaBitQ moves the same 4
+> bytes per dimension out of anonymous memory.
 
 ### How does it work?
 
@@ -278,13 +285,66 @@ behaves as `full`.
 
 ---
 
+## Measured resident set
+
+Taken 2026-08-24 on a 4-vCPU Linux container, 16 GiB RAM, via
+`cargo run --release --example resident_set --features persistence -- <mode>`
+with `mode` one of `full`, `sq8`, `cold`, one per process. Numbers
+are deltas across building one collection of **100 000 x 768-d** vectors, each
+mode in its own process — the first collection built in a process absorbs
+every one-time cost (thread pools, allocator arenas), so measuring both in one
+run charges the whole difference to whichever ran first.
+
+| Mode | Anonymous RSS | File-backed RSS | Total | Build |
+|---|---|---|---|---|
+| `Full` (heap arena) | **385.0 MiB** | 132.9 MiB | 517.9 MiB | 28.2 s |
+| `SQ8` (file-backed arena) | **150.4 MiB** | 425.8 MiB | 576.2 MiB | 134.6 s |
+| Delta | **−234.6 MiB (−61%)** | +292.9 MiB | +58.3 MiB (+11%) | 4.8x |
+
+**Read the anonymous column.** A mapped file's pages count toward total RSS
+while they are resident, so `VmRSS` barely moves and reporting it would hide
+the change. What matters on a device without swap is `RssAnon`: the kernel can
+reclaim file-backed pages by dropping them, and anonymous pages only by
+swapping. The file-backed arena moves 293.0 MiB — exactly `100 000 x 768 x 4` —
+out of the column that cannot be reclaimed — anonymous RSS falls 234.6 MiB,
+not the full 293.0, because the 73.2 MiB of codes land in that same column.
+The residual 150.4 MiB is those codes plus the graph, which is the
+`codes + graph` the design aimed at. Total RSS rises 58.3 MiB: this buys a
+lower un-evictable floor, not a smaller process.
+
+The 4.8x build time is the honest other side: SQ8 trains a quantizer, encodes
+every vector, and writes the arena through a mapping instead of to the heap.
+
+### Cold-page re-rank cost
+
+The price of evictability, measured on 100 scattered vectors — a re-rank-shaped
+access — with every dimension read, since a 3 KiB vector straddles one or two
+pages and a distance touches all of them.
+
+| State | Median | vs warm |
+|---|---|---|
+| warm | 0.14 ms | — |
+| pages dropped, page cache warm | 0.55 ms | +0.4 ms |
+| pages dropped, page cache dropped | 8–10 ms | +8 to +9 ms |
+
+The two cold rows are different events and the gap between them is a factor of
+15. `MADV_DONTNEED` alone takes the process's pages while the file's contents
+stay cached, so the next touch is a minor fault. Reclaim under real memory
+pressure takes the cache too, and the next touch is a disk read — that bottom
+row is what an edge device actually pays, and it varies about 15% run to run
+on shared storage.
+
+Budget roughly **8-10 ms of added latency on the first query after a reclaim**,
+per 100 candidates re-ranked. Subsequent queries touching the same vectors are
+warm again.
+
 ## Choosing the right method
 
 | Scenario | Recommendation |
 |----------|----------------|
 | **General production** | f32 (default); `sq8` on Euclidean/Cosine at 10K+ vectors for a lighter traversal hot loop |
 | **Large dataset (100K+)** | PQ m=8 + rescore |
-| **Very limited RAM** | f32 with modest HNSW `M` — no current mode shrinks the resident set (see [#2112](https://github.com/cyberlife-coder/VelesDB/issues/2112)) |
+| **Very limited RAM** | `sq8` or `rabitq` — the f32 arena is file-backed, cutting anonymous RSS 61% at 100K x 768-d; budget ~8 ms per cold re-rank |
 | **Maximum precision** | f32 (no quantization) |
 | **High compression + good recall** | RaBitQ |
 | **Fingerprints/hashes** | `BinaryQuantizedVector` primitives (direct use) |


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → **targets `develop`**. ✅

## Description

#2112 asks for the resident set of a 100 000 × 768-d SQ8 index *"demonstrated in a test or bench artifact — not asserted in prose"*, plus the cold-page re-rank cost that evictability buys. Both were still prose. They are numbers now — and two of those numbers contradict what the docs said.

### `VmRSS` is the wrong number

A mapped file's pages count toward `VmRSS` while they are resident, so an index whose f32 arena is file-backed reports the *same* `VmRSS` as one whose arena is on the heap, right up until pressure arrives. Reading `VmRSS` and concluding "no saving" would be wrong; waiting for pressure would measure the host.

What changed is which *kind* of page holds the f32, and Linux reports that directly: `RssAnon` is reclaimable only by swapping — the floor that decides whether a process fits on a device without swap — while `RssFile` is reclaimable by dropping.

### Measured — 100 000 × 768-d, each mode in its own process

| Mode | Anonymous RSS | File-backed RSS | Total | Build |
|---|---|---|---|---|
| `Full` (heap arena) | **385.0 MiB** | 132.9 MiB | 517.9 MiB | 28.2 s |
| `SQ8` (file-backed arena) | **150.4 MiB** | 425.8 MiB | 576.2 MiB | 134.6 s |
| Delta | **−234.6 MiB (−61%)** | +292.9 MiB | +58.3 MiB (+11%) | 4.8× |

Anonymous RSS falls 61%. **Total RSS *rises* 11%** — the f32 moves rather than disappears, and the 73.2 MiB of codes are additive on top. `QUANTIZATION.md`, the `StorageMode` rustdoc and `VELESQL_SPEC.md` now say that, where they previously said either "no current mode shrinks the resident set" or (in my own first draft) "total RSS is unchanged". The 4.8× build cost is stated too.

The residual 150.4 MiB is codes + graph — the target the design named.

### Cold-page re-rank cost

100 scattered vectors, every dimension read (a 3 KiB vector straddles two pages and a distance touches both):

| State | Median | vs warm |
|---|---|---|
| warm | 0.14 ms | — |
| pages dropped, page cache warm | 0.55 ms | +0.4 ms |
| pages dropped, page cache dropped | 8–10 ms | +8 to +9 ms |

The two cold rows are **different events, 15× apart**. `MADV_DONTNEED` alone takes the process's pages while the file stays cached — a minor fault. Reclaim under real pressure takes the cache too. Reporting only the first would have understated the honest cost by an order of magnitude.

## Type of Change

- [x] ⚡ Performance improvement (measurement + documentation of an existing one)
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests

Two tests in `contiguous_file_arena_tests.rs`: eviction preserves every vector across an arena spanning 64 pages, and eviction on a heap arena is a no-op rather than an error. 14 tests in that file pass.

Clean: `cargo fmt --check`, `cargo clippy --all-targets --features persistence -D warnings`, `cargo check --all-targets`, `cargo doc` (no new warnings), and `check-ai-attribution`, `check-file-budgets`, `check-doc-freshness`, `check-inline-tests`, `check-perf-claims`, `check-feature-claims`, `verify_unsafe_safety_template --strict`.

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-24.

### Three measurement defects found and fixed before any number was published

1. **Order effect.** Building both modes in one process charged `Full` +310 MiB for a 14.6 MiB arena — the first collection absorbs the process's one-time costs. One mode per invocation now.
2. **"Cold" was not cold.** `MADV_DONTNEED` leaves the contents in the page cache, so the first figure was a minor fault. `POSIX_FADV_DONTNEED` was added and both are reported.
3. **One page per vector.** Reading only `v[0]` undercounted; every dimension is summed now, which moved the warm baseline from 0.011 ms to 0.141 ms and made the ratios honest.

### A documented rationale that was wrong

`FileArena::evict`'s first draft claimed the flush before `MADV_DONTNEED` was a **correctness** requirement — that a dirty page discarded before writeback would come back as zeros. Removing the flush and re-running showed the test still green: on Linux the mapping's pages *are* the file's page-cache pages, and the kernel never drops a dirty one.

The flush stays, for the reason that survives verification: it makes a later `POSIX_FADV_DONTNEED` deterministic (8.2 ms cold with it, 6.9 ms without, the difference being pages writeback had not yet reached). The doc says that now, and the test's own docstring records that it does **not** pin the flush.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #2117 and #2118 are on `develop`

## Unsafe Code Checklist

- [x] All `unsafe {}` blocks have numbered `// SAFETY:` comments — two added (`MADV_DONTNEED` on the arena's own mapping; `posix_fadvise` on a descriptor the function owns)
- [x] No undefined behavior possible with valid inputs
- [x] The `unsafe impl Sync for FileArena` audit trail was updated — `evict(&self)` is a fourth `&self` entry point and the enumeration named only three

## High-Risk Change Checklist

- [x] I listed the invariants impacted — `evict` takes `&self` and must not be observable as a mutation; the re-faulted pages read back identically, which the new test pins.
- [x] I added tests for lifecycle behaviour (evict on both backings)
- [ ] Two maintainers — this is measurement and documentation; the production surface added is one `pub fn` that no query path calls.

## Additional Notes

Closes the first two acceptance criteria of #2112 and unblocks #20 (whether the mapped arena should be configurable), which needed exactly these numbers to be decidable: 61% less un-evictable memory against 8–10 ms on the first query after a reclaim is now a trade a reader can weigh instead of guess.

An assistant-attribution footer was appended to this body automatically on creation and is removed here, per `AGENTS.md` principle 5.
