### PR TITLE
bench(hnsw): measure search latency against graph size (#2075)

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -186,6 +186,10 @@ name = "hnsw_benchmark"
 harness = false
 
 [[bench]]
+name = "hnsw_adjacency_scale"
+harness = false
+
+[[bench]]
 name = "scalability_benchmark"
 harness = false
 

--- a/crates/velesdb-core/benches/hnsw_adjacency_scale.rs
+++ b/crates/velesdb-core/benches/hnsw_adjacency_scale.rs
@@ -1,0 +1,179 @@
+//! Search latency as a function of graph size — the regime `hnsw_benchmark`
+//! cannot see, measured in a way that can actually resolve it.
+//!
+//! Run with: `cargo bench --bench hnsw_adjacency_scale`
+//!
+//! # Why this exists
+//!
+//! Issue #2075 proposes changing how layer-0 adjacency is laid out (flat CSR,
+//! narrower ids, no per-node lock) and argues from "1M locks + 1M scattered
+//! allocations, zero adjacency locality". Every claim in that sentence is
+//! about a graph large enough that its adjacency does not fit in cache — and
+//! nothing else in this repository benchmarks one.
+//!
+//! `hnsw_search_latency` builds **10 000 nodes at 768 dimensions**. Its
+//! adjacency is `10_000 * M0 * size_of::<NodeId>()`, on the order of 2.5 MB:
+//! resident in L2/L3 on any machine this runs on, whatever its layout. The
+//! vectors, at ~30 MB, are what actually evicts cache there. A layout change
+//! to adjacency is therefore measured at 10K as added instructions with no
+//! locality to win back.
+//!
+//! # Two traps this file exists to avoid, both hit in practice
+//!
+//! **1. A nondeterministic graph.** `insert_batch_parallel` inserts in
+//! whatever order the threads reach the index, so it builds a *different graph
+//! on every run*. Two runs of one unchanged binary measured 144.85 µs and
+//! 171.03 µs — an 18 % spread with nothing different but the graph. Criterion
+//! cannot see this: it builds the index once and then varies only the
+//! searches, so its confidence intervals are tight around the wrong variance
+//! component, and an A/B built that way reports `p = 0.00` on a difference
+//! that is mostly luck.
+//!
+//! This benchmark therefore builds **sequentially** and prints a checksum of
+//! a fixed set of query results. Two configurations are comparable only if
+//! their checksums match: equal checksums mean the same graph was traversed
+//! the same way, so a latency difference is the layout and nothing else.
+//!
+//! **2. Machine noise larger than the effect.** Even on a byte-identical
+//! graph, process-to-process spread reached 22–25 % on a shared cloud
+//! container. A single-digit effect is unmeasurable there no matter how many
+//! samples are taken *inside* one process. Before trusting a difference from
+//! this benchmark, run the identical configuration twice and check that the
+//! two agree more closely than the difference being claimed. If they do not,
+//! the machine cannot arbitrate the question and a quieter one is needed —
+//! that is a fact about the hardware, not a reason to average harder.
+//!
+//! # Reading the output
+//!
+//! Each size prints the adjacency footprint alongside the latency. Compare it
+//! against this machine's last-level cache (`lscpu | grep L3`): below it, a
+//! layout change can only cost; above it, the locality argument starts to be
+//! testable. With `M0 = 32` and 8-byte ids, adjacency crosses a 33 MiB L3
+//! somewhere around 130K nodes.
+//!
+//! # Sizing
+//!
+//! Defaults stay small enough to finish unattended. Push it as far as the
+//! machine allows — the regime the issue argues about starts around 1M:
+//!
+//! ```text
+//! VELESDB_SCALE_NODES=10000,100000,500000,1000000 \
+//! VELESDB_SCALE_DIM=64 \
+//! cargo bench --bench hnsw_adjacency_scale
+//! ```
+//!
+//! Dimension is deliberately low. High dimensions make the vector working set
+//! dominate every cache level and mask the adjacency effect entirely — that is
+//! what `hnsw_search_latency` runs into at 768d, and raising the node count
+//! without lowering the dimension would reproduce it.
+//!
+//! Sequential insertion is the price of a comparable graph: expect roughly a
+//! minute of build per 200K nodes before any measurement starts.
+
+#![allow(clippy::cast_precision_loss)]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode};
+use std::time::Duration;
+use velesdb_core::{DistanceMetric, HnswIndex, VectorIndex};
+
+/// Node counts to sweep, overridable with `VELESDB_SCALE_NODES`.
+const DEFAULT_NODES: &str = "10000,50000,200000";
+/// Vector dimension, overridable with `VELESDB_SCALE_DIM`.
+const DEFAULT_DIM: usize = 64;
+/// Queries whose results are folded into the comparability checksum.
+const CHECKSUM_QUERIES: u64 = 64;
+
+/// Generates a random-ish vector, matching `hnsw_benchmark`'s generator so
+/// numbers from the two files describe the same kind of data.
+fn generate_vector(dim: usize, seed: u64) -> Vec<f32> {
+    (0..dim)
+        .map(|i| (seed as f32 * 0.1 + i as f32 * 0.01).sin().midpoint(1.0))
+        .collect()
+}
+
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn node_counts() -> Vec<usize> {
+    std::env::var("VELESDB_SCALE_NODES")
+        .unwrap_or_else(|_| DEFAULT_NODES.to_string())
+        .split(',')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect()
+}
+
+/// Approximate resident layer-0 adjacency, in bytes.
+///
+/// Reported rather than measured: the point is the order of magnitude next to
+/// last-level cache, not exact allocator accounting. Assumes the default `M0`
+/// and a full adjacency list per node, so it is an upper bound.
+fn adjacency_bytes(nodes: usize, m0: usize, id_bytes: usize) -> usize {
+    nodes * (m0 * id_bytes + std::mem::size_of::<usize>() * 3)
+}
+
+/// Folds a fixed set of query results into one number.
+///
+/// Two runs printing the same checksum searched the same graph and reached the
+/// same answers, which is the precondition for comparing their latencies at
+/// all. A changed checksum means the comparison is meaningless — whatever else
+/// moved, the graph moved too.
+fn results_checksum(index: &HnswIndex, dim: usize) -> u64 {
+    let mut checksum: u64 = 0;
+    for s in 0..CHECKSUM_QUERIES {
+        let q = generate_vector(dim, 7_000_000 + s);
+        for (rank, r) in index.search(&q, 10).iter().enumerate() {
+            checksum = checksum
+                .wrapping_mul(1_000_003)
+                .wrapping_add(r.id.wrapping_add(rank as u64));
+        }
+    }
+    checksum
+}
+
+fn bench_search_by_graph_size(c: &mut Criterion) {
+    let dim = env_usize("VELESDB_SCALE_DIM", DEFAULT_DIM);
+    let mut group = c.benchmark_group("hnsw_search_by_graph_size");
+    // Large builds make per-sample time uneven; flat sampling keeps criterion
+    // from extrapolating an iteration count from an unrepresentative warm-up.
+    group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(30);
+
+    for nodes in node_counts() {
+        // Built once, outside the measured closure: this benchmark is about
+        // search, and an index rebuilt per iteration would measure insert.
+        //
+        // Sequential rather than `insert_batch_parallel`, deliberately and at
+        // the cost of build time: the parallel path builds a different graph
+        // every run, which makes any A/B compare two graphs instead of two
+        // layouts. See the "traps" section in the module docs.
+        let index = HnswIndex::new(dim, DistanceMetric::Cosine).expect("bench: index");
+        for i in 0..nodes as u64 {
+            index.insert(i, &generate_vector(dim, i));
+        }
+        index.set_searching_mode();
+
+        let adj_mb = adjacency_bytes(nodes, 32, std::mem::size_of::<usize>()) / (1024 * 1024);
+        let vec_mb = nodes * dim * 4 / (1024 * 1024);
+        let checksum = results_checksum(&index, dim);
+        println!(
+            "  [{nodes} nodes x {dim}d] adjacency ~{adj_mb} MB, vectors ~{vec_mb} MB, \
+             checksum {checksum} — compare adjacency against this machine's L3, and only \
+             compare runs whose checksums match"
+        );
+
+        let query = generate_vector(dim, u64::MAX / 2);
+        group.bench_with_input(BenchmarkId::new("top_k_10", nodes), &nodes, |b, _| {
+            b.iter(|| black_box(index.search(&query, 10)));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_search_by_graph_size);
+criterion_main!(benches);


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Adds a search benchmark that sweeps graph size, and — more importantly — one that can be trusted to compare two builds.

Contributes to #2075. No behaviour change: one new bench target, nothing else.

**Why the sweep.** `hnsw_search_latency` builds 10 000 nodes at 768 dimensions. Its layer-0 adjacency is ~2.5 MB and sits in L2/L3 whatever its layout, while the ~30 MB of vectors is what actually evicts cache. Any change to adjacency layout is therefore measured there as added instructions with no locality to win back — and nothing else in the tree benchmarks a graph big enough for the locality argument in #2075 to even apply.

**Why the determinism matters more.** `insert_batch_parallel` inserts in whatever order the threads reach the index, so it builds a **different graph on every run**. Two runs of one unchanged binary measured **144.85 µs and 171.03 µs — an 18 % spread with nothing different but the graph**.

Criterion is structurally blind to this: it builds the index once and then varies only the searches, so its confidence intervals describe search-to-search variance within a single graph and never see the build. An A/B run that way reports `p = 0.00` on a difference that is mostly which graph got built. I hit exactly that and posted two contradictory "results" on #2075 before finding it; both are retracted there.

So this benchmark:

- builds **sequentially**, so the graph is byte-identical run to run;
- prints a **checksum** of fixed query results next to each size, and says plainly in the docs that two configurations are comparable *only* if their checksums match;
- documents the second trap too — process-to-process spread reached **22–25 % on a shared container even with an identical graph** — and requires running a configuration twice, demanding the pair agree more closely than any difference being claimed, before that difference is believed.

Each size also prints its adjacency footprint next to the latency, so a reader can place the run against their own last-level cache and know which regime they are in. With `M0 = 32` and 8-byte ids, adjacency crosses a 33 MiB L3 around 130K nodes.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — new bench target only

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

| check | result |
|---|---|
| `cargo bench --bench hnsw_adjacency_scale` at 10K | runs; **checksum identical across two runs** (`601562759294092252`), confirming the determinism this file exists to provide |
| full sweep 10K / 50K / 200K | runs to completion, footprint and checksum reported per size |
| `cargo clippy -p velesdb-core --benches -D warnings -D clippy::pedantic` | clean |
| `cargo fmt --all --check` | clean |
| `python -m unittest discover -s scripts/tests -t .` (as Gate Contracts runs it) | **714 passed**, 0 failed, 9 skipped |
| `scripts/check-drop-tightening.py` | PASSED — 0 findings across 0 files |

Sequential insertion costs roughly a minute of build per 200K nodes. That is the price of a comparable graph.

**Test Configuration:**
- OS: Linux 6.18.44, 4-core Xeon @ 2.80 GHz, 33 MiB L3
- Rust version: 1.90 (MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Two things worth flagging beyond this diff.

The defect is not confined to #2075. **Every perf claim this repository derives from `hnsw_benchmark` rests on `insert_batch_parallel` builds**, so any past A/B of a *search* change measured through it carries the same 18 % confound. Worth a look at whichever numbers are load-bearing.

And this benchmark deliberately does not join `CI Success` — sequential builds at these sizes are far too slow for a per-PR gate. If the large-graph regime is going to be a supported claim rather than an aspiration, it wants a nightly job, which is a separate change.