### PR TITLE
perf(bm25): intern terms in a dictionary, key documents by TermId

### DIFF
--- a/crates/velesdb-core/src/index/bm25.rs
+++ b/crates/velesdb-core/src/index/bm25.rs
@@ -38,6 +38,7 @@
 //! // Returns [(1, score)] - document 1 matches "rust"
 //! ```
 
+use super::bm25_term_dict::{TermDict, TermId};
 use super::posting_list::PostingList;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
@@ -59,10 +60,14 @@ impl Default for Bm25Params {
 }
 
 /// A document stored in the BM25 index.
+///
+/// Terms are stored as [`TermId`]s resolved against the owning index's
+/// [`TermDict`] (#2090) — the term string itself lives once in the
+/// dictionary, not once per document.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct Document {
     /// Term frequencies in this document
-    pub(crate) term_freqs: FxHashMap<String, u32>,
+    pub(crate) term_freqs: FxHashMap<TermId, u32>,
     /// Total number of terms in the document
     pub(crate) length: u32,
 }
@@ -79,6 +84,11 @@ pub(crate) struct Bm25Snapshot {
     /// Schema version for forward-compat (bump on breaking changes).
     pub(crate) version: u32,
     pub(crate) params: Bm25Params,
+    /// Interned terms indexed by [`TermId`] — the wire form of the
+    /// index's [`TermDict`]. Version-1 snapshots (no dictionary,
+    /// `String`-keyed documents) are migrated on load by
+    /// [`super::bm25_term_dict::parse_snapshot`].
+    pub(crate) term_dict: Vec<String>,
     pub(crate) documents: FxHashMap<u64, Document>,
     pub(crate) point_to_doc: FxHashMap<u64, u32>,
     pub(crate) doc_to_point: FxHashMap<u32, u64>,
@@ -89,7 +99,11 @@ pub(crate) struct Bm25Snapshot {
 }
 
 /// Current [`Bm25Snapshot`] schema version. Bump on breaking changes.
-pub(crate) const BM25_SNAPSHOT_VERSION: u32 = 1;
+///
+/// Version 2 (#2090): terms interned in a `term_dict`, documents keyed
+/// by [`TermId`]. Version 1 (`String`-keyed documents) is still readable
+/// via [`super::bm25_term_dict::parse_snapshot`].
+pub(crate) const BM25_SNAPSHOT_VERSION: u32 = 2;
 
 /// BM25 full-text search index.
 ///
@@ -104,8 +118,17 @@ pub(crate) const BM25_SNAPSHOT_VERSION: u32 = 1;
 pub struct Bm25Index {
     /// BM25 parameters
     params: Bm25Params,
-    /// Inverted index: term -> adaptive posting list (auto-promotes to Roaring)
-    inverted_index: RwLock<FxHashMap<String, PostingList>>,
+    /// Term dictionary: term string -> [`TermId`] (#2090). Grows
+    /// monotonically — removing a document never un-interns terms.
+    ///
+    /// Lock order (stable across all paths): `term_dict` →
+    /// `inverted_index` → `documents` → `point_to_doc` → `doc_to_point`
+    /// → `free_doc_ids` → `next_doc_id` → `doc_count` →
+    /// `total_doc_length`. No path takes a lower-positioned lock while
+    /// holding a higher-positioned one.
+    term_dict: RwLock<TermDict>,
+    /// Inverted index: term id -> adaptive posting list (auto-promotes to Roaring)
+    inverted_index: RwLock<FxHashMap<TermId, PostingList>>,
     /// Document storage: id -> Document
     documents: RwLock<FxHashMap<u64, Document>>,
     /// Point ID -> internal BM25 doc ID mapping.
@@ -134,6 +157,7 @@ impl Bm25Index {
     pub fn with_params(params: Bm25Params) -> Self {
         Self {
             params,
+            term_dict: RwLock::new(TermDict::default()),
             inverted_index: RwLock::new(FxHashMap::default()),
             documents: RwLock::new(FxHashMap::default()),
             point_to_doc: RwLock::new(FxHashMap::default()),
@@ -169,20 +193,7 @@ impl Bm25Index {
             return;
         }
 
-        // Count term frequencies.
-        //
-        // Look up by &str BEFORE inserting: `entry()` demands an owned key,
-        // which would allocate one String per token even for repeats within
-        // the same document. The owned copy is made only the first time a
-        // token is seen in this document.
-        let mut term_freqs: FxHashMap<String, u32> = FxHashMap::default();
-        for token in &tokens {
-            if let Some(count) = term_freqs.get_mut(token.as_str()) {
-                *count += 1;
-            } else {
-                term_freqs.insert(token.clone(), 1);
-            }
-        }
+        let term_freqs = self.intern_term_freqs(&tokens);
 
         // Reason: Document token count is bounded by practical text length limits.
         // Even a 1GB document with single-char tokens would have ~1B tokens, fitting in u32.
@@ -205,23 +216,15 @@ impl Bm25Index {
         };
 
         // Update inverted index with adaptive PostingList.
-        // PostingList auto-promotes to Roaring when cardinality exceeds threshold.
-        //
-        // Look up by &str BEFORE inserting: `entry()` demands an owned key,
-        // which allocates a String per document per term even when the term
-        // is already in the corpus vocabulary (the common case once the
-        // index has ingested more than a handful of documents). The owned
-        // copy is made only on the term's first appearance in the index.
+        // PostingList auto-promotes to Roaring when cardinality exceeds
+        // threshold. `TermId` is `Copy`, so `entry()` allocates nothing.
         {
             let mut inv_idx = self.inverted_index.write();
-            for term in doc.term_freqs.keys() {
-                if let Some(posting_list) = inv_idx.get_mut(term.as_str()) {
-                    posting_list.insert(id_u32);
-                } else {
-                    let mut posting_list = PostingList::new();
-                    posting_list.insert(id_u32);
-                    inv_idx.insert(term.clone(), posting_list);
-                }
+            for term_id in doc.term_freqs.keys() {
+                inv_idx
+                    .entry(*term_id)
+                    .or_insert_with(PostingList::new)
+                    .insert(id_u32);
             }
         }
 
@@ -244,6 +247,29 @@ impl Bm25Index {
             let mut total = self.total_doc_length.write();
             *total += u64::from(doc_length);
         }
+    }
+
+    /// Counts term frequencies, interning each token into the dictionary.
+    ///
+    /// A token already in the corpus vocabulary (the common case once the
+    /// index has ingested more than a handful of documents) costs one hash
+    /// lookup and zero allocations; the term string is copied only on its
+    /// first appearance in the whole index. The dictionary write lock is
+    /// scoped to this function and released before any other index lock is
+    /// taken (lock order: `term_dict` first).
+    fn intern_term_freqs(&self, tokens: &[String]) -> FxHashMap<TermId, u32> {
+        let mut term_freqs: FxHashMap<TermId, u32> = FxHashMap::default();
+        let mut dict = self.term_dict.write();
+        for token in tokens {
+            // Dictionary full (`u32::MAX` distinct terms): skip the term,
+            // mirroring the doc-id overflow contract of `add_document`.
+            let Some(term_id) = dict.intern(token) else {
+                continue;
+            };
+            *term_freqs.entry(term_id).or_insert(0) += 1;
+        }
+        drop(dict);
+        term_freqs
     }
 
     /// Removes a document from the index.
@@ -282,19 +308,35 @@ impl Bm25Index {
             return Vec::new();
         }
 
+        // Resolve query terms to ids once per query. A term absent from the
+        // dictionary appears in no document: its BM25 contribution is
+        // exactly +0.0 (tf == 0 for every candidate), so dropping it here
+        // leaves every score bit-identical. Duplicate query terms are kept —
+        // they contribute once each, as before.
+        let query_ids: Vec<TermId> = {
+            let dict = self.term_dict.read();
+            query_terms
+                .iter()
+                .filter_map(|term| dict.get(term))
+                .collect()
+        };
+        if query_ids.is_empty() {
+            return Vec::new();
+        }
+
         let total_length = *self.total_doc_length.read();
         let avgdl = total_length as f32 / doc_count as f32;
 
-        let mut scores = self.score_candidates(&query_terms, doc_count, avgdl);
+        let mut scores = self.score_candidates(&query_ids, doc_count, avgdl);
         Self::top_k_sort(&mut scores, k);
         scores
     }
 
-    /// Scores all candidate documents for the given query terms.
+    /// Scores all candidate documents for the given query term ids.
     #[allow(clippy::cast_precision_loss)]
     fn score_candidates(
         &self,
-        query_terms: &[String],
+        query_ids: &[TermId],
         doc_count: usize,
         avgdl: f32,
     ) -> Vec<(u64, f32)> {
@@ -306,15 +348,15 @@ impl Bm25Index {
         let doc_to_point = self.doc_to_point.read();
         let n = doc_count as f32;
 
-        let idf_cache = Self::build_idf_cache(query_terms, &inv_idx, n);
-        let candidate_union = Self::build_candidate_union(query_terms, &inv_idx);
+        let idf_cache = Self::build_idf_cache(query_ids, &inv_idx, n);
+        let candidate_union = Self::build_candidate_union(query_ids, &inv_idx);
 
         let scored = candidate_union
             .iter()
             .filter_map(|doc_id_u32| {
                 let doc_id = *doc_to_point.get(&doc_id_u32)?;
                 let doc = docs.get(&doc_id)?;
-                let score = Self::score_document_fast(doc, query_terms, &idf_cache, k1, b, avgdl);
+                let score = Self::score_document_fast(doc, query_ids, &idf_cache, k1, b, avgdl);
                 (score > 0.0).then_some((doc_id, score))
             })
             .collect();
@@ -324,36 +366,36 @@ impl Bm25Index {
         scored
     }
 
-    /// Builds an IDF cache for each query term.
+    /// Builds an IDF cache for each query term id.
     #[allow(clippy::cast_precision_loss)]
-    fn build_idf_cache<'a>(
-        query_terms: &'a [String],
-        inv_idx: &FxHashMap<String, PostingList>,
+    fn build_idf_cache(
+        query_ids: &[TermId],
+        inv_idx: &FxHashMap<TermId, PostingList>,
         n: f32,
-    ) -> FxHashMap<&'a str, f32> {
-        query_terms
+    ) -> FxHashMap<TermId, f32> {
+        query_ids
             .iter()
-            .map(|term| {
-                let df = inv_idx.get(term).map_or(0, PostingList::len);
+            .map(|&id| {
+                let df = inv_idx.get(&id).map_or(0, PostingList::len);
                 let idf_val = if df == 0 {
                     0.0
                 } else {
                     let df_f = df as f32;
                     ((n - df_f + 0.5) / (df_f + 0.5) + 1.0).ln()
                 };
-                (term.as_str(), idf_val)
+                (id, idf_val)
             })
             .collect()
     }
 
-    /// Builds a union of posting lists for all query terms.
+    /// Builds a union of posting lists for all query term ids.
     fn build_candidate_union(
-        query_terms: &[String],
-        inv_idx: &FxHashMap<String, PostingList>,
+        query_ids: &[TermId],
+        inv_idx: &FxHashMap<TermId, PostingList>,
     ) -> PostingList {
         let mut candidate_union = PostingList::new();
-        for term in query_terms {
-            if let Some(posting_list) = inv_idx.get(term) {
+        for id in query_ids {
+            if let Some(posting_list) = inv_idx.get(id) {
                 candidate_union = candidate_union.union(posting_list);
             }
         }
@@ -371,8 +413,8 @@ impl Bm25Index {
     #[allow(clippy::cast_precision_loss)]
     fn score_document_fast(
         doc: &Document,
-        query_terms: &[String],
-        idf_cache: &FxHashMap<&str, f32>,
+        query_ids: &[TermId],
+        idf_cache: &FxHashMap<TermId, f32>,
         k1: f32,
         b: f32,
         avgdl: f32,
@@ -380,15 +422,15 @@ impl Bm25Index {
         let doc_len = doc.length as f32;
         let len_norm = 1.0 - b + b * doc_len / avgdl;
 
-        query_terms
+        query_ids
             .iter()
-            .map(|term| {
-                let tf = doc.term_freqs.get(term).copied().unwrap_or(0) as f32;
+            .map(|id| {
+                let tf = doc.term_freqs.get(id).copied().unwrap_or(0) as f32;
                 if tf == 0.0 {
                     return 0.0;
                 }
 
-                let idf = idf_cache.get(term.as_str()).copied().unwrap_or(0.0);
+                let idf = idf_cache.get(id).copied().unwrap_or(0.0);
 
                 // BM25 term score (optimized: len_norm pre-computed)
                 let numerator = tf * (k1 + 1.0);
@@ -523,11 +565,12 @@ impl Bm25Index {
     #[must_use]
     pub(crate) fn to_snapshot(&self) -> Bm25Snapshot {
         // Lock acquisition order (stable across to_snapshot / load paths):
-        //   documents → point_to_doc → doc_to_point → free_doc_ids
-        //   → next_doc_id → doc_count → total_doc_length.
+        //   term_dict → documents → point_to_doc → doc_to_point
+        //   → free_doc_ids → next_doc_id → doc_count → total_doc_length.
         // Holding multiple read locks simultaneously is safe: parking_lot
         // RwLock reads never block each other, and no code path takes a
         // write lock *after* a read lock on a lower-positioned field.
+        let term_dict = self.term_dict.read();
         let documents = self.documents.read();
         let point_to_doc = self.point_to_doc.read();
         let doc_to_point = self.doc_to_point.read();
@@ -538,6 +581,7 @@ impl Bm25Index {
         Bm25Snapshot {
             version: BM25_SNAPSHOT_VERSION,
             params: self.params,
+            term_dict: term_dict.to_strings(),
             documents: documents.clone(),
             point_to_doc: point_to_doc.clone(),
             doc_to_point: doc_to_point.clone(),
@@ -588,9 +632,9 @@ impl Bm25Index {
                     );
                     continue;
                 };
-                for term in doc.term_freqs.keys() {
+                for term_id in doc.term_freqs.keys() {
                     inv_idx
-                        .entry(term.clone())
+                        .entry(*term_id)
                         .or_insert_with(PostingList::new)
                         .insert(doc_id_u32);
                 }
@@ -598,6 +642,7 @@ impl Bm25Index {
         }
 
         // Install primary state under the same lock order as to_snapshot.
+        *index.term_dict.write() = TermDict::from_strings(std::mem::take(&mut snapshot.term_dict));
         *index.documents.write() = snapshot.documents;
         *index.point_to_doc.write() = snapshot.point_to_doc;
         *index.doc_to_point.write() = snapshot.doc_to_point;

--- a/crates/velesdb-core/src/index/bm25_persistence.rs
+++ b/crates/velesdb-core/src/index/bm25_persistence.rs
@@ -31,7 +31,8 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
-use crate::index::bm25::{Bm25Index, Bm25Snapshot};
+use crate::index::bm25::Bm25Index;
+use crate::index::bm25_term_dict::parse_snapshot;
 use crate::storage::atomic_write::atomic_write;
 
 /// Snapshot filename under a collection directory.
@@ -79,8 +80,11 @@ pub(crate) fn load_snapshot(dir: &Path) -> Result<Option<Bm25Index>> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => return Err(Error::Index(format!("BM25 snapshot read: {e}"))),
     };
-    let snapshot: Bm25Snapshot = postcard::from_bytes(&bytes)
-        .map_err(|e| Error::Index(format!("BM25 snapshot deserialize: {e}")))?;
+    // `parse_snapshot` dispatches on the leading version field: current
+    // snapshots deserialize directly, version-1 (pre-#2090) snapshots are
+    // migrated in memory. Corruption surfaces as `Err`, per the contract
+    // above.
+    let snapshot = parse_snapshot(&bytes)?;
     Ok(Some(Bm25Index::from_snapshot(snapshot)?))
 }
 

--- a/crates/velesdb-core/src/index/bm25_term_dict.rs
+++ b/crates/velesdb-core/src/index/bm25_term_dict.rs
@@ -1,0 +1,178 @@
+//! Term dictionary for the BM25 index (#2090), plus the legacy snapshot
+//! format it replaced and the migration from it.
+//!
+//! Before #2090 every [`Document`](super::bm25::Document) owned a `String`
+//! per distinct term and the inverted index owned the same term again — the
+//! corpus vocabulary materialized once per document. The dictionary stores
+//! each term once as an `Arc<str>` shared between the id map's key and the
+//! resolve table (the #2089 `LabelTable` treatment), and everything else
+//! keys by [`TermId`].
+
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Interned id of a BM25 term. `u32` bounds the vocabulary at ~4 billion
+/// distinct terms; the id is only meaningful against the index's own
+/// [`TermDict`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct TermId(u32);
+
+/// Interning table mapping term strings to [`TermId`]s.
+///
+/// Grows monotonically: removing a document never un-interns its terms —
+/// the vocabulary is bounded by the corpus's distinct-term count, which is
+/// exactly what this table exists to stop paying per document.
+#[derive(Debug, Default)]
+pub(crate) struct TermDict {
+    /// Interned terms indexed by [`TermId`]. Each entry shares its
+    /// allocation with the `ids` key.
+    terms: Vec<Arc<str>>,
+    /// Reverse lookup: term -> id.
+    ids: FxHashMap<Arc<str>, TermId>,
+}
+
+impl TermDict {
+    /// Interns `term`, returning its id.
+    ///
+    /// Returns `None` when the dictionary is full (`u32::MAX` distinct
+    /// terms) — the same silent-skip contract as BM25's doc-id overflow.
+    pub(crate) fn intern(&mut self, term: &str) -> Option<TermId> {
+        if let Some(&id) = self.ids.get(term) {
+            return Some(id);
+        }
+        let id = TermId(u32::try_from(self.terms.len()).ok()?);
+        let shared: Arc<str> = Arc::from(term);
+        self.terms.push(Arc::clone(&shared));
+        self.ids.insert(shared, id);
+        Some(id)
+    }
+
+    /// Looks up `term` without interning.
+    pub(crate) fn get(&self, term: &str) -> Option<TermId> {
+        self.ids.get(term).copied()
+    }
+
+    /// Snapshot of the dictionary as plain strings, indexed by [`TermId`] —
+    /// the wire representation.
+    pub(crate) fn to_strings(&self) -> Vec<String> {
+        self.terms.iter().map(ToString::to_string).collect()
+    }
+
+    /// Rebuilds a dictionary from its wire representation.
+    ///
+    /// Positions become ids, so a dictionary round-trips exactly.
+    pub(crate) fn from_strings(terms: Vec<String>) -> Self {
+        let mut dict = Self {
+            terms: Vec::with_capacity(terms.len()),
+            ids: FxHashMap::with_capacity_and_hasher(terms.len(), rustc_hash::FxBuildHasher),
+        };
+        for term in terms {
+            let id = TermId(u32::try_from(dict.terms.len()).unwrap_or(u32::MAX));
+            let shared: Arc<str> = Arc::from(term.as_str());
+            dict.terms.push(Arc::clone(&shared));
+            dict.ids.insert(shared, id);
+        }
+        dict
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy (version-1) snapshot wire format and its migration
+// ---------------------------------------------------------------------------
+
+use super::bm25::{Bm25Params, Bm25Snapshot, Document, BM25_SNAPSHOT_VERSION};
+
+/// The version-1 document wire shape: term frequencies keyed by owned
+/// `String`s — the layout #2090 retired.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DocumentV1 {
+    pub(crate) term_freqs: FxHashMap<String, u32>,
+    pub(crate) length: u32,
+}
+
+/// The version-1 snapshot wire shape, kept only to read pre-#2090
+/// `bm25.snapshot` files.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Bm25SnapshotV1 {
+    pub(crate) version: u32,
+    pub(crate) params: Bm25Params,
+    pub(crate) documents: FxHashMap<u64, DocumentV1>,
+    pub(crate) point_to_doc: FxHashMap<u64, u32>,
+    pub(crate) doc_to_point: FxHashMap<u32, u64>,
+    pub(crate) free_doc_ids: Vec<u32>,
+    pub(crate) next_doc_id: u32,
+    pub(crate) doc_count: usize,
+    pub(crate) total_doc_length: u64,
+}
+
+/// Migrates a version-1 snapshot to the current format by interning every
+/// document's term keys into one dictionary.
+///
+/// Term-frequency VALUES and every counter are carried over untouched, so
+/// scoring over a migrated snapshot is bit-identical to scoring over the
+/// original (only the key representation moves — pinned by
+/// `test_v1_snapshot_migrates_and_scores_identically`).
+pub(crate) fn migrate_v1(v1: Bm25SnapshotV1) -> Bm25Snapshot {
+    let mut dict = TermDict::default();
+    let documents: FxHashMap<u64, Document> = v1
+        .documents
+        .into_iter()
+        .map(|(point_id, doc)| {
+            let term_freqs: FxHashMap<TermId, u32> = doc
+                .term_freqs
+                .into_iter()
+                .filter_map(|(term, freq)| dict.intern(&term).map(|id| (id, freq)))
+                .collect();
+            (
+                point_id,
+                Document {
+                    term_freqs,
+                    length: doc.length,
+                },
+            )
+        })
+        .collect();
+    Bm25Snapshot {
+        version: BM25_SNAPSHOT_VERSION,
+        params: v1.params,
+        term_dict: dict.to_strings(),
+        documents,
+        point_to_doc: v1.point_to_doc,
+        doc_to_point: v1.doc_to_point,
+        free_doc_ids: v1.free_doc_ids,
+        next_doc_id: v1.next_doc_id,
+        doc_count: v1.doc_count,
+        total_doc_length: v1.total_doc_length,
+    }
+}
+
+/// Parses snapshot bytes, dispatching on the leading `version` field.
+///
+/// Postcard is positional, so the version is read first on its own and the
+/// full buffer is then re-parsed with the matching struct (both wire shapes
+/// begin with the same `u32 version` field).
+///
+/// # Errors
+///
+/// Returns [`crate::Error::IndexCorrupted`] for unknown versions and
+/// undecodable bytes.
+pub(crate) fn parse_snapshot(bytes: &[u8]) -> crate::Result<Bm25Snapshot> {
+    let (version, _rest) = postcard::take_from_bytes::<u32>(bytes)
+        .map_err(|e| crate::Error::IndexCorrupted(format!("BM25 snapshot header: {e}")))?;
+    match version {
+        1 => {
+            let v1: Bm25SnapshotV1 = postcard::from_bytes(bytes).map_err(|e| {
+                crate::Error::IndexCorrupted(format!("BM25 v1 snapshot deserialize: {e}"))
+            })?;
+            debug_assert_eq!(v1.version, 1);
+            Ok(migrate_v1(v1))
+        }
+        BM25_SNAPSHOT_VERSION => postcard::from_bytes(bytes).map_err(|e| {
+            crate::Error::IndexCorrupted(format!("BM25 snapshot deserialize: {e}"))
+        }),
+        other => Err(crate::Error::IndexCorrupted(format!(
+            "BM25 snapshot version mismatch: got {other}, expected {BM25_SNAPSHOT_VERSION} (or 1 for migration)"
+        ))),
+    }
+}

--- a/crates/velesdb-core/src/index/bm25_term_dict_tests.rs
+++ b/crates/velesdb-core/src/index/bm25_term_dict_tests.rs
@@ -1,0 +1,187 @@
+//! Tests for the BM25 term dictionary, the versioned snapshot parser, and
+//! the v1 → v2 migration (#2090).
+
+use super::bm25::{Bm25Index, Bm25Params, BM25_SNAPSHOT_VERSION};
+use super::bm25_term_dict::{parse_snapshot, TermDict};
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+
+/// Serializable mirror of the version-1 document wire shape. The real
+/// [`super::bm25_term_dict::DocumentV1`] is deserialize-only, so tests
+/// forge legacy bytes through this twin (postcard is positional: same
+/// field order ⇒ same bytes).
+#[derive(Serialize)]
+struct DocV1Wire {
+    term_freqs: FxHashMap<String, u32>,
+    length: u32,
+}
+
+/// Serializable mirror of the version-1 snapshot wire shape.
+#[derive(Serialize)]
+struct SnapV1Wire {
+    version: u32,
+    params: Bm25Params,
+    documents: FxHashMap<u64, DocV1Wire>,
+    point_to_doc: FxHashMap<u64, u32>,
+    doc_to_point: FxHashMap<u32, u64>,
+    free_doc_ids: Vec<u32>,
+    next_doc_id: u32,
+    doc_count: usize,
+    total_doc_length: u64,
+}
+
+const CORPUS: &[(u64, &str)] = &[
+    (10, "rust programming language for systems programming"),
+    (20, "python programming for data science"),
+    (30, "database systems in rust"),
+    (40, "graph database with vector search"),
+];
+
+const QUERIES: &[&str] = &[
+    "rust database",
+    "programming",
+    "vector search systems",
+    "rust rust programming", // duplicate query term
+    "unknown_term rust",     // term absent from the corpus
+    "totally unknown terms", // nothing matches
+];
+
+/// Replicates what the pre-#2090 `add_document` persisted, producing
+/// version-1 snapshot bytes for the given corpus.
+fn v1_snapshot_bytes(corpus: &[(u64, &str)]) -> Vec<u8> {
+    let mut documents = FxHashMap::default();
+    let mut point_to_doc = FxHashMap::default();
+    let mut doc_to_point = FxHashMap::default();
+    let mut total_doc_length = 0u64;
+    for (i, (point_id, text)) in corpus.iter().enumerate() {
+        let doc_id = u32::try_from(i).unwrap();
+        let tokens = Bm25Index::tokenize(text);
+        let mut term_freqs: FxHashMap<String, u32> = FxHashMap::default();
+        for token in &tokens {
+            *term_freqs.entry(token.clone()).or_insert(0) += 1;
+        }
+        let length = u32::try_from(tokens.len()).unwrap();
+        total_doc_length += u64::from(length);
+        documents.insert(*point_id, DocV1Wire { term_freqs, length });
+        point_to_doc.insert(*point_id, doc_id);
+        doc_to_point.insert(doc_id, *point_id);
+    }
+    let snap = SnapV1Wire {
+        version: 1,
+        params: Bm25Params::default(),
+        documents,
+        point_to_doc,
+        doc_to_point,
+        free_doc_ids: Vec::new(),
+        next_doc_id: u32::try_from(corpus.len()).unwrap(),
+        doc_count: corpus.len(),
+        total_doc_length,
+    };
+    postcard::to_allocvec(&snap).unwrap()
+}
+
+/// Builds a fresh index through the public ingestion path.
+fn fresh_index(corpus: &[(u64, &str)]) -> Bm25Index {
+    let index = Bm25Index::new();
+    for (point_id, text) in corpus {
+        index.add_document(*point_id, text);
+    }
+    index
+}
+
+/// Asserts two indexes return identical results — same documents in the
+/// same order with bit-identical scores — for every probe query.
+fn assert_search_identical(a: &Bm25Index, b: &Bm25Index) {
+    for query in QUERIES {
+        let ra = a.search(query, 10);
+        let rb = b.search(query, 10);
+        let ka: Vec<(u64, u32)> = ra.iter().map(|(id, s)| (*id, s.to_bits())).collect();
+        let kb: Vec<(u64, u32)> = rb.iter().map(|(id, s)| (*id, s.to_bits())).collect();
+        assert_eq!(ka, kb, "results diverge for query {query:?}");
+    }
+}
+
+#[test]
+fn test_term_dict_intern_is_idempotent_and_positional() {
+    let mut dict = TermDict::default();
+    let a = dict.intern("alpha").unwrap();
+    let b = dict.intern("beta").unwrap();
+    assert_ne!(a, b);
+    assert_eq!(dict.intern("alpha"), Some(a));
+    assert_eq!(dict.get("alpha"), Some(a));
+    assert_eq!(dict.get("gamma"), None);
+    assert_eq!(
+        dict.to_strings(),
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+}
+
+#[test]
+fn test_term_dict_string_roundtrip_preserves_ids() {
+    let mut dict = TermDict::default();
+    let ids: Vec<_> = ["one", "two", "three"]
+        .iter()
+        .map(|t| dict.intern(t).unwrap())
+        .collect();
+    let rebuilt = TermDict::from_strings(dict.to_strings());
+    for (term, id) in ["one", "two", "three"].iter().zip(ids) {
+        assert_eq!(rebuilt.get(term), Some(id), "id moved for {term:?}");
+    }
+    assert_eq!(rebuilt.to_strings(), dict.to_strings());
+}
+
+#[test]
+fn test_current_snapshot_roundtrips_through_parse() {
+    let index = fresh_index(CORPUS);
+    let bytes = postcard::to_allocvec(&index.to_snapshot()).unwrap();
+    let restored = Bm25Index::from_snapshot(parse_snapshot(&bytes).unwrap()).unwrap();
+    assert_eq!(restored.len(), index.len());
+    assert_eq!(restored.term_count(), index.term_count());
+    assert_search_identical(&index, &restored);
+}
+
+#[test]
+fn test_v1_snapshot_migrates_and_scores_identically() {
+    let bytes = v1_snapshot_bytes(CORPUS);
+    let snapshot = parse_snapshot(&bytes).unwrap();
+    assert_eq!(snapshot.version, BM25_SNAPSHOT_VERSION);
+    let migrated = Bm25Index::from_snapshot(snapshot).unwrap();
+    let reference = fresh_index(CORPUS);
+    assert_eq!(migrated.len(), reference.len());
+    assert_eq!(migrated.term_count(), reference.term_count());
+    assert_search_identical(&migrated, &reference);
+}
+
+#[test]
+fn test_migrated_index_keeps_ingesting() {
+    let migrated =
+        Bm25Index::from_snapshot(parse_snapshot(&v1_snapshot_bytes(CORPUS)).unwrap()).unwrap();
+    // New document mixing known terms (must reuse migrated ids) and a new
+    // one (must intern past the migrated dictionary without collision).
+    migrated.add_document(50, "rust database sharding");
+    let results = migrated.search("sharding", 10);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, 50);
+    // The updated corpus must behave exactly like one built from scratch.
+    let mut corpus: Vec<(u64, &str)> = CORPUS.to_vec();
+    corpus.push((50, "rust database sharding"));
+    assert_search_identical(&migrated, &fresh_index(&corpus));
+}
+
+#[test]
+fn test_unknown_snapshot_version_is_rejected() {
+    let index = fresh_index(CORPUS);
+    let mut snapshot = index.to_snapshot();
+    snapshot.version = 99;
+    let bytes = postcard::to_allocvec(&snapshot).unwrap();
+    let err = parse_snapshot(&bytes).unwrap_err();
+    assert!(
+        err.to_string().contains("version mismatch"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_garbage_bytes_are_rejected() {
+    assert!(parse_snapshot(&[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]).is_err());
+}

--- a/crates/velesdb-core/src/index/mod.rs
+++ b/crates/velesdb-core/src/index/mod.rs
@@ -11,6 +11,9 @@ pub(crate) mod bm25_persistence;
 mod bm25_persistence_tests;
 #[cfg(feature = "persistence")]
 pub(crate) mod bm25_persistence_wal;
+mod bm25_term_dict;
+#[cfg(test)]
+mod bm25_term_dict_tests;
 #[cfg(test)]
 mod bm25_tests;
 pub mod hnsw;


### PR DESCRIPTION
Closes #2090.

## Problem

Every BM25 `Document` owned one `String` per distinct term, and the inverted index owned the same strings again as its keys — the corpus vocabulary materialized once per document. Ingesting, snapshotting and loading all paid for it.

## Approach

The #2089 `LabelTable` playbook, applied to BM25:

- **`TermDict`** interns each term once as an `Arc<str>` shared between the resolve table and the id map. It grows monotonically — removing a document never un-interns, so the table is bounded by the corpus's distinct-term count, which is exactly what it exists to stop paying per document.
- **`Document.term_freqs` and the inverted index key by `TermId`** (`Copy` `u32`), so `entry()` allocates nothing and postings updates stop hashing strings.
- **Search resolves each query term exactly once.** A term absent from the dictionary appears in no document: its contribution was exactly `+0.0`, so dropping it at resolution leaves every score **bit-identical**. Duplicate query terms still contribute once each.
- Lock order is documented on the struct: `term_dict` first, and the dictionary write lock is released before any other index lock is taken.

## Measurements (before → after)

Measured first, per the #2089/#2075 discipline — counting-`GlobalAlloc` harness, 20k docs × 120 tokens, 5k-term vocabulary, 10k queries, release build, deterministic corpus. Baseline numbers are in #2090.

| Metric | Before | After | Δ |
|---|---|---|---|
| Live memory after ingest | 215.1 MB (10,756 B/doc) | 74.1 MB (3,704 B/doc) | **−65.6%** |
| Allocations per doc | 255.1 | 136.5 | −46% |
| Ingest time (20k docs) | 1.35 s | 0.91 s | −33% |
| Snapshot file | 23.45 MB | 7.36 MB | **−68.6%** |
| Snapshot write | 556 ms | 132 ms | −76% |
| Snapshot load | 859 ms | 457 ms | −47% |
| Search per query | 1.39 ms | 0.77 ms | −44% |
| Allocations per query | 30.0 | 31.0 | +1 (id resolution) |

## Persistence & migration

- Snapshot format bumps to **version 2** (`term_dict` vector, `TermId`-keyed documents); `BM25_SNAPSHOT_VERSION = 2`.
- `parse_snapshot` dispatches on the leading postcard `version` field: v2 loads directly, **v1 files migrate in memory** by interning their string keys — frequency values and every counter carried over untouched. Unknown versions and garbage bytes surface as `IndexCorrupted` (fail-fast contract of #618 preserved).
- The WAL stores raw `(point_id, text)` and replays through `add_document`, so it needs no format change.

## Tests

- `test_v1_snapshot_migrates_and_scores_identically` — forges v1 bytes through a serializable twin of the legacy wire shape, migrates, and asserts results are identical to a freshly built index **including bit-identical scores** (`f32::to_bits`).
- `test_migrated_index_keeps_ingesting` — post-migration interning continues past the migrated dictionary without id collision, and the updated corpus behaves exactly like one built from scratch.
- v2 round-trip through `parse_snapshot`, dictionary id-stability round-trip, unknown-version and garbage-byte rejection.
- Full `velesdb-core` lib suite: 5445 passed, 0 failed (`--test-threads=1`); BDD + hybrid integration suites green; clippy pedantic `-D warnings` green; no function exceeds CC 8 / NLOC 50.