### PR TITLE
fix(velesql): NOT (similarity AND metadata) returned the wrong rows — De Morgan and three-valued logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`NOT (similarity(...) AND metadata)` no longer drops the rows it should
+  return.** The `NOT similarity()` scan inverted the similarity leaf and
+  separately pushed the metadata leaves down through
+  `extract_metadata_filter` — which wraps what it finds under a `NOT` in its
+  own `NOT` — then AND-ed the two. That distributes the negation over the
+  connective, which is De Morgan's error: `NOT (A AND B)` was executed as
+  `NOT A AND NOT B`. On a three-row fixture the correct `[2, 3]` came back as
+  `[]`, and `NOT (A OR B)` returned `[2, 3]` where `[3]` was correct. Neither
+  raised an error. The scan now decides each candidate with
+  `evaluate_where_condition_for_record`, the same evaluator the graph and
+  aggregation paths use, so the engine has one WHERE semantics rather than one
+  per execution path; the similarity leaf is still extracted, but only to
+  score the rows that pass. A stale comment in `extraction.rs` recorded the
+  assumption that broke — "NOT similarity() is rejected earlier in
+  validation" — which stopped being true when EPIC-044 US-003 enabled the
+  full-scan path. (#2112)
+
+- **WHERE now evaluates in three-valued logic.** A `similarity()` predicate is
+  UNKNOWN for a row whose vector cannot be scored (length mismatch, empty, or
+  absent), where it previously answered `false`. The two are indistinguishable
+  until something negates them: `NOT false` admits the row, `NOT UNKNOWN` must
+  not, so the old answer let `NOT similarity()` return rows nothing had been
+  computed for. `AND` and `OR` follow Kleene's tables and keep short-circuiting
+  on the value that decides them (`false` for `AND`, `true` for `OR`), and a
+  top-level UNKNOWN excludes the row exactly as SQL's `WHERE` does. One
+  consequence is a row that is now *returned* where it used to be dropped:
+  under `NOT (unscoreable AND meta)` with `meta` false, the conjunction is
+  false whatever the vector would have scored, so the negation is a known
+  true. Documented in `docs/VELESQL_SPEC.md`. (#2112)
+
 - **`ANALYZE` no longer returns wrong points on collections over 1 000
   vectors.** `analyze_collection` runs `reorder_for_locality()`, which
   renumbers every graph node — and `HnswIndex`'s external-id mappings are

--- a/crates/velesdb-core/src/collection/search/query/extraction.rs
+++ b/crates/velesdb-core/src/collection/search/query/extraction.rs
@@ -175,9 +175,23 @@ impl Collection {
             Condition::Group(inner) => {
                 Self::extract_metadata_filter(inner).map(|c| Condition::Group(Box::new(c)))
             }
-            // Handle NOT: preserve NOT wrapper if inner condition exists
-            // Note: NOT similarity() is rejected earlier in validation, so we only
-            // need to handle NOT with metadata conditions here
+            // Handle NOT: preserve NOT wrapper if inner condition exists.
+            //
+            // This is only sound when the negation applies to metadata alone.
+            // Re-wrapping what survives the recursion drops any non-metadata
+            // leaf out of the negation first, so `NOT (similarity AND meta)`
+            // reduces to `NOT meta` — the similarity conjunct silently gone,
+            // and the negation distributed over an `AND` it no longer spans.
+            //
+            // A comment here used to justify that with "NOT similarity() is
+            // rejected earlier in validation". It was true until EPIC-044
+            // US-003 enabled the full-scan path, and nothing updated it.
+            // The `NOT similarity()` scan therefore no longer uses this
+            // function to decide anything: it evaluates the whole condition
+            // per candidate through the shared WHERE evaluator, which applies
+            // De Morgan correctly (#2112). Callers that still push the result
+            // down as a payload filter must not hand it a `NOT` spanning a
+            // similarity leaf.
             Condition::Not(inner) => {
                 Self::extract_metadata_filter(inner).map(|c| Condition::Not(Box::new(c)))
             }

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter.rs
@@ -27,19 +27,16 @@ pub(crate) struct TrackedScan {
     pub(crate) unscanned_ids: usize,
 }
 
-/// Inverted-similarity threshold bundle for the NOT-similarity scan.
 /// Per-scan invariants for the NOT-similarity loop, hoisted once.
 struct NotSimilarityScanCtx<'a> {
     vector_storage: &'a crate::storage::MmapStorage,
     payload_storage: &'a crate::storage::LogPayloadStorage,
     metric: crate::distance::DistanceMetric,
     now_secs: u64,
-}
-
-struct NotSimilarityThreshold {
-    op: crate::velesql::CompareOp,
-    value: f32,
-    higher_is_better: bool,
+    /// The `similarity()` field this scan reports a score for.
+    sim_field: &'a str,
+    /// Resolved query vector for that leaf.
+    sim_vec: &'a [f32],
 }
 
 impl Collection {
@@ -113,11 +110,29 @@ impl Collection {
             .collect()
     }
 
-    /// EPIC-044 US-003: Execute NOT similarity() query via full scan.
+    /// EPIC-044 US-003: Execute a `NOT similarity()` query via full scan.
     ///
-    /// This method handles queries like:
-    /// `WHERE NOT similarity(v, $v) > 0.8`
-    /// Which is equivalent to: `WHERE similarity(v, $v) <= 0.8`
+    /// Handles queries like `WHERE NOT similarity(v, $v) > 0.8`, and any
+    /// boolean combination around that leaf.
+    ///
+    /// # The whole condition is evaluated, not just the negated leaf
+    ///
+    /// Each candidate is decided by
+    /// [`evaluate_where_condition_for_record`](Self::evaluate_where_condition_for_record)
+    /// — the same evaluator the graph and aggregation paths use — so there is
+    /// one WHERE semantics in the engine rather than one per execution path.
+    ///
+    /// The predecessor inverted the similarity leaf and separately pushed the
+    /// metadata leaves down through `extract_metadata_filter`, which wraps
+    /// what it finds under a `NOT` in its own `NOT`, then AND-ed the two.
+    /// That distributes the negation over the connective — De Morgan's error —
+    /// so `NOT (sim AND meta)` was executed as `NOT sim AND NOT meta`.
+    /// Measured on a three-row fixture, the correct `[2, 3]` came back as
+    /// `[]`, and `NOT (sim OR meta)` returned `[2, 3]` for a correct `[3]`.
+    /// No error was raised in either case.
+    ///
+    /// The similarity leaf is still extracted, but only to score the rows that
+    /// pass: the score reported is that leaf's, as it always was.
     ///
     /// **Performance Warning**: This requires scanning ALL documents.
     /// Always use with LIMIT for acceptable performance.
@@ -131,7 +146,9 @@ impl Collection {
         limit: usize,
         candidates: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<SearchResult>> {
-        let (sim_field, sim_vec, sim_op, sim_threshold) =
+        // Extracted for the reported score only — the pass/fail decision comes
+        // from evaluating `condition` itself, below.
+        let (sim_field, sim_vec, _, _) =
             self.extract_not_similarity_condition(condition, params)?;
 
         let all_ids = match candidates {
@@ -146,44 +163,44 @@ impl Collection {
         Self::guard_not_similarity_scan(total_count)?;
         Self::warn_large_scan(total_count, limit);
 
-        let metadata_filter = Self::extract_metadata_filter(condition);
-        let filter = metadata_filter
-            .map(|cond| crate::filter::Filter::new(crate::filter::Condition::from(cond)));
-
-        let higher_is_better = self.storage.config.read().metric.higher_is_better();
-
-        #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
-        let threshold_f32 = sim_threshold as f32;
         let mut results = Vec::new();
 
-        let threshold = NotSimilarityThreshold {
-            op: sim_op,
-            value: threshold_f32,
-            higher_is_better,
-        };
-        // Hoist the per-row invariants: the metric snapshot, the expiry
-        // clock, and both storage guards (vector rank 2 before payload rank
-        // 3, decree order). The per-candidate helper previously acquired
-        // three locks and called SystemTime::now() for every scanned row.
+        // LOCK ORDER: metric snapshot (config, rank 1) first, then
+        // vector_storage (2) before payload_storage (3) — the order a real
+        // HTTP deadlock was traced to (.investigation/http-deadlock-2026-07-22/).
+        // The guards are then handed to the evaluator so a nested MATCH leaf
+        // reuses them instead of re-acquiring the same locks mid-scan.
         let metric = self.storage.config.read().metric;
         let now_secs = now_unix_secs();
         let vector_storage = self.storage.vector_storage.read();
         let payload_storage = self.storage.payload_storage.read();
+        let match_guards = crate::collection::search::query::match_exec::MatchStorageGuards {
+            metric,
+            vector_guard: &vector_storage,
+            payload_guard: &payload_storage,
+            payload_memo: crate::collection::search::query::match_exec::PayloadMemo::new(
+                &payload_storage,
+            ),
+            where_filters: crate::collection::search::query::match_exec::WhereFilterMemo::default(),
+        };
+        let mut graph_cache = super::where_eval::GraphMatchEvalCache::default();
         let scan = NotSimilarityScanCtx {
             vector_storage: &vector_storage,
             payload_storage: &payload_storage,
             metric,
             now_secs,
+            sim_field: &sim_field,
+            sim_vec: &sim_vec,
         };
         for id in all_ids {
-            if let Some(result) = Self::eval_not_similarity_candidate(
+            if let Some(result) = self.eval_not_similarity_candidate(
                 id,
-                &sim_field,
-                &sim_vec,
-                &threshold,
-                filter.as_ref(),
+                condition,
+                params,
                 &scan,
-            ) {
+                &match_guards,
+                &mut graph_cache,
+            )? {
                 results.push(result);
                 if results.len() >= limit {
                     break;
@@ -194,46 +211,55 @@ impl Collection {
         Ok(results)
     }
 
-    /// Evaluates one candidate id for the NOT-similarity scan: returns the
-    /// hydrated result when it passes both the inverted similarity threshold
-    /// and the metadata filter.
+    /// Evaluates one candidate against the full condition, hydrating it when
+    /// the condition holds.
+    ///
+    /// The similarity leaf is scored a second time here, only to fill
+    /// `SearchResult::score`; the admit/reject decision was already made by
+    /// the shared evaluator. A row whose vector cannot be scored still gets a
+    /// score of `0.0` — it can only have reached here because the metadata
+    /// alone settled the condition, so no similarity value exists to report.
     fn eval_not_similarity_candidate(
+        &self,
         id: u64,
-        sim_field: &str,
-        sim_vec: &[f32],
-        threshold: &NotSimilarityThreshold,
-        filter: Option<&crate::filter::Filter>,
+        condition: &crate::velesql::Condition,
+        params: &std::collections::HashMap<String, serde_json::Value>,
         scan: &NotSimilarityScanCtx<'_>,
-    ) -> Option<SearchResult> {
-        let vector = Self::retrieve_vector_for_scan_in(
+        guards: &crate::collection::search::query::match_exec::MatchStorageGuards<'_>,
+        graph_cache: &mut super::where_eval::GraphMatchEvalCache,
+    ) -> Result<Option<SearchResult>> {
+        let Some(vector) = Self::retrieve_vector_for_scan_in(
             scan.vector_storage,
             scan.payload_storage,
             id,
-            sim_field,
-        )?;
-        // A length-mismatched vector can't be scored against `sim_vec`; exclude
-        // rather than fabricate a score (a fake 0.0 used to read as a perfect
-        // match for distance metrics, letting it pass the inverted threshold).
-        if vector.len() != sim_vec.len() || vector.is_empty() {
-            return None;
-        }
-        let score = scan.metric.calculate(&vector, sim_vec);
-        if Self::compare_similarity(
-            score,
-            threshold.value,
-            threshold.op,
-            threshold.higher_is_better,
-        ) {
-            return None; // excluded by the NOT-similarity threshold
-        }
+            scan.sim_field,
+        ) else {
+            return Ok(None);
+        };
         let payload = scan.payload_storage.retrieve(id).ok().flatten();
         if is_payload_expired(payload.as_ref(), scan.now_secs) {
-            return None;
+            return Ok(None);
         }
-        if !Self::passes_metadata_filter(filter, payload.as_ref()) {
-            return None;
+
+        if !self.evaluate_where_condition_for_record(
+            condition,
+            id,
+            payload.as_ref(),
+            Some(&vector),
+            params,
+            &[],
+            graph_cache,
+            Some(guards),
+        )? {
+            return Ok(None);
         }
-        Some(SearchResult::new(
+
+        let score = if vector.len() == scan.sim_vec.len() && !vector.is_empty() {
+            scan.metric.calculate(&vector, scan.sim_vec)
+        } else {
+            0.0
+        };
+        Ok(Some(SearchResult::new(
             Point {
                 id,
                 vector,
@@ -241,7 +267,7 @@ impl Collection {
                 sparse_vectors: None,
             },
             score,
-        ))
+        )))
     }
 
     /// Compares a similarity score against a threshold using the given operator.
@@ -274,20 +300,6 @@ impl Collection {
                 );
                 None
             }
-        }
-    }
-
-    /// Checks if a payload passes an optional metadata filter.
-    fn passes_metadata_filter(
-        filter: Option<&crate::filter::Filter>,
-        payload: Option<&serde_json::Value>,
-    ) -> bool {
-        match filter {
-            Some(f) => match payload {
-                Some(p) => f.matches(p),
-                None => f.matches(&serde_json::Value::Null),
-            },
-            None => true,
         }
     }
 

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
@@ -177,6 +177,176 @@ mod scan_score_semantics {
         );
     }
 
+    /// Builds a `NOT (...)` condition over a similarity leaf and a metadata
+    /// leaf, so the scan is handed the exact shape De Morgan applies to.
+    fn not_of(inner: crate::velesql::Condition) -> crate::velesql::Condition {
+        crate::velesql::Condition::Not(Box::new(inner))
+    }
+
+    /// `similarity(vector, [1,0]) > threshold`.
+    fn sim_gt(threshold: f64) -> crate::velesql::Condition {
+        crate::velesql::Condition::Similarity(crate::velesql::SimilarityCondition {
+            field: "vector".to_string(),
+            vector: crate::velesql::VectorExpr::Literal(vec![1.0, 0.0]),
+            operator: crate::velesql::CompareOp::Gt,
+            threshold,
+        })
+    }
+
+    /// `cat = 'a'` — true for `tagged_point`, false for `other_point`.
+    fn cat_is_a() -> crate::velesql::Condition {
+        crate::velesql::Condition::Comparison(crate::velesql::Comparison {
+            column: "cat".to_string(),
+            operator: crate::velesql::CompareOp::Eq,
+            value: crate::velesql::Value::String("a".to_string()),
+        })
+    }
+
+    /// A point whose payload fails `cat = 'a'`.
+    fn other_point(id: u64, vector: Vec<f32>) -> Point {
+        Point {
+            id,
+            vector,
+            payload: Some(serde_json::json!({"cat": "b"})),
+            sparse_vectors: None,
+        }
+    }
+
+    /// `NOT (A AND B)` must mean `NOT A OR NOT B`, not `NOT A AND NOT B`.
+    ///
+    /// The scan used to invert the similarity leaf and separately push the
+    /// metadata leaf down through `extract_metadata_filter`, which wraps it in
+    /// its own `NOT`. The two were then AND-ed — distributing the negation
+    /// over the conjunction, which is exactly the De Morgan error. Rows that
+    /// satisfy `NOT B` but fail `NOT A` were dropped with no error.
+    #[test]
+    fn test_not_similarity_honours_de_morgan_over_conjunction() {
+        // Cosine on 2-d unit-ish vectors against the query [1, 0]:
+        //   id 1 [1,0]  -> similarity 1.0  (A true: sim > 0.5)
+        //   id 2 [0,1]  -> similarity 0.0  (A false)
+        // id 1 has cat='a' (B true), id 3 has cat='b' (B false).
+        let (_dir, col) = setup(
+            DistanceMetric::Cosine,
+            vec![
+                tagged_point(1, vec![1.0, 0.0]),
+                tagged_point(2, vec![0.0, 1.0]),
+                other_point(3, vec![1.0, 0.0]),
+            ],
+        );
+
+        let condition = not_of(crate::velesql::Condition::And(
+            Box::new(sim_gt(0.5)),
+            Box::new(cat_is_a()),
+        ));
+
+        let results = col
+            .execute_not_similarity_query_over(
+                &condition,
+                &std::collections::HashMap::new(),
+                10,
+                None,
+            )
+            .expect("test: NOT similarity scan");
+        let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        ids.sort_unstable();
+
+        // NOT (sim > 0.5 AND cat = 'a')
+        //   id 1: A=true,  B=true  -> NOT(true)  = false -> excluded
+        //   id 2: A=false, B=true  -> NOT(false) = true  -> included
+        //   id 3: A=true,  B=false -> NOT(false) = true  -> included
+        assert_eq!(
+            ids,
+            vec![2, 3],
+            "NOT (A AND B) must admit every row failing either conjunct"
+        );
+    }
+
+    /// `NOT (A OR B)` must mean `NOT A AND NOT B`.
+    #[test]
+    fn test_not_similarity_honours_de_morgan_over_disjunction() {
+        let (_dir, col) = setup(
+            DistanceMetric::Cosine,
+            vec![
+                tagged_point(1, vec![1.0, 0.0]),
+                tagged_point(2, vec![0.0, 1.0]),
+                other_point(3, vec![0.0, 1.0]),
+            ],
+        );
+
+        let condition = not_of(crate::velesql::Condition::Or(
+            Box::new(sim_gt(0.5)),
+            Box::new(cat_is_a()),
+        ));
+
+        let results = col
+            .execute_not_similarity_query_over(
+                &condition,
+                &std::collections::HashMap::new(),
+                10,
+                None,
+            )
+            .expect("test: NOT similarity scan");
+        let mut ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+        ids.sort_unstable();
+
+        // NOT (sim > 0.5 OR cat = 'a')
+        //   id 1: A=true,  B=true  -> excluded
+        //   id 2: A=false, B=true  -> excluded
+        //   id 3: A=false, B=false -> NOT(false) = true -> included
+        assert_eq!(ids, vec![3], "NOT (A OR B) admits only rows failing both");
+    }
+
+    /// A row whose metadata alone decides the answer is returned even when its
+    /// vector cannot be scored.
+    ///
+    /// This is the one place the "unscoreable is excluded" rule must NOT be
+    /// read as "drop the row": under `NOT (A AND B)` with `B` false, the
+    /// conjunction is false whatever `A` would have been, so the negation is
+    /// true. Three-valued logic gets this right by construction —
+    /// `UNKNOWN AND false` is `false`, not `UNKNOWN`.
+    #[test]
+    fn test_not_similarity_decides_on_metadata_when_vector_is_unscoreable() {
+        let (_dir, col) = setup(
+            DistanceMetric::Cosine,
+            vec![
+                tagged_point(1, vec![1.0, 0.0]),
+                other_point(2, vec![1.0, 0.0]),
+            ],
+        );
+
+        // A 3-dim literal against a 2-dim collection: the similarity leaf is
+        // UNKNOWN for every row.
+        let unscoreable =
+            crate::velesql::Condition::Similarity(crate::velesql::SimilarityCondition {
+                field: "vector".to_string(),
+                vector: crate::velesql::VectorExpr::Literal(vec![1.0, 0.0, 0.0]),
+                operator: crate::velesql::CompareOp::Gt,
+                threshold: 0.5,
+            });
+        let condition = not_of(crate::velesql::Condition::And(
+            Box::new(unscoreable),
+            Box::new(cat_is_a()),
+        ));
+
+        let results = col
+            .execute_not_similarity_query_over(
+                &condition,
+                &std::collections::HashMap::new(),
+                10,
+                None,
+            )
+            .expect("test: NOT similarity scan");
+        let ids: Vec<u64> = results.iter().map(|r| r.point.id).collect();
+
+        // id 1: UNKNOWN AND true  = UNKNOWN -> NOT UNKNOWN = UNKNOWN -> excluded
+        // id 2: UNKNOWN AND false = false   -> NOT false    = true    -> included
+        assert_eq!(
+            ids,
+            vec![2],
+            "the row whose metadata alone settles the conjunction must be returned"
+        );
+    }
+
     /// The `NOT similarity()` scan must likewise exclude, not fabricate a
     /// score for, a candidate whose vector length doesn't match the query.
     #[test]

--- a/crates/velesdb-core/src/collection/search/query/where_eval.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval.rs
@@ -244,16 +244,27 @@ impl Collection {
             from_aliases,
             guards,
         };
-        self.eval_condition(condition, &ctx, graph_cache)
+        // UNKNOWN excludes the row, exactly as SQL's `WHERE` does: only a
+        // predicate that is *known* true admits it.
+        Ok(self
+            .eval_condition(condition, &ctx, graph_cache)?
+            .unwrap_or(false))
     }
 
-    /// Recursively evaluates a single condition node.
+    /// Recursively evaluates a single condition node, three-valued.
+    ///
+    /// `None` is SQL's UNKNOWN: the predicate could not be decided for this
+    /// record — today only a `similarity()` leaf whose vector cannot be scored
+    /// produces it. It is deliberately NOT folded into `false` here, because
+    /// the two differ under negation: `NOT false` admits the row, `NOT
+    /// UNKNOWN` does not. Collapsing them at the leaf is what made
+    /// `NOT similarity()` return rows it could not actually score.
     fn eval_condition(
         &self,
         condition: &Condition,
         ctx: &WhereEvalCtx<'_>,
         graph_cache: &mut GraphMatchEvalCache,
-    ) -> Result<bool> {
+    ) -> Result<Option<bool>> {
         match condition {
             Condition::GraphMatch(predicate) => {
                 let ids = graph_cache.get_or_compute(
@@ -263,53 +274,81 @@ impl Collection {
                     ctx.from_aliases,
                     ctx.guards,
                 )?;
-                Ok(ids.contains(&ctx.id))
+                Ok(Some(ids.contains(&ctx.id)))
             }
             Condition::And(left, right) => {
                 self.eval_short_circuit_and(left, right, ctx, graph_cache)
             }
             Condition::Or(left, right) => self.eval_short_circuit_or(left, right, ctx, graph_cache),
-            Condition::Not(inner) => self.eval_condition(inner, ctx, graph_cache).map(|v| !v),
+            Condition::Not(inner) => Ok(self
+                .eval_condition(inner, ctx, graph_cache)?
+                .map(|known| !known)),
             Condition::Group(inner) => self.eval_condition(inner, ctx, graph_cache),
             Condition::Similarity(sim) => {
                 self.evaluate_similarity(sim, ctx.vector, ctx.params, graph_cache)
             }
-            Condition::VectorSearch(_) | Condition::VectorFusedSearch(_) => Ok(true),
+            Condition::VectorSearch(_) | Condition::VectorFusedSearch(_) => Ok(Some(true)),
             // #904: reuse the per-query cached `Filter` for this metadata leaf
             // instead of rebuilding it (and cloning the AST) on every row.
             other => {
                 let filter = graph_cache.metadata_filter(other);
-                Ok(Self::payload_passes_filter(filter, ctx.payload))
+                Ok(Some(Self::payload_passes_filter(filter, ctx.payload)))
             }
         }
     }
 
-    /// Evaluates AND with short-circuit: returns false immediately if left is false.
+    /// Evaluates AND, three-valued, still short-circuiting on `false`.
+    ///
+    /// `false AND anything` is `false` even when the other side is UNKNOWN, so
+    /// a known-false left still skips the right. An UNKNOWN left cannot
+    /// short-circuit: the right may yet be `false` and decide the conjunction.
     fn eval_short_circuit_and(
         &self,
         left: &Condition,
         right: &Condition,
         ctx: &WhereEvalCtx<'_>,
         graph_cache: &mut GraphMatchEvalCache,
-    ) -> Result<bool> {
-        if !self.eval_condition(left, ctx, graph_cache)? {
-            return Ok(false);
+    ) -> Result<Option<bool>> {
+        let left_value = self.eval_condition(left, ctx, graph_cache)?;
+        if left_value == Some(false) {
+            return Ok(Some(false));
         }
-        self.eval_condition(right, ctx, graph_cache)
+        let right_value = self.eval_condition(right, ctx, graph_cache)?;
+        if right_value == Some(false) {
+            return Ok(Some(false));
+        }
+        // Neither side is false: true only when both are known true.
+        Ok(match (left_value, right_value) {
+            (Some(true), Some(true)) => Some(true),
+            _ => None,
+        })
     }
 
-    /// Evaluates OR with short-circuit: returns true immediately if left is true.
+    /// Evaluates OR, three-valued, still short-circuiting on `true`.
+    ///
+    /// The mirror of [`Self::eval_short_circuit_and`]: `true OR anything` is
+    /// `true` even against UNKNOWN, while an UNKNOWN left must still let the
+    /// right run in case it is `true`.
     fn eval_short_circuit_or(
         &self,
         left: &Condition,
         right: &Condition,
         ctx: &WhereEvalCtx<'_>,
         graph_cache: &mut GraphMatchEvalCache,
-    ) -> Result<bool> {
-        if self.eval_condition(left, ctx, graph_cache)? {
-            return Ok(true);
+    ) -> Result<Option<bool>> {
+        let left_value = self.eval_condition(left, ctx, graph_cache)?;
+        if left_value == Some(true) {
+            return Ok(Some(true));
         }
-        self.eval_condition(right, ctx, graph_cache)
+        let right_value = self.eval_condition(right, ctx, graph_cache)?;
+        if right_value == Some(true) {
+            return Ok(Some(true));
+        }
+        // Neither side is true: false only when both are known false.
+        Ok(match (left_value, right_value) {
+            (Some(false), Some(false)) => Some(false),
+            _ => None,
+        })
     }
 
     /// Evaluates a similarity condition against a record's vector.
@@ -319,9 +358,9 @@ impl Collection {
         vector: Option<&[f32]>,
         params: &std::collections::HashMap<String, serde_json::Value>,
         graph_cache: &mut GraphMatchEvalCache,
-    ) -> Result<bool> {
+    ) -> Result<Option<bool>> {
         let Some(record_vector) = vector else {
-            return Ok(false);
+            return Ok(None);
         };
         // Per-query invariants come from the eval cache: the resolved query
         // vector (was one alloc+copy or `$param` re-parse per row) and the
@@ -329,22 +368,24 @@ impl Collection {
         // one inside `compute_metric_score`, one for the direction).
         let metric = graph_cache.metric_snapshot(self);
         let query_vec = graph_cache.similarity_query_vector(sim, params)?;
-        // A length-mismatched vector can't be scored against `query_vec`;
-        // fail the predicate rather than fabricate a score (a fake 0.0 used
-        // to read as a perfect match for distance metrics like Euclidean).
+        // A length-mismatched vector can't be scored against `query_vec`, so
+        // the predicate is UNKNOWN rather than false — fabricating a score
+        // used to read as a perfect match for distance metrics like
+        // Euclidean, and answering `false` would let an enclosing `NOT` admit
+        // a row nothing was ever computed for.
         if record_vector.len() != query_vec.len() || record_vector.is_empty() {
-            return Ok(false);
+            return Ok(None);
         }
         let score = metric.calculate(record_vector, query_vec);
         #[allow(clippy::cast_possible_truncation)]
         // Reason: similarity thresholds are approximate floating bounds.
         let threshold = sim.threshold as f32;
-        Ok(Self::compare_score(
+        Ok(Some(Self::compare_score(
             score,
             threshold,
             sim.operator,
             metric.higher_is_better(),
-        ))
+        )))
     }
 
     /// Compares a score against a threshold using the given operator and metric direction.

--- a/crates/velesdb-core/src/collection/search/query/where_eval_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/where_eval_tests.rs
@@ -150,4 +150,94 @@ mod similarity_length_mismatch {
             "an unscorable vector pair must fail the predicate, got {filtered:?}"
         );
     }
+
+    /// The three-valued truth table, pinned through the public evaluator.
+    ///
+    /// An unscoreable `similarity()` leaf is UNKNOWN, not `false`. The two are
+    /// indistinguishable until something negates them, which is exactly where
+    /// `NOT similarity()` used to go wrong: `NOT false` admits the row, `NOT
+    /// UNKNOWN` must not. Each case names the Kleene reduction it checks.
+    #[test]
+    fn test_unknown_similarity_follows_three_valued_logic() {
+        let dir = tempfile::tempdir().expect("test: tempdir");
+        let col = Collection::create(PathBuf::from(dir.path()), 2, DistanceMetric::Euclidean)
+            .expect("test: collection");
+
+        // A 3-d literal against a 2-d record: this leaf is UNKNOWN for it.
+        let unknown = || {
+            Condition::Similarity(SimilarityCondition {
+                field: "vector".to_string(),
+                vector: VectorExpr::Literal(vec![0.0, 0.0, 0.0]),
+                operator: CompareOp::Gt,
+                threshold: 0.9,
+            })
+        };
+        let meta = |value: &str| {
+            Condition::Comparison(crate::velesql::Comparison {
+                column: "cat".to_string(),
+                operator: CompareOp::Eq,
+                value: crate::velesql::Value::String(value.to_string()),
+            })
+        };
+        let row = || {
+            vec![SearchResult::new(
+                Point {
+                    id: 1,
+                    vector: vec![3.0, 0.0],
+                    payload: Some(serde_json::json!({"cat": "a"})),
+                    sparse_vectors: None,
+                },
+                0.0,
+            )]
+        };
+        let admits = |condition: &Condition| -> bool {
+            !col.apply_where_condition_to_results(
+                row(),
+                condition,
+                &std::collections::HashMap::new(),
+                &[],
+            )
+            .expect("test: where evaluation")
+            .is_empty()
+        };
+
+        // UNKNOWN alone -> WHERE admits only a known-true predicate.
+        assert!(!admits(&unknown()), "UNKNOWN must not admit the row");
+
+        // NOT UNKNOWN = UNKNOWN. This is the whole point: were the leaf
+        // `false`, the negation would be `true` and the row would appear.
+        assert!(
+            !admits(&Condition::Not(Box::new(unknown()))),
+            "NOT UNKNOWN is UNKNOWN, not true"
+        );
+
+        // UNKNOWN AND true = UNKNOWN.
+        assert!(
+            !admits(&Condition::And(Box::new(unknown()), Box::new(meta("a")))),
+            "UNKNOWN AND true is UNKNOWN"
+        );
+
+        // UNKNOWN AND false = false — the metadata leaf settles it alone.
+        // So the negation is a known true, and the row IS admitted.
+        assert!(
+            admits(&Condition::Not(Box::new(Condition::And(
+                Box::new(unknown()),
+                Box::new(meta("z"))
+            )))),
+            "NOT (UNKNOWN AND false) is true: the conjunction is false whatever \
+             the unscoreable leaf would have been"
+        );
+
+        // UNKNOWN OR true = true.
+        assert!(
+            admits(&Condition::Or(Box::new(unknown()), Box::new(meta("a")))),
+            "UNKNOWN OR true is true"
+        );
+
+        // UNKNOWN OR false = UNKNOWN.
+        assert!(
+            !admits(&Condition::Or(Box::new(unknown()), Box::new(meta("z")))),
+            "UNKNOWN OR false is UNKNOWN"
+        );
+    }
 }

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -433,6 +433,34 @@ WHERE vector NEAR $v AND NOT (category = 'spam')
 LIMIT 10
 ```
 
+`NOT` distributes over `AND` and `OR` by De Morgan's laws, as in SQL:
+`NOT (A AND B)` admits every row failing *either* conjunct, and
+`NOT (A OR B)` only rows failing *both*. This holds when one side is a
+`similarity()` predicate.
+
+#### Three-valued logic
+
+WHERE evaluates in SQL's three-valued logic: a predicate is true, false, or
+**unknown**. A `similarity()` predicate is unknown for a row whose vector
+cannot be scored against the query vector — different lengths, an empty
+vector, or no vector on that field. Unknown is not false, and the difference
+is only visible under negation:
+
+| Expression | Result |
+|---|---|
+| `sim` unknown | row excluded (WHERE admits only *known* true) |
+| `NOT sim` where `sim` is unknown | row excluded — `NOT unknown` is unknown |
+| `unknown AND false` | `false`, so `NOT (unknown AND false)` admits the row |
+| `unknown AND true` | unknown |
+| `unknown OR true` | `true` |
+| `unknown OR false` | unknown |
+
+The fourth row is the case worth reading twice: when the metadata side alone
+settles a conjunction, the row is decided without ever scoring the vector, and
+the negation admits it. Treating unknown as false instead would both admit
+rows nothing was computed for (under `NOT`) and hide rows the metadata had
+already decided.
+
 ### IN / NOT IN
 
 Test membership in a list of values:


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → **targets `develop`**. ✅

## Description

`NOT (similarity(...) AND metadata)` silently returned the wrong rows.

The `NOT similarity()` scan inverted the similarity leaf and separately pushed the metadata leaves down through `extract_metadata_filter` — which wraps whatever it finds under a `NOT` in its own `NOT` — then AND-ed the two. That distributes the negation over the connective, which is De Morgan's error: `NOT (A AND B)` was executed as `NOT A AND NOT B`.

Measured on a three-row fixture (`A` = `similarity > 0.5`, `B` = `cat = 'a'`):

| Query | Correct | Returned |
|---|---|---|
| `NOT (A AND B)` | `[2, 3]` | **`[]`** — every correct row dropped |
| `NOT (A OR B)` | `[3]` | **`[2, 3]`** — a row that fails neither |

No error in either case.

### The assumption that broke, in a comment

`extraction.rs` justified the re-wrapping with *"NOT similarity() is rejected earlier in validation, so we only need to handle NOT with metadata conditions here"*. That was true when written and untrue from the moment EPIC-044 US-003 enabled the full-scan path — `validation.rs` says so three lines from the check it refers to. This is the second time in two changes that a correct note failed to travel with the wiring it constrained; the first was #2129's reorder deferral.

### One evaluator instead of one per path

The scan now decides each candidate with `evaluate_where_condition_for_record` — the evaluator the graph and aggregation paths already use — so the engine has one WHERE semantics rather than one per execution path. The similarity leaf is still extracted, but only to score the rows that pass.

Storage guards are built in the order a real HTTP deadlock was traced to (`config` → `vector` → `payload`, per `.investigation/http-deadlock-2026-07-22/`) and forwarded through `MatchStorageGuards`, so a nested MATCH leaf reuses them instead of re-acquiring the same locks mid-scan — the pattern `aggregation/` already uses for its scan loop.

### Three-valued logic

Unifying onto that evaluator required fixing what it did with a similarity it could not compute. It answered `false`. The honest answer is UNKNOWN, and the two are indistinguishable until something negates them: **`NOT false` admits the row, `NOT UNKNOWN` must not.** Answering `false` let `NOT similarity()` return rows nothing had been computed for.

WHERE now evaluates in SQL's three-valued logic:

| Expression | Result |
|---|---|
| `sim` unknown | excluded — WHERE admits only *known* true |
| `NOT sim`, `sim` unknown | excluded |
| `unknown AND false` | `false` → `NOT (…)` admits the row |
| `unknown AND true` | unknown |
| `unknown OR true` | `true` |
| `unknown OR false` | unknown |

`AND`/`OR` follow Kleene's tables and still short-circuit on the value that decides them (`false` for `AND`, `true` for `OR`); an UNKNOWN side cannot short-circuit, because the other may yet decide. A top-level UNKNOWN excludes the row.

**One row changes from dropped to returned**, and it is the correct direction: under `NOT (unscoreable AND meta)` with `meta` false, the conjunction is false whatever the vector would have scored, so the negation is a known true. The existing pin that an unscoreable vector is excluded still holds wherever the similarity actually decides the outcome — `test_not_similarity_scan_excludes_length_mismatched_vector` is untouched and green.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

`cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` → **5412 passed, 0 failed**. Python gate suites: **664 passed** (9 skipped). Clean: `cargo fmt --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings`, `check-ai-attribution`, `check-inline-tests`, `check-file-budgets`, `check_prod_unwraps`, `check-doc-freshness`.

The two halves are pinned separately, each seen red against its own defect:

| guard | against | result |
|---|---|---|
| `test_not_similarity_honours_de_morgan_over_conjunction` | old scan | FAILED — got `[]`, wanted `[2, 3]` |
| `test_not_similarity_honours_de_morgan_over_disjunction` | old scan | FAILED — got `[2, 3]`, wanted `[3]` |
| `test_not_similarity_decides_on_metadata_when_vector_is_unscoreable` | old scan | FAILED — got `[]`, wanted `[2]` |
| `test_unknown_similarity_follows_three_valued_logic` | leaf answering `false` | FAILED — "NOT UNKNOWN is UNKNOWN, not true" |

The separation is deliberate: with the leaf reverted to `false` the De Morgan pair still passes, so neither half is carrying the other's proof.

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-25.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — branched from `develop` at #2129

## Unsafe Code Checklist

Not applicable — no `unsafe` added or changed.

## High-Risk Change Checklist

No `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path changes behaviour. Two things do warrant naming:

- [x] **Lock order.** The scan takes `config` → `vector` → `payload` and forwards the guards, matching `aggregation/`. No new lock is acquired inside the loop: the metric snapshot, each leaf's `Filter`, and each `similarity()` query vector are all memoised in `GraphMatchEvalCache` before or on first use, and the nested-MATCH path reuses the forwarded guards rather than re-locking.
- [x] **Query semantics.** `NOT` over a `similarity()` predicate changes results — that is the fix. The direction is documented in `docs/VELESQL_SPEC.md` under a new *Three-valued logic* section, with the truth table and the one case that flips from dropped to returned.

## Additional Notes

`passes_metadata_filter` and the `NotSimilarityThreshold` bundle are gone — the scan no longer combines the two predicates itself, so they had no callers left. `compare_similarity` stays; the positive similarity filter still uses it.

The tracking task behind this was framed as "align `NOT similarity()` between `where_eval` and the dedicated scan". Instrumenting `where_eval` showed it is never reached with a similarity under `NOT` — not in any of five hand-built query shapes, and not once across the 5 424-test suite — because routing sends every such query to the dedicated scan first. The framing was right about the coupling and wrong about the symptom; the reachable bug was De Morgan, and fixing it properly is what made the tri-state necessary.

An assistant-attribution footer is appended to these bodies automatically on creation; removed here per `AGENTS.md` principle 5, and done before CI so the no-op `edited` run drains behind the real one instead of adding a second wait.