### PR TITLE
refactor(core): drain 3 more significant_drop_tightening sites (#2110)

### DIFF
--- a/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
+++ b/crates/velesdb-core/src/collection/streaming/async_index_builder.rs
@@ -125,6 +125,7 @@ impl AsyncIndexBuilder {
                 (*id, dist)
             })
             .collect();
+        drop(buf);
 
         metric.sort_results(&mut results);
         results.truncate(k);

--- a/crates/velesdb-core/src/database/training.rs
+++ b/crates/velesdb-core/src/database/training.rs
@@ -84,8 +84,8 @@ impl Database {
         collection: &crate::collection::Collection,
         force: bool,
     ) -> Result<()> {
-        let quantizer = collection.pq_quantizer_read();
-        if quantizer.is_some() && !force {
+        let already_trained = collection.pq_quantizer_read().is_some();
+        if already_trained && !force {
             return Err(Error::InvalidQuantizerConfig(
                 "Quantizer already trained. Use force=true to retrain.".into(),
             ));

--- a/crates/velesdb-core/src/storage/mmap_capacity.rs
+++ b/crates/velesdb-core/src/storage/mmap_capacity.rs
@@ -67,6 +67,7 @@ impl MmapStorage {
             did_resize = true;
             bytes_resized = new_len.saturating_sub(current_len);
         }
+        drop(mmap);
 
         self.metrics()
             .record_ensure_capacity(start.elapsed(), did_resize, bytes_resized);

--- a/scripts/drop-tightening-baseline.txt
+++ b/scripts/drop-tightening-baseline.txt
@@ -39,10 +39,8 @@ crates/velesdb-core/src/collection/search/query/similarity_filter.rs	10
 crates/velesdb-core/src/collection/search/text.rs	4
 crates/velesdb-core/src/collection/search/vector.rs	10
 crates/velesdb-core/src/collection/search/vector_filter.rs	2
-crates/velesdb-core/src/collection/streaming/async_index_builder.rs	2
 crates/velesdb-core/src/database/collection_ops.rs	8
 crates/velesdb-core/src/database/database_tests.rs	2
-crates/velesdb-core/src/database/training.rs	2
 crates/velesdb-core/src/gpu/gpu_csr.rs	2
 crates/velesdb-core/src/guardrails/resilience.rs	6
 crates/velesdb-core/src/index/bm25.rs	4
@@ -66,7 +64,6 @@ crates/velesdb-core/src/storage/compaction_tests.rs	2
 crates/velesdb-core/src/storage/guard_tests.rs	6
 crates/velesdb-core/src/storage/log_payload.rs	8
 crates/velesdb-core/src/storage/mmap/vector_io.rs	4
-crates/velesdb-core/src/storage/mmap_capacity.rs	2
 crates/velesdb-core/src/storage/sharded_index.rs	2
 crates/velesdb-core/src/storage/tests.rs	12
 crates/velesdb-core/src/vector_ref_tests.rs	2


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Follow-up to #2110 (drain the `clippy::significant_drop_tightening` backlog), continuing the module-spanning batch approach from #2151/#2157/#2158. Tightens the lock-guard scope in three functions, each verified by hand against the issue's own reject-list (no loop, I/O, or second lock acquisition under the guard):

- `AsyncIndexBuilder::search_buffer` — drop the `buffer` read guard right after the eager `.collect()`, before `sort_results`/`truncate`, which only touch the already-owned `Vec`.
- `MmapStorage::ensure_capacity` — drop the `mmap` write guard after the resize branch, before the unrelated metrics recording call.
- `Database::check_already_trained` — bind the `is_some()` bool instead of the quantizer read guard, so the guard drops at the end of that statement instead of living to the end of the function.

Two other candidates from this pass turned out to be **false positives** for tightening once read in full, so they were left alone: `bulk_import.rs`'s `label_index` guard and `quantizer_restore.rs`'s `vector_storage` guard are both held across a `for` loop that uses them on every iteration. Clippy's own suggested fix for each is flagged `MaybeIncorrect`, and applying either literally would drop the guard after the loop's first iteration — a correctness bug, not a fix. Two more (`crud_indexing.rs`, `crud_read_delete.rs`) hold their `sparse_indexes` guard across a WAL-append-then-apply sequence with an explicit comment documenting why the two phases must be indivisible — load-bearing, not mechanical.

Verified with a full `velesdb-core` + `velesdb-server` `--all-targets` clippy pass: all three files now report zero `significant_drop_tightening` findings, so their lines are removed from `scripts/drop-tightening-baseline.txt`. 318 findings across 71 files remain in the backlog, tracked by #2110.

Fixes # (partial — contributes to #2110, does not close it)

## Type of Change

- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --features persistence --lib -- --test-threads=1 training mmap_capacity ensure_capacity search_buffer async_index_builder check_already_trained` → 33 passed, 0 failed.
- `cargo fmt --all -- --check` → clean.
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` → clean.
- `python3 scripts/check-drop-tightening.py` (via `--from-json` against a fresh `--all-targets` run) → `PASSED: ... 318 finding(s) across 71 file(s), none grown.`
- `python3 -m unittest scripts.tests.test_check_drop_tightening` → 19 passed.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## High-Risk Change Checklist

> Touches a `storage`-owned lock (`mmap`), so included for completeness even though the change is a pure scope tightening.

- [x] I listed the invariants impacted by this change: none — each guard's critical section is unchanged; only the syntactic drop point moved to the guard's true last use.
- [x] I documented crash/durability semantics where relevant: `ensure_capacity` still holds the `mmap` guard across the resize branch (including `set_len` and the remap); the guard is only dropped after that branch completes, before the unrelated metrics call. No change to the crash-recovery ordering described in the surrounding comments.
- [x] I added/updated tests for concurrency or lifecycle where applicable: existing coverage (`storage::metrics_tests`, `perf_optimizations_tests`, `async_index_builder_tests`) already exercises these paths; no new lock-ordering behavior was introduced.

## Additional Notes

Small, mechanical batch by design — see #2110 for the suggested module-sized-batch approach to the remaining backlog. This pass also spent real time on adversarial review of clippy's *suggested fixes*, not just its findings: two of the five candidates initially considered would have been correctness bugs if the auto-fix diff had been applied without reading the surrounding loop.
