### PR TITLE
fix(graph): retire dead node metrics and per-op edge timing

### DIFF
--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -202,7 +202,6 @@ impl ConcurrentEdgeStore {
     /// Returns `Error::EdgeExists` if an edge with the same ID already exists.
     pub fn add_edge(&self, edge: GraphEdge) -> Result<()> {
         let edge_id = edge.id();
-        let start = Instant::now();
 
         {
             // CRITICAL: Hold edge_ids lock throughout the entire operation to prevent race
@@ -252,7 +251,7 @@ impl ConcurrentEdgeStore {
         self.invalidate_snapshot();
         self.rebuild_snapshot_best_effort();
         // Record after all shard locks drop so the atomic ops never overlap a held lock.
-        self.metrics.record_edge_insert(start.elapsed());
+        self.metrics.record_edge_insert();
         Ok(())
     }
 
@@ -373,7 +372,6 @@ impl ConcurrentEdgeStore {
     ///
     /// Lock ordering: edge_ids FIRST, then shards in ascending order.
     pub(crate) fn remove_edge_detailed(&self, edge_id: u64) -> EdgeRemoval {
-        let start = Instant::now();
         {
             let mut ids = self.edge_ids.write();
 
@@ -428,7 +426,7 @@ impl ConcurrentEdgeStore {
         self.invalidate_snapshot();
         self.rebuild_snapshot_best_effort();
         // Record after all shard locks drop (removed path only).
-        self.metrics.record_edge_delete(start.elapsed());
+        self.metrics.record_edge_delete();
         EdgeRemoval::Removed
     }
 

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent_tests.rs
@@ -1468,7 +1468,6 @@ fn test_metrics_record_edge_inserts() {
     let m = store.metrics();
     assert_eq!(m.edge_inserts_total(), 3, "3 inserts recorded");
     assert_eq!(m.edges_total(), 3, "3 live edges");
-    assert_eq!(m.edge_insert_latency.count(), 3, "3 latency observations");
 }
 
 #[test]
@@ -1485,11 +1484,6 @@ fn test_metrics_record_edge_delete() {
     let m = store.metrics();
     assert_eq!(m.edge_deletes_total(), 1, "1 delete recorded");
     assert_eq!(m.edges_total(), 2, "edges_total decremented to 2");
-    assert_eq!(
-        m.edge_delete_latency.count(),
-        1,
-        "1 delete latency observed"
-    );
 }
 
 #[test]

--- a/crates/velesdb-core/src/collection/graph/metrics/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/mod.rs
@@ -127,26 +127,18 @@ impl LatencyHistogram {
 ///
 /// ```rust,ignore
 /// use velesdb_core::collection::graph::GraphMetrics;
-/// use std::time::Instant;
 ///
 /// let metrics = GraphMetrics::new();
 ///
-/// // Record an edge insertion
-/// let start = Instant::now();
-/// // ... perform insertion ...
-/// metrics.record_edge_insert(start.elapsed());
+/// // Record an edge insertion (counters only — see `record_edge_inserts_batch`
+/// // for the batch path, which is what feeds `edge_insert_latency`)
+/// metrics.record_edge_insert();
 ///
 /// // Get statistics
 /// println!("Total edges inserted: {}", metrics.edge_inserts_total());
-/// println!("Avg insert latency: {:.2}µs", metrics.edge_insert_latency.avg_ns() / 1000.0);
 /// ```
 #[derive(Debug, Default)]
 pub struct GraphMetrics {
-    // Node counters
-    nodes_total: AtomicU64,
-    node_inserts_total: AtomicU64,
-    node_deletes_total: AtomicU64,
-
     // Edge counters
     edges_total: AtomicU64,
     edge_inserts_total: AtomicU64,
@@ -157,10 +149,10 @@ pub struct GraphMetrics {
     traversal_nodes_visited: AtomicU64,
 
     // Latency histograms
-    /// Edge insertion latency histogram
+    /// Edge insertion latency histogram. Populated by the batch insert path
+    /// only — the single-edge path records counters without a clock read
+    /// (see `record_edge_insert`).
     pub edge_insert_latency: LatencyHistogram,
-    /// Edge deletion latency histogram
-    pub edge_delete_latency: LatencyHistogram,
     /// Traversal latency histogram
     pub traversal_latency: LatencyHistogram,
     /// Query latency histogram
@@ -175,49 +167,19 @@ impl GraphMetrics {
     }
 
     // =========================================================================
-    // Node metrics
-    // =========================================================================
-
-    /// Records a node insertion.
-    pub fn record_node_insert(&self) {
-        self.node_inserts_total.fetch_add(1, Ordering::Relaxed);
-        self.nodes_total.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Records a node deletion.
-    ///
-    /// Uses saturating subtraction to prevent underflow if called
-    /// more times than `record_node_insert`.
-    pub fn record_node_delete(&self) {
-        self.node_deletes_total.fetch_add(1, Ordering::Relaxed);
-        self.nodes_total
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
-                Some(x.saturating_sub(1))
-            })
-            .ok();
-    }
-
-    /// Returns total node count.
-    #[must_use]
-    pub fn nodes_total(&self) -> u64 {
-        self.nodes_total.load(Ordering::Relaxed)
-    }
-
-    /// Returns total node insertions.
-    #[must_use]
-    pub fn node_inserts_total(&self) -> u64 {
-        self.node_inserts_total.load(Ordering::Relaxed)
-    }
-
-    // =========================================================================
     // Edge metrics
     // =========================================================================
 
-    /// Records an edge insertion with latency.
-    pub fn record_edge_insert(&self, latency: Duration) {
+    /// Records an edge insertion.
+    ///
+    /// Counters only — no clock read. The single-edge path runs per write, so
+    /// a per-call `Instant::now()` plus histogram bucketing was a real cost
+    /// paid on every insert; nothing reads it. `edge_insert_latency` is
+    /// still fed by `record_edge_inserts_batch`, which pays that cost once
+    /// per batch instead of once per edge.
+    pub fn record_edge_insert(&self) {
         self.edge_inserts_total.fetch_add(1, Ordering::Relaxed);
         self.edges_total.fetch_add(1, Ordering::Relaxed);
-        self.edge_insert_latency.observe(latency);
     }
 
     /// Records a batch edge insertion.
@@ -233,17 +195,19 @@ impl GraphMetrics {
         self.edge_insert_latency.observe(latency);
     }
 
-    /// Records an edge deletion with latency.
+    /// Records an edge deletion.
+    ///
+    /// Counters only — no clock read. See `record_edge_insert` for why: the
+    /// per-delete `Instant::now()` this used to take had no reader.
     ///
     /// Uses saturating subtraction to prevent underflow.
-    pub fn record_edge_delete(&self, latency: Duration) {
+    pub fn record_edge_delete(&self) {
         self.edge_deletes_total.fetch_add(1, Ordering::Relaxed);
         self.edges_total
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
                 Some(x.saturating_sub(1))
             })
             .ok();
-        self.edge_delete_latency.observe(latency);
     }
 
     /// Returns total edge count.
@@ -305,19 +269,6 @@ impl GraphMetrics {
     #[must_use]
     pub fn to_prometheus(&self) -> String {
         let mut output = String::with_capacity(2048);
-
-        // Node metrics
-        output.push_str("# HELP velesdb_graph_nodes_total Current number of nodes\n");
-        output.push_str("# TYPE velesdb_graph_nodes_total gauge\n");
-        let _ = writeln!(output, "velesdb_graph_nodes_total {}\n", self.nodes_total());
-
-        output.push_str("# HELP velesdb_graph_node_inserts_total Total node insertions\n");
-        output.push_str("# TYPE velesdb_graph_node_inserts_total counter\n");
-        let _ = writeln!(
-            output,
-            "velesdb_graph_node_inserts_total {}\n",
-            self.node_inserts_total()
-        );
 
         // Edge metrics
         output.push_str("# HELP velesdb_graph_edges_total Current number of edges\n");
@@ -390,16 +341,12 @@ impl GraphMetrics {
 
     /// Resets all metrics to zero.
     pub fn reset(&self) {
-        self.nodes_total.store(0, Ordering::Relaxed);
-        self.node_inserts_total.store(0, Ordering::Relaxed);
-        self.node_deletes_total.store(0, Ordering::Relaxed);
         self.edges_total.store(0, Ordering::Relaxed);
         self.edge_inserts_total.store(0, Ordering::Relaxed);
         self.edge_deletes_total.store(0, Ordering::Relaxed);
         self.traversals_total.store(0, Ordering::Relaxed);
         self.traversal_nodes_visited.store(0, Ordering::Relaxed);
         self.edge_insert_latency.reset();
-        self.edge_delete_latency.reset();
         self.traversal_latency.reset();
         self.query_latency.reset();
     }

--- a/crates/velesdb-core/src/collection/graph/metrics/tests.rs
+++ b/crates/velesdb-core/src/collection/graph/metrics/tests.rs
@@ -47,24 +47,11 @@ fn test_latency_histogram_reset() {
 fn test_graph_metrics_edge_insert() {
     let metrics = GraphMetrics::new();
 
-    metrics.record_edge_insert(Duration::from_millis(5));
-    metrics.record_edge_insert(Duration::from_millis(10));
+    metrics.record_edge_insert();
+    metrics.record_edge_insert();
 
     assert_eq!(metrics.edges_total(), 2);
     assert_eq!(metrics.edge_inserts_total(), 2);
-    assert_eq!(metrics.edge_insert_latency.count(), 2);
-}
-
-#[test]
-fn test_graph_metrics_node_operations() {
-    let metrics = GraphMetrics::new();
-
-    metrics.record_node_insert();
-    metrics.record_node_insert();
-    metrics.record_node_delete();
-
-    assert_eq!(metrics.nodes_total(), 1);
-    assert_eq!(metrics.node_inserts_total(), 2);
 }
 
 #[test]
@@ -83,16 +70,13 @@ fn test_graph_metrics_traversal() {
 fn test_graph_metrics_prometheus_format() {
     let metrics = GraphMetrics::new();
 
-    metrics.record_edge_insert(Duration::from_millis(5));
-    metrics.record_node_insert();
+    metrics.record_edge_inserts_batch(1, Duration::from_millis(5));
     metrics.record_traversal(Duration::from_millis(10), 100);
 
     let output = metrics.to_prometheus();
 
     // Verify Prometheus format
-    assert!(output.contains("# HELP velesdb_graph_nodes_total"));
-    assert!(output.contains("# TYPE velesdb_graph_nodes_total gauge"));
-    assert!(output.contains("velesdb_graph_nodes_total 1"));
+    assert!(output.contains("# HELP velesdb_graph_edges_total"));
     assert!(output.contains("velesdb_graph_edges_total 1"));
     assert!(output.contains("velesdb_graph_edge_insert_duration_seconds_bucket"));
 }
@@ -101,13 +85,11 @@ fn test_graph_metrics_prometheus_format() {
 fn test_graph_metrics_reset() {
     let metrics = GraphMetrics::new();
 
-    metrics.record_edge_insert(Duration::from_millis(5));
-    metrics.record_node_insert();
+    metrics.record_edge_inserts_batch(1, Duration::from_millis(5));
 
     metrics.reset();
 
     assert_eq!(metrics.edges_total(), 0);
-    assert_eq!(metrics.nodes_total(), 0);
     assert_eq!(metrics.edge_insert_latency.count(), 0);
 }
 

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -192,7 +192,7 @@ VelesDB core architecture is explicitly **hybrid by design**:
 │  ┌──────────────────┐  ┌──────────────────┐  ┌────────────────────────┐ │
 │  │   LabelTable     │  │   BfsIterator    │  │    GraphMetrics        │ │
 │  │ String interning │  │ Streaming BFS    │  │  LatencyHistogram      │ │
-│  │  LabelId (u32)   │  │ memory-bounded   │  │  node/edge counters    │ │
+│  │  LabelId (u32)   │  │ memory-bounded   │  │  edge counters         │ │
 │  └──────────────────┘  └──────────────────┘  └────────────────────────┘ │
 └─────────────────────────────────────────────────────────────────────────┘
 ```


### PR DESCRIPTION
## Description

`GraphMetrics` paid a real, unconditional cost for data nobody read.
The single-edge insert and delete paths (`ConcurrentEdgeStore::add_edge`,
`remove_edge_detailed`) each took an `Instant::now()` + `elapsed()` plus a
10-bucket atomic histogram `observe()` on every write. The node counters
(`record_node_insert`/`record_node_delete`/`nodes_total`/`node_inserts_total`)
were never called from anywhere except the metrics module's own unit tests.
Across the whole tree, the only callers of `.metrics()` on the edge store
were test files — no exporter, no server `/metrics` wiring, no
`CollectionStats` surface.

This retires the per-op timing (option 2 from #2091) rather than wiring an
exporter, since nothing downstream currently consumes the snapshot:

- `record_edge_insert`/`record_edge_delete` are now counters-only — no
  clock read, no histogram write on the single-edge hot path.
- `edge_insert_latency` stays fed by `record_edge_inserts_batch`, which
  already paid the clock read once per batch instead of once per edge.
- `edge_delete_latency` had no other producer, so the field goes with the
  timing that fed it.
- The node-metric fields and methods are deleted outright — dead even on
  the write side, per the issue.
- `to_prometheus()` and `reset()` are updated to match; the ASCII diagram
  in `ARCHITECTURE.md` no longer claims node counters that don't exist.

`record_query`/`query_latency` are equally dead (no caller anywhere, not
even in tests) but are left untouched — out of scope for this pass, not
named in #2091.

Fixes #2091

## Type of Change

- [x] 🔧 Refactoring (no functional changes)
- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

Existing tests updated to match the new (latency-free) single-edge
signatures; no new test surface was needed since the counters they pin
are unchanged in behavior.

```
cargo test -p velesdb-core --features persistence --lib graph::metrics -- --test-threads=1   # 9 passed
cargo test -p velesdb-core --features persistence --lib edge_concurrent -- --test-threads=1   # 63 passed
cargo test -p velesdb-core --features persistence --lib graph_api -- --test-threads=1         # 74 passed
cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic
cargo fmt --all -- --check
python3 scripts/check-ai-attribution.py "origin/develop..HEAD"
python3 scripts/check-doc-freshness.py --guard <stamp|index|tracked|versions|decisions> --mode strict
```

**Test Configuration:**
- OS: Linux
- Rust version: per `rust-toolchain.toml` (1.90)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

N/A — no `unsafe` added or modified.

## High-Risk Change Checklist

N/A — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Bounded to what #2091 named: node-metric dead code and the two hot-path
clock reads. `record_query`/`query_latency` are mentioned above as a
known, separately-scoped follow-up rather than folded in here.