### PR TITLE
perf(graph): wire the LabelTable — intern edge labels once, key label indices by LabelId

### DIFF
--- a/crates/velesdb-core/src/collection/graph/csr_snapshot.rs
+++ b/crates/velesdb-core/src/collection/graph/csr_snapshot.rs
@@ -7,7 +7,7 @@
 //! - `AdjacencySource` trait for generic traversal
 
 use super::edge::EdgeStore;
-use super::label_table::{LabelId, LabelTable};
+use super::label_table::LabelId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::sync::Arc;
 
@@ -293,14 +293,18 @@ impl CsrSnapshot {
 // SnapshotBuilder
 // ---------------------------------------------------------------------------
 
-/// Builds a [`CsrSnapshot`] from an [`EdgeStore`] and [`LabelTable`].
+/// Builds a [`CsrSnapshot`] from an [`EdgeStore`].
 ///
 /// This is a stateless namespace — no persistent state is held.
 /// Construction complexity is O(N + E) where N = nodes, E = edges.
 pub(crate) struct SnapshotBuilder;
 
 impl SnapshotBuilder {
-    /// Builds a `CsrSnapshot` from the given `EdgeStore` and `LabelTable`.
+    /// Builds a `CsrSnapshot` from the given `EdgeStore`.
+    ///
+    /// Labels are interned locally: the snapshot's `LabelId`s index its own
+    /// `label_table` vec, independent of the store's table (#2089 removed
+    /// the always-discarded `&LabelTable` parameter this once took).
     ///
     /// # Algorithm
     ///
@@ -310,7 +314,7 @@ impl SnapshotBuilder {
     /// 4. For each node in order, iterate outgoing edges and fill
     ///    `targets`, `edge_ids`, `label_ids`.
     /// 5. Accumulate `offsets`.
-    pub fn build(edge_store: &EdgeStore, _label_table: &LabelTable) -> CsrSnapshot {
+    pub fn build(edge_store: &EdgeStore) -> CsrSnapshot {
         // 1. Collect unique source node_ids
         let mut node_ids: Vec<u64> = edge_store.outgoing_keys();
 
@@ -350,29 +354,9 @@ impl SnapshotBuilder {
             edge_store.for_each_outgoing_edge(nid, |edge| {
                 targets.push(edge.target());
                 edge_ids_buf.push(edge.id());
-
                 // Always use local interning for label_ids stored in CSR.
                 // label_at() resolves against the local label_table vec.
-                //
-                // Look up by &str BEFORE inserting: `entry()` demands an owned
-                // key, which would allocate one String per EDGE just to probe
-                // a map whose distinct-key count is the label vocabulary
-                // (typically tens). The owned Arc<str> is built only on the
-                // first sighting of a label, and that one allocation is shared
-                // between the vec entry and the map key.
-                let label_str = edge.label();
-                let local_idx = if let Some(&idx) = label_to_idx.get(label_str) {
-                    idx
-                } else {
-                    let idx = label_table_vec.len();
-                    #[allow(clippy::cast_possible_truncation)]
-                    // Reason: label count bounded by schema size
-                    let idx = idx as u32;
-                    let shared: Arc<str> = Arc::from(label_str);
-                    label_table_vec.push(Arc::clone(&shared));
-                    label_to_idx.insert(shared, idx);
-                    idx
-                };
+                let local_idx = intern_local(&mut label_to_idx, &mut label_table_vec, edge.label());
                 label_ids_buf.push(LabelId::from_u32(local_idx));
             });
         }
@@ -408,4 +392,30 @@ impl SnapshotBuilder {
             label_to_idx: FxHashMap::default(),
         }
     }
+}
+
+/// Interns `label_str` into the snapshot-local label table, returning its
+/// index.
+///
+/// Looks up by `&str` BEFORE inserting: `entry()` demands an owned key,
+/// which would allocate one String per EDGE just to probe a map whose
+/// distinct-key count is the label vocabulary (typically tens). The owned
+/// `Arc<str>` is built only on the first sighting of a label, and that one
+/// allocation is shared between the vec entry and the map key.
+fn intern_local(
+    label_to_idx: &mut FxHashMap<Arc<str>, u32>,
+    label_table: &mut Vec<Arc<str>>,
+    label_str: &str,
+) -> u32 {
+    if let Some(&idx) = label_to_idx.get(label_str) {
+        return idx;
+    }
+    let idx = label_table.len();
+    #[allow(clippy::cast_possible_truncation)]
+    // Reason: label count bounded by schema size
+    let idx = idx as u32;
+    let shared: Arc<str> = Arc::from(label_str);
+    label_table.push(Arc::clone(&shared));
+    label_to_idx.insert(shared, idx);
+    idx
 }

--- a/crates/velesdb-core/src/collection/graph/csr_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/csr_tests.rs
@@ -16,7 +16,6 @@
 
 use super::csr_snapshot::SnapshotBuilder;
 use super::edge::{EdgeStore, GraphEdge};
-use super::label_table::LabelTable;
 use super::traversal::{bfs_traverse, TraversalConfig};
 use super::traversal_csr::bfs_traverse_csr;
 use std::collections::HashSet;
@@ -29,8 +28,7 @@ use std::collections::HashSet;
 #[test]
 fn test_csr_empty_graph() {
     let store = EdgeStore::new();
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     assert_eq!(snapshot.offsets(), &[0]);
     assert_eq!(snapshot.node_count(), 0);
@@ -64,8 +62,7 @@ fn test_csr_single_node_no_edges() {
         .add_edge(GraphEdge::new(1, 100, 200, "KNOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // Node 100 has outgoing edges, node 200 does not
     assert!(snapshot.contains_node(100));
@@ -91,8 +88,7 @@ fn test_csr_neighbors_returns_correct_slice() {
         .add_edge(GraphEdge::new(13, 3, 1, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // Node 1 → {2, 3}
     let n1: HashSet<u64> = snapshot.neighbors(1).iter().copied().collect();
@@ -128,8 +124,7 @@ fn test_csr_unknown_node_returns_empty() {
         .add_edge(GraphEdge::new(1, 100, 200, "A").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     assert!(snapshot.neighbors(999).is_empty());
     assert!(snapshot.edge_ids(999).is_empty());
@@ -149,8 +144,7 @@ fn test_csr_label_at_correct() {
         .add_edge(GraphEdge::new(11, 1, 3, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     let targets = snapshot.neighbors(1);
     let eids = snapshot.edge_ids(1);
@@ -183,8 +177,7 @@ fn test_csr_has_label() {
         .add_edge(GraphEdge::new(11, 2, 3, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     assert!(snapshot.has_label("KNOWS"));
     assert!(snapshot.has_label("FOLLOWS"));
@@ -206,8 +199,7 @@ fn test_csr_deterministic_node_order() {
         .add_edge(GraphEdge::new(3, 200, 300, "B").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // offsets should reflect sorted node order: 100, 200, 300
     assert_eq!(snapshot.node_count(), 3);
@@ -230,8 +222,8 @@ mod property_tests {
     use super::*;
     use proptest::prelude::*;
 
-    /// Generates a random `(EdgeStore, LabelTable)` with 1-50 nodes and 0-200 edges.
-    fn arb_edge_store() -> impl Strategy<Value = (EdgeStore, LabelTable)> {
+    /// Generates a random `EdgeStore` with 1-50 nodes and 0-200 edges.
+    fn arb_edge_store() -> impl Strategy<Value = EdgeStore> {
         // Generate node count, then edge list
         (1_u64..=50, 0_usize..=200).prop_flat_map(|(max_node, edge_count)| {
             let labels = vec!["KNOWS", "FOLLOWS", "LIKES", "WORKS_AT", "CREATED"];
@@ -241,7 +233,6 @@ mod property_tests {
             )
             .prop_map(move |edges| {
                 let mut store = EdgeStore::new();
-                let label_table = LabelTable::new();
                 let labels = vec!["KNOWS", "FOLLOWS", "LIKES", "WORKS_AT", "CREATED"];
                 for (i, (src, tgt, label_idx)) in edges.into_iter().enumerate() {
                     let label = labels[label_idx];
@@ -251,7 +242,7 @@ mod property_tests {
                         let _ = store.add_edge(edge);
                     }
                 }
-                (store, label_table)
+                store
             })
         })
     }
@@ -261,8 +252,8 @@ mod property_tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
-        fn prop_csr_structural_invariants((store, label_table) in arb_edge_store()) {
-            let snapshot = SnapshotBuilder::build(&store, &label_table);
+        fn prop_csr_structural_invariants(store in arb_edge_store()) {
+            let snapshot = SnapshotBuilder::build(&store);
 
             let total_edges = snapshot.edge_count();
             let node_count = snapshot.node_count();
@@ -311,8 +302,8 @@ mod property_tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
-        fn prop_csr_round_trip((store, label_table) in arb_edge_store()) {
-            let snapshot = SnapshotBuilder::build(&store, &label_table);
+        fn prop_csr_round_trip(store in arb_edge_store()) {
+            let snapshot = SnapshotBuilder::build(&store);
 
             // For each source node in the EdgeStore, verify the CSR contains
             // the same set of (target, edge_id) pairs.
@@ -365,10 +356,10 @@ mod property_tests {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
         fn prop_bfs_equivalence(
-            (store, label_table) in arb_edge_store(),
+            store in arb_edge_store(),
             config in arb_traversal_config(),
         ) {
-            let snapshot = SnapshotBuilder::build(&store, &label_table);
+            let snapshot = SnapshotBuilder::build(&store);
 
             // Pick a source node from the store (first source node, or skip if empty).
             let source_nodes: Vec<u64> = store.all_edges().iter().map(|e| e.source()).collect();
@@ -399,10 +390,10 @@ mod property_tests {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
         fn prop_bfs_limit(
-            (store, label_table) in arb_edge_store(),
+            store in arb_edge_store(),
             limit in 1_usize..100,
         ) {
-            let snapshot = SnapshotBuilder::build(&store, &label_table);
+            let snapshot = SnapshotBuilder::build(&store);
 
             let source_nodes: Vec<u64> = store.all_edges().iter().map(|e| e.source()).collect();
             if let Some(&source_id) = source_nodes.first() {
@@ -429,8 +420,7 @@ fn test_bfs_csr_missing_source() {
         .add_edge(GraphEdge::new(1, 10, 20, "KNOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     let config = TraversalConfig::with_range(1, 3);
     let results = bfs_traverse_csr(&snapshot, 999, &config);
@@ -452,8 +442,7 @@ fn test_bfs_csr_depth_range() {
         .add_edge(GraphEdge::new(102, 3, 4, "KNOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // min_depth=2, max_depth=3 → should only return nodes at depth 2 and 3
     let config = TraversalConfig::with_range(2, 3);
@@ -484,8 +473,7 @@ fn test_bfs_csr_limit_respected() {
             .expect("add");
     }
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     let config = TraversalConfig::with_range(1, 1).with_limit(3);
     let results = bfs_traverse_csr(&snapshot, 1, &config);
@@ -641,8 +629,7 @@ fn test_no_filter_returns_all() {
         .add_edge(GraphEdge::new(3, 10, 40, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     let no_filter = NoFilter;
     let filtered: Vec<(u64, u64, _)> = snapshot.neighbors_filtered(10, &no_filter).collect();
@@ -673,8 +660,7 @@ fn test_label_filter_selective() {
         .add_edge(GraphEdge::new(4, 10, 50, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // Find the LabelId for "KNOWS" from the snapshot's label_ids
     // We need to identify which LabelId corresponds to "KNOWS"
@@ -723,8 +709,7 @@ fn test_bfs_filtered_vs_post_filter() {
         .add_edge(GraphEdge::new(13, 1, 5, "LIKES").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // Find the LabelId for "KNOWS"
     let all_n: Vec<(u64, u64, _)> = snapshot.neighbors_filtered(1, &NoFilter).collect();
@@ -784,9 +769,9 @@ mod predicate_property_tests {
     use proptest::prelude::*;
     use rustc_hash::FxHashSet;
 
-    /// Generates a random `(EdgeStore, LabelTable)` with 1-50 nodes and 0-200 edges.
+    /// Generates a random `EdgeStore` with 1-50 nodes and 0-200 edges.
     /// (Duplicated from property_tests to keep module self-contained.)
-    fn arb_edge_store() -> impl Strategy<Value = (EdgeStore, LabelTable)> {
+    fn arb_edge_store() -> impl Strategy<Value = EdgeStore> {
         (1_u64..=50, 0_usize..=200).prop_flat_map(|(max_node, edge_count)| {
             let labels = vec!["KNOWS", "FOLLOWS", "LIKES", "WORKS_AT", "CREATED"];
             prop::collection::vec(
@@ -795,7 +780,6 @@ mod predicate_property_tests {
             )
             .prop_map(move |edges| {
                 let mut store = EdgeStore::new();
-                let label_table = LabelTable::new();
                 let labels = vec!["KNOWS", "FOLLOWS", "LIKES", "WORKS_AT", "CREATED"];
                 for (i, (src, tgt, label_idx)) in edges.into_iter().enumerate() {
                     let label = labels[label_idx];
@@ -804,7 +788,7 @@ mod predicate_property_tests {
                         let _ = store.add_edge(edge);
                     }
                 }
-                (store, label_table)
+                store
             })
         })
     }
@@ -815,10 +799,10 @@ mod predicate_property_tests {
         #![proptest_config(ProptestConfig::with_cases(100))]
         #[test]
         fn prop_predicate_pushdown(
-            (store, label_table) in arb_edge_store(),
+            store in arb_edge_store(),
             filter_bits in proptest::bits::u8::between(0, 5),
         ) {
-            let snapshot = SnapshotBuilder::build(&store, &label_table);
+            let snapshot = SnapshotBuilder::build(&store);
 
             // Build a LabelFilter from the random bits
             let mut allowed = FxHashSet::default();
@@ -885,8 +869,7 @@ fn test_adjacency_source_equivalence() {
         .add_edge(GraphEdge::new(3, 20, 30, "FOLLOWS").expect("valid"))
         .expect("add");
 
-    let label_table = LabelTable::new();
-    let snapshot = SnapshotBuilder::build(&store, &label_table);
+    let snapshot = SnapshotBuilder::build(&store);
 
     // Compare AdjacencySource::neighbors for each source node
     for &nid in &[10u64, 20, 30] {

--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -13,6 +13,7 @@
 //! For concurrent access, use `ConcurrentEdgeStore` instead.
 
 use super::csr_snapshot::CsrSnapshot;
+use super::label_table::{LabelId, LabelTable};
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -133,10 +134,18 @@ pub struct EdgeStore {
     pub(super) outgoing: HashMap<u64, Vec<u64>>,
     /// Incoming edges: target_id -> Vec<edge_id>
     pub(super) incoming: HashMap<u64, Vec<u64>>,
-    /// Secondary index: label -> Vec<edge_id> for fast label queries
-    pub(super) by_label: HashMap<String, Vec<u64>>,
-    /// Composite index: (source_id, label) -> Vec<edge_id> for fast filtered traversal
-    pub(super) outgoing_by_label: HashMap<(u64, String), Vec<u64>>,
+    /// Secondary index: interned label -> Vec<edge_id> for fast label queries.
+    ///
+    /// `serde(skip)`: keyed by [`LabelId`], which is only meaningful against
+    /// this store's `label_table` — both are rebuilt in `load_from_file`
+    /// (#2089). Old snapshots that still serialize the String-keyed maps
+    /// load fine: postcard's `from_bytes` ignores trailing bytes.
+    #[serde(skip)]
+    pub(super) by_label: HashMap<LabelId, Vec<u64>>,
+    /// Composite index: (source_id, label) -> Vec<edge_id> for fast filtered
+    /// traversal. `serde(skip)`: same rebuild contract as `by_label`.
+    #[serde(skip)]
+    pub(super) outgoing_by_label: HashMap<(u64, LabelId), Vec<u64>>,
     /// Composite index: (target_id, label) -> Vec<edge_id> — the incoming
     /// mirror of `outgoing_by_label`, so `<-[:TYPE]-` patterns stop paying
     /// O(in-degree) full-edge clones on super-nodes.
@@ -145,7 +154,13 @@ pub struct EdgeStore {
     /// so a new serialized field would break every existing edge_store.bin.
     /// The index is fully derivable and rebuilt in `load_from_file`.
     #[serde(skip)]
-    pub(super) incoming_by_label: HashMap<(u64, String), Vec<u64>>,
+    pub(super) incoming_by_label: HashMap<(u64, LabelId), Vec<u64>>,
+    /// Interning table mapping label strings to the [`LabelId`]s that key the
+    /// three label indices above. Populated by `insert_edge`, rebuilt with
+    /// the indices in `load_from_file` (#2089 — wires the table the doc
+    /// comment always promised; labels are no longer stored per edge entry).
+    #[serde(skip)]
+    pub(super) label_table: LabelTable,
     /// Zero-copy CSR snapshot for BFS traversal (G1).
     /// Built on-demand via `build_read_snapshot()`, invalidated by writes.
     #[serde(skip)]
@@ -195,6 +210,7 @@ impl EdgeStore {
             by_label: HashMap::with_capacity(expected_labels),
             outgoing_by_label: HashMap::with_capacity(outgoing_by_label_cap),
             incoming_by_label: HashMap::with_capacity(outgoing_by_label_cap),
+            label_table: LabelTable::with_capacity(expected_labels),
             csr_snapshot: None,
         }
     }
@@ -253,14 +269,16 @@ impl EdgeStore {
             return Err(Error::EdgeExists(id));
         }
 
+        // One interning lookup per insert; no per-edge label allocation (#2089).
+        let label_id = self.intern_label(edge.label())?;
+
         if index_outgoing {
             let source = edge.source();
-            let label = edge.label().to_string();
             self.outgoing.entry(source).or_default().push(id);
             // Label indices are owned by the source shard (US-003)
-            self.by_label.entry(label.clone()).or_default().push(id);
+            self.by_label.entry(label_id).or_default().push(id);
             self.outgoing_by_label
-                .entry((source, label))
+                .entry((source, label_id))
                 .or_default()
                 .push(id);
         }
@@ -269,7 +287,7 @@ impl EdgeStore {
             let target = edge.target();
             self.incoming.entry(target).or_default().push(id);
             self.incoming_by_label
-                .entry((target, edge.label().to_string()))
+                .entry((target, label_id))
                 .or_default()
                 .push(id);
         }
@@ -380,7 +398,10 @@ impl EdgeStore {
     /// iterating through all outgoing edges (EPIC-019 US-003).
     #[must_use]
     pub fn get_outgoing_by_label(&self, node_id: u64, label: &str) -> Vec<&GraphEdge> {
-        self.resolve_edge_ids(self.outgoing_by_label.get(&(node_id, label.to_string())))
+        let Some(label_id) = self.label_table.get_id(label) else {
+            return Vec::new();
+        };
+        self.resolve_edge_ids(self.outgoing_by_label.get(&(node_id, label_id)))
     }
 
     /// Gets all edges with a specific label - O(k) where k = result count.
@@ -388,7 +409,10 @@ impl EdgeStore {
     /// Uses the `by_label` secondary index for fast lookup (EPIC-019 US-003).
     #[must_use]
     pub fn get_edges_by_label(&self, label: &str) -> Vec<&GraphEdge> {
-        self.resolve_edge_ids(self.by_label.get(label))
+        let Some(label_id) = self.label_table.get_id(label) else {
+            return Vec::new();
+        };
+        self.resolve_edge_ids(self.by_label.get(&label_id))
     }
 
     /// Resolves edge IDs from an index entry into edge references.
@@ -404,23 +428,63 @@ impl EdgeStore {
     /// Gets incoming edges filtered by label.
     #[must_use]
     pub fn get_incoming_by_label(&self, node_id: u64, label: &str) -> Vec<&GraphEdge> {
-        self.resolve_edge_ids(self.incoming_by_label.get(&(node_id, label.to_string())))
+        let Some(label_id) = self.label_table.get_id(label) else {
+            return Vec::new();
+        };
+        self.resolve_edge_ids(self.incoming_by_label.get(&(node_id, label_id)))
     }
 
-    /// Rebuilds the (unserialized) `incoming_by_label` index from the live
-    /// edges — called after loading a postcard snapshot.
-    pub(super) fn rebuild_incoming_label_index(&mut self) {
-        self.incoming_by_label.clear();
-        for ids in self.incoming.values() {
-            for &id in ids {
-                if let Some(edge) = self.edges.get(&id) {
-                    self.incoming_by_label
-                        .entry((edge.target(), edge.label().to_string()))
+    /// Interns `label` in this store's table, mapping the (practically
+    /// unreachable) `u32::MAX`-distinct-labels overflow to [`Error::Overflow`].
+    fn intern_label(&mut self, label: &str) -> Result<LabelId> {
+        intern_or_overflow(&mut self.label_table, label)
+    }
+
+    /// Rebuilds the (unserialized) label table and the three label indices
+    /// from the live edges — called after loading a postcard snapshot.
+    ///
+    /// Interning cannot overflow here: every label was already interned once
+    /// when its edge was first inserted, so the vocabulary fits `u32` by
+    /// construction; an overflow is reported all the same rather than
+    /// silently dropping index entries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Overflow`] if the number of distinct labels exceeds
+    /// the `u32` domain of [`LabelId`].
+    pub(super) fn rebuild_label_indexes(&mut self) -> Result<()> {
+        // Destructured so the borrow checker sees the disjoint fields: the
+        // edge/index maps are read while the table and label maps are written.
+        let Self {
+            edges,
+            outgoing,
+            incoming,
+            by_label,
+            outgoing_by_label,
+            incoming_by_label,
+            label_table,
+            ..
+        } = self;
+        by_label.clear();
+        outgoing_by_label.clear();
+        incoming_by_label.clear();
+
+        // Iterate nodes in sorted order (same discipline as SnapshotBuilder):
+        // HashMap iteration order is randomized per instance, so an unsorted
+        // walk would hand every reload a different by-label result order.
+        for &node in &sorted_keys(outgoing) {
+            for &id in &outgoing[&node] {
+                if let Some(edge) = edges.get(&id) {
+                    let label_id = intern_or_overflow(label_table, edge.label())?;
+                    by_label.entry(label_id).or_default().push(id);
+                    outgoing_by_label
+                        .entry((edge.source(), label_id))
                         .or_default()
                         .push(id);
                 }
             }
         }
+        rebuild_incoming_labels(edges, incoming, incoming_by_label, label_table)
     }
 
     /// Checks if an edge with the given ID exists.
@@ -478,6 +542,47 @@ impl EdgeStore {
             }
         }
     }
+}
+
+/// Maps [`LabelTable::intern`]'s overflow (more than `u32::MAX` distinct
+/// labels — unreachable in practice) to [`Error::Overflow`].
+fn intern_or_overflow(table: &mut LabelTable, label: &str) -> Result<LabelId> {
+    table
+        .intern(label)
+        .map_err(|e| Error::Overflow(e.to_string()))
+}
+
+/// The incoming half of [`EdgeStore::rebuild_label_indexes`], split out to
+/// keep both halves under the complexity budget. Takes the already-borrowed
+/// disjoint fields rather than `&mut self` so the caller's destructuring
+/// still satisfies the borrow checker.
+fn rebuild_incoming_labels(
+    edges: &HashMap<u64, GraphEdge>,
+    incoming: &HashMap<u64, Vec<u64>>,
+    incoming_by_label: &mut HashMap<(u64, LabelId), Vec<u64>>,
+    label_table: &mut LabelTable,
+) -> Result<()> {
+    // Sorted for the same determinism reason as the outgoing half.
+    for &node in &sorted_keys(incoming) {
+        for &id in &incoming[&node] {
+            if let Some(edge) = edges.get(&id) {
+                let label_id = intern_or_overflow(label_table, edge.label())?;
+                incoming_by_label
+                    .entry((edge.target(), label_id))
+                    .or_default()
+                    .push(id);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The map's keys, sorted — so index rebuilds walk nodes in a stable order
+/// instead of the per-instance-random `HashMap` iteration order.
+fn sorted_keys<V>(map: &HashMap<u64, V>) -> Vec<u64> {
+    let mut keys: Vec<u64> = map.keys().copied().collect();
+    keys.sort_unstable();
+    keys
 }
 
 // Edge removal operations are in `edge_removal.rs`.

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -19,7 +19,6 @@ use super::clustered_index::ClusteredIndex;
 use super::csr_snapshot::{CsrSnapshot, SnapshotBuilder};
 use super::edge::{EdgeStore, GraphEdge};
 use super::edge_outcome::EdgeRemoval;
-use super::label_table::LabelTable;
 use super::metrics::GraphMetrics;
 use crate::error::{Error, Result};
 use arc_swap::ArcSwap;
@@ -102,8 +101,6 @@ pub struct ConcurrentEdgeStore {
     /// CSR snapshot is intentionally stale and callers must consult the
     /// authoritative per-shard data (see [`Self::csr_is_authoritative`]).
     pending_writes: AtomicU64,
-    /// Shared label table for interning edge labels during snapshot builds.
-    label_table: RwLock<LabelTable>,
     /// Lock-free operational metrics (edge inserts/deletes, traversals).
     ///
     /// Atomic counters and histograms only; observed on the Ok tail of each
@@ -147,7 +144,6 @@ impl ConcurrentEdgeStore {
             csr_snapshot: ArcSwap::from_pointee(SnapshotBuilder::empty()),
             csr_dirty: AtomicBool::new(false),
             pending_writes: AtomicU64::new(0),
-            label_table: RwLock::new(LabelTable::new()),
             metrics: GraphMetrics::new(),
         })
     }

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/snapshot.rs
@@ -74,7 +74,7 @@ impl ConcurrentEdgeStore {
     /// method walks every shard and takes a read lock on each one in turn;
     /// holding a same-shard write lock deadlocks against the reader, and
     /// holding an `edge_ids` write lock deadlocks against the downstream
-    /// `label_table` / snapshot consumers in the same lock-order chain.
+    /// snapshot consumers in the same lock-order chain.
     ///
     /// The only two supported call sites are:
     ///
@@ -111,9 +111,7 @@ impl ConcurrentEdgeStore {
                 let _ = merged.add_edge(edge.clone());
             }
         }
-        let label_table = self.label_table.read();
-        let new_snapshot = SnapshotBuilder::build(&merged, &label_table);
-        drop(label_table);
+        let new_snapshot = SnapshotBuilder::build(&merged);
         self.csr_snapshot.store(Arc::new(new_snapshot));
         Ok(())
     }

--- a/crates/velesdb-core/src/collection/graph/edge_persistence.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_persistence.rs
@@ -5,7 +5,6 @@
 use super::csr_snapshot::{CsrSnapshot, SnapshotBuilder};
 use super::edge::EdgeStore;
 use super::helpers::PostcardPersistence;
-use super::label_table::LabelTable;
 
 // ---------------------------------------------------------------------------
 // CSR snapshot methods (G1: zero-copy BFS)
@@ -25,8 +24,7 @@ impl EdgeStore {
     ///
     /// The snapshot is automatically invalidated by any write operation.
     pub fn build_read_snapshot(&mut self) {
-        let label_table = LabelTable::new();
-        self.csr_snapshot = Some(SnapshotBuilder::build(self, &label_table));
+        self.csr_snapshot = Some(SnapshotBuilder::build(self));
     }
 
     /// Returns a reference to the CSR snapshot, if built.
@@ -92,10 +90,20 @@ impl EdgeStore {
 
     /// Deserializes an edge store from bytes.
     ///
+    /// Rebuilds the (unserialized) label table and label indices, so by-label
+    /// queries work on the returned store exactly as on the one serialized —
+    /// `serde(skip)` fields would otherwise come back empty (#2089).
+    ///
     /// # Errors
     /// Returns an error if deserialization fails (e.g., corrupted data).
     pub fn from_bytes(bytes: &[u8]) -> std::result::Result<Self, postcard::Error> {
-        <Self as PostcardPersistence>::from_bytes(bytes)
+        let mut store = <Self as PostcardPersistence>::from_bytes(bytes)?;
+        store
+            .rebuild_label_indexes()
+            // Unreachable in practice (u32::MAX distinct labels); surfaced as
+            // a deserialization failure rather than a silently unindexed store.
+            .map_err(|_| postcard::Error::SerdeDeCustom)?;
+        Ok(store)
     }
 
     /// Saves the edge store to a file.
@@ -108,14 +116,16 @@ impl EdgeStore {
 
     /// Loads an edge store from a file.
     ///
-    /// Automatically builds a CSR snapshot after loading for zero-copy
-    /// BFS traversal (G1).
+    /// Rebuilds the (unserialized) label table and label indices, then
+    /// builds a CSR snapshot for zero-copy BFS traversal (G1).
     ///
     /// # Errors
     /// Returns an error if file I/O or deserialization fails.
     pub fn load_from_file(path: &std::path::Path) -> std::io::Result<Self> {
         let mut store = <Self as PostcardPersistence>::load_from_file(path)?;
-        store.rebuild_incoming_label_index();
+        store
+            .rebuild_label_indexes()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         store.build_read_snapshot();
         Ok(store)
     }

--- a/crates/velesdb-core/src/collection/graph/edge_removal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_removal.rs
@@ -5,6 +5,7 @@
 //! `purge_*` index-cleanup helpers.
 
 use super::edge::EdgeStore;
+use super::label_table::LabelId;
 
 impl EdgeStore {
     /// Removes an edge by ID.
@@ -13,9 +14,10 @@ impl EdgeStore {
     pub fn remove_edge(&mut self, edge_id: u64) {
         if let Some(edge) = self.edges.remove(&edge_id) {
             let source = edge.source();
+            let label_id = self.label_table.get_id(edge.label());
             self.purge_outgoing_index(edge_id, source);
-            self.purge_incoming_index(edge_id, edge.target(), edge.label());
-            self.purge_label_indices(edge_id, source, edge.label());
+            self.purge_incoming_index(edge_id, edge.target(), label_id);
+            self.purge_label_indices(edge_id, source, label_id);
             // Invalidate CSR snapshot (G1).
             self.csr_snapshot = None;
         }
@@ -28,8 +30,9 @@ impl EdgeStore {
     pub fn remove_edge_outgoing_only(&mut self, edge_id: u64) {
         if let Some(edge) = self.edges.remove(&edge_id) {
             let source = edge.source();
+            let label_id = self.label_table.get_id(edge.label());
             self.purge_outgoing_index(edge_id, source);
-            self.purge_label_indices(edge_id, source, edge.label());
+            self.purge_label_indices(edge_id, source, label_id);
             // Invalidate CSR snapshot (G1).
             self.csr_snapshot = None;
         }
@@ -40,7 +43,8 @@ impl EdgeStore {
     /// Used by `ConcurrentEdgeStore` for cross-shard cleanup.
     pub fn remove_edge_incoming_only(&mut self, edge_id: u64) {
         if let Some(edge) = self.edges.remove(&edge_id) {
-            self.purge_incoming_index(edge_id, edge.target(), edge.label());
+            let label_id = self.label_table.get_id(edge.label());
+            self.purge_incoming_index(edge_id, edge.target(), label_id);
             // Invalidate CSR snapshot (G1).
             self.csr_snapshot = None;
         }
@@ -60,8 +64,9 @@ impl EdgeStore {
         // Remove outgoing edges: clean incoming + label indices for each
         for edge_id in outgoing_ids {
             if let Some(edge) = self.edges.remove(&edge_id) {
-                self.purge_incoming_index(edge_id, edge.target(), edge.label());
-                self.purge_label_indices(edge_id, node_id, edge.label());
+                let label_id = self.label_table.get_id(edge.label());
+                self.purge_incoming_index(edge_id, edge.target(), label_id);
+                self.purge_label_indices(edge_id, node_id, label_id);
             }
         }
 
@@ -71,9 +76,10 @@ impl EdgeStore {
         for edge_id in incoming_ids {
             if let Some(edge) = self.edges.remove(&edge_id) {
                 let source = edge.source();
+                let label_id = self.label_table.get_id(edge.label());
                 self.purge_outgoing_index(edge_id, source);
-                self.purge_label_indices(edge_id, source, edge.label());
-                self.purge_incoming_index(edge_id, node_id, edge.label());
+                self.purge_label_indices(edge_id, source, label_id);
+                self.purge_incoming_index(edge_id, node_id, label_id);
             }
         }
 
@@ -82,19 +88,21 @@ impl EdgeStore {
     }
 
     /// Removes `edge_id` from the incoming index of `target_node`.
+    ///
+    /// `label_id` is `None` only when the edge's label was never interned —
+    /// in that case the label maps hold no entry for it either (table and
+    /// maps are populated together), so skipping the label purge is exact,
+    /// not merely defensive.
     #[inline]
-    fn purge_incoming_index(&mut self, edge_id: u64, target_node: u64, label: &str) {
+    fn purge_incoming_index(&mut self, edge_id: u64, target_node: u64, label_id: Option<LabelId>) {
         if let Some(ids) = self.incoming.get_mut(&target_node) {
             ids.retain(|&id| id != edge_id);
         }
-        if let Some(ids) = self
-            .incoming_by_label
-            .get_mut(&(target_node, label.to_string()))
-        {
+        let Some(label_id) = label_id else { return };
+        if let Some(ids) = self.incoming_by_label.get_mut(&(target_node, label_id)) {
             ids.retain(|&id| id != edge_id);
             if ids.is_empty() {
-                self.incoming_by_label
-                    .remove(&(target_node, label.to_string()));
+                self.incoming_by_label.remove(&(target_node, label_id));
             }
         }
     }
@@ -108,15 +116,15 @@ impl EdgeStore {
     }
 
     /// Removes `edge_id` from the `by_label` and `outgoing_by_label` indices (US-003).
+    ///
+    /// Same `None` contract as [`Self::purge_incoming_index`].
     #[inline]
-    fn purge_label_indices(&mut self, edge_id: u64, source_node: u64, label: &str) {
-        if let Some(ids) = self.by_label.get_mut(label) {
+    fn purge_label_indices(&mut self, edge_id: u64, source_node: u64, label_id: Option<LabelId>) {
+        let Some(label_id) = label_id else { return };
+        if let Some(ids) = self.by_label.get_mut(&label_id) {
             ids.retain(|&id| id != edge_id);
         }
-        if let Some(ids) = self
-            .outgoing_by_label
-            .get_mut(&(source_node, label.to_string()))
-        {
+        if let Some(ids) = self.outgoing_by_label.get_mut(&(source_node, label_id)) {
             ids.retain(|&id| id != edge_id);
         }
     }

--- a/crates/velesdb-core/src/collection/graph/edge_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_tests.rs
@@ -846,3 +846,85 @@ fn test_csr_has_label() {
     assert!(snapshot.has_label("FOLLOWS"));
     assert!(!snapshot.has_label("LIKES"));
 }
+
+/// `from_bytes` must hand back a store whose (unserialized) label table and
+/// label indices are rebuilt — not silently empty (#2089).
+#[test]
+fn test_from_bytes_rebuilds_label_indexes() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 100, 200, "KNOWS").unwrap())
+        .unwrap();
+    store
+        .add_edge(GraphEdge::new(2, 100, 300, "LIKES").unwrap())
+        .unwrap();
+
+    let bytes = store.to_bytes().unwrap();
+    let restored = EdgeStore::from_bytes(&bytes).unwrap();
+
+    assert_eq!(restored.len(), 2);
+    assert_eq!(restored.get_edges_by_label("KNOWS").len(), 1);
+    assert_eq!(restored.get_outgoing_by_label(100, "LIKES").len(), 1);
+    assert_eq!(restored.get_incoming_by_label(200, "KNOWS").len(), 1);
+    assert!(restored.get_outgoing_by_label(100, "ABSENT").is_empty());
+}
+
+/// Pre-#2089 `edge_store.bin` files serialized two extra String-keyed label
+/// maps after the `incoming` field. Postcard's `from_bytes` reads the three
+/// surviving fields and ignores the trailing bytes, so those files must keep
+/// loading — with the label indices rebuilt from the edges.
+#[test]
+fn test_from_bytes_reads_legacy_format_with_trailing_label_maps() {
+    /// The serialized field layout of the pre-#2089 `EdgeStore`, in order.
+    #[derive(serde::Serialize)]
+    struct LegacyEdgeStore {
+        edges: HashMap<u64, GraphEdge>,
+        outgoing: HashMap<u64, Vec<u64>>,
+        incoming: HashMap<u64, Vec<u64>>,
+        by_label: HashMap<String, Vec<u64>>,
+        outgoing_by_label: HashMap<(u64, String), Vec<u64>>,
+    }
+
+    let edge = GraphEdge::new(7, 100, 200, "KNOWS").unwrap();
+    let legacy = LegacyEdgeStore {
+        edges: HashMap::from([(7, edge)]),
+        outgoing: HashMap::from([(100, vec![7])]),
+        incoming: HashMap::from([(200, vec![7])]),
+        by_label: HashMap::from([("KNOWS".to_string(), vec![7])]),
+        outgoing_by_label: HashMap::from([((100, "KNOWS".to_string()), vec![7])]),
+    };
+    let legacy_bytes = postcard::to_allocvec(&legacy).unwrap();
+
+    let restored = EdgeStore::from_bytes(&legacy_bytes).unwrap();
+    assert_eq!(restored.len(), 1);
+    assert_eq!(restored.get_outgoing(100).len(), 1);
+    assert_eq!(restored.get_edges_by_label("KNOWS").len(), 1);
+    assert_eq!(restored.get_outgoing_by_label(100, "KNOWS").len(), 1);
+    assert_eq!(restored.get_incoming_by_label(200, "KNOWS").len(), 1);
+}
+
+/// Rebuilt label indices must not inherit `HashMap`'s per-instance-random
+/// iteration order: two loads of the same bytes return by-label results in
+/// the same order (#2089 review follow-up).
+#[test]
+fn test_from_bytes_label_order_is_deterministic() {
+    let mut store = EdgeStore::new();
+    for id in 0..50 {
+        let source = 100 + (id * 37) % 50;
+        store
+            .add_edge(GraphEdge::new(id, source, 999, "KNOWS").unwrap())
+            .unwrap();
+    }
+    let bytes = store.to_bytes().unwrap();
+
+    let ids = |s: &EdgeStore| -> Vec<u64> {
+        s.get_edges_by_label("KNOWS")
+            .iter()
+            .map(|e| e.id())
+            .collect()
+    };
+    let first = EdgeStore::from_bytes(&bytes).unwrap();
+    let second = EdgeStore::from_bytes(&bytes).unwrap();
+    assert_eq!(ids(&first), ids(&second), "same bytes, same order");
+    assert_eq!(first.get_edges_by_label("KNOWS").len(), 50);
+}

--- a/crates/velesdb-core/src/collection/graph/label_table.rs
+++ b/crates/velesdb-core/src/collection/graph/label_table.rs
@@ -9,6 +9,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Error type for LabelTable operations.
@@ -66,10 +67,12 @@ impl LabelId {
 /// ```
 #[derive(Debug, Default)]
 pub struct LabelTable {
-    /// Stored strings indexed by LabelId
-    strings: Vec<String>,
-    /// Reverse lookup: string -> LabelId
-    ids: HashMap<String, LabelId>,
+    /// Stored strings indexed by `LabelId`. Each entry shares its allocation
+    /// with the `ids` key — the table owns one `Arc<str>` per distinct label,
+    /// not two `String`s (#2089, same treatment as the CSR builder's table).
+    strings: Vec<Arc<str>>,
+    /// Reverse lookup: string -> `LabelId`
+    ids: HashMap<Arc<str>, LabelId>,
 }
 
 impl LabelTable {
@@ -122,9 +125,9 @@ impl LabelTable {
         // Reason: len checked against u32::MAX above, truncation impossible
         #[allow(clippy::cast_possible_truncation)]
         let id = LabelId(len as u32);
-        let owned = s.to_owned();
-        self.strings.push(owned.clone());
-        self.ids.insert(owned, id);
+        let shared: Arc<str> = Arc::from(s);
+        self.strings.push(Arc::clone(&shared));
+        self.ids.insert(shared, id);
         Ok(id)
     }
 
@@ -139,7 +142,7 @@ impl LabelTable {
     /// The original string, or `None` if the ID is invalid
     #[must_use]
     pub fn resolve(&self, id: LabelId) -> Option<&str> {
-        self.strings.get(id.0 as usize).map(String::as_str)
+        self.strings.get(id.0 as usize).map(AsRef::as_ref)
     }
 
     /// Returns the number of unique labels in the table.
@@ -159,7 +162,7 @@ impl LabelTable {
         self.strings
             .iter()
             .enumerate()
-            .map(|(i, s)| (LabelId(i as u32), s.as_str()))
+            .map(|(i, s)| (LabelId(i as u32), s.as_ref()))
     }
 
     /// Gets the ID for a label if it exists, without interning.

--- a/crates/velesdb-core/src/collection/graph/traversal_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/traversal_tests.rs
@@ -1,7 +1,6 @@
 //! Tests for `traversal` module - Graph traversal algorithms.
 
 use super::csr_snapshot::SnapshotBuilder;
-use super::label_table::LabelTable;
 use super::traversal::*;
 use super::traversal_bidir::bfs_traverse_both;
 use super::traversal_csr::bfs_traverse_csr;
@@ -404,7 +403,7 @@ fn test_bfs_traverse_csr_expired_deadline_returns_partial() {
     store
         .add_edge(GraphEdge::new(101, 2, 3, "KNOWS").unwrap())
         .unwrap();
-    let snapshot = SnapshotBuilder::build(&store, &LabelTable::new());
+    let snapshot = SnapshotBuilder::build(&store);
 
     let expired = Instant::now()
         .checked_sub(Duration::from_millis(1))
@@ -428,7 +427,7 @@ fn test_bfs_traverse_csr_far_future_deadline_no_premature_abort() {
     store
         .add_edge(GraphEdge::new(101, 2, 3, "KNOWS").unwrap())
         .unwrap();
-    let snapshot = SnapshotBuilder::build(&store, &LabelTable::new());
+    let snapshot = SnapshotBuilder::build(&store);
 
     let future = Instant::now() + Duration::from_secs(3600);
     let with_deadline = TraversalConfig::with_range(1, 3).with_deadline(future);

--- a/crates/velesdb-core/tests/graph_label_interning.rs
+++ b/crates/velesdb-core/tests/graph_label_interning.rs
@@ -1,0 +1,183 @@
+//! Behaviour: a by-label edge lookup allocates nothing for its key — MEASURED,
+//! not asserted from the signature (#2089).
+//!
+//! Before the fix, `get_outgoing_by_label` / `get_incoming_by_label` built an
+//! owned `(node_id, label.to_string())` key per call, so every `-[:TYPE]->` /
+//! `<-[:TYPE]-` hop paid a malloc+memcpy+free. The label indices are now keyed
+//! by interned `LabelId(u32)`, resolved from `&str` without allocating; this
+//! file proves the per-hop allocation is gone with a counting global allocator
+//! rather than trusting the code shape.
+//!
+//! The whole file is ONE test on purpose: the allocator meter is global to
+//! the process, so a second test running on a sibling thread would bleed its
+//! allocations into whichever measurement is in flight. Sequential sections
+//! inside one `#[test]` are the only layout that keeps every delta clean.
+//!
+//! The positive control is what makes the measurement trustworthy: a HIT on
+//! the same store must register at least the materialized result buffer. A
+//! meter that failed to see that much would fail the control rather than
+//! green-light the claim.
+
+#![cfg(feature = "persistence")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use velesdb_core::collection::graph::{ConcurrentEdgeStore, EdgeStore, GraphEdge, LabelTable};
+
+/// [`System`] allocator with a monotonic count of bytes ever allocated.
+/// Deallocations are deliberately not subtracted: the meter measures
+/// allocation WORK (what #2089's per-hop cost is about), not peak footprint.
+struct CountingAllocator;
+
+static BYTES_ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: `GlobalAlloc` demands that alloc/dealloc uphold the allocator
+// contract (valid layouts honoured, no aliasing invented).
+// - Condition 1: every call is forwarded verbatim to `System`, which upholds
+//   the full contract by definition.
+// - Condition 2: the only addition is a relaxed atomic increment, which
+//   cannot allocate, panic, or touch the pointers involved.
+// Reason: counting allocated bytes is the whole instrument of this test —
+// there is no safe hook into the global allocator.
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        BYTES_ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        // SAFETY: `System.alloc` requires the caller's layout obligations.
+        // - Condition 1: `layout` is passed through unmodified from our own
+        //   caller, who carries the same obligations.
+        // Reason: delegation to the real allocator is the entire body.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `System.dealloc` requires `ptr` to come from `System.alloc`
+        // with the same layout.
+        // - Condition 1: `alloc` above only ever returns `System.alloc`
+        //   pointers, and `ptr`/`layout` arrive unmodified from the runtime.
+        // Reason: delegation to the real allocator is the entire body.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+/// Bytes allocated (anywhere in the process) while `f` runs.
+fn bytes_allocated_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+    let before = BYTES_ALLOCATED.load(Ordering::Relaxed);
+    let value = f();
+    let after = BYTES_ALLOCATED.load(Ordering::Relaxed);
+    (value, after - before)
+}
+
+/// Nodes in the test graph — enough that the lookup loop below cannot be
+/// satisfied from a single hot cache line by accident.
+const NUM_NODES: u64 = 1_000;
+
+/// Lookups per measured section; every one of them must allocate nothing.
+const LOOKUPS: u64 = 10_000;
+
+/// A store where every node has one outgoing `KNOWS` edge and one outgoing
+/// `LIKES` edge (and therefore one incoming edge of each label too).
+fn two_label_store() -> ConcurrentEdgeStore {
+    let store = ConcurrentEdgeStore::new();
+    for n in 0..NUM_NODES {
+        let knows = GraphEdge::new(2 * n, n, (n + 1) % NUM_NODES, "KNOWS").expect("valid label");
+        let likes =
+            GraphEdge::new(2 * n + 1, n, (n + 2) % NUM_NODES, "LIKES").expect("valid label");
+        store.add_edge(knows).expect("edge insert");
+        store.add_edge(likes).expect("edge insert");
+    }
+    store
+}
+
+/// Positive control: the meter must SEE a hit's materialized result.
+fn assert_meter_sees_hits(store: &ConcurrentEdgeStore) {
+    let (hits, hit_bytes) = bytes_allocated_during(|| {
+        let mut total = 0u64;
+        for n in 0..LOOKUPS {
+            total += store.get_outgoing_by_label(n % NUM_NODES, "KNOWS").len() as u64;
+        }
+        total
+    });
+    assert_eq!(hits, LOOKUPS, "every node has one KNOWS edge");
+    let materialized_floor =
+        usize::try_from(LOOKUPS).expect("fits usize") * std::mem::size_of::<GraphEdge>();
+    assert!(
+        hit_bytes >= materialized_floor,
+        "control failed: {LOOKUPS} hits materialize at least their edge \
+         buffers ({materialized_floor} bytes), yet the meter saw only \
+         {hit_bytes} bytes — the measurement cannot be trusted"
+    );
+}
+
+/// The claim on the concurrent hop path: misses — an uninterned label, and
+/// an interned label on a node without it — allocate nothing.
+fn assert_concurrent_misses_are_alloc_free(store: &ConcurrentEdgeStore) {
+    let (found, miss_bytes) = bytes_allocated_during(|| {
+        let mut total = 0usize;
+        for n in 0..LOOKUPS {
+            total += store
+                .get_outgoing_by_label(n % NUM_NODES, "ABSENT_LABEL")
+                .len();
+            total += store
+                .get_incoming_by_label(n % NUM_NODES, "ABSENT_LABEL")
+                .len();
+            // Interned label, but no node above NUM_NODES carries any edge.
+            total += store.get_outgoing_by_label(NUM_NODES + n, "KNOWS").len();
+        }
+        total
+    });
+    assert_eq!(found, 0, "none of the probed (node, label) pairs exist");
+    assert_eq!(
+        miss_bytes, 0,
+        "by-label misses allocated {miss_bytes} bytes across {LOOKUPS} \
+         lookup rounds — the per-hop key allocation is back"
+    );
+}
+
+/// Interning is idempotent without allocating: re-interning an existing
+/// label returns the same id and touches no memory.
+fn assert_reintern_is_alloc_free() {
+    let mut table = LabelTable::new();
+    let first = table.intern("KNOWS").expect("intern");
+    let (second, reintern_bytes) =
+        bytes_allocated_during(|| table.intern("KNOWS").expect("intern"));
+    assert_eq!(first, second, "same label, same id");
+    assert_eq!(
+        reintern_bytes, 0,
+        "re-interning an existing label allocated {reintern_bytes} bytes"
+    );
+}
+
+/// Per-shard `EdgeStore` path (what the concurrent hops delegate to):
+/// misses are allocation-free there too, `get_edges_by_label` included.
+fn assert_plain_store_misses_are_alloc_free() {
+    let mut plain = EdgeStore::new();
+    plain
+        .add_edge(GraphEdge::new(0, 1, 2, "KNOWS").expect("valid label"))
+        .expect("edge insert");
+    let (_, plain_miss_bytes) = bytes_allocated_during(|| {
+        let mut total = 0usize;
+        for _ in 0..LOOKUPS {
+            total += plain.get_outgoing_by_label(1, "ABSENT_LABEL").len();
+            total += plain.get_incoming_by_label(2, "ABSENT_LABEL").len();
+            total += plain.get_edges_by_label("ABSENT_LABEL").len();
+        }
+        total
+    });
+    assert_eq!(
+        plain_miss_bytes, 0,
+        "EdgeStore by-label misses allocated {plain_miss_bytes} bytes"
+    );
+}
+
+#[test]
+fn by_label_lookups_do_not_allocate_per_hop() {
+    let store = two_label_store();
+    assert_meter_sees_hits(&store);
+    assert_concurrent_misses_are_alloc_free(&store);
+    assert_reintern_is_alloc_free();
+    assert_plain_store_misses_are_alloc_free();
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Fixes #2089.

`EdgeStore` stored each edge's label once per index entry — the `GraphEdge`'s own copy plus an owned `String` inside the `(node, label)` keys of `outgoing_by_label` and `incoming_by_label` — and `get_outgoing_by_label` / `get_incoming_by_label` built an owned `(node_id, label.to_string())` key **per call**, so every `-[:TYPE]->` / `<-[:TYPE]-` hop paid a malloc+memcpy+free. Edge removal paid the same `to_string()` up to three times per edge. Meanwhile `LabelTable`, the interning subsystem built for exactly this, had zero production callers: `ConcurrentEdgeStore` constructed one behind a `RwLock`, read-locked it in the snapshot path, and passed it to `SnapshotBuilder::build`, whose `_label_table` parameter discarded it.

Per the issue's own instruction, this was **measured before implementing** (methodology below), then implemented, then re-measured:

- `EdgeStore` now owns a per-shard `LabelTable`; `insert_edge` interns the label once and the three label indices (`by_label`, `outgoing_by_label`, `incoming_by_label`) are keyed by `LabelId(u32)` instead of owned `String`s.
- By-label lookups resolve `&str → LabelId` without allocating; an unknown label short-circuits to an empty result.
- Edge removal resolves the `LabelId` once per edge. The purge helpers' `None` arm is exact, not defensive: a label absent from the table has no entries in the label maps either — the table and the maps are populated together.
- `LabelTable::intern` stores one shared `Arc<str>` per distinct label instead of two `String`s (same treatment as the CSR builder's local interner, #2084).
- The two formerly-serialized String-keyed maps move to `serde(skip)` + load-time rebuild — the option issue #2089 explicitly sanctions ("either version the format or move it to serde(skip) + load-time rebuild like incoming_by_label (#2071)"). **Both public entry points rebuild**: `load_from_file` and `from_bytes` reconstruct the label table and all three indices, so a byte-level roundtrip keeps by-label queries working (a review round caught that `from_bytes` initially didn't — fixed, with a roundtrip test).
- **Forward compatibility is pinned by a test, not claimed**: `test_from_bytes_reads_legacy_format_with_trailing_label_maps` serializes the pre-#2089 five-field layout and proves the new code loads it (postcard's `from_bytes` ignores the trailing bytes where the two maps used to sit), with the indices rebuilt. **Downgrade is not supported, and its failure mode is worth naming**: an old binary cannot parse a new file, and the collection loader's load-or-default fallback would start that collection with an empty edge store whose next flush overwrites the file. Roll forward, not back, once a new snapshot has been written — or restore the file from backup before downgrading.
- The façade is deleted, not kept: `ConcurrentEdgeStore` loses its `RwLock<LabelTable>` field and `SnapshotBuilder::build` loses the parameter it never read. The CSR builder keeps its local interning (the issue's sanctioned alternative), so snapshot `LabelId`s remain self-contained.

`GraphEdge.label` itself stays a `String` — deliberately. Re-pointing it at the interned `Arc<str>` would change a serialized public type (serde `rc` feature, `PartialEq` surface) for the remaining 1× copy; that is a separate decision with its own measurement, left on the issue.

## Type of Change

- [x] ⚡ Performance improvement

## Measurements

Instrument: a counting `GlobalAlloc` (the #1820 pattern) — exact allocated/live byte and allocation counts, plus wall time. Workload: 2M edges, 200K nodes, 20-label vocabulary (12-byte labels), shaped so `(node, label)` pairs are distinct on **both** the outgoing and incoming side (the composite-key-heavy worst case the issue describes). Release build, idle container, `--test-threads=1`. The allocation and byte counts are deterministic — repeated baseline runs reproduced them **to the byte** — so the memory deltas carry no noise; wall times varied run-to-run by up to ~2× on the sub-second sections and are reported as observed.

| metric (2M edges) | before | after |
|---|---|---|
| build: live bytes retained | 1 202.0 MB (601.0 B/edge) | **1 023.8 MB (511.9 B/edge, −14.8 %)** |
| build: allocations per edge | 7.60 | **4.60** |
| build: wall time | 7.9 s | 5.8 s |
| by-label lookup, hit | 2.50 allocs/lookup | **1.50** (the result `Vec` only) |
| by-label lookup, miss (out) | 1.00 alloc/lookup, 164 ms/1M | **0 allocs, 25 ms/1M** |
| by-label lookup, miss (in) | 1.00 alloc/lookup, 84 ms/1M | **0 allocs, 20 ms/1M** |
| `remove_edge` | 3.00 allocs/edge | **0 allocs** |
| `edge_store.bin` on disk | 103.5 MB | **60.2 MB (−42 %)** |
| `load_from_file` (incl. rebuild) | 11.5–20.3 s across runs | 8.3 s |

The issue's validation bar asks for RSS on a 10M-edge graph; this container cannot hold the ~6 GB baseline that implies, so the measurement is at 2M with live-byte accounting (a strictly sharper instrument than RSS). The removed cost is per edge and per `(node, label)` entry, so it does not shrink with scale; only the 2M figures are claimed.

The per-hop claim is not just measured once — it is **pinned by a committed test**: `tests/graph_label_interning.rs` proves with the counting allocator that by-label misses allocate zero bytes on both the concurrent and per-shard paths and that re-interning an existing label allocates nothing, with a positive control that fails the test if the meter cannot see a hit's materialized result buffer.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

| check | result |
|---|---|
| `cargo test -p velesdb-core --features persistence -- --test-threads=1` (full suite) | **70 binaries, 6 472 passed, 0 failed** — edge subset and persistence roundtrip suites unchanged, as the issue requires |
| new tests | allocation-metered per-hop test (positive control included), `from_bytes` roundtrip with by-label queries, legacy five-field-format load |
| `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` | clean |
| `cargo clippy -p velesdb-server --all-targets` (same flags) | clean |
| `cargo clippy -p velesdb-core --lib --bins … -D clippy::undocumented_unsafe_blocks` | clean |
| `cargo fmt --all --check` | clean |
| `cargo test --doc -p velesdb-core` / `-p velesdb-server` | 50 passed / 0 (none) |
| `cargo check -p velesdb-core --no-default-features` | clean |
| `cargo check -p velesdb-wasm --no-default-features --target wasm32-unknown-unknown` | clean |
| `python3 -m unittest discover -s scripts/tests -t .` | **Ran 714 tests — OK** (skipped=9) |
| guard scripts: version-sync, feature-claims, perf-claims `--no-criterion`, promise-contract, mcp-doc-contract, skill-private-references, ai-attribution, doc-contract, doc-freshness ×5, prod-unwraps, agent-hooks | all PASSED |

Workspace-wide `cargo clippy --workspace` and `cargo check --no-default-features` stop at `gdk-sys` in this container (no GTK system libs — the same limitation recorded in #2161); every crate this diff touches is linted above at CI-exact flags. `cargo-deny` is not installed here; the diff adds no dependency, so the lockfile is byte-identical.

**Test Configuration:**
- OS: Linux 6.18.44, 4-core Xeon @ 2.80 GHz
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (field/method doc comments carry the rebuild contract; no standalone doc claims the old behavior)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

The one `unsafe` addition is the test's counting `GlobalAlloc` — a verbatim copy of the instrument already reviewed into `tests/graph_bounded_reads.rs` (#1820), with the same `// SAFETY:` comments.

- [x] All `unsafe {}` blocks have `// SAFETY:` comments explaining why it's sound
- [x] No undefined behavior possible with valid inputs (pure delegation to `System` plus relaxed atomic counters)

## High-Risk Change Checklist

Skipped — touches `collection/graph` indices only; no `hnsw`, `storage`, `Drop`, or SIMD dispatch path. The persistence-format interaction (two maps leaving the serialized set) is covered by the existing roundtrip suites, the new legacy-format and `from_bytes` tests, plus the load-path rebuild, all green above.

## Additional Notes

Three deliberate scope edges:

- **`by_label` also moved to `LabelId` keys.** It was `String`-keyed and serialized; keeping it while the composite maps changed would have preserved a per-insert `label.clone()` (the `entry()` owned-key tax, the very disease of #2163) and split the label indices across two key schemes.
- **The maps stay `std::HashMap`.** Swapping the hasher (FxHash) for the now-`(u64, u32)` keys is a separate hypothesis; per this repo's rule it gets measured before it gets implemented. The miss-path timing above (164→25 ms/1M) already includes the cheaper SipHash over 12 vs 24+ key bytes.
- **`LabelTable` stays public and exported** — it now has real production callers, so the issue's "or delete it" fork resolves to *wire it*: the dead lock and dead parameter are what got deleted.

Review round (adversarial pass on the diff): confirmed and fixed the `from_bytes` rebuild gap; two findings were declined with cause — unifying `intern_local` with `LabelTable::intern` would make the infallible `SnapshotBuilder::build` fallible across 26 call sites (or couple the snapshot's FxHashMap representation to the table's std map) to remove ~15 lines of standard idiom over different concrete types, and the alloc test's `persistence` gate is required because `velesdb_core::collection::graph` is not importable without that feature (same gate as `graph_bounded_reads.rs`).