### PR TITLE
fix(release): define __ARM_ARCH so the aarch64 glibc wheel builds (#2107)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,26 @@ jobs:
             3.10
             3.11
       - uses: PyO3/maturin-action@db323e2cf5679b7feb8bcb561a36b27a0bc19e79 # v1
+        env:
+          # ring's pregenerated ARM assembly opens on a guard —
+          # `#error "ARM assembler must define __ARM_ARCH"` (ring-core/asm_base.h:73)
+          # — and the manylinux2014 cross image's gcc does not define that macro when
+          # it assembles a .S file. That is what cost 5.2.0 its manylinux_2_17_aarch64
+          # wheel while every other wheel published: the job failed identically on two
+          # attempts, deterministic rather than flaky (#2107). ring reaches this crate
+          # through velesdb-memory -> ureq -> rustls.
+          #
+          # Set unconditionally rather than per-matrix-entry because the name is
+          # already target-scoped: `cc` reads CFLAGS_<target with underscores>, so only
+          # the entry building aarch64-unknown-linux-gnu consumes it. The aarch64 musl
+          # wheel targets aarch64-unknown-linux-musl under a toolchain that defines the
+          # macro itself and never published broken, so it stays untouched; every
+          # non-aarch64 entry ignores the variable outright. 8 is the manylinux aarch64
+          # baseline (ARMv8-A), which is what the pregenerated assembly is built for.
+          #
+          # It survives the docker boundary because CFLAGS is one of maturin-action's
+          # ALLOWED_ENV_PREFIXES, so the action forwards it into the build container.
+          CFLAGS_aarch64_unknown_linux_gnu: -D__ARM_ARCH=8
         with:
           target: ${{ matrix.target }}
           working-directory: crates/velesdb-python

--- a/scripts/tests/test_release_aarch64_wheel_builds.py
+++ b/scripts/tests/test_release_aarch64_wheel_builds.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""The aarch64 glibc wheel must be built, and built with the flag that lets it link.
+
+Two separate ways to lose that wheel, both of which 5.2.0 demonstrated are
+survivable by a green release run:
+
+1. **The build fails.** ring's pregenerated ARM assembly refuses to assemble
+   unless `__ARM_ARCH` is defined (`ring-core/asm_base.h:73`), and the
+   manylinux2014 cross image's gcc does not define it. The job failed twice,
+   identically, while the other twelve publish jobs succeeded — so the release
+   reported success and PyPI simply had no `manylinux_2_17_aarch64` file (#2107).
+
+2. **The entry is deleted.** Dropping the matrix row would also turn the run
+   green, and would be the more tempting "fix" of the two. A wheel that is never
+   built cannot fail to build.
+
+So this pins both: the matrix row exists, *and* it carries the flag. Asserting
+only the flag would let someone delete the row and still pass.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+# The cc-rs env var that carries flags to an aarch64-unknown-linux-gnu build.
+# Target-scoped by name: no other matrix entry reads it.
+CFLAGS_VAR = "CFLAGS_aarch64_unknown_linux_gnu"
+
+
+def wheels_job() -> str:
+    """The text of the `publish-pypi-wheels:` job, up to the next job key."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    after = text.split("\n  publish-pypi-wheels:\n", 1)
+    if len(after) != 2:
+        raise AssertionError(
+            "the `publish-pypi-wheels` job is gone from release.yml — if it was "
+            "renamed, retarget this test rather than deleting it"
+        )
+    # Jobs are two-space indented; the next one ends this block.
+    return re.split(r"\n  [a-z0-9-]+:\n", after[1], maxsplit=1)[0]
+
+
+class ReleaseAarch64Wheel(unittest.TestCase):
+    def test_the_glibc_aarch64_entry_is_still_in_the_matrix(self) -> None:
+        entries = re.findall(r"^\s+- \{([^}]*)\}", wheels_job(), re.M)
+        glibc_aarch64 = [
+            e
+            for e in entries
+            if re.search(r"target:\s*aarch64\s*,", e + ",")
+            and "musllinux" not in e
+            and "manylinux" in e
+        ]
+        self.assertTrue(
+            glibc_aarch64,
+            "no aarch64 glibc wheel is built any more: `pip install velesdb` on "
+            "Graviton and other glibc ARM64 hosts falls back to the sdist. A "
+            "release with this row removed is green and still ships nothing.",
+        )
+
+    def test_the_aarch64_build_defines_arm_arch_for_ring(self) -> None:
+        job = wheels_job()
+        self.assertIn(
+            CFLAGS_VAR,
+            job,
+            f"{CFLAGS_VAR} is unset, so ring's ARM assembly hits "
+            f'`#error "ARM assembler must define __ARM_ARCH"` under the '
+            f"manylinux2014 cross gcc and the aarch64 wheel never publishes (#2107)",
+        )
+        value = re.search(rf"^\s+{CFLAGS_VAR}:\s*(.+)$", job, re.M)
+        assert value is not None  # implied by the assertIn above
+        self.assertRegex(
+            value.group(1).strip(),
+            r"-D__ARM_ARCH=\d+",
+            "the variable no longer defines __ARM_ARCH, which is the only reason "
+            "it exists",
+        )
+
+    def test_the_flag_reaches_the_container(self) -> None:
+        """maturin-action only forwards a documented set of env prefixes.
+
+        The variable is set on the step, but the compile runs inside the
+        manylinux docker container. `CFLAGS` is one of the action's
+        ALLOWED_ENV_PREFIXES, which is what carries it across; a rename to
+        something outside those prefixes would leave the build unfixed while
+        this file still looked correct.
+        """
+        self.assertTrue(
+            CFLAGS_VAR.startswith("CFLAGS"),
+            "the variable must keep a CFLAGS prefix or maturin-action drops it "
+            "at the docker boundary",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Fixes #2107. v5.2.0 published twelve of thirteen PyPI artifacts. The missing one was `manylinux_2_17_aarch64`, and the release run still reported success — a job that fails alone among twelve that pass does not make the release red enough to notice, so `pip install velesdb==5.2.0` on glibc ARM64 (Graviton, most ARM cloud VMs, 64-bit Raspberry Pi OS) has been falling back to the sdist ever since.

**Root cause.** `ring`'s pregenerated ARM assembly opens on a guard — `#error "ARM assembler must define __ARM_ARCH"` (`ring-core/asm_base.h:73`) — and the manylinux2014 cross image's gcc does not define that macro when it assembles a `.S` file. `ring` reaches `velesdb-python` through `velesdb-memory` → `ureq` → `rustls`. The musl aarch64 job's toolchain defines the macro itself, which is why that wheel published normally.

**Fix.** `CFLAGS_aarch64_unknown_linux_gnu: -D__ARM_ARCH=8` on the wheels job's maturin step. Set unconditionally rather than per-matrix-entry because the name is already target-scoped: `cc` reads `CFLAGS_$TARGET` with the target's dashes turned into underscores, so only the entry building `aarch64-unknown-linux-gnu` consumes it. The other six matrix entries — including the aarch64 musl wheel, which targets `aarch64-unknown-linux-musl` — ignore it outright. `8` is the manylinux aarch64 baseline (ARMv8-A), which is what the pregenerated assembly is built for.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Verified, not assumed

Three links had to hold for this to work, each checked in the source rather than recalled:

| link | evidence |
|---|---|
| the variable crosses the docker boundary | `maturin-action` **at the pinned SHA** lists `CFLAGS` in `ALLOWED_ENV_PREFIXES`, so the action forwards it into the build container |
| `cc` consumes it for `.S` files | `cc-1.2.57`'s `envflags()` reads the target-suffixed `CFLAGS` variant first and appends it to the compiler invocation; the assembler path only diverges for MSVC |
| `ring` does not suppress it | builds with a bare `cc::Build::new()`, no `no_default_flags`, no env override |

**Reproduced end to end** with a cross gcc, simulating the one property of the container's compiler that matters:

| | command | result |
|---|---|---|
| repro | `CFLAGS_aarch64_unknown_linux_gnu="-U__ARM_ARCH"` | `asm_base.h:73: #error "ARM assembler must define __ARM_ARCH"`, assembling `chacha-armv8-linux64.S` — **exit 101**, byte-identical to the CI log in #2107 |
| fix | `CFLAGS_aarch64_unknown_linux_gnu="-U__ARM_ARCH -D__ARM_ARCH=8"` | **exit 0**, zero errors, artifact produced |

Pulling the exact `ghcr.io/rust-cross/manylinux2014-cross:aarch64` image is blocked by this environment's network policy (403 on the ghcr blob host), hence simulating the missing macro on a local cross gcc instead of running the real image. What that leaves unproven is only that the container has no *second*, unrelated obstacle behind this one; the guard that failed is reproduced and fixed exactly.

## The guard

`scripts/tests/test_release_aarch64_wheel_builds.py`. There are **two** ways to lose this wheel while the release run stays green, and the fix only addresses one:

1. the build fails — what happened for 5.2.0;
2. the matrix row is deleted — which would also turn the run green, and is the more tempting "fix" of the two. A wheel that is never built cannot fail to build.

So the test pins both. Stdlib-only parsing: `Gate Contracts` runs the suite on a bare Python 3.12 with no `pip install`, so a PyYAML-based test would have gone red in CI.

**Mutation-tested** — each of these turns it red: removing the flag, deleting the aarch64 glibc matrix row, renaming the variable to something outside maturin-action's forwarded prefixes.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

| check | result |
|---|---|
| `python -m unittest discover -s scripts/tests -t .` (full suite, as Gate Contracts runs it) | **714 passed**, 0 failed, 9 skipped |
| new guard, mutation-tested 3 ways | each mutation fails it; restored tree passes |
| `release.yml` parses, env on the correct step | confirmed; the sdist job's maturin step is untouched |
| cross-compile repro / fix | exit 101 → exit 0, table above |

No Rust changed, so the Rust pre-push block does not apply here — the gates this touches are `Gate Contracts` and `PR Governance`.

**Test Configuration:**
- OS: Linux 6.18.44
- Rust version: 1.90 (MSRV), cross gcc 13.3 for `aarch64-unknown-linux-gnu`

## Recovering the wheel that 5.2.0 never published

Worth flagging because it contradicts the remedy proposed in the issue: **re-running the failed job on the v5.2.0 run will not work.** A re-run replays the workflow file from the original commit, so it would fail identically.

Once this merges, the missing file can be published by dispatching `Release` from `develop` — which still carries version **5.2.0** — with `publish_pypi: true` and the other publish inputs `false`. `skip-existing: true` on the upload step means the already-published files are skipped and only `velesdb-5.2.0-cp39-abi3-manylinux_2_17_aarch64` lands. Your call whether to do that now or let the next release carry it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The issue listed two other candidates. Neither was taken: `manylinux: 2_28` would fix the build by raising that wheel's glibc floor from 2.17 to 2.28, dropping users on Ubuntu 18.04 (glibc 2.27) and CentOS 7 — a compatibility regression to fix a toolchain hole. Dropping `ring` from the tree (an `aws-lc-rs` or `native-tls` provider for `ureq`) is the durable answer for every future cross target, but it touches crate features across `velesdb-memory` and deserves its own change rather than riding a release hotfix.