### PR TITLE
fix(metrics): normalize MAP by the corpus-wide relevant count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`mean_average_precision` now takes the corpus-wide relevant count, and MAP
+  penalises what a search missed (#2106 item 12).** The signature was
+  `&[Vec<bool>]` and the implementation divided by the number of relevant items
+  *retrieved*, while the doc comment stated the textbook
+  `AP = (1/R)·Sum P(k)·rel(k)` with `R` the total relevant in the corpus. The two
+  disagree exactly where the metric earns its keep: retrieving **1 of 10**
+  relevant documents, at rank 1, scored a flawless `AP = 1.0` for 10% recall. A
+  ranking-quality metric blind to what it missed always flatters a system that
+  returns one confident result and stops.
+
+  The doc was not the thing to fix. `&[bool]` over retrieved positions simply
+  cannot express `R`, so the signature moved instead: `&[(&[bool], usize)]`, each
+  query pairing its relevance flags with the corpus total. A caller with no
+  corpus-wide count reproduces the old behaviour by passing the retrieved count —
+  explicitly, at the call site, rather than silently inside the metric. A
+  `total_relevant` below the retrieved count is a caller error describing an
+  impossible corpus; the denominator is raised to the retrieved count so a bad
+  input cannot push `AP` above 1.0 and corrupt an average over many queries.
+
+  The four pre-existing tests could not have caught this: every one used
+  `total_relevant == retrieved`, the single case where both denominators agree.
+  Two new tests encode the defect itself — 1-of-10 scoring 0.1 rather than 1.0,
+  and AP falling monotonically as recall falls with the ranking held fixed — and
+  both go red when the old normalisation is restored, while all four old tests
+  stay green.
+
+
 - **The `RaBitQ` traversal backend became a codec: one quantized-precision
   state machine, two codecs.** `RaBitQPrecisionHnsw`'s concurrent
   insert/train/install machinery and its graph traversal are now the

--- a/crates/velesdb-core/src/metrics/retrieval.rs
+++ b/crates/velesdb-core/src/metrics/retrieval.rs
@@ -251,53 +251,82 @@ pub fn hit_rate<T: Eq + Hash + Copy>(query_results: &[(Vec<T>, Vec<T>)], k: usiz
 
 /// Calculates Mean Average Precision (MAP).
 ///
-/// MAP is the mean of Average Precision (AP) over all queries.
-/// AP rewards systems that return relevant items early in the result list.
+/// MAP is the mean of Average Precision (AP) over all queries. AP rewards a
+/// system that returns relevant items early *and* penalises one that misses
+/// relevant items entirely — the second half is why `total_relevant` is a
+/// parameter rather than something derived from the flags.
 ///
 /// # Formula
 ///
-/// `AP = (1/R) * Σ P(k) * rel(k)` where R is total relevant items
-/// `MAP = (1/Q) * Σ AP_q` where Q is number of queries
+/// `AP = (1/R) * Σ P(k) * rel(k)` where `R` is the total number of relevant
+/// items **in the corpus**, not the number this query happened to retrieve.
+/// `MAP = (1/Q) * Σ AP_q` where `Q` is the number of queries.
+///
+/// # Why the signature carries `total_relevant`
+///
+/// This used to take `&[Vec<bool>]` and divide by the count of relevant items
+/// *retrieved*, while its documentation stated the formula above. The two
+/// disagree exactly where the metric earns its keep: retrieving 1 of 10
+/// relevant documents, at rank 1, scored `AP = 1.0` — a perfect score for 10%
+/// recall. A ranking quality metric that cannot see what it missed will always
+/// flatter a system that returns one confident result and stops.
+///
+/// The old shape could not express the fix: `&[bool]` over retrieved positions
+/// simply does not know `R`. So the signature moved rather than the doc. Where
+/// a caller genuinely has no corpus-wide count, passing the retrieved-relevant
+/// count reproduces the previous behaviour — explicitly, at the call site,
+/// instead of silently inside the metric.
 ///
 /// # Arguments
 ///
-/// * `relevance_lists` - For each query, a list of booleans indicating relevance
-///   at each position (true = relevant, false = not relevant)
+/// * `queries` - one entry per query: the relevance flags at each retrieved
+///   position (`true` = relevant), paired with the total number of relevant
+///   items in the corpus for that query.
 ///
 /// # Returns
 ///
-/// A value between 0.0 and 1.0, where 1.0 means perfect precision at every position.
+/// A value between 0.0 and 1.0. A query whose `total_relevant` is 0 contributes
+/// 0.0: there was nothing to find, so no ranking of it can be credited.
+///
+/// `total_relevant` below the number actually retrieved is a caller error — it
+/// describes a corpus with fewer relevant items than the results contain. Rather
+/// than return an `AP > 1.0` that would quietly corrupt an average, the
+/// denominator is raised to the retrieved count, which keeps the result inside
+/// its documented range.
 #[must_use]
-pub fn mean_average_precision(relevance_lists: &[Vec<bool>]) -> f64 {
-    if relevance_lists.is_empty() {
+pub fn mean_average_precision(queries: &[(&[bool], usize)]) -> f64 {
+    if queries.is_empty() {
         return 0.0;
     }
 
-    let total_ap: f64 = relevance_lists
+    let total_ap: f64 = queries
         .iter()
-        .map(|relevances| {
-            let mut relevant_count = 0;
+        .map(|(relevances, total_relevant)| {
+            let mut retrieved_relevant = 0u32;
             let mut precision_sum = 0.0;
 
-            for (i, &is_relevant) in relevances.iter().enumerate() {
+            for (index, &is_relevant) in relevances.iter().enumerate() {
                 if is_relevant {
-                    relevant_count += 1;
+                    retrieved_relevant += 1;
                     #[allow(clippy::cast_precision_loss)]
-                    let precision_at_i = f64::from(relevant_count) / (i + 1) as f64;
-                    precision_sum += precision_at_i;
+                    let precision_at_index = f64::from(retrieved_relevant) / (index + 1) as f64;
+                    precision_sum += precision_at_index;
                 }
             }
 
-            if relevant_count == 0 {
+            let denominator = (*total_relevant).max(retrieved_relevant as usize);
+            if denominator == 0 {
                 0.0
             } else {
-                precision_sum / f64::from(relevant_count)
+                #[allow(clippy::cast_precision_loss)]
+                let denominator = denominator as f64;
+                precision_sum / denominator
             }
         })
         .sum();
 
     #[allow(clippy::cast_precision_loss)]
-    let map = total_ap / relevance_lists.len() as f64;
+    let map = total_ap / queries.len() as f64;
     map
 }
 

--- a/crates/velesdb-core/src/metrics_tests.rs
+++ b/crates/velesdb-core/src/metrics_tests.rs
@@ -537,13 +537,11 @@ fn test_hit_rate_empty() {
 #[test]
 fn test_map_perfect() {
     // Arrange: all results are relevant (perfect precision at every position)
-    let relevance_lists = vec![
-        vec![true, true, true], // Query 1: all relevant
-        vec![true, true, true], // Query 2: all relevant
-    ];
+    // Every relevant item retrieved, all at the top: AP = 1.0 per query.
+    let queries: Vec<(&[bool], usize)> = vec![(&[true, true, true], 3), (&[true, true, true], 3)];
 
     // Act
-    let map = mean_average_precision(&relevance_lists);
+    let map = mean_average_precision(&queries);
 
     // Assert: 1.0 (perfect MAP)
     assert!((map - 1.0).abs() < f64::EPSILON, "Expected 1.0, got {map}");
@@ -551,11 +549,12 @@ fn test_map_perfect() {
 
 #[test]
 fn test_map_no_relevant() {
-    // Arrange: no relevant results
-    let relevance_lists = vec![vec![false, false, false], vec![false, false, false]];
+    // Arrange: nothing relevant retrieved, and nothing relevant to find.
+    let queries: Vec<(&[bool], usize)> =
+        vec![(&[false, false, false], 0), (&[false, false, false], 0)];
 
     // Act
-    let map = mean_average_precision(&relevance_lists);
+    let map = mean_average_precision(&queries);
 
     // Assert: 0.0
     assert!((map - 0.0).abs() < f64::EPSILON, "Expected 0.0, got {map}");
@@ -563,14 +562,15 @@ fn test_map_no_relevant() {
 
 #[test]
 fn test_map_mixed() {
-    // Arrange: mixed relevance
-    // Query 1: [true, false, true] -> AP = (1/1 + 2/3) / 2 = 0.833...
-    // Query 2: [false, true, false] -> AP = 1/2 / 1 = 0.5
+    // Arrange: mixed relevance, every relevant item retrieved.
+    // Query 1: [true, false, true], R = 2 -> AP = (1/1 + 2/3) / 2 = 0.833...
+    // Query 2: [false, true, false], R = 1 -> AP = (1/2) / 1 = 0.5
     // MAP = (0.833 + 0.5) / 2 = 0.666...
-    let relevance_lists = vec![vec![true, false, true], vec![false, true, false]];
+    let queries: Vec<(&[bool], usize)> =
+        vec![(&[true, false, true], 2), (&[false, true, false], 1)];
 
     // Act
-    let map = mean_average_precision(&relevance_lists);
+    let map = mean_average_precision(&queries);
 
     // Assert: should be around 0.666
     let q1_ap = 1.0_f64.midpoint(2.0_f64 / 3.0);
@@ -584,12 +584,81 @@ fn test_map_mixed() {
 #[test]
 fn test_map_empty() {
     // Arrange: no queries
-    let relevance_lists: Vec<Vec<bool>> = vec![];
+    let queries: Vec<(&[bool], usize)> = vec![];
 
     // Act
-    let map = mean_average_precision(&relevance_lists);
+    let map = mean_average_precision(&queries);
 
     // Assert: 0.0
+    assert!((map - 0.0).abs() < f64::EPSILON, "Expected 0.0, got {map}");
+}
+
+/// The defect this signature exists to make unrepresentable (#2106 item 12).
+///
+/// One relevant document out of ten, returned at rank 1. The old shape divided
+/// by the retrieved-relevant count — one — and reported a flawless `1.0` for
+/// 10% recall. Textbook AP divides by the corpus total, so it reports 0.1: high
+/// precision on what came back, and no credit for the nine that did not.
+#[test]
+fn test_map_penalises_missed_relevant_documents() {
+    let queries: Vec<(&[bool], usize)> = vec![(&[true], 10)];
+
+    let map = mean_average_precision(&queries);
+
+    assert!(
+        (map - 0.1).abs() < 1e-10,
+        "retrieving 1 of 10 relevant at rank 1 must score 0.1, not a perfect \
+         1.0; got {map}"
+    );
+}
+
+/// Recall is what separates the two denominators, so vary only that.
+///
+/// Same ranking, same precision at every position — only the corpus size
+/// changes. AP must fall as the number of documents missed rises. Under the old
+/// normalisation all three of these scored 1.0.
+#[test]
+fn test_map_falls_as_recall_falls_with_the_ranking_held_fixed() {
+    let scores: Vec<f64> = [2usize, 4, 8]
+        .into_iter()
+        .map(|total_relevant| mean_average_precision(&[(&[true, true] as &[bool], total_relevant)]))
+        .collect();
+
+    assert!(
+        (scores[0] - 1.0).abs() < 1e-10,
+        "retrieving both of 2 relevant must be perfect, got {}",
+        scores[0]
+    );
+    assert!(
+        scores[0] > scores[1] && scores[1] > scores[2],
+        "AP must decrease as more relevant documents go unretrieved: {scores:?}"
+    );
+}
+
+/// A `total_relevant` smaller than what was retrieved cannot produce `AP > 1`.
+///
+/// It describes a corpus with fewer relevant items than the results contain, so
+/// it is a caller error. Clamping the denominator keeps the value inside its
+/// documented `[0, 1]` range rather than letting a bad input quietly corrupt an
+/// average over many queries.
+#[test]
+fn test_map_stays_within_range_when_total_relevant_is_understated() {
+    let map = mean_average_precision(&[(&[true, true, true] as &[bool], 1)]);
+
+    assert!(
+        (0.0..=1.0).contains(&map),
+        "an understated total must not push AP above 1.0, got {map}"
+    );
+    assert!(
+        (map - 1.0).abs() < f64::EPSILON,
+        "expected the clamp to yield 1.0, got {map}"
+    );
+}
+
+/// Nothing relevant exists, so no ranking of it earns credit.
+#[test]
+fn test_map_scores_zero_when_the_corpus_holds_nothing_relevant() {
+    let map = mean_average_precision(&[(&[false, false] as &[bool], 0)]);
     assert!((map - 0.0).abs() < f64::EPSILON, "Expected 0.0, got {map}");
 }
 


### PR DESCRIPTION
## Description

Closes #2106 item 12. `mean_average_precision` took `&[Vec<bool>]` and divided by the number of relevant items **retrieved**, while its own doc comment stated the textbook formula:

```rust
/// `AP = (1/R) * Σ P(k) * rel(k)` where R is total relevant items
```

The two disagree exactly where the metric earns its keep:

| retrieved | corpus has | old AP | textbook AP |
|---|---|---|---|
| `[true]` at rank 1 | 10 relevant | **1.0** | **0.1** |

A flawless score for **10% recall**. A ranking-quality metric that cannot see what it missed will always flatter a system that returns one confident result and stops.

The issue offered "fix the doc or the signature". **The doc was not the thing to fix** — a MAP that cannot penalise missed relevant documents is not MAP, and this is the retrieval-metrics module, whose whole job is honest evaluation. Silently redefining a standard metric is the worst of the three options.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change — the signature moves from `&[Vec<bool>]` to `&[(&[bool], usize)]`

## How Has This Been Tested?

- [x] Unit tests

`&[bool]` over retrieved positions simply **cannot express `R`**, so the shape had to move:

```rust
pub fn mean_average_precision(queries: &[(&[bool], usize)]) -> f64
```

Each query pairs its relevance flags with the corpus-wide relevant count. A caller with no such count reproduces the old behaviour by passing the retrieved count — **explicitly, at the call site**, rather than silently inside the metric.

A `total_relevant` below the retrieved count is a caller error: it describes a corpus holding fewer relevant items than the results contain. The denominator is raised to the retrieved count, so a bad input cannot yield `AP > 1.0` and quietly corrupt an average over many queries.

### The old tests were blind to this by construction

This is the part worth pausing on. All four pre-existing tests used `total_relevant == retrieved` — **the single case where both denominators agree.** That is why the defect survived: the suite could not have caught it.

Two new tests encode the defect itself:

| test | holds |
|---|---|
| `test_map_penalises_missed_relevant_documents` | 1-of-10 at rank 1 scores `0.1`, not `1.0` |
| `test_map_falls_as_recall_falls_with_the_ranking_held_fixed` | same ranking, same precision at every position, only corpus size varies → AP must fall |

Plus two guarding the edges: an understated `total_relevant` stays within `[0, 1]`, and a corpus with nothing relevant scores 0.

### Mutation-checked

Restoring the old normalisation (`denominator = retrieved_relevant`):

```
test test_map_falls_as_recall_falls_with_the_ranking_held_fixed ... FAILED
test test_map_penalises_missed_relevant_documents             ... FAILED
test test_map_empty                                           ... ok
test test_map_mixed                                           ... ok
test test_map_no_relevant                                     ... ok
test test_map_perfect                                         ... ok
```

The two new tests go red; **all four old ones stay green** — the clearest possible statement of why this needed a signature change and not a doc edit. `retrieval.rs` was restored from backup afterwards.

**Test Configuration:**
- OS: Linux x86_64
- Rust: 1.90

Full validation: `cargo fmt --check` clean; `cargo clippy -p velesdb-core -p velesdb-server --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean (the CI's own flags); **5470 lib tests pass**; `cargo check --benches --tests --features persistence,internal-bench` clean (the gate #2144 just added); all three repo guards pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**On the breaking change.** `mean_average_precision` is public API (re-exported from `lib.rs` and `metrics/mod.rs`), but its only callers in the tree are its own tests — no server, binding, SDK or integration uses it. The migration is mechanical: `&[flags]` becomes `&[(&flags, total_relevant)]`, and passing the retrieved-relevant count as `total_relevant` gives byte-identical results to today.

The doc comment now carries the *why* rather than just the formula, including the 1-of-10 example, so the next reader does not have to rediscover which denominator was intended.
