### PR TITLE
perf(storage): pay one durability barrier per batch in store_batch_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`store_batch_async` pays one durability barrier instead of one per vector
+  (#2078).** Despite its name, it looped over `VectorStorage::store`, and
+  `MmapStorage::store` under `DurabilityMode::Fsync` issues its own `flush` +
+  `sync_all` per call. A 2 000-vector batch therefore paid 2 000 fsyncs, every
+  one of them while holding the storage write lock — so the function billed as
+  the one "for large batches that would otherwise block the async executor"
+  was the slowest way in the crate to write them, and stalled every concurrent
+  writer for the duration.
+
+  `VectorStorage::store_batch` already exists for exactly this, coalescing the
+  WAL entries into one grouped write and deliberately leaving the barrier to
+  the caller; the fix is to call it and then `flush` once. Measured on 2 000
+  vectors × 128 dimensions at the default `Fsync`: **11–21× faster across three
+  runs** (320–540 ms down to 22–28 ms).
+
+  The durability guarantee on return is unchanged, because `flush` dispatches
+  on the same mode the per-vector path consulted — and marginally stronger,
+  since the mmap is flushed too, which the loop never did. Error behaviour
+  improves as well: `store_batch` validates every dimension before writing
+  anything, so a malformed entry now rejects the batch rather than leaving the
+  prefix before it committed.
+
+  The one pre-existing test asserted only that the returned count was 100 —
+  something the broken loop satisfied just as well — and never read a vector
+  back. Three tests now pin what that count was standing in for: every vector
+  is retrievable, a bad dimension commits nothing, and the batch survives
+  closing and reopening the directory without the caller flushing.
+
 - **A PR can no longer break `internal-bench` and merge green.** The feature is
   not bench-only: it gates seven sites of *production* source —
   `index/hnsw/index/search.rs`, `index/hnsw/native/distance.rs`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is retrievable, a bad dimension commits nothing, and the batch survives
   closing and reopening the directory without the caller flushing.
 
+  The write lock is scoped to the store-and-flush rather than to the whole
+  closure. The barrier is the last thing it is needed for, and every concurrent
+  writer waits behind it; holding it across the return bought nothing. The
+  tests read under the lock and assert after releasing it, for the same reason
+  — an assertion panics, and unwinding while holding the guard is worth
+  avoiding even in a test.
+
 - **A non-finite fusion weight can no longer reorder a result set (#2095).**
   Every weight rule in `fusion/strategy.rs` was an ordering comparison —
   `w < 0.0` for weights, `k <= 0.0` for the rank-smoothing constant — and every

--- a/crates/velesdb-core/src/storage/async_ops.rs
+++ b/crates/velesdb-core/src/storage/async_ops.rs
@@ -100,10 +100,25 @@ pub async fn flush_async(storage: Arc<RwLock<MmapStorage>>) -> io::Result<()> {
     .map_err(|e| io::Error::other(format!("Task join error: {e}")))?
 }
 
-/// Asynchronously stores a batch of vectors.
+/// Asynchronously stores a batch of vectors, paying one durability barrier
+/// for the whole batch.
 ///
 /// Wraps bulk insertion in `spawn_blocking` for large batches that would
 /// otherwise block the async executor.
+///
+/// This used to loop over [`VectorStorage::store`], which under
+/// [`DurabilityMode::Fsync`](super::DurabilityMode::Fsync) issues its own
+/// `flush` + `sync_all` per vector — so a 10 000-vector batch paid 10 000
+/// fsyncs, every one of them while holding the storage write lock, which is
+/// the opposite of what the name promises. [`VectorStorage::store_batch`]
+/// coalesces the WAL entries into a single grouped write and deliberately
+/// leaves the barrier to the caller; the explicit `flush` afterwards is that
+/// barrier.
+///
+/// The durability guarantee on return is unchanged — every entry is on disk
+/// when this resolves under `Fsync` — because `flush` dispatches on the same
+/// mode the per-vector path consulted. It is in fact marginally stronger: the
+/// mmap is flushed too, which the per-vector loop never did.
 ///
 /// # Arguments
 ///
@@ -112,18 +127,23 @@ pub async fn flush_async(storage: Arc<RwLock<MmapStorage>>) -> io::Result<()> {
 ///
 /// # Errors
 ///
-/// Returns an error if any store operation fails.
+/// Returns an error if any dimension is wrong, if the write fails, or if the
+/// durability barrier fails. Dimensions are validated for the whole batch
+/// before anything is written, so a malformed entry rejects the batch instead
+/// of leaving the prefix before it committed.
 pub async fn store_batch_async(
     storage: Arc<RwLock<MmapStorage>>,
     vectors: Vec<(u64, Vec<f32>)>,
 ) -> io::Result<usize> {
     tokio::task::spawn_blocking(move || {
+        let borrowed: Vec<(u64, &[f32])> = vectors
+            .iter()
+            .map(|(id, vector)| (*id, vector.as_slice()))
+            .collect();
+
         let mut guard = storage.write();
-        let mut count = 0;
-        for (id, vector) in vectors {
-            guard.store(id, &vector)?;
-            count += 1;
-        }
+        let count = guard.store_batch(&borrowed)?;
+        guard.flush()?;
         Ok(count)
     })
     .await

--- a/crates/velesdb-core/src/storage/async_ops.rs
+++ b/crates/velesdb-core/src/storage/async_ops.rs
@@ -141,9 +141,16 @@ pub async fn store_batch_async(
             .map(|(id, vector)| (*id, vector.as_slice()))
             .collect();
 
-        let mut guard = storage.write();
-        let count = guard.store_batch(&borrowed)?;
-        guard.flush()?;
+        // Scoped so the write lock is released before this closure returns,
+        // rather than at the end of it: the barrier is the last thing the lock
+        // is needed for, and every concurrent writer waits on it.
+        let count = {
+            let mut guard = storage.write();
+            let count = guard.store_batch(&borrowed)?;
+            guard.flush()?;
+            count
+        };
+
         Ok(count)
     })
     .await

--- a/crates/velesdb-core/src/storage/async_ops_tests.rs
+++ b/crates/velesdb-core/src/storage/async_ops_tests.rs
@@ -22,6 +22,97 @@ async fn test_store_batch_async() {
     assert_eq!(result.unwrap(), 100);
 }
 
+/// The count is not the guarantee. `test_store_batch_async` above asserts
+/// only that 100 came back, which the old per-vector loop and the batch path
+/// both satisfy; neither it nor anything else read a vector back.
+#[tokio::test]
+async fn store_batch_async_stores_every_vector_it_counts() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let storage = Arc::new(RwLock::new(
+        MmapStorage::new(dir.path(), 4).expect("test: open storage"),
+    ));
+
+    let vectors: Vec<(u64, Vec<f32>)> = (0..100)
+        .map(|i| (i, vec![i as f32, 1.0, 2.0, 3.0]))
+        .collect();
+
+    let count = store_batch_async(storage.clone(), vectors)
+        .await
+        .expect("test: batch must store");
+    assert_eq!(count, 100);
+
+    let guard = storage.read();
+    for i in 0..100u64 {
+        let stored = guard
+            .retrieve(i)
+            .expect("test: retrieve must not fail")
+            .unwrap_or_else(|| panic!("test: vector {i} is missing"));
+        assert_eq!(stored, vec![i as f32, 1.0, 2.0, 3.0], "vector {i}");
+    }
+}
+
+/// `store_batch` validates every dimension before writing anything, so a
+/// malformed entry rejects the batch. The per-vector loop wrote each vector as
+/// it went and stopped at the bad one, leaving the prefix committed.
+#[tokio::test]
+async fn store_batch_async_rejects_the_whole_batch_on_a_bad_dimension() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let storage = Arc::new(RwLock::new(
+        MmapStorage::new(dir.path(), 4).expect("test: open storage"),
+    ));
+
+    let vectors = vec![
+        (1u64, vec![1.0, 1.0, 1.0, 1.0]),
+        (2u64, vec![2.0, 2.0, 2.0, 2.0]),
+        (3u64, vec![3.0, 3.0]), // wrong dimension
+    ];
+
+    store_batch_async(storage.clone(), vectors)
+        .await
+        .expect_err("test: a wrong dimension must reject the batch");
+
+    let guard = storage.read();
+    for id in [1u64, 2, 3] {
+        assert!(
+            guard
+                .retrieve(id)
+                .expect("test: retrieve must not fail")
+                .is_none(),
+            "vector {id} was committed by a batch that failed"
+        );
+    }
+}
+
+/// The barrier is paid, not skipped: reopening the same directory recovers
+/// every vector without the caller having flushed. `store_batch` itself does
+/// not fsync — it leaves that to the caller — so this is what proves the
+/// explicit `flush` is there and dispatching on the durability mode.
+#[tokio::test]
+async fn store_batch_async_leaves_the_batch_durable_on_disk() {
+    let dir = TempDir::new().expect("test: temp dir");
+    let vectors: Vec<(u64, Vec<f32>)> = (0..64)
+        .map(|i| (i, vec![i as f32, 0.5, 0.25, 0.125]))
+        .collect();
+
+    {
+        let storage = Arc::new(RwLock::new(
+            MmapStorage::new(dir.path(), 4).expect("test: open storage"),
+        ));
+        store_batch_async(storage, vectors)
+            .await
+            .expect("test: batch must store");
+    }
+
+    let reopened = MmapStorage::new(dir.path(), 4).expect("test: reopen storage");
+    for i in 0..64u64 {
+        let stored = reopened
+            .retrieve(i)
+            .expect("test: retrieve must not fail")
+            .unwrap_or_else(|| panic!("test: vector {i} did not survive the reopen"));
+        assert_eq!(stored, vec![i as f32, 0.5, 0.25, 0.125], "vector {i}");
+    }
+}
+
 #[tokio::test]
 async fn test_flush_async() {
     let dir = TempDir::new().unwrap();

--- a/crates/velesdb-core/src/storage/async_ops_tests.rs
+++ b/crates/velesdb-core/src/storage/async_ops_tests.rs
@@ -41,13 +41,19 @@ async fn store_batch_async_stores_every_vector_it_counts() {
         .expect("test: batch must store");
     assert_eq!(count, 100);
 
-    let guard = storage.read();
-    for i in 0..100u64 {
-        let stored = guard
-            .retrieve(i)
-            .expect("test: retrieve must not fail")
-            .unwrap_or_else(|| panic!("test: vector {i} is missing"));
-        assert_eq!(stored, vec![i as f32, 1.0, 2.0, 3.0], "vector {i}");
+    // Read under the lock, assert after releasing it: a failing assertion
+    // panics, and unwinding while holding the guard is worth avoiding even in
+    // a test.
+    let stored: Vec<Option<Vec<f32>>> = {
+        let guard = storage.read();
+        (0..100u64)
+            .map(|i| guard.retrieve(i).expect("test: retrieve must not fail"))
+            .collect()
+    };
+
+    for (i, entry) in stored.into_iter().enumerate() {
+        let vector = entry.unwrap_or_else(|| panic!("test: vector {i} is missing"));
+        assert_eq!(vector, vec![i as f32, 1.0, 2.0, 3.0], "vector {i}");
     }
 }
 
@@ -71,15 +77,22 @@ async fn store_batch_async_rejects_the_whole_batch_on_a_bad_dimension() {
         .await
         .expect_err("test: a wrong dimension must reject the batch");
 
-    let guard = storage.read();
-    for id in [1u64, 2, 3] {
-        assert!(
-            guard
-                .retrieve(id)
-                .expect("test: retrieve must not fail")
-                .is_none(),
-            "vector {id} was committed by a batch that failed"
-        );
+    let committed: Vec<(u64, bool)> = {
+        let guard = storage.read();
+        [1u64, 2, 3]
+            .into_iter()
+            .map(|id| {
+                let present = guard
+                    .retrieve(id)
+                    .expect("test: retrieve must not fail")
+                    .is_some();
+                (id, present)
+            })
+            .collect()
+    };
+
+    for (id, present) in committed {
+        assert!(!present, "vector {id} was committed by a batch that failed");
     }
 }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Found while auditing #2078 (the `WalBatcher` wire-or-retire question). Looking for the paths that still pay a durability barrier per operation turned up one that is not a design trade-off but a plain defect.

`store_batch_async` looped over `VectorStorage::store`:

```rust
let mut guard = storage.write();
for (id, vector) in vectors {
    guard.store(id, &vector)?;
}
```

and `MmapStorage::store` under `DurabilityMode::Fsync` (the default) does its own `wal.flush()` + `wal.get_ref().sync_all()` on every call — see `storage/mmap/vector_io.rs:163-171`, added by #898 precisely so the *single*-store path is durable on return. A 2 000-vector batch therefore paid 2 000 fsyncs, every one of them while holding the storage write lock.

So the function whose own doc says it is "for large batches that would otherwise block the async executor" was the slowest way in the crate to write a large batch, and blocked every concurrent writer for the duration.

Fixes # (none — a finding of #2078, which stays open for its own wire-or-retire decision)

## Type of Change

- [x] ⚡ Performance improvement

## What changed

`VectorStorage::store_batch` already exists for exactly this shape: it validates every dimension upfront, pre-allocates once, coalesces the WAL entries into a single grouped `write_all`, and deliberately does **no** fsync — `vector_io.rs:259` says so in as many words, leaving the barrier to the caller. The fix is to call it and then pay that barrier once.

```rust
let mut guard = storage.write();
let count = guard.store_batch(&borrowed)?;
guard.flush()?;
```

**The durability guarantee on return is unchanged.** `flush` dispatches on the same `DurabilityMode` the per-vector path consulted (`Fsync` → flush + `sync_all`, `FlushOnly` → flush, `None` → nothing), so every entry is on disk when the call resolves under `Fsync`, exactly as before. It is in fact marginally *stronger*: `flush` also flushes the mmap, which the per-vector loop never did.

**Error behaviour improves too.** The loop wrote each vector as it went and stopped at the first bad one, leaving everything before it committed. `store_batch` validates all dimensions before writing anything, so a malformed entry rejects the batch.

## How Has This Been Tested?

- [x] Unit tests

**Measured, not asserted.** A throwaway probe ran the old loop and the new path back to back against fresh temp directories, 2 000 vectors × 128 dimensions, default `Fsync`:

| run | per-vector loop | `store_batch` + 1 flush | speedup |
|---|---|---|---|
| 1 | 538 ms | 25.5 ms | 21.1× |
| 2 | 440 ms | 22.5 ms | 19.6× |
| 3 | 319 ms | 28.3 ms | 11.3× |

The spread is the host's fsync latency, not the change; the floor is stable at 22–28 ms. The probe is not shipped — it exists to produce this table.

**The pre-existing test could not have caught this.** `test_store_batch_async` asserts only that the returned count is 100, which the broken loop satisfied just as well, and nothing in the tree ever read a vector back from this function. Three tests now pin what that count was standing in for:

| test | pins |
|---|---|
| `store_batch_async_stores_every_vector_it_counts` | all 100 vectors retrievable with the right contents, not just counted |
| `store_batch_async_rejects_the_whole_batch_on_a_bad_dimension` | a wrong dimension in position 3 commits nothing, including positions 1 and 2 |
| `store_batch_async_leaves_the_batch_durable_on_disk` | reopening the directory recovers all 64 vectors without the caller having flushed — which is what proves the explicit `flush` is present, since `store_batch` alone does not fsync |

```
cargo test -p velesdb-core --features persistence --lib storage::   # 275 passed, 0 failed
```

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

Local validation: `cargo fmt --all -- --check` clean; `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean; `check-ai-attribution.py` and `check-file-budgets.py` pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG, and the function's own rustdoc, which now states the barrier contract instead of leaving it implicit)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code added or modified.

## High-Risk Change Checklist

Touches `storage`, so stated explicitly rather than skipped:

- **Durability contract:** unchanged on return, and the reason is checkable — `MmapStorage::flush` (`vector_io.rs:328-357`) matches on the same `DurabilityMode` as `store` (`vector_io.rs:163-171`). `store_batch_async_leaves_the_batch_durable_on_disk` exercises it through a real close-and-reopen.
- **Crash window:** narrower, not wider. Previously the mmap was never flushed by this path at all; recovery relied entirely on WAL replay. It now flushes the mmap as well.
- **Partial-write window:** removed. The loop could leave a committed prefix behind a failure; the batch cannot.
- **No `Drop`, `unsafe`, `hnsw`, or SIMD dispatch involved.**

## Additional Notes

`store_batch_async` and its siblings in `storage::async_ops` have no caller inside the workspace — the module is `pub`, so this is public API a downstream async user can reach, which is why the answer here is to fix it rather than to delete it. Whether `async_ops` should stay is a separate wire-or-retire question from #2078's, and not one this PR decides.

## Performance Labels

- ARM64 benchmark is cost-gated on PRs.
- Add label `run-arm64-bench` to run the full ARM64 benchmark workflow for this PR.
