### PR TITLE
fix(lint): lower the drop-tightening baseline after #2151 drained two sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pending a drain. The drain never started, and nothing measured it.
 
   **The tracked figure was wrong.** #2110 records "192 sites"; re-measured
-  against `develop` @ `64a21b65` the real count is **326 diagnostics across 75
+  against `develop` @ `64a21b65` the real count was **326 diagnostics across 75
   files** for `velesdb-core` + `velesdb-server` with `--all-targets` (135 for
   `velesdb-core --lib` alone). 192 is reproducible only as a `grep -c` over
   clippy's human-readable output, which counts note lines rather than findings.

--- a/scripts/check-drop-tightening.py
+++ b/scripts/check-drop-tightening.py
@@ -10,12 +10,16 @@ That sibling is contention rather than deadlock, so it was left off pending a
 drain (#2110).
 
 The drain never started, and nothing measured it. #2110 recorded "192 sites"
-on 2026-08-22; re-measured against `develop` @ `86b063ea` the real figure is
-**326 diagnostics across 75 files** for `velesdb-core` + `velesdb-server` with
-`--all-targets` (135 for `velesdb-core --lib` alone). 192 is reproducible only
-as a `grep -c` over clippy's human-readable output, which counts note lines
-rather than findings. A number nobody can recompute cannot be drained against,
-and — with no guard in the tree — it can grow faster than anyone drains it.
+on 2026-08-22; re-measured on 2026-08-27 the real figure was **326 diagnostics
+across 75 files** for `velesdb-core` + `velesdb-server` with `--all-targets`
+(135 for `velesdb-core --lib` alone), and #2151 has since drained 2 of them.
+192 is reproducible only as a `grep -c` over clippy's human-readable output,
+which counts note lines rather than findings. A number nobody can recompute
+cannot be drained against, and — with no guard in the tree — it can grow faster
+than anyone drains it.
+
+The live figure is whatever `scripts/drop-tightening-baseline.txt` sums to;
+this paragraph records where the count started, not where it is.
 
 This guard is the missing half. It does not drain anything and it does not
 promote the lint; it freezes the per-file counts so the backlog can only
@@ -46,7 +50,7 @@ workspace: those are the crates that build without GTK, so the baseline is
 one anybody can regenerate and verify. `velesdb-core`'s library is linted
 even when only `velesdb-server` is named — a workspace path dependency is a
 primary unit, so it is not `--cap-lints`ed — which is why the two crates
-account for all 326. Widening to the crates that need GTK is a follow-up
+account for all of them. Widening to the crates that need GTK is a follow-up
 for someone who can build them; it must be a measured baseline, not an
 estimate, or this guard reintroduces the defect it exists to fix.
 

--- a/scripts/drop-tightening-baseline.txt
+++ b/scripts/drop-tightening-baseline.txt
@@ -61,7 +61,6 @@ crates/velesdb-core/src/index/hnsw/native_index.rs	4
 crates/velesdb-core/src/index/io_counters_tests.rs	1
 crates/velesdb-core/src/index/secondary/mod.rs	6
 crates/velesdb-core/src/sparse_index/inverted_index.rs	4
-crates/velesdb-core/src/storage/async_ops.rs	2
 crates/velesdb-core/src/storage/compaction.rs	2
 crates/velesdb-core/src/storage/compaction_tests.rs	2
 crates/velesdb-core/src/storage/guard_tests.rs	6


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

**`develop` is currently red** on the `Drop-Tightening Backlog Frozen` gate that #2152 added an hour ago, and the cause is a merge ordering I got wrong.

#2152's baseline was measured against `develop` @ `64a21b65`. #2151 merged *after* it and scoped the write lock in `storage/async_ops.rs`, removing the two findings that file carried. The baseline still listed them, so on `develop` @ `8de2af07` the gate reports:

```
FAILED: the clippy::significant_drop_tightening backlog drifted from the frozen baseline (1 issue(s)):
  - crates/velesdb-core/src/storage/async_ops.rs: baseline carries 2 finding(s), but the file
    has none left (or is gone) — delete this line from scripts/drop-tightening-baseline.txt.
```

This is the gate working, not misfiring. A baseline entry sitting *above* the true count would let a later regrowth hide underneath it, which is why `check-file-budgets.py` refuses a stale entry the same way and why this guard copied that rule. The message names the file and the exact edit.

Fixes # (none — repairs the interaction between #2151 and #2152, both merged)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## What changed

**`scripts/drop-tightening-baseline.txt`** — one line deleted. The backlog goes from **326 findings across 75 files** to **324 across 74**: the ratchet tightening, which is the only direction it moves.

**`scripts/check-drop-tightening.py`** and **`CHANGELOG.md`** — both quoted 326/75 as the current figure. They now say that is where the count *started* and point at the baseline file as the live number.

That second edit is the more interesting half. Restating a total in prose is precisely how the "192 sites" figure in #2110 went stale and stayed stale for five days, and I had reproduced the same pattern in the very PR that corrected it — a docstring and a changelog entry that would drift the first time anybody drained a file. The baseline file is the single source; the prose now defers to it.

## How Has This Been Tested?

```
$ git checkout develop && python3 scripts/check-drop-tightening.py
FAILED: ... async_ops.rs: baseline carries 2 finding(s), but the file has none left

$ git checkout fix/2110-lower-baseline-after-2151 && python3 scripts/check-drop-tightening.py
PASSED: clippy::significant_drop_tightening backlog matches the frozen baseline
        (324 finding(s) across 74 file(s), none grown).
```

The failure was reproduced on `develop` first, then shown passing on this branch — the same order the repo's own CI-fix rule asks for.

```
python3 -m unittest scripts.tests.test_check_drop_tightening   # 19 tests, OK
```

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the script docstring and the CHANGELOG both stop quoting a total that drifts)
- [x] My changes generate no new warnings
- [ ] I have added tests (none needed — the guard's 19 tests already cover the stale-entry case; this is data, not logic)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no Rust source is touched.

## High-Risk Change Checklist

Not applicable — one baseline line and two prose edits.

## Additional Notes

**The operational lesson, recorded rather than left implicit.** A shrink-must-be-recorded ratchet has a real cost: when PR A drains findings and PR B freezes the baseline, whichever merges second leaves the other's number stale. That is inherent to the design and the alternative — tolerating entries above the true count — is worse, because it is exactly the hiding place a ratchet exists to remove. The mitigation is not a policy change but an ordering habit: regenerate the baseline against the base branch immediately before merging a PR that touches it, which is one command.

Worth knowing when the scope widens to the GTK crates, since that regeneration will collide with in-flight work more often.

## Performance Labels

- ARM64 benchmark is cost-gated on PRs.
- Add label `run-arm64-bench` to run the full ARM64 benchmark workflow for this PR.
