### PR TITLE
fix(hnsw): ANALYZE's locality reorder renumbered nodes and left two structures behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (lazy training persists on each full flush, parity with RaBitQ), and is
   re-installed on reopen before gap recovery. On metrics whose ordering
   int8 L2 cannot preserve (DotProduct/Hamming/Jaccard) the mode stays exact
-  f32, and `TRAIN QUANTIZER type=sq8` is rejected up front. Resident memory
-  is unchanged: the f32 vectors stay resident for re-ranking and the codes
-  are additive — the codes-resident variant remains #2112 Phase B. (#2112)
+  f32, and `TRAIN QUANTIZER type=sq8` is rejected up front. The f32 vectors
+  stay in the index for re-ranking, but a quantized mode now holds them in a
+  file-backed arena the kernel can reclaim: at 100 000 x 768-d that moves
+  293.0 MiB out of anonymous RSS, cutting it **61%** (385.0 -> 150.4 MiB),
+  while total RSS rises 11% and a cold re-rank costs ~8 ms. Measured, not
+  projected — see
+  [Measured resident set](docs/guides/QUANTIZATION.md#measured-resident-set).
+  Getting the codes themselves out of the resident set remains #2112
+  Phase B. (#2112)
 
 ### Removed
 
@@ -59,6 +65,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is tracked in #2112. (#2112)
 
 ### Fixed
+
+- **`ANALYZE` no longer returns wrong points on collections over 1 000
+  vectors.** `analyze_collection` runs `reorder_for_locality()`, which
+  renumbers every graph node — and `HnswIndex`'s external-id mappings are
+  keyed by that numbering, so they were left pointing at whatever vector had
+  moved into each slot. Nothing failed: every lookup still resolved, to the
+  wrong point. On a 1 100-point Euclidean collection a self-query's correct
+  top-5 `[500, 501, 499, 502, 498]` came back as `[575, 601, 586, 560, 588]`
+  after `ANALYZE`. `vacuum` renumbers too and has always rebuilt the mappings;
+  the reorder path never did. It now remaps both directions under the index
+  write lock, so a search cannot observe the half-renumbered state. Affects
+  every storage mode. (#2112)
+
+- **A quantized collection no longer loses its search quality to `ANALYZE`.**
+  The `SQ8` and `RaBitQ` backends index their code store positionally — entry
+  N holds node N's code — and the reorder dispatch went straight to the inner
+  graph, leaving every code describing a different node. Traversal then walked
+  a graph scored on unrelated codes while the exact-f32 re-rank reported
+  honest distances for whatever that walk reached, so no error surfaced
+  anywhere: measured through the int8 path at 2 000 x 64-d, recall@10 went
+  from 1.000 to **0.000** (RaBitQ: 0.025). The quantized backends now own
+  their reorder and rebuild the store in the new node order, under the same
+  install gate that protects a quantizer install. (#2112)
+
+- **A BFS reorder no longer silently un-does the file-backed arena.**
+  `ContiguousVectors::reorder` gathered into a fresh heap buffer and swapped
+  the backing to `Heap`, so the first `reorder_for_locality()` on a quantized
+  collection put the f32 arena back into anonymous RSS, gave up the 61% cut,
+  released the mapping and its exclusive lock, and turned `flush_backing()`
+  into a no-op that still returned `Ok`. The permutation is now applied in
+  place by rotating each cycle through one vector of scratch, so the backing
+  survives, `capacity` is no longer shrunk to `count`, and the peak
+  allocation during a reorder is the arena rather than twice it. At
+  100 000 x 768-d that is 0.044-0.060 s against 0.158-0.209 s for the copying
+  shape (eight runs), with no 293 MiB second buffer. A `new_order` that repeats an index is
+  now rejected instead of silently duplicating one vector and dropping
+  another. (#2112)
 
 - **A vector that can't be scored is excluded, not scored 0.0.** Every
   `similarity()` path fell back to `0.0` when the candidate and query

--- a/crates/velesdb-core/examples/resident_set.rs
+++ b/crates/velesdb-core/examples/resident_set.rs
@@ -63,10 +63,11 @@
 //! cargo run --release --example resident_set --features persistence -- <mode> [N] [D]
 //! ```
 //!
-//! `mode` is `full`, `sq8`, or `cold`, and only one runs per invocation — see
-//! above for why. `N` and `D` default to the configuration #2112 names, so the
-//! three runs behind the published tables are `-- full`, `-- sq8` and
-//! `-- cold`. Linux only: no other platform
+//! `mode` is `full`, `sq8`, `cold`, `write` or `reorder`, and only one runs
+//! per invocation — see above for why. `N` and `D` default to the
+//! configuration #2112 names, so the runs behind the published tables are
+//! `-- full`, `-- sq8`, `-- cold`, `-- write` and `-- reorder`. Linux only:
+//! no other platform
 //! exposes the anonymous/file split, and reporting `VmRSS` alone would be
 //! reporting the very number this program exists to reject.
 
@@ -227,8 +228,12 @@ mod linux {
                 arena_write_cost(count, dimension);
                 return;
             }
+            "reorder" => {
+                reorder_cost(count, dimension);
+                return;
+            }
             other => {
-                eprintln!("unknown mode {other:?}; expected full | sq8 | cold | write");
+                eprintln!("unknown mode {other:?}; expected full | sq8 | cold | write | reorder");
                 std::process::exit(2);
             }
         };
@@ -323,6 +328,64 @@ mod linux {
             "major",
             time_scattered_reads(&arena, count, K, ROUNDS),
             warm,
+        );
+    }
+
+    /// What an in-place permutation costs, per backing.
+    ///
+    /// `reorder` used to gather into a fresh heap buffer, which demoted a
+    /// mapped arena to the heap (#2112). Permuting in place fixes that, and
+    /// the question this answers is what it costs to walk cycles through a
+    /// mapping instead of writing a second buffer sequentially.
+    ///
+    /// `gather_flat` is the comparison because it *is* the old shape: the
+    /// same scattered reads, into a freshly allocated arena-sized `Vec`. It
+    /// is a floor for the copying implementation, not a re-creation of it —
+    /// the real one also paid a `dealloc` and a backing swap.
+    ///
+    /// The permutation is a single cycle covering every vector, which is the
+    /// unfriendly case: no fixed points to skip, and each write lands in a
+    /// page unrelated to the last.
+    fn reorder_cost(count: usize, dimension: usize) {
+        let dir = tempfile::tempdir().expect("a writable temp dir");
+        let order: Vec<usize> = (0..count).map(|i| (i * 7 + 1) % count).collect();
+
+        println!("Reorder — {count} × {dimension}-d, one cycle over every vector");
+        let mut heap = ContiguousVectors::new(dimension, count).expect("a heap arena");
+        fill_arena(&mut heap, count, dimension);
+        report_reorder("heap", &mut heap, &order);
+
+        let mut mapped =
+            ContiguousVectors::new_file_backed(&dir.path().join("reorder.bin"), dimension, count)
+                .expect("a file-backed arena");
+        fill_arena(&mut mapped, count, dimension);
+        report_reorder("file-mapped", &mut mapped, &order);
+    }
+
+    /// Pushes `count` deterministic vectors into an arena.
+    fn fill_arena(arena: &mut ContiguousVectors, count: usize, dimension: usize) {
+        for i in 0..count {
+            arena.push(&vector(i, dimension)).expect("push succeeds");
+        }
+    }
+
+    /// Times one backing's in-place permutation against the copying shape.
+    fn report_reorder(label: &str, arena: &mut ContiguousVectors, order: &[usize]) {
+        let started = Instant::now();
+        let copied = arena.gather_flat(order);
+        let gather = started.elapsed();
+        std::hint::black_box(&copied);
+        let copied_mib = mib((copied.len() * std::mem::size_of::<f32>() / 1024) as u64);
+        drop(copied);
+
+        let started = Instant::now();
+        arena.reorder(order).expect("a permutation of 0..count");
+        let in_place = started.elapsed();
+
+        println!(
+            "  {label:<12} in place {:>7.3} s   gather copy {:>7.3} s   (copy needs +{copied_mib:.1} MiB)",
+            in_place.as_secs_f64(),
+            gather.as_secs_f64(),
         );
     }
 

--- a/crates/velesdb-core/src/contiguous_file_arena_tests.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena_tests.rs
@@ -173,13 +173,16 @@ fn open_refuses_a_count_beyond_capacity() {
     );
 }
 
-/// Reordering a file-backed arena moves it onto the heap and frees the map.
+/// Reordering a file-backed arena keeps it file-backed.
 ///
-/// The dangerous shape this pins: `reorder` allocates a fresh heap buffer and
-/// deallocates the old one. If the backing were not switched first, that
-/// `dealloc` would be handed a mapped pointer.
+/// The regression this pins: `reorder` used to gather into a fresh heap
+/// buffer and swap the backing to `Heap`, which silently cost the arena the
+/// one property it exists for — its pages stopped being evictable — and made
+/// `flush_backing` a no-op that still returned `Ok`. Nothing in the vectors
+/// read back would have shown it, which is why the backing is asserted
+/// directly.
 #[test]
-fn reorder_moves_a_mapped_arena_onto_the_heap() {
+fn reorder_keeps_a_mapped_arena_mapped() {
     let dir = tempdir().expect("tempdir");
     let dimension = 4;
     let mut storage =
@@ -191,9 +194,112 @@ fn reorder_moves_a_mapped_arena_onto_the_heap() {
 
     let expected: Vec<Vec<f32>> = written.iter().rev().cloned().collect();
     assert_contents(&storage, &expected);
-    // Dropping here exercises the heap path on a formerly mapped arena; a
-    // wrong backing would fault or corrupt the allocator under Miri/ASan.
+    assert!(
+        format!("{storage:?}").contains("FileMapped"),
+        "arena must still be file-mapped after a reorder, got: {storage:?}"
+    );
+    // The capacity the file was sized for survives too: an in-place
+    // permutation has no reason to shrink it, and shrinking would make the
+    // next push re-map.
+    assert_eq!(storage.capacity(), 16, "reorder must not resize the arena");
     drop(storage);
+}
+
+/// The reordered bytes are the ones on disk.
+///
+/// `flush_backing` reaching the file is the observable end of "the mapping
+/// survived": with the pre-#2112 heap demotion this file still held the
+/// insertion-order bytes, and a reopen would have served them.
+#[test]
+fn reorder_writes_the_new_order_through_to_the_file() {
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("persisted.arena");
+    let dimension = 4;
+    let mut storage = ContiguousVectors::new_file_backed(&path, dimension, 16).expect("file arena");
+    let written = fill(&mut storage, 4, dimension);
+
+    storage.reorder(&[3, 2, 1, 0]).expect("reorder");
+    storage.flush_backing().expect("flush");
+
+    // Read the raw file rather than reopening: the arena still holds its
+    // exclusive lock, and reading the bytes underneath a live mapping is what
+    // proves `flush_backing` reached the file — a reopen would also pass on
+    // the writeback that `munmap` does anyway.
+    let expected: Vec<f32> = written.iter().rev().flatten().copied().collect();
+    assert_eq!(on_disk_vectors(&path, expected.len()), expected);
+}
+
+/// Reads `len` f32s from an arena file's data section.
+///
+/// Native byte order, because that is what the mapping wrote — the v1 layout
+/// is deliberately host-native (#2112); a portable one is tracked separately.
+fn on_disk_vectors(path: &std::path::Path, len: usize) -> Vec<f32> {
+    let bytes = std::fs::read(path).expect("read arena file");
+    let data = &bytes[DATA_OFFSET..];
+    data.chunks_exact(std::mem::size_of::<f32>())
+        .take(len)
+        .map(|c| {
+            let mut word = [0_u8; 4];
+            word.copy_from_slice(c);
+            f32::from_ne_bytes(word)
+        })
+        .collect()
+}
+
+/// A `new_order` that is not a bijection is refused, not applied.
+///
+/// The copying implementation accepted one: a repeated index duplicated a
+/// vector and dropped whichever index was missing, with no error. The
+/// in-place algorithm walks cycles, so the same input would not terminate —
+/// validating up front is what turns a hang into a message.
+#[test]
+fn reorder_refuses_a_permutation_that_repeats_an_index() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 4;
+    let mut storage =
+        ContiguousVectors::new_file_backed(&dir.path().join("dup.arena"), dimension, 16)
+            .expect("file arena");
+    let written = fill(&mut storage, 4, dimension);
+
+    let err = storage
+        .reorder(&[0, 1, 1, 3])
+        .expect_err("a repeated index is not a permutation");
+    assert!(
+        err.to_string().contains("appears twice"),
+        "error should name the violation, got: {err}"
+    );
+    assert_contents(&storage, &written);
+}
+
+/// A mapped arena and a heap arena come out of the same permutation identical.
+///
+/// The arena's claim is indistinguishability; a reorder is the operation
+/// where the two backings most recently diverged, so it is checked rather
+/// than assumed.
+#[test]
+fn reorder_agrees_between_the_two_backings() {
+    let dir = tempdir().expect("tempdir");
+    let dimension = 3;
+    let count = 9;
+    // A single 9-cycle plus a fixed point exercises both branches of the
+    // outer loop: `[1, 2, 3, 4, 5, 6, 7, 0, 8]` maps slot 8 to itself.
+    let order = [1, 2, 3, 4, 5, 6, 7, 0, 8];
+
+    let mut mapped =
+        ContiguousVectors::new_file_backed(&dir.path().join("cmp.arena"), dimension, 16)
+            .expect("file arena");
+    let written = fill(&mut mapped, count, dimension);
+    let mut heap = ContiguousVectors::new(dimension, 16).expect("heap arena");
+    for v in &written {
+        heap.push(v).expect("push");
+    }
+
+    mapped.reorder(&order).expect("reorder mapped");
+    heap.reorder(&order).expect("reorder heap");
+
+    let expected: Vec<Vec<f32>> = order.iter().map(|&old| written[old].clone()).collect();
+    assert_contents(&mapped, &expected);
+    assert_contents(&heap, &expected);
 }
 
 /// The mapped data pointer is f32-aligned — a soundness invariant, not a

--- a/crates/velesdb-core/src/contiguous_ops.rs
+++ b/crates/velesdb-core/src/contiguous_ops.rs
@@ -43,11 +43,12 @@ impl ContiguousVectors {
     /// the 293 MiB second arena the copy needed.
     ///
     /// Measured at 100 000 × 768-d over a single cycle covering every vector,
-    /// which is the unfriendly case (2026-08-24, 4-vCPU Linux container):
-    /// **0.044–0.053 s in place against 0.195–0.209 s** for the same
-    /// scattered reads gathered into a fresh buffer, and the two backings are
-    /// within noise of each other. Reproduce with the `reorder` mode of the
-    /// `resident_set` example.
+    /// which is the unfriendly case (2026-08-24, 4-vCPU Linux container,
+    /// eight runs): **0.044–0.060 s in place against 0.158–0.209 s** for the
+    /// same scattered reads gathered into a fresh buffer, and the two
+    /// backings are within noise of each other. Ranges rather than points
+    /// because a single run of either understates the spread on a shared
+    /// host. Reproduce with the `reorder` mode of the `resident_set` example.
     ///
     /// Those figures are with the arena resident, which is the state a
     /// post-build reorder finds it in. On pages the kernel has already

--- a/crates/velesdb-core/src/contiguous_ops.rs
+++ b/crates/velesdb-core/src/contiguous_ops.rs
@@ -3,9 +3,8 @@
 //! Extracted from `perf_optimizations.rs` to reduce NLOC.
 //! Contains reorder permutation, dot-product batching, Drop, and free SIMD helpers.
 
-use super::perf_optimizations::{ArenaBacking, ContiguousVectors};
+use super::perf_optimizations::ContiguousVectors;
 use std::alloc::dealloc;
-use std::ptr::{self, NonNull};
 
 // =============================================================================
 // ContiguousVectors: Reorder + Dot-Product + Drop
@@ -15,33 +14,54 @@ impl ContiguousVectors {
     /// Reorders vectors according to the given permutation.
     ///
     /// `new_order[i]` contains the old index of the vector that should occupy
-    /// position `i` after reordering. The permutation must have exactly
-    /// `self.len()` elements and every index must be `< self.len()`.
+    /// position `i` after reordering. It must be a genuine permutation of
+    /// `0..self.len()`: exactly `self.len()` entries, each index appearing
+    /// exactly once.
     ///
-    /// # A file-backed arena is demoted to the heap
+    /// # The backing survives
     ///
-    /// Reordering copies into a fresh heap buffer, so an arena that was
-    /// file-mapped **stops being file-mapped here**: its mapping is released,
-    /// its exclusive lock with it, and the file is left on disk holding the
-    /// pre-reorder bytes. Two consequences a caller has to know about:
+    /// The permutation is applied **in place**, through whichever buffer the
+    /// arena already holds, so a file-mapped arena is still file-mapped when
+    /// this returns (#2112). Its pages stay evictable — the property the
+    /// mapped backing exists for — [`flush_backing`](Self::flush_backing)
+    /// still reaches the file, and the bytes that land on disk are the
+    /// reordered ones. The predecessor of this implementation gathered into a
+    /// fresh heap buffer and silently demoted the arena, which cost the
+    /// eviction saving and turned `flush_backing` into a no-op returning
+    /// `Ok`.
     ///
-    /// - The pages stop being evictable, which is the property the mapped
-    ///   backing existed for (#2112). A quantized index that reorders is back
-    ///   to `f32 + graph + codes` resident.
-    /// - [`flush_backing`](Self::flush_backing) becomes a no-op that still
-    ///   returns `Ok`, because there is no longer a mapping to flush.
+    /// In place is also what the heap arena wants: no second buffer means the
+    /// peak allocation during a reorder is the arena itself rather than twice
+    /// it. `capacity` is therefore left alone, where the copying version
+    /// shrank it to `count` and made the next `push` reallocate.
     ///
-    /// This is stated rather than fixed because no production path takes a
-    /// file-backed arena yet; preserving the backing across a reorder costs a
-    /// second copy and belongs with the wiring that gives it a caller, where
-    /// it can be measured. Whoever does that wiring owns this.
+    /// # Cost
+    ///
+    /// Each vector is written once, plus one scratch copy per permutation
+    /// cycle; the bookkeeping is a `bool` per vector and one vector of
+    /// scratch — 100 KiB and 3 KiB respectively at 100 000 × 768-d, against
+    /// the 293 MiB second arena the copy needed.
+    ///
+    /// Measured at 100 000 × 768-d over a single cycle covering every vector,
+    /// which is the unfriendly case (2026-08-24, 4-vCPU Linux container):
+    /// **0.044–0.053 s in place against 0.195–0.209 s** for the same
+    /// scattered reads gathered into a fresh buffer, and the two backings are
+    /// within noise of each other. Reproduce with the `reorder` mode of the
+    /// `resident_set` example.
+    ///
+    /// Those figures are with the arena resident, which is the state a
+    /// post-build reorder finds it in. On pages the kernel has already
+    /// reclaimed, in place faults them back — but so does a copy, which has
+    /// to read every vector too, so the ordering does not change.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - `new_order.len() != self.len()`
     /// - Any index in `new_order` is out of bounds
-    /// - The new buffer allocation fails
+    /// - Any index appears more than once — a non-bijective `new_order` would
+    ///   duplicate vectors and lose others, which the copying predecessor did
+    ///   silently
     pub fn reorder(&mut self, new_order: &[usize]) -> crate::error::Result<()> {
         if new_order.len() != self.count {
             return Err(crate::error::Error::Internal(format!(
@@ -53,94 +73,34 @@ impl ContiguousVectors {
         if self.count == 0 {
             return Ok(());
         }
+        validate_permutation(new_order, self.count)?;
 
-        self.reorder_copy(new_order)
-    }
-
-    /// Performs the out-of-place vector copy for reordering.
-    ///
-    /// Allocates a temporary buffer, copies vectors in permuted order, then
-    /// swaps the buffer into place. Uses `AllocGuard` for panic-safety.
-    fn reorder_copy(&mut self, new_order: &[usize]) -> crate::error::Result<()> {
-        use crate::alloc_guard::AllocGuard;
-
-        let new_layout = Self::layout(self.dimension, self.count)?;
-        let guard = AllocGuard::new_zeroed(new_layout).ok_or_else(|| {
-            crate::error::Error::AllocationFailed(format!(
-                "Reorder: failed to allocate {} bytes",
-                new_layout.size()
-            ))
-        })?;
-        let new_ptr = NonNull::new(guard.cast::<f32>()).ok_or_else(|| {
-            crate::error::Error::AllocationFailed(
-                "Reorder: AllocGuard returned null pointer".to_string(),
-            )
-        })?;
-
-        self.copy_permuted_vectors(new_ptr.as_ptr(), new_order)?;
-
-        // Transfer ownership — guard will not free on drop
-        let _ = guard.into_raw();
-
-        self.adopt_reordered_buffer(new_ptr)
-    }
-
-    /// Installs the freshly reordered heap buffer and releases the old one.
-    ///
-    /// Reordering always lands the arena on the heap, so a file-mapped arena
-    /// changes backing here. Taking the old backing out *first* is what keeps
-    /// a mapped pointer away from `dealloc`: only a `Heap` predecessor
-    /// reaches the allocator, and a `FileMapped` one is released by dropping
-    /// it (#2112).
-    fn adopt_reordered_buffer(&mut self, new_ptr: NonNull<f32>) -> crate::error::Result<()> {
-        let previous = std::mem::replace(&mut self.backing, ArenaBacking::Heap);
-        let old_data = self.data;
-        let old_capacity = self.capacity;
-
-        self.data = new_ptr;
-        self.capacity = self.count;
-
-        if previous.is_heap() {
-            let old_layout = Self::layout(self.dimension, old_capacity)?;
-            // SAFETY: `old_data` was allocated with `old_layout` and is non-null
-            // (NonNull invariant).
-            // - Condition 1: the `is_heap` branch proves the allocator owns it.
-            // - Condition 2: `old_layout` matches its allocation parameters.
-            // SAFETY: Free the pre-reorder buffer now that its data has moved.
-            unsafe { dealloc(old_data.as_ptr().cast::<u8>(), old_layout) };
-        }
+        let dimension = self.dimension;
+        permute_in_place(self.live_flat_mut(), dimension, new_order);
         Ok(())
     }
 
-    /// Copies vectors from the current buffer to `dst` in permuted order.
-    fn copy_permuted_vectors(
-        &self,
-        dst: *mut f32,
-        new_order: &[usize],
-    ) -> crate::error::Result<()> {
-        let dim = self.dimension;
-        for (new_idx, &old_idx) in new_order.iter().enumerate() {
-            if old_idx >= self.count {
-                return Err(crate::error::Error::Internal(format!(
-                    "Reorder index {old_idx} out of bounds (count={})",
-                    self.count
-                )));
-            }
-            // SAFETY: src is within the current allocation (old_idx < count, count <= capacity).
-            // dst is within the new allocation (new_idx < new_order.len() == count).
-            // Both buffers are distinct (non-overlapping) allocations with room for `dim` f32s.
-            // - Condition 1: old_idx < count ensures src offset is in bounds.
-            // - Condition 2: new_idx < count ensures dst offset is in bounds.
-            // SAFETY: Out-of-place copy for cache-locality reordering.
-            unsafe {
-                ptr::copy_nonoverlapping(
-                    self.data.as_ptr().add(old_idx * dim),
-                    dst.add(new_idx * dim),
-                    dim,
-                );
-            }
-        }
-        Ok(())
+    /// The `count * dimension` live f32s as one mutable slice.
+    ///
+    /// Private to this module: it hands out write access to the whole arena
+    /// at once, which only the permutation needs. Everything else goes
+    /// through `get_mut`, whose bounds check is the point.
+    fn live_flat_mut(&mut self) -> &mut [f32] {
+        // `count <= capacity` and `capacity * dimension` was validated to fit
+        // in `usize` at allocation time, so this product cannot overflow.
+        let total = self.count.saturating_mul(self.dimension);
+        // SAFETY: `data` addresses `capacity * dimension` initialized f32s —
+        // both the heap allocation (`alloc_zeroed`) and the mapped arena
+        // (a file zero-extended to its declared length) start zeroed.
+        // - Condition 1: `data` is a valid, aligned `NonNull<f32>` pointer,
+        //   for the mapped backing because `DATA_OFFSET` is a whole number of
+        //   pages and the mmap base is page-aligned.
+        // - Condition 2: `total <= capacity * dimension`, so the slice stays
+        //   inside the allocation.
+        // - Condition 3: `&mut self` excludes any other live reference to
+        //   these bytes for the slice's lifetime.
+        // SAFETY: The in-place permutation needs one mutable view of the arena.
+        unsafe { std::slice::from_raw_parts_mut(self.data.as_ptr(), total) }
     }
 
     /// Computes dot product with another vector using SIMD.
@@ -272,4 +232,86 @@ pub fn batch_cosine_similarities(vectors: &[&[f32]], query: &[f32]) -> Vec<f32> 
     }
 
     results
+}
+
+/// Rejects anything that is not a bijection of `0..count`.
+///
+/// Checked before the permutation rather than during it: the in-place
+/// algorithm follows cycles, and a repeated index makes a cycle that never
+/// closes. Validating first turns that into an error instead of a hang, and
+/// also catches the duplicate-vector case the copying implementation used to
+/// accept silently.
+fn validate_permutation(new_order: &[usize], count: usize) -> crate::error::Result<()> {
+    let mut seen = vec![false; count];
+    for &old_idx in new_order {
+        let slot = seen.get_mut(old_idx).ok_or_else(|| {
+            crate::error::Error::Internal(format!(
+                "Reorder index {old_idx} out of bounds (count={count})"
+            ))
+        })?;
+        if *slot {
+            return Err(crate::error::Error::Internal(format!(
+                "Reorder index {old_idx} appears twice; new_order must be a permutation"
+            )));
+        }
+        *slot = true;
+    }
+    Ok(())
+}
+
+/// Applies `new_order` to `flat` without a second arena.
+///
+/// A permutation decomposes into disjoint cycles, and each cycle can be
+/// rotated with a single vector of scratch space. `moved` is what keeps the
+/// outer loop from re-entering a cycle it already rotated.
+///
+/// `new_order` is a validated bijection of `0..new_order.len()` and `flat`
+/// holds `new_order.len() * dimension` f32s, so every index computed here is
+/// in bounds.
+fn permute_in_place(flat: &mut [f32], dimension: usize, new_order: &[usize]) {
+    let mut scratch = vec![0.0_f32; dimension];
+    let mut moved = vec![false; new_order.len()];
+
+    for start in 0..new_order.len() {
+        if moved[start] {
+            continue;
+        }
+        // A fixed point is its own cycle; rotating it would copy a vector
+        // out to scratch and straight back.
+        if new_order[start] == start {
+            moved[start] = true;
+            continue;
+        }
+        rotate_cycle(flat, dimension, new_order, start, &mut moved, &mut scratch);
+    }
+}
+
+/// Rotates the one permutation cycle that contains `start`.
+///
+/// `flat[start]` is parked in `scratch` first, which frees the slot the cycle
+/// needs; every other member is then pulled from its source, whose own move
+/// has not happened yet. The vector in scratch closes the cycle.
+fn rotate_cycle(
+    flat: &mut [f32],
+    dimension: usize,
+    new_order: &[usize],
+    start: usize,
+    moved: &mut [bool],
+    scratch: &mut [f32],
+) {
+    scratch.copy_from_slice(&flat[start * dimension..][..dimension]);
+    let mut dst = start;
+    loop {
+        moved[dst] = true;
+        let src = new_order[dst];
+        if src == start {
+            flat[dst * dimension..][..dimension].copy_from_slice(scratch);
+            return;
+        }
+        flat.copy_within(
+            src * dimension..src * dimension + dimension,
+            dst * dimension,
+        );
+        dst = src;
+    }
 }

--- a/crates/velesdb-core/src/database/stats_tests.rs
+++ b/crates/velesdb-core/src/database/stats_tests.rs
@@ -243,3 +243,84 @@ fn histogram_survives_database_reopen() {
     );
     assert!(!hist.stale, "fresh histogram should not be stale");
 }
+
+/// `ANALYZE` must not change which points a query returns.
+///
+/// The regression this pins: `analyze_collection` runs `reorder_for_locality`
+/// above 1 000 points, which renumbers every graph node — and the external-id
+/// mappings are keyed by that numbering. Nothing failed when they were left
+/// behind: every lookup still resolved, to a different point than the one
+/// found. On this fixture the correct `[500, 501, 499, 502, 498]` came back
+/// as `[575, 601, 586, 560, 588]` (#2112).
+///
+/// A self-query is used so the expected answer is known independently of the
+/// index, and the vectors are given distinct directions so the ordering is
+/// strict — `vec![i; dim]` under cosine makes every point parallel to every
+/// other, and any permutation of the ties would satisfy the assertion.
+#[test]
+#[cfg(feature = "persistence")]
+fn analyze_preserves_the_points_a_query_returns() {
+    assert_analyze_preserves_results(1_100);
+}
+
+/// The same collection below the reorder threshold, where no renumbering
+/// happens — so a failure above can be attributed to the reorder rather than
+/// to `ANALYZE`'s other work.
+#[test]
+#[cfg(feature = "persistence")]
+fn analyze_below_the_reorder_threshold_preserves_results() {
+    assert_analyze_preserves_results(900);
+}
+
+/// Builds an `n`-point collection, records a self-query's top-5, runs
+/// `ANALYZE`, and requires the same five ids in the same order.
+#[cfg(feature = "persistence")]
+fn assert_analyze_preserves_results(n: u64) {
+    let (_dir, db) = temp_database();
+    db.create_collection("analyze_ids", 4, DistanceMetric::Euclidean)
+        .expect("create collection");
+    let coll = db
+        .get_vector_collection("analyze_ids")
+        .expect("collection exists");
+
+    let points: Vec<Point> = (1..=n)
+        .map(|i| Point {
+            id: i,
+            vector: vec![
+                (i as f32 * 0.013).sin(),
+                (i as f32 * 0.029).cos(),
+                (i as f32 * 0.007).sin(),
+                (i as f32 * 0.041).cos(),
+            ],
+            payload: None,
+            sparse_vectors: None,
+        })
+        .collect();
+    let query = points[499].vector.clone();
+    coll.upsert(points).expect("upsert");
+
+    let before = top_ids(&coll, &query);
+    assert_eq!(
+        before.first().copied(),
+        Some(500),
+        "the fixture is only meaningful if the self-query finds itself first"
+    );
+
+    db.analyze_collection("analyze_ids").expect("analyze");
+
+    assert_eq!(
+        before,
+        top_ids(&coll, &query),
+        "ANALYZE changed the ids a query returns"
+    );
+}
+
+/// The ids of a collection's top-5 for `query`.
+#[cfg(feature = "persistence")]
+fn top_ids(coll: &crate::VectorCollection, query: &[f32]) -> Vec<u64> {
+    coll.search(query, 5)
+        .expect("search")
+        .iter()
+        .map(|r| r.point.id)
+        .collect()
+}

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -212,11 +212,27 @@ impl HnswIndex {
     /// Automatically skipped for small indices (< 1000 vectors) where the
     /// entire working set fits in L2 cache.
     ///
+    /// # Why the write lock
+    ///
+    /// The pass renumbers every node, and [`mappings`](Self::mappings) is
+    /// keyed by that numbering, so the two are only consistent together. A
+    /// read guard would let a search run between them and resolve external
+    /// ids against the old numbering — confident, wrong answers rather than
+    /// an error. `vacuum` takes the write lock to renumber for the same
+    /// reason. `ANALYZE` is the caller, so the exclusion lasts one
+    /// maintenance pass.
+    ///
     /// # Errors
     ///
     /// Returns an error if vector storage reordering fails.
     pub fn reorder_for_locality(&self) -> crate::error::Result<()> {
-        self.inner.read().reorder_for_locality()
+        let guard = self.inner.write();
+        let reordered = guard.reorder_for_locality()?;
+        if let Some(old_to_new) = reordered {
+            self.mappings.remap_indices(&old_to_new);
+        }
+        drop(guard);
+        Ok(())
     }
 }
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph/reorder.rs
@@ -29,26 +29,44 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     /// - After compaction of a dynamic index
     /// - Not needed for small indices (< 1000 vectors)
     ///
+    /// # What the caller has to do with the answer
+    ///
+    /// **This renumbers every node.** The returned `old_to_new` — `result[i]`
+    /// is the new id of the node that was `i` — is not a diagnostic: anything
+    /// outside this graph that is keyed by node id is stale until it has been
+    /// put through it. Two things are, and neither used to be:
+    ///
+    /// - `HnswIndex`'s external-id mappings. Without the remap, `ANALYZE` on
+    ///   a 1 100-point collection turned the correct answer
+    ///   `[500, 501, 499, 502, 498]` into `[575, 601, 586, 560, 588]` — every
+    ///   lookup still resolved, to the wrong vector.
+    /// - The quantized backends' positional code store, whose codes then
+    ///   describe other nodes: recall@10 measured 1.000 before a reorder and
+    ///   **0.000** after, with no error raised anywhere (#2112).
+    ///
+    /// `None` means the pass declined (below the threshold, or no entry
+    /// point) and nothing moved.
+    ///
     /// # Errors
     ///
     /// Returns an error if vector storage reordering fails.
-    pub fn reorder_for_locality(&self) -> crate::error::Result<()> {
+    pub fn reorder_for_locality(&self) -> crate::error::Result<Option<Vec<usize>>> {
         let count = self.count.load(Ordering::Relaxed);
         if count < REORDER_THRESHOLD {
-            return Ok(());
+            return Ok(None);
         }
 
         let entry = self.entry_point.load(Ordering::Acquire);
         if entry == NO_ENTRY_POINT {
-            return Ok(());
+            return Ok(None);
         }
 
         let permutation = self.compute_bfs_order(entry, count);
         if permutation.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
 
-        self.apply_permutation(&permutation)?;
+        let old_to_new = self.apply_permutation(&permutation)?;
 
         // Reordering rewrites both the vector buffer AND every neighbour
         // list, so any cached CSR / flat-vector snapshot built from the
@@ -62,7 +80,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         #[cfg(feature = "gpu")]
         self.invalidate_gpu_caches();
 
-        Ok(())
+        Ok(Some(old_to_new))
     }
 
     /// Computes BFS traversal order starting from the entry point on layer 0.
@@ -125,7 +143,10 @@ impl<D: DistanceEngine> NativeHnsw<D> {
     }
 
     /// Applies a permutation to vectors, neighbor lists, and the entry point.
-    fn apply_permutation(&self, new_order: &[NodeId]) -> crate::error::Result<()> {
+    ///
+    /// Returns the `old_to_new` map it used, so the caller can put whatever
+    /// it keys by node id through the same renumbering.
+    fn apply_permutation(&self, new_order: &[NodeId]) -> crate::error::Result<Vec<usize>> {
         let count = new_order.len();
 
         let old_to_new = Self::build_reverse_mapping(new_order, count);
@@ -134,7 +155,7 @@ impl<D: DistanceEngine> NativeHnsw<D> {
         self.remap_neighbor_ids(&old_to_new);
         self.update_entry_point(&old_to_new, count);
 
-        Ok(())
+        Ok(old_to_new)
     }
 
     /// Builds a reverse mapping: `result[old_id] = new_id`.

--- a/crates/velesdb-core/src/index/hnsw/native/precision_contract_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/precision_contract_tests.rs
@@ -451,3 +451,86 @@ pub(super) fn check_recall_10k<C: TraversalCodec>() {
         "recall@{k} should be >= 0.95 through the default config, got {avg_recall:.3}"
     );
 }
+
+/// A BFS locality reorder must not desynchronize the codes from the graph.
+///
+/// `ANALYZE` calls `reorder_for_locality()`, which renumbers every node. The
+/// codec's store is **positional** — entry N holds node N's code — so it has
+/// to be rebuilt against the new numbering; if it is not, traversal scores
+/// every candidate against another node's code while the re-rank quietly
+/// reports honest distances for whatever that traversal happened to reach.
+/// Measured before the fix: 1.000 to 0.000, no error raised.
+///
+/// Quality is compared by **score**, not by id: a reorder renumbers nodes by
+/// design, so comparing raw node ids across one would fail even for a
+/// correct index. What must survive is that the k best distances are still
+/// the k best distances.
+pub(super) fn check_recall_survives_reorder<C: TraversalCodec>() {
+    let (dim, n, k, ef_search) = (64, 2_000, 10, 200);
+    let hnsw = euclidean_backend::<C>(dim, 32, 200, n);
+    let vectors: Vec<Vec<f32>> = (0..n)
+        .map(|i| {
+            (0..dim)
+                .map(|j| ((i * dim + j) as f32 * 0.001).sin())
+                .collect()
+        })
+        .collect();
+    for v in &vectors {
+        hnsw.insert(v).expect("test");
+    }
+    assert!(hnsw.is_quantizer_trained(), "auto-trained at 1000 inserts");
+
+    let queries = [0, 500, 1234, 1999];
+    let before = mean_score_recall(&hnsw, &vectors, &queries, k, ef_search);
+    assert!(
+        before >= 0.95,
+        "baseline recall must hold before the reorder, got {before:.3}"
+    );
+
+    // Through the wrapper, which is what the backend dispatch calls: the
+    // inner graph cannot keep the store aligned on its own.
+    hnsw.reorder_for_locality().expect("test");
+
+    let after = mean_score_recall(&hnsw, &vectors, &queries, k, ef_search);
+    assert!(
+        after >= 0.95,
+        "recall@{k} collapsed from {before:.3} to {after:.3} across a locality \
+         reorder — the codes no longer describe the nodes they are indexed by"
+    );
+}
+
+/// Mean fraction of a query's returned scores that are genuine top-k scores.
+///
+/// Brute force gives the k best distances; a search that reached the right
+/// neighbourhood returns those same values whatever ids the nodes now carry.
+#[allow(clippy::cast_precision_loss)]
+fn mean_score_recall<C: TraversalCodec>(
+    hnsw: &Backend<C>,
+    vectors: &[Vec<f32>],
+    queries: &[usize],
+    k: usize,
+    ef_search: usize,
+) -> f64 {
+    const TOLERANCE: f32 = 1e-4;
+    let total: f64 = queries
+        .iter()
+        .map(|&qi| {
+            let query = &vectors[qi];
+            let best: Vec<f32> = brute_force_top_ids(vectors, query, DistanceMetric::Euclidean, k)
+                .into_iter()
+                .map(|i| DistanceMetric::Euclidean.calculate(query, &vectors[i]))
+                .collect();
+            // `search_bounded` with a zero floor, not `search`: the default
+            // `min_index_size` (10 000) would route a 2 000-vector index to
+            // the exact-f32 fallback, and a test that never reads a code
+            // cannot notice the codes being wrong.
+            let hit = hnsw
+                .search_bounded(query, k, ef_search, C::DEFAULT_OVERSAMPLING, 0)
+                .iter()
+                .filter(|(_, score)| best.iter().any(|b| (b - score).abs() <= TOLERANCE))
+                .count();
+            hit as f64 / k as f64
+        })
+        .sum();
+    total / queries.len() as f64
+}

--- a/crates/velesdb-core/src/index/hnsw/native/quantized_precision.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/quantized_precision.rs
@@ -591,6 +591,61 @@ impl<D: DistanceEngine, C: TraversalCodec> QuantizedPrecisionHnsw<D, C> {
         Ok(true)
     }
 
+    /// Reorders the graph for cache locality and rebuilds the store to match.
+    ///
+    /// The inner pass renumbers every node, and this backend's store is
+    /// positional — entry N holds node N's code — so a reorder that stopped
+    /// at the graph would leave every code describing a different vector
+    /// than the node it is read for. Traversal then walks a graph scored on
+    /// unrelated codes while the re-rank reports honest distances for
+    /// whatever that walk reached, so nothing downstream looks wrong:
+    /// measured at 2 000 x 64-d, recall@10 went from 1.000 to **0.000**
+    /// with no error anywhere (#2112).
+    ///
+    /// The store is rebuilt by re-encoding rather than permuted. Encoding is
+    /// deterministic, so the two produce the same store, and re-encoding
+    /// reuses the path that `install_trained_quantizer` already relies on
+    /// instead of adding a positional-permutation duty to every codec — one
+    /// more place a future store shape could get it wrong.
+    ///
+    /// A no-op beyond the graph pass when the backend is untrained or the
+    /// codec is disabled for this metric: there is no store to hold aligned.
+    ///
+    /// # Locking
+    ///
+    /// The install gate (write) drains in-flight inserts, exactly as
+    /// [`install_trained_quantizer`] needs it to — an insert that pushed to
+    /// the old store mid-reorder would land at a position the permutation
+    /// has already moved. `quantizer.write()` is then held across the whole
+    /// operation, and the vectors guard taken inside
+    /// `encode_all_in_node_order` is released before `store.write()`, which
+    /// keeps the documented `quantizer -> store` order (see
+    /// `docs/CONCURRENCY_MODEL.md`).
+    ///
+    /// [`install_trained_quantizer`]: Self::install_trained_quantizer
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the graph pass fails, or if re-encoding any
+    /// stored vector does.
+    pub(in crate::index::hnsw) fn reorder_for_locality(
+        &self,
+    ) -> crate::error::Result<Option<Vec<usize>>> {
+        let _gate = self.install_gate.write();
+        let quantizer_guard = self.quantizer.write();
+
+        let Some(old_to_new) = self.inner.reorder_for_locality()? else {
+            return Ok(None);
+        };
+        let Some(quantizer) = quantizer_guard.as_ref() else {
+            return Ok(Some(old_to_new));
+        };
+
+        let store = self.encode_all_in_node_order(quantizer)?;
+        *self.store.write() = Some(store);
+        Ok(Some(old_to_new))
+    }
+
     /// Encodes every vector in `inner` (`NodeId` order `0..len`) into a
     /// fresh store.
     ///

--- a/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/rabitq_precision_tests.rs
@@ -151,3 +151,9 @@ fn test_rabitq_dot_product_rerank_keeps_best_candidates() {
 fn test_rabitq_cosine_unnormalized_query_matches_normalized() {
     suite::check_cosine_scale_invariance::<RaBitQCodec>(64);
 }
+
+/// A locality reorder must not desynchronize the RaBitQ store from the graph.
+#[test]
+fn test_rabitq_recall_survives_locality_reorder() {
+    suite::check_recall_survives_reorder::<RaBitQCodec>();
+}

--- a/crates/velesdb-core/src/index/hnsw/native/sq8_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/sq8_precision_tests.rs
@@ -277,3 +277,9 @@ fn test_concurrent_inserts_and_search_keep_store_aligned() {
         );
     }
 }
+
+/// A locality reorder must not desynchronize the int8 store from the graph.
+#[test]
+fn test_sq8_recall_survives_locality_reorder() {
+    suite::check_recall_survives_reorder::<Sq8Codec>();
+}

--- a/crates/velesdb-core/src/index/hnsw/native_inner.rs
+++ b/crates/velesdb-core/src/index/hnsw/native_inner.rs
@@ -606,14 +606,19 @@ impl NativeHnswInner {
     /// Skips reordering for small indices (< 1000 vectors) where the entire
     /// working set fits in L2 cache.
     ///
+    /// A quantized backend goes through its own wrapper rather than straight
+    /// to `inner`: reordering renumbers the nodes, and the wrapper's code
+    /// store is indexed by node id, so only the wrapper can keep the two in
+    /// step (#2112).
+    ///
     /// # Errors
     ///
     /// Returns an error if vector storage reordering fails.
-    pub fn reorder_for_locality(&self) -> crate::error::Result<()> {
+    pub fn reorder_for_locality(&self) -> crate::error::Result<Option<Vec<usize>>> {
         match &self.backend {
             HnswBackend::Standard(hnsw) => hnsw.reorder_for_locality(),
-            HnswBackend::RaBitQ(rabitq) => rabitq.inner.reorder_for_locality(),
-            HnswBackend::Sq8(sq8) => sq8.inner.reorder_for_locality(),
+            HnswBackend::RaBitQ(rabitq) => rabitq.reorder_for_locality(),
+            HnswBackend::Sq8(sq8) => sq8.reorder_for_locality(),
         }
     }
 }

--- a/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
+++ b/crates/velesdb-core/src/index/hnsw/sharded_mappings.rs
@@ -393,6 +393,44 @@ impl ShardedMappings {
         self.tombstone_slots.store(0, Ordering::Relaxed);
     }
 
+    /// Renumbers every internal index through `old_to_new`.
+    ///
+    /// The graph owns the node numbering, and a BFS locality reorder changes
+    /// it. Both directions of this map are keyed by that numbering, so they
+    /// have to move with it — `vacuum` renumbers too and rebuilds them from
+    /// scratch for the same reason. Skipping it does not fail: every lookup
+    /// still resolves, to a different vector than the one asked for, so a
+    /// query returns confident, wrong answers (#2112).
+    ///
+    /// `old_to_new[i]` is the new index of the node that was `i`. Entries
+    /// beyond its length are left alone: those are index slots with no graph
+    /// node behind them (the orphan slots `tombstone_slots` counts), and
+    /// since every remapped value is `< old_to_new.len()` they cannot
+    /// collide with one.
+    ///
+    /// Tombstoned nodes need no special case — deletion removes the mapping
+    /// and leaves the node, so they simply have no entry to move.
+    ///
+    /// Not atomic against concurrent readers. The caller holds the index
+    /// write lock across the graph permutation and this call, which is what
+    /// keeps a search from observing the half-renumbered state.
+    pub fn remap_indices(&self, old_to_new: &[usize]) {
+        let renumber = |idx: usize| old_to_new.get(idx).copied().unwrap_or(idx);
+
+        let moved: Vec<(u64, usize)> = self
+            .id_to_idx
+            .iter()
+            .map(|entry| (*entry.key(), renumber(*entry.value())))
+            .collect();
+
+        self.id_to_idx.clear();
+        self.idx_to_id.clear();
+        for (id, idx) in moved {
+            self.id_to_idx.insert(id, idx);
+            self.idx_to_id.insert(idx, id);
+        }
+    }
+
     /// Creates mappings from existing data (for deserialization).
     ///
     /// # Arguments

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -292,10 +292,10 @@ impl ContiguousVectors {
 
     /// Flushes a file-backed arena's dirty pages to disk.
     ///
-    /// A no-op on a heap-backed arena, which has no file to reach. Note that
-    /// this includes an arena that *used* to be file-backed: [`reorder`] moves
-    /// one onto the heap, after which this returns `Ok` without writing
-    /// anything. Call it before reordering, not after.
+    /// A no-op on a heap-backed arena, which has no file to reach. Every
+    /// arena that started file-backed still is: [`reorder`] permutes in place
+    /// and keeps the mapping, so this reaches the file before and after one
+    /// alike (#2112).
     ///
     /// [`reorder`]: Self::reorder
     ///


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → **targets `develop`**. ✅

## Description

This started as a memory fix: `ContiguousVectors::reorder` demoted a file-backed arena to the heap, silently undoing the 61% anonymous-RSS cut #2127 measured. Chasing the only production caller found two correctness bugs sitting on the same line, both reachable through `ANALYZE`, and both silent.

### `ANALYZE` returned the wrong points

`reorder_for_locality()` renumbers every node. `HnswIndex::mappings` is `external id ↔ internal index` **in both directions**, and it was left on the old numbering — so every lookup still resolved, to whatever vector had moved into that slot.

On a 1 100-point Euclidean collection, a self-query for point 500:

| | top-5 |
|---|---|
| before `ANALYZE` | `[500, 501, 499, 502, 498]` |
| after `ANALYZE` | `[575, 601, 586, 560, 588]` |

No error, no warning, no failing test. `vacuum` renumbers too and has always rebuilt the mappings; this path never did. **Every storage mode is affected**, not just the quantized ones.

### A quantized collection lost all of its recall

`SQ8` and `RaBitQ` index their code store positionally — entry N holds node N's code — and the backend dispatch called straight through to `inner`, so after a reorder every code described a different node. Traversal then walked a graph scored on unrelated codes while the exact-f32 re-rank reported honest distances for whatever that walk happened to reach, which is why nothing downstream looked wrong.

Measured through the int8 path at 2 000 × 64-d:

| | recall@10 |
|---|---|
| before the reorder | 1.000 |
| after, SQ8 | **0.000** |
| after, RaBitQ | 0.025 |

### The arena, which is where this started

Reordering copied into a fresh heap buffer, so the mapping and its exclusive lock were released, the pages stopped being evictable, and `flush_backing()` became a no-op that still returned `Ok`. Rotating each permutation cycle through one vector of scratch keeps whatever backing the arena was given, so the question disappears instead of being handled — and the heap path stops paying for a second buffer:

| 100 000 × 768-d, one cycle over every vector | |
|---|---|
| in place | **0.044–0.060 s** |
| gathered into a fresh buffer | 0.158–0.209 s, plus 293 MiB |

Eight runs, ranges not points — a first reading has landed outside the eventual range in each of the last three PRs. The two backings are within noise of each other.

## Design

The pass now returns the `old_to_new` map it applied, and its rustdoc says what a caller owes it rather than leaving that to be discovered. `HnswIndex` puts the mappings through it under the index **write** lock: a read guard would leave a window where a search sees the half-renumbered state, and `vacuum` takes the write lock to renumber for exactly that reason.

The quantized backends own their reorder and rebuild the store in the new node order, behind the same install gate that keeps an in-flight insert from landing at a position the permutation has already moved. Re-encoding rather than permuting reuses the path `install_trained_quantizer` already depends on, instead of giving every codec a positional-permutation duty to get wrong — encoding is deterministic, so the two produce the same store.

Everything keyed by node id is now accounted for: vectors, neighbour lists and entry point (already handled), the external-id mappings and the code store (this PR), GPU caches (already invalidated here). `NativeHnsw` holds no other node-keyed state.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

`cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` → **5408 passed, 0 failed**. Python gate suites: **664 passed**. Clean: `cargo fmt --all --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings`, `check-ai-attribution`, `check-inline-tests`, `check-file-budgets`, `check_prod_unwraps`, `check-doc-freshness`, `check-perf-claims`, `check-feature-claims`.

Each guard was seen red against the defect it exists for before being kept:

| guard | against the old code |
|---|---|
| `analyze_preserves_the_points_a_query_returns` | FAILED — `[575, 601, …]` |
| `analyze_below_the_reorder_threshold_preserves_results` | passed (control: no reorder, no corruption) |
| `test_sq8_recall_survives_locality_reorder` | FAILED — recall 0.000 |
| `test_rabitq_recall_survives_locality_reorder` | FAILED — recall 0.025 |
| `reorder_keeps_a_mapped_arena_mapped` | FAILED — backing was `Heap` |
| `reorder_writes_the_new_order_through_to_the_file` | FAILED — file held pre-reorder bytes |
| `reorder_refuses_a_permutation_that_repeats_an_index` | FAILED — accepted silently |

Two things worth flagging about the recall contract, because a weaker version of it passed against the bug:

- It compares **scores**, not node ids. A reorder renumbers by design, so an id-based comparison fails even on a correct index — the first draft "caught" nothing but the renumbering.
- It searches through `search_bounded` with a zero floor. The default `min_index_size` of 10 000 routes a 2 000-vector index to the exact-f32 fallback, and a test that never reads a code cannot notice the codes being wrong.

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-24. Reproduce the reorder cost with `cargo run --release --example resident_set --features persistence -- reorder`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — #2128 is on `develop`, and this is rebased on it

## Unsafe Code Checklist

- [x] Every `unsafe` block carries a numbered `// SAFETY:` comment

The reorder path now holds **one** `unsafe` block where it held two. The permutation runs on a `&mut [f32]` through `copy_within`, so the only thing needing justification is the slice itself; the per-vector `copy_nonoverlapping` loop and the `dealloc` of the old buffer are both gone.

## High-Risk Change Checklist

Touches `hnsw` and the vector arena, so:

- [x] Recall contract pinned for both quantized backends, and the Perf Gate's recall ≥ 0.95 covers the standard path
- [x] Concurrency reasoned about explicitly and documented at each site: the index write lock makes the graph permutation and the mapping remap atomic against searches; the install gate drains in-flight inserts before the store is rebuilt; the `quantizer → store` order documented in `docs/CONCURRENCY_MODEL.md` is preserved, and the vectors guard is released before `store.write()` is taken
- [x] No `Drop` or SIMD behaviour changed

## Additional Notes

`reorder` now rejects a `new_order` that repeats an index. The copying implementation checked bounds only, so a non-bijective permutation silently duplicated one vector and dropped another; cycle-following would not terminate on one, so the check turns a hang into a message. The only production producer is `compute_bfs_order`, which is a bijection by construction.

The original deferral is worth quoting, since it was honest and still did not hold: *"This is stated rather than fixed because no production path takes a file-backed arena yet … Whoever does that wiring owns this."* #2118 did the wiring three PRs later and the note did not travel with it. What made the two correctness bugs findable was not that note but asking who actually calls `reorder` before changing it.

An assistant-attribution footer is appended to these bodies automatically on creation; removed here per `AGENTS.md` principle 5, and done now rather than after CI so the no-op `edited` run drains behind the real one instead of adding a second wait.