### PR TITLE
fix(quantization): TRAIN QUANTIZER could not see a collection without payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`TRAIN QUANTIZER` no longer reports an empty corpus for a collection that
+  has no payloads.** Training enumerated the collection through
+  `Collection::all_ids`, which is the *payload* store's view and says so in its
+  own doc: "Only returns IDs that have payload entries stored. Points inserted
+  with `None` payload may not appear." A collection used for pure vector search
+  carries no payloads at all, so that view was empty and every quantizer type —
+  pq, opq, rabitq and sq8, which share the extraction — failed with
+  `[VELES-029] Training failed: no vectors available for training` about a
+  collection holding its full count. Measured on a 256-point collection:
+  `all_ids` 0, `all_point_ids` 256, `point_count` 256. Training now uses
+  `all_point_ids`, documented as the authoritative set because it unions vector
+  and payload storage; the existing `is_empty` filter already drops the
+  metadata-only points it additionally brings in. (#2095)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and payload storage; the existing `is_empty` filter already drops the
   metadata-only points it additionally brings in. (#2095)
 
+- **`Database.train_pq` (Python) accepts every collection name core does.**
+  The binding rendered VelesQL as text —
+  `format!("TRAIN QUANTIZER ON {collection_name} WITH (m={m}, k={k}")` — and
+  parsed it back. Interpolating a name into a query string is what forced the
+  method to carry its own identifier rule ("prevent VelesQL injection via
+  string interpolation"), and that rule was a second definition of what a
+  collection may be called. It drifted from `velesdb_core::validation` three
+  ways: it rejected the interior hyphen core accepts and pins (`a-b`, with
+  `docs-v2` as the doc example); it passed a leading digit the grammar's
+  `regular_identifier` then refused, surfacing as "Failed to construct TRAIN
+  query"; and it passed the empty string vacuously, rendering
+  `TRAIN QUANTIZER ON  WITH (...)`. The binding now builds the statement AST
+  directly through `Query::new_train`, as `velesdb-mobile` and
+  `tauri-plugin-velesdb` already do. No identifier text is produced, so there
+  is no charset rule to keep in step and all three cases dissolve together;
+  a bad name now fails in the engine with the engine's own error. (#2095)
+
 - **Clearing a point's text now takes it out of full-text search.** The BM25
   index only ever saw the incoming payload, so a payload that still existed but
   no longer yielded indexable text wrote nothing and the point kept matching a

--- a/crates/velesdb-core/src/database/training.rs
+++ b/crates/velesdb-core/src/database/training.rs
@@ -98,7 +98,16 @@ impl Database {
         collection: &crate::collection::Collection,
         sample_limit: Option<usize>,
     ) -> Result<Vec<Vec<f32>>> {
-        let all_ids = collection.all_ids();
+        // `all_point_ids`, not `all_ids`: the latter enumerates the payload
+        // store and documents that "points inserted with `None` payload may
+        // not appear". A collection used for pure vector search carries no
+        // payloads at all, so training saw an empty corpus and every
+        // `TRAIN QUANTIZER` on it — pq, opq, rabitq, sq8 — failed with "no
+        // vectors available for training" while the collection held its full
+        // count. `all_point_ids` unions vector and payload storage and is the
+        // authoritative set; the `is_empty` filter below already drops the
+        // metadata-only points it also brings in.
+        let all_ids = collection.all_point_ids();
         // get_raw: PQ training only consumes vectors; TTL-expired points are
         // still valid training samples and must not shrink the corpus.
         let points = collection.get_raw(&all_ids);

--- a/crates/velesdb-core/tests/train_payload_free_tests.rs
+++ b/crates/velesdb-core/tests/train_payload_free_tests.rs
@@ -1,0 +1,119 @@
+#![cfg(feature = "persistence")]
+//! `TRAIN QUANTIZER` must see a collection's vectors, payload or not.
+//!
+//! Training enumerates the collection's ids before extracting vectors, and
+//! `Collection::all_ids` is the *payload* store's view — its own doc says
+//! "Only returns IDs that have payload entries stored. Points inserted with
+//! `None` payload may not appear." A collection used for pure vector search
+//! carries no payloads, so that view is empty and training reported "no
+//! vectors available" about a collection holding its full count.
+//!
+//! `all_point_ids` unions vector and payload storage and is documented as the
+//! authoritative set.
+
+use std::collections::HashMap;
+
+use tempfile::TempDir;
+use velesdb_core::velesql::Parser;
+use velesdb_core::{Database, DistanceMetric, Point, StorageMode};
+
+const DIM: usize = 8;
+const POINTS: u64 = 256;
+
+fn vector_for(i: u64) -> Vec<f32> {
+    #[allow(clippy::cast_precision_loss)]
+    (0..DIM)
+        .map(|d| ((i as f32) * 0.37 + (d as f32) * 1.13).sin())
+        .collect()
+}
+
+/// Seeds a collection whose points carry `None` payload.
+fn payload_free_db(name: &str) -> (TempDir, Database) {
+    let dir = TempDir::new().expect("test: temp dir");
+    let db = Database::open(dir.path()).expect("test: open database");
+    db.create_collection(name, DIM, DistanceMetric::Cosine)
+        .expect("test: create collection");
+
+    let coll = db
+        .get_vector_collection(name)
+        .expect("test: collection must exist");
+    let points: Vec<Point> = (0..POINTS)
+        .map(|i| Point::without_payload(i, vector_for(i)))
+        .collect();
+    coll.upsert(points).expect("test: upsert");
+
+    (dir, db)
+}
+
+/// The two id views disagree, and only one of them is authoritative.
+#[test]
+fn payload_free_points_are_invisible_to_the_payload_id_view() {
+    let (_dir, db) = payload_free_db("vecs");
+    let coll = db.get_vector_collection("vecs").expect("test: exists");
+
+    assert_eq!(
+        coll.all_ids().len(),
+        0,
+        "all_ids reads the payload store, which is empty here"
+    );
+    assert_eq!(
+        u64::try_from(coll.all_point_ids().len()).expect("test: id count fits in u64"),
+        POINTS,
+        "all_point_ids unions vector storage and sees every point"
+    );
+}
+
+/// Training must succeed on a collection that carries no payloads.
+#[test]
+fn train_pq_succeeds_on_a_payload_free_collection() {
+    let (_dir, db) = payload_free_db("vecs");
+
+    let query = Parser::parse("TRAIN QUANTIZER ON vecs WITH (m=2, k=4)").expect("test: parse");
+    db.execute_query(&query, &HashMap::new())
+        .expect("test: a collection full of vectors must be trainable");
+
+    let coll = db.get_vector_collection("vecs").expect("test: exists");
+    assert_eq!(
+        coll.config().storage_mode,
+        StorageMode::ProductQuantization,
+        "training must have flipped the storage mode"
+    );
+}
+
+/// The same holds for the other quantizer types, which share the extraction.
+#[test]
+fn every_quantizer_type_trains_on_a_payload_free_collection() {
+    for (name, sql) in [
+        (
+            "opq_c",
+            "TRAIN QUANTIZER ON opq_c WITH (type='opq', m=2, k=4)",
+        ),
+        (
+            "rabitq_c",
+            "TRAIN QUANTIZER ON rabitq_c WITH (type='rabitq')",
+        ),
+        ("sq8_c", "TRAIN QUANTIZER ON sq8_c WITH (type='sq8')"),
+    ] {
+        let (_dir, db) = payload_free_db(name);
+        let query = Parser::parse(sql).expect("test: parse");
+        db.execute_query(&query, &HashMap::new())
+            .unwrap_or_else(|e| {
+                panic!("test: {sql} must succeed on a payload-free collection: {e}")
+            });
+    }
+}
+
+/// A genuinely empty collection still reports that it has nothing to train on.
+#[test]
+fn an_empty_collection_still_reports_no_vectors() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let db = Database::open(dir.path()).expect("test: open database");
+    db.create_collection("empty_c", DIM, DistanceMetric::Cosine)
+        .expect("test: create collection");
+
+    let query = Parser::parse("TRAIN QUANTIZER ON empty_c WITH (m=2, k=4)").expect("test: parse");
+    assert!(
+        db.execute_query(&query, &HashMap::new()).is_err(),
+        "an empty collection must still fail training"
+    );
+}

--- a/crates/velesdb-core/tests/train_statement_ast_tests.rs
+++ b/crates/velesdb-core/tests/train_statement_ast_tests.rs
@@ -1,0 +1,122 @@
+#![cfg(feature = "persistence")]
+//! Building a `TRAIN QUANTIZER` statement, versus printing one and parsing it back.
+//!
+//! A collection name and a VelesQL *bare identifier* are not the same alphabet.
+//! `validation::is_valid_name_char` accepts `-` — `validate_collection_name`
+//! pins `a-b` and the doc example is `docs-v2` — while `grammar.pest`'s
+//! `regular_identifier` is `(ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*`
+//! and cannot spell one.
+//!
+//! A binding that renders `format!("TRAIN QUANTIZER ON {name} ...")` therefore
+//! has to invent its own name rule, and that rule is a second definition which
+//! drifts. The AST route emits no identifier text at all, so the question does
+//! not arise; `velesdb-mobile` and `tauri-plugin-velesdb` already take it, and
+//! the Python binding now does too.
+
+#![allow(clippy::cast_precision_loss, clippy::doc_markdown)]
+
+use std::collections::HashMap;
+
+use tempfile::TempDir;
+use velesdb_core::velesql::{Parser, Query, TrainStatement, WithValue};
+use velesdb_core::{Database, DistanceMetric, Point};
+
+const HYPHENATED: &str = "docs-v2";
+const DIM: usize = 8;
+
+fn seeded_db() -> (TempDir, Database) {
+    let dir = TempDir::new().expect("test: temp dir");
+    let db = Database::open(dir.path()).expect("test: open database");
+    db.create_collection(HYPHENATED, DIM, DistanceMetric::Cosine)
+        .expect("test: core accepts a hyphenated collection name");
+
+    let coll = db
+        .get_vector_collection(HYPHENATED)
+        .expect("test: collection must exist");
+    let points: Vec<Point> = (0..64_u64)
+        .map(|i| {
+            let v: Vec<f32> = (0..DIM)
+                .map(|d| ((i as f32) * 0.37 + (d as f32) * 1.13).sin())
+                .collect();
+            Point::without_payload(i, v)
+        })
+        .collect();
+    coll.upsert(points).expect("test: upsert");
+
+    (dir, db)
+}
+
+fn train_params() -> HashMap<String, WithValue> {
+    let mut params = HashMap::new();
+    params.insert("m".to_string(), WithValue::Integer(2));
+    params.insert("k".to_string(), WithValue::Integer(4));
+    params
+}
+
+/// The name is legal for a collection but cannot be a bare identifier.
+///
+/// This is the gap a string-building binding falls into: it must either
+/// reject names core accepts, or quote and escape them — reintroducing the
+/// injection surface the quoting was meant to close.
+#[test]
+fn a_hyphenated_collection_name_is_legal_but_unspellable_as_a_bare_identifier() {
+    let rendered = format!("TRAIN QUANTIZER ON {HYPHENATED} WITH (m=2, k=4)");
+    assert!(
+        Parser::parse(&rendered).is_err(),
+        "`{rendered}` must not parse: `regular_identifier` has no hyphen"
+    );
+}
+
+/// The AST route reaches the collection the text route cannot name.
+#[test]
+fn training_through_the_ast_reaches_a_hyphenated_collection() {
+    let (_dir, db) = seeded_db();
+
+    let query = Query::new_train(TrainStatement {
+        collection: HYPHENATED.to_string(),
+        params: train_params(),
+    });
+
+    db.execute_query(&query, &HashMap::new())
+        .expect("test: the AST route must train a hyphenated collection");
+}
+
+/// The AST route carries no charset rule of its own, so a name core rejects
+/// fails in core with core's error rather than in a binding's private guard.
+#[test]
+fn a_name_core_rejects_fails_in_core_not_in_a_private_guard() {
+    let (_dir, db) = seeded_db();
+
+    let query = Query::new_train(TrainStatement {
+        collection: "no-such-collection".to_string(),
+        params: train_params(),
+    });
+
+    let err = db
+        .execute_query(&query, &HashMap::new())
+        .expect_err("training an absent collection must fail");
+    let message = err.to_string();
+    assert!(
+        message.to_lowercase().contains("collection"),
+        "the error must come from core and name the collection, got: {message}"
+    );
+}
+
+/// An empty collection name is refused rather than rendering a malformed query.
+///
+/// The string route accepted it — `.all()` is vacuously true on an empty
+/// iterator — and produced `TRAIN QUANTIZER ON  WITH (...)`.
+#[test]
+fn an_empty_collection_name_is_refused() {
+    let (_dir, db) = seeded_db();
+
+    let query = Query::new_train(TrainStatement {
+        collection: String::new(),
+        params: train_params(),
+    });
+
+    assert!(
+        db.execute_query(&query, &HashMap::new()).is_err(),
+        "an empty collection name must be refused"
+    );
+}

--- a/crates/velesdb-python/src/database.rs
+++ b/crates/velesdb-python/src/database.rs
@@ -14,6 +14,7 @@ use crate::options::{AutoReindexOptions, HnswOptions, VelesConfigOptions};
 use crate::utils::{self, parse_metric, parse_storage_mode};
 
 use velesdb_core::collection::auto_reindex::AutoReindexManager;
+use velesdb_core::velesql::{Query, TrainStatement, WithValue};
 use velesdb_core::{
     AnyCollection, CollectionType, Database as CoreDatabase, DatabaseObserver, GraphSchema,
 };
@@ -538,26 +539,43 @@ impl Database {
         k: usize,
         opq: bool,
     ) -> PyResult<String> {
-        // Validate collection_name to prevent VelesQL injection via string interpolation.
-        if !collection_name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            return Err(PyValueError::new_err(format!(
-                "Invalid collection name '{collection_name}': only ASCII letters, digits, \
-                 and underscores are allowed"
-            )));
-        }
-
-        let mut query = format!("TRAIN QUANTIZER ON {collection_name} WITH (m={m}, k={k}");
+        // Build the statement, rather than printing VelesQL and parsing it
+        // back. The round-trip was what forced this method to invent an
+        // identifier sanitizer ("prevent VelesQL injection via string
+        // interpolation"), and that sanitizer drifted from
+        // `velesdb_core::validation`: it rejected the interior hyphen core
+        // accepts and pins as a doc example (`docs-v2`), while passing a
+        // leading digit the grammar's `regular_identifier` then refused, and
+        // passing the empty string, which produced `TRAIN QUANTIZER ON  WITH
+        // (...)`. Constructing the AST emits no identifier text at all, so
+        // there is no charset rule to keep in step and all three dissolve
+        // together. `velesdb-mobile` and `tauri-plugin-velesdb` already build
+        // this statement the same way.
+        let mut params = std::collections::HashMap::new();
+        params.insert(
+            "m".to_string(),
+            WithValue::Integer(i64::try_from(m).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "m={m} exceeds the maximum supported subspace count"
+                ))
+            })?),
+        );
+        params.insert(
+            "k".to_string(),
+            WithValue::Integer(i64::try_from(k).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "k={k} exceeds the maximum supported centroid count"
+                ))
+            })?),
+        );
         if opq {
-            query.push_str(", type=opq");
+            params.insert("type".to_string(), WithValue::Identifier("opq".to_string()));
         }
-        query.push(')');
 
-        let parsed = velesdb_core::velesql::Parser::parse(&query).map_err(|e| {
-            PyValueError::new_err(format!("Failed to construct TRAIN query: {}", e.message))
-        })?;
+        let parsed = Query::new_train(TrainStatement {
+            collection: collection_name.to_string(),
+            params,
+        });
 
         // Drop the GIL for the training run: k-means codebook fitting is
         // CPU-bound Rust work that scales with the collection size and easily

--- a/crates/velesdb-python/tests/test_train_pq_names.py
+++ b/crates/velesdb-python/tests/test_train_pq_names.py
@@ -1,0 +1,107 @@
+"""
+Regression tests for `Database.train_pq` collection-name handling.
+
+`train_pq` used to render VelesQL as text —
+``format!("TRAIN QUANTIZER ON {collection_name} WITH (m={m}, k={k}")`` — and
+parse it back. Interpolating a name into a query string forced the method to
+invent its own identifier rule, and that rule became a second definition of
+what a collection may be called. It drifted from `velesdb_core::validation`
+in three ways:
+
+- it rejected the interior hyphen core accepts (`validate_collection_name`
+  pins `a-b`, and the doc example is `docs-v2`);
+- it accepted a leading digit that the VelesQL grammar's `regular_identifier`
+  then refused, surfacing as "Failed to construct TRAIN query";
+- it accepted the empty string vacuously, rendering
+  ``TRAIN QUANTIZER ON  WITH (...)``.
+
+The binding now builds the statement AST directly, as velesdb-mobile and
+tauri-plugin-velesdb already do, so no identifier text is produced and no
+charset rule is needed.
+
+Run with: pytest tests/test_train_pq_names.py -v
+"""
+
+import pytest
+
+from conftest import _SKIP_NO_BINDINGS
+
+# temp_db fixture is provided by conftest.py auto-discovery.
+pytestmark = _SKIP_NO_BINDINGS
+
+DIM = 8
+POINTS = 256
+
+
+def _seed(db, name):
+    """Creates `name` and fills it with enough vectors to train on."""
+    coll = db.create_collection(name, DIM, "cosine")
+    coll.upsert(
+        [
+            {
+                "id": i,
+                "vector": [((i * 37 + d * 113) % 199) / 199.0 for d in range(DIM)],
+            }
+            for i in range(POINTS)
+        ]
+    )
+    return coll
+
+
+@pytest.mark.parametrize("name", ["docs-v2", "a-b-c"])
+def test_train_pq_accepts_hyphenated_names_like_core(temp_db, name):
+    """A name core accepts must not be rejected by the binding.
+
+    `validate_collection_name` allows interior hyphens and `docs-v2` is its
+    own documented example, so a collection created under that name must be
+    trainable through the same SDK that created it.
+    """
+    _seed(temp_db, name)
+
+    result = temp_db.train_pq(name, m=2, k=4)
+
+    assert isinstance(result, str)
+    assert "complete" in result.lower()
+
+
+def test_train_pq_accepts_a_leading_digit(temp_db):
+    """A leading digit passed the old charset guard but broke the grammar.
+
+    `regular_identifier` is `(ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")*`,
+    so `2docs` could never be spelled as a bare identifier — the old code
+    waved it through its own guard and then failed at parse time with a
+    confusing "Failed to construct TRAIN query".
+    """
+    _seed(temp_db, "2docs")
+
+    result = temp_db.train_pq("2docs", m=2, k=4)
+
+    assert "complete" in result.lower()
+
+
+def test_train_pq_underscore_names_still_work(temp_db):
+    """The names the old guard did allow keep working."""
+    _seed(temp_db, "plain_name")
+
+    result = temp_db.train_pq("plain_name", m=2, k=4)
+
+    assert "complete" in result.lower()
+
+
+def test_train_pq_on_a_missing_collection_raises(temp_db):
+    """An unknown name fails in core, with core's error.
+
+    The binding no longer has a private charset guard to fail in first, so
+    the error the caller sees is the engine's own.
+    """
+    with pytest.raises(Exception) as excinfo:
+        temp_db.train_pq("never-created", m=2, k=4)
+
+    assert "collection" in str(excinfo.value).lower()
+
+
+def test_train_pq_on_an_empty_name_raises(temp_db):
+    """The empty string satisfied `.all()` vacuously and rendered a
+    malformed query; it must be refused."""
+    with pytest.raises(Exception):
+        temp_db.train_pq("", m=2, k=4)


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/2095-python-train-pq-ast` → **`develop`**.

## Description

Two `TRAIN QUANTIZER` defects. Independent of #2135 and #2136 (all three
branched from `develop`); conflicts only in `CHANGELOG.md`.

The first was **not in any issue** — it surfaced because a test fixture for
the second one would not work.

### 1. Training saw an empty corpus whenever the points had no payload

`extract_training_vectors` enumerated the collection through
`Collection::all_ids`, which is the *payload* store's view and says so in its
own doc:

> Only returns IDs that have payload entries stored. Points inserted with
> `None` payload may not appear. For a complete set of IDs, use `all_point_ids`.

A collection used for pure vector search carries no payloads at all. Measured
on a 256-point fixture:

```
all_ids = 0    all_point_ids = 256    point_count = 256
TRAIN -> Err([VELES-029] Training failed: no vectors available for training)
```

Every quantizer type is affected — pq, opq, rabitq and sq8 all share this
extraction — so **no quantizer can be trained on a metadata-free collection**,
which is a first-class use case.

The shape of the miss is worth seeing. The comment on the very next line
reasons carefully about one way the corpus could be wrongly shrunk:

```rust
// get_raw: PQ training only consumes vectors; TTL-expired points are
// still valid training samples and must not shrink the corpus.
```

Careful about the near miss, blind to the near-total one: the id set being
filtered had already dropped every point. Training now reads `all_point_ids`,
documented as authoritative because it unions vector and payload storage. The
`is_empty` filter directly below already drops the metadata-only points that
union additionally brings in, so no second guard is needed.

### 2. `Database.train_pq` (Python) built VelesQL as text and had to police it

```rust
// Validate collection_name to prevent VelesQL injection via string interpolation.
```

The comment names its own cause. Because the method rendered
`format!("TRAIN QUANTIZER ON {collection_name} WITH (m={m}, k={k}")` and parsed
it back, it had to carry an identifier rule — and that rule was a second
definition of what a collection may be called. It drifted from
`velesdb_core::validation` in three directions at once:

| Input | Old binding | Reality |
|---|---|---|
| `docs-v2` | rejected | core accepts it; `validation_tests.rs` pins `a-b`, and `docs-v2` is `validate_collection_name`'s own doc example |
| `2docs` | accepted | the grammar's `regular_identifier` refuses it → "Failed to construct TRAIN query" |
| `""` | accepted (`.all()` is vacuously true) | rendered `TRAIN QUANTIZER ON  WITH (...)` |

Tightening the charset fixes one row and leaves the class. The statement is now
built as an AST through `Query::new_train`, the way `velesdb-mobile` and
`tauri-plugin-velesdb` already build it. No identifier text is produced at any
point, so there is no alphabet to keep in step with core's and all three rows
resolve together; a bad name now fails in the engine with the engine's own
error. `m` and `k` cross a `usize` → `i64` boundary the string form hid, and
are converted with `try_from` rather than a cast.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

Strictly a loosening on the Python side: every name that worked before still
works, and names core always accepted now work too. The error *type* changes
for a genuinely bad name — the engine's error instead of the binding's
`ValueError`.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

`train_payload_free_tests.rs` was proved red against the unfixed tree: 2 of its
4 guards fail (the two asserting training succeeds; the two id-view invariants
hold either way).

The diagnosis went through a wrong hypothesis worth recording. The fixture's
first failure looked like the *hyphenated collection name* breaking the upsert,
which would have been a far more serious finding. A controlled probe across
names (`plain`, `with_underscore`, `docs-v2`, `a-b`), sizes (64/200/1000) and
flush states showed every name gave zero and the discriminator was the payload
— not the name, and not the delta buffer.

Run locally, all green:

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --features persistence,gpu,update-check \
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic
cargo clippy -p velesdb-node --lib -- -D warnings
PYO3_PYTHON=python3 cargo clippy -p velesdb-python --lib -- -D warnings
cargo test -p velesdb-core --features persistence -- --test-threads=1   # 60 binaries, 0 failed
cargo test --doc --package velesdb-core                                 # 50 passed, 42 ignored
cargo check --workspace --no-default-features
cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown
pytest tests/test_stub_parity.py                                        # 1 passed, 1 skipped
python3 scripts/check-{inline-tests,file-budgets,prod-unwraps,todo-annotations,
  feature-claims,ai-attribution}.py
bash scripts/check-doc-contract.sh
python3 scripts/check-doc-freshness.py --guard {stamp,index,tracked,versions,decisions} --mode strict
```

**The Python-level tests could not be executed here.** `tests/test_train_pq_names.py`
needs the built extension, and this environment has no `maturin`. They collect
and skip cleanly under the repository's own `_SKIP_NO_BINDINGS` mark (6 tests)
and will run in the `Python SDK Tests` job. To keep the claim testable where it
*can* be executed, `train_statement_ast_tests.rs` pins the mechanism in core: a
hyphenated name is legal for a collection, unspellable as a bare identifier, and
reachable through the AST.

`tauri-plugin-velesdb` was excluded from the clippy and `--no-default-features`
sweeps: it needs GTK system libraries (`gdk-3.0`) absent in this environment.
Nothing in this diff touches it.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: workspace MSRV toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` code is added, removed or modified.

## High-Risk Change Checklist

Touches quantizer training, which reads the collection and writes a codebook.

- [x] I listed the invariants impacted by this change:
  - training's corpus is every point that has a vector, whether or not it has
    a payload
  - metadata-only points are still excluded, by the existing `is_empty` filter
  - a genuinely empty collection still fails training (pinned)
  - a binding produces no VelesQL identifier text, so it needs no name rule of
    its own
- [x] Crash/durability semantics unchanged — the extraction is read-only, and
      the codebook write path is untouched.
- [x] Tests added across all four quantizer types, which share the extraction.
- [ ] I requested review from at least 2 maintainers/reviewers for this risky
      path.

## Additional Notes

Worth a maintainer's eye: `all_ids` and `all_point_ids` are both public, differ
subtly, and the difference is documented only on the accessors themselves. This
PR fixes the one caller I found reading the wrong one, but the naming invites
the mistake — `all_ids` reads like the authoritative set and is not. A rename,
or folding the payload-only view into a more explicit name, would remove the
trap rather than this one instance of it. Out of scope here since it is a
public API change.
