### PR TITLE
refactor(core): drain 3 significant_drop_tightening sites (#2110)

### DIFF
--- a/crates/velesdb-core/src/collection/core/crud.rs
+++ b/crates/velesdb-core/src/collection/core/crud.rs
@@ -213,6 +213,7 @@ impl Collection {
         let mut payload_storage = self.storage.payload_storage.write();
         Self::write_deduped_payloads(points, &mut payload_storage, dedup_map)?;
         payload_storage.flush()?;
+        drop(payload_storage);
         Ok(())
     }
 

--- a/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
+++ b/crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs
@@ -255,6 +255,8 @@ impl Collection {
         let covering = mgr.find_covering_indexes(label, properties);
         let index_name = covering.first()?;
         let idx = mgr.get(index_name)?;
-        Some(idx.lookup(values).to_vec())
+        let result = idx.lookup(values).to_vec();
+        drop(mgr);
+        Some(result)
     }
 }

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/cascade.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/cascade.rs
@@ -35,6 +35,7 @@ impl ConcurrentEdgeStore {
             .iter()
             .map(|e| (e.id(), e.source()))
             .collect();
+        drop(guard);
         (outgoing, incoming)
     }
 

--- a/crates/velesdb-core/src/collection/query_cost/query_executor.rs
+++ b/crates/velesdb-core/src/collection/query_cost/query_executor.rs
@@ -42,11 +42,12 @@ impl PlanCache {
     #[must_use]
     pub fn get(&self, key: u64) -> Option<CandidatePlan> {
         let mut cache = self.cache.write();
-        if let Some(entry) = cache.get_mut(&key) {
+        let result = cache.get_mut(&key).map(|entry| {
             entry.access_count += 1;
-            return Some(entry.plan.clone());
-        }
-        None
+            entry.plan.clone()
+        });
+        drop(cache);
+        result
     }
 
     /// Inserts a plan into the cache.

--- a/scripts/drop-tightening-baseline.txt
+++ b/scripts/drop-tightening-baseline.txt
@@ -17,7 +17,6 @@ crates/velesdb-core/src/collection/core/flush.rs	6
 crates/velesdb-core/src/collection/core/index_management.rs	20
 crates/velesdb-core/src/collection/core/quantizer_restore.rs	2
 crates/velesdb-core/src/collection/core/statistics.rs	4
-crates/velesdb-core/src/collection/graph/edge_concurrent/cascade.rs	2
 crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs	8
 crates/velesdb-core/src/collection/graph/edge_concurrent/persistence.rs	2
 crates/velesdb-core/src/collection/graph/edge_concurrent/query.rs	6

--- a/scripts/drop-tightening-baseline.txt
+++ b/scripts/drop-tightening-baseline.txt
@@ -9,13 +9,11 @@ crates/velesdb-core/src/cache/bloom.rs	6
 crates/velesdb-core/src/collection/auto_reindex/mod.rs	4
 crates/velesdb-core/src/collection/auto_reindex/tests.rs	3
 crates/velesdb-core/src/collection/core/bulk_import.rs	2
-crates/velesdb-core/src/collection/core/crud.rs	2
 crates/velesdb-core/src/collection/core/crud_bulk.rs	4
 crates/velesdb-core/src/collection/core/crud_indexing.rs	2
 crates/velesdb-core/src/collection/core/crud_read_delete.rs	2
 crates/velesdb-core/src/collection/core/crud_tests.rs	11
 crates/velesdb-core/src/collection/core/flush.rs	6
-crates/velesdb-core/src/collection/core/graph_property_index_wiring.rs	2
 crates/velesdb-core/src/collection/core/index_management.rs	20
 crates/velesdb-core/src/collection/core/quantizer_restore.rs	2
 crates/velesdb-core/src/collection/core/statistics.rs	4
@@ -27,7 +25,6 @@ crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs	4
 crates/velesdb-core/src/collection/graph/property_index_tests.rs	1
 crates/velesdb-core/src/collection/payload_mirror/mirror_tests.rs	1
 crates/velesdb-core/src/collection/payload_mirror/mod.rs	2
-crates/velesdb-core/src/collection/query_cost/query_executor.rs	2
 crates/velesdb-core/src/collection/search/batch.rs	8
 crates/velesdb-core/src/collection/search/query/aggregation/grouped.rs	4
 crates/velesdb-core/src/collection/search/query/aggregation/mod.rs	4


### PR DESCRIPTION
## Description

Follow-up to #2110 (drain the `clippy::significant_drop_tightening` backlog). Tightens the lock-guard scope in four functions, each a guard that lived to the end of its function with no work left to do under it:

- `Collection::write_and_flush_payloads` — drop the `payload_storage` write guard after `flush()`, before the trailing `Ok(())`.
- `Collection::composite_index_lookup` — bind the lookup result, drop the `composite_index_manager` read guard, then wrap the result in `Some`.
- `PlanCache::get` — drop the `cache` write guard before returning; restructured through `Option::map` instead of an early return.
- `ConcurrentEdgeStore::collect_node_edges` — drop the shard read guard after building `incoming`, before returning the tuple.

None of the four span a loop, I/O, or a second lock acquisition, so this is a pure scope tightening with no behavior change — per the issue's own triage guidance, these were the "cheap mechanical" class, not the ones needing an `#[allow]` with a load-bearing justification.

Verified with a full `velesdb-core` + `velesdb-server` `--all-targets` clippy pass: all four files now report zero `significant_drop_tightening` findings, so their lines are removed from `scripts/drop-tightening-baseline.txt`. 317 findings across 70 files remain in the backlog, tracked by #2110.

Fixes # (partial — contributes to #2110, does not close it)

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --features persistence --lib -- --test-threads=1 crud query_executor composite_index_lookup graph_property_index write_and_flush_payloads collect_node_edges cascade` → 58 passed, 0 failed.
- `cargo fmt --all -- --check` → clean.
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` → clean.
- `python3 scripts/check-drop-tightening.py` (via `--from-json` against a fresh `--all-targets` run) → `PASSED: ... 317 finding(s) across 70 file(s), none grown.`
- `python3 -m unittest discover -s scripts/tests -p "test_check_drop_tightening.py" -t .` → 19 passed.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches a `storage`-owned lock (`payload_storage`) and graph shard locks, so included for completeness even though the change is a pure scope tightening.

- [x] I listed the invariants impacted by this change: none — each guard's critical section is unchanged; only the syntactic drop point moved to the guard's true last use.
- [x] I documented crash/durability semantics where relevant: `write_and_flush_payloads` still holds the guard across both the write and the `flush()` call; the guard is only dropped after `flush()` returns, so durability ordering is unchanged.
- [x] I added/updated tests for concurrency or lifecycle where applicable: existing coverage (`crud_tests`, `query_executor::tests`, `edge_concurrent_tests`) already exercises these paths; no new lock-ordering behavior was introduced.

## Additional Notes

Small, mechanical batch by design — see #2110 for the suggested module-sized-batch approach to the remaining backlog.
