### PR TITLE
fix(simd): stop computing out-of-bounds pointers in the AVX loop guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The AVX kernels no longer compute out-of-bounds pointers (#2106 item 9).**
+  Eleven loops guarded themselves with `while p.add(N) <= end_ptr`, and that is
+  undefined behaviour on the final evaluation — the one that ends the loop.
+  `pointer::add` requires the *computed* pointer to stay inside the same
+  allocated object, one past the end included; when fewer than `N` elements
+  remain it does not, and never dereferencing the result does not save it.
+  Miri reports it as an out-of-bounds pointer computation, reproduced here on
+  the guard shape with the intrinsics stripped out:
+
+  ```
+  error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting to
+  offset pointer by 32 bytes, but got alloc271+0x40 which is only 16 bytes from
+  the end of the allocation
+     --> while p.add(8) <= end
+  ```
+
+  Every compiler in use today emits the obvious address comparison, which is
+  why this never produced a wrong answer — but LLVM is entitled to assume an
+  `inbounds` GEP is in bounds, and one feeding a comparison is precisely the
+  shape a future optimisation may fold. The defect is that the code asks a
+  question it has no right to ask.
+
+  `simd_native::ptr_span::has_at_least` asks it of the *distance* between the
+  two cursors instead, on integers, where the arithmetic is defined for every
+  input; the index-form guards already in the tree (`i + 16 <= len`) are the
+  same idea for the loops that carry indices rather than pointers. All eleven
+  sites now use it — eight in `x86_avx512.rs`, three in
+  `x86_avx2_similarity.rs` — and the file-level claim that "loop guards ensure
+  pointer arithmetic stays within the original slice bounds", which was the
+  false one, is replaced by a pointer to the guard that now makes it true.
+
+  Equivalence with the old guard is pinned exhaustively rather than sampled:
+  for every length 0..=80, every cursor position within it, and every lane
+  width in use, the new guard returns what `p.add(count) <= end` would have
+  returned, and the consuming loop runs exactly `len / count` times leaving
+  `len % count` for the scalar tail. A cursor past the end — unreachable
+  through the kernels' own loop structure — is pinned to fail closed rather
+  than wrap to a span that would walk off the buffer. `ptr_span_tests.rs`
+  carries no intrinsics on purpose, so unlike the kernels it can be run under
+  Miri. (#2106)
+
 - **A manual CI dispatch can no longer turn a green `CI Success` red.**
   `ci-success` asserts `result == 'success'` for every job it reads, and
   `python-integrations` admitted only `pull_request` and `push`. Under

--- a/crates/velesdb-core/src/simd_native/l2_dot_tail_tests.rs
+++ b/crates/velesdb-core/src/simd_native/l2_dot_tail_tests.rs
@@ -28,6 +28,12 @@
 //! - `warmup_tests.rs` looks like it reaches the 4-acc tail at 767, but that
 //!   767 is a *value* inside the generator; the vector is 768 long, a multiple
 //!   of 64.
+//! - `simd_native_tests.rs` — the crate-level suite, one directory up from
+//!   this one rather than beside it, which is why an earlier note here called
+//!   it absent. It exists. Its dimensions are 0, 16, 19, 32, 100, 384, 768 and
+//!   1536: 19 and 100 reach the 2-acc mask, and every one at or above 512 is
+//!   an exact multiple of its kernel's stride. It changes the file list, not
+//!   the conclusion.
 //!
 //! So the 2-acc mask was already exercised and the 4-acc and 8-acc remainders
 //! — both stages of each — were not.

--- a/crates/velesdb-core/src/simd_native/mod.rs
+++ b/crates/velesdb-core/src/simd_native/mod.rs
@@ -8,6 +8,7 @@
 //! - `scalar` — Scalar fallback implementations and fast-rsqrt helpers
 //! - `tail_unroll` — Remainder/tail handling macros for SIMD loops
 //! - `prefetch` — CPU cache prefetch utilities
+//! - `ptr_span` — remaining-length guards for the pointer-walked kernels
 //! - `reduction` — Shared horizontal sum helpers for SIMD accumulators
 //! - `x86_avx512` — AVX-512F kernel implementations (x86_64 only)
 //! - `x86_avx2` — AVX2+FMA dot product and squared L2 kernels (x86_64 only)
@@ -35,6 +36,8 @@
 // =============================================================================
 
 pub mod prefetch;
+#[cfg(target_arch = "x86_64")]
+pub(crate) mod ptr_span;
 pub(crate) mod reduction;
 pub mod scalar;
 mod tail_unroll;
@@ -57,7 +60,9 @@ pub use prefetch::{
 // =============================================================================
 // SAFETY: Shared invariants for SIMD unsafe blocks in this module tree.
 // - Condition 1: All pointer arithmetic is derived from slice pointers with loop bounds
-//   proving in-range access for each lane width.
+//   proving in-range access for each lane width. Where a loop walks cursors rather
+//   than indices, the bound is `ptr_span::has_at_least`, which measures the distance
+//   between them instead of forming the past-the-end pointer the check is about.
 // - Condition 2: Target-featured functions are called only after runtime feature checks
 //   or on architectures where the feature is guaranteed.
 // - Condition 3: Unaligned loads use `*_loadu_*`/masked-load intrinsics or equivalent
@@ -154,3 +159,7 @@ mod distance_engine_tests;
 
 #[cfg(test)]
 mod hamming_jaccard_tests;
+
+#[cfg(all(test, target_arch = "x86_64"))]
+#[path = "ptr_span_tests.rs"]
+mod ptr_span_tests;

--- a/crates/velesdb-core/src/simd_native/ptr_span.rs
+++ b/crates/velesdb-core/src/simd_native/ptr_span.rs
@@ -1,0 +1,46 @@
+//! Remaining-length checks for the pointer-walked SIMD loops.
+//!
+//! The kernels in this module tree walk a pair of `*const f32` cursors towards
+//! an `end_ptr` one past the last element, consuming a lane's worth per
+//! iteration. The guard they used to spell that with was:
+//!
+//! ```text
+//! while a_ptr.add(16) <= end_ptr { … }
+//! ```
+//!
+//! which is undefined behaviour on its final evaluation, and the fact that the
+//! result is only compared and never dereferenced does not save it.
+//! `pointer::add` requires the *computed* pointer to stay inside the same
+//! allocated object (one past the end included). On the last check — the one
+//! that ends the loop — fewer than 16 elements remain, so `a_ptr.add(16)`
+//! lands beyond one-past-the-end and the call is UB before the comparison
+//! happens. Miri reports it as an out-of-bounds pointer computation.
+//!
+//! In practice every compiler in use today emits the obvious address
+//! comparison, which is why this never produced a wrong answer. That is not a
+//! guarantee: LLVM is entitled to assume the pointer is in bounds, and an
+//! `inbounds` GEP feeding a comparison is exactly the shape a future
+//! optimisation is allowed to fold. The bug is that the code asks a question
+//! it has no right to ask, not that anyone has yet answered it wrongly.
+//!
+//! [`has_at_least`] asks the same question about the *distance* between the
+//! two cursors instead, on integers, where the arithmetic is defined for every
+//! input. The index-form guards elsewhere in the tree (`i + 16 <= len`) are
+//! the same idea; this is that idea for the sites that carry pointers rather
+//! than indices, so neither has to be rewritten into the other.
+
+/// Whether at least `count` values of `T` remain between `cur` and `end`.
+///
+/// `cur` and `end` must delimit a range of `T` — `end` one past its last
+/// element — and both must derive from the same allocation. That is the same
+/// precondition the callers already rely on; nothing here reads either
+/// pointer, so violating it yields a wrong answer rather than UB.
+///
+/// The subtraction saturates rather than wrapping so that a cursor past `end`,
+/// which the callers' loop structure makes unreachable, reports "nothing
+/// remains" and stops the loop instead of computing an enormous span and
+/// running off the buffer. Failing closed is the only safe direction here.
+#[inline]
+pub(crate) fn has_at_least<T>(cur: *const T, end: *const T, count: usize) -> bool {
+    end.addr().saturating_sub(cur.addr()) >= count * core::mem::size_of::<T>()
+}

--- a/crates/velesdb-core/src/simd_native/ptr_span_tests.rs
+++ b/crates/velesdb-core/src/simd_native/ptr_span_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for the remaining-length guard the pointer-walked kernels use.
+//!
+//! The property that matters is not "does it count chunks" — that was never
+//! wrong — but that it answers the same question the old `p.add(N) <= end`
+//! guard answered, at every length, without forming the pointer that made the
+//! old form UB. So the tests pin the *answer*, exhaustively over the lengths
+//! where the two could disagree, and pin the loop that consumes it.
+//!
+//! Deliberately free of intrinsics, so this file runs under Miri
+//! (`cargo +nightly miri test -p velesdb-core ptr_span`) — which the kernels
+//! themselves cannot, Miri having no AVX-512 support. That is what makes this
+//! the place the soundness claim can be checked rather than asserted.
+
+use super::ptr_span::has_at_least;
+
+/// What `p.add(count) <= end` would have said, computed on integers.
+///
+/// The reference for equivalence, deliberately not written with pointer
+/// arithmetic: the whole point is that the pointer form cannot legally be
+/// evaluated at the boundary this compares against.
+fn remaining(consumed: usize, len: usize, count: usize) -> bool {
+    len - consumed >= count
+}
+
+/// The guard agrees with the arithmetic answer at every length and position.
+///
+/// Ranges chosen to straddle both lane widths in use (8 for AVX2, 16 for
+/// AVX-512) several times over, so an off-by-one at a chunk boundary shows up
+/// rather than hiding between the probed points.
+#[test]
+fn the_guard_matches_the_remaining_element_count_everywhere() {
+    for len in 0..=80usize {
+        let buffer = vec![0.0f32; len];
+        let start = buffer.as_ptr();
+        // SAFETY: one past the last element is in bounds for `add`.
+        let end = unsafe { start.add(len) };
+
+        for consumed in 0..=len {
+            // SAFETY: `consumed <= len`, so this stays inside the allocation.
+            let cur = unsafe { start.add(consumed) };
+            for count in [1usize, 2, 4, 8, 16, 32] {
+                assert_eq!(
+                    has_at_least(cur, end, count),
+                    remaining(consumed, len, count),
+                    "len {len}, consumed {consumed}, count {count}"
+                );
+            }
+        }
+    }
+}
+
+/// An empty range never has room, whatever is asked of it.
+///
+/// `Vec::as_ptr` on an empty vector returns a dangling-but-aligned pointer and
+/// `start == end`. The guard must read that as "nothing remains" rather than
+/// subtracting two unrelated addresses.
+#[test]
+fn an_empty_range_has_room_for_nothing() {
+    let empty: Vec<f32> = Vec::new();
+    let start = empty.as_ptr();
+    for count in [1usize, 8, 16] {
+        assert!(!has_at_least(start, start, count));
+    }
+    // Zero elements always fit, including here: the loops never ask, but a
+    // guard that answered `false` would be saying something untrue.
+    assert!(has_at_least(start, start, 0));
+}
+
+/// A cursor past the end reports "nothing remains" instead of wrapping.
+///
+/// Unreachable through the kernels' own loop structure, which is exactly why
+/// it is worth pinning: `end - cur` on `usize` would wrap to a huge span and
+/// wave the loop straight off the end of the buffer. The saturating form fails
+/// closed, and this is the test that says so.
+#[test]
+fn a_cursor_past_the_end_fails_closed() {
+    let buffer = [0.0f32; 32];
+    let start = buffer.as_ptr();
+    // SAFETY: both offsets are within the 32-element allocation.
+    let (end, past) = unsafe { (start.add(16), start.add(24)) };
+
+    assert!(!has_at_least(past, end, 1));
+    assert!(!has_at_least(past, end, 16));
+}
+
+/// The consuming loop terminates and covers exactly the full chunks.
+///
+/// The guard is only ever read as a `while` condition, so the property the
+/// kernels actually depend on is this one: the loop runs `len / count` times
+/// and leaves the cursor with `len % count` elements to hand to the tail.
+#[test]
+fn the_loop_consumes_every_full_chunk_and_no_more() {
+    for len in 0..=80usize {
+        for count in [8usize, 16] {
+            let buffer = vec![0.0f32; len];
+            let start = buffer.as_ptr();
+            // SAFETY: one past the last element is in bounds for `add`.
+            let end = unsafe { start.add(len) };
+
+            let mut cur = start;
+            let mut chunks = 0usize;
+            while has_at_least(cur, end, count) {
+                chunks += 1;
+                // SAFETY: the guard just proved `count` elements remain.
+                cur = unsafe { cur.add(count) };
+            }
+
+            assert_eq!(chunks, len / count, "len {len}, count {count}");
+            // SAFETY: `cur` is within the allocation; so is `end`.
+            let left = unsafe { end.offset_from(cur) };
+            assert_eq!(
+                usize::try_from(left).expect("cursor never passes end"),
+                len % count,
+                "len {len}, count {count}: tail left for the scalar path"
+            );
+        }
+    }
+}

--- a/crates/velesdb-core/src/simd_native/x86_avx2_similarity.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx2_similarity.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::similar_names)]
 
+use super::ptr_span::has_at_least;
 use super::reduction::hsum_avx256;
 use super::scalar::cosine_finish_fast;
 
@@ -46,11 +47,11 @@ unsafe fn cosine_avx2_remainder(
     mut nb_acc: std::arch::x86_64::__m256,
 ) -> f32 {
     // SAFETY: AVX2+FMA guaranteed by #[target_feature]; unaligned loads are safe.
-    // Loop guards ensure pointer arithmetic stays within the original slice bounds.
+    // `has_at_least` keeps every pointer the loops form inside the slice.
     use std::arch::x86_64::*;
 
     // Vectorized 8-wide remainder to reduce scalar tail to at most 7 elements
-    while a_ptr.add(8) <= end_ptr {
+    while has_at_least(a_ptr, end_ptr, 8) {
         let va = _mm256_loadu_ps(a_ptr);
         let vb = _mm256_loadu_ps(b_ptr);
         dot_acc = _mm256_fmadd_ps(va, vb, dot_acc);
@@ -264,7 +265,7 @@ pub(crate) unsafe fn hamming_avx2(a: &[f32], b: &[f32]) -> f32 {
     let acc23 = _mm256_add_ps(acc2, acc3);
     let mut acc = _mm256_add_ps(acc01, acc23);
 
-    while a_ptr.add(8) <= end_ptr {
+    while has_at_least(a_ptr, end_ptr, 8) {
         // SAFETY: Guard ensures 8 elements remain.
         acc = hamming_avx2_fp_acc(a_ptr, b_ptr, threshold, one_vec, acc);
         a_ptr = a_ptr.add(8);
@@ -394,11 +395,11 @@ unsafe fn jaccard_avx2_remainder(
     mut acc_union: std::arch::x86_64::__m256,
 ) -> f32 {
     // SAFETY: AVX2 guaranteed by #[target_feature]; unaligned loads are safe.
-    // Loop guards ensure pointer arithmetic stays within the original slice bounds.
+    // `has_at_least` keeps every pointer the loops form inside the slice.
     use std::arch::x86_64::*;
 
     // Vectorized 8-wide remainder to reduce scalar tail to at most 7 elements
-    while a_ptr.add(8) <= end_ptr {
+    while has_at_least(a_ptr, end_ptr, 8) {
         let va = _mm256_loadu_ps(a_ptr);
         let vb = _mm256_loadu_ps(b_ptr);
         acc_inter = _mm256_add_ps(acc_inter, _mm256_min_ps(va, vb));

--- a/crates/velesdb-core/src/simd_native/x86_avx512.rs
+++ b/crates/velesdb-core/src/simd_native/x86_avx512.rs
@@ -23,9 +23,9 @@ use crate::simd_4acc_l2_loop;
 use crate::simd_8acc_dot_loop;
 use crate::simd_8acc_l2_loop;
 
+use super::ptr_span::has_at_least;
 use super::reduction::hsum_avx512;
-use super::scalar;
-use super::scalar::cosine_finish_fast;
+use super::scalar::{self, cosine_finish_fast};
 
 // =============================================================================
 // Dot Product
@@ -124,7 +124,7 @@ pub(crate) unsafe fn dot_product_avx512_4acc(a: &[f32], b: &[f32]) -> f32 {
     );
 
     // Process remaining 16-element chunks with same accumulator
-    while a_p.add(16) <= end_ptr {
+    while has_at_least(a_p, end_ptr, 16) {
         let va = _mm512_loadu_ps(a_p);
         let vb = _mm512_loadu_ps(b_p);
         acc = _mm512_fmadd_ps(va, vb, acc);
@@ -190,7 +190,7 @@ pub(crate) unsafe fn dot_product_avx512_8acc(a: &[f32], b: &[f32]) -> f32 {
     );
 
     // Process remaining 16-element chunks with single accumulator
-    while a_p.add(16) <= end_ptr {
+    while has_at_least(a_p, end_ptr, 16) {
         acc = _mm512_fmadd_ps(_mm512_loadu_ps(a_p), _mm512_loadu_ps(b_p), acc);
         a_p = a_p.add(16);
         b_p = b_p.add(16);
@@ -246,7 +246,7 @@ pub(crate) unsafe fn squared_l2_avx512_4acc(a: &[f32], b: &[f32]) -> f32 {
     );
 
     // Process remaining 16-element chunks
-    while a_p.add(16) <= end_ptr {
+    while has_at_least(a_p, end_ptr, 16) {
         let va = _mm512_loadu_ps(a_p);
         let vb = _mm512_loadu_ps(b_p);
         let diff = _mm512_sub_ps(va, vb);
@@ -352,7 +352,7 @@ pub(crate) unsafe fn squared_l2_avx512_8acc(a: &[f32], b: &[f32]) -> f32 {
     );
 
     // Process remaining 16-element chunks
-    while a_p.add(16) <= end_ptr {
+    while has_at_least(a_p, end_ptr, 16) {
         let diff = _mm512_sub_ps(_mm512_loadu_ps(a_p), _mm512_loadu_ps(b_p));
         acc = _mm512_fmadd_ps(diff, diff, acc);
         a_p = a_p.add(16);
@@ -535,7 +535,7 @@ pub(crate) unsafe fn cosine_fused_avx512_4acc(a: &[f32], b: &[f32]) -> f32 {
 
     // Remainder with masked loads (up to 63 elements)
     let mut rem_dot = dot_acc;
-    while cur_a.add(16) <= end_ptr {
+    while has_at_least(cur_a, end_ptr, 16) {
         let va = _mm512_loadu_ps(cur_a);
         let vb = _mm512_loadu_ps(cur_b);
         rem_dot = _mm512_fmadd_ps(va, vb, rem_dot);
@@ -802,7 +802,7 @@ unsafe fn cosine_8acc_remainder(
     use std::arch::x86_64::*;
 
     // Process remaining 16-element full chunks
-    while (*cur_a).add(16) <= end_ptr {
+    while has_at_least(*cur_a, end_ptr, 16) {
         // SAFETY: Loop guard ensures 16 elements remain
         let va = _mm512_loadu_ps(*cur_a);
         let vb = _mm512_loadu_ps(*cur_b);
@@ -1286,7 +1286,7 @@ unsafe fn jaccard_8acc_remainder(
     use std::arch::x86_64::*;
 
     // Process remaining 16-element full chunks
-    while cur_a.add(16) <= end_ptr {
+    while has_at_least(cur_a, end_ptr, 16) {
         // SAFETY: Loop guard ensures 16 elements remain
         let va = _mm512_loadu_ps(cur_a);
         let vb = _mm512_loadu_ps(cur_b);
@@ -1327,7 +1327,7 @@ unsafe fn jaccard_4acc_remainder(
     use std::arch::x86_64::*;
 
     // Process remaining 16-element full chunks (up to 3 iterations)
-    while cur_a.add(16) <= end_ptr {
+    while has_at_least(cur_a, end_ptr, 16) {
         // SAFETY: Loop guard ensures 16 elements remain
         let va = _mm512_loadu_ps(cur_a);
         let vb = _mm512_loadu_ps(cur_b);


### PR DESCRIPTION
## Description

Closes #2106 item 9. Eleven loops in the x86 kernels guarded themselves with

```rust
while p.add(N) <= end_ptr { … }
```

and that is **undefined behaviour on its final evaluation — the one that ends the loop**. `pointer::add` requires the *computed* pointer to stay inside the same allocated object, one past the end included. When fewer than `N` elements remain it does not, and the fact that the result is only compared and never dereferenced does not save it.

Not asserted from the docs — reproduced. The guard shape with the intrinsics stripped out, run under Miri:

```
error: Undefined Behavior: in-bounds pointer arithmetic failed: attempting to
offset pointer by 32 bytes, but got alloc271+0x40 which is only 16 bytes from
the end of the allocation
  --> src/main.rs:7:11
   |
 7 |     while p.add(8) <= end {
   |           ^^^^^^^^ Undefined Behavior occurred here
```

The same function rewritten with the new guard runs clean and returns the same chunk count.

Every compiler in use today emits the obvious address comparison, which is why this never produced a wrong answer. That is not a guarantee: LLVM may assume an `inbounds` GEP is in bounds, and one feeding a comparison is exactly the shape a future optimisation is allowed to fold. **The defect is that the code asks a question it has no right to ask**, not that anyone has yet answered it wrongly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`simd_native::ptr_span::has_at_least` asks the question of the *distance* between the two cursors instead, on integers, where the arithmetic is defined for every input:

```rust
pub(crate) fn has_at_least<T>(cur: *const T, end: *const T, count: usize) -> bool {
    end.addr().saturating_sub(cur.addr()) >= count * core::mem::size_of::<T>()
}
```

The index-form guards already in this tree (`i + 16 <= len`, which the issue itself names as the correct pattern) are the same idea for loops that carry indices rather than pointers — so neither kind has to be rewritten into the other and **no kernel signature moves**. All eleven sites now use it: eight in `x86_avx512.rs`, three in `x86_avx2_similarity.rs`. Zero old probes remain (`grep` on the pushed tip confirms it).

The subtraction saturates deliberately. A cursor past `end` is unreachable through the kernels' own loop structure, but a wrapping `usize` subtraction there would produce an enormous span and wave the loop straight off the buffer; failing closed is the only safe direction, and there is a test that says so.

Two file-level comments claimed *"loop guards ensure pointer arithmetic stays within the original slice bounds"*. That was the false claim, and it is what let this survive review — they now name the guard that makes it true.

### Equivalence pinned exhaustively, not sampled

| property | coverage |
|---|---|
| new guard == `p.add(count) <= end` | every length `0..=80`, every cursor position within it, counts 1/2/4/8/16/32 |
| loop runs `len / count` times | every length `0..=80`, both lane widths (8, 16) |
| tail left is `len % count` | same |
| empty range has room for nothing | `start == end`, dangling-but-aligned |
| cursor past end fails closed | pinned, so a wrapping rewrite goes red |

`ptr_span_tests.rs` carries no intrinsics **on purpose**: unlike the kernels, which Miri cannot execute for want of AVX-512 support, it can be run under Miri directly —

```
cargo +nightly miri test -p velesdb-core ptr_span
```

That is what makes it the place the soundness claim can be checked rather than restated. I ran Miri on the extracted shape (above), not on the crate: a Miri build of `velesdb-core` and its dependency tree did not fit the disk this container had left, and I would rather say so than imply a run I did not do.

**Test Configuration:**
- OS: Linux x86_64 (AVX-512F + AVX2 + FMA)
- Rust: 1.90 for the build; nightly 1.100.0 (`787af2b8c`) for Miri

Full local validation: `cargo fmt --check` clean; `cargo clippy -p velesdb-core -p velesdb-server --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean (the CI's own flags); 156 SIMD tests pass with `--test-threads=1` (152 before, +4 here); all three repo guards pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

- [x] All `unsafe {}` blocks have `// SAFETY:` comments explaining why it's sound — the new test file's blocks included
- [x] No undefined behavior possible with valid inputs — **this PR is that item**
- [x] Edge cases tested (empty, boundary values, alignment): zero length, `start == end`, cursor past end, every position at both lane widths
- [x] Miri: run on the extracted guard shape, red before and clean after; the new test file is intrinsic-free so it can be run under Miri in full

## High-Risk Change Checklist

> Touches SIMD dispatch paths.

- [x] Invariant impacted: exactly one — "a pointer the loop forms is inside the allocation". It was violated; it now holds. No arithmetic, no dispatch threshold and no kernel signature changes.
- [x] Edge cases tested — see the table above.
- [ ] Two reviewers for this risky path — worth having, given it is `unsafe` in the hot path.

## Additional Notes

`x86_avx512.rs` sits at its frozen line budget and may only shrink, so the helper import is paid for by merging its two `super::scalar` imports into one. The file is unchanged in length.

**A correction owed on #2141**, which is merged and whose changelog entry says otherwise: it claimed `simd_native_tests.rs` "does not exist in the tree". It does — at `crates/velesdb-core/src/simd_native_tests.rs`, one directory *up* from `simd_native/` rather than beside it, which is where the search went. It turned up while running the suite for this PR. Its dimensions are 0, 16, 19, 32, 100, 384, 768 and 1536: 19 and 100 reach the 2-acc mask, and every one at or above 512 is an exact multiple of its kernel's stride. So it lengthens the list of files checked and leaves the conclusion — that the 4-acc and 8-acc remainders were unreached — standing. The doc comment in `l2_dot_tail_tests.rs` is corrected here to say so.
