### PR TITLE
fix(graph): evict empty index buckets on edge removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`EdgeStore`'s index maps kept an empty bucket alive for every node/label
+  that ever had an edge, instead of evicting the key once its `Vec` emptied.**
+  `purge_incoming_index`, `purge_outgoing_index` and `purge_label_indices` are
+  the three helpers behind every edge-removal path (`remove_edge`,
+  `remove_edge_outgoing_only`, `remove_edge_incoming_only`,
+  `remove_node_edges`), and only one of the five maps they touch
+  (`incoming_by_label`) ever removed its key when the bucket it pointed to
+  went empty — `outgoing`, `incoming`, `by_label` and `outgoing_by_label` kept
+  a stale key mapped to `vec![]` forever. Node ids are effectively never
+  reused, so long-running ingest-then-remove workloads grew these maps
+  without bound. `outgoing`/`incoming` are also the two fields without
+  `#[serde(skip)]`, so their leaked keys were written to every snapshot and
+  survived a reload — unlike the three label indices, which are rebuilt from
+  `edges` on load and so only leaked within a process's lifetime.
+  `csr_snapshot.rs`'s rebuild walks `outgoing_keys()` to size `node_to_index`,
+  so the leak also inflated the cost of every CSR rebuild after add/remove
+  churn. All four helpers now evict the key alongside the existing
+  `incoming_by_label` behaviour they were supposed to match; no format or
+  query-result change, verified by asserting the maps themselves return to
+  empty rather than only checking `get_outgoing`/`get_edges_by_label`, which
+  read the same whether a key is missing or mapped to an empty `Vec`.
+
 - **`AnyCollection::upsert`'s graph arm pays one durability barrier instead of
   one per node (#2153).** The `Vector` and `Metadata` arms reach `crud.rs` and
   pay a single barrier for the whole batch; the `Graph` arm looped the

--- a/crates/velesdb-core/src/collection/graph/edge_removal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_removal.rs
@@ -3,6 +3,13 @@
 //! Extracted from `edge.rs` to keep file NLOC under the 500 threshold.
 //! Contains `remove_edge`, `remove_node_edges`, and the internal
 //! `purge_*` index-cleanup helpers.
+//!
+//! Every `purge_*` helper drops the map key itself once its bucket empties,
+//! not just the `edge_id` inside it — a node or label that no longer has any
+//! edge must not keep a permanently empty `Vec` alive. Node ids are
+//! effectively never reused, so leaving the key behind means `outgoing` and
+//! `incoming` (persisted fields, unlike the `serde(skip)` label indices)
+//! grow without bound under add/remove churn and never shrink back down.
 
 use super::edge::EdgeStore;
 use super::label_table::LabelId;
@@ -97,6 +104,9 @@ impl EdgeStore {
     fn purge_incoming_index(&mut self, edge_id: u64, target_node: u64, label_id: Option<LabelId>) {
         if let Some(ids) = self.incoming.get_mut(&target_node) {
             ids.retain(|&id| id != edge_id);
+            if ids.is_empty() {
+                self.incoming.remove(&target_node);
+            }
         }
         let Some(label_id) = label_id else { return };
         if let Some(ids) = self.incoming_by_label.get_mut(&(target_node, label_id)) {
@@ -112,6 +122,9 @@ impl EdgeStore {
     fn purge_outgoing_index(&mut self, edge_id: u64, source_node: u64) {
         if let Some(ids) = self.outgoing.get_mut(&source_node) {
             ids.retain(|&id| id != edge_id);
+            if ids.is_empty() {
+                self.outgoing.remove(&source_node);
+            }
         }
     }
 
@@ -123,9 +136,15 @@ impl EdgeStore {
         let Some(label_id) = label_id else { return };
         if let Some(ids) = self.by_label.get_mut(&label_id) {
             ids.retain(|&id| id != edge_id);
+            if ids.is_empty() {
+                self.by_label.remove(&label_id);
+            }
         }
         if let Some(ids) = self.outgoing_by_label.get_mut(&(source_node, label_id)) {
             ids.retain(|&id| id != edge_id);
+            if ids.is_empty() {
+                self.outgoing_by_label.remove(&(source_node, label_id));
+            }
         }
     }
 }

--- a/crates/velesdb-core/src/collection/graph/edge_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_tests.rs
@@ -662,6 +662,45 @@ fn test_remove_node_edges_evicts_empty_index_buckets_on_other_endpoint() {
     assert!(store.incoming_by_label.is_empty());
 }
 
+/// Same eviction contract via `remove_edge_outgoing_only`, the cross-shard
+/// removal path `ConcurrentEdgeStore` uses when it owns only the source
+/// shard's half of an edge.
+#[test]
+fn test_remove_edge_outgoing_only_evicts_empty_index_buckets() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge_outgoing_only(GraphEdge::new(1, 100, 200, "KNOWS").expect("valid"))
+        .expect("add");
+
+    store.remove_edge_outgoing_only(1);
+
+    assert!(
+        !store.outgoing.contains_key(&100),
+        "empty outgoing bucket for 100 should be evicted, not left empty"
+    );
+    assert!(store.by_label.is_empty());
+    assert!(store.outgoing_by_label.is_empty());
+}
+
+/// Same eviction contract via `remove_edge_incoming_only`, the cross-shard
+/// removal path `ConcurrentEdgeStore` uses when it owns only the target
+/// shard's half of an edge.
+#[test]
+fn test_remove_edge_incoming_only_evicts_empty_index_buckets() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge_incoming_only(GraphEdge::new(1, 100, 200, "KNOWS").expect("valid"))
+        .expect("add");
+
+    store.remove_edge_incoming_only(1);
+
+    assert!(
+        !store.incoming.contains_key(&200),
+        "empty incoming bucket for 200 should be evicted, not left empty"
+    );
+    assert!(store.incoming_by_label.is_empty());
+}
+
 // =============================================================================
 // G1: CSR Snapshot — zero-copy BFS via contiguous memory layout
 // =============================================================================

--- a/crates/velesdb-core/src/collection/graph/edge_tests.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_tests.rs
@@ -598,6 +598,70 @@ fn test_remove_node_edges_cleans_label_index() {
     assert!(store.get_edges_by_label("FOLLOWS").is_empty());
 }
 
+/// A node/label whose last edge is removed must not keep an empty bucket
+/// alive in the index maps — `get_*` looking empty isn't enough to prove
+/// that, since a missing key and a key mapped to an empty `Vec` both read as
+/// empty through that API. `outgoing`/`incoming` are persisted fields, so a
+/// leaked key here also bloats every snapshot going forward.
+#[test]
+fn test_remove_edge_evicts_empty_index_buckets() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 100, 200, "KNOWS").expect("valid"))
+        .expect("add");
+
+    store.remove_edge(1);
+
+    assert!(
+        !store.outgoing.contains_key(&100),
+        "empty outgoing bucket for 100 should be evicted, not left empty"
+    );
+    assert!(
+        !store.incoming.contains_key(&200),
+        "empty incoming bucket for 200 should be evicted, not left empty"
+    );
+    assert!(
+        store.by_label.is_empty(),
+        "empty by_label bucket for KNOWS should be evicted, not left empty"
+    );
+    assert!(
+        store.outgoing_by_label.is_empty(),
+        "empty outgoing_by_label bucket should be evicted, not left empty"
+    );
+    assert!(
+        store.incoming_by_label.is_empty(),
+        "empty incoming_by_label bucket should be evicted, not left empty"
+    );
+}
+
+/// Same eviction contract via the cascade-delete path (`remove_node_edges`),
+/// which purges the *other* endpoint of each edge through the same
+/// `purge_incoming_index`/`purge_outgoing_index`/`purge_label_indices` helpers.
+#[test]
+fn test_remove_node_edges_evicts_empty_index_buckets_on_other_endpoint() {
+    let mut store = EdgeStore::new();
+    store
+        .add_edge(GraphEdge::new(1, 100, 200, "KNOWS").expect("valid"))
+        .expect("add");
+    store
+        .add_edge(GraphEdge::new(2, 300, 100, "FOLLOWS").expect("valid"))
+        .expect("add");
+
+    store.remove_node_edges(100);
+
+    assert!(
+        !store.incoming.contains_key(&200),
+        "node 100's own removal must not leave an empty bucket at the far endpoint"
+    );
+    assert!(
+        !store.outgoing.contains_key(&300),
+        "node 100's own removal must not leave an empty bucket at the far endpoint"
+    );
+    assert!(store.by_label.is_empty());
+    assert!(store.outgoing_by_label.is_empty());
+    assert!(store.incoming_by_label.is_empty());
+}
+
 // =============================================================================
 // G1: CSR Snapshot — zero-copy BFS via contiguous memory layout
 // =============================================================================


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`EdgeStore` removes an edge from five internal maps through three shared `purge_*` helpers (`purge_incoming_index`, `purge_outgoing_index`, `purge_label_indices`), called from every removal path: `remove_edge`, `remove_edge_outgoing_only`, `remove_edge_incoming_only`, `remove_node_edges`.

Only one of the five maps they touch — `incoming_by_label` — ever removed its key once the bucket it pointed to went empty. `outgoing`, `incoming`, `by_label` and `outgoing_by_label` kept a stale key mapped to an empty `Vec` forever, even though `purge_label_indices`'s own doc comment claims the "same `None` contract as `purge_incoming_index`" — parity that held for the `None` short-circuit but not for the emptiness pruning.

Node ids are effectively never reused, so a long-running ingest-then-remove workload grows these maps without bound:
- `outgoing_keys()` (walked by every CSR snapshot rebuild in `csr_snapshot.rs`) returns a stale id for as long as the process runs, inflating the cost of every rebuild after add/remove churn.
- `outgoing`/`incoming` are the two fields *without* `#[serde(skip)]` (unlike the three label indices), so their leaked keys are written to every snapshot and survive a reload. The label indices are rebuilt from `edges` on load and so only leak within one process's lifetime.

Fixes # (no tracked issue — found during a routine codebase review)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- Added `test_remove_edge_evicts_empty_index_buckets` and `test_remove_node_edges_evicts_empty_index_buckets_on_other_endpoint` to `edge_tests.rs`, asserting directly on the index maps (`get_outgoing`/`get_edges_by_label` read identically whether a key is missing or maps to an empty `Vec`, so the existing suite never caught this).
- `cargo test -p velesdb-core --features persistence --lib -- --test-threads=1` — **5439 passed, 0 failed, 16 ignored** (full lib suite).
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean.
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- `cargo fmt --all -- --check` — clean.
- `scripts/check_prod_unwraps.py`, `scripts/check-ai-attribution.py`, `scripts/check-doc-freshness.py` (all guards), `scripts/check-perf-claims.py`, `scripts/check-feature-claims.py`, `scripts/check-promise-contract.py` — all pass.

**Test Configuration:**
- OS: Linux
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published (none)

## Unsafe Code Checklist

N/A — no `unsafe` code added or modified.

## High-Risk Change Checklist

N/A — this touches the graph module's in-memory index bookkeeping, not `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch.

## Additional Notes

Pure in-memory bookkeeping fix: the serde schema of `outgoing`/`incoming` (`HashMap<u64, Vec<u64>>`) is unchanged — only which keys are present shrinks. The three label indices are already `#[serde(skip)]` and rebuilt on load, so nothing about the on-disk format changes.