### PR TITLE
fix(core): six silent scoring, metrics and dispatch defects from the #2106 sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   beside the bounds that drive bucketing; the labels are now derived from
   those bounds, so the two cannot drift. (#2106)
 
+- **`PathScorer::score_rel_types` charges one decay factor per hop.** It raised
+  `distance_decay` to the hop's ordinal, compounding to `decay^(n(n+1)/2)`,
+  while `score_length` on the same path returned `decay^n` and the
+  `distance_decay` field documents "each hop reduces score by 20%". At five
+  hops with the default 0.8 the two functions answered 0.035 and 0.328 — a
+  ninefold gap between two documented spellings of one contract. (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hot path on Euclidean, so reusing it would have silently changed that
   contract. (#2106)
 
+- **`TRAIN QUANTIZER ... TYPE opq` is refused on Hamming and Jaccard
+  collections.** OPQ keeps its codes in a rotated basis and the rescore path
+  rotates the query to match. A rotation preserves inner products and norms,
+  so cosine, Euclidean and dot product survive it — Hamming and Jaccard are
+  defined component by component on the original axes, and a rotated "binary"
+  vector is not binary at all. The combination trained happily and every later
+  rescore measured the metric in a space where it means nothing. The rule now
+  lives on the metric as `DistanceMetric::is_rotation_invariant`, mirroring the
+  guard `train_sq8` already had. A codebook trained before this guard is still
+  on disk somewhere, so open-time restore applies the same rule: a rotated
+  `codebook.pq` on such a collection is not installed and the collection scores
+  exact f32, the warn-and-degrade the dimension-mismatch arm beside it already
+  used. Plain PQ has no rotation and stays available for these metrics.
+  (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A sparse query whose score cancels to zero no longer returns the same
+  document twice.** `linear_scan_dense` tracked "have I recorded this
+  document?" by testing `scores[idx] == 0.0`, reading membership out of the
+  accumulated value. A negative query weight — the "like A but not B" shape,
+  where both sides carry a shared term at the same weight — drives the running
+  score back to exactly zero, and the next term's posting then recorded the
+  document a second time. The duplicate is not merely a repeated row: it takes
+  a slot in the top-k heap, so a genuine result is evicted. On a three-document
+  fixture the correct `[1, 0, 2]` came back as `[1, 0, 0]`. Membership is now
+  an explicit `seen` array, which also restores parity with the hash-map
+  accumulator the router picks for sparse ID spaces — the two are chosen on
+  performance grounds and must be observationally identical. (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accumulator the router picks for sparse ID spaces — the two are chosen on
   performance grounds and must be observationally identical. (#2106)
 
+- **Latency histograms bucket on the bound they export.** Both millisecond
+  histograms — graph operations and MATCH queries — placed an observation with
+  `ms < bound` while exporting the counts under Prometheus `le` labels, and
+  `le` is *less than or equal*. A request taking exactly 5 ms was counted in
+  `le="0.01"` and left out of `le="0.005"`, so every dashboard percentile and
+  every SLO burn-rate alert read a bucket that excluded the requests sitting
+  on its own boundary — the values latency bounds are most often written to.
+  The graph exporter also kept its `le` labels in a second, hand-written array
+  beside the bounds that drive bucketing; the labels are now derived from
+  those bounds, so the two cannot drift. (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hops with the default 0.8 the two functions answered 0.035 and 0.328 — a
   ninefold gap between two documented spellings of one contract. (#2106)
 
+- **The scalar distance baseline computes the same metric as production.**
+  `CpuDistance` exists to be the un-vectorized reference the SIMD kernels are
+  checked against, and it implemented different formulas: Hamming compared raw
+  bit patterns instead of bucketing at the 0.5 binary threshold (so `[1,2,3]`
+  against `[4,5,6]` scored 3 where production scores 0), and Jaccard called an
+  empty union maximally distant where production calls it identical. A
+  reference that disagrees with its subject makes a real SIMD bug and a
+  reference bug indistinguishable. All three non-Euclidean metrics now
+  delegate to the scalar kernels production falls back on — which also gives
+  cosine the `[-1, 1]` clamp the hand-rolled copy omitted — and a parity test
+  pins baseline against SIMD across adversarial inputs. Euclidean still
+  differs on purpose: the hot path returns squared L2. The unused
+  `simd_distance_for_metric` dispatch was removed; its `dead_code`
+  justification claimed a caller it did not have, and it disagreed with the
+  hot path on Euclidean, so reusing it would have silently changed that
+  contract. (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hot path on Euclidean, so reusing it would have silently changed that
   contract. (#2106)
 
+- **AVX-512 detection now requires the AVX2 + FMA baseline it falls back on.**
+  `detect_simd_level` granted `SimdLevel::Avx512` on `avx512f` alone, but the
+  dispatcher is not a strict hierarchy: an AVX-512 arm with no kernel for the
+  input width falls through to the AVX2 kernel — Hamming and Jaccard below 16
+  elements, and `scale_inplace` throughout — and those carry
+  `#[target_feature(enable = "avx2")]`. Their safety contract was met by an ISA
+  folk theorem ("Avx512 implies Avx2 support", as the SAFETY comment put it)
+  rather than by a check. Every shipping AVX-512 part does advertise AVX2, so
+  no physical CPU was affected; a hypervisor masking CPUID need not, and the
+  failure there is an illegal instruction. Detection now requires `avx2` and
+  `fma` for both non-scalar levels, which makes the fall-through sound by
+  construction and the `SimdLevel::Avx512` doc true. (#2106)
+
 - **`TRAIN QUANTIZER ... TYPE opq` is refused on Hamming and Jaccard
   collections.** OPQ keeps its codes in a rotated basis and the rescore path
   rotates the query to match. A rotation preserves inner products and norms,

--- a/crates/velesdb-core/src/collection/core/mod.rs
+++ b/crates/velesdb-core/src/collection/core/mod.rs
@@ -38,6 +38,8 @@ mod lifecycle_tests;
 mod open_reload_tests;
 #[cfg(feature = "persistence")]
 mod quantizer_restore;
+#[cfg(all(test, feature = "persistence"))]
+mod quantizer_restore_tests;
 mod recovery;
 #[cfg(all(test, feature = "persistence"))]
 mod recovery_tests;

--- a/crates/velesdb-core/src/collection/core/quantizer_restore.rs
+++ b/crates/velesdb-core/src/collection/core/quantizer_restore.rs
@@ -50,7 +50,10 @@ impl Collection {
         // Warn-and-degrade like the RaBitQ restore below: a stale or foreign
         // codebook would fail to encode every vector (empty cache + silent
         // f32 fallback), so reject it once here instead.
-        let dimension = self.storage.config.read().dimension;
+        let (dimension, metric) = {
+            let config = self.storage.config.read();
+            (config.dimension, config.metric)
+        };
         if pq.codebook.dimension != dimension {
             tracing::warn!(
                 codebook_dim = pq.codebook.dimension,
@@ -63,6 +66,21 @@ impl Collection {
         // standalone rotation.opq artifact covers codebooks saved without it.
         if pq.rotation.is_none() {
             pq.rotation = ProductQuantizer::load_rotation(&self.storage.path)?;
+        }
+        // An OPQ rotation puts the codes in a different basis, which Hamming
+        // and Jaccard do not survive — the rescore path rotates the query to
+        // match, and a rotated "binary" vector is not binary. `train_opq`
+        // refuses that combination now, but a codebook trained before the
+        // guard is still on disk somewhere. Dropping the rotation is not a
+        // repair (the codes themselves live in the rotated basis), so degrade
+        // the whole quantizer and let the collection score exact f32.
+        if pq.rotation.is_some() && !metric.is_rotation_invariant() {
+            tracing::warn!(
+                ?metric,
+                "codebook.pq carries an OPQ rotation, which does not preserve this metric; \
+                 quantizer not installed"
+            );
+            return Ok(());
         }
 
         let cache = self.encode_pq_cache(&pq);

--- a/crates/velesdb-core/src/collection/core/quantizer_restore_tests.rs
+++ b/crates/velesdb-core/src/collection/core/quantizer_restore_tests.rs
@@ -1,0 +1,103 @@
+#![cfg(all(test, feature = "persistence"))]
+//! Tests for open-time quantizer restore.
+//!
+//! `train_opq` refuses metrics an orthogonal transform does not preserve, but
+//! that guard only covers codebooks trained from now on. A `codebook.pq`
+//! written before it exists — or copied in from another collection — reaches
+//! the process through `restore_persisted_pq` instead, so the same rule has to
+//! hold there.
+
+#![allow(clippy::cast_precision_loss)]
+
+use std::path::PathBuf;
+
+use crate::collection::Collection;
+use crate::distance::DistanceMetric;
+use crate::point::Point;
+
+const DIM: usize = 8;
+
+fn training_vectors() -> Vec<Vec<f32>> {
+    (0..64_u64)
+        .map(|i| {
+            (0..DIM)
+                .map(|d| ((i as f32) * 0.37 + (d as f32) * 1.13).sin())
+                .collect()
+        })
+        .collect()
+}
+
+fn points(vectors: &[Vec<f32>]) -> Vec<Point> {
+    vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| Point::without_payload(i as u64, v.clone()))
+        .collect()
+}
+
+/// Writes an OPQ codebook (rotation included) into `dir`, as a collection
+/// trained before the metric guard existed would have left behind.
+fn plant_opq_codebook(dir: &std::path::Path, vectors: &[Vec<f32>]) {
+    let pq = crate::quantization::train_opq(vectors, 2, 4, true, 5).expect("test: train OPQ");
+    assert!(
+        pq.rotation.is_some(),
+        "test setup: the planted codebook must carry a rotation"
+    );
+    pq.save_codebook(dir).expect("test: save codebook");
+}
+
+fn restore_with_metric(metric: DistanceMetric) -> bool {
+    let temp = tempfile::tempdir().expect("test: temp dir");
+    let vectors = training_vectors();
+
+    {
+        let coll = Collection::create(PathBuf::from(temp.path()), DIM, metric)
+            .expect("test: create collection");
+        coll.upsert(points(&vectors)).expect("test: upsert");
+        // Restore is gated on the storage mode, which training flips alongside
+        // writing the codebook; without it `restore_persisted_pq` never runs
+        // and every assertion below would pass for the wrong reason.
+        {
+            let mut config = coll.config_write();
+            config.storage_mode = crate::StorageMode::ProductQuantization;
+        }
+        coll.save_config().expect("test: persist config");
+        coll.flush_full().expect("test: flush");
+    }
+
+    plant_opq_codebook(temp.path(), &vectors);
+
+    let reopened = Collection::open(PathBuf::from(temp.path())).expect("test: reopen");
+    let installed = reopened.pq_quantizer_read().is_some();
+    installed
+}
+
+/// A rotated codebook must not be installed on a metric the rotation destroys.
+///
+/// Dropping just the rotation would not repair it: the codes themselves live
+/// in the rotated basis. Degrading the whole quantizer costs speed and keeps
+/// the answers right, which is what the dimension-mismatch arm beside it does.
+#[test]
+fn a_rotated_codebook_is_refused_on_a_rotation_sensitive_metric() {
+    for metric in [DistanceMetric::Hamming, DistanceMetric::Jaccard] {
+        assert!(
+            !restore_with_metric(metric),
+            "{metric:?}: an OPQ codebook must not be installed"
+        );
+    }
+}
+
+/// The same codebook still restores on the metrics a rotation preserves.
+#[test]
+fn a_rotated_codebook_still_restores_on_rotation_invariant_metrics() {
+    for metric in [
+        DistanceMetric::Cosine,
+        DistanceMetric::Euclidean,
+        DistanceMetric::DotProduct,
+    ] {
+        assert!(
+            restore_with_metric(metric),
+            "{metric:?}: an OPQ codebook must still restore"
+        );
+    }
+}

--- a/crates/velesdb-core/src/collection/graph/metrics/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/mod.rs
@@ -23,14 +23,18 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 /// Latency histogram buckets (milliseconds).
+///
+/// These are the upper bounds exported as Prometheus `le` labels, and a
+/// Prometheus bucket is inclusive: an observation equal to a bound belongs to
+/// that bound's bucket, not the next one.
 const BUCKET_BOUNDS_MS: [u64; 9] = [1, 5, 10, 50, 100, 500, 1000, 5000, 10000];
 
 /// Simple latency histogram with fixed buckets.
 ///
-/// Buckets: <1ms, <5ms, <10ms, <50ms, <100ms, <500ms, <1s, <5s, <10s, ≥10s
+/// Buckets: ≤1ms, ≤5ms, ≤10ms, ≤50ms, ≤100ms, ≤500ms, ≤1s, ≤5s, ≤10s, >10s
 #[derive(Debug, Default)]
 pub struct LatencyHistogram {
-    /// Bucket counts [<1ms, <5ms, <10ms, <50ms, <100ms, <500ms, <1s, <5s, <10s, ≥10s]
+    /// Bucket counts [≤1ms, ≤5ms, ≤10ms, ≤50ms, ≤100ms, ≤500ms, ≤1s, ≤5s, ≤10s, >10s]
     buckets: [AtomicU64; 10],
     /// Sum of all observed durations in nanoseconds
     sum_ns: AtomicU64,
@@ -71,8 +75,8 @@ impl LatencyHistogram {
         };
         let bucket_idx = BUCKET_BOUNDS_MS
             .iter()
-            .position(|&bound| ms < bound)
-            .unwrap_or(9);
+            .position(|&bound| ms <= bound)
+            .unwrap_or(BUCKET_BOUNDS_MS.len());
         self.buckets[bucket_idx].fetch_add(1, Ordering::Relaxed);
     }
 
@@ -349,9 +353,6 @@ impl GraphMetrics {
     }
 
     fn append_histogram_prometheus(output: &mut String, name: &str, histogram: &LatencyHistogram) {
-        let bucket_bounds = [
-            "0.001", "0.005", "0.01", "0.05", "0.1", "0.5", "1", "5", "10", "+Inf",
-        ];
         let counts = histogram.bucket_counts();
         let mut cumulative = 0u64;
 
@@ -366,13 +367,21 @@ impl GraphMetrics {
             "# TYPE velesdb_graph_{name}_duration_seconds histogram"
         );
 
-        for (i, &bound) in bucket_bounds.iter().enumerate() {
+        // Labels are derived from the bounds that drive `record`, so the
+        // exported `le` can never drift from the bucket a sample landed in.
+        for (i, &bound_ms) in BUCKET_BOUNDS_MS.iter().enumerate() {
             cumulative += counts[i];
+            let bound = bound_ms as f64 / 1000.0;
             let _ = writeln!(
                 output,
                 "velesdb_graph_{name}_duration_seconds_bucket{{le=\"{bound}\"}} {cumulative}",
             );
         }
+        cumulative += counts[BUCKET_BOUNDS_MS.len()];
+        let _ = writeln!(
+            output,
+            "velesdb_graph_{name}_duration_seconds_bucket{{le=\"+Inf\"}} {cumulative}",
+        );
 
         let _ = writeln!(
             output,

--- a/crates/velesdb-core/src/collection/graph/metrics/tests.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/tests.rs
@@ -162,7 +162,11 @@ fn an_observation_above_the_last_bound_overflows() {
 #[test]
 fn exported_bucket_labels_are_the_recorded_bounds_in_seconds() {
     let metrics = GraphMetrics::new();
-    metrics.record_edge_insert(Duration::from_millis(5));
+    // The batch path is the only remaining producer for `edge_insert_latency`:
+    // the single-edge `record_edge_insert` bumps counters without a clock read,
+    // so it would leave the histogram empty and these bucket assertions would
+    // fail for an unrelated reason.
+    metrics.record_edge_inserts_batch(1, Duration::from_millis(5));
 
     let output = metrics.to_prometheus();
 

--- a/crates/velesdb-core/src/collection/graph/metrics/tests.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/tests.rs
@@ -7,15 +7,15 @@ use std::time::Duration;
 fn test_latency_histogram_observe() {
     let hist = LatencyHistogram::new();
 
-    hist.observe(Duration::from_micros(500)); // <1ms bucket
-    hist.observe(Duration::from_millis(3)); // <5ms bucket
-    hist.observe(Duration::from_millis(75)); // <100ms bucket
+    hist.observe(Duration::from_micros(500)); // le=1ms bucket
+    hist.observe(Duration::from_millis(3)); // le=5ms bucket
+    hist.observe(Duration::from_millis(75)); // le=100ms bucket
 
     assert_eq!(hist.count(), 3);
     let buckets = hist.bucket_counts();
-    assert_eq!(buckets[0], 1); // <1ms
-    assert_eq!(buckets[1], 1); // <5ms
-    assert_eq!(buckets[4], 1); // <100ms
+    assert_eq!(buckets[0], 1); // le=1ms
+    assert_eq!(buckets[1], 1); // le=5ms
+    assert_eq!(buckets[4], 1); // le=100ms
 }
 
 #[test]
@@ -121,9 +121,86 @@ fn test_latency_histogram_empty_avg() {
 fn test_latency_histogram_large_duration() {
     let hist = LatencyHistogram::new();
 
-    // Test >10s bucket
+    // Test the >10s overflow bucket
     hist.observe(Duration::from_secs(15));
 
     let buckets = hist.bucket_counts();
-    assert_eq!(buckets[9], 1); // ≥10s bucket
+    assert_eq!(buckets[9], 1); // >10s bucket
+}
+
+/// An observation landing exactly on a bucket bound belongs to that bucket.
+///
+/// The counts are exported with `le="{bound}"`, and Prometheus defines `le` as
+/// **less than or equal**. Bucketing with `ms < bound` pushed an exact-bound
+/// observation into the next bucket, so `le="5"` under-reported every request
+/// that took exactly 5 ms — the scrape said "no request was ≤ 5 ms" about a
+/// request that was.
+#[test]
+fn an_observation_on_a_bucket_bound_lands_in_that_bucket() {
+    let hist = LatencyHistogram::new();
+    hist.observe(Duration::from_millis(5));
+
+    let counts = hist.bucket_counts();
+    assert_eq!(
+        counts[1], 1,
+        "5 ms must fall in le=\"5\" (index 1), got {counts:?}"
+    );
+    assert_eq!(counts[2], 0, "it must not spill into le=\"10\"");
+}
+
+/// Every bound is inclusive, not just the one probed above.
+#[test]
+fn every_bucket_bound_is_inclusive() {
+    for (index, bound) in BUCKET_BOUNDS_MS.into_iter().enumerate() {
+        let hist = LatencyHistogram::new();
+        hist.observe(Duration::from_millis(bound));
+        let counts = hist.bucket_counts();
+        assert_eq!(
+            counts[index], 1,
+            "{bound} ms must land in le=\"{bound}\" (index {index}), got {counts:?}"
+        );
+    }
+}
+
+/// A value above the last bound still lands in the overflow bucket.
+#[test]
+fn an_observation_above_the_last_bound_overflows() {
+    let hist = LatencyHistogram::new();
+    hist.observe(Duration::from_millis(10_001));
+    assert_eq!(hist.bucket_counts()[9], 1, "overflow bucket keeps its role");
+}
+
+/// The exported `le` labels are the recorded bounds in seconds, and the
+/// cumulative counts are consistent with the bucket an observation landed in.
+///
+/// The label list used to be a hand-written array of strings sitting next to
+/// `BUCKET_BOUNDS_MS`. Two sources of truth for one fact drift silently: a
+/// bound added or moved on one side would have relabelled every sample on the
+/// other. Deriving the labels removes the possibility; this locks the result.
+#[test]
+fn exported_bucket_labels_are_the_recorded_bounds_in_seconds() {
+    let metrics = GraphMetrics::new();
+    metrics.record_edge_insert(Duration::from_millis(5));
+
+    let output = metrics.to_prometheus();
+
+    for (index, bound_ms) in BUCKET_BOUNDS_MS.into_iter().enumerate() {
+        #[allow(clippy::cast_precision_loss)]
+        let seconds = bound_ms as f64 / 1000.0;
+        // 5 ms sits on the second bound, so every bucket from there on is
+        // cumulative 1 and every earlier one is 0.
+        let expected = u64::from(index >= 1);
+        let line = format!(
+            "velesdb_graph_edge_insert_duration_seconds_bucket{{le=\"{seconds}\"}} {expected}"
+        );
+        assert!(
+            output.contains(&line),
+            "missing or miscounted bucket line: {line}\n--- output ---\n{output}"
+        );
+    }
+
+    assert!(
+        output.contains("velesdb_graph_edge_insert_duration_seconds_bucket{le=\"+Inf\"} 1"),
+        "the overflow bucket must close the cumulative series\n--- output ---\n{output}"
+    );
 }

--- a/crates/velesdb-core/src/collection/search/query/match_metrics.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_metrics.rs
@@ -26,6 +26,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Bucket bounds for latency histogram in milliseconds.
+///
+/// These are the upper bounds exported as Prometheus `le` labels, and a
+/// Prometheus bucket is inclusive: an observation equal to a bound belongs to
+/// that bound's bucket, not the next one.
 pub const LATENCY_BUCKETS_MS: [u64; 10] = [1, 5, 10, 25, 50, 100, 250, 500, 1000, 5000];
 
 /// MATCH query metrics collector (EPIC-050 US-001).
@@ -98,7 +102,7 @@ impl MatchMetrics {
         // Find the right bucket
         let bucket_idx = LATENCY_BUCKETS_MS
             .iter()
-            .position(|&bound| ms < bound)
+            .position(|&bound| ms <= bound)
             .unwrap_or(LATENCY_BUCKETS_MS.len());
 
         self.latency_buckets[bucket_idx].fetch_add(1, Ordering::Relaxed);

--- a/crates/velesdb-core/src/collection/search/query/match_metrics_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/match_metrics_tests.rs
@@ -44,20 +44,20 @@ fn test_metrics_latency_buckets() {
     assert_eq!(
         metrics.latency_buckets[0].load(Ordering::Relaxed),
         1,
-        "500us -> bucket 0 (<1ms)"
+        "500us -> bucket 0 (le=1ms)"
     );
     assert_eq!(
         metrics.latency_buckets[1].load(Ordering::Relaxed),
         1,
-        "3ms -> bucket 1 (<5ms)"
+        "3ms -> bucket 1 (le=5ms)"
     );
     assert_eq!(
-        metrics.latency_buckets[5].load(Ordering::Relaxed),
+        metrics.latency_buckets[4].load(Ordering::Relaxed),
         1,
-        "50ms -> bucket 5 (<100ms; strict < skips the le=50 bound at idx 4)"
+        "50ms -> bucket 4 (le=50ms is inclusive)"
     );
     for (i, b) in metrics.latency_buckets.iter().enumerate() {
-        if i != 0 && i != 1 && i != 5 {
+        if i != 0 && i != 1 && i != 4 {
             assert_eq!(b.load(Ordering::Relaxed), 0, "bucket {i} should be empty");
         }
     }
@@ -92,4 +92,52 @@ fn test_query_timer_drop_counts_as_failure() {
         let _timer = QueryTimer::new(&metrics);
     }
     assert_eq!(metrics.failed_queries.load(Ordering::Relaxed), 1);
+}
+
+/// A MATCH latency landing exactly on a bucket bound belongs to that bucket.
+///
+/// `to_prometheus` exports these counts as `le="{bound}"`, and Prometheus
+/// defines `le` as **less than or equal**. Bucketing with `ms < bound` moved an
+/// exact-bound observation one bucket up, so a query that took exactly 25 ms
+/// was reported as *not* being ≤ 25 ms.
+#[test]
+fn a_match_latency_on_a_bucket_bound_lands_in_that_bucket() {
+    let metrics = MatchMetrics::new();
+    metrics.record_success(Duration::from_millis(25), 1, 1);
+
+    let counts: Vec<u64> = metrics
+        .latency_buckets
+        .iter()
+        .map(|b| b.load(Ordering::Relaxed))
+        .collect();
+    let index = LATENCY_BUCKETS_MS
+        .iter()
+        .position(|&b| b == 25)
+        .expect("25 is a declared bound");
+    assert_eq!(
+        counts[index], 1,
+        "25 ms must fall in le=\"25\" (index {index}), got {counts:?}"
+    );
+}
+
+/// Every declared bound is inclusive, and the overflow bucket keeps its role.
+#[test]
+fn every_match_latency_bound_is_inclusive() {
+    for (index, bound) in LATENCY_BUCKETS_MS.into_iter().enumerate() {
+        let metrics = MatchMetrics::new();
+        metrics.record_success(Duration::from_millis(bound), 1, 1);
+        let count = metrics.latency_buckets[index].load(Ordering::Relaxed);
+        assert_eq!(
+            count, 1,
+            "{bound} ms must land in le=\"{bound}\" (index {index})"
+        );
+    }
+
+    let metrics = MatchMetrics::new();
+    metrics.record_success(Duration::from_millis(5_001), 1, 1);
+    assert_eq!(
+        metrics.latency_buckets[LATENCY_BUCKETS_MS.len()].load(Ordering::Relaxed),
+        1,
+        "a latency above the last bound still overflows"
+    );
 }

--- a/crates/velesdb-core/src/collection/search/query/score_fusion/path.rs
+++ b/crates/velesdb-core/src/collection/search/query/score_fusion/path.rs
@@ -77,6 +77,13 @@ impl PathScorer {
     }
 
     /// Scores a path given only relationship types (simplified API).
+    ///
+    /// Each hop contributes one `distance_decay` factor and its relationship
+    /// weight, so an `n`-hop path with default weights scores exactly
+    /// [`Self::score_length`]`(n)`. Raising the decay to the hop's ordinal
+    /// instead would compound it to `decay^(n(n+1)/2)`, which contradicts both
+    /// `score_length` and the "each hop reduces score by 20%" contract on
+    /// [`Self::distance_decay`].
     #[must_use]
     pub fn score_rel_types(&self, rel_types: &[&str]) -> f32 {
         if rel_types.is_empty() {
@@ -85,14 +92,13 @@ impl PathScorer {
 
         let mut score = 1.0;
 
-        for (i, rel_type) in rel_types.iter().enumerate() {
-            let hop_decay = self.distance_decay.powi(i as i32 + 1);
+        for rel_type in rel_types {
             let rel_weight = self
                 .rel_type_weights
                 .get(*rel_type)
                 .copied()
                 .unwrap_or(self.default_weight);
-            score *= hop_decay * rel_weight;
+            score *= self.distance_decay * rel_weight;
         }
 
         score.clamp(0.0, 1.0)

--- a/crates/velesdb-core/src/collection/search/query/score_fusion_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/score_fusion_tests.rs
@@ -243,10 +243,32 @@ fn test_path_scorer_score_rel_types() {
 
     let score = scorer.score_rel_types(&["A", "B"]);
 
-    // First hop: 0.8 * 1.0 = 0.8
-    // Second hop: 0.8^2 * 0.5 = 0.64 * 0.5 = 0.32
-    // Product: 0.8 * 0.32 = 0.256
-    assert!((score - 0.256).abs() < 0.001);
+    // One decay factor per hop, times that hop's relationship weight:
+    // (0.8 * 1.0) * (0.8 * 0.5) = 0.8 * 0.4 = 0.32
+    assert!((score - 0.32).abs() < 0.001);
+}
+
+/// `score_rel_types` and `score_length` must agree on the same path.
+///
+/// They are two spellings of one contract — "each hop costs one decay
+/// factor" — and a caller picks between them only by whether it has the
+/// relationship types to hand. `score_rel_types` used to raise the decay to
+/// the hop's ordinal, giving `decay^(n(n+1)/2)`: at five hops with the
+/// default 0.8 that is 0.035 against `score_length`'s 0.328, a ninefold gap
+/// between two functions documented to do the same thing.
+#[test]
+fn test_path_scorer_rel_types_agrees_with_length_under_default_weights() {
+    let scorer = PathScorer::new().with_decay(0.8);
+
+    for hops in 0..=5_usize {
+        let rel_types = vec!["ANY"; hops];
+        let by_types = scorer.score_rel_types(&rel_types);
+        let by_length = scorer.score_length(hops);
+        assert!(
+            (by_types - by_length).abs() < 1e-6,
+            "{hops} hops: score_rel_types {by_types} != score_length {by_length}"
+        );
+    }
 }
 
 #[test]

--- a/crates/velesdb-core/src/database/training.rs
+++ b/crates/velesdb-core/src/database/training.rs
@@ -156,11 +156,26 @@ impl Database {
     }
 
     /// Trains an Optimized Product Quantizer (with rotation) and persists it.
+    ///
+    /// OPQ keeps its codes in a rotated basis and rescoring rotates the query
+    /// to match, so training is rejected on metrics an orthogonal transform
+    /// does not preserve — see [`crate::DistanceMetric::is_rotation_invariant`].
+    /// Without this, `TRAIN QUANTIZER ... TYPE opq` on a Hamming or Jaccard
+    /// collection succeeded and every later rescore measured the metric in a
+    /// space where it means nothing.
     fn train_opq(
         collection: &crate::collection::Collection,
         vectors: &[Vec<f32>],
         params: &TrainParams,
     ) -> Result<Vec<SearchResult>> {
+        let metric = collection.config().metric;
+        if !metric.is_rotation_invariant() {
+            return Err(Error::InvalidQuantizerConfig(format!(
+                "OPQ rotates vectors into another basis, which does not preserve {metric:?}; \
+                 train plain PQ instead, or use a cosine/euclidean/dot-product collection"
+            )));
+        }
+
         let pq = crate::quantization::train_opq(vectors, params.m, params.k, true, 10)
             .map_err(|e| Error::TrainingFailed(e.to_string()))?;
 

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -159,6 +159,24 @@ impl DistanceMetric {
         }
     }
 
+    /// Returns whether an orthogonal change of basis leaves this metric
+    /// unchanged.
+    ///
+    /// OPQ stores codes in a rotated space and rescoring rotates the query to
+    /// match. That is sound only for metrics built from inner products and
+    /// norms, which a rotation preserves: cosine, dot product, Euclidean.
+    /// Hamming and Jaccard are defined component by component on the original
+    /// axes — a rotated "binary" vector is no longer binary — so the same
+    /// trick computes a number that has no relation to the metric the user
+    /// asked for.
+    #[must_use]
+    pub const fn is_rotation_invariant(&self) -> bool {
+        match self {
+            Self::Cosine | Self::Euclidean | Self::DotProduct => true,
+            Self::Hamming | Self::Jaccard => false,
+        }
+    }
+
     /// Returns this metric's score polarity for fusion
     /// ([`ScoreDirection`](crate::fusion::ScoreDirection)).
     ///

--- a/crates/velesdb-core/src/index/hnsw/native/distance.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/distance.rs
@@ -38,22 +38,6 @@ pub trait DistanceEngine: Send + Sync {
 // Shared SIMD distance helpers (RF-DEDUP: eliminates 3x copy-paste)
 // =============================================================================
 
-/// Computes SIMD-accelerated distance for any metric via `simd_native`.
-///
-/// This is the single source of truth for metric-to-SIMD dispatch.
-/// All SIMD-based `DistanceEngine` implementations delegate here.
-#[allow(dead_code)] // Reason: Central dispatch — used by CpuDistance; kept as reference impl
-#[inline]
-pub(crate) fn simd_distance_for_metric(metric: DistanceMetric, a: &[f32], b: &[f32]) -> f32 {
-    match metric {
-        DistanceMetric::Cosine => 1.0 - crate::simd_native::cosine_similarity_native(a, b),
-        DistanceMetric::Euclidean => crate::simd_native::euclidean_native(a, b),
-        DistanceMetric::DotProduct => -crate::simd_native::dot_product_native(a, b),
-        DistanceMetric::Hamming => crate::simd_native::hamming_distance_native(a, b),
-        DistanceMetric::Jaccard => 1.0 - crate::simd_native::jaccard_similarity_native(a, b),
-    }
-}
-
 /// Batch distance with CPU prefetch hints to hide memory latency.
 ///
 /// Returns `SmallVec<[f32; 64]>` to avoid heap allocation for real batch
@@ -193,24 +177,16 @@ impl DistanceEngine for CachedSimdDistance {
 // Scalar implementations (baseline for comparison)
 // =============================================================================
 
+/// Cosine distance, derived from the same similarity kernel as production.
+///
+/// `cosine_scalar` clamps to `[-1, 1]` and scores a zero-norm pair 0.0, so the
+/// distance stays in `[0, 2]` and a zero vector is maximally distant — the
+/// same contract `CachedSimdDistance` enforces on its pre-normalized arm. The
+/// hand-rolled copy this replaced omitted the clamp, so two identical vectors
+/// could come back at a distance slightly below zero.
 #[inline]
 fn cosine_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
-    let mut dot = 0.0_f32;
-    let mut norm_a = 0.0_f32;
-    let mut norm_b = 0.0_f32;
-
-    for (x, y) in a.iter().zip(b.iter()) {
-        dot += x * y;
-        norm_a += x * x;
-        norm_b += y * y;
-    }
-
-    let denom = (norm_a * norm_b).sqrt();
-    if denom == 0.0 {
-        1.0
-    } else {
-        1.0 - (dot / denom)
-    }
+    1.0 - crate::simd_native::scalar::cosine_scalar(a, b)
 }
 
 #[inline]
@@ -228,32 +204,24 @@ fn dot_product_scalar(a: &[f32], b: &[f32]) -> f32 {
     -a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f32>()
 }
 
+/// Hamming distance, delegating to the kernel production falls back on.
+///
+/// A baseline that computes a *different* formula is worse than no baseline:
+/// a parity test between it and the SIMD path reports a divergence as "the
+/// SIMD kernel is wrong". This engine's job is to be the same metric without
+/// the vectorization, so the formula has exactly one definition —
+/// [`crate::simd_native::scalar::hamming_scalar`], which buckets each
+/// component at the 0.5 binary threshold.
 #[inline]
 fn hamming_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
-    // SAFETY (cast): Vector dimensions are bounded by collection config (max 65536).
-    // f32 has 24-bit mantissa, so counts up to 2^24 (16M) are exact.
-    #[allow(clippy::cast_precision_loss)]
-    let count = a
-        .iter()
-        .zip(b.iter())
-        .filter(|(x, y)| (x.to_bits() ^ y.to_bits()) != 0)
-        .count() as f32;
-    count
+    crate::simd_native::scalar::hamming_scalar(a, b)
 }
 
+/// Jaccard distance, derived from the same similarity kernel as production.
+///
+/// `jaccard_scalar` returns a *similarity*, and an empty union scores 1.0
+/// (two all-zero vectors are identical), so the distance is 0.0 there.
 #[inline]
 fn jaccard_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
-    let mut intersection = 0.0_f32;
-    let mut union = 0.0_f32;
-
-    for (x, y) in a.iter().zip(b.iter()) {
-        intersection += x.min(*y);
-        union += x.max(*y);
-    }
-
-    if union == 0.0 {
-        1.0
-    } else {
-        1.0 - (intersection / union)
-    }
+    1.0 - crate::simd_native::scalar::jaccard_scalar(a, b)
 }

--- a/crates/velesdb-core/src/index/hnsw/native/distance_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/distance_tests.rs
@@ -520,14 +520,17 @@ fn test_cosine_scalar_zero_norm() {
 
 #[test]
 fn test_jaccard_scalar_zero_union() {
-    // Test division by zero case
+    // Division-by-zero case. `jaccard_scalar` scores an empty union 1.0 —
+    // two all-zero vectors are identical, the conventional J(∅,∅) = 1 — so
+    // the distance is 0.0. The baseline used to answer 1.0 here, calling the
+    // same pair maximally distant while production called them identical.
     let engine = CpuDistance::new(DistanceMetric::Jaccard);
     let a = vec![0.0, 0.0, 0.0];
     let b = vec![0.0, 0.0, 0.0];
     let dist = engine.distance(&a, &b);
     assert!(
-        (dist - 1.0).abs() < 1e-5,
-        "Zero union should return distance 1.0"
+        dist.abs() < 1e-5,
+        "empty union means identical: distance 0.0, got {dist}"
     );
 }
 
@@ -556,10 +559,71 @@ fn test_hamming_scalar_all_same() {
 #[test]
 fn test_hamming_scalar_all_different() {
     let engine = CpuDistance::new(DistanceMetric::Hamming);
-    let a = vec![1.0, 2.0, 3.0];
-    let b = vec![4.0, 5.0, 6.0];
+    let a = vec![1.0, 0.0, 1.0];
+    let b = vec![0.0, 1.0, 0.0];
     let dist = engine.distance(&a, &b);
     assert!((dist - 3.0).abs() < 1e-5);
+}
+
+/// Hamming buckets each component at 0.5 before comparing.
+///
+/// The baseline used to compare raw bit patterns, so `[1,2,3]` against
+/// `[4,5,6]` scored 3 — every component "differs" — while production scored
+/// 0, because all six values are on the same side of the threshold. Hamming
+/// is defined on binary vectors; a baseline that reads the mantissa is
+/// measuring something else entirely.
+#[test]
+fn test_hamming_thresholds_at_half_rather_than_comparing_bit_patterns() {
+    let engine = CpuDistance::new(DistanceMetric::Hamming);
+
+    let above = vec![1.0, 2.0, 3.0];
+    let also_above = vec![4.0, 5.0, 6.0];
+    assert!(
+        engine.distance(&above, &also_above).abs() < 1e-5,
+        "values on the same side of 0.5 are the same bit"
+    );
+
+    let below = vec![0.0, 0.1, 0.4];
+    assert!(
+        (engine.distance(&above, &below) - 3.0).abs() < 1e-5,
+        "values straddling 0.5 differ in every position"
+    );
+}
+
+/// The scalar baseline and the production SIMD engine must agree.
+///
+/// `CpuDistance` exists to be the un-vectorized reference the SIMD kernels
+/// are checked against; when it implements a different formula, a real SIMD
+/// bug and a reference bug are indistinguishable. Euclidean is excluded on
+/// purpose: `CachedSimdDistance` returns *squared* L2 for the HNSW hot loop
+/// (documented at its `distance` impl) while the baseline takes the square
+/// root.
+#[test]
+fn test_cpu_baseline_agrees_with_cached_simd_on_adversarial_inputs() {
+    let cases: [(&[f32], &[f32]); 4] = [
+        (&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0]),
+        (&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]),
+        (&[1.0, 0.0, 1.0, 0.0], &[1.0, 1.0, 0.0, 0.0]),
+        (&[0.9, 0.4, 0.6, 0.1], &[0.4, 0.9, 0.1, 0.6]),
+    ];
+
+    for metric in [
+        DistanceMetric::Cosine,
+        DistanceMetric::DotProduct,
+        DistanceMetric::Hamming,
+        DistanceMetric::Jaccard,
+    ] {
+        for (a, b) in cases {
+            let cpu = CpuDistance::new(metric);
+            let cached = CachedSimdDistance::new(metric, a.len());
+            let baseline = cpu.distance(a, b);
+            let simd = cached.distance(a, b);
+            assert!(
+                (baseline - simd).abs() < 1e-5,
+                "{metric:?} on {a:?} vs {b:?}: baseline {baseline} != simd {simd}"
+            );
+        }
+    }
 }
 
 // =========================================================================

--- a/crates/velesdb-core/src/simd_native/dispatch/euclidean.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/euclidean.rs
@@ -104,7 +104,8 @@ fn scale_inplace_native(v: &mut [f32], factor: f32) {
         #[cfg(target_arch = "x86_64")]
         SimdLevel::Avx512 | SimdLevel::Avx2 if v.len() >= 8 => {
             // SAFETY: AVX2 scale kernel requires CPU feature + minimum dim.
-            // - Condition 1: `simd_level()` confirmed AVX2+ after runtime detection.
+            // - Condition 1: `detect_simd_level` grants neither Avx2 nor Avx512
+            //   without the avx2 + fma baseline, so this arm has avx2 either way.
             // SAFETY: broadcast factor and multiply 8 floats per iteration.
             unsafe { scale_inplace_avx2(v, factor) };
         }

--- a/crates/velesdb-core/src/simd_native/dispatch/hamming.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/hamming.rs
@@ -60,7 +60,8 @@ fn hamming_simd(a: &[f32], b: &[f32]) -> f32 {
         #[cfg(target_arch = "x86_64")]
         SimdLevel::Avx512 | SimdLevel::Avx2 if a.len() >= 8 => {
             // SAFETY: AVX2 hamming kernel requires CPU feature + minimum dim.
-            // - Condition 1: `simd_level()` confirmed AVX2+ (Avx512 implies Avx2 support).
+            // - Condition 1: `detect_simd_level` grants neither Avx2 nor Avx512
+            //   without the avx2 + fma baseline, so this arm has avx2 either way.
             // SAFETY: fallthrough for Avx512 with short vectors that don't meet 16-element minimum.
             unsafe { crate::simd_native::hamming_avx2(a, b) }
         }
@@ -98,7 +99,8 @@ fn jaccard_simd(a: &[f32], b: &[f32]) -> f32 {
         #[cfg(target_arch = "x86_64")]
         SimdLevel::Avx512 | SimdLevel::Avx2 if a.len() >= 8 => {
             // SAFETY: AVX2 jaccard kernel requires CPU feature + minimum dim.
-            // - Condition 1: `simd_level()` confirmed AVX2+ (Avx512 implies Avx2 support).
+            // - Condition 1: `detect_simd_level` grants neither Avx2 nor Avx512
+            //   without the avx2 + fma baseline, so this arm has avx2 either way.
             // SAFETY: fallthrough for Avx512 with short vectors that don't meet 16-element minimum.
             unsafe { crate::simd_native::jaccard_avx2(a, b) }
         }

--- a/crates/velesdb-core/src/simd_native/dispatch/mod.rs
+++ b/crates/velesdb-core/src/simd_native/dispatch/mod.rs
@@ -20,7 +20,7 @@ pub use hamming::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SimdLevel {
-    /// AVX-512F available (x86_64 only).
+    /// AVX-512F on top of the AVX2 + FMA baseline (x86_64 only).
     Avx512,
     /// AVX2 + FMA available (x86_64 only).
     Avx2,
@@ -48,14 +48,29 @@ pub(super) fn squared_l2_scalar(a: &[f32], b: &[f32]) -> f32 {
         .sum()
 }
 
+/// AVX2 + FMA — the baseline every non-scalar x86 level is built on.
+///
+/// `Avx512` is not a superset of `Avx2` in this dispatcher: an AVX-512 arm
+/// that has no kernel for the input width falls through to the AVX2 kernel
+/// (`hamming`, `jaccard`, `scale_inplace`), and those carry
+/// `#[target_feature(enable = "avx2")]`. Granting `Avx512` on `avx512f` alone
+/// would satisfy their safety contract with an ISA folk theorem rather than a
+/// check — every shipping AVX-512 part does advertise AVX2, but a hypervisor
+/// that masks CPUID need not, and the result there is an illegal instruction.
+/// Requiring the baseline makes the fall-through sound by construction.
+#[cfg(target_arch = "x86_64")]
+fn has_avx2_baseline() -> bool {
+    is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
+}
+
 fn detect_simd_level() -> SimdLevel {
     let level;
 
     #[cfg(target_arch = "x86_64")]
     {
-        if is_x86_feature_detected!("avx512f") {
+        if is_x86_feature_detected!("avx512f") && has_avx2_baseline() {
             level = SimdLevel::Avx512;
-        } else if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
+        } else if has_avx2_baseline() {
             level = SimdLevel::Avx2;
         } else {
             level = SimdLevel::Scalar;

--- a/crates/velesdb-core/src/simd_native/scalar.rs
+++ b/crates/velesdb-core/src/simd_native/scalar.rs
@@ -139,7 +139,7 @@ pub(crate) fn cosine_scalar(a: &[f32], b: &[f32]) -> f32 {
 /// Uses binary threshold at 0.5 for consistency with SIMD versions.
 /// This is the standard interpretation for binary/categorical vectors.
 #[inline]
-pub(super) fn hamming_scalar(a: &[f32], b: &[f32]) -> f32 {
+pub(crate) fn hamming_scalar(a: &[f32], b: &[f32]) -> f32 {
     a.iter()
         .zip(b.iter())
         .filter(|(&x, &y)| (x > 0.5) != (y > 0.5))
@@ -148,7 +148,7 @@ pub(super) fn hamming_scalar(a: &[f32], b: &[f32]) -> f32 {
 
 /// Scalar Jaccard similarity implementation.
 #[inline]
-pub(super) fn jaccard_scalar(a: &[f32], b: &[f32]) -> f32 {
+pub(crate) fn jaccard_scalar(a: &[f32], b: &[f32]) -> f32 {
     let (intersection, union) = jaccard_scalar_accum(a, b);
     if union == 0.0 {
         1.0

--- a/crates/velesdb-core/src/simd_native/simd_native_dispatch_tests.rs
+++ b/crates/velesdb-core/src/simd_native/simd_native_dispatch_tests.rs
@@ -204,3 +204,51 @@ fn test_euclidean_dispatch_thresholds() {
         );
     }
 }
+
+// ============================================================================
+// Feature-detection contract
+// ============================================================================
+
+/// Every non-scalar x86 level implies the AVX2 + FMA baseline.
+///
+/// `Avx512` arms fall through to AVX2 kernels for inputs narrower than their
+/// own minimum — `hamming`, `jaccard` and `scale_inplace` all do — and those
+/// kernels carry `#[target_feature(enable = "avx2")]`. Detection used to
+/// grant `Avx512` on `avx512f` alone, so the fall-through rested on "every
+/// AVX-512 CPU has AVX2" rather than on a check; a hypervisor masking CPUID
+/// breaks that, and the failure mode is an illegal instruction. This asserts
+/// the property on whatever CPU runs the suite, so it fails exactly on the
+/// hardware where the omission would have bitten.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn every_non_scalar_level_implies_the_avx2_baseline() {
+    use super::{simd_level, SimdLevel};
+
+    let baseline = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+    match simd_level() {
+        SimdLevel::Avx512 | SimdLevel::Avx2 => assert!(
+            baseline,
+            "level {:?} was granted without avx2 + fma",
+            simd_level()
+        ),
+        SimdLevel::Neon | SimdLevel::Scalar => {}
+    }
+}
+
+/// AVX-512F alone must not grant the `Avx512` level.
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn avx512_level_requires_more_than_avx512f() {
+    use super::{simd_level, SimdLevel};
+
+    if simd_level() == SimdLevel::Avx512 {
+        assert!(
+            is_x86_feature_detected!("avx512f"),
+            "Avx512 must still require avx512f"
+        );
+        assert!(
+            is_x86_feature_detected!("avx2"),
+            "Avx512 must not be granted without avx2"
+        );
+    }
+}

--- a/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
@@ -357,6 +357,47 @@ fn test_sparse_search_upsert_across_segments_uses_latest_weight() {
     );
 }
 
+// ---------- REGRESSION: exact cancellation must not duplicate a document ----------
+//
+// The dense accumulator used to infer "have I seen this document before?"
+// from `scores[idx] == 0.0`. A negative query weight can drive an
+// accumulated score back to exactly zero — the "like A but not B" shape,
+// where both vectors carry a shared term at the same weight — after which
+// the next term's posting sees a zero and records the document a second
+// time. The duplicate then occupies a slot in the top-k heap, evicting a
+// document that belongs there.
+
+#[test]
+fn test_sparse_search_cancelling_query_returns_distinct_documents() {
+    let index = SparseInvertedIndex::new();
+    index.insert(0, &SparseVector::new(vec![(1, 1.0), (2, 1.0), (3, 1.0)]));
+    index.insert(1, &SparseVector::new(vec![(1, 5.0)]));
+    index.insert(2, &SparseVector::new(vec![(3, 0.75)]));
+
+    // doc 0 = 1.0 - 1.0 + 2.0 = 2.0, doc 1 = 5.0, doc 2 = 1.5.
+    // Term 2 cancels doc 0's running score to exactly 0.0 before term 3 runs.
+    let query = SparseVector::new(vec![(1, 1.0), (2, -1.0), (3, 2.0)]);
+
+    let ms = sparse_search(&index, &query, 3);
+    let bf = brute_force_search(&index, &query, 3);
+
+    let mut seen: HashSet<u64> = HashSet::new();
+    for doc in &ms {
+        assert!(
+            seen.insert(doc.doc_id),
+            "doc {} returned more than once: {:?}",
+            doc.doc_id,
+            doc_ids(&ms)
+        );
+    }
+    assert_eq!(
+        doc_ids(&bf),
+        doc_ids(&ms),
+        "cancelling query: IDs diverge from brute-force"
+    );
+    assert_scores_close(&bf, &ms, "cancelling query");
+}
+
 #[test]
 fn test_sparse_search_deterministic_across_invocations() {
     let corpus = gen_positive_corpus(500, 11);

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -40,9 +40,11 @@ const SMALL_CORPUS_LINEAR_THRESHOLD: u64 = 100_000;
 /// Maximum doc ID for which we use a dense accumulator array.
 /// Above this threshold we fall back to a hash map.
 ///
-/// Capped at `1_000_000` to bound the worst-case allocation to ~4 MB
-/// (`(max_doc_id + 1) * size_of::<f32>() == ~4 MB`). The density check
-/// in `linear_scan_search` further restricts this path to compact ID spaces.
+/// Capped at `1_000_000` to bound the worst-case allocation to ~5 MB — a
+/// `f32` score plus a `bool` membership flag per slot
+/// (`(max_doc_id + 1) * (size_of::<f32>() + size_of::<bool>())`). The density
+/// check in `linear_scan_search` further restricts this path to compact ID
+/// spaces.
 const MAX_DENSE_ACCUMULATOR: u64 = 1_000_000;
 
 /// Searches the sparse inverted index for the top-k documents by inner product.

--- a/crates/velesdb-core/src/sparse_index/search/strategy.rs
+++ b/crates/velesdb-core/src/sparse_index/search/strategy.rs
@@ -112,13 +112,18 @@ fn linear_scan_dense(
     #[allow(clippy::cast_possible_truncation)]
     let size = (max_doc_id + 1) as usize;
     let mut scores = vec![0.0_f32; size];
+    // Membership is a fact about the scan, not about the value: a negative
+    // query weight can drive an accumulated score back to exactly `0.0`, so
+    // testing `scores[idx] == 0.0` would record the same document twice and
+    // let the duplicate evict a genuine result from the top-k heap.
+    let mut seen = vec![false; size];
     let mut touched: Vec<u64> = Vec::new();
 
     for (qw, postings) in term_postings {
         for entry in postings {
             #[allow(clippy::cast_possible_truncation)]
             let idx = entry.doc_id as usize;
-            if scores[idx] == 0.0 {
+            if !std::mem::replace(&mut seen[idx], true) {
                 touched.push(entry.doc_id);
             }
             scores[idx] += qw * entry.weight;
@@ -152,3 +157,7 @@ fn linear_scan_hashmap(k: usize, term_postings: &[(f32, Vec<PostingEntry>)]) -> 
 
     extract_sorted_results(heap)
 }
+
+#[cfg(test)]
+#[path = "strategy_tests.rs"]
+mod tests;

--- a/crates/velesdb-core/src/sparse_index/search/strategy_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/strategy_tests.rs
@@ -1,0 +1,95 @@
+//! Parity between the two linear-scan accumulators.
+//!
+//! `linear_scan_search` picks between a dense array and a hash map purely on
+//! the shape of the doc ID space. That choice is a performance decision, so
+//! the two variants must be observationally identical: same documents, same
+//! scores, for the same posting lists. These tests call both directly on
+//! hand-built posting lists so a divergence is attributed to the accumulator
+//! rather than to routing.
+
+use crate::sparse_index::types::{PostingEntry, ScoredDoc};
+
+use super::{linear_scan_dense, linear_scan_hashmap};
+
+fn entry(doc_id: u64, weight: f32) -> PostingEntry {
+    PostingEntry { doc_id, weight }
+}
+
+fn as_pairs(results: &[ScoredDoc]) -> Vec<(u64, f32)> {
+    results.iter().map(|r| (r.doc_id, r.score)).collect()
+}
+
+/// Query weights `+1` then `-1` against equal document weights drive the
+/// accumulated score for doc 0 back to exactly `0.0` before the third term
+/// contributes. Realistic for any "like A but not B" query built from two
+/// document vectors that share a term at the same weight.
+fn cancelling_term_postings() -> Vec<(f32, Vec<PostingEntry>)> {
+    vec![
+        (1.0, vec![entry(0, 1.0), entry(1, 5.0)]),
+        (-1.0, vec![entry(0, 1.0)]),
+        (2.0, vec![entry(0, 1.0), entry(2, 0.75)]),
+    ]
+}
+
+#[test]
+fn a_document_whose_score_cancels_to_zero_is_returned_once() {
+    let term_postings = cancelling_term_postings();
+
+    let dense = linear_scan_dense(10, 2, &term_postings);
+
+    let mut ids: Vec<u64> = dense.iter().map(|r| r.doc_id).collect();
+    ids.sort_unstable();
+    let distinct = {
+        let mut d = ids.clone();
+        d.dedup();
+        d
+    };
+    assert_eq!(
+        ids, distinct,
+        "linear_scan_dense returned a duplicate document: {ids:?}"
+    );
+}
+
+#[test]
+fn both_accumulators_agree_on_a_cancelling_query() {
+    let term_postings = cancelling_term_postings();
+
+    let dense = linear_scan_dense(10, 2, &term_postings);
+    let hashmap = linear_scan_hashmap(10, &term_postings);
+
+    assert_eq!(
+        as_pairs(&dense),
+        as_pairs(&hashmap),
+        "dense and hash map accumulators must be interchangeable"
+    );
+}
+
+/// The duplicate does not merely repeat a result — it occupies a slot in the
+/// top-k heap, evicting a document that genuinely belongs there.
+#[test]
+fn a_duplicate_must_not_evict_a_genuine_result_from_top_k() {
+    let term_postings = cancelling_term_postings();
+
+    // Truth: doc 1 = 5.0, doc 0 = 1.0 - 1.0 + 2.0 = 2.0, doc 2 = 1.5.
+    let dense = linear_scan_dense(3, 2, &term_postings);
+
+    let ids: Vec<u64> = dense.iter().map(|r| r.doc_id).collect();
+    assert_eq!(
+        ids,
+        vec![1, 0, 2],
+        "top-3 must hold three distinct documents, got {ids:?}"
+    );
+}
+
+#[test]
+fn both_accumulators_agree_on_a_plain_positive_query() {
+    let term_postings = vec![
+        (1.0, vec![entry(0, 1.0), entry(2, 3.0)]),
+        (0.5, vec![entry(1, 4.0), entry(2, 2.0)]),
+    ];
+
+    let dense = linear_scan_dense(10, 2, &term_postings);
+    let hashmap = linear_scan_hashmap(10, &term_postings);
+
+    assert_eq!(as_pairs(&dense), as_pairs(&hashmap));
+}

--- a/crates/velesdb-core/tests/pq_adc_e2e_tests.rs
+++ b/crates/velesdb-core/tests/pq_adc_e2e_tests.rs
@@ -344,3 +344,62 @@ fn test_pq_empty_collection_search_returns_empty() {
         "search on empty collection must return empty results"
     );
 }
+
+/// GIVEN: A Hamming or Jaccard collection with vectors
+/// WHEN:  `TRAIN QUANTIZER ... TYPE opq` is executed
+/// THEN:  Training is refused, and plain PQ still works
+///
+/// OPQ stores codes in a rotated basis and the rescore path rotates the query
+/// to match. A rotation preserves inner products and norms, so cosine,
+/// Euclidean and dot product survive it; Hamming and Jaccard are defined
+/// component by component on the original axes and do not. The combination
+/// used to be accepted, and every later rescore measured the metric in a
+/// space where it means nothing.
+#[test]
+fn test_opq_training_refused_on_metrics_a_rotation_does_not_preserve() {
+    for (name, metric) in [
+        ("opq_hamming", DistanceMetric::Hamming),
+        ("opq_jaccard", DistanceMetric::Jaccard),
+    ] {
+        let (_dir, db) = create_test_db();
+        db.create_collection(name, 16, metric)
+            .expect("test: create collection");
+        insert_vectors(&db, name, &generate_vectors(64, 16, 7));
+
+        let err = execute_sql(
+            &db,
+            &format!("TRAIN QUANTIZER ON {name} WITH (type='opq', m=4, k=8)"),
+        )
+        .expect_err("OPQ on a rotation-sensitive metric must be refused");
+        let message = err.to_string();
+        assert!(
+            message.contains("OPQ"),
+            "{metric:?}: the error must name OPQ as the problem, got: {message}"
+        );
+
+        // Plain PQ has no rotation, so it stays available for these metrics.
+        execute_sql(&db, &format!("TRAIN QUANTIZER ON {name} WITH (m=4, k=8)"))
+            .unwrap_or_else(|e| panic!("{metric:?}: plain PQ must still train: {e}"));
+    }
+}
+
+/// OPQ remains available on the metrics a rotation does preserve.
+#[test]
+fn test_opq_training_accepted_on_rotation_invariant_metrics() {
+    for (name, metric) in [
+        ("opq_cosine", DistanceMetric::Cosine),
+        ("opq_euclidean", DistanceMetric::Euclidean),
+        ("opq_dot", DistanceMetric::DotProduct),
+    ] {
+        let (_dir, db) = create_test_db();
+        db.create_collection(name, 16, metric)
+            .expect("test: create collection");
+        insert_vectors(&db, name, &generate_vectors(64, 16, 11));
+
+        execute_sql(
+            &db,
+            &format!("TRAIN QUANTIZER ON {name} WITH (type='opq', m=4, k=8)"),
+        )
+        .unwrap_or_else(|e| panic!("{metric:?}: OPQ must remain available: {e}"));
+    }
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/2106-live-scoring-and-metrics` → **`develop`**.

## Description

Six defects from the #2106 cross-reference, each one a computation that returns
a wrong number (or reaches an unsafe kernel without the check its contract
asks for) while every existing test stays green. None of them failed anything
before this branch; each now has a guard that was proved red against the
unfixed tree first.

Refs #2106 — this is the first batch of that issue's live findings, not all of
them, so the issue stays open.

| Defect | Effect | Reachable from |
|---|---|---|
| `linear_scan_dense` inferred membership from `scores[idx] == 0.0` | a document returned twice, evicting a genuine top-k result | any sparse query with a negative weight |
| both ms histograms bucketed `ms < bound` under inclusive `le` labels | boundary observations counted one bucket too high | every Prometheus scrape |
| `PathScorer::score_rel_types` compounded `decay^(n(n+1)/2)` | 9× divergence from `score_length` at five hops | public API |
| `CpuDistance` implemented different Hamming/Jaccard formulas | a SIMD parity failure and a reference bug look identical | test baseline only |
| `train_opq` had no metric guard | Hamming/Jaccard rescored in a rotated basis | `TRAIN QUANTIZER ... TYPE opq` |
| `detect_simd_level` granted `Avx512` on `avx512f` alone | AVX2 `target_feature` kernels called unchecked | x86 with masked CPUID |

### The sparse duplicate, in detail

`linear_scan_dense` decided "have I recorded this document?" by testing whether
its accumulated score was still zero. The score is a fact about arithmetic, not
about the scan: a negative query weight drives it back to exactly zero, and the
next term's posting then records the document a second time. `sparse_search`
routes negative-weight queries to this scan deliberately (the MaxScore upper
bound is invalid for them), and the shape producing exact cancellation — "like
A but not B", where both sides carry a shared term at the same weight — is why
someone writes one.

The duplicate takes a slot in the top-k heap, so on a three-document fixture
the correct `[1, 0, 2]` came back as `[1, 0, 0]`. `linear_scan_hashmap`, the
variant the router picks for sparse ID spaces, cannot produce it; the two
accumulators are chosen on cache-footprint grounds and are meant to be
interchangeable, so this was a parity break as well.

### Scope notes

- `PathScorer` is public API with no internal caller, so its scores change for
  direct library consumers. The old form contradicted the `distance_decay`
  field doc and `score_length`, and nothing in the tree argued for it.
- The OPQ rule is enforced at training *and* at open-time restore, because a
  codebook written before the guard is still on disk somewhere. Restore
  degrades to exact f32 rather than dropping just the rotation — the codes
  themselves live in the rotated basis, so dropping it is not a repair.
- The AVX-512 narrowing is a no-op on every physical CPU (all shipping AVX-512
  parts advertise AVX2 and FMA). It matters where CPUID is masked, and it makes
  the fall-through sound by construction rather than by an ISA claim in a
  comment.
- `simd_distance_for_metric` is deleted: zero callers, and its `dead_code`
  justification named one it never had.

Two characterization tests recorded the old behaviour and are corrected rather
than kept — `test_metrics_latency_buckets` ("strict < skips the le=50 bound at
idx 4") and `test_hamming_scalar_all_different`. Both described a mechanism
without ever arguing it was right, so neither is a recorded decision under
principle 8.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change — `PathScorer::score_rel_types` returns different
      values for multi-hop paths, and `TRAIN QUANTIZER ... TYPE opq` now errors
      on Hamming/Jaccard collections instead of succeeding wrongly

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

Every guard was proved red first. The two whose red state was not
self-evident were verified by disabling the fix and re-running:

- `test_opq_training_refused_on_metrics_a_rotation_does_not_preserve` — fails
  without the `train_opq` guard.
- `a_rotated_codebook_is_refused_on_a_rotation_sensitive_metric` — fails
  without the restore guard. Its first draft passed for the wrong reason:
  restore is gated on `StorageMode::ProductQuantization`, which the fixture did
  not set, so `restore_persisted_pq` never ran. The fixture now flips the mode
  and a companion test pins that a rotated codebook *does* still install on
  cosine, Euclidean and dot product.

Run locally, all green:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic
cargo clippy -p velesdb-node --lib -- -D warnings
PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib -- -D warnings
cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check \
  -- -A warnings -D clippy::undocumented_unsafe_blocks
cargo test -p velesdb-core --features persistence -- --test-threads=1   # 60 binaries, 0 failed
cargo test --doc --package velesdb-core                                 # 50 passed, 42 ignored
cargo check --no-default-features
cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
cargo check -p velesdb-memory  (x4 feature shapes)
python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .
python3 scripts/check-{version-sync,feature-claims,perf-claims,promise-contract,
  mcp-doc-contract,skill-private-references,inline-tests,file-budgets,
  prod-unwraps,todo-annotations,durability-barrier,ai-attribution}.py
bash scripts/check-doc-contract.sh
python3 scripts/check-doc-freshness.py --guard {stamp,index,tracked,versions,decisions} --mode strict
```

`tauri-plugin-velesdb` was excluded from the clippy and `--no-default-features`
sweeps: it needs GTK system libraries (`gdk-3.0`) that are absent in this
environment. Nothing in this diff touches it.

**Test Configuration:**
- OS: Linux x86_64 (AVX-512F + AVX2 + FMA, so the AVX-512 dispatch arms are the
  ones exercised)
- Rust version: workspace MSRV toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` block is added or removed. Three `SAFETY` comments are rewritten:
they justified calling `avx2` `target_feature` kernels with "Avx512 implies
Avx2 support", which CPUID does not guarantee. They now cite
`detect_simd_level`, which does establish it.

- [x] All `unsafe fn` have `# Safety` documentation describing preconditions
- [x] All `unsafe {}` blocks have `// SAFETY:` comments explaining why it's sound
- [x] No undefined behavior possible with valid inputs
- [x] Edge cases tested (empty, boundary values, alignment)

## High-Risk Change Checklist

Touches SIMD dispatch and the HNSW distance engines.

- [x] I listed the invariants impacted by this change:
  - every non-scalar x86 `SimdLevel` implies `avx2` + `fma` (new, and pinned by
    a test that asserts it on whatever CPU runs the suite)
  - `CpuDistance` and `CachedSimdDistance` agree on all metrics except
    Euclidean, where the hot path returns squared L2 on purpose
  - the two linear-scan accumulators are observationally identical
  - a Prometheus `le` label names the bucket an observation actually landed in
  - an OPQ rotation is only ever installed on a rotation-invariant metric
- [x] Crash/durability semantics unchanged — no write path is touched.
- [x] Lifecycle test added: open-time quantizer restore, both directions.
- [ ] I requested review from at least 2 maintainers/reviewers for this risky
      path.

## Additional Notes

Findings from the same sweep deliberately **not** in this batch:

- `2106-1-cosine-range` (HNSW clamps cosine to `[0,1]`, exact and GPU paths
  return `[-1,1]`) — a score-contract decision across three paths, too broad to
  fold in here.
- `2106-4` and `2106-5` (NEON Jaccard NaN divergence, unclamped
  `cosine_neon_safe`) — aarch64-only; this environment cannot execute them, and
  pushing an unvalidated SIMD change is not worth the cycle.
- `2106-6` (RRF divide-by-zero) and `2106-7` (`BoostCombination::Max` identity)
  — unreachable, and frozen by a recorded decision in
  `tests/bdd/fusion_weighted_bug.rs`. Principle 8 applies.