### PR TITLE
fix(core): refuse a non-finite vector component at the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A non-finite vector component can no longer enter or query the database
+  (#2106 items 4 and 16).** The dense ingest path validated dimension and
+  nothing else, so a `NaN` or an infinity reached storage. Its sparse sibling
+  has always refused non-finite values — this is the dense path catching up to a
+  decision the codebase had already made.
+
+  This is not garbage-in-garbage-out. NaN compares `false` against everything,
+  so **one** stored NaN makes HNSW's ordering arbitrary for every subsequent
+  query, including well-formed ones. Measuring what the kernels do with one
+  turned up something the audit did not have: the divergence it recorded as an
+  aarch64 concern is live on x86 too, and worse than a scalar/SIMD split.
+  `jaccard_similarity_native(a, b)` returns a finite score when the NaN sits in
+  `a` and `NaN` when the identical NaN sits in `b`, from dimension 8 upward —
+  `_mm256_min_ps(va, vb)` yields `vb` whenever either operand is NaN, while the
+  scalar path's `f32::min` yields whichever operand is *not*. Jaccard is
+  symmetric by definition, so `J(a, b) != J(b, a)` was reachable from stored
+  data on the default platform.
+
+  The fix is at the boundary, not in the kernels: `validate_vector_is_finite`
+  refuses the value on upsert and on search, so no kernel ever sees one.
+  Branching on NaN inside the hot SIMD loops would tax every well-formed query
+  to serve a malformed one. The read side needed one call — every typed wrapper
+  (`VectorCollection`, `MetadataCollection`, `GraphCollection`) delegates to the
+  same `Collection::search` — and it costs one `O(dim)` pass against a search
+  that is `O(dim × candidates)`.
+
+  `simd_native::nan_contract_tests` pins the measured kernel behaviour so the
+  guard cannot later be deleted as unnecessary: those tests are the evidence of
+  what returns the moment it goes. The aarch64 half of item 4 is left
+  deliberately unmeasured rather than asserted from the intrinsic's
+  documentation.
+
 - **The AVX kernels no longer compute out-of-bounds pointers (#2106 item 9).**
   Eleven loops guarded themselves with `while p.add(N) <= end_ptr`, and that is
   undefined behaviour on the final evaluation — the one that ends the loop.

--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -77,6 +77,7 @@ impl Collection {
         self.enforce_upsert_limits(points)?;
         for point in points {
             validate_dimension_match(dimension, point.dimension())?;
+            crate::validation::validate_vector_is_finite(&point.vector)?;
         }
         Ok(())
     }

--- a/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
+++ b/crates/velesdb-core/src/collection/search/query/similarity_filter_tests.rs
@@ -113,16 +113,30 @@ mod scan_score_semantics {
 
     /// A NaN-bearing stored vector must sort last (worst key), never first —
     /// the old clamp let NaN through into the top-k comparator.
+    /// A stored NaN still sorts last, even though one can no longer be inserted.
+    ///
+    /// `Collection::upsert` now refuses a non-finite component (#2106 items 4
+    /// and 16), so this seeds finite vectors and then writes the NaN straight
+    /// into the vector store — which is the route that remains open and the
+    /// reason this guard is still load-bearing: a database written before that
+    /// validation existed is not re-validated on open, and its NaN would
+    /// otherwise sort *first* under a naive comparator.
     #[test]
     fn test_scan_score_nan_vector_sorts_last() {
         let (_dir, col) = setup(
             DistanceMetric::Euclidean,
             vec![
                 tagged_point(1, vec![3.0, 0.0]),
-                tagged_point(2, vec![f32::NAN, 0.0]),
+                tagged_point(2, vec![5.0, 0.0]),
                 tagged_point(3, vec![7.0, 0.0]),
             ],
         );
+        {
+            use crate::storage::VectorStorage;
+            let mut vs = col.storage.vector_storage.write();
+            vs.store(2, &[f32::NAN, 0.0])
+                .expect("test: seed a stored NaN");
+        }
 
         let results = col.scan_and_score_by_vector(&cat_filter(), &[0.0, 0.0], 3);
 

--- a/crates/velesdb-core/src/collection/search/vector.rs
+++ b/crates/velesdb-core/src/collection/search/vector.rs
@@ -312,6 +312,13 @@ impl Collection {
         validate_dimension_match(config.dimension, query.len())?;
         drop(config);
 
+        // Every typed wrapper — VectorCollection, MetadataCollection,
+        // GraphCollection — delegates its `search` here, so this one call
+        // closes the read side against the same non-finite input the ingest
+        // path refuses. One O(dim) pass per query, against a search that is
+        // O(dim x candidates); the hot loops stay branch-free.
+        crate::validation::validate_vector_is_finite(query)?;
+
         // Use HNSW index for fast ANN search
         let index_results = self.search_ids_with_adc_if_pq(query, k);
 

--- a/crates/velesdb-core/src/simd_native/mod.rs
+++ b/crates/velesdb-core/src/simd_native/mod.rs
@@ -161,5 +161,9 @@ mod distance_engine_tests;
 mod hamming_jaccard_tests;
 
 #[cfg(all(test, target_arch = "x86_64"))]
+#[path = "nan_contract_tests.rs"]
+mod nan_contract_tests;
+
+#[cfg(all(test, target_arch = "x86_64"))]
 #[path = "ptr_span_tests.rs"]
 mod ptr_span_tests;

--- a/crates/velesdb-core/src/simd_native/nan_contract_tests.rs
+++ b/crates/velesdb-core/src/simd_native/nan_contract_tests.rs
@@ -1,0 +1,115 @@
+//! What the distance kernels actually do with a NaN, measured (#2106 items 4, 16).
+//!
+//! These tests assert **current x86 behaviour**, not desired behaviour. That is
+//! deliberate. The audit recorded NaN divergence as an aarch64 concern — NEON's
+//! `vminq_f32` propagates NaN while the scalar path's `f32::min` returns the
+//! non-NaN operand. Measuring it on x86 showed something the record did not
+//! have: the divergence is live on the default platform too, and it is worse
+//! than a scalar/SIMD split.
+//!
+//! `jaccard_similarity_native(a, b)` on x86 returns a finite score when the NaN
+//! sits in `a`, and `NaN` when the identical NaN sits in `b` — from dimension 8
+//! upward, where the AVX2 kernel takes over from the scalar path. The cause is
+//! that `_mm256_min_ps(va, vb)` yields `vb` whenever either operand is NaN,
+//! whereas `f32::min` yields whichever operand is *not* NaN. Jaccard is
+//! symmetric by definition, so `J(a, b) != J(b, a)` is a broken contract.
+//!
+//! The fix is not to branch on NaN inside the hot loops — that taxes every
+//! well-formed query to serve a malformed one. It is
+//! [`crate::validation::validate_vector_is_finite`], which refuses the value at
+//! the cold boundary so no kernel ever sees it. These tests exist so that guard
+//! can never be deleted as "probably unnecessary": they are the evidence of
+//! what returns the moment it goes.
+//!
+//! Scoped to x86_64 deliberately. The aarch64 half of item 4 stays *unmeasured*
+//! rather than asserted from the intrinsic's documentation: `vminq_f32` is
+//! specified to propagate NaN, which would make NEON Jaccard return NaN from
+//! either argument, but nothing here has run on aarch64 and a test asserting an
+//! unverified behaviour is worse than no test. The boundary guard makes the
+//! question moot in practice on both architectures; whoever gets an aarch64
+//! runner should point these same probes at it and record what they see.
+
+#![allow(clippy::cast_precision_loss)]
+
+use super::{hamming_distance_native, jaccard_similarity_native};
+
+/// Dimensions straddling the scalar/AVX2 handover, where the split appears.
+const DIMS: &[usize] = &[3, 4, 8, 16, 17, 64, 520, 1030];
+
+fn pair(dim: usize) -> (Vec<f32>, Vec<f32>) {
+    (
+        (0..dim).map(|i| (i % 3) as f32 * 0.4).collect(),
+        (0..dim).map(|i| ((i + 1) % 3) as f32 * 0.4).collect(),
+    )
+}
+
+/// Jaccard is not symmetric under a NaN, and the asymmetry is dimension-
+/// dependent. This is the defect the boundary guard exists to make unreachable.
+#[test]
+fn jaccard_is_asymmetric_under_a_nan_which_is_why_nan_is_refused_at_the_edge() {
+    let mut split_seen = false;
+
+    for &dim in DIMS {
+        let (base_a, base_b) = pair(dim);
+
+        let mut a = base_a.clone();
+        a[0] = f32::NAN;
+        let nan_in_a = jaccard_similarity_native(&a, &base_b);
+
+        let mut b = base_b.clone();
+        b[0] = f32::NAN;
+        let nan_in_b = jaccard_similarity_native(&base_a, &b);
+
+        // The NaN never survives when it is the *first* argument: `f32::min`
+        // and `_mm256_min_ps` both hand back the other operand there.
+        assert!(
+            !nan_in_a.is_nan(),
+            "dim {dim}: NaN in the first argument produced {nan_in_a}; if this \
+             ever starts propagating, the guard's rationale has changed"
+        );
+
+        if nan_in_b.is_nan() {
+            split_seen = true;
+            assert!(
+                dim >= 8,
+                "dim {dim}: the split is expected only once the AVX2 kernel \
+                 takes over at 8 lanes, but it appeared here"
+            );
+        }
+    }
+
+    assert!(
+        split_seen,
+        "no dimension propagated a NaN from the second argument. Either the \
+         kernels were fixed — in which case delete this test and say so — or \
+         the dispatch no longer reaches the AVX2 Jaccard kernel at all, which \
+         is a coverage regression worth knowing about."
+    );
+}
+
+/// Hamming absorbs a NaN on every path, in either argument.
+///
+/// Its threshold comparison is ordered (`x > 0.5` is `false` for NaN, and
+/// `_mm256_cmp_ps` with `_CMP_GT_OQ` agrees), so a NaN reads as a zero bit
+/// rather than poisoning the count. Pinned to keep the two metrics' differing
+/// stories straight: only Jaccard has the asymmetry.
+#[test]
+fn hamming_absorbs_a_nan_in_either_argument() {
+    for &dim in DIMS {
+        let (base_a, base_b) = pair(dim);
+
+        let mut a = base_a.clone();
+        a[0] = f32::NAN;
+        let mut b = base_b.clone();
+        b[0] = f32::NAN;
+
+        assert!(
+            !hamming_distance_native(&a, &base_b).is_nan(),
+            "dim {dim}, a"
+        );
+        assert!(
+            !hamming_distance_native(&base_a, &b).is_nan(),
+            "dim {dim}, b"
+        );
+    }
+}

--- a/crates/velesdb-core/src/validation.rs
+++ b/crates/velesdb-core/src/validation.rs
@@ -43,6 +43,42 @@ pub fn validate_dimension_match(expected: usize, actual: usize) -> Result<()> {
     Ok(())
 }
 
+/// Validates that every component of a dense vector is finite.
+///
+/// A `NaN` or an infinity has no meaning as a vector component, and letting one
+/// reach storage is not a garbage-in-garbage-out problem — it is persistent
+/// corruption. NaN compares `false` against everything, so a single stored NaN
+/// makes HNSW's ordering arbitrary for *every subsequent query*, not just the
+/// one that inserted it.
+///
+/// It also makes the distance kernels disagree with themselves. On x86,
+/// `jaccard_similarity_native` returns a finite score when the NaN is in the
+/// first argument and `NaN` when it is in the second, from dimension 8 upward —
+/// because `_mm256_min_ps(a, b)` yields `b` when either operand is NaN, while
+/// the scalar path's `f32::min` returns whichever operand is *not* NaN. Jaccard
+/// is symmetric by definition, so that is a contract violation reachable from
+/// stored data. `simd_native::nan_contract_tests` pins the measurement.
+///
+/// Rather than branch on NaN inside the hot SIMD loops — which would cost every
+/// well-formed query to serve a malformed one — the value is refused here, at
+/// the cold boundary. The sparse ingest path already refuses non-finite values
+/// (`api_types::requests`); this is the dense path catching up.
+///
+/// # Errors
+///
+/// Returns [`crate::error::Error::InvalidVector`] naming the first offending
+/// index and its value.
+pub fn validate_vector_is_finite(vector: &[f32]) -> Result<()> {
+    for (index, &value) in vector.iter().enumerate() {
+        if !value.is_finite() {
+            return Err(Error::InvalidVector(format!(
+                "vector component at index {index} is not finite: {value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Validates that a collection name is safe for use as a filesystem directory.
 ///
 /// # Rules

--- a/crates/velesdb-core/tests/nan_boundary_tests.rs
+++ b/crates/velesdb-core/tests/nan_boundary_tests.rs
@@ -1,0 +1,107 @@
+#![cfg(feature = "persistence")]
+//! A non-finite vector component cannot enter or query the database (#2106).
+//!
+//! The dense ingest path validated dimension only. Its sparse sibling has
+//! always refused non-finite values, so this is the dense path catching up to a
+//! decision the codebase had already made.
+//!
+//! Why it matters more than "garbage in, garbage out": a NaN in a *query* spoils
+//! one call, but a NaN in a *stored* vector is persistent corruption. NaN
+//! compares `false` against everything, so one stored NaN makes HNSW's ordering
+//! arbitrary for every subsequent query — including queries that are themselves
+//! perfectly well-formed. `simd_native::nan_contract_tests` measures the kernel
+//! behaviour that follows from letting one through.
+
+use tempfile::TempDir;
+use velesdb_core::{Database, DistanceMetric, Point};
+
+fn seeded(dimension: usize) -> (TempDir, velesdb_core::VectorCollection) {
+    let dir = TempDir::new().expect("temp dir");
+    let db = Database::open(dir.path()).expect("database");
+    db.create_collection("points", dimension, DistanceMetric::Cosine)
+        .expect("create collection");
+    let collection = db
+        .get_vector_collection("points")
+        .expect("collection just created");
+    (dir, collection)
+}
+
+/// Every non-finite value is refused on ingest, and the error names the culprit.
+#[test]
+fn upsert_refuses_a_non_finite_component() {
+    let (_dir, collection) = seeded(4);
+
+    for (label, bad) in [
+        ("NaN", f32::NAN),
+        ("+inf", f32::INFINITY),
+        ("-inf", f32::NEG_INFINITY),
+    ] {
+        let point = Point::without_payload(1, vec![0.1, bad, 0.3, 0.4]);
+        let error = collection
+            .upsert(vec![point])
+            .expect_err(&format!("{label} must be refused"));
+        let message = error.to_string();
+        assert!(
+            message.contains("index 1"),
+            "{label}: the error must name which component is bad, got: {message}"
+        );
+    }
+}
+
+/// A well-formed vector still goes in — the guard rejects, it does not block.
+#[test]
+fn upsert_still_accepts_a_finite_vector() {
+    let (_dir, collection) = seeded(4);
+    collection
+        .upsert(vec![Point::without_payload(1, vec![0.1, 0.2, 0.3, 0.4])])
+        .expect("a finite vector is accepted");
+    assert_eq!(collection.len(), 1);
+}
+
+/// The refusal covers a batch, not just its first element.
+///
+/// `upsert` validates the whole batch before storing any of it, so one bad
+/// point must reject the batch rather than leave a partial write behind.
+#[test]
+fn a_bad_point_rejects_the_whole_batch_without_a_partial_write() {
+    let (_dir, collection) = seeded(4);
+
+    let batch = vec![
+        Point::without_payload(1, vec![0.1, 0.2, 0.3, 0.4]),
+        Point::without_payload(2, vec![0.1, 0.2, f32::NAN, 0.4]),
+        Point::without_payload(3, vec![0.5, 0.6, 0.7, 0.8]),
+    ];
+    collection.upsert(batch).expect_err("the batch is refused");
+
+    assert_eq!(
+        collection.len(),
+        0,
+        "no point may survive a refused batch — a partial write is the \
+         corruption this guard exists to prevent"
+    );
+}
+
+/// The read side is closed too: a non-finite query is refused.
+///
+/// Every typed wrapper delegates to the same `Collection::search`, so one guard
+/// there covers `VectorCollection`, `MetadataCollection` and `GraphCollection`
+/// alike.
+#[test]
+fn search_refuses_a_non_finite_query() {
+    let (_dir, collection) = seeded(4);
+    collection
+        .upsert(vec![Point::without_payload(1, vec![0.1, 0.2, 0.3, 0.4])])
+        .expect("seed");
+
+    let error = collection
+        .search(&[0.1, f32::NAN, 0.3, 0.4], 1)
+        .expect_err("a NaN query must be refused");
+    assert!(
+        error.to_string().contains("index 1"),
+        "the error must name the offending component, got: {error}"
+    );
+
+    collection
+        .search(&[0.1, 0.2, 0.3, 0.4], 1)
+        .expect("a finite query still works");
+}


### PR DESCRIPTION
## Description

Closes #2106 items 4 and 16. The dense ingest path validated **dimension and nothing else**, so a `NaN` or an infinity reached storage. The *sparse* ingest path has always refused non-finite values (`api_types::requests`) — this is the dense path catching up to a decision the codebase had already made.

**This is not garbage-in-garbage-out.** NaN compares `false` against everything, so **one** stored NaN makes HNSW's ordering arbitrary for every subsequent query, including well-formed ones. A single bad write is persistent corruption.

### What measuring it turned up

Item 16 asked for NaN test coverage. Writing it found a live defect the audit did not have. Item 4 records NaN divergence as an **aarch64** concern — NEON's `vminq_f32` propagates NaN while the scalar path's `f32::min` does not. On **x86**, `jaccard_similarity_native(a, b)` with a NaN at index 0:

| dim | NaN in `a` | NaN in `b` |
|---|---|---|
| 3 | `0.4` | `0.25` |
| 4 | `0.3333333` | `0.2` |
| **8** | `0.3076923` | **`NaN`** |
| 16 | `0.23076923` | **`NaN`** |
| 520 | `0.20092379` | **`NaN`** |
| 1030 | `0.2004662` | **`NaN`** |

The same NaN yields a finite score or `NaN` **depending on which argument holds it and how long the vector is**. `_mm256_min_ps(va, vb)` yields `vb` whenever either operand is NaN; `f32::min` yields whichever operand is *not*. Jaccard is symmetric by definition, so `J(a, b) != J(b, a)` was reachable from stored data on the **default platform**, not just on aarch64.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Behaviour change — `upsert` and `search` now **reject** a non-finite component that previously went through silently

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

**The fix is at the boundary, not in the kernels.** `validation::validate_vector_is_finite` refuses the value on upsert and on search, so no kernel ever sees one. Branching on NaN inside the hot SIMD loops would tax every well-formed query to serve a malformed one — the wrong trade for a value that has no meaning as a vector component.

The read side needed **exactly one call**: `VectorCollection`, `MetadataCollection` and `GraphCollection` all delegate to the same `Collection::search`. It costs one `O(dim)` pass against a search that is `O(dim × candidates)`.

| test | what it holds |
|---|---|
| `upsert_refuses_a_non_finite_component` | NaN, +inf, −inf all refused; the error names the offending index |
| `upsert_still_accepts_a_finite_vector` | the guard rejects, it does not block |
| `a_bad_point_rejects_the_whole_batch_without_a_partial_write` | one bad point rejects the batch, count stays 0 — a partial write is the corruption this prevents |
| `search_refuses_a_non_finite_query` | read side closed, finite query still works |
| `nan_contract_tests::jaccard_is_asymmetric_under_a_nan_…` | pins the measured kernel split |
| `nan_contract_tests::hamming_absorbs_a_nan_in_either_argument` | Hamming's ordered comparison has no such split — keeps the two metrics' stories straight |

`nan_contract_tests` exists so the guard **cannot later be deleted as unnecessary**: those tests are the evidence of what returns the moment it goes. Its failure message says so explicitly, including what to do if someone *does* fix the kernels.

**Test Configuration:**
- OS: Linux x86_64 (AVX-512F + AVX2 + FMA)
- Rust: 1.90

Full suite green: **5466 lib tests, 0 failed**, plus the four new boundary tests. `cargo fmt --check` clean; `cargo clippy -p velesdb-core -p velesdb-server --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean (the CI's own flags); all three repo guards pass.

### One existing test had to move, and that is worth reading

`test_scan_score_nan_vector_sorts_last` seeded its NaN **through `upsert`** — which the guard now refuses. The full suite caught it; it was the only failure.

The behaviour is kept and the setup changed, because that guard is still load-bearing: it now seeds finite vectors and writes the NaN straight into the vector store. That models **the route that remains open** — a database written before this validation existed is not re-validated on open, and its NaN would otherwise sort *first* under a naive comparator. Defence in depth for the compatibility case, with the guard closing the new-writes case.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches `hnsw` and `storage` reachability, and SIMD dispatch semantics.

- [x] Invariants impacted: one added — *no stored or queried dense vector holds a non-finite component*. Nothing is relaxed.
- [x] Crash/durability semantics unchanged: the guard runs at the cold boundary, before any storage lock or WAL write, so a refused batch leaves no trace.
- [x] Edge cases tested: NaN, +∞, −∞; first/middle position; single point and batch; ingest and query sides; the pre-existing-database route.
- [ ] Two reviewers — worth it, since this rejects input that used to be accepted.

## Additional Notes

**The behaviour change is the point, and it deserves a plain statement.** Code that today stores a NaN vector will start getting an error. That is the correct outcome — it was silently corrupting its own index — but it is a change, and anyone hitting it should be told *why* rather than left to discover it. The error names the offending index and value.

**What this deliberately does not do:** the aarch64 half of item 4 stays **unmeasured** rather than asserted from `vminq_f32`'s documentation. Nothing here has run on aarch64, and a test asserting unverified behaviour is worse than no test. The boundary guard makes the question moot in practice on both architectures; whoever gets an aarch64 runner should point the same probes at it and record what they see. `nan_contract_tests`'s module doc says exactly this, so the omission is a live note in the tree rather than a remembered one.

**CHANGELOG conflict is expected** with #2144 — both add an entry at the top of `### Fixed`. Whichever merges second keeps both entries.
