### PR TITLE
ci: run the attribution guard on title and body edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1861,8 +1861,17 @@ jobs:
   # is a larger decision than this defect warrants. The next push re-runs
   # everything and blocks normally.
   #
-  # The cost is one cheap job (checkout + Python, no toolchain) per body edit,
-  # and freshness may now report a stale branch on an edit that did not cause
+  # The cost is one cheap job (checkout + Python, no toolchain) per body edit —
+  # cheap to RUN, but not necessarily quick to REPORT. An `edited` run joins
+  # this workflow's concurrency group with `cancel-in-progress` false, so it
+  # queues behind any run already in flight instead of starting at once. On
+  # #2159, the PR that made this change, the `edited` run sat pending with zero
+  # jobs for ~44 minutes while the `opened` run worked through the heavy jobs.
+  # Edit a quiet PR and the verdict is seconds away; edit a busy one and it
+  # waits for the running CI. Worth knowing before treating this as fast
+  # feedback.
+  #
+  # Freshness may also now report a stale branch on an edit that did not cause
   # it — true information, arriving earlier than it used to, not a false
   # positive. `RETARGET_GUARD_EXEMPT` records this exemption.
   pr-governance:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1844,9 +1844,29 @@ jobs:
   # `permissions:` is explicit because a called workflow cannot exceed its
   # caller: ci.yml grants `contents: read` at the top level, and
   # pr-governance.yml declares `pull-requests: read` too.
+  #
+  # Deliberately carries NO retarget guard, for the same class of reason
+  # mcp-doc-contract does not: the guard admits `edited` only when the base
+  # changed, and this is the one job whose INPUT is the title and body. Guarded,
+  # it was skipped exactly when the thing it reads changed — so a PR opened
+  # clean and then edited to reintroduce an attribution trailer was never
+  # re-checked. That is not hypothetical: it is how the trailer on #2157
+  # survived its first edit, and it was caught by hand rather than by this gate.
+  #
+  # What this buys and what it does not. It SURFACES a violation on a body
+  # edit; it does not BLOCK one, because `CI Success` — the only required check
+  # on develop and main — keeps its own retarget guard and stays skipped on such
+  # an edit. Making it block would mean running the required gate with most of
+  # its needs skipped, i.e. rewriting the chain's `== "success"` contract, which
+  # is a larger decision than this defect warrants. The next push re-runs
+  # everything and blocks normally.
+  #
+  # The cost is one cheap job (checkout + Python, no toolchain) per body edit,
+  # and freshness may now report a stale branch on an edit that did not cause
+  # it — true information, arriving earlier than it used to, not a false
+  # positive. `RETARGET_GUARD_EXEMPT` records this exemption.
   pr-governance:
     name: PR Governance
-    if: github.event.action != 'edited' || github.event.changes.base != null
     permissions:
       contents: read
       pull-requests: read

--- a/scripts/tests/test_ci_gate_reachability.py
+++ b/scripts/tests/test_ci_gate_reachability.py
@@ -1254,12 +1254,24 @@ PR_TYPES_RE = re.compile(r"^\s*types:\s*\[([^\]]*)\]", re.MULTILINE)
 JOB_ID_RE = re.compile(r"^  ([a-z][a-z0-9_-]*):$", re.MULTILINE)
 # The clause that admits `edited` only for a base change. Whitespace-tolerant
 # so reformatting the expression does not read as removing it.
-# The one job that must NOT carry the guard, with its reason — same shape as
+# The jobs that must NOT carry the guard, with their reasons — same shape as
 # CHAIN_EXEMPT above. `mcp-doc-contract` runs the guard suites' own self-tests,
 # and `test_the_gate_job_cannot_opt_out_of_blocking` forbids it any job-level
 # `if:` at all: a condition that can skip it can disarm them. It pays for that
 # by running on title-only edits, which is one cheap Python job.
-RETARGET_GUARD_EXEMPT = {"mcp-doc-contract": "runs the guard self-tests; must never be skippable"}
+#
+# `pr-governance` is exempt for a different reason: the guard admits `edited`
+# only for a base change, and this is the one job whose INPUT is the title and
+# body. Guarded, it was skipped exactly when the thing it reads changed, so a
+# PR opened clean and then edited to reintroduce an attribution trailer was
+# never re-checked — which is how the trailer on #2157 survived its first edit.
+# It surfaces such a violation rather than blocking it: `CI Success` keeps its
+# own guard, so the required check stays skipped on a body edit and the next
+# push blocks normally.
+RETARGET_GUARD_EXEMPT = {
+    "mcp-doc-contract": "runs the guard self-tests; must never be skippable",
+    "pr-governance": "reads the title and body; skipping it on an edit is skipping its input",
+}
 
 RETARGET_GUARD_RE = re.compile(
     r"github\.event\.action\s*!=\s*'edited'\s*\|\|\s*github\.event\.changes\.base\s*!=\s*null"


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

The retarget guard (`github.event.action != 'edited' || github.event.changes.base != null`) admits `edited` only when the base changed. `pr-governance` carried it — and `pr-governance` is the one job whose **input is the title and body**. Guarded, it was skipped exactly when the thing it reads changed.

Found the hard way on #2157: the tooling appended an attribution footer to the PR body, `PR Governance` caught it on the `opened` run, the footer was stripped — and a later body edit was then re-checked by nothing. That edit was verified by hand. A guard whose input can change without re-running it is not a guard for that input.

Follows #2156, which put the attribution rule on every surface, and the concurrency work that made `edited` runs no-ops in the first place.

## Type of Change

- [x] 🔧 CI / tooling

## The change

`pr-governance` now carries no job-level `if:`, the same shape `mcp-doc-contract` already has, and `RETARGET_GUARD_EXEMPT` records the second exemption with its reason.

That constant is not documentation: `test_the_exempt_job_really_is_unguarded` asserts every listed job really is unguarded ("an exemption nobody exercises is an exemption that has rotted"), so the entry fails if someone re-adds the condition, and `test_every_ci_job_guards_against_a_title_only_edit` still holds every other job to the guard.

## This PR exercised the change on itself, twice

**Run 1 — `opened`.** The body carried an attribution footer appended on publish, not written by hand. `PR Governance` refused it. That is the guard working correctly at `opened`, as it already did before this change.

**Run 2 — `edited`, from stripping that footer.** This is the event that, on `develop` today, is checked by nothing. On this branch the job **ran** rather than being skipped — the behaviour this PR adds, observed live.

It also refused that run, and the second refusal was mine rather than the tooling's: the body quoted the guard's own failure line verbatim while narrating run 1, and the guard has no exemption for quotation — the same property `CLAUDE.md` records for the `commit-msg` hook, which fails a trailer at the start of any line "even inside a quotation". The narration has been reworded to describe the violation without reproducing it.

Two useful facts, neither of which was designed: the guard is strict enough to catch a violation inside prose *about* the rule, and it now fires on the edit that introduced it.

## What this buys, and what it does not

**It surfaces a violation on a body edit. It does not block one.**

`CI Success` — the only required check on `develop` and `main` — keeps its own retarget guard and stays skipped on a body-only edit. So a violation shows red on the PR page and is visible, but branch protection is not consulted.

Making it *block* would mean running the required gate with most of its needs `skipped`, i.e. rewriting the `[[ "${{ needs.X.result }}" == "success" ]]` chain's contract. That is a materially larger decision than this defect warrants, and it is deliberately not attempted here. The next push re-runs everything and blocks normally.

I would rather state that limit than imply the hole is fully closed.

## Cost, corrected by what this PR observed

- One cheap job per body edit: checkout + Python, no toolchain, seconds of runtime.
- **But not seconds of latency.** An `edited` run joins the workflow's concurrency group with `cancel-in-progress` false, so it **queues behind any in-flight run** rather than starting immediately. Observed here: the `edited` run sat `pending` with zero jobs for ~44 minutes while the `opened` run worked through the heavy jobs. A body edit made while CI is running gets its attribution verdict only after that CI finishes. Edit a quiet PR and it is seconds; edit a busy one and it waits. That is worth knowing before relying on it as fast feedback.
- Branch **freshness** may now report a stale branch on an edit that did not cause it. True information arriving earlier than it used to, not a false positive.
- Behaviour on `push`, `workflow_dispatch` and every non-`edited` `pull_request` event is **unchanged** — the removed condition was already true for all of them, since `github.event.action` is not `'edited'` there.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing — `ci.yml` parses under `yaml.safe_load`; the change observed live on this PR

| check | result |
|---|---|
| every suite that reads `ci.yml` (5 suites) | 163 tests, OK |
| `unittest discover -s scripts/tests`, as `gate-contracts` runs it | **711 tests, OK** (9 skipped) |
| `scripts/check-ai-attribution.py --tree` | PASSED |

The five suites reading `ci.yml` are `test_ci_gate_reachability`, `test_propagation_guard_concurrency`, `test_skill_copies_are_identical`, `test_sync_agent_hooks`, `test_test_target_reachability` — found by grep rather than assumed, since a workflow edit's blast radius is whoever parses the workflow.

**Test Configuration:**
- OS: Linux 6.18.44
- Python 3.12

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## High-Risk Change Checklist

Not applicable: touches no `hnsw`, `storage`, `Drop`, `unsafe` or SIMD dispatch path. It changes CI reachability only.

## Additional Notes

`CI Success` on the `opened` run is red because `pr-governance` failed inside it, and a body edit does not re-run `CI Success` — it keeps its own guard. Green therefore requires a fresh push, which the commit recording the queueing cost provides.

The repository has one collaborator, who is the author, so the template's "two maintainer reviews" line cannot be satisfied here either; it is not part of this checklist since the change is not a high-risk path.
