### PR TITLE
ci: make the merge gate satisfiable under every trigger it declares

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,7 +934,23 @@ jobs:
     # Runs on PRs too (and gates CI Success) so connector regressions are
     # caught before merge — the LangChain suite once rotted to 21 failures
     # while this job was push-only and advisory.
-    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'))) && (github.event.action != 'edited' || github.event.changes.base != null)
+    #
+    # `workflow_dispatch` is in the list because this job's result is asserted
+    # by the ci-success chain, and a chain entry that cannot run under a
+    # declared trigger makes the gate unsatisfiable under it. Leaving it out
+    # meant a manual dispatch — the documented escape hatch for the #1465
+    # "required check is absent" failure mode — could only ever produce a RED
+    # `CI Success`, because this one need came back `skipped` while every
+    # other job passed. That is worse than the hole it was meant to plug: an
+    # absent check blocks, a red one *overwrites a green check-run of the same
+    # name* on the head SHA. Hit on PR #2141, where dispatch run 4378 replaced
+    # the green verdict of pull_request run 4380 on the same commit.
+    #
+    # `push` needs no such clause: ci.yml's push trigger is already filtered to
+    # main/develop, exactly the refs this condition admits.
+    #
+    # Pinned by scripts/tests/test_ci_gate_reachability.py.
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'))) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A manual CI dispatch can no longer turn a green `CI Success` red.**
+  `ci-success` asserts `result == 'success'` for every job it reads, and
+  `python-integrations` admitted only `pull_request` and `push`. Under
+  `workflow_dispatch` it came back `skipped`, never `success`, so the gate was
+  unsatisfiable under that trigger however green everything else was — the one
+  manual escape hatch this workflow documents for the #1465 "required check is
+  absent" failure mode could only ever produce a red verdict. That is worse
+  than the hole it plugs: an absent check blocks a merge, a red one *replaces
+  a green check-run of the same name* on the head SHA. Seen on PR #2141, where
+  a dispatch run overwrote the green `CI Success` an earlier `pull_request` run
+  had already recorded for the same commit.
+
+  The job now admits `workflow_dispatch` too, and the rule is pinned rather
+  than left to review: `test_ci_gate_reachability.py` now asserts that every
+  job the chain reads can run under every trigger the `on:` block declares.
+  `sonarcloud` is out of scope by construction — it is in `needs` but
+  deliberately absent from the chain, so it may skip freely. Both directions
+  were mutation-checked: reverting the guard and, separately, narrowing `lint`
+  to `pull_request` each turn the new suite red at the offending job and
+  trigger.
+
 - **Cosine search scores keep their sign, on every path.** `transform_score`
   on the HNSW graph path shared one match arm with Jaccard and clamped to
   `[0, 1]`, so a genuinely negative cosine came back as exactly `0.0` — while

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1476,5 +1476,182 @@ class CancelInProgressParserTests(unittest.TestCase):
         self.assertEqual(cancel_in_progress("concurrency:\n  group: g\n"), "")
 
 
+# ---------------------------------------------------------------------------
+# Every trigger the workflow declares must be able to satisfy the gate
+# ---------------------------------------------------------------------------
+
+# `on:` keys that are events, in the position PR_TRIGGER_RE would find them.
+# Anchored at four spaces under `on:` so a job key never matches.
+DECLARED_TRIGGER_RE = re.compile(r"^  ([a-z_]+):\s*$", re.MULTILINE)
+EVENT_NAME_RE = re.compile(r"github\.event_name\s*==\s*'([a-z_]+)'")
+
+# Triggers a chain-checked job may exclude, and why. Empty on purpose: there is
+# currently no trigger under which the gate is allowed to be unsatisfiable, and
+# an entry here would be a documented hole rather than an accidental one.
+TRIGGER_EXEMPT: "dict[tuple[str, str], str]" = {}
+
+
+def declared_triggers(text: str) -> "list[str]":
+    """Events the workflow's `on:` block subscribes to, in declaration order."""
+    stripped = strip_comments(text)
+    start = stripped.find("\non:\n")
+    if start == -1:
+        raise AssertionError("no `on:` block found")
+    end = stripped.find("\njobs:\n", start)
+    block = stripped[start : end if end != -1 else len(stripped)]
+    return DECLARED_TRIGGER_RE.findall(block)
+
+
+def job_condition(text: str, job: str) -> str:
+    """One job's whole `if:` value, folded continuation lines included.
+
+    Reading only the `if:` line would make a condition written as a YAML block
+    (`if: >-` with the expression indented beneath) parse as *no* condition —
+    and "no condition" is the reachable-everywhere verdict below, so a
+    reformat nobody thought of as a change would silently empty the check.
+    """
+    head = job_block(strip_comments(text), job).split("\n    steps:", 1)[0]
+    lines = head.split("\n")
+    for index, line in enumerate(lines):
+        if not line.startswith("    if:"):
+            continue
+        parts = [line[len("    if:") :].strip()]
+        for follower in lines[index + 1 :]:
+            if follower.strip() and not follower.startswith("      "):
+                break
+            parts.append(follower.strip())
+        return " ".join(part for part in parts if part)
+    return ""
+
+
+def job_event_names(text: str, job: str) -> "set[str]":
+    """The `github.event_name == '…'` literals in one job's `if:`.
+
+    An empty set means the job does not constrain the event at all, which is
+    the reachable-everywhere case — not the unreachable one.
+    """
+    return set(EVENT_NAME_RE.findall(job_condition(text, job)))
+
+
+class GateReachableUnderEveryTriggerTests(unittest.TestCase):
+    """A gate entry that cannot run under a trigger makes the gate unsatisfiable.
+
+    `ci-success` asserts `result == 'success'` for each job it reads. A job
+    that its own `if:` excludes for the current event comes back `skipped`,
+    never `success`, so the chain fails however green everything else is.
+
+    This bit in production on PR #2141. `python-integrations` admitted only
+    `pull_request` and `push`, so a manual `workflow_dispatch` — the escape
+    hatch this file's own comments name for the #1465 "required check is
+    absent" failure mode — could only ever produce a RED `CI Success`. That is
+    strictly worse than the hole it plugs: an absent check blocks a merge, a
+    red one *replaces a green check-run of the same name* on the head SHA.
+    Dispatch run 4378 overwrote the green verdict pull_request run 4380 had
+    already recorded for the same commit.
+
+    The rule is mechanical rather than a review habit: for every job the chain
+    reads, the set of events its `if:` admits must cover every event the `on:`
+    block declares. `sonarcloud` is out of scope by construction — it is in
+    `needs` but deliberately absent from the chain (see CHAIN_EXEMPT), so it
+    can skip freely.
+    """
+
+    def setUp(self) -> None:
+        self.ci = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_the_workflow_declares_the_triggers_this_suite_assumes(self) -> None:
+        """Fail loudly if trigger discovery breaks, rather than vacuously pass."""
+        triggers = declared_triggers(self.ci)
+        for expected in ("push", "pull_request", "workflow_dispatch"):
+            self.assertIn(expected, triggers, f"trigger discovery found {triggers}")
+
+    def test_every_chain_entry_can_run_under_every_declared_trigger(self) -> None:
+        triggers = declared_triggers(self.ci)
+        unreachable = []
+        for job in sorted(chain_checked_jobs(self.ci)):
+            admitted = job_event_names(self.ci, job)
+            if not admitted:
+                continue
+            for trigger in triggers:
+                if trigger not in admitted and (job, trigger) not in TRIGGER_EXEMPT:
+                    unreachable.append(f"{job} cannot run on {trigger}")
+        self.assertEqual(
+            unreachable,
+            [],
+            "`ci-success` demands `success` from each of these, so a trigger the job "
+            "excludes makes the gate unsatisfiable under that trigger — a required check "
+            f"that is permanently red. Add the event to the job's `if:`. Found: {unreachable}",
+        )
+
+    def test_the_job_that_regressed_admits_the_manual_trigger(self) -> None:
+        """The specific case above, named so a regression reads as itself."""
+        self.assertIn(
+            "workflow_dispatch",
+            job_event_names(self.ci, "python-integrations"),
+            "a manual dispatch is the documented way out of an absent `CI Success`; "
+            "with this job excluded it can only ever produce a red one",
+        )
+
+    def test_the_exempt_job_is_out_of_the_chain_not_merely_tolerated(self) -> None:
+        """`sonarcloud` skips on dispatch; that is only safe while it is unread."""
+        self.assertNotIn("sonarcloud", chain_checked_jobs(self.ci))
+        self.assertIn("sonarcloud", CHAIN_EXEMPT)
+
+
+class TriggerReachabilityParserTests(unittest.TestCase):
+    """RED-then-GREEN on synthetic text, per this module's parser contract."""
+
+    WORKFLOW = (
+        "name: X\n"
+        "\non:\n"
+        "  push:\n    branches: [main]\n"
+        "  pull_request:\n    types: [opened]\n"
+        "  workflow_dispatch:\n"
+        "\njobs:\n"
+        "  alpha:\n    name: A\n"
+        "    if: github.event_name == 'pull_request' || github.event_name == 'push'\n"
+        "    steps:\n      - run: true\n"
+        "  beta:\n    name: B\n    steps:\n      - run: true\n"
+    )
+
+    def test_trigger_parser_reads_the_on_block_and_stops_at_jobs(self) -> None:
+        self.assertEqual(
+            declared_triggers(self.WORKFLOW),
+            ["push", "pull_request", "workflow_dispatch"],
+        )
+
+    def test_event_parser_reads_a_disjunction(self) -> None:
+        self.assertEqual(
+            job_event_names(self.WORKFLOW, "alpha"), {"pull_request", "push"}
+        )
+
+    def test_a_job_that_does_not_constrain_the_event_reads_as_unconstrained(self) -> None:
+        self.assertEqual(job_event_names(self.WORKFLOW, "beta"), set())
+
+    def test_event_parser_reads_a_folded_condition(self) -> None:
+        """A condition written as a YAML block is still a condition."""
+        text = (
+            "name: X\n"
+            "\non:\n  push:\n  workflow_dispatch:\n"
+            "\njobs:\n"
+            "  alpha:\n    name: A\n"
+            "    if: >-\n"
+            "      github.event_name == 'push' ||\n"
+            "      github.event_name == 'workflow_dispatch'\n"
+            "    steps:\n      - run: true\n"
+        )
+        self.assertEqual(
+            job_event_names(text, "alpha"), {"push", "workflow_dispatch"}
+        )
+
+    def test_a_commented_out_condition_does_not_count_as_admitting(self) -> None:
+        """The disarm this module's `strip_comments` exists for, at job level."""
+        text = self.WORKFLOW.replace(
+            "    if: github.event_name == 'pull_request' || github.event_name == 'push'\n",
+            "    # if: github.event_name == 'pull_request'\n",
+        )
+        self.assertEqual(job_event_names(text, "alpha"), set())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

`ci-success` asserts `result == 'success'` for every job it reads. `python-integrations` admitted only `pull_request` and `push`, so under `workflow_dispatch` it came back **`skipped` — never `success`** — and the gate was unsatisfiable under that trigger however green everything else was.

That trigger is not decorative. It is the manual escape hatch this workflow's own comments name for the #1465 failure mode, where a required check is *absent* and blocks a merge with no way to resolve it. Using it produced something strictly worse than the hole it plugs:

> an absent check blocks a merge; a **red** one *replaces a green check-run of the same name* on the head SHA.

Observed on #2141, on commit `b4beb8d1`:

| run | event | jobs | `CI Success` | finished |
|---|---|---|---|---|
| 4380 | `pull_request` | 41 | ✅ success | 17:17:38 |
| 4378 | `workflow_dispatch` | 41 | ❌ **failure** | 17:19:55 |

Every one of run 4378's jobs was green or legitimately path-skipped. Only the aggregator was red, and its log says why — one `[[ "skipped" == "success" ]]` in a chain of 23:

```
[[ "success" == "success" ]] && \
...
[[ "skipped" == "success" ]] && \   # ← needs.python-integrations.result
...
echo "✅ CI passed" || { echo "❌ CI failed"; exit 1; }
```

No issue number: found while driving #2141 to green.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

**The fix is one event name, not a loosening of what the job checks.** `push` needs no equivalent clause: ci.yml's `push` trigger is already filtered to `main`/`develop`, exactly the refs the existing condition admits. The gate still demands the same 23 successes.

**The rule is pinned rather than left to review.** `test_ci_gate_reachability.py` gains `GateReachableUnderEveryTriggerTests`: for every job the chain reads, the events its `if:` admits must cover every event the `on:` block declares. A job that does not constrain `github.event_name` at all is reachable everywhere and passes trivially. `sonarcloud` is out of scope by construction — it is in `needs` but deliberately absent from the chain (`CHAIN_EXEMPT`), so it may skip freely; a test asserts that remains true rather than trusting the comment.

The condition parser folds YAML block scalars. Reading only the `if:` line would make a condition written as `if: >-` with the expression indented beneath parse as *no* condition — and "no condition" is the reachable-everywhere verdict, so a reformat nobody thought of as a change would have emptied the check silently. That is the same disarm shape `strip_comments` already exists for in this module, one level down.

### Mutation-checked, not asserted

| injected defect | new suite reports |
|---|---|
| revert the guard on `python-integrations` | `python-integrations cannot run on workflow_dispatch` (2 tests red) |
| narrow `lint` to `pull_request` | `lint cannot run on push`, `lint cannot run on workflow_dispatch` |

`ci.yml` was restored from backup between injections. 78 tests green on the restored file.

**Test Configuration:**
- OS: Linux x86_64
- Python: 3.x, stdlib `unittest` only (this module is deliberately regex-based, not PyYAML — `gate-contracts.yml` runs it with a bare `setup-python` and installs nothing)

Also green: `test_ci_test_gate`, `test_propagation_guard_concurrency`, `test_skill_copies_are_identical`, `test_sync_agent_hooks`, `test_test_target_reachability` — every other suite that reads `ci.yml`. The three repo guards (`check-ai-attribution`, `check-inline-tests`, `check-file-budgets`) pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Worth recording: the exemption list `TRIGGER_EXEMPT` ships **empty**, on purpose. There is currently no trigger under which the gate may be unsatisfiable, and an entry there would be a documented hole rather than an accidental one — the same shape as `CHAIN_EXEMPT` and `RETARGET_GUARD_EXEMPT` above it, both of which carry a test asserting their entries are still real.

One correction to an earlier read of this branch's history, since it is in the record: opening #2141 was reported as producing **no** `ci.yml` run at all, a repeat of the "required check is absent" gap. That was wrong. Runs 4379 and 4380 did fire on `pull_request`; they simply appeared ~10 minutes after the PR was opened, and the check happened before they existed. The dispatch fired in the meantime is what produced the red check — so the incident here is entirely this defect, not a missing-run gap.
