### PR TITLE
perf(bm25): avoid cloning terms already present in the maps

### DIFF
--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -169,10 +169,19 @@ impl Bm25Index {
             return;
         }
 
-        // Count term frequencies
+        // Count term frequencies.
+        //
+        // Look up by &str BEFORE inserting: `entry()` demands an owned key,
+        // which would allocate one String per token even for repeats within
+        // the same document. The owned copy is made only the first time a
+        // token is seen in this document.
         let mut term_freqs: FxHashMap<String, u32> = FxHashMap::default();
         for token in &tokens {
-            *term_freqs.entry(token.clone()).or_insert(0) += 1;
+            if let Some(count) = term_freqs.get_mut(token.as_str()) {
+                *count += 1;
+            } else {
+                term_freqs.insert(token.clone(), 1);
+            }
         }
 
         // Reason: Document token count is bounded by practical text length limits.
@@ -197,13 +206,22 @@ impl Bm25Index {
 
         // Update inverted index with adaptive PostingList.
         // PostingList auto-promotes to Roaring when cardinality exceeds threshold.
+        //
+        // Look up by &str BEFORE inserting: `entry()` demands an owned key,
+        // which allocates a String per document per term even when the term
+        // is already in the corpus vocabulary (the common case once the
+        // index has ingested more than a handful of documents). The owned
+        // copy is made only on the term's first appearance in the index.
         {
             let mut inv_idx = self.inverted_index.write();
             for term in doc.term_freqs.keys() {
-                inv_idx
-                    .entry(term.clone())
-                    .or_insert_with(PostingList::new)
-                    .insert(id_u32);
+                if let Some(posting_list) = inv_idx.get_mut(term.as_str()) {
+                    posting_list.insert(id_u32);
+                } else {
+                    let mut posting_list = PostingList::new();
+                    posting_list.insert(id_u32);
+                    inv_idx.insert(term.clone(), posting_list);
+                }
             }
         }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Part of the interning/wiring audit tracked in #2090 ("intern terms — the corpus vocabulary is materialized once per document"). That issue's full `TermId(u32)` dictionary is a persistence-format change requiring its own PR series; this PR ships the one step the issue calls out as "shippable independently": the `get`-before-`entry` probe, mirroring the fix already applied to the CSR label interner (#2084).

`Bm25Index::add_document` builds its per-document `term_freqs` map and updates the global `inverted_index` using `map.entry(key.clone())`. `entry()` demands an owned key, so every token paid a `String` allocation to probe the map even when the key was already present:

- `term_freqs.entry(token.clone())` — clones on every repeated word within the same document (e.g. "the", "a").
- `inverted_index.entry(term.clone())` — clones once per document per term, including for terms already in the corpus vocabulary, which is the common case once the index holds more than a handful of documents.

Both sites now do a borrowed `&str` lookup (`get_mut`) first and only clone into an owned key the first time that key is seen. No change to BM25 scoring math, stored data, or the wire/persistence format — allocation is removed only on the already-present path.

Fixes # (none — partial progress on #2090; the `TermId(u32)` dictionary and its persistence-format change are left for a separate PR)

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Ran the existing BM25 suite (58 tests covering tokenization, scoring, persistence roundtrip, WAL replay, concurrent inserts) unchanged — all green, proving the change is behavior-preserving:

```
cargo test -p velesdb-core --lib bm25 -- --test-threads=1
test result: ok. 58 passed; 0 failed; 2 ignored
```

Also ran, at CI-exact flags:

```
cargo fmt --all -- --check
cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic
python3 scripts/check_prod_unwraps.py   # PASSED
```

**Test Configuration:**
- OS: Linux
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed — internal allocation detail, no observable behavior change)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (behavior-preserving; existing tests cover correctness, and the win is an allocation count that the issue itself notes is "measurable by allocation count" rather than by a new functional test)

## Unsafe Code Checklist

Skipped — no `unsafe` code touched.

## High-Risk Change Checklist

Skipped — does not touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Scoped deliberately narrow per AGENTS.md's surgical-change principle: the rest of #2090 (the `TermId(u32)` dictionary, WAL/snapshot format versioning) is a bigger, format-affecting change that the issue itself says needs its own validation bar (bit-identical scoring on a fixture corpus, persistence roundtrip, RSS measurement) and is left for a follow-up PR.
