### PR TITLE
perf(quantization): decide the arena is not configurable, and say why

### DIFF
--- a/crates/velesdb-core/examples/resident_set.rs
+++ b/crates/velesdb-core/examples/resident_set.rs
@@ -223,8 +223,12 @@ mod linux {
                 cold_page_cost(count, dimension);
                 return;
             }
+            "write" => {
+                arena_write_cost(count, dimension);
+                return;
+            }
             other => {
-                eprintln!("unknown mode {other:?}; expected full | sq8 | cold");
+                eprintln!("unknown mode {other:?}; expected full | sq8 | cold | write");
                 std::process::exit(2);
             }
         };
@@ -239,6 +243,44 @@ mod linux {
         // Alive to here: the reading above describes memory that must still be
         // held for it to mean anything.
         drop(db);
+    }
+
+    /// What the arena itself costs to fill, with nothing else in the frame.
+    ///
+    /// The `full` and `sq8` runs differ by two things at once — quantizer
+    /// training plus code encoding, *and* writing the f32 through a mapping
+    /// instead of to the heap — so their 4.8x build gap cannot be attributed
+    /// to either. Whether the mapped arena deserves an opt-out turns on which
+    /// term dominates, so this measures the arena term alone: the same
+    /// vectors pushed into each backing, no graph, no quantizer.
+    fn arena_write_cost(count: usize, dimension: usize) {
+        let dir = tempfile::tempdir().expect("a writable temp dir");
+        let vectors: Vec<Vec<f32>> = (0..count).map(|i| vector(i, dimension)).collect();
+
+        let mut heap = ContiguousVectors::new(dimension, count).expect("heap arena");
+        let heap_started = Instant::now();
+        for v in &vectors {
+            heap.push(v).expect("push succeeds");
+        }
+        let heap_elapsed = heap_started.elapsed();
+
+        let mut mapped =
+            ContiguousVectors::new_file_backed(&dir.path().join("arena.bin"), dimension, count)
+                .expect("file-backed arena");
+        let mapped_started = Instant::now();
+        for v in &vectors {
+            mapped.push(v).expect("push succeeds");
+        }
+        let mapped_elapsed = mapped_started.elapsed();
+
+        println!("Arena fill cost — {count} × {dimension}-d, no graph, no quantizer");
+        println!("  heap   {:>9.3} ms", heap_elapsed.as_secs_f64() * 1e3);
+        println!(
+            "  mapped {:>9.3} ms   ({:.2}× heap, +{:.1} ms)",
+            mapped_elapsed.as_secs_f64() * 1e3,
+            mapped_elapsed.as_secs_f64() / heap_elapsed.as_secs_f64().max(f64::MIN_POSITIVE),
+            (mapped_elapsed.as_secs_f64() - heap_elapsed.as_secs_f64()) * 1e3,
+        );
     }
 
     /// The honest price of evictability, isolated from graph traversal.

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -659,6 +659,17 @@ impl NativeHnswInner {
         // traverses on codes can afford an evictable f32 arena. `path` is the
         // collection directory, which is where the arena file belongs — it is
         // a cache of `{basename}.vectors`, deleted when this graph drops.
+        //
+        // The mode decides this, and nothing else does: there is deliberately
+        // no switch. Measured at 100 000 x 768-d, filling the arena costs
+        // 58-62 ms on the heap against 0.30-1.35 s through the mapping (the
+        // second is I/O-bound and climbs across consecutive runs) — at worst
+        // 1.3% of the 106 s that separates an SQ8 build from a Full one, the
+        // rest being quantizer training and encoding. An opt-out would trade
+        // a new persisted setting and another dispatch branch for avoiding
+        // that, plus a cold-re-rank penalty a host with free memory never
+        // pays, since its pages are never reclaimed. See the resident-set
+        // tables in docs/guides/QUANTIZATION.md for what reopening it needs.
         let arena_dir = match storage_mode {
             crate::StorageMode::RaBitQ | crate::StorageMode::SQ8 => Some(path),
             _ => None,

--- a/docs/guides/QUANTIZATION.md
+++ b/docs/guides/QUANTIZATION.md
@@ -312,8 +312,36 @@ The residual 150.4 MiB is those codes plus the graph, which is the
 `codes + graph` the design aimed at. Total RSS rises 58.3 MiB: this buys a
 lower un-evictable floor, not a smaller process.
 
-The 4.8x build time is the honest other side: SQ8 trains a quantizer, encodes
-every vector, and writes the arena through a mapping instead of to the heap.
+The 4.8x build time is the honest other side — but almost none of it is the
+arena. Filling the same 100 000 vectors into each backing, with no graph and
+no quantizer in the frame:
+
+| Backing | Fill time |
+|---|---|
+| heap | 58–62 ms, stable across runs |
+| file-mapped | 0.30–1.35 s, rising with each consecutive run |
+
+The heap figure is steady; the mapped one is I/O-bound and climbs as repeated
+293 MiB writes fill the host's dirty-page pool, so it is reported as a range
+rather than a point. Even at its worst it is **1.3 s of the 106.4 s that
+separates an SQ8 build from a Full one — under 1.3%**. The rest is quantizer
+training and code encoding, which `SQ8` pays with any backing.
+
+### Why the arena is not configurable
+
+That 1.3% ceiling is the whole case. An opt-out would let a caller avoid at
+most ~1 s of build time and the cold-re-rank penalty, in exchange for
+234.6 MiB of un-evictable RAM, a new persisted setting, and another branch
+through the backend dispatch.
+
+It would also mostly avoid a cost that is not being paid. A host with free
+memory never has these pages reclaimed, so the 8-10 ms cold re-rank never
+happens there; the mapping only costs latency once memory is tight, which is
+exactly when its 61% saving is worth having. The trade is self-regulating.
+
+Two costs *are* paid unconditionally and are the honest counterweight: the
++11% total RSS, and the 0.24 s. Reopen this if either turns out to hurt a
+real deployment — measurements first, per the note above.
 
 ### Cold-page re-rank cost
 

--- a/docs/reference/ECOSYSTEM_PARITY.md
+++ b/docs/reference/ECOSYSTEM_PARITY.md
@@ -156,6 +156,12 @@ All 5 variants (`Cosine`, `Euclidean`, `DotProduct`, `Hamming`, `Jaccard`) are s
 
 All 5 variants (`Full`, `SQ8`, `Binary`, `ProductQuantization`, `RaBitQ`) are supported in all 10 components (Haystack inherits via the Python binding pass-through).
 
+> **Documented divergence — the memory behaviour of `SQ8` and `RaBitQ` is not uniform across surfaces.** The API is: every component accepts and persists all 5 variants, which is what the 10/10 above measures. What differs is what the mode *does* to the resident set.
+>
+> Since #2112 those two modes keep their f32 vectors in a file-backed arena rather than an anonymous allocation, cutting anonymous RSS 61% at 100 000 × 768-d (see [QUANTIZATION.md](../guides/QUANTIZATION.md#measured-resident-set)). That arena is gated on the `persistence` feature and needs a writable collection directory. `velesdb-wasm` takes `velesdb-core` with `default-features = false`, so **on WASM and in the browser, `SQ8` and `RaBitQ` run with a heap arena and deliver no resident-set saving** — same mode name, same results, different memory profile. A native host that cannot host the arena file (read-only directory, no space) degrades the same way, by design and with a `warn!`.
+>
+> Nothing to fix in the bindings: they pass the mode through and core decides. It is recorded here because "supported everywhere" is true of the surface and would be misread as true of the benefit.
+
 | Component | Status |
 |-----------|--------|
 | Core | ✅ (source of truth) |


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → **targets `develop`**. ✅

## Description

#2127 attributed the 4.8× SQ8 build cost to *"quantizer training, code encoding, and writing the arena through a mapping"*. That conflated three terms — and whether the mapped arena deserves an opt-out turns entirely on which one dominates. So the arena term is measured alone here, and the answer settles the question.

### The arena's own fill cost

100 000 × 768-d pushed into each backing, no graph and no quantizer in the frame:

| Backing | Fill time |
|---|---|
| heap | **58–62 ms**, stable across runs |
| file-mapped | **0.30–1.35 s**, rising with each consecutive run |

A range, not a point. The heap figure is steady; the mapped one is I/O-bound and climbs as repeated 293 MiB writes fill the host's dirty-page pool. **The first run read 0.30 s, and publishing that alone would have been false precision** — five runs put the ceiling at 1.35 s.

At worst that is **1.3% of the 106 s** separating an SQ8 build from a Full one. The rest is training and encoding, which SQ8 pays with any backing.

### The decision: no switch

An opt-out would trade a persisted setting and another branch through the backend dispatch for avoiding at most a second of build time — plus a cold-re-rank penalty **a host with free memory never pays**. Its pages are never reclaimed, so the mapping only costs latency once memory is tight, which is exactly when its 61% saving is worth having. The trade is self-regulating.

Two costs *are* paid unconditionally and are named as the counterweight: the +11% total RSS, and that second of build time. Reopening the question needs one of them to hurt a real deployment — measurements first.

The reasoning sits next to the `match storage_mode` that makes the choice, so a reader who wonders why there is no flag finds the answer where the choice is made rather than in a changelog.

### A divergence `ECOSYSTEM_PARITY` did not carry

The table says `StorageMode` is 10/10. That is true of the **API surface** — every component accepts and persists all 5 variants — and would be misread as true of the benefit.

`velesdb-wasm` takes `velesdb-core` with `default-features = false`, so the arena's `persistence` gate is off: **on WASM and in the browser, `SQ8` and `RaBitQ` run with a heap arena and deliver no resident-set saving.** Same mode, same results, different memory profile. A native host that cannot host the arena file degrades identically, by design and with a `warn!`.

Nothing to fix in the bindings — they pass the mode through and core decides. It is recorded because the claim as written invites the wrong reading.

## Type of Change

- [x] 📚 Documentation update
- [x] ⚡ Performance improvement (measurement of an existing one; no behaviour change)

## How Has This Been Tested?

- [x] Unit tests

No behaviour changes: the diff adds a `write` mode to the `resident_set` example and three prose sites. The 14 tests in `contiguous_file_arena_tests.rs` pass.

Clean: `cargo fmt --check`, `cargo clippy --all-targets --features persistence -D warnings`, and `check-ai-attribution`, `check-file-budgets`, `check-doc-freshness`, `check-perf-claims`, `check-feature-claims`.

Reproduce with `cargo run --release --example resident_set --features persistence -- write`. Run it more than once — the point of the range is that a single run understates it.

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-24.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests — the change is a measurement mode and three prose sites; the property it informs is already pinned by #2127's tests
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #2127 is on `develop`

## Unsafe Code Checklist

Not applicable — no `unsafe` added.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path changes behaviour. The only edit under `hnsw/` is a comment.

## Additional Notes

This is the second time in two PRs that a first-run number would have been wrong if published alone — the warm baseline in #2127, and 0.30 s here. Both were caught by re-running rather than by review, which is worth noting for anything that measures I/O on a shared host.

An assistant-attribution footer is appended to these bodies automatically on creation; removed here per `AGENTS.md` principle 5, and done now rather than after CI so the no-op `edited` run drains behind the real one instead of adding a second wait.
