### PR TITLE
fix(hnsw): cosine scores lost their sign on the graph path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Cosine search scores keep their sign, on every path.** `transform_score`
+  on the HNSW graph path shared one match arm with Jaccard and clamped to
+  `[0, 1]`, so a genuinely negative cosine came back as exactly `0.0` — while
+  brute force, the exact rerank and `DistanceMetric::calculate` all returned
+  the cosine itself. Which path runs is not something the caller chooses: it
+  falls out of corpus size (≤ 100 points goes brute force), `SearchQuality`,
+  and even `k` (the rerank stage needs `len() > k * 2`). The same index and
+  query returned `-0.557` at `k=10` and `0.0` at `k=80`.
+
+  The two ranges also met inside a single result list. `merge_delta`
+  concatenates HNSW results with delta-buffer results scored through
+  `calculate` and sorts them together, so a freshly written point at true
+  cosine `-0.2` sorted *below* an indexed point at `-0.5` that had been
+  clamped to zero; VelesQL's `Parallel` execution strategy merges a scan leg
+  and an HNSW leg the same way. And because every dissimilar document
+  clamped to the same `0.0`, the ordering among anti-correlated matches was
+  not merely wrong — it was gone.
+
+  The range now has one definition, `DistanceMetric::score_range`, with
+  `clamp_score` applying it; the graph path and the GPU rerank derive from it
+  instead of each carrying a table. Cosine is `[-1, 1]`, Jaccard keeps its
+  true `[0, 1]` floor, and the unbounded metrics declare no range. The GPU
+  path's local table needed a `_ =>` catch-all; `score_range` matches every
+  variant, so a new metric now fails to compile rather than silently landing
+  in the wildcard. Two tests that had written the old range down as a rule
+  are corrected to state what is actually true of their fixtures.
+
+  Restoring the sign exposed a heuristic the clamp had been hiding.
+  `search_adaptive` decides whether to widen `ef` from the first/last score
+  gap divided by `min(|first|, |last|)` — a baseline that assumes zero is the
+  metric's floor. It is, for an unbounded distance. On a similarity over
+  `[-1, 1]` zero sits mid-range, so a merely mediocre tail of `-0.01` against
+  a `0.9` top reads as a spread of 91 and escalates a query that is not hard.
+  Cosine never hit that only because every non-positive score clamped to
+  exactly `0.0`, which made the baseline zero and the guard fail: phase 2 had
+  never escalated on this metric at all. The baseline is now the tail's
+  distance from `score_range`'s floor, which is unchanged for the unbounded
+  metrics (whose floor is zero) and keeps easy cosine queries cheap while
+  still escalating a genuinely heterogeneous neighbourhood. The rule moved
+  into a pure `should_escalate` so it is testable rather than inlined
+  arithmetic. (#2106)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/search_tests.rs
@@ -206,9 +206,17 @@ fn test_search_ids_returns_id_score_pairs() {
     assert_eq!(results.len(), 3);
     // Exact match (id=1) should be closest.
     assert_eq!(results[0].id, 1);
-    // Scores should be non-negative for cosine distance.
+    // Cosine spans [-1, 1]; these fixture vectors all sit in the non-negative
+    // orthant, so *their* cosines cannot be negative. The bound is a property
+    // of this fixture, not of the metric — asserting it as a metric contract
+    // is how the graph path's `[0, 1]` clamp went unnoticed.
     for r in &results {
-        assert!(r.score >= 0.0, "cosine scores should be non-negative");
+        assert!(
+            r.score >= 0.0,
+            "non-negative fixture vectors cannot yield a negative cosine, got {}",
+            r.score
+        );
+        assert!(r.score <= 1.0, "cosine cannot exceed 1, got {}", r.score);
     }
 }
 

--- a/crates/velesdb-core/src/distance.rs
+++ b/crates/velesdb-core/src/distance.rs
@@ -172,6 +172,45 @@ impl DistanceMetric {
         }
     }
 
+    /// The closed range this metric's user-visible scores occupy, or `None`
+    /// when the metric is unbounded.
+    ///
+    /// This is the one definition of the score contract. A caller cannot tell
+    /// which path produced its results — `HnswIndex` reaches a score through
+    /// brute force, through the exact rerank, or through the graph's
+    /// `transform_score`, chosen by corpus size, quality and `k` — so those
+    /// paths must not each carry their own table. They derive from this one.
+    ///
+    /// - **Cosine** is `[-1, 1]`. An anti-correlated pair has a genuinely
+    ///   negative similarity; flooring it at zero does not merely lose the
+    ///   sign, it ties every anti-correlated match at one value and destroys
+    ///   the ordering among them.
+    /// - **Jaccard** is `[0, 1]`: `intersection / union` over non-negative
+    ///   weights cannot go below zero.
+    /// - **Euclidean**, **Hamming** and **`DotProduct`** are unbounded — a
+    ///   distance grows with the data, and an inner product is not normalized.
+    #[must_use]
+    pub const fn score_range(&self) -> Option<(f32, f32)> {
+        match self {
+            Self::Cosine => Some((-1.0, 1.0)),
+            Self::Jaccard => Some((0.0, 1.0)),
+            Self::Euclidean | Self::Hamming | Self::DotProduct => None,
+        }
+    }
+
+    /// Clamps `score` into [`Self::score_range`], leaving unbounded metrics
+    /// untouched.
+    ///
+    /// Absorbs floating-point drift at the boundary without moving a value
+    /// that is genuinely inside the range.
+    #[must_use]
+    pub fn clamp_score(&self, score: f32) -> f32 {
+        match self.score_range() {
+            Some((low, high)) => score.clamp(low, high),
+            None => score,
+        }
+    }
+
     /// Sorts search results by distance/similarity according to the metric.
     ///
     /// - **Similarity metrics** (`Cosine`, `DotProduct`, `Jaccard`): sorts descending (higher = better)

--- a/crates/velesdb-core/src/distance_tests.rs
+++ b/crates/velesdb-core/src/distance_tests.rs
@@ -297,3 +297,147 @@ fn test_parse_ip_alias() {
         Some(DistanceMetric::DotProduct)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Score contract (`score_range` / `clamp_score`)
+// ---------------------------------------------------------------------------
+
+/// The declared range must match what `calculate` can actually produce.
+///
+/// These two travelled separately once: `transform_score` on the HNSW path
+/// floored cosine at 0.0 while `calculate` returned the real cosine, so the
+/// same document scored differently depending on which path ranked it.
+#[test]
+fn score_range_matches_what_calculate_produces() {
+    let aligned = vec![1.0_f32, 0.0, 0.0];
+    let opposed = vec![-1.0_f32, 0.0, 0.0];
+
+    let cosine = DistanceMetric::Cosine.calculate(&aligned, &opposed);
+    let (low, high) = DistanceMetric::Cosine
+        .score_range()
+        .expect("cosine is a bounded metric");
+    assert!(
+        (cosine - low).abs() < 1e-6,
+        "opposed vectors must reach the declared floor {low}, got {cosine}"
+    );
+    assert!((high - 1.0).abs() < f32::EPSILON);
+
+    // Jaccard over non-negative weights cannot go below zero.
+    let disjoint_a = vec![1.0_f32, 0.0];
+    let disjoint_b = vec![0.0_f32, 1.0];
+    let jaccard = DistanceMetric::Jaccard.calculate(&disjoint_a, &disjoint_b);
+    let (j_low, j_high) = DistanceMetric::Jaccard
+        .score_range()
+        .expect("jaccard is a bounded metric");
+    assert!((j_low - 0.0).abs() < f32::EPSILON);
+    assert!((j_high - 1.0).abs() < f32::EPSILON);
+    assert!(jaccard >= j_low && jaccard <= j_high);
+}
+
+/// Cosine keeps its sign; Jaccard keeps its floor.
+#[test]
+fn clamp_score_respects_each_metrics_own_floor() {
+    assert!((DistanceMetric::Cosine.clamp_score(-0.5) + 0.5).abs() < f32::EPSILON);
+    assert!(DistanceMetric::Jaccard.clamp_score(-0.5).abs() < f32::EPSILON);
+}
+
+/// Drift past a boundary is absorbed; a value inside the range is untouched.
+#[test]
+fn clamp_score_absorbs_boundary_drift_without_moving_interior_values() {
+    assert!((DistanceMetric::Cosine.clamp_score(1.000_001) - 1.0).abs() < f32::EPSILON);
+    assert!((DistanceMetric::Cosine.clamp_score(-1.000_001) + 1.0).abs() < f32::EPSILON);
+    assert!((DistanceMetric::Cosine.clamp_score(0.25) - 0.25).abs() < f32::EPSILON);
+}
+
+/// An unbounded metric is passed through, not squeezed into someone's range.
+#[test]
+fn clamp_score_leaves_unbounded_metrics_alone() {
+    for metric in [
+        DistanceMetric::Euclidean,
+        DistanceMetric::Hamming,
+        DistanceMetric::DotProduct,
+    ] {
+        assert!(
+            metric.score_range().is_none(),
+            "{metric:?} is unbounded and must declare no range"
+        );
+        for value in [-42.0_f32, 0.0, 1.5, 9_000.0] {
+            assert!(
+                (metric.clamp_score(value) - value).abs() < f32::EPSILON,
+                "{metric:?} must pass {value} through unchanged"
+            );
+        }
+    }
+}
+
+/// On in-contract input, a bounded metric's `calculate` already lands inside
+/// its declared range, so the clamp is the identity.
+///
+/// "In contract" differs per metric and that is the point: cosine is defined
+/// for any real vector, so an anti-correlated pair belongs in its set;
+/// Jaccard is defined over set-like (non-negative) weights, so it gets
+/// non-negative pairs. See
+/// [`jaccard_calculate_escapes_its_declared_range_on_negative_weights`] for
+/// what happens outside that contract.
+#[test]
+fn clamp_score_is_the_identity_on_real_calculate_output() {
+    let cosine_pairs: [(&[f32], &[f32]); 4] = [
+        (&[1.0, 0.0, 0.0], &[1.0, 0.0, 0.0]),
+        (&[1.0, 0.0, 0.0], &[-1.0, 0.0, 0.0]),
+        (&[1.0, 2.0, 3.0], &[3.0, 2.0, 1.0]),
+        (&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]),
+    ];
+    let jaccard_pairs: [(&[f32], &[f32]); 4] = [
+        (&[1.0, 0.0, 0.0], &[1.0, 0.0, 0.0]),
+        (&[1.0, 0.0, 0.0], &[0.0, 1.0, 0.0]),
+        (&[1.0, 2.0, 3.0], &[3.0, 2.0, 1.0]),
+        (&[0.0, 0.0, 0.0], &[0.0, 0.0, 0.0]),
+    ];
+
+    for (metric, pairs) in [
+        (DistanceMetric::Cosine, cosine_pairs),
+        (DistanceMetric::Jaccard, jaccard_pairs),
+    ] {
+        for (a, b) in pairs {
+            let raw = metric.calculate(a, b);
+            let clamped = metric.clamp_score(raw);
+            assert!(
+                (raw - clamped).abs() < f32::EPSILON,
+                "{metric:?} produced {raw} on {a:?} vs {b:?}, outside its declared range"
+            );
+        }
+    }
+}
+
+/// Jaccard's kernels do not enforce their own range on out-of-contract input.
+///
+/// `jaccard_scalar` is `intersection / union` with no clamp, where
+/// `cosine_scalar` ends in `.clamp(-1.0, 1.0)` — the asymmetry is visible in
+/// the same file. Feed a negative weight (meaningless for a set-like metric,
+/// but nothing rejects it at insert) and `calculate` returns -1.0 while the
+/// HNSW graph path, which goes through `transform_score` -> `clamp_score`,
+/// returns 0.0. That is the same shape of path disagreement this module's
+/// score contract exists to prevent, one metric over.
+///
+/// Closing it means clamping inside the Jaccard kernels on all three ISAs
+/// (scalar, AVX2/AVX-512, NEON); this test pins the current behaviour so the
+/// gap is a live, named fact rather than a silent one, and fails loudly the
+/// moment someone fixes it.
+#[test]
+fn jaccard_calculate_escapes_its_declared_range_on_negative_weights() {
+    let positive = vec![1.0_f32, 0.0, 0.0];
+    let negative = vec![-1.0_f32, 0.0, 0.0];
+
+    let raw = DistanceMetric::Jaccard.calculate(&positive, &negative);
+    let (low, _) = DistanceMetric::Jaccard
+        .score_range()
+        .expect("jaccard is bounded");
+
+    assert!(
+        raw < low,
+        "expected the known unclamped kernel output below the declared floor {low}, got {raw}"
+    );
+    // The declared contract still holds wherever `clamp_score` is applied,
+    // which is what every score-producing path now routes through.
+    assert!((DistanceMetric::Jaccard.clamp_score(raw) - low).abs() < f32::EPSILON);
+}

--- a/crates/velesdb-core/src/index/hnsw/index/rerank.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/rerank.rs
@@ -161,18 +161,17 @@ impl HnswIndex {
     /// slightly outside their theoretical range. Clamping guarantees
     /// downstream assertions and comparisons are never violated.
     ///
-    /// Only Cosine ([-1, 1]) and Jaccard ([0, 1]) are bounded.
-    /// DotProduct, Euclidean, and Hamming are unbounded.
+    /// Which metrics are bounded, and to what, is
+    /// [`DistanceMetric::score_range`]'s to say — this path needs a clamp for
+    /// its own reason (GPU rounding) but must not carry a second copy of the
+    /// range table, or the two drift and the same document scores differently
+    /// depending on which engine ranked it. The wildcard arm the local table
+    /// needed is gone with it: `score_range` matches every variant, so adding
+    /// a metric fails to compile there instead of silently landing in `_`.
     #[cfg(feature = "gpu")]
     #[inline]
     pub(crate) fn clamp_score_for_metric(&self, score: f32) -> f32 {
-        use crate::distance::DistanceMetric;
-        match self.metric {
-            DistanceMetric::Cosine => score.clamp(-1.0, 1.0),
-            DistanceMetric::Jaccard => score.clamp(0.0, 1.0),
-            // DotProduct, Euclidean, Hamming: unbounded
-            _ => score,
-        }
+        self.metric.clamp_score(score)
     }
 
     /// Re-ranks candidates using GPU batch distance computation.

--- a/crates/velesdb-core/src/index/hnsw/index/search.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search.rs
@@ -429,23 +429,11 @@ impl HnswIndex {
 
         // Check result spread to determine if this is a hard query.
         // Use first/last scores -- ordering differs by metric (similarity=desc,
-        // distance=asc) so we take the absolute spread.
+        // distance=asc) so the spread is taken as an absolute gap.
         let score_a = results.first().map_or(0.0, |r| r.score);
         let score_b = results.last().map_or(0.0, |r| r.score);
-        let diff = (score_a - score_b).abs();
 
-        // Relative spread: normalize by the smaller absolute score to handle
-        // both similarity metrics (high scores) and distance metrics (low scores).
-        let baseline = score_a.abs().min(score_b.abs());
-        let spread = if baseline > f32::EPSILON {
-            diff / baseline
-        } else {
-            diff
-        };
-
-        // Threshold 2.0: empirically tuned. Easy queries have spread < 1.0,
-        // hard queries typically > 3.0.
-        if spread < 2.0 {
+        if !should_escalate(self.metric, score_a, score_b) {
             return results;
         }
 
@@ -479,3 +467,42 @@ impl HnswIndex {
         inner.set_searching_mode(true);
     }
 }
+
+/// Spread above which `search_adaptive` widens `ef` and runs a second pass.
+///
+/// Empirically tuned: easy queries sit below 1.0, hard ones above 3.0.
+const ESCALATION_SPREAD_THRESHOLD: f32 = 2.0;
+
+/// Whether the phase-1 result spread marks this as a hard query.
+///
+/// The spread is the first/last score gap relative to a baseline, and the
+/// baseline is the tail's distance from **the metric's floor**, not from zero.
+/// Zero is the floor only for an unbounded distance. On a bounded similarity
+/// it sits in the middle of the range, so `|score|` collapses toward zero for
+/// a merely mediocre tail and the ratio explodes on a query that is not hard
+/// at all — a cosine tail of `-0.01` against a `0.9` top would read as a
+/// spread of 91.
+///
+/// Cosine never reached that trap before, for the wrong reason: the graph
+/// path clamped every non-positive score to exactly `0.0`, so `baseline` was
+/// zero, the guard below failed, and phase 2 never escalated on this metric at
+/// all. Restoring cosine's sign is what makes the baseline matter, and taking
+/// the floor from [`DistanceMetric::score_range`] keeps easy queries cheap
+/// while letting a genuinely heterogeneous neighbourhood escalate.
+fn should_escalate(metric: DistanceMetric, first: f32, last: f32) -> bool {
+    let diff = (first - last).abs();
+    let baseline = match metric.score_range() {
+        Some((low, _)) => first.min(last) - low,
+        None => first.abs().min(last.abs()),
+    };
+    let spread = if baseline > f32::EPSILON {
+        diff / baseline
+    } else {
+        diff
+    };
+    spread >= ESCALATION_SPREAD_THRESHOLD
+}
+
+#[cfg(test)]
+#[path = "search_tests.rs"]
+mod tests;

--- a/crates/velesdb-core/src/index/hnsw/index/search_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/search_tests.rs
@@ -1,0 +1,67 @@
+//! Tests for the adaptive-search escalation rule.
+
+use super::should_escalate;
+use crate::distance::DistanceMetric;
+
+/// A cosine tail that merely lands near zero is not a hard query.
+///
+/// Under a baseline of `min(|first|, |last|)` this reads as a spread of ~91
+/// and escalates; measured from cosine's own floor of `-1.0` it is ~0.92 and
+/// correctly does not. Every `Adaptive`/`AutoTune` query whose result tail
+/// crosses zero would otherwise pay a second traversal.
+#[test]
+fn a_cosine_tail_near_zero_is_not_a_hard_query() {
+    assert!(
+        !should_escalate(DistanceMetric::Cosine, 0.9, -0.01),
+        "a 0.9 -> -0.01 spread is ordinary for cosine and must not escalate"
+    );
+    // What the zero-based baseline would have computed, for contrast.
+    let naive = (0.9_f32 - -0.01).abs() / 0.9_f32.abs().min(0.01);
+    assert!(
+        naive > 2.0,
+        "the zero-based baseline really would have escalated here ({naive})"
+    );
+}
+
+/// A genuinely heterogeneous cosine neighbourhood still escalates.
+#[test]
+fn a_wide_cosine_neighbourhood_escalates() {
+    assert!(should_escalate(DistanceMetric::Cosine, 0.95, -0.9));
+}
+
+/// A tightly clustered cosine result set does not.
+#[test]
+fn a_tight_cosine_neighbourhood_does_not_escalate() {
+    assert!(!should_escalate(DistanceMetric::Cosine, 0.95, 0.90));
+}
+
+/// Unbounded distance metrics keep the original zero-based relative spread.
+///
+/// Zero *is* the floor for a distance, so nothing changes for these: the ratio
+/// is the meaningful quantity because the scale is set by the data.
+#[test]
+fn unbounded_metrics_keep_the_zero_based_relative_spread() {
+    // A 1.0 -> 100.0 Euclidean gap is a 99x ratio: hard.
+    assert!(should_escalate(DistanceMetric::Euclidean, 1.0, 100.0));
+    // 10.0 -> 11.0 is a 0.1 ratio: easy.
+    assert!(!should_escalate(DistanceMetric::Euclidean, 10.0, 11.0));
+    assert!(should_escalate(DistanceMetric::Hamming, 1.0, 64.0));
+}
+
+/// Jaccard's floor is zero, so its baseline is unchanged by the floor rule.
+#[test]
+fn jaccard_floor_is_zero_so_its_baseline_is_unchanged() {
+    // 0.9 -> 0.1 : baseline 0.1, spread 8 — hard either way.
+    assert!(should_escalate(DistanceMetric::Jaccard, 0.9, 0.1));
+    // 0.9 -> 0.5 : baseline 0.5, spread 0.8 — easy either way.
+    assert!(!should_escalate(DistanceMetric::Jaccard, 0.9, 0.5));
+}
+
+/// A degenerate all-equal result set must not divide by zero into an escalation.
+#[test]
+fn an_all_equal_result_set_does_not_escalate() {
+    assert!(!should_escalate(DistanceMetric::Cosine, 0.5, 0.5));
+    assert!(!should_escalate(DistanceMetric::Euclidean, 0.0, 0.0));
+    // Cosine pinned at its floor: baseline 0, diff 0 — still no escalation.
+    assert!(!should_escalate(DistanceMetric::Cosine, -1.0, -1.0));
+}

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter.rs
@@ -367,21 +367,26 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 
     /// Transforms raw distance to appropriate score based on metric type.
     ///
-    /// - **Cosine**: `(1.0 - distance).clamp(0.0, 1.0)` (similarity in `[0,1]`)
+    /// - **Cosine** and **Jaccard**: `1.0 - distance`, clamped through
+    ///   [`DistanceMetric::clamp_score`]. The engine traverses on
+    ///   `1 - similarity` for both, and `DistanceMetric::higher_is_better()`
+    ///   declares both similarities, so every downstream sort/top-k/merge
+    ///   expects the similarity back — but the two do **not** share a range,
+    ///   and taking it from the metric is what keeps this path agreeing with
+    ///   brute force and the exact rerank. Flooring cosine at zero, as a
+    ///   shared arm with Jaccard once did, tied every anti-correlated match at
+    ///   `0.0` and made the score depend on which path `k` happened to select.
     /// - **Euclidean**: `sqrt(raw_distance)` — the search loop stores squared L2
     ///   to skip redundant sqrt during traversal; this restores the actual
     ///   Euclidean distance for user-visible scores.
     /// - **Hamming**: raw distance (lower is better)
-    /// - **Jaccard**: `(1.0 - distance).clamp(0.0, 1.0)` — the engine traverses
-    ///   on `1 - jaccard`, but `DistanceMetric::higher_is_better()` declares
-    ///   Jaccard a similarity, so every downstream sort/top-k/merge expects
-    ///   the similarity back (same contract as Cosine).
     /// - **DotProduct**: `-distance` (negated for consistency)
     #[must_use]
     pub fn transform_score(&self, raw_distance: f32) -> f32 {
-        match self.distance.metric() {
+        let metric = self.distance.metric();
+        match metric {
             DistanceMetric::Cosine | DistanceMetric::Jaccard => {
-                (1.0 - raw_distance).clamp(0.0, 1.0)
+                metric.clamp_score(1.0 - raw_distance)
             }
             // Reason: CachedSimdDistance stores squared L2 during HNSW traversal
             // to avoid per-comparison sqrt. Apply sqrt here on the final k results.

--- a/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/backend_adapter_tests.rs
@@ -126,9 +126,27 @@ fn test_transform_score_cosine() {
     let engine = CachedSimdDistance::new(DistanceMetric::Cosine, 32);
     let hnsw = NativeHnsw::new(engine, 16, 100, 100);
 
-    // Cosine: similarity = 1 - distance
+    // Cosine: similarity = 1 - distance, over the metric's own [-1, 1].
     assert!((hnsw.transform_score(0.3) - 0.7).abs() < f32::EPSILON);
-    assert!((hnsw.transform_score(1.5) - 0.0).abs() < f32::EPSILON); // clamped
+    // A raw distance above 1.0 means the pair is anti-correlated. The
+    // similarity is genuinely negative and keeps its sign; flooring it at 0.0
+    // here (a shared match arm with Jaccard once did) tied every
+    // anti-correlated match at zero and disagreed with the brute-force and
+    // rerank paths, which have always returned the cosine itself.
+    assert!((hnsw.transform_score(1.5) - (-0.5)).abs() < f32::EPSILON);
+    // The clamp still absorbs drift past the true bound.
+    assert!((hnsw.transform_score(2.5) - (-1.0)).abs() < f32::EPSILON);
+}
+
+#[test]
+fn test_transform_score_jaccard_keeps_its_zero_floor() {
+    let engine = CachedSimdDistance::new(DistanceMetric::Jaccard, 32);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+
+    // Jaccard is intersection/union: it cannot go below zero, so unlike
+    // cosine its floor at 0.0 is the metric's real bound, not a lost sign.
+    assert!((hnsw.transform_score(0.3) - 0.7).abs() < f32::EPSILON);
+    assert!((hnsw.transform_score(1.5) - 0.0).abs() < f32::EPSILON);
 }
 
 #[test]

--- a/crates/velesdb-core/src/index/hnsw/native/sq8_precision_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/sq8_precision_tests.rs
@@ -191,7 +191,11 @@ fn test_sq8_install_refused_on_unsupported_metric() {
 
 /// The query and the codes must both live in the normalized (stored) vector
 /// space, the rerank must sort by similarity (higher = better), and scores
-/// must be clamped to [0, 1].
+/// must land inside cosine's own range.
+///
+/// That range is `[-1, 1]`, not `[0, 1]`: this fixture's planted neighbours
+/// are all strongly correlated with the query, so its scores happen to be
+/// positive, but that is a property of the planting, not of the metric.
 #[test]
 fn test_int8_cosine_rerank_keeps_best_candidates() {
     let (dim, k) = (32, 10);
@@ -207,10 +211,18 @@ fn test_int8_cosine_rerank_keeps_best_candidates() {
         DistanceMetric::Cosine,
         k,
     );
+    let (low, high) = DistanceMetric::Cosine
+        .score_range()
+        .expect("test: cosine is a bounded metric");
     for (id, score) in &results {
         assert!(
-            (0.0..=1.0).contains(score),
-            "Cosine score for node {id} should be in [0,1], got {score}"
+            (low..=high).contains(score),
+            "Cosine score for node {id} should be in [{low},{high}], got {score}"
+        );
+        assert!(
+            *score > 0.0,
+            "this fixture plants correlated neighbours, so node {id} should \
+             score positively; got {score}"
         );
     }
 }

--- a/crates/velesdb-core/tests/cosine_score_range_tests.rs
+++ b/crates/velesdb-core/tests/cosine_score_range_tests.rs
@@ -1,0 +1,288 @@
+#![cfg(feature = "persistence")]
+//! The cosine score contract: one range, whichever path produced it.
+//!
+//! `HnswIndex` reaches a user-visible score down three different paths and they
+//! must agree, because the caller cannot tell which one ran:
+//!
+//! - `search_brute_force` -> `compute_distance` -> `cosine_similarity_native`,
+//!   taken for `SearchQuality::Perfect` and for any index of 100 vectors or
+//!   fewer;
+//! - `rerank_candidates_simd` -> `compute_distance`, taken when
+//!   `len() > k * 2` with vector storage on;
+//! - `search_hnsw_only` -> `NativeHnsw::transform_score`, taken otherwise.
+//!
+//! The first two return the cosine itself, in `[-1, 1]`. The third used to
+//! share a match arm with Jaccard and clamp to `[0, 1]`, so every genuinely
+//! negative cosine collapsed to exactly `0.0` — losing the sign and, worse,
+//! the ordering among anti-correlated results, which all tied at zero.
+//!
+//! Nothing about the query says which path runs. `k` alone decides between the
+//! second and the third.
+
+#![allow(clippy::cast_precision_loss)]
+
+use velesdb_core::index::hnsw::SearchQuality;
+use velesdb_core::index::{HnswIndex, VectorIndex};
+use velesdb_core::scored_result::ScoredResult;
+use velesdb_core::DistanceMetric;
+
+const DIM: usize = 16;
+/// Above the 100-vector brute-force cutoff, so the graph paths are in play.
+const CORPUS: u64 = 150;
+
+/// The query direction: the first basis vector.
+fn query() -> Vec<f32> {
+    let mut q = vec![0.0_f32; DIM];
+    q[0] = 1.0;
+    q
+}
+
+/// Vector `i` points away from the query, with a cosine that rises toward zero
+/// as `i` grows: `cos_i = -1 / sqrt(1 + (i/100)^2)`.
+///
+/// Every vector in the corpus is anti-correlated, and no two share a cosine, so
+/// a clamp at zero does not merely change a sign — it makes the whole corpus
+/// tie, and top-k becomes an arbitrary pick among 150 equal scores.
+fn anti_correlated(i: u64) -> Vec<f32> {
+    let mut v = vec![0.0_f32; DIM];
+    v[0] = -1.0;
+    v[1] = i as f32 / 100.0;
+    v
+}
+
+fn expected_cosine(i: u64) -> f32 {
+    let t = i as f32 / 100.0;
+    -1.0 / (1.0 + t * t).sqrt()
+}
+
+fn build() -> HnswIndex {
+    let index = HnswIndex::new(DIM, DistanceMetric::Cosine).expect("test: create index");
+    for i in 0..CORPUS {
+        index.insert(i, &anti_correlated(i));
+    }
+    index
+}
+
+fn score_of(results: &[ScoredResult], id: u64) -> Option<f32> {
+    results.iter().find(|r| r.id == id).map(|r| r.score)
+}
+
+/// `k` must not change the range a cosine score is reported in.
+///
+/// `k = 10` on a 150-vector index satisfies `len() > k * 2`, so the two-stage
+/// rerank runs and the score is the raw cosine. `k = 80` does not, so the
+/// query falls through to `search_hnsw_only` and `transform_score`. Same
+/// index, same query, same vector — the only difference is how many results
+/// were asked for.
+#[test]
+fn cosine_scores_do_not_depend_on_how_many_results_were_requested() {
+    let index = build();
+    let q = query();
+
+    let reranked = index
+        .search_with_quality(&q, 10, SearchQuality::Balanced)
+        .expect("test: small-k search");
+    let graph_only = index
+        .search_with_quality(&q, 80, SearchQuality::Balanced)
+        .expect("test: large-k search");
+
+    let top_id = reranked.first().expect("test: k=10 must return results").id;
+    let small_k = score_of(&reranked, top_id).expect("test: id present at k=10");
+    let large_k = score_of(&graph_only, top_id).expect("test: id present at k=80");
+
+    assert!(
+        (small_k - large_k).abs() < 1e-5,
+        "doc {top_id} scored {small_k} at k=10 and {large_k} at k=80 — \
+         the requested result count changed the score range"
+    );
+}
+
+/// An anti-correlated match keeps its negative cosine on the graph path.
+#[test]
+fn the_graph_path_reports_a_negative_cosine_rather_than_zero() {
+    let index = build();
+    let q = query();
+
+    // k = 80 on 150 vectors: `len() > k * 2` is false, so no rerank stage.
+    let results = index
+        .search_with_quality(&q, 80, SearchQuality::Balanced)
+        .expect("test: search");
+
+    assert!(!results.is_empty(), "test: expected results");
+    for r in &results {
+        let expected = expected_cosine(r.id);
+        assert!(
+            r.score < 0.0,
+            "every corpus vector is anti-correlated, so doc {} cannot score {} \
+             (true cosine {expected})",
+            r.id,
+            r.score
+        );
+        assert!(
+            (r.score - expected).abs() < 1e-4,
+            "doc {} scored {} but its cosine is {expected}",
+            r.id,
+            r.score
+        );
+    }
+}
+
+/// Clamping at zero costs the ranking, not just the sign.
+///
+/// With every cosine distinct and negative, the correct top-10 is the ten
+/// vectors closest to orthogonal — the highest ids. A floor at zero makes all
+/// 150 scores equal, so which ten come back is arbitrary.
+#[test]
+fn clamping_at_zero_would_destroy_the_ordering_among_anti_correlated_matches() {
+    let index = build();
+    let q = query();
+
+    let results = index
+        .search_with_quality(&q, 80, SearchQuality::Balanced)
+        .expect("test: search");
+
+    let scores: Vec<f32> = results.iter().map(|r| r.score).collect();
+    let all_equal = scores
+        .windows(2)
+        .all(|w| (w[0] - w[1]).abs() < f32::EPSILON);
+    assert!(
+        !all_equal,
+        "all {} returned scores are identical ({:?}) — the ordering was lost",
+        scores.len(),
+        scores.first()
+    );
+
+    for w in results.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "results must stay sorted by descending similarity: {} then {}",
+            w[0].score,
+            w[1].score
+        );
+    }
+}
+
+/// The graph path and the exhaustive path agree.
+#[test]
+fn the_graph_path_agrees_with_brute_force() {
+    let index = build();
+    let q = query();
+
+    let graph = index
+        .search_with_quality(&q, 80, SearchQuality::Balanced)
+        .expect("test: graph search");
+    let exact = index
+        .search_with_quality(&q, 80, SearchQuality::Perfect)
+        .expect("test: brute-force search");
+
+    for r in &graph {
+        let reference = score_of(&exact, r.id)
+            .unwrap_or_else(|| panic!("test: doc {} missing from brute force", r.id));
+        assert!(
+            (r.score - reference).abs() < 1e-4,
+            "doc {}: graph path scored {}, brute force {reference}",
+            r.id,
+            r.score
+        );
+    }
+}
+
+/// Jaccard keeps its floor at zero — the fix must not over-correct.
+///
+/// Jaccard similarity is genuinely `intersection / union`, so `[0, 1]` is its
+/// true range and sharing Cosine's `[-1, 1]` would be as wrong as the shared
+/// arm was in the other direction.
+#[test]
+fn jaccard_keeps_its_zero_floor() {
+    let index = HnswIndex::new(DIM, DistanceMetric::Jaccard).expect("test: create index");
+    for (slot, id) in (0..CORPUS).enumerate() {
+        // Disjoint supports: every pair has an empty intersection.
+        let mut v = vec![0.0_f32; DIM];
+        v[slot % DIM] = 1.0;
+        index.insert(id, &v);
+    }
+
+    let mut q = vec![0.0_f32; DIM];
+    q[0] = 1.0;
+
+    let results = index
+        .search_with_quality(&q, 80, SearchQuality::Balanced)
+        .expect("test: search");
+
+    for r in &results {
+        assert!(
+            r.score >= 0.0,
+            "Jaccard similarity cannot be negative: doc {} scored {}",
+            r.id,
+            r.score
+        );
+        assert!(
+            r.score <= 1.0,
+            "Jaccard similarity cannot exceed 1: doc {} scored {}",
+            r.id,
+            r.score
+        );
+    }
+}
+
+/// `SearchQuality::Adaptive` must not escalate on an easy query just because
+/// the result tail sits near zero.
+///
+/// The escalation heuristic divides the first/last score gap by a baseline.
+/// Taking that baseline as `min(|first|, |last|)` assumes zero is the metric's
+/// floor — true for an unbounded distance, false for a similarity on
+/// `[-1, 1]`, where a merely mediocre tail score of `-0.01` would make the
+/// ratio explode to ~90 and force a second traversal on every such query.
+/// Measuring from `score_range`'s floor instead keeps an easy query easy.
+///
+/// This heuristic never fired for cosine before: the `[0, 1]` clamp pinned
+/// every non-positive tail at exactly `0.0`, so `baseline > f32::EPSILON` was
+/// always false. Removing the clamp is what makes the baseline matter.
+#[test]
+fn adaptive_search_does_not_escalate_on_a_near_zero_tail() {
+    let index = HnswIndex::new(DIM, DistanceMetric::Cosine).expect("test: create index");
+
+    // A cluster tightly aligned with the query, plus a tail that lands just
+    // below zero — the shape that made `min(|a|, |b|)` collapse.
+    for i in 0..CORPUS {
+        let mut v = vec![0.0_f32; DIM];
+        if i < CORPUS - 10 {
+            v[0] = 1.0;
+            v[1] = i as f32 / 1000.0;
+        } else {
+            v[0] = -0.01;
+            v[1] = 1.0;
+        }
+        index.insert(i, &v);
+    }
+
+    let adaptive = index
+        .search_with_quality(
+            &query(),
+            20,
+            SearchQuality::Adaptive {
+                min_ef: 32,
+                max_ef: 256,
+            },
+        )
+        .expect("test: adaptive search");
+
+    assert!(!adaptive.is_empty(), "adaptive search must return results");
+    let (low, high) = DistanceMetric::Cosine
+        .score_range()
+        .expect("cosine is bounded");
+    for r in &adaptive {
+        assert!(
+            r.score >= low && r.score <= high,
+            "doc {} scored {} outside cosine's range",
+            r.id,
+            r.score
+        );
+    }
+    for w in adaptive.windows(2) {
+        assert!(
+            w[0].score >= w[1].score,
+            "adaptive results must stay sorted by descending similarity"
+        );
+    }
+}

--- a/crates/velesdb-core/tests/pq_adc_e2e_tests.rs
+++ b/crates/velesdb-core/tests/pq_adc_e2e_tests.rs
@@ -151,15 +151,23 @@ fn test_pq_train_and_search_maintains_recall() {
             .search(&normalized_query, k)
             .expect("test: PQ search must succeed");
 
-        // THEN: all results have valid IDs and non-negative scores
+        // THEN: all results have valid IDs and in-range scores.
+        //
+        // The corpus is sign-mixed (components drawn from [-1, 1]), so a
+        // cosine here is genuinely signed and the bound that matters is the
+        // metric's own range, not a floor at zero. Asserting `>= 0.0` was
+        // asserting a property of the old HNSW clamp rather than of cosine.
         assert!(
             !results.is_empty(),
             "PQ search must return at least one result"
         );
+        let (low, high) = DistanceMetric::Cosine
+            .score_range()
+            .expect("cosine is a bounded metric");
         for r in &results {
             assert!(
-                r.score >= 0.0,
-                "PQ search score must be non-negative, got {}",
+                r.score >= low && r.score <= high,
+                "PQ search score must lie in cosine's range [{low}, {high}], got {}",
                 r.score
             );
             assert!(

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -273,7 +273,7 @@ per-artifact load-time validation (file-length-bounded counts).
 and the vector branch has little or no visible influence.
 
 **Why**: `maximum` and `average` operate on the **raw** per-branch scores with
-no normalization. Vector similarity is bounded (cosine ∈ [0, 1]) while BM25 is
+no normalization. Vector similarity is bounded (cosine ∈ [-1, 1]) while BM25 is
 unbounded (routinely > 1, often 5–20 on longer queries), so under `maximum` the
 BM25 score almost always wins, and under `average` it dwarfs the vector
 contribution. These strategies are designed for branches whose scores share a


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/2106-cosine-score-contract` → **`develop`**.

## Description

Refs #2106. Independent of #2135 (different files, both branched from
`develop`); the two will conflict only in `CHANGELOG.md`.

`NativeHnsw::transform_score` shared one match arm between Cosine and Jaccard
and clamped both to `[0, 1]`. For Jaccard that floor is the metric's real
bound. For Cosine it is not — the raw distance is `1 - cos`, so `1.0 - raw`
**is** the cosine, and clamping at zero turned every anti-correlated match into
exactly `0.0`.

Three other sites had always returned the cosine itself: `compute_distance` on
the brute-force path, `clamp_score_for_metric` on the GPU rerank, and
`DistanceMetric::calculate`. **Nothing about a query says which one runs.** It
falls out of corpus size (100 points or fewer goes brute force),
`SearchQuality`, and even `k` — the rerank stage requires `len() > k * 2`. On
one 150-vector index, one query, one document:

```
doc 149 scored -0.5572696 at k=10 and 0 at k=80
```

### It corrupted ordering inside a single result list

Not just a contract split across paths. `merge_delta` concatenates HNSW results
with delta-buffer results scored through `calculate`, then hands the lot to
`sort_results` — so a freshly written point at true cosine `-0.2` sorted
**below** an indexed point at `-0.5` that had been clamped to zero. VelesQL's
`Parallel` strategy merges a scan leg and an HNSW leg the same way, keeping the
best score per id, where the clamped `0.0` beats the true `-0.2` for the same
document.

And the loss was not only the sign. Every dissimilar document clamped to the
same `0.0`, so among anti-correlated matches the ordering did not survive at
all: on a corpus of 150 vectors with 150 distinct negative cosines, top-k
became an arbitrary pick from 150 tied scores.

### The root cause, and the fix

The range had no single definition — four sites each decided it. It now lives
on the metric as `DistanceMetric::score_range`, with `clamp_score` applying it,
and the two sites that were clamping derive from it. That is the shape
`score_direction` already uses, derived from `higher_is_better` so the two
cannot drift.

| Metric | Range |
|---|---|
| Cosine | `[-1, 1]` |
| Jaccard | `[0, 1]` (its real floor, unchanged) |
| Euclidean, Hamming, `DotProduct` | none — unbounded |

The GPU path's local table needed a `_ =>` catch-all to satisfy
`#[non_exhaustive]`. `score_range` is inside the defining crate and matches
every variant, so adding a metric now fails to compile there instead of falling
silently into the wildcard.

### Restoring the sign exposed a dead heuristic

`search_adaptive` decides whether to widen `ef` from the first/last score gap
over `min(|first|, |last|)` — a baseline that takes zero for the metric's
floor. Zero *is* the floor for an unbounded distance. On a similarity over
`[-1, 1]` it sits mid-range, so a mediocre tail of `-0.01` against a `0.9` top
reads as a spread of **91** and escalates a query that is not hard; every
`Adaptive`/`AutoTune` search whose tail crosses zero would pay a second
traversal.

Cosine never hit that, for the wrong reason: the clamp pinned every
non-positive score at exactly `0.0`, making the baseline zero and the
`> f32::EPSILON` guard fail. **Phase 2 had never escalated on this metric at
all.**

Same root cause — one formula serving two score spaces — so it gets the same
treatment. The baseline is now the tail's distance from `score_range`'s floor,
which is *identical* for the unbounded metrics (whose floor is zero), keeps
easy cosine queries cheap, and still escalates a genuinely heterogeneous
neighbourhood. The rule moved out of inline arithmetic into a pure
`should_escalate` so it can be tested against numbers rather than inferred from
a search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change — cosine scores from the HNSW graph path can now be
      negative where they were previously floored at `0.0`. This is the range
      the exact and rerank paths have always returned; the change makes them
      agree rather than introducing a range that never occurred.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

Every guard was proved red first. `tests/cosine_score_range_tests.rs` (6 tests)
failed 4/5 against the unfixed tree with the evidence quoted above; the Jaccard
control passed throughout, which is what proves the fix does not over-correct.
`should_escalate`'s unit tests include a contrast assertion computing what the
old zero-based baseline *would* have returned, so the easy-query case is pinned
against the specific arithmetic that was wrong.

Run locally, all green:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic
cargo clippy -p velesdb-node --lib -- -D warnings
PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib -- -D warnings
cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check \
  -- -A warnings -D clippy::undocumented_unsafe_blocks
cargo test -p velesdb-core --features persistence -- --test-threads=1   # 60 binaries, 0 failed
cargo test --doc --package velesdb-core                                 # 50 passed, 42 ignored
cargo check --workspace --no-default-features
cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
cargo check -p velesdb-memory  (x4 feature shapes)
python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .
python3 scripts/check-{inline-tests,file-budgets,prod-unwraps,todo-annotations,
  durability-barrier,ai-attribution}.py
bash scripts/check-doc-contract.sh
python3 scripts/check-doc-freshness.py --guard {stamp,index,tracked,versions,decisions} --mode strict
```

`tauri-plugin-velesdb` was excluded from the clippy and `--no-default-features`
sweeps: it needs GTK system libraries (`gdk-3.0`) absent in this environment.
Nothing in this diff touches it.

**Test Configuration:**
- OS: Linux x86_64 (AVX-512F + AVX2 + FMA)
- Rust version: workspace MSRV toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` code is added, removed or modified.

## High-Risk Change Checklist

Touches the HNSW search path and score transformation.

- [x] I listed the invariants impacted by this change:
  - a metric's user-visible score lies in `DistanceMetric::score_range`, on
    every path that produces one
  - the graph path, the exact rerank and brute force agree on the same document
  - Jaccard's `[0, 1]` floor is its own bound and is untouched
  - the adaptive escalation baseline is measured from the metric's floor, so
    the unbounded metrics are unaffected
- [x] Crash/durability semantics unchanged — no write path is touched, and no
      score is persisted (`transform_score` runs at read time only).
- [x] Tests added for the boundary cases: exact-bound drift, all-equal result
      sets, and a corpus that is entirely anti-correlated.
- [ ] I requested review from at least 2 maintainers/reviewers for this risky
      path.

## Additional Notes

Three things found while doing this that are **not** fixed here, each with a
reason:

- **Jaccard escapes its own declared range.** `Jaccard.calculate([1,0,0],
  [-1,0,0])` returns `-1.0`: `jaccard_scalar` has no clamp where `cosine_scalar`
  ends in `.clamp(-1.0, 1.0)`, and the asymmetry sits in one file. Negative
  weights are out of contract for a set-like metric but nothing rejects them at
  insert, so exact paths return a negative "similarity" while the graph path
  clamps it to `0.0` — the same shape of disagreement this PR fixes, one metric
  over. Closing it means clamping in the Jaccard kernels on scalar, AVX2/AVX-512
  **and NEON**, which cannot be executed in this environment. Pinned by
  `jaccard_calculate_escapes_its_declared_range_on_negative_weights` so it is a
  named fact that fails loudly when someone fixes it.
- **Multiplicative boost inversion and `Product` sign flip** in
  `score_fusion/mod.rs`: a negative base score times a boost `> 1` demotes
  instead of promoting, and two negative components multiply to a positive.
  Both live in `ScoreFusionMethod`, which `tests/bdd/fusion_weighted_bug.rs`
  records as a dead path — "never selected by any query… intentionally left
  as-is". Principle 8 applies.
- **`fuse_weighted`'s hit-ratio tie-break and RSF min-max scaling** shift
  slightly now that dissimilar documents are no longer all pinned at `0.0`.
  Both are arithmetically safe (affine-invariant normalization, no NaN/Inf) and
  the new behaviour is the more faithful one.

This also corrects a note in #2135, which deferred this finding as "a
score-contract decision across three paths, too broad to fold in here". That
was wrong: the cause is one shared match arm plus a missing single definition.
