### PR TITLE
fix(collection): a bulk upsert left points indexed under labels they had dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A bulk upsert no longer leaves a point indexed under labels it dropped.**
+  Both bulk paths indexed the incoming payload and never removed the old
+  labels, on the recorded assumption that "for the bulk path, points are
+  always new inserts (no old payload to remove from the label index)". The
+  same functions collect the pre-batch payloads for histogram decrements, so
+  overwrites plainly reach them: after `upsert_bulk` changed a point's
+  `_labels` from `Doc` to `Archived`, it stayed indexed under **both**, and
+  `MATCH (d:Doc)` returned a point that is no longer a `Doc`. The
+  single-upsert path has always done remove-then-index; the bulk paths now
+  run the same sequence through the same helpers. Three shapes were wrong and
+  are each pinned: a changed label, a payload that drops labels entirely (the
+  early return asked only whether *incoming* points carried `_labels`, so it
+  never reached the loop), and a label carried on both sides of the update
+  (removal must precede indexing or it is added and taken straight back out).
+  `upsert_bulk_from_raw` had the identical gap — it already hands the old
+  payloads to the secondary indexes, and the label index was the one left
+  out. (#2112)
+
 - **`NOT (similarity(...) AND metadata)` no longer drops the rows it should
   return.** The `NOT similarity()` scan inverted the similarity leaf and
   separately pushed the metadata leaves down through

--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -89,7 +89,7 @@ impl Collection {
         self.store_vectors_and_payload_entries(&vector_refs, &payload_entries)?;
 
         self.update_text_index_from_raw(ids, payloads)?;
-        self.update_label_index_from_raw(ids, payloads);
+        self.update_label_index_from_raw(ids, payloads, &old_payloads);
         self.update_secondary_indexes_from_raw(ids, payloads, &old_payloads);
 
         let inserted = self.bulk_index_or_defer(&vector_refs);
@@ -338,26 +338,53 @@ impl Collection {
     /// Batch-updates the label index from raw payload slices.
     ///
     /// Mirrors `update_text_index_from_raw` but for the label index.
-    /// Only indexes payloads that contain `_labels` arrays.
+    ///
+    /// This indexed the incoming payloads only, so a raw bulk *upsert* that
+    /// changed a point's `_labels` left it listed under the old ones too.
+    /// `old_payloads` is already collected a few lines up for the histogram
+    /// decrements, and already handed to `update_secondary_indexes_from_raw`
+    /// right below — the label index was the one index left out.
+    ///
+    /// Removal precedes indexing so a label carried on both sides of the
+    /// update survives, and the within-batch duplicate rule matches the
+    /// `Point` path: a repeated id removes the previous occurrence's labels,
+    /// not the pre-batch ones (which `old_payloads` already reports as `None`
+    /// for duplicates).
     ///
     /// LOCK ORDER: label_index(7) -- after payload_storage(3).
     fn update_label_index_from_raw(
         &self,
         ids: &[u64],
         payloads: Option<&[Option<serde_json::Value>]>,
+        old_payloads: &[Option<serde_json::Value>],
     ) {
         let Some(ps) = payloads else { return };
-        let has_labels = ps
-            .iter()
-            .any(|opt| opt.as_ref().is_some_and(|v| v.get("_labels").is_some()));
-        if !has_labels {
+        let carries_labels = |opt: &Option<serde_json::Value>| {
+            opt.as_ref().is_some_and(|v| v.get("_labels").is_some())
+        };
+        // An update that *drops* every label has no labels on the incoming
+        // side and still has stale entries to remove, so the old payloads
+        // decide this too.
+        if !ps.iter().any(carries_labels) && !old_payloads.iter().any(carries_labels) {
             return;
         }
+        let mut seen: std::collections::HashMap<u64, Option<&serde_json::Value>> =
+            std::collections::HashMap::with_capacity(ids.len());
         let mut label_idx = self.graph.label_index.write();
-        for (i, opt) in ps.iter().enumerate() {
-            if let Some(payload) = opt {
-                label_idx.index_from_payload(ids[i], payload);
+        for (i, &id) in ids.iter().enumerate() {
+            let pre_batch_old = old_payloads.get(i).and_then(Option::as_ref);
+            let effective_old = match seen.get(&id) {
+                Some(&previous) => previous,
+                None => pre_batch_old,
+            };
+            if let Some(old) = effective_old {
+                label_idx.remove_from_payload(id, old);
             }
+            let new_payload = ps.get(i).and_then(Option::as_ref);
+            if let Some(payload) = new_payload {
+                label_idx.index_from_payload(id, payload);
+            }
+            seen.insert(id, new_payload);
         }
     }
 }

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -126,7 +126,7 @@ impl Collection {
         };
 
         // WAL + payload write (same durability guarantees as standard path).
-        self.store_vectors_and_payloads_inner(vector_refs, points, fsync)?;
+        self.store_vectors_and_payloads_inner(vector_refs, points, &old_payloads, fsync)?;
 
         // Write directly to the graph's ContiguousVectors so vectors are
         // immediately visible to rerank/brute-force while HNSW construction
@@ -175,7 +175,7 @@ impl Collection {
             Self::collect_old_payloads(points, &storage)
         };
 
-        self.store_vectors_and_payloads_inner(vector_refs, points, fsync)?;
+        self.store_vectors_and_payloads_inner(vector_refs, points, &old_payloads, fsync)?;
 
         let inserted = self.bulk_index_or_defer(vector_refs);
         self.finalize_bulk_upsert(points, &old_payloads, sparse_batch)?;
@@ -215,13 +215,14 @@ impl Collection {
         &self,
         vector_refs: &[(u64, &[f32])],
         points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
         fsync: bool,
     ) -> Result<()> {
         #[cfg(feature = "persistence")]
         {
             let (vec_result, pay_result) = rayon::join(
                 || self.bulk_store_vectors_inner(vector_refs, fsync),
-                || self.bulk_store_payloads_inner(points, fsync),
+                || self.bulk_store_payloads_inner(points, old_payloads, fsync),
             );
             vec_result?;
             pay_result?;
@@ -230,7 +231,7 @@ impl Collection {
         #[cfg(not(feature = "persistence"))]
         {
             self.bulk_store_vectors_inner(vector_refs, fsync)?;
-            self.bulk_store_payloads_inner(points, fsync)?;
+            self.bulk_store_payloads_inner(points, old_payloads, fsync)?;
         }
 
         Ok(())
@@ -281,7 +282,12 @@ impl Collection {
     ///
     /// When `fsync` is `false`, WAL entries are written and the buffer is
     /// flushed to the OS kernel, but `sync_all()` is skipped.
-    fn bulk_store_payloads_inner(&self, points: &[Point], fsync: bool) -> Result<()> {
+    fn bulk_store_payloads_inner(
+        &self,
+        points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
+        fsync: bool,
+    ) -> Result<()> {
         let entries: Vec<(u64, &serde_json::Value)> = points
             .iter()
             .filter_map(|p| p.payload.as_ref().map(|pl| (p.id, pl)))
@@ -315,30 +321,56 @@ impl Collection {
         // per_point_updates for the single-upsert path). Without this,
         // MATCH queries with label patterns (e.g., `(d:Doc)`) return
         // empty results for points inserted via upsert_bulk / REST API.
-        Self::update_label_index_bulk(&self.graph.label_index, points);
+        self.update_label_index_bulk(points, old_payloads);
 
         Ok(())
     }
 
-    /// Batch-updates the label index for bulk-inserted points.
+    /// Batch-updates the label index for bulk-upserted points.
     ///
-    /// For the bulk path, points are always new inserts (no old payload to
-    /// remove from the label index), so we only need to index the new payloads.
+    /// This used to index the incoming payloads and nothing else, justified by
+    /// "for the bulk path, points are always new inserts (no old payload to
+    /// remove from the label index)". That was never true: both bulk paths
+    /// call [`collect_old_payloads`](Self::collect_old_payloads) precisely
+    /// because a bulk upsert overwrites existing points, and the pre-batch
+    /// payload it returns is the one whose labels have to come back out.
+    /// Re-upserting a point with `_labels` changed from `Doc` to `Archived`
+    /// left it indexed under both, so `MATCH (d:Doc)` returned a point that
+    /// is no longer a `Doc`.
+    ///
+    /// It now runs the same remove-then-index sequence as the single-upsert
+    /// path, through the same helpers, so the two cannot drift again:
+    ///
+    /// - [`needs_label_updates`](Self::needs_label_updates) also asks whether
+    ///   an *old* payload carried labels. Asking only about the incoming
+    ///   points made a payload that dropped its labels return before the loop
+    ///   and keep the stale entry forever.
+    /// - [`resolve_effective_old`](Self::resolve_effective_old) resolves the
+    ///   old payload for a duplicate id within one batch to the previous
+    ///   occurrence rather than the pre-batch value.
+    /// - [`apply_label_updates`](Self::apply_label_updates) removes before it
+    ///   indexes, which is what keeps a label carried on *both* sides of the
+    ///   update from being added and then taken straight back out.
     ///
     /// LOCK ORDER: label_index(7) — after payload_storage(3).
     fn update_label_index_bulk(
-        label_index: &parking_lot::RwLock<crate::collection::graph::LabelIndex>,
+        &self,
         points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
     ) {
-        if !Self::any_point_has_labels(points) {
+        if !Self::needs_label_updates(points, old_payloads) {
             return;
         }
-        let mut label_idx = label_index.write();
-        for point in points {
-            if let Some(ref payload) = point.payload {
-                label_idx.index_from_payload(point.id, payload);
-            }
+        let mut seen: std::collections::HashMap<u64, Option<&serde_json::Value>> =
+            std::collections::HashMap::with_capacity(points.len());
+        let mut label_updates = Vec::with_capacity(points.len());
+        for (point, pre_batch_old) in points.iter().zip(old_payloads) {
+            let effective_old =
+                Self::resolve_effective_old(&seen, point.id, pre_batch_old.as_ref());
+            label_updates.push((point.id, effective_old.cloned(), point.payload.clone()));
+            seen.insert(point.id, point.payload.as_ref());
         }
+        Self::apply_label_updates(&self.graph.label_index, &label_updates);
     }
 
     /// Applies sparse batch with WAL-before-apply for bulk insert.

--- a/crates/velesdb-core/src/collection/core/crud_tests.rs
+++ b/crates/velesdb-core/src/collection/core/crud_tests.rs
@@ -1570,3 +1570,148 @@ fn test_execute_match_with_similarity_order_by_overrides_score() {
         "ORDER BY n.age DESC must override the vector score sort (which would be 3,2,1)"
     );
 }
+
+/// Helper: the ids currently indexed under `label`.
+#[cfg(test)]
+fn label_members(coll: &Collection, label: &str) -> Vec<u32> {
+    coll.graph
+        .label_index
+        .read()
+        .lookup(label)
+        .map(|b| b.iter().collect())
+        .unwrap_or_default()
+}
+
+/// A labelled point, so the fixtures differ only in their `_labels`.
+#[cfg(test)]
+fn labelled_point(id: u64, labels: &[&str]) -> Point {
+    Point {
+        id,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: Some(serde_json::json!({ "_labels": labels })),
+        sparse_vectors: None,
+    }
+}
+
+/// `upsert_bulk` must drop the labels a re-upserted point no longer carries.
+///
+/// The bulk path only ever indexed the incoming payload, on the recorded
+/// assumption that "points are always new inserts (no old payload to remove
+/// from the label index)". The same functions collect the pre-batch payloads
+/// for histogram decrements, so overwrites plainly do reach it: after
+/// changing `_labels` from `Doc` to `Archived`, the point stayed indexed
+/// under BOTH, and `MATCH (d:Doc)` returned a point that is no longer a Doc.
+#[test]
+fn bulk_upsert_drops_labels_the_point_no_longer_carries() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert_bulk(&[labelled_point(1, &["Doc"])])
+        .expect("bulk insert");
+    assert_eq!(label_members(&coll, "Doc"), vec![1], "indexed on insert");
+
+    coll.upsert_bulk(&[labelled_point(1, &["Archived"])])
+        .expect("bulk update");
+
+    assert_eq!(
+        label_members(&coll, "Archived"),
+        vec![1],
+        "new label indexed"
+    );
+    assert!(
+        label_members(&coll, "Doc").is_empty(),
+        "the point is no longer a Doc, so Doc must not still list it"
+    );
+}
+
+/// Clearing every label must empty the index, not leave the old one.
+///
+/// This shape also defeated the early return: the guard asked only whether
+/// any *incoming* point carried `_labels`, so a payload that dropped them
+/// returned before the loop and the stale entry survived forever.
+#[test]
+fn bulk_upsert_clearing_labels_removes_the_old_ones() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert_bulk(&[labelled_point(1, &["Doc"])])
+        .expect("bulk insert");
+    coll.upsert_bulk(&[Point {
+        id: 1,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: Some(serde_json::json!({ "title": "no labels now" })),
+        sparse_vectors: None,
+    }])
+    .expect("bulk update");
+
+    assert!(
+        label_members(&coll, "Doc").is_empty(),
+        "a payload that carries no _labels must leave none behind"
+    );
+}
+
+/// A label the point keeps across an update must survive the removal.
+///
+/// The order matters: remove the old labels *before* indexing the new ones,
+/// or a label present on both sides is added and then taken straight back
+/// out.
+#[test]
+fn bulk_upsert_keeps_a_label_present_on_both_sides() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert_bulk(&[labelled_point(1, &["Doc", "Draft"])])
+        .expect("bulk insert");
+    coll.upsert_bulk(&[labelled_point(1, &["Doc", "Final"])])
+        .expect("bulk update");
+
+    assert_eq!(label_members(&coll, "Doc"), vec![1], "Doc is still carried");
+    assert_eq!(label_members(&coll, "Final"), vec![1], "Final was added");
+    assert!(
+        label_members(&coll, "Draft").is_empty(),
+        "Draft was dropped by the update"
+    );
+}
+
+/// The zero-copy raw path has the same duty.
+///
+/// `upsert_bulk_from_raw` already collects the pre-batch payloads and hands
+/// them to the secondary indexes; only the label index was left indexing the
+/// new payload alone.
+#[test]
+fn bulk_upsert_from_raw_drops_stale_labels() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+    let vector = [1.0_f32, 0.0, 0.0, 0.0];
+
+    coll.upsert_bulk_from_raw(
+        &vector,
+        &[1],
+        4,
+        Some(&[Some(serde_json::json!({ "_labels": ["Doc"] }))]),
+    )
+    .expect("raw insert");
+    assert_eq!(label_members(&coll, "Doc"), vec![1], "indexed on insert");
+
+    coll.upsert_bulk_from_raw(
+        &vector,
+        &[1],
+        4,
+        Some(&[Some(serde_json::json!({ "_labels": ["Archived"] }))]),
+    )
+    .expect("raw update");
+
+    assert_eq!(
+        label_members(&coll, "Archived"),
+        vec![1],
+        "new label indexed"
+    );
+    assert!(
+        label_members(&coll, "Doc").is_empty(),
+        "the raw path must drop the label the point no longer carries"
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → **targets `develop`**. ✅

## Description

Both bulk paths indexed the incoming payload's `_labels` and never removed the old ones. Re-upserting a point with its labels changed from `Doc` to `Archived` left it indexed under **both**, so `MATCH (d:Doc)` returned a point that is no longer a `Doc`. Nothing failed — the label index simply kept a membership the payload had revoked.

| Path | `_labels` `["Doc"]` → `["Archived"]` |
|---|---|
| `upsert_bulk` | `Doc` = {1}, `Archived` = {1} — **stale** |
| `upsert` (single) | `Doc` = {}, `Archived` = {1} — correct |

### The assumption that broke, in a comment

> `// For the bulk path, points are always new inserts (no old payload to remove from the label index), so we only need to index the new payloads.`

That was never true. The very functions calling this collect the pre-batch payloads a few lines earlier — `collect_old_payloads`, for the histogram decrements — *because* a bulk **upsert** overwrites existing points.

### Three shapes, not one

Comparing against the single-upsert path found three defects:

1. **A changed label** — the old one was never removed.
2. **A payload that drops labels entirely** — the early return asked only whether any *incoming* point carried `_labels`, so it returned before the loop and the stale entry survived every subsequent write. The single path's `needs_label_updates` also asks whether an *old* payload had labels.
3. **A label carried on both sides** — removal must precede indexing, or the label is added and then taken straight back out.

### The fix: stop having a second implementation

The bulk path now runs `needs_label_updates` → `resolve_effective_old` → `apply_label_updates`, the same helpers the single-upsert path uses, so the two cannot drift again. `resolve_effective_old` also brings the within-batch duplicate-id rule the bulk path never had. `old_payloads` is threaded down from the callers that already computed it, so **no extra read is introduced**.

`upsert_bulk_from_raw` carried the identical gap: it already collects the old payloads and already passes them to `update_secondary_indexes_from_raw` on the adjacent line — the label index was the one index left out.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` → **5416 passed, 0 failed**. Clean: `cargo fmt --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings`, `check-ai-attribution`, `check-inline-tests`, `check-file-budgets`, `check_prod_unwraps`, `check-doc-freshness`.

Each guard was seen red against the defect it exists for:

| guard | against the old code |
|---|---|
| `bulk_upsert_drops_labels_the_point_no_longer_carries` | FAILED — `Doc` still listed the point |
| `bulk_upsert_clearing_labels_removes_the_old_ones` | FAILED — early return skipped the loop |
| `bulk_upsert_keeps_a_label_present_on_both_sides` | FAILED — `Draft` never dropped |
| `bulk_upsert_from_raw_drops_stale_labels` | FAILED — same gap on the zero-copy path |

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-25.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — branched from `develop` at #2131

## Unsafe Code Checklist

Not applicable — no `unsafe` added or changed.

## High-Risk Change Checklist

No `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path changes behaviour.

- [x] **Lock order** unchanged: `label_index(7)` is still taken after `payload_storage(3)`, and the documented order on `upsert_bulk_from_raw` still holds. `apply_label_updates` takes the same single write-lock scope the single path uses.
- [x] **No extra I/O**: `old_payloads` already existed at both call sites for the histogram decrements; this threads the existing value rather than re-reading.

## Additional Notes

Found by sweeping for comments that assert a distant invariant *in order to license an omission* — "so we only need to…", "no production path takes X yet". This is the third such comment to hide a defect, after #2129's reorder deferral and #2131's `NOT similarity()` validation note. The sweep also cleared several candidates that turned out to be sound (`ordering.rs`'s V008 claim, verified unreachable through both parser construction sites; `log_payload`'s crash contract, verified against the write→sync→remove order in its own body), so the pattern is a filter, not a verdict.

One adjacent behaviour was confirmed but deliberately **not** changed here: clearing a point's text (payload kept, text field removed) leaves it in the BM25 index — `upsert_bulk` and `upsert` behave identically, so it is a uniform engine behaviour and a design question ("does clearing text remove the document from full-text search?"), not a bulk/single divergence. Raising it separately rather than widening this PR.

An assistant-attribution footer is appended to these bodies automatically on creation; removed here per `AGENTS.md` principle 5, and done before CI so the no-op `edited` run drains behind the real one instead of adding a second wait.