### PR TITLE
perf(graph): drop redundant label-string allocations in EdgeStore

### DIFF
--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -255,12 +255,19 @@ impl EdgeStore {
 
         if index_outgoing {
             let source = edge.source();
-            let label = edge.label().to_string();
+            let label = edge.label();
             self.outgoing.entry(source).or_default().push(id);
-            // Label indices are owned by the source shard (US-003)
-            self.by_label.entry(label.clone()).or_default().push(id);
+            // Label indices are owned by the source shard (US-003).
+            // Probe with the borrowed label first so an already-seen label
+            // (the common case — label cardinality is low) costs no clone.
+            match self.by_label.get_mut(label) {
+                Some(ids) => ids.push(id),
+                None => {
+                    self.by_label.insert(label.to_string(), vec![id]);
+                }
+            }
             self.outgoing_by_label
-                .entry((source, label))
+                .entry((source, label.to_string()))
                 .or_default()
                 .push(id);
         }

--- a/crates/velesdb-core/src/collection/graph/edge_removal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_removal.rs
@@ -87,14 +87,13 @@ impl EdgeStore {
         if let Some(ids) = self.incoming.get_mut(&target_node) {
             ids.retain(|&id| id != edge_id);
         }
-        if let Some(ids) = self
-            .incoming_by_label
-            .get_mut(&(target_node, label.to_string()))
-        {
+        // Build the composite key once — `get_mut`/`remove` used to each
+        // allocate their own copy of the same (node, label) key.
+        let key = (target_node, label.to_string());
+        if let Some(ids) = self.incoming_by_label.get_mut(&key) {
             ids.retain(|&id| id != edge_id);
             if ids.is_empty() {
-                self.incoming_by_label
-                    .remove(&(target_node, label.to_string()));
+                self.incoming_by_label.remove(&key);
             }
         }
     }


### PR DESCRIPTION
## Description

Bounded, format-preserving allocation-count cleanup on the `EdgeStore` insert/remove hot path, called out in #2089 as low-risk, independently shippable steps (same class of fix as #2163 for BM25):

- `insert_edge`: `by_label` (a plain `String`-keyed map) was populated via `entry(label.clone())` after `label` had already been `to_string()`'d for the composite-key maps — an unconditional clone even though edge-label cardinality is typically low, so the label is usually already present. Now probed with the borrowed `&str` first (`get_mut`), and only cloned into an owned `String` when the label is genuinely new.
- `purge_incoming_index` (edge removal): built the identical `(target_node, label.to_string())` composite key twice — once for `get_mut`, again for the follow-up `remove` when the bucket emptied. Now built once and reused.

Both changes are allocation-count only: no map key type changes, no persisted/wire format changes, no BM25/HNSW scoring changes. The bigger fix in #2089 — interning labels as `LabelId(u32)` to remove the composite-key allocation entirely — needs its own PR because `outgoing_by_label`'s serialization has to be checked/versioned first; not attempted here.

Progress on #2089 (not a full fix — see scope note above).

## Type of Change

- [x] ⚡ Performance improvement
- [x] 🔧 Refactoring (no functional changes)

## How Has This Been Tested?

- [x] Unit tests

Ran the full `velesdb-core` lib suite single-threaded under `persistence`, with explicit focus on the touched paths:

```
cargo test -p velesdb-core --features persistence --lib "graph::edge_tests" -- --test-threads=1
# 42 passed

cargo test -p velesdb-core --features persistence --lib edge_concurrent -- --test-threads=1
# 63 passed
```

Also verified:
```
cargo fmt --all -- --check
cargo check -p velesdb-core --features persistence
cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic
```
All clean.

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

No new tests were added — this is a behavior-preserving allocation-count reduction covered entirely by the existing `edge_tests`/`edge_concurrent_tests` suites (label-index, cascade-delete, cross-shard removal), and no data structure or persisted format changed.

## Unsafe Code Checklist

Skipped — this PR does not add or modify `unsafe` code.

## High-Risk Change Checklist

Skipped — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths touched.

## Additional Notes

No perf numbers claimed here per AGENTS.md principle 8 (never claim a win that isn't measured) — this removes allocations on a path the issue already identifies as hot, but I did not run a microbenchmark for this narrow slice; the issue's own validation bar (RSS before/after, traversal micro-benchmark) applies to the full `LabelId` wiring, not this preparatory step.
