### PR TITLE
ci: gate that `internal-bench` still compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,6 +702,47 @@ jobs:
       - name: mcp + persistence (daemon)
         run: cargo check -p velesdb-memory --no-default-features --features mcp,persistence
 
+  # ===========================================================================
+  # `internal-bench` compiles (#2106 follow-up)
+  # ===========================================================================
+  # `internal-bench` is not a bench-only feature. It gates seven sites of
+  # production source — `index/hnsw/index/search.rs`, `index/hnsw/native/
+  # distance.rs`, `index/hnsw/mod.rs`, `velesql/cache.rs` and `lib.rs` — and
+  # until this job existed nothing on a pull request ever compiled it. The two
+  # workflows that do (quality-deep.yml, bench-scalability.yml) run weekly, so
+  # a PR could break the feature, merge green, and surface the breakage the
+  # following Sunday with no obvious culprit SHA.
+  #
+  # That is the same bargain `memory-feature-matrix` above already strikes, and
+  # it is deliberately a `cargo check`, not a bench run: the cost this gate is
+  # allowed to have is a compile. Catching the cfg regression is the point;
+  # measuring anything is not.
+  #
+  # `--benches` is load-bearing — the feature's `required-features` targets
+  # (Cargo.toml:440, :445) are bench targets, so a lib-only check would miss
+  # exactly the code the feature exists for.
+  internal-bench-check:
+    name: Internal Bench Compiles
+    if: github.event.action != 'edited' || github.event.changes.base != null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@stable # Intentionally unpinned - uses toolchain input
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "velesdb-ci-internal-bench"
+          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
+
+      - name: Library and benches under internal-bench
+        run: cargo check -p velesdb-core --benches --features persistence,internal-bench
+
+      - name: Tests under internal-bench
+        run: cargo check -p velesdb-core --tests --features persistence,internal-bench
+
   wasm-check:
     name: WASM Build Check
     if: github.event.action != 'edited' || github.event.changes.base != null
@@ -1787,7 +1828,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [lint, test, security, hygiene, wasm-check, memory-feature-matrix, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
+    needs: [lint, test, security, hygiene, wasm-check, memory-feature-matrix, internal-bench-check, openapi-drift, mcp-doc-contract, velesql-conformance, perf-smoke, bench-sift1m-compile, perf-gate-e2e, python-sdk-tests, python-integrations, node-binding-tests, node-binding-tests-windows, gate-contracts, doc-contract, promise-contract, production-gates, propagation-guard, binary-size, pr-governance, sonarcloud]
     if: (always()) && (github.event.action != 'edited' || github.event.changes.base != null)
     steps:
       # sonarcloud is intentionally absent from the gate below: it is an
@@ -1799,6 +1840,7 @@ jobs:
           [[ "${{ needs.test.result }}" == "success" ]] && \
           [[ "${{ needs.wasm-check.result }}" == "success" ]] && \
           [[ "${{ needs.memory-feature-matrix.result }}" == "success" ]] && \
+          [[ "${{ needs.internal-bench-check.result }}" == "success" ]] && \
           [[ "${{ needs.openapi-drift.result }}" == "success" ]] && \
           [[ "${{ needs.mcp-doc-contract.result }}" == "success" ]] && \
           [[ "${{ needs.velesql-conformance.result }}" == "success" ]] && \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A PR can no longer break `internal-bench` and merge green.** The feature is
+  not bench-only: it gates seven sites of *production* source —
+  `index/hnsw/index/search.rs`, `index/hnsw/native/distance.rs`,
+  `index/hnsw/mod.rs`, `velesql/cache.rs` and `lib.rs` — and nothing on a pull
+  request ever compiled it. The two workflows that do, `quality-deep.yml` and
+  `bench-scalability.yml`, run weekly, so a cfg regression could merge on a
+  Tuesday and surface the following Sunday with no obvious culprit SHA. That is
+  the failure mode `memory-feature-matrix` was added to close for
+  `velesdb-memory`; `internal-bench` had the same hole and no gate.
+
+  Demonstrated rather than asserted: renaming `eval_count::record_eval`, which
+  only the `internal-bench` call sites reach, leaves today's CI build green in
+  0.18 s and fails the new job with `E0425: cannot find function record_eval`.
+
+  `Internal Bench Compiles` runs `cargo check` over the library, benches and
+  tests under `persistence,internal-bench`, and is read by the `ci-success`
+  chain. Deliberately a compile and not a bench run — the cost this gate is
+  allowed to have is a compile, the same bargain `memory-feature-matrix`
+  strikes. `--benches` is load-bearing: the feature's `required-features`
+  targets are bench targets, so a lib-only check would miss the code the
+  feature exists for.
+
 - **The AVX kernels no longer compute out-of-bounds pointers (#2106 item 9).**
   Eleven loops guarded themselves with `while p.add(N) <= end_ptr`, and that is
   undefined behaviour on the final evaluation — the one that ends the loop.


### PR DESCRIPTION
## Description

`internal-bench` is **not a bench-only feature**. It gates seven sites of *production* source, and nothing on a pull request ever compiled it:

| file | line |
|---|---|
| `index/hnsw/index/search.rs` | 60 |
| `index/hnsw/native/distance.rs` | 85, 141 |
| `index/hnsw/mod.rs` | 24 |
| `velesql/cache.rs` | 170 |
| `lib.rs` | 136, 139 |

The two workflows that *do* compile it — `quality-deep.yml` and `bench-scalability.yml` — run **weekly**. So a cfg regression could merge on a Tuesday and surface the following Sunday with no obvious culprit SHA.

That is precisely the failure mode `memory-feature-matrix` was added to close for `velesdb-memory`, in a comment already in this file:

> a cfg regression on a non-default combination could merge on a Tuesday and surface the following Monday with no obvious culprit SHA

`internal-bench` had the same hole and no gate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

**Demonstrated, not argued.** Renaming `eval_count::record_eval` — a function only the `internal-bench` call sites reach — and running both commands on the same tree:

```
$ cargo check -p velesdb-core --features persistence
    Finished `dev` profile in 0.18s                        ← today's CI: GREEN, would have merged

$ cargo check -p velesdb-core --benches --features persistence,internal-bench
error[E0425]: cannot find function `record_eval` in module
              `crate::index::hnsw::eval_count`             ← the new job: RED
```

`eval_count.rs` was restored from backup afterwards; `git diff` confirms it byte-identical.

Both of the job's own commands pass on `develop` as it stands, so this lands green rather than red:

```
cargo check -p velesdb-core --benches --features persistence,internal-bench   # Finished in 37.32s
cargo check -p velesdb-core --tests   --features persistence,internal-bench   # Finished in  4.40s
```

### Design choices worth stating

- **A `cargo check`, not a bench run.** The cost this gate is allowed to have is a compile — the same bargain `memory-feature-matrix` strikes. Catching the cfg regression is the point; measuring anything is not, and benchmark noise on PRs would be a different and worse problem.
- **`--benches` is load-bearing.** The feature's `required-features` targets (`Cargo.toml:440`, `:445`) *are* bench targets, so a lib-only check would miss exactly the code the feature exists for.
- **Wired into both halves of the gate** — `needs` *and* the assertion chain. Either alone is a job you can watch fail while the merge button stays green, which is the defect `test_ci_gate_reachability` exists to prevent. Mutation-checked: dropping the chain line while leaving it in `needs` fails that suite at `['internal-bench-check'] != []`.

**Test Configuration:**
- OS: Linux x86_64
- Rust: 1.90

Also green: `test_ci_gate_reachability` (78 tests — it independently confirms the new job admits every trigger the `on:` block declares, per #2142), YAML parses to 30 jobs, and the three repo guards.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This closes one of the open questions on the backlog rather than deferring it further. The alternative considered and rejected was running the benchmarks themselves on PRs: that buys measurement nobody reads on a PR, at minutes of runner time per push, to catch a failure a compile already catches.
