### PR TITLE
perf(graph): stop allocating a label String per traversal hop (#2089)

### DIFF
--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -133,9 +133,30 @@ pub struct EdgeStore {
     pub(super) outgoing: HashMap<u64, Vec<u64>>,
     /// Incoming edges: target_id -> Vec<edge_id>
     pub(super) incoming: HashMap<u64, Vec<u64>>,
-    /// Secondary index: label -> Vec<edge_id> for fast label queries
+    /// Secondary index: label -> Vec<edge_id> for fast label queries.
+    ///
+    /// **Serialized — changing this type is a format break.** See the note on
+    /// `outgoing_by_label` below; it applies to both.
     pub(super) by_label: HashMap<String, Vec<u64>>,
-    /// Composite index: (source_id, label) -> Vec<edge_id> for fast filtered traversal
+    /// Composite index: (source_id, label) -> Vec<edge_id> for fast filtered
+    /// traversal.
+    ///
+    /// **Serialized — changing this type is a format break, and a silent one.**
+    /// This field and `by_label` are written into `edge_store.bin` by postcard,
+    /// which is not self-describing, and nothing in the path carries a format
+    /// version: `PostcardPersistence` is a blanket trait over raw bytes. A file
+    /// the new code cannot deserialize does not surface as a loud error either
+    /// — per `helpers.rs`, callers fall back to an **empty store**, so the
+    /// symptom is a graph that lost its edges.
+    ///
+    /// This is why #2089 stopped short here. Keying these by `LabelId` (the
+    /// unwired `LabelTable`) or nesting them the way `incoming_by_label` is
+    /// nested below would remove the last per-hop `String` allocation on
+    /// `-[:TYPE]->`, and it is worth doing — but only behind a format decision,
+    /// the same one #2090 needs for the BM25 dictionary. Marking them
+    /// `#[serde(skip)]` and rebuilding on load is a defensible answer, and is
+    /// still a format change, since removing a field moves the postcard layout
+    /// exactly as changing one does.
     pub(super) outgoing_by_label: HashMap<(u64, String), Vec<u64>>,
     /// Nested index: target_id -> label -> Vec<edge_id> — the incoming
     /// mirror of `outgoing_by_label`, so `<-[:TYPE]-` patterns stop paying

--- a/crates/velesdb-core/src/collection/graph/edge.rs
+++ b/crates/velesdb-core/src/collection/graph/edge.rs
@@ -137,15 +137,21 @@ pub struct EdgeStore {
     pub(super) by_label: HashMap<String, Vec<u64>>,
     /// Composite index: (source_id, label) -> Vec<edge_id> for fast filtered traversal
     pub(super) outgoing_by_label: HashMap<(u64, String), Vec<u64>>,
-    /// Composite index: (target_id, label) -> Vec<edge_id> — the incoming
+    /// Nested index: target_id -> label -> Vec<edge_id> — the incoming
     /// mirror of `outgoing_by_label`, so `<-[:TYPE]-` patterns stop paying
     /// O(in-degree) full-edge clones on super-nodes.
+    ///
+    /// Nested rather than keyed by `(u64, String)` so a lookup can borrow:
+    /// no `Borrow` path exists into a tuple, so a composite key forces every
+    /// `<-[:TYPE]-` hop to allocate a `String` purely to build a probe key
+    /// (#2089). Nesting lets `HashMap<String, _>::get` take the `&str`
+    /// directly, and lets an insert probe before it allocates.
     ///
     /// `serde(skip)`: the snapshot format is postcard (not self-describing),
     /// so a new serialized field would break every existing edge_store.bin.
     /// The index is fully derivable and rebuilt in `load_from_file`.
     #[serde(skip)]
-    pub(super) incoming_by_label: HashMap<(u64, String), Vec<u64>>,
+    pub(super) incoming_by_label: HashMap<u64, HashMap<String, Vec<u64>>>,
     /// Zero-copy CSR snapshot for BFS traversal (G1).
     /// Built on-demand via `build_read_snapshot()`, invalidated by writes.
     #[serde(skip)]
@@ -194,7 +200,8 @@ impl EdgeStore {
             incoming: HashMap::with_capacity(expected_nodes),
             by_label: HashMap::with_capacity(expected_labels),
             outgoing_by_label: HashMap::with_capacity(outgoing_by_label_cap),
-            incoming_by_label: HashMap::with_capacity(outgoing_by_label_cap),
+            // Keyed by node, not by (node, label): one entry per node.
+            incoming_by_label: HashMap::with_capacity(expected_nodes),
             csr_snapshot: None,
         }
     }
@@ -255,12 +262,20 @@ impl EdgeStore {
 
         if index_outgoing {
             let source = edge.source();
-            let label = edge.label().to_string();
+            let label = edge.label();
             self.outgoing.entry(source).or_default().push(id);
-            // Label indices are owned by the source shard (US-003)
-            self.by_label.entry(label.clone()).or_default().push(id);
+            // Label indices are owned by the source shard (US-003).
+            // Probe before `entry`: `entry` demands an owned key, so it
+            // allocates even for a label the map already holds. The label
+            // vocabulary is tiny next to the edge count, so after warmup
+            // every insert takes the borrowing path (#2089).
+            if let Some(ids) = self.by_label.get_mut(label) {
+                ids.push(id);
+            } else {
+                self.by_label.insert(label.to_owned(), vec![id]);
+            }
             self.outgoing_by_label
-                .entry((source, label))
+                .entry((source, label.to_owned()))
                 .or_default()
                 .push(id);
         }
@@ -268,10 +283,7 @@ impl EdgeStore {
         if index_incoming {
             let target = edge.target();
             self.incoming.entry(target).or_default().push(id);
-            self.incoming_by_label
-                .entry((target, edge.label().to_string()))
-                .or_default()
-                .push(id);
+            Self::push_incoming_label(&mut self.incoming_by_label, target, edge.label(), id);
         }
 
         self.edges.insert(id, edge);
@@ -404,7 +416,30 @@ impl EdgeStore {
     /// Gets incoming edges filtered by label.
     #[must_use]
     pub fn get_incoming_by_label(&self, node_id: u64, label: &str) -> Vec<&GraphEdge> {
-        self.resolve_edge_ids(self.incoming_by_label.get(&(node_id, label.to_string())))
+        self.resolve_edge_ids(
+            self.incoming_by_label
+                .get(&node_id)
+                .and_then(|per_label| per_label.get(label)),
+        )
+    }
+
+    /// Pushes `edge_id` into the incoming label mirror under `(target, label)`.
+    ///
+    /// Takes the index rather than `&mut self` so callers can hold a borrow of
+    /// another field (`edges`) across the call. Probes before inserting, for
+    /// the reason given on `insert_edge`.
+    fn push_incoming_label(
+        index: &mut HashMap<u64, HashMap<String, Vec<u64>>>,
+        target: u64,
+        label: &str,
+        edge_id: u64,
+    ) {
+        let per_label = index.entry(target).or_default();
+        if let Some(ids) = per_label.get_mut(label) {
+            ids.push(edge_id);
+        } else {
+            per_label.insert(label.to_owned(), vec![edge_id]);
+        }
     }
 
     /// Rebuilds the (unserialized) `incoming_by_label` index from the live
@@ -414,10 +449,12 @@ impl EdgeStore {
         for ids in self.incoming.values() {
             for &id in ids {
                 if let Some(edge) = self.edges.get(&id) {
-                    self.incoming_by_label
-                        .entry((edge.target(), edge.label().to_string()))
-                        .or_default()
-                        .push(id);
+                    Self::push_incoming_label(
+                        &mut self.incoming_by_label,
+                        edge.target(),
+                        edge.label(),
+                        id,
+                    );
                 }
             }
         }

--- a/crates/velesdb-core/src/collection/graph/edge_removal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_removal.rs
@@ -87,15 +87,23 @@ impl EdgeStore {
         if let Some(ids) = self.incoming.get_mut(&target_node) {
             ids.retain(|&id| id != edge_id);
         }
-        if let Some(ids) = self
-            .incoming_by_label
-            .get_mut(&(target_node, label.to_string()))
-        {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.incoming_by_label
-                    .remove(&(target_node, label.to_string()));
+        // Nested index: probe by `&str`, so purging allocates nothing. The
+        // composite key this replaced needed two `to_string()` per call, one
+        // to look up and one to remove (#2089).
+        let node_now_empty = {
+            let Some(per_label) = self.incoming_by_label.get_mut(&target_node) else {
+                return;
+            };
+            if let Some(ids) = per_label.get_mut(label) {
+                ids.retain(|&id| id != edge_id);
+                if ids.is_empty() {
+                    per_label.remove(label);
+                }
             }
+            per_label.is_empty()
+        };
+        if node_now_empty {
+            self.incoming_by_label.remove(&target_node);
         }
     }
 

--- a/crates/velesdb-core/src/collection/graph/edge_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_tests.rs
@@ -351,6 +351,59 @@ fn test_get_incoming_by_label() {
 }
 
 #[test]
+fn test_incoming_label_index_prunes_emptied_entries() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 100, 500, "FOLLOWS").expect("valid"))
+        .expect("add");
+    store
+        .add_edge(GraphEdge::new(2, 200, 500, "BLOCKS").expect("valid"))
+        .expect("add");
+
+    assert_eq!(store.incoming_by_label.len(), 1, "one target node indexed");
+
+    store.remove_edge(1);
+    assert!(
+        store.get_incoming_by_label(500, "FOLLOWS").is_empty(),
+        "the removed label must no longer resolve"
+    );
+    assert_eq!(
+        store.incoming_by_label[&500].len(),
+        1,
+        "the emptied label must not linger beside BLOCKS"
+    );
+
+    store.remove_edge(2);
+    assert!(
+        !store.incoming_by_label.contains_key(&500),
+        "a node with no incoming labels left must not keep an entry"
+    );
+}
+
+#[test]
+fn test_rebuild_incoming_label_index_matches_live_edges() {
+    let mut store = EdgeStore::new();
+    for (id, source, label) in [
+        (1u64, 100u64, "FOLLOWS"),
+        (2, 200, "FOLLOWS"),
+        (3, 300, "BLOCKS"),
+    ] {
+        store
+            .add_edge(GraphEdge::new(id, source, 500, label).expect("valid"))
+            .expect("add");
+    }
+
+    // Rebuilding from the live edges must reproduce the index the inserts
+    // built — this is the path a postcard load takes, since the index is
+    // `serde(skip)`.
+    store.rebuild_incoming_label_index();
+
+    assert_eq!(store.get_incoming_by_label(500, "FOLLOWS").len(), 2);
+    assert_eq!(store.get_incoming_by_label(500, "BLOCKS").len(), 1);
+    assert!(store.get_incoming_by_label(500, "LIKES").is_empty());
+}
+
+#[test]
 fn test_contains_edge() {
     let mut store = EdgeStore::new();
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/2089-label-lookup-allocations` → **`develop`**. ✅

## Description

Partial fix for #2089 — the half that carries no persistence-format risk.

`incoming_by_label` was keyed `(u64, String)`. No `Borrow` path exists into a tuple, so every `<-[:TYPE]-` traversal hop allocated a `String` purely to build a probe key, and `purge_incoming_index` allocated **two** per call, one to look up and one to remove. Nesting the index as `target -> label -> Vec<edge_id>` lets `HashMap<String, _>::get` borrow the `&str` directly: those lookups and the purge now allocate nothing.

`by_label` needed no type change. `entry()` demands an owned key, so it allocated even for a label the map already held; probing with `get_mut` first removes that clone on every insert after warmup, the label vocabulary being tiny next to the edge count. Same shape as #2084 and #2163.

Net effect per edge insert: **two of the four label copies are gone**. Per `<-[:TYPE]-` hop and per edge removal: **all probe-key allocations are gone**.

### What this deliberately does not do, and why

#2089 is named for wiring the `LabelTable`, and that is not here. While implementing, I found a constraint the issue does not record and posted it there in full ([comment](https://github.com/cyberlife-coder/VelesDB/issues/2089#issuecomment-5479774236)):

`by_label` and `outgoing_by_label` are **serialized** fields of `EdgeStore`. Persistence goes through `PostcardPersistence`, a blanket trait over raw postcard bytes — postcard is not self-describing and **there is no format version anywhere in the path**. The existing `#[serde(skip)]` comment on `incoming_by_label` already says as much. Worse, `helpers.rs` records that a file `load_from_file` rejects means *"callers would fall back to an empty store, losing data"* — so a key-type change on a serialized index does not fail loudly, it can present as an empty graph.

So this PR touches only what is provably format-neutral: `incoming_by_label` is `#[serde(skip)]` and rebuilt on load, and `by_label` keeps its type. `outgoing_by_label` and the `LabelTable` interning proper stay open on #2089, pending the same format decision #2090 needs for BM25.

Partially addresses #2089.

## Type of Change

- [x] ⚡ Performance improvement

## How Has This Been Tested?

- [x] Unit tests

`cargo test -p velesdb-core --features persistence -- --test-threads=1` — **6473 passed, 0 failed** across 69 suites (lib suite 5436, up from 5434 by the two tests added here).

`cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean. `cargo fmt --all` applied.

Two tests added, both covering behaviour this change is responsible for:

- `test_incoming_label_index_prunes_emptied_entries` — the nested index must drop a label once its last edge goes, and drop the node entry once its last label goes. The composite key never pruned the node level at all, so this is new behaviour, not a regression guard.
- `test_rebuild_incoming_label_index_matches_live_edges` — rebuilding from live edges reproduces what the inserts built. This is the path a postcard load actually takes, since the index is `serde(skip)`.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified.

## High-Risk Change Checklist

Not a `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path, but it does touch an index that participates in persistence, so:

- [x] **Invariants impacted.** `incoming_by_label` must hold exactly the edge ids whose target is the outer key and whose label is the inner key; it must contain no empty `Vec`, no empty inner map, and no node entry without labels. The last two are newly enforced and covered by the added test.
- [x] **Durability semantics.** Unchanged, and that is the point: no serialized field moves. `incoming_by_label` remains `#[serde(skip)]` and derived, so `edge_store.bin` keeps the layout `develop` writes and reads.
- [x] **Lifecycle tests.** The rebuild path — what runs after a snapshot load — is covered by the second added test.
- [ ] Two reviewers: leaving to maintainer judgement, given no serialized field changes.

## Additional Notes

No wall-clock figure is claimed here on purpose. The change removes allocations, which is provable by inspection; whether that shows up as latency at a given graph size is a separate question, and this container had just spent 450 s compiling and running the suite. Measuring on a machine in that state is precisely the error documented at length on #2075, where a busy container showed 22–25 % spread against an idle floor of 0.35 %. If a number is wanted, `edge_store_benchmark` (`add_edge`, `cascade_delete`) is the right instrument, run on an idle machine with each arm run twice.