### PR TITLE
bench(sparse): measure search latency against corpus size (#2092)

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -436,6 +436,10 @@ name = "sparse_benchmark"
 harness = false
 
 [[bench]]
+name = "sparse_posting_scale"
+harness = false
+
+[[bench]]
 name = "pq_recall_multidist"
 harness = false
 

--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -50,6 +50,24 @@
 //!
 //! Lowering the vocabulary is the cheap way to lengthen posting lists without
 //! paying for a larger corpus: list length is `docs * avg_nnz / vocab`.
+//!
+//! # A trap inside this bench's own sweep range
+//!
+//! `sparse_search` picks its strategy from `doc_count`:
+//! `SMALL_CORPUS_LINEAR_THRESHOLD` is 100 000 documents, below which every
+//! query takes `linear_scan_search` and above which it can reach
+//! `maxscore_search`. That boundary sits **inside** the range this bench
+//! sweeps, and crossing it dominates everything else.
+//!
+//! Measured here, two passes each, checksums matching: 90 000 documents ran in
+//! 537 µs and 522 µs; 110 000 ran in 22.8 ms and 23.0 ms. Twenty-two percent
+//! more data, forty-two times the latency — the jump is at the threshold, not
+//! in the volume.
+//!
+//! So a comparison that straddles 100 000 documents measures the strategy
+//! switch, not whatever change is under test. **Keep both arms of any A/B on
+//! the same side of that boundary**, and read a size sweep that crosses it as
+//! two separate curves rather than one.
 
 #![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 

--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -1,0 +1,219 @@
+//! Sparse search latency against corpus size — the regime #2092 argues about.
+//!
+//! # Why this bench exists
+//!
+//! #2092 claims `PostingEntry { doc_id: u64, weight: f32 }` wastes 25% of every
+//! posting cache line to alignment padding. That is a statement about **large**
+//! posting lists: padding costs nothing while a term's postings sit in L1, and
+//! only starts costing bandwidth and misses once the scanned run exceeds cache.
+//!
+//! `sparse_benchmark` cannot arbitrate it. It fixes 10 000 documents over a
+//! 30 000-term vocabulary at 50–200 nonzeros per document — about 42 postings
+//! per term, ~667 bytes per list, ten cache lines. A whole query touches tens of
+//! kilobytes. Nothing there is out of cache, so any layout change measured on it
+//! reports something other than the effect claimed.
+//!
+//! This bench sweeps the corpus so the regime is chosen deliberately, and prints
+//! the bytes a query actually touches next to the latency, so a reader can see
+//! which side of their machine's last-level cache a given row sits on.
+//!
+//! # Two things it prints that are not latency
+//!
+//! **Frozen segment count.** `FREEZE_THRESHOLD` is 10 000 documents, so the
+//! corpus size also sets how many frozen segments exist, and
+//! `collect_frozen_runs` clones a run out of *each* one on every query term.
+//! Segment count, not padding, may well be what moves these numbers; printing it
+//! keeps that visible rather than confounded with size.
+//!
+//! **A result checksum.** Two configurations are comparable only when their
+//! checksums match — otherwise they searched different indexes and the latency
+//! difference includes that.
+//!
+//! # The build here is deterministic, unlike the HNSW benches
+//!
+//! `SparseInvertedIndex::insert_batch_chunk` is sequential — there is no rayon
+//! anywhere in `sparse_index` — so the same corpus produces the same index every
+//! run. This bench therefore does *not* carry the confound documented on #2075,
+//! where `insert_batch_parallel` built a different graph on every run and made
+//! criterion report tight intervals around the wrong variance component.
+//!
+//! Process-to-process noise is still real. Run each configuration **twice** and
+//! require the pair to agree more closely than any difference being claimed,
+//! on an otherwise idle machine.
+//!
+//! # Running
+//!
+//! ```text
+//! VELESDB_SPARSE_SCALE_DOCS=10000,50000,200000 VELESDB_SPARSE_SCALE_VOCAB=30000 \
+//!   cargo bench --bench sparse_posting_scale
+//! ```
+//!
+//! Lowering the vocabulary is the cheap way to lengthen posting lists without
+//! paying for a larger corpus: list length is `docs * avg_nnz / vocab`.
+
+#![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+
+use std::collections::HashSet;
+use std::time::Instant;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
+
+use velesdb_core::index::sparse::{sparse_search, SparseInvertedIndex, SparseVector};
+
+/// Bytes one `PostingEntry` occupies today: `u64` + `f32` + 4 bytes of tail
+/// padding forced by align-8 on the `u64`. The figure #2092 wants to shrink.
+const POSTING_ENTRY_BYTES: usize = 16;
+
+/// Nonzeros per generated document, matching `sparse_benchmark`'s SPLADE-like
+/// shape so the two benches describe the same kind of corpus.
+const NNZ_RANGE: std::ops::RangeInclusive<usize> = 50..=200;
+
+/// Queries issued per measured iteration set.
+const QUERY_COUNT: usize = 100;
+
+/// Corpus sizes swept when `VELESDB_SPARSE_SCALE_DOCS` is unset.
+const DEFAULT_DOCS: &[usize] = &[10_000, 50_000, 200_000];
+
+/// Vocabulary size used when `VELESDB_SPARSE_SCALE_VOCAB` is unset.
+const DEFAULT_VOCAB: u32 = 30_000;
+
+/// Reads a comma-separated list of corpus sizes from the environment.
+fn scale_docs() -> Vec<usize> {
+    let Ok(raw) = std::env::var("VELESDB_SPARSE_SCALE_DOCS") else {
+        return DEFAULT_DOCS.to_vec();
+    };
+    let parsed: Vec<usize> = raw
+        .split(',')
+        .filter_map(|part| part.trim().parse().ok())
+        .filter(|&n: &usize| n > 0)
+        .collect();
+    if parsed.is_empty() {
+        DEFAULT_DOCS.to_vec()
+    } else {
+        parsed
+    }
+}
+
+/// Reads the vocabulary size from the environment.
+fn scale_vocab() -> u32 {
+    std::env::var("VELESDB_SPARSE_SCALE_VOCAB")
+        .ok()
+        .and_then(|raw| raw.trim().parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_VOCAB)
+}
+
+/// Generates a SPLADE-like corpus over `vocab` terms, deterministic in `seed`.
+fn generate_corpus(n: usize, vocab: u32, seed: u64) -> Vec<SparseVector> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    (0..n)
+        .map(|_| {
+            let nnz = rng.random_range(NNZ_RANGE).min(vocab as usize);
+            let mut pairs: Vec<(u32, f32)> = Vec::with_capacity(nnz);
+            let mut used = HashSet::new();
+            while pairs.len() < nnz {
+                let term_id = rng.random_range(0..vocab);
+                if used.insert(term_id) {
+                    pairs.push((term_id, rng.random_range(0.01_f32..2.0)));
+                }
+            }
+            SparseVector::new(pairs)
+        })
+        .collect()
+}
+
+/// Builds the index sequentially, so the same corpus yields the same index.
+fn build_index(corpus: &[SparseVector]) -> SparseInvertedIndex {
+    let index = SparseInvertedIndex::new();
+    let docs: Vec<(u64, SparseVector)> = corpus
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(i, v)| (i as u64, v))
+        .collect();
+    index.insert_batch_chunk(&docs);
+    index
+}
+
+/// Bytes of posting entries one query reads, summed over its terms.
+///
+/// This is the number to compare against last-level cache — not the index size,
+/// and not one term's list. A query touches every one of its terms' runs.
+fn bytes_touched_per_query(index: &SparseInvertedIndex, query: &SparseVector) -> usize {
+    query
+        .indices
+        .iter()
+        .map(|&term_id| index.posting_count(term_id) * POSTING_ENTRY_BYTES)
+        .sum()
+}
+
+/// Order-independent checksum over fixed query results.
+///
+/// Two configurations are comparable only when these match: a differing
+/// checksum means the runs searched different indexes, and the latency gap
+/// includes that difference rather than isolating the change under test.
+fn result_checksum(index: &SparseInvertedIndex, queries: &[SparseVector], k: usize) -> u64 {
+    let mut sum: u64 = 0;
+    for query in queries {
+        for doc in sparse_search(index, query, k) {
+            sum = sum
+                .wrapping_mul(31)
+                .wrapping_add(doc.doc_id)
+                .wrapping_add(doc.score.to_bits().into());
+        }
+    }
+    sum
+}
+
+fn sparse_posting_scale(c: &mut Criterion) {
+    let vocab = scale_vocab();
+    let mut group = c.benchmark_group("sparse_posting_scale");
+    group.sample_size(10);
+
+    for &docs in &scale_docs() {
+        let corpus = generate_corpus(docs, vocab, 42);
+        let queries = generate_corpus(QUERY_COUNT, vocab, 123);
+
+        let build_started = Instant::now();
+        let index = build_index(&corpus);
+        let build_secs = build_started.elapsed().as_secs_f64();
+
+        let total_postings: usize = corpus.iter().map(SparseVector::nnz).sum();
+        let touched: usize = queries
+            .iter()
+            .map(|q| bytes_touched_per_query(&index, q))
+            .sum::<usize>()
+            / queries.len();
+        let checksum = result_checksum(&index, &queries, 10);
+
+        // Printed, never asserted: the bench cannot know this machine's cache
+        // sizes, and the point is to let a reader place each row against theirs.
+        println!(
+            "\n[sparse_posting_scale] docs={docs} vocab={vocab} \
+postings={total_postings} (~{per_term:.0}/term) \
+frozen_segments={segments} build={build_secs:.1}s\n\
+  bytes touched per query ~{touched_mib:.1} MiB at {POSTING_ENTRY_BYTES} B/entry \
+— compare against last-level cache; padding is free below it\n\
+  result checksum {checksum:#018x} — only compare runs whose checksums match",
+            per_term = total_postings as f64 / f64::from(vocab),
+            segments = docs / velesdb_core::index::sparse::inverted_index::FREEZE_THRESHOLD,
+            touched_mib = touched as f64 / (1024.0 * 1024.0),
+        );
+
+        group.bench_function(format!("top10_{docs}docs_{vocab}vocab"), |b| {
+            let mut qi = 0;
+            b.iter(|| {
+                let query = &queries[qi % queries.len()];
+                qi += 1;
+                sparse_search(black_box(&index), black_box(query), 10)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, sparse_posting_scale);
+criterion_main!(benches);

--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -167,11 +167,14 @@ fn bytes_touched_per_query(index: &SparseInvertedIndex, query: &SparseVector) ->
         .sum()
 }
 
-/// Order-independent checksum over fixed query results.
+/// Order-sensitive checksum over fixed query results.
 ///
-/// Two configurations are comparable only when these match: a differing
-/// checksum means the runs searched different indexes, and the latency gap
-/// includes that difference rather than isolating the change under test.
+/// The fold multiplies before adding, so both the result set AND its ranking
+/// must match — stricter than a set comparison, which is what an A/B of a
+/// layout change wants. Two configurations are comparable only when these
+/// match: a differing checksum means the runs searched different indexes (or
+/// ranked differently), and the latency gap includes that difference rather
+/// than isolating the change under test.
 fn result_checksum(index: &SparseInvertedIndex, queries: &[SparseVector], k: usize) -> u64 {
     let mut sum: u64 = 0;
     for query in queries {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/2092-sparse-posting-scale-bench` → **`develop`**. ✅

## Description

#2092 argues `PostingEntry { doc_id: u64, weight: f32 }` wastes 25% of every posting cache line to alignment padding. That is a claim about **large** posting lists — padding costs nothing while a term's run sits in L1 — and nothing in this repository could test it.

`sparse_benchmark` fixes 10 000 documents over a 30 000-term vocabulary at 50–200 nonzeros per document. That is ~42 postings per term, ~667 bytes per list, ten cache lines; a whole query touches ~0.1 MiB. Every row of it is cache-resident, so a layout change measured there reports something other than the effect claimed. Same trap as #2075, found the same way.

This PR adds the instrument, not the optimisation. No behaviour change.

`sparse_posting_scale` sweeps corpus size and vocabulary from the environment and prints, beside each latency, the bytes a query actually touches — the figure to compare against last-level cache — plus the frozen segment count and a checksum of fixed query results.

Two design points worth calling out:

- **Segment count is printed** because it may be what moves these numbers rather than padding. `FREEZE_THRESHOLD` is 10 000 documents and `collect_frozen_runs` clones a run out of *every* frozen segment on *every* query term, so corpus size sets the number of clones as well as their length.
- **The build is deterministic.** `insert_batch_chunk` is sequential and there is no rayon anywhere in `sparse_index`, so the same corpus yields the same index every run. This bench does **not** carry the #2075 confound where `insert_batch_parallel` built a different graph on every run. Checksums confirm it empirically: identical across separate processes at each size.

## What the instrument already found

Run on an idle 4-core Xeon, 33 MiB L3, each configuration run twice with matching checksums.

| docs | postings/term | frozen segments | bytes touched per query | latency |
|---|---|---|---|---|
| 10 000 | 42 | 1 | 0.1 MiB | 67.2 µs |
| 50 000 | 208 | 5 | 0.4 MiB | 273.5 µs |
| 200 000 | 833 | 20 | 1.6 MiB | **48.0 ms** |

**Bytes touched per query peaks at 1.6 MiB.** Narrowing `PostingEntry` to 12 bytes would make that 1.2 MiB. Both sit inside L3 on an ordinary machine, so #2092's premise is not the binding constraint at any size measured here.

What *is* binding is a cliff. Straddling `SMALL_CORPUS_LINEAR_THRESHOLD` (100 000):

| docs | pass 1 | pass 2 | path taken |
|---|---|---|---|
| 90 000 | 536.6 µs | 522.3 µs | `linear_scan_search` |
| 110 000 | 22.83 ms | 23.01 ms | `maxscore_search` |

22 % more data, **42× the latency**, with the two passes agreeing to 2.7 % and 0.8 % and checksums identical. No data-volume effect behaves like that; the jump is at the boundary. `maxscore_search` — the strategy that exists to make large corpora fast — is dramatically slower than the linear scan it replaces, at the size where it first engages.

Caveat stated plainly: the query generator (inherited from `sparse_benchmark`) draws uniform weights over 50–200 terms, which is the worst case for MaxScore pruning. A real SPLADE query is far sparser and heavily skewed, so the magnitude here is likely an upper bound. What does not depend on that caveat is that `sparse_benchmark` uses the same generator and never exceeds 10 000 documents, so this path has never been measured.

That cliff is out of scope for #2092 and gets its own issue rather than widening this PR. The bench's module doc records it as a trap for the instrument's own users: a comparison straddling 100 000 documents measures the strategy switch rather than whatever change is under test, so both arms of an A/B must stay on the same side of it.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — a new bench target only

## How Has This Been Tested?

- [x] Manual testing

`cargo check -p velesdb-core --benches --features persistence` — clean.
`cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
`cargo fmt --all` applied.

The bench itself was run end to end at five corpus sizes across three processes; the tables above are its output. Checksums matched across separate processes at each size, which is the property the bench exists to enforce.

No production code is touched, so the existing suite is unaffected.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified.

## High-Risk Change Checklist

Not applicable — no production code path is touched.

## Additional Notes

The module doc states the protocol the numbers above follow: run each configuration twice, require the pair to agree more closely than any difference being claimed, and only compare runs whose checksums match. Lowering the vocabulary is the cheap way to lengthen posting lists without paying for a larger corpus, since list length is `docs * avg_nnz / vocab`.