### PR TITLE
fix(fusion): refuse non-finite fusion weights and validate them at the REST edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A non-finite fusion weight can no longer reorder a result set (#2095).**
+  Every weight rule in `fusion/strategy.rs` was an ordering comparison —
+  `w < 0.0` for weights, `k <= 0.0` for the rank-smoothing constant — and every
+  ordering comparison against `NaN` is false. A `NaN` therefore satisfied all of
+  them, `FusionStrategy::weighted`, `relative_score` and `weighted_rrf` each
+  returned `Ok`, and the kernel then produced a `NaN` contribution for every
+  document in that branch.
+
+  The consequence is worse than a `NaN` score. `sort_descending` orders by a
+  partial comparison, so the `NaN`-scored documents did not sink — measured on a
+  two-branch fusion with one `NaN` weight, the result was
+  `[(1, NaN), (2, NaN), (3, 0.0164)]`: the only document carrying a real score
+  ranked **last**, behind two documents with no score at all. A caller reading
+  the top-k got a confident, silently inverted answer.
+
+  `validate_non_negative` now checks finiteness before range, and the two
+  hand-rolled `k <= 0.0` guards are replaced by a shared
+  `validate_smoothing_constant`, so the rule is stated once for both the
+  constructor and `fuse` (which revalidates, because the enum variants are
+  public and can be built as literals). The new `FusionError::NonFiniteWeight`
+  joins a `#[non_exhaustive]` enum, so no downstream `match` breaks.
+
+  Both guards are mutation-checked: deleting the weight-side finiteness test
+  fails 5 of the 8 new tests, deleting the `k`-side one fails the other 2, and
+  the pre-existing 56 fusion tests stay green either way.
+
+- **REST fusion weights are validated instead of applied verbatim (#2095).**
+  Three of the four arms that build a weighted `FusionStrategy` from an HTTP
+  body did it with a struct literal, which accepts any `f32` that deserialized.
+  The core constructors — the ones enforcing non-negative, finite, summing to
+  1.0 — were never called, so `/collections/{name}/search/multi` and the
+  `fusion` block of `/search`, `/search/ids` and `/search/hybrid` accepted
+  weights such as `avg_w = -0.2, max_w = 0.9, hit_w = 0.3` and returned `200`
+  with a ranking that honoured none of the contract the weights imply.
+
+  All four arms now go through the validating constructors and report the core
+  message verbatim as a `400`, so the server carries no second copy of the
+  weight rules to drift from. `multi.rs` splits the decision into a pure
+  `build_fusion_strategy(&req) -> Result<_, String>` and a thin shell that owns
+  the metrics and the HTTP response, which is what makes the eight new cases
+  testable without standing up an `AppState`.
+
+  The rustdoc table above `pipeline::parse_fusion_strategy` is corrected in the
+  same pass: it advertised the pre-#1545 weighted defaults `0.5 / 0.3 / 0.2` and
+  went on advertising them after #2093 fixed the code to read
+  `DEFAULT_WEIGHTED_AVG_WEIGHT` and its siblings (`0.6 / 0.3 / 0.1`).
+
+  Not addressed here, and recorded rather than dropped: `velesdb-cli` and
+  `tauri-plugin-velesdb` each carry a fifth and sixth hand-written copy of the
+  same name-to-strategy mapping, and the CLI's copy still hardcodes the
+  pre-#1545 `0.5 / 0.3 / 0.2`. Collapsing all six onto one core entry point is
+  the single-sourcing work of #2095 section B.
+
 - **A PR can no longer break `internal-bench` and merge green.** The feature is
   not bench-only: it gates seven sites of *production* source —
   `index/hnsw/index/search.rs`, `index/hnsw/native/distance.rs`,

--- a/crates/velesdb-core/src/fusion/mod.rs
+++ b/crates/velesdb-core/src/fusion/mod.rs
@@ -25,6 +25,9 @@ mod strategy;
 #[cfg(test)]
 mod strategy_tests;
 
+#[cfg(test)]
+mod weight_validation_tests;
+
 pub use strategy::{
     min_max_normalize, FusionError, FusionStrategy, ScoreDirection, DEFAULT_WEIGHTED_AVG_WEIGHT,
     DEFAULT_WEIGHTED_HIT_WEIGHT, DEFAULT_WEIGHTED_MAX_WEIGHT,

--- a/crates/velesdb-core/src/fusion/strategy.rs
+++ b/crates/velesdb-core/src/fusion/strategy.rs
@@ -18,6 +18,16 @@ pub enum FusionError {
         /// The negative weight value.
         weight: f32,
     },
+    /// Non-finite weight or smoothing constant provided (NaN or +/-infinity).
+    ///
+    /// Ordering comparisons against NaN are all false, so a NaN slips through
+    /// every `< 0.0` / `<= 0.0` guard and then poisons the fused score of
+    /// every document the branch touches. Rejecting it here keeps the range
+    /// checks meaningful.
+    NonFiniteWeight {
+        /// The non-finite value.
+        weight: f32,
+    },
     /// Weight slice length does not match the number of result branches.
     WeightCountMismatch {
         /// Number of weights provided.
@@ -42,6 +52,9 @@ impl std::fmt::Display for FusionError {
             }
             Self::NegativeWeight { weight } => {
                 write!(f, "Weights must be non-negative, got {weight:.4}")
+            }
+            Self::NonFiniteWeight { weight } => {
+                write!(f, "Weights must be finite, got {weight}")
             }
             Self::WeightCountMismatch { weights, branches } => write!(
                 f,
@@ -182,12 +195,11 @@ impl FusionStrategy {
     ///
     /// # Errors
     ///
-    /// Returns an error if any weight is negative or `k` ≤ 0.
+    /// Returns an error if any weight or `k` is non-finite, if any weight is
+    /// negative, or if `k` ≤ 0.
     pub fn weighted_rrf(weights: Vec<f32>, k: f32) -> Result<Self, FusionError> {
         validate_non_negative(&weights)?;
-        if k <= 0.0 {
-            return Err(FusionError::NegativeWeight { weight: k });
-        }
+        validate_smoothing_constant(k)?;
         Ok(Self::WeightedRRF { weights, k })
     }
 
@@ -198,6 +210,7 @@ impl FusionStrategy {
     /// Returns an error if:
     /// - Weights do not sum to 1.0 (within 0.001 tolerance)
     /// - Any weight is negative
+    /// - Any weight is non-finite (NaN or +/-infinity)
     pub fn relative_score(dense_weight: f32, sparse_weight: f32) -> Result<Self, FusionError> {
         validate_non_negative(&[dense_weight, sparse_weight])?;
         validate_weight_sum(dense_weight + sparse_weight)?;
@@ -214,6 +227,7 @@ impl FusionStrategy {
     /// Returns an error if:
     /// - Weights do not sum to 1.0 (within 0.001 tolerance)
     /// - Any weight is negative
+    /// - Any weight is non-finite (NaN or +/-infinity)
     pub fn weighted(
         avg_weight: f32,
         max_weight: f32,
@@ -577,9 +591,7 @@ impl FusionStrategy {
         k: f32,
     ) -> Result<Vec<(u64, f32)>, FusionError> {
         validate_non_negative(weights)?;
-        if k <= 0.0 {
-            return Err(FusionError::NegativeWeight { weight: k });
-        }
+        validate_smoothing_constant(k)?;
         if weights.len() != branches.len() {
             return Err(FusionError::WeightCountMismatch {
                 weights: weights.len(),
@@ -620,9 +632,30 @@ impl Default for FusionStrategy {
 /// Validates that no weight in the slice is negative.
 fn validate_non_negative(weights: &[f32]) -> Result<(), FusionError> {
     for &w in weights {
+        // Finiteness first: `w < 0.0` is false for NaN, so a NaN would pass
+        // the range check and reach the kernel, where it turns the fused
+        // score of every document in its branch into NaN.
+        if !w.is_finite() {
+            return Err(FusionError::NonFiniteWeight { weight: w });
+        }
         if w < 0.0 {
             return Err(FusionError::NegativeWeight { weight: w });
         }
+    }
+    Ok(())
+}
+
+/// Validates a rank-smoothing constant: finite and strictly positive.
+///
+/// `k` sits in the denominator of every reciprocal-rank contribution, so a
+/// NaN propagates the same way a NaN weight does, and a zero divides the
+/// top-ranked document's contribution by zero.
+fn validate_smoothing_constant(k: f32) -> Result<(), FusionError> {
+    if !k.is_finite() {
+        return Err(FusionError::NonFiniteWeight { weight: k });
+    }
+    if k <= 0.0 {
+        return Err(FusionError::NegativeWeight { weight: k });
     }
     Ok(())
 }

--- a/crates/velesdb-core/src/fusion/weight_validation_tests.rs
+++ b/crates/velesdb-core/src/fusion/weight_validation_tests.rs
@@ -1,0 +1,146 @@
+//! Non-finite fusion weights are refused wherever weights enter the engine.
+//!
+//! Every range check in `strategy.rs` is an ordering comparison — `w < 0.0`,
+//! `k <= 0.0` — and every ordering comparison against NaN is false. A NaN
+//! therefore satisfied all of them, and the strategy it built produced a NaN
+//! contribution for every document in its branch. Because `sort_descending`
+//! orders by a partial comparison, those NaN-scored documents did not sink to
+//! the bottom: they kept whatever position the sort left them in, so a
+//! document with a genuine score ranked *below* documents with no score at
+//! all.
+//!
+//! These tests pin the rejection at both gates — the validating constructor
+//! and `fuse`, which revalidates because the enum variants are public and can
+//! be built as literals.
+
+use super::{FusionError, FusionStrategy};
+
+/// The three shapes a non-finite `f32` takes, each of which defeats a
+/// different-looking guard.
+const NON_FINITE: [f32; 3] = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY];
+
+#[test]
+fn weighted_rrf_rejects_non_finite_weights_at_construction() {
+    for bad in NON_FINITE {
+        let err = FusionStrategy::weighted_rrf(vec![bad, 1.0], 60.0)
+            .expect_err("a non-finite weight must not build a strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "weight {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+#[test]
+fn weighted_rrf_rejects_non_finite_k_at_construction() {
+    for bad in NON_FINITE {
+        let err = FusionStrategy::weighted_rrf(vec![1.0], bad)
+            .expect_err("a non-finite k must not build a strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "k {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+#[test]
+fn weighted_rejects_non_finite_weights_at_construction() {
+    for bad in NON_FINITE {
+        let err = FusionStrategy::weighted(bad, 0.3, 0.1)
+            .expect_err("a non-finite weight must not build a strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "weight {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+#[test]
+fn relative_score_rejects_non_finite_weights_at_construction() {
+    for bad in NON_FINITE {
+        let err = FusionStrategy::relative_score(bad, 0.5)
+            .expect_err("a non-finite weight must not build a strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "weight {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+/// The enum variants are public, so a caller can skip the constructor. `fuse`
+/// is the second gate and must refuse the same values.
+#[test]
+fn fuse_rejects_a_non_finite_weight_built_as_an_enum_literal() {
+    for bad in NON_FINITE {
+        let strategy = FusionStrategy::WeightedRRF {
+            weights: vec![bad],
+            k: 60.0,
+        };
+        let err = strategy
+            .fuse(vec![vec![(1u64, 0.9)]])
+            .expect_err("fuse must revalidate a literal-built strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "weight {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+#[test]
+fn fuse_rejects_a_non_finite_k_built_as_an_enum_literal() {
+    for bad in NON_FINITE {
+        let strategy = FusionStrategy::WeightedRRF {
+            weights: vec![1.0],
+            k: bad,
+        };
+        let err = strategy
+            .fuse(vec![vec![(1u64, 0.9)]])
+            .expect_err("fuse must revalidate a literal-built strategy");
+        assert!(
+            matches!(err, FusionError::NonFiniteWeight { .. }),
+            "k {bad} produced {err} instead of NonFiniteWeight"
+        );
+    }
+}
+
+/// The consequence the guard prevents, measured rather than asserted from
+/// reasoning: before the fix this fused to `[(1, NaN), (2, NaN), (3, 0.0164)]`
+/// — document 3, the only one carrying a real score, ranked last.
+///
+/// Bypassing the constructor to build the strategy is what makes this test a
+/// regression guard rather than a duplicate of the constructor tests: it
+/// exercises the ranking, not just the rejection.
+#[test]
+fn a_nan_weight_can_no_longer_sink_a_genuinely_scored_document() {
+    let strategy = FusionStrategy::WeightedRRF {
+        weights: vec![f32::NAN, 1.0],
+        k: 60.0,
+    };
+    let branches = vec![
+        vec![(1u64, 0.9f32), (2u64, 0.5f32)],
+        vec![(2u64, 0.8f32), (3u64, 0.4f32)],
+    ];
+
+    let err = strategy
+        .fuse(branches)
+        .expect_err("the NaN branch weight must be refused, not ranked");
+    assert!(matches!(err, FusionError::NonFiniteWeight { .. }));
+}
+
+/// Finite weights must still pass — the guard is a filter, not a ban.
+#[test]
+fn finite_weights_still_build_and_fuse() {
+    let strategy =
+        FusionStrategy::weighted_rrf(vec![0.7, 0.3], 60.0).expect("finite weights must build");
+    let fused = strategy
+        .fuse(vec![
+            vec![(1u64, 0.9f32), (2u64, 0.5f32)],
+            vec![(2u64, 0.8f32), (3u64, 0.4f32)],
+        ])
+        .expect("finite weights must fuse");
+
+    assert_eq!(fused.len(), 3, "every document must survive the fusion");
+    for (id, score) in fused {
+        assert!(score.is_finite(), "document {id} scored {score}");
+    }
+}

--- a/crates/velesdb-server/src/handlers/search/build_fusion_strategy_tests.rs
+++ b/crates/velesdb-server/src/handlers/search/build_fusion_strategy_tests.rs
@@ -1,0 +1,133 @@
+//! `/search/multi` refuses fusion weights the strategy cannot honour.
+//!
+//! The weighted arms of this parser used to build their `FusionStrategy` as
+//! struct literals, which accept any `f32` the JSON body carries. The core
+//! constructors — the ones that check the weights are non-negative, finite,
+//! and sum to 1.0 — were never called, so a request could name weights the
+//! fusion kernel then applied verbatim, returning a 200 with a ranking nobody
+//! asked for (#2095).
+
+use super::multi::build_fusion_strategy;
+use crate::types::MultiQuerySearchRequest;
+
+/// A request with the canonical defaults, ready for one field to be perturbed.
+///
+/// Built by deserializing rather than by struct literal so the `#[serde]`
+/// defaults are the ones under test — a literal would hardcode a second copy
+/// of them here.
+fn request(strategy: &str) -> MultiQuerySearchRequest {
+    serde_json::from_value(serde_json::json!({
+        "vectors": [[0.1f32, 0.2f32]],
+        "strategy": strategy,
+    }))
+    .expect("test: the default multi-query body must deserialize")
+}
+
+#[test]
+fn the_defaults_of_every_strategy_are_accepted() {
+    for strategy in [
+        "average",
+        "avg",
+        "maximum",
+        "max",
+        "rrf",
+        "weighted",
+        "relative_score",
+        "rsf",
+    ] {
+        build_fusion_strategy(&request(strategy))
+            .unwrap_or_else(|error| panic!("'{strategy}' must build with its defaults: {error}"));
+    }
+}
+
+#[test]
+fn weighted_defaults_are_the_canonical_constants() {
+    let strategy = build_fusion_strategy(&request("weighted")).expect("weighted must build");
+    match strategy {
+        velesdb_core::FusionStrategy::Weighted {
+            avg_weight,
+            max_weight,
+            hit_weight,
+        } => {
+            assert!((avg_weight - velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT).abs() < f32::EPSILON);
+            assert!((max_weight - velesdb_core::DEFAULT_WEIGHTED_MAX_WEIGHT).abs() < f32::EPSILON);
+            assert!((hit_weight - velesdb_core::DEFAULT_WEIGHTED_HIT_WEIGHT).abs() < f32::EPSILON);
+        }
+        other => panic!("expected Weighted, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_negative_weighted_component_is_refused() {
+    let mut req = request("weighted");
+    req.avg_weight = -0.2;
+    req.max_weight = 0.9;
+    req.hit_weight = 0.3;
+    let error = build_fusion_strategy(&req).expect_err("a negative weight must be refused");
+    assert!(
+        error.contains("non-negative"),
+        "message should name the rule it broke, got: {error}"
+    );
+}
+
+#[test]
+fn weighted_components_that_do_not_sum_to_one_are_refused() {
+    let mut req = request("weighted");
+    req.avg_weight = 0.9;
+    req.max_weight = 0.9;
+    req.hit_weight = 0.9;
+    let error = build_fusion_strategy(&req).expect_err("weights summing to 2.7 must be refused");
+    assert!(
+        error.contains("sum to 1.0"),
+        "message should name the rule it broke, got: {error}"
+    );
+}
+
+#[test]
+fn a_non_finite_weighted_component_is_refused() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut req = request("weighted");
+        req.avg_weight = bad;
+        let error = build_fusion_strategy(&req)
+            .err()
+            .unwrap_or_else(|| panic!("{bad} must be refused"));
+        assert!(
+            error.contains("finite") || error.contains("sum to 1.0"),
+            "message should name the rule {bad} broke, got: {error}"
+        );
+    }
+}
+
+#[test]
+fn relative_score_weights_that_do_not_sum_to_one_are_refused() {
+    let mut req = request("rsf");
+    req.dense_weight = 0.9;
+    req.sparse_weight = 0.9;
+    let error = build_fusion_strategy(&req).expect_err("weights summing to 1.8 must be refused");
+    assert!(
+        error.contains("sum to 1.0"),
+        "message should name the rule it broke, got: {error}"
+    );
+}
+
+#[test]
+fn a_non_finite_relative_score_weight_is_refused() {
+    let mut req = request("rsf");
+    req.dense_weight = f32::NAN;
+    req.sparse_weight = 0.5;
+    let error = build_fusion_strategy(&req).expect_err("a NaN weight must be refused");
+    assert!(
+        error.contains("finite"),
+        "message should name the rule it broke, got: {error}"
+    );
+}
+
+#[test]
+fn an_unknown_strategy_keeps_its_original_casing_in_the_message() {
+    let error = build_fusion_strategy(&request("NoSuchStrategy"))
+        .expect_err("an unknown strategy must be refused");
+    assert!(
+        error.contains("NoSuchStrategy"),
+        "message should echo what the caller sent, got: {error}"
+    );
+}

--- a/crates/velesdb-server/src/handlers/search/mod.rs
+++ b/crates/velesdb-server/src/handlers/search/mod.rs
@@ -5,6 +5,10 @@ pub(crate) mod multi;
 mod pipeline;
 mod workers;
 
+#[cfg(test)]
+#[path = "build_fusion_strategy_tests.rs"]
+mod build_fusion_strategy_tests;
+
 use axum::{
     extract::{Path, State},
     http::StatusCode,

--- a/crates/velesdb-server/src/handlers/search/multi.rs
+++ b/crates/velesdb-server/src/handlers/search/multi.rs
@@ -18,43 +18,57 @@ use super::pipeline::{
 use super::workers::run_blocking_search;
 use crate::handlers::helpers::{apply_pre_check, extract_client_id, get_vector_collection_or_404};
 
-/// Parse the fusion strategy name into a `FusionStrategy`, returning a 400
-/// response (and bumping the error counter) for an unknown strategy.
-#[allow(clippy::result_large_err)]
-fn parse_fusion_strategy(
+/// Build the `FusionStrategy` a multi-query request asks for, or the message
+/// explaining why it cannot be built.
+///
+/// Split from [`parse_fusion_strategy`] so the decision is testable without
+/// an `AppState`: everything here is a pure function of the request body,
+/// and the caller owns the metrics and the HTTP shell.
+///
+/// The weighted strategies go through their validating constructors rather
+/// than being built as struct literals. The literals accepted any `f32` the
+/// JSON body carried, so a negative weight, a set that did not sum to 1.0, or
+/// a non-finite value reached the fusion kernel and came back as a silently
+/// wrong ranking instead of an error (#2095). The weight rules stay on the
+/// core constructors and their message is reported verbatim, so the server
+/// never carries a second, driftable copy of the same contract.
+pub(super) fn build_fusion_strategy(
     req: &MultiQuerySearchRequest,
-    state: &AppState,
-) -> Result<velesdb_core::FusionStrategy, axum::response::Response> {
+) -> Result<velesdb_core::FusionStrategy, String> {
     use velesdb_core::FusionStrategy;
     match req.strategy.to_lowercase().as_str() {
         "average" | "avg" => Ok(FusionStrategy::Average),
         "maximum" | "max" => Ok(FusionStrategy::Maximum),
         "rrf" => Ok(FusionStrategy::RRF { k: req.rrf_k }),
-        "weighted" => Ok(FusionStrategy::Weighted {
-            avg_weight: req.avg_weight,
-            max_weight: req.max_weight,
-            hit_weight: req.hit_weight,
-        }),
-        "relative_score" | "rsf" => Ok(FusionStrategy::RelativeScore {
-            dense_weight: req.dense_weight,
-            sparse_weight: req.sparse_weight,
-        }),
-        _ => {
-            state.operational_metrics.inc_errors();
-            Err((
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse {
-                    error: format!(
-                        "Invalid strategy: {}. Valid: average, maximum, rrf, weighted, \
-                         relative_score",
-                        req.strategy
-                    ),
-                    code: None,
-                }),
-            )
-                .into_response())
+        "weighted" => FusionStrategy::weighted(req.avg_weight, req.max_weight, req.hit_weight)
+            .map_err(|error| format!("Invalid weighted fusion weights: {error}")),
+        "relative_score" | "rsf" => {
+            FusionStrategy::relative_score(req.dense_weight, req.sparse_weight)
+                .map_err(|error| format!("Invalid relative_score fusion weights: {error}"))
         }
+        _ => Err(format!(
+            "Invalid strategy: {}. Valid: average, maximum, rrf, weighted, relative_score",
+            req.strategy
+        )),
     }
+}
+
+/// Parse the fusion strategy the request asks for, returning a 400 response
+/// (and bumping the error counter) for an unknown strategy or for weights the
+/// strategy refuses.
+#[allow(clippy::result_large_err)]
+fn parse_fusion_strategy(
+    req: &MultiQuerySearchRequest,
+    state: &AppState,
+) -> Result<velesdb_core::FusionStrategy, axum::response::Response> {
+    build_fusion_strategy(req).map_err(|error| {
+        state.operational_metrics.inc_errors();
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse { error, code: None }),
+        )
+            .into_response()
+    })
 }
 
 /// Validate every query vector's dimension, returning a 400 on the first

--- a/crates/velesdb-server/src/handlers/search/parse_fusion_strategy_tests.rs
+++ b/crates/velesdb-server/src/handlers/search/parse_fusion_strategy_tests.rs
@@ -121,6 +121,62 @@ fn test_relative_score_alias() {
     ));
 }
 
+/// The `weighted` arm built its strategy as a struct literal, so the core
+/// weight rules were never consulted and any `f32` the request carried was
+/// applied verbatim by the fusion kernel (#2095).
+#[test]
+fn test_weighted_rejects_weights_that_do_not_sum_to_one() {
+    let mut req = strat("weighted");
+    req.avg_w = Some(0.9);
+    req.max_w = Some(0.9);
+    req.hit_w = Some(0.9);
+    let result = parse_fusion_strategy(Some(&req));
+    assert!(
+        result.is_err(),
+        "weights summing to 2.7 must return Err (400 response)"
+    );
+}
+
+#[test]
+fn test_weighted_rejects_a_negative_component() {
+    let mut req = strat("weighted");
+    req.avg_w = Some(-0.2);
+    req.max_w = Some(0.9);
+    req.hit_w = Some(0.3);
+    let result = parse_fusion_strategy(Some(&req));
+    assert!(
+        result.is_err(),
+        "a negative weight must return Err (400 response)"
+    );
+}
+
+#[test]
+fn test_weighted_rejects_non_finite_components() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut req = strat("weighted");
+        req.avg_w = Some(bad);
+        let result = parse_fusion_strategy(Some(&req));
+        assert!(
+            result.is_err(),
+            "weight {bad} must return Err (400 response)"
+        );
+    }
+}
+
+#[test]
+fn test_rsf_rejects_non_finite_components() {
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let mut req = strat("rsf");
+        req.dense_w = Some(bad);
+        req.sparse_w = Some(0.5);
+        let result = parse_fusion_strategy(Some(&req));
+        assert!(
+            result.is_err(),
+            "weight {bad} must return Err (400 response)"
+        );
+    }
+}
+
 #[test]
 fn test_unknown_strategy_returns_error() {
     let req = strat("nonexistent");

--- a/crates/velesdb-server/src/handlers/search/pipeline.rs
+++ b/crates/velesdb-server/src/handlers/search/pipeline.rs
@@ -168,11 +168,18 @@ pub(crate) fn resolve_sparse_input(
 /// | Relative Score | `rsf`, `relative_score` | `dense_w`, `sparse_w` (default 0.5 / 0.5) |
 /// | Average | `average`, `avg` | — |
 /// | Maximum | `maximum`, `max` | — |
-/// | Weighted | `weighted` | `avg_w`, `max_w`, `hit_w` (default 0.5 / 0.3 / 0.2) |
+/// | Weighted | `weighted` | `avg_w`, `max_w`, `hit_w` (default 0.6 / 0.3 / 0.1) |
+///
+/// The weighted defaults are the #1545 canon, read from
+/// [`velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT`] and its siblings; this table
+/// listed the pre-#1545 literals 0.5 / 0.3 / 0.2 for as long as the code did,
+/// and kept listing them after #2093 fixed the code.
 ///
 /// Unknown strategies yield a 400 Bad Request response listing the
-/// supported values. This propagates the full `velesdb_core::FusionStrategy`
-/// enum to the REST surface (findings PROP-FUS-HYBRID / PROP-FUS-SPARSE).
+/// supported values, as do weights the strategy refuses (negative, non-finite,
+/// or not summing to 1.0). This propagates the full
+/// `velesdb_core::FusionStrategy` enum to the REST surface (findings
+/// PROP-FUS-HYBRID / PROP-FUS-SPARSE).
 #[allow(clippy::result_large_err)]
 pub(crate) fn parse_fusion_strategy(
     fusion: Option<&crate::types::FusionRequest>,
@@ -205,13 +212,23 @@ pub(crate) fn parse_fusion_strategy(
         }
         "average" | "avg" => Ok(velesdb_core::FusionStrategy::Average),
         "maximum" | "max" => Ok(velesdb_core::FusionStrategy::Maximum),
-        "weighted" => Ok(velesdb_core::FusionStrategy::Weighted {
+        "weighted" => velesdb_core::FusionStrategy::weighted(
             // Canonical defaults from core's fusion module (#1545) — this
             // arm previously froze the pre-#1545 literals 0.5/0.3/0.2,
             // forking the REST default from every other surface.
-            avg_weight: f.avg_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT),
-            max_weight: f.max_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_MAX_WEIGHT),
-            hit_weight: f.hit_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_HIT_WEIGHT),
+            f.avg_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_AVG_WEIGHT),
+            f.max_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_MAX_WEIGHT),
+            f.hit_w.unwrap_or(velesdb_core::DEFAULT_WEIGHTED_HIT_WEIGHT),
+        )
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Invalid weighted fusion weights: {e}"),
+                    code: None,
+                }),
+            )
+                .into_response()
         }),
         other => Err((
             StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two defects in the same path, found while reproducing item A3 of #2095.

**1. Every weight rule was NaN-blind.** The guards in `fusion/strategy.rs` are ordering comparisons — `w < 0.0` for weights, `k <= 0.0` for the rank-smoothing constant — and every ordering comparison against `NaN` is false. A `NaN` satisfied all of them, so `FusionStrategy::weighted`, `relative_score` and `weighted_rrf` each returned `Ok`, and the kernel then produced a `NaN` contribution for every document in that branch.

The consequence is worse than a `NaN` score. `sort_descending` orders by a partial comparison, so the `NaN`-scored documents did not sink. Measured on a two-branch fusion with one `NaN` weight:

```
[(1, NaN), (2, NaN), (3, 0.016393442)]
```

Document 3 — the only one carrying a real score — ranked **last**, behind two documents with no score at all. A caller reading the top-k got a confident, silently inverted answer.

**2. The REST edge bypassed the validating constructors.** Three of the four arms that build a weighted `FusionStrategy` from an HTTP body did it with a struct literal, which accepts any `f32` that deserialized. The core constructors were never called, so these accepted a `200`:

```json
{"strategy": "weighted", "avg_weight": -0.2, "max_weight": 0.9, "hit_weight": 0.3}
```

— a negative weight and a set summing to 1.0 only by accident, applied verbatim by the fusion kernel.

Fixes # (none — a finding of #2095, which stays open for the rest of its 54)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## What changed

**`crates/velesdb-core/src/fusion/strategy.rs`**

- `validate_non_negative` checks finiteness *before* range.
- The two hand-rolled `k <= 0.0` guards (constructor and `fuse`) are replaced by a shared `validate_smoothing_constant`, so the rule is stated once. `fuse` keeps revalidating because the enum variants are public and can be built as literals — that second gate is pre-existing and load-bearing.
- New `FusionError::NonFiniteWeight`. The enum is `#[non_exhaustive]`, so no downstream `match` breaks.
- `validate_weight_sum` is deliberately left alone: every caller runs `validate_non_negative` on the same values first, so by the time the sum is taken it can only be non-finite through overflow to `±inf`, which the existing `(sum - 1.0).abs() > 0.001` already rejects.

**`crates/velesdb-server/src/handlers/search/multi.rs`** — `/search/multi`, `/search/multi/ids`

- `weighted` and `relative_score` go through the validating constructors; the core message is reported verbatim so the server carries no second copy of the rules to drift from.
- The decision is split into a pure `build_fusion_strategy(&req) -> Result<_, String>` and a thin shell that owns the metrics counter and the HTTP response. That split is what makes the new cases testable without standing up an `AppState`.

**`crates/velesdb-server/src/handlers/search/pipeline.rs`** — the `fusion` block of `/search`, `/search/ids`, `/search/hybrid`

- The `weighted` arm goes through `FusionStrategy::weighted`. (`rsf` already did; `rrf`, `average` and `maximum` take no weights.)
- The rustdoc table is corrected: it advertised the pre-#1545 weighted defaults `0.5 / 0.3 / 0.2`, and went on advertising them after #2093 fixed the code to read `DEFAULT_WEIGHTED_AVG_WEIGHT` and its siblings (`0.6 / 0.3 / 0.1`).

**Left alone, deliberately, and recorded rather than dropped:** `velesdb-cli` and `tauri-plugin-velesdb` each carry a fifth and sixth hand-written copy of the same name-to-strategy mapping, and the CLI's copy still hardcodes the pre-#1545 `0.5 / 0.3 / 0.2` *and* ignores user-supplied weights entirely. Collapsing all six onto one core entry point is the single-sourcing work of #2095 section B; `tauri-plugin-velesdb` needs GTK, which this environment cannot build, so it is not something this PR can validate.

## How Has This Been Tested?

- [x] Unit tests

Two new files, both siblings of what they cover:

| file | tests | pins |
|---|---|---|
| `crates/velesdb-core/src/fusion/weight_validation_tests.rs` | 8 | `NaN`, `+inf` and `-inf` refused at each of the three constructors and at `fuse` for both weights and `k`; the measured ranking inversion; finite weights still build and fuse |
| `crates/velesdb-server/src/handlers/search/build_fusion_strategy_tests.rs` | 8 | every strategy's defaults still accepted; weighted defaults are the canonical constants; negative, non-summing and non-finite components refused for `weighted` and `rsf`; an unknown strategy keeps its original casing in the message |

Plus 4 cases added to the existing `parse_fusion_strategy_tests.rs` for the `pipeline.rs` parser.

The new core tests live in a new sibling file rather than in `strategy_tests.rs` because that file is at 990 lines against the 1000-line budget.

**Mutation-checked, not assumed.** Deleting the weight-side finiteness check fails 5 of the 8 new core tests; deleting the `k`-side one fails the other 2. The 56 pre-existing fusion tests stay green under both mutations, which is the point — they could not have caught this.

Full runs on this branch:

```
cargo test -p velesdb-core   --features persistence --lib   # 5437 passed, 0 failed
cargo test -p velesdb-core   --features persistence --test bdd  # 631 passed, 0 failed
cargo test -p velesdb-server --features persistence --lib   #  168 passed, 0 failed
```

Every existing production caller of the three constructors passes finite literal weights or already has an `unwrap_or_else` fallback (`sparse_dispatch.rs:205,229`, `text_fusion.rs:233`), so no behaviour changes for them.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

Local validation: `cargo fmt --all -- --check` clean; `cargo clippy -p velesdb-core -p velesdb-server --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean; `check-ai-attribution.py`, `check-file-budgets.py` and `check-inline-tests.py` all pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG, the corrected `pipeline.rs` rustdoc table)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code added or modified.

## High-Risk Change Checklist

Not applicable — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch.

## Additional Notes

A request that used to get a `200` with a wrong ranking now gets a `400`. That is the intended change and the reason this is filed as a fix: the previous response was not a weaker guarantee, it was a wrong answer presented as a correct one.

## Performance Labels

- ARM64 benchmark is cost-gated on PRs.
- Add label `run-arm64-bench` to run the full ARM64 benchmark workflow for this PR.
