### PR TITLE
fix(bench): ask the compiler for PostingEntry's size instead of writing 16

### DIFF
--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -78,11 +78,24 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
-use velesdb_core::index::sparse::{sparse_search, SparseInvertedIndex, SparseVector};
+use velesdb_core::index::sparse::{sparse_search, PostingEntry, SparseInvertedIndex, SparseVector};
 
-/// Bytes one `PostingEntry` occupies today: `u64` + `f32` + 4 bytes of tail
-/// padding forced by align-8 on the `u64`. The figure #2092 wants to shrink.
-const POSTING_ENTRY_BYTES: usize = 16;
+/// Bytes one `PostingEntry` occupies — asked of the compiler, never written
+/// down.
+///
+/// This bench exists to arbitrate #2092, whose proposal is to shrink this
+/// exact struct. A literal here would keep reporting the pre-change footprint
+/// for post-change code: the `bytes touched per query` line — the one figure
+/// this file is built to produce — would read identically before and after the
+/// shrink, and an A/B would conclude the layout change did nothing. The
+/// instrument would be blind to the only change it exists to measure.
+///
+/// Same defect class as #2165, where the adjacency bench printed a width it
+/// could not observe. There the neighbour id type was `pub(crate)` and the
+/// honest fix was to print both plausible widths; `PostingEntry` is `pub` and
+/// reachable through the path this file already imports, so here the compiler
+/// can simply be asked.
+const POSTING_ENTRY_BYTES: usize = std::mem::size_of::<PostingEntry>();
 
 /// Nonzeros per generated document, matching `sparse_benchmark`'s SPLADE-like
 /// shape so the two benches describe the same kind of corpus.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Follow-up to #2176, from an adversarial re-read of the bench it merged.

`sparse_posting_scale` exists to arbitrate #2092, whose proposal is to shrink `PostingEntry` from 16 bytes to 12. Its byte figure was a literal:

```rust
const POSTING_ENTRY_BYTES: usize = 16;
```

So the instrument was **blind to the one change it was built to measure.** After that shrink lands, the bench would still compute bytes-touched at 16 B/entry and still print `at 16 B/entry` — reporting the pre-change footprint for post-change code. Someone running the A/B the bench exists for would read an unchanged byte figure across both arms and conclude the layout change did nothing to the footprint, when in fact it cut it by a quarter. The `bytes touched per query` line is the single number this file is built to produce and the one #2176's own analysis compares against L3.

`PostingEntry` is `pub` and re-exported through `velesdb_core::index::sparse` — the exact path this bench already imports from — so `size_of::<PostingEntry>()` is a const expression available right here.

This is the same defect class as #2165, which fixed the adjacency bench printing a width it could not observe. The difference is what makes this fix stronger: there the neighbour id type is `pub(crate)` and genuinely invisible from a bench binary, so the honest answer was to print both plausible widths and say which question the bench cannot answer. Here the type is visible, so the compiler can simply be asked.

It is also what AGENTS.md principle 6 asks for in as many words: *an invariant belongs to the compiler first, to a test second, to prose never — "kept in lock-step" as a comment is a bug report waiting to happen.* The old constant carried its layout derivation (`u64` + `f32` + 4 bytes of tail padding) in prose; that prose is now unnecessary.

**Nothing already published is wrong.** `PostingEntry` is `#[repr(C)]` and measures 16 bytes today, so every figure on #2176 stands and the printed line is byte-identical. The defect is latent: it becomes a wrong number only once someone acts on #2092.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

| check | result |
|---|---|
| `size_of::<PostingEntry>()` reachable and correct from a bench target | verified with a throwaway probe bench: prints `size_of = 16`, `align_of = 8` — the substitution is available and behaviour-preserving today |
| bench runs, output unchanged | `VELESDB_SPARSE_SCALE_DOCS=3000 VELESDB_SPARSE_SCALE_VOCAB=2000 cargo bench --bench sparse_posting_scale` → `bytes touched per query ~0.4 MiB at 16 B/entry`, byte-identical wording to before |
| `cargo clippy -p velesdb-core --bench sparse_posting_scale --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` | clean |
| `cargo fmt --all` | applied, clean |
| `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` | PASSED |

No production code is touched, so the test suite is unaffected.

**Test Configuration:**
- OS: Linux 6.18.44, 4-core Xeon @ 2.80 GHz
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (the const's doc comment now records why the value is compiler-derived, and cites the #2165 precedent)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — `size_of::<T>()` tracking `T` is a language guarantee, not a property a test can add confidence to; what needed proving was that the expression is *available* here, which the probe above established
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — bench-only, one constant.

## Additional Notes

The rest of the bench survived the same adversarial pass without findings, and the checks are worth recording so the next reader does not redo them:

- **The frozen-segment formula** (`docs / FREEZE_THRESHOLD`) uses the real public constant, and the freeze condition is `doc_count >= FREEZE_THRESHOLD`, so the count is exact at every size the default sweep uses. There is no public segment accessor to prefer over it.
- **The query-cycling `qi` counter** inside `b.iter` makes each iteration use a different query, so the reported latency is a mean over the 100 generated queries rather than one query's — deliberate, and the checksum still pins the result set.
- **The corpus generator cannot hang** on a small vocabulary: `nnz` is capped at `vocab`, so the dedup loop is a terminating coupon-collector draw, and `scale_vocab` filters `0` before it can produce an empty range.
- **The `f64::from(vocab)` conversion** is lossless and avoids the cast lint the file otherwise allows.