### PR TITLE
fix(collection): clearing a point's text left it searchable in BM25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Clearing a point's text now takes it out of full-text search.** The BM25
+  index only ever saw the incoming payload, so a payload that still existed but
+  no longer yielded indexable text wrote nothing and the point kept matching a
+  term its payload no longer contains. `add_document` replaces the previous
+  version, so *changing* the text was always correct — only *clearing* it went
+  stale, on every write path. The rule is now stated once and applied from the
+  old payload as well as the new: a point is searchable exactly when its current
+  payload yields indexable text. A point that never carried text is still not
+  written to the index, so a bulk load of text-free vectors costs nothing — that
+  is what deciding on the old payload buys over removing whenever there is no
+  text. A repeated id inside one batch resolves to the batch's own earlier
+  occurrence, matching the label path. (#2112)
+
 - **A bulk upsert no longer leaves a point indexed under labels it dropped.**
   Both bulk paths indexed the incoming payload and never removed the old
   labels, on the recorded assumption that "for the bulk path, points are

--- a/crates/velesdb-core/src/collection/core/bulk_import.rs
+++ b/crates/velesdb-core/src/collection/core/bulk_import.rs
@@ -88,7 +88,7 @@ impl Collection {
 
         self.store_vectors_and_payload_entries(&vector_refs, &payload_entries)?;
 
-        self.update_text_index_from_raw(ids, payloads)?;
+        self.update_text_index_from_raw(ids, payloads, &old_payloads)?;
         self.update_label_index_from_raw(ids, payloads, &old_payloads);
         self.update_secondary_indexes_from_raw(ids, payloads, &old_payloads);
 
@@ -293,9 +293,14 @@ impl Collection {
 
     /// Updates BM25 text index from raw payload slices (WAL-then-apply).
     ///
-    /// Points with `Some(payload)` get their text indexed; points with
-    /// `None` payload get their stale BM25 entry removed. Mirrors the
-    /// contract of `bulk_update_text_index` in `crud_indexing.rs`.
+    /// Mirrors the contract of `classify_text_mutations` in
+    /// `crud_indexing.rs`, whose doc holds the truth table: a point is
+    /// searchable exactly when its current payload yields indexable text, so
+    /// the mutation follows from comparing the old payload with the new. A
+    /// payload that still exists but no longer yields text is a **removal**,
+    /// not a no-op — that case is why this takes `old_payloads`, which is
+    /// already collected upstream for the histogram decrements and already
+    /// handed to the secondary and label indexes.
     ///
     /// Issue #389: each mutation is appended to the BM25 WAL BEFORE it
     /// is applied in-memory so that a crash between the two replays
@@ -306,19 +311,25 @@ impl Collection {
         &self,
         ids: &[u64],
         payloads: Option<&[Option<serde_json::Value>]>,
+        old_payloads: &[Option<serde_json::Value>],
     ) -> Result<()> {
         let Some(ps) = payloads else { return Ok(()) };
+        let mut seen: HashMap<u64, Option<&serde_json::Value>> = HashMap::with_capacity(ids.len());
         let mut adds: Vec<(u64, String)> = Vec::new();
         let mut removes: Vec<u64> = Vec::new();
-        for (i, opt) in ps.iter().enumerate() {
-            if let Some(payload) = opt {
-                let text = Self::extract_text_from_payload(payload);
-                if !text.is_empty() {
-                    adds.push((ids[i], text));
-                }
-            } else {
-                removes.push(ids[i]);
+        for (i, &id) in ids.iter().enumerate() {
+            let new_payload = ps.get(i).and_then(Option::as_ref);
+            let pre_batch_old = old_payloads.get(i).and_then(Option::as_ref);
+            let effective_old = match seen.get(&id) {
+                Some(&previous) => previous,
+                None => pre_batch_old,
+            };
+            match Self::indexable_text(new_payload) {
+                Some(text) => adds.push((id, text)),
+                None if Self::indexable_text(effective_old).is_some() => removes.push(id),
+                None => {}
             }
+            seen.insert(id, new_payload);
         }
         if adds.is_empty() && removes.is_empty() {
             return Ok(());

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -400,7 +400,7 @@ impl Collection {
         // flushed by `batch_store_all`, so the BM25 WAL never leads payload
         // durability. A failure propagates with the in-memory index untouched.
         if !skip_bm25 {
-            self.bulk_update_text_index(points)?;
+            self.bulk_update_text_index(points, old_payloads)?;
         }
         let needs_label_updates = Self::needs_label_updates(points, old_payloads);
         let mut label_updates = Self::alloc_label_buffer(needs_label_updates, points.len());
@@ -464,7 +464,7 @@ impl Collection {
         // Issue #389 + #1797: one BM25 WAL barrier for the whole batch,
         // sequenced after the payload flush so the BM25 WAL never leads
         // payload durability — the same envelope as the vector upsert path.
-        self.bulk_update_text_index(&points)?;
+        self.bulk_update_text_index(&points, &old_payloads_for_hist)?;
 
         // config(1) only — payload_storage(3) and label_index(7) both released above.
         self.storage.config.write().point_count = point_count;

--- a/crates/velesdb-core/src/collection/core/crud_bulk.rs
+++ b/crates/velesdb-core/src/collection/core/crud_bulk.rs
@@ -313,7 +313,7 @@ impl Collection {
         // bulk insertion of text-bearing points at roughly one fsync each. The
         // batch below writes every frame under a single open + flush + fsync.
         if !entries.is_empty() || !self.storage.text_index.is_empty() {
-            self.bulk_update_text_index(points)?;
+            self.bulk_update_text_index(points, old_payloads)?;
         }
 
         // Issue #486: Update label index for bulk-inserted points.

--- a/crates/velesdb-core/src/collection/core/crud_indexing.rs
+++ b/crates/velesdb-core/src/collection/core/crud_indexing.rs
@@ -127,8 +127,12 @@ impl Collection {
     /// # Errors
     ///
     /// Propagates any WAL open / write / flush / fsync failure.
-    pub(super) fn bulk_update_text_index(&self, points: &[Point]) -> Result<()> {
-        let (adds, removes) = Self::classify_text_mutations(points);
+    pub(super) fn bulk_update_text_index(
+        &self,
+        points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
+    ) -> Result<()> {
+        let (adds, removes) = Self::classify_text_mutations(points, old_payloads);
         if adds.is_empty() && removes.is_empty() {
             return Ok(());
         }
@@ -146,23 +150,68 @@ impl Collection {
 
     /// Splits a batch into the BM25 mutations it implies.
     ///
-    /// The three cases stay separate here rather than being decided inline, so
-    /// that "a payload with no indexable string writes nothing" is a visible
-    /// decision and not an accident of control flow.
-    fn classify_text_mutations(points: &[Point]) -> (Vec<(u64, String)>, Vec<u64>) {
+    /// The rule is that the index mirrors the payload: a point is searchable
+    /// exactly when its current payload yields indexable text. Everything
+    /// follows from that one predicate, applied to the old payload and the
+    /// new one.
+    ///
+    /// | previously indexable | now indexable | mutation |
+    /// |---|---|---|
+    /// | no  | yes | add |
+    /// | yes | yes | add (`add_document` replaces in place) |
+    /// | yes | no  | **remove** |
+    /// | no  | no  | none — no WAL record, no index lock |
+    ///
+    /// The third row is the one this used to get wrong. A comment here
+    /// recorded "a payload with no indexable string writes nothing" as a
+    /// deliberate decision, and it was — but only the *insert* case was in
+    /// view. On an upsert it meant a point that had its text removed kept
+    /// matching a term its payload no longer contains, with nothing to
+    /// signal it. Changing the text was always fine, because `add_document`
+    /// removes the previous version first; only clearing it went stale.
+    ///
+    /// The fourth row is why this needs the old payload rather than simply
+    /// removing whenever there is no text: a bulk insert of points that never
+    /// carry text would otherwise write one tombstone per point for documents
+    /// that were never indexed. Deciding on the old payload keeps that path
+    /// writing nothing, which is also what it did before.
+    ///
+    /// `resolve_effective_old` is what makes a repeated id inside one batch
+    /// resolve to the batch's own earlier occurrence: `old_payloads` reports
+    /// `None` for a duplicate, so the pre-batch value alone would miss that
+    /// the batch had already indexed it.
+    fn classify_text_mutations(
+        points: &[Point],
+        old_payloads: &[Option<serde_json::Value>],
+    ) -> (Vec<(u64, String)>, Vec<u64>) {
+        debug_assert_eq!(
+            points.len(),
+            old_payloads.len(),
+            "old_payloads is positional: a short slice would silently drop removals"
+        );
+        let mut seen: HashMap<u64, Option<&serde_json::Value>> =
+            HashMap::with_capacity(points.len());
         let mut adds: Vec<(u64, String)> = Vec::new();
         let mut removes: Vec<u64> = Vec::new();
-        for point in points {
-            if let Some(payload) = &point.payload {
-                let text = Self::extract_text_from_payload(payload);
-                if !text.is_empty() {
-                    adds.push((point.id, text));
-                }
-            } else {
-                removes.push(point.id);
+        for (index, point) in points.iter().enumerate() {
+            let pre_batch_old = old_payloads.get(index).and_then(Option::as_ref);
+            let effective_old = Self::resolve_effective_old(&seen, point.id, pre_batch_old);
+            match Self::indexable_text(point.payload.as_ref()) {
+                Some(text) => adds.push((point.id, text)),
+                None if Self::indexable_text(effective_old).is_some() => removes.push(point.id),
+                None => {}
             }
+            seen.insert(point.id, point.payload.as_ref());
         }
         (adds, removes)
+    }
+
+    /// The text a payload contributes to BM25, or `None` when it contributes
+    /// nothing — an absent payload and one with no indexable string are the
+    /// same thing to the index.
+    pub(super) fn indexable_text(payload: Option<&serde_json::Value>) -> Option<String> {
+        let text = Self::extract_text_from_payload(payload?);
+        (!text.is_empty()).then_some(text)
     }
 
     /// Writes the whole batch to the BM25 WAL under one durability barrier.

--- a/crates/velesdb-core/src/collection/core/crud_tests.rs
+++ b/crates/velesdb-core/src/collection/core/crud_tests.rs
@@ -1715,3 +1715,93 @@ fn bulk_upsert_from_raw_drops_stale_labels() {
         "the raw path must drop the label the point no longer carries"
     );
 }
+
+/// A point whose payload carries `content` text.
+#[cfg(test)]
+fn texted_point(id: u64, payload: serde_json::Value) -> Point {
+    Point {
+        id,
+        vector: vec![1.0, 0.0, 0.0, 0.0],
+        payload: Some(payload),
+        sparse_vectors: None,
+    }
+}
+
+/// Clearing a point's text must take it out of full-text search.
+///
+/// The BM25 index only ever saw the incoming payload: a payload that still
+/// exists but no longer yields indexable text wrote nothing, so the document
+/// kept matching a term its payload no longer contains. `add_document`
+/// already replaces on re-index, which is why *changing* the text was fine
+/// and only *clearing* it went stale.
+#[test]
+fn clearing_text_removes_the_point_from_full_text_search() {
+    for bulk in [true, false] {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let coll = Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine)
+            .expect("create");
+        let with_text = texted_point(1, serde_json::json!({ "content": "zebra" }));
+        let without = texted_point(1, serde_json::json!({ "other": 1 }));
+
+        if bulk {
+            coll.upsert_bulk(&[with_text]).expect("insert");
+            coll.upsert_bulk(&[without]).expect("clear text");
+        } else {
+            coll.upsert(vec![with_text]).expect("insert");
+            coll.upsert(vec![without]).expect("clear text");
+        }
+
+        assert!(
+            coll.storage.text_index.search("zebra", 10).is_empty(),
+            "bulk={bulk}: the payload no longer contains 'zebra', so it must not match"
+        );
+    }
+}
+
+/// Changing the text keeps only the new terms searchable.
+///
+/// Non-regression: `add_document` removes the previous version first, so this
+/// case was already correct and must stay so.
+#[test]
+fn changing_text_leaves_only_the_new_terms_searchable() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert_bulk(&[texted_point(1, serde_json::json!({ "content": "zebra" }))])
+        .expect("insert");
+    coll.upsert_bulk(&[texted_point(1, serde_json::json!({ "content": "giraffe" }))])
+        .expect("update");
+
+    assert!(
+        coll.storage.text_index.search("zebra", 10).is_empty(),
+        "the old term must not survive"
+    );
+    assert_eq!(
+        coll.storage.text_index.search("giraffe", 10).len(),
+        1,
+        "the new term must be searchable"
+    );
+}
+
+/// A repeated id within one batch is settled by its last payload.
+///
+/// The pre-batch payload is `None` for the duplicate, so deciding on that
+/// alone would miss that the batch's own earlier occurrence indexed the text.
+#[test]
+fn a_repeated_id_in_one_batch_is_settled_by_its_last_payload() {
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let coll =
+        Collection::create(dir.path().to_path_buf(), 4, DistanceMetric::Cosine).expect("create");
+
+    coll.upsert_bulk(&[
+        texted_point(1, serde_json::json!({ "content": "zebra" })),
+        texted_point(1, serde_json::json!({ "other": 1 })),
+    ])
+    .expect("bulk with a duplicate id");
+
+    assert!(
+        coll.storage.text_index.search("zebra", 10).is_empty(),
+        "the last payload in the batch carries no text, so nothing must match"
+    );
+}

--- a/docs/VELESQL_SPEC.md
+++ b/docs/VELESQL_SPEC.md
@@ -641,6 +641,18 @@ LIMIT 10
 > **Tip**: For strict text filtering (exclude results that do not contain a keyword),
 > use `CONTAINS_TEXT` instead of `MATCH`. See the CONTAINS_TEXT section below.
 
+#### What is searchable
+
+A point is searchable exactly when its **current** payload yields indexable
+text. Upserting it with a payload that no longer carries any takes it out of
+the text index, so `MATCH` never returns a point over a term its payload has
+since lost — the same rule that governs `_labels` and the secondary indexes.
+Re-upserting with *different* text replaces the old terms rather than adding
+to them.
+
+A point that has never carried text is not written to the index at all, so a
+bulk load of vectors without text costs nothing here.
+
 ### Strict Text Filter (CONTAINS_TEXT, v3.8+)
 
 The `CONTAINS_TEXT` operator performs case-sensitive substring matching on a


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → **targets `develop`**. ✅

## Description

The BM25 index only ever saw the incoming payload. A payload that **still existed** but no longer yielded indexable text wrote nothing, so the point kept matching a term its payload no longer contains — on every write path, with nothing to signal it.

```
upsert  id=1  { "content": "zebra" }     -> MATCH 'zebra' finds it
upsert  id=1  { "other": 1 }             -> MATCH 'zebra' STILL finds it
```

`add_document` removes the previous version first, which is why *changing* the text was always correct and only *clearing* it went stale. That asymmetry is what made it invisible.

### This was a recorded decision, so here is the new evidence

`classify_text_mutations` carried the note that *"a payload with no indexable string writes nothing"* is **a visible decision and not an accident of control flow** — and it was a real decision. Per principle 8 it does not get "fixed" on taste. What it did not record is the upsert consequence, and that consequence is a point matching a term it no longer contains. The decision was right about inserts and never revisited for updates.

### The rule, stated once and derived from both sides

A point is searchable exactly when its **current** payload yields indexable text. Everything follows from that one predicate applied to the old payload and the new:

| previously indexable | now indexable | mutation |
|---|---|---|
| no | yes | add |
| yes | yes | add (`add_document` replaces in place) |
| yes | no | **remove** ← the fix |
| no | no | none — no WAL record, no index lock |

### Why it takes the old payload instead of just removing when there is no text

The fourth row. Removing unconditionally is the one-line fix, and it would write **one tombstone per point** for documents that were never indexed — a bulk load of text-free vectors would pay a WAL record each, for nothing. The old code avoided that by accident of control flow; deciding on the old payload keeps it deliberately while fixing the third row.

`old_payloads` is already collected at every call site for the histogram decrements and already handed to the secondary and label indexes, so **nothing is re-read and no lock is added**. The common path (`no` → `no`) still writes nothing, exactly as before.

A repeated id inside one batch resolves through `resolve_effective_old` to the batch's own earlier occurrence — matching the label path, since the pre-batch value is `None` for a duplicate and would miss that the batch had already indexed it. `update_text_index_from_raw` carried the same asymmetry on the zero-copy path and now shares the predicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` → **5419 passed, 0 failed**. Clean: `cargo fmt --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings`, `check-ai-attribution`, `check-inline-tests`, `check-file-budgets`, `check_prod_unwraps`, `check-doc-freshness`.

| guard | against the old code |
|---|---|
| `clearing_text_removes_the_point_from_full_text_search` (bulk **and** single) | FAILED — `'zebra'` still matched |
| `a_repeated_id_in_one_batch_is_settled_by_its_last_payload` | FAILED — the batch's own earlier occurrence stayed indexed |
| `changing_text_leaves_only_the_new_terms_searchable` | passed — non-regression, `add_document` already replaced |

The third one is deliberately a case that was **already correct**: it pins the half of the behaviour that made the bug asymmetric, so a future change cannot fix clearing by breaking replacement.

**Test Configuration:** 4-vCPU Linux container, 16 GiB RAM, 2026-08-25.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published — branched from `develop` at #2132

## Unsafe Code Checklist

Not applicable — no `unsafe` added or changed.

## High-Risk Change Checklist

No `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path changes behaviour.

- [x] **WAL-before-apply preserved** at both sites: the batch is appended to the BM25 WAL and only then applied in memory, so a crash between the two replays the mutation (issue #389). The added removals go through the same barrier as the adds.
- [x] **No extra I/O or locks**: `old_payloads` already existed at every call site; the `no` → `no` case still writes nothing, so a text-free bulk load is unchanged.
- [x] **Positional invariant guarded**: `classify_text_mutations` carries a `debug_assert_eq!` on the two slice lengths, because a short `old_payloads` would silently drop removals — the exact failure mode this PR fixes.

## Additional Notes

`indexable_text` folds "no payload" and "payload with no indexable string" into one `Option<String>`, because to the index they are the same thing. That is what let the three-way `if/else` become a match on the predicate, and it is what both write paths now share.

Documented in `docs/VELESQL_SPEC.md` under *Full-Text Search (MATCH)* → *What is searchable*, including the "never carried text costs nothing" property so the performance shape is on the record next to the semantics.

An assistant-attribution footer is appended to these bodies automatically on creation; removed here per `AGENTS.md` principle 5, and done before CI so the no-op `edited` run drains behind the real one.