### PR TITLE
perf(sparse): route the whole dense-accumulator regime to linear scan

### DIFF
--- a/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
+++ b/crates/velesdb-core/src/sparse_index/search/bmw_parity_tests.rs
@@ -287,7 +287,8 @@ fn test_sparse_search_all_zero_query_returns_empty() {
 // `sparse_search` now routes every corpus ≤ SMALL_CORPUS_LINEAR_THRESHOLD
 // to linear_scan, so the existing router-level tests no longer exercise
 // `maxscore_search`. These tests call the DAAT path directly to keep it
-// under parity coverage — the fast path in production is for > 100K docs.
+// under parity coverage — in production DAAT can engage only past
+// SMALL_CORPUS_LINEAR_THRESHOLD (1M docs, #2177).
 
 #[test]
 fn test_maxscore_search_direct_matches_brute_force_1k_corpus() {

--- a/crates/velesdb-core/src/sparse_index/search/mod.rs
+++ b/crates/velesdb-core/src/sparse_index/search/mod.rs
@@ -24,18 +24,25 @@ const FULL_SCAN_THRESHOLD: f32 = 0.3;
 /// Doc-count threshold below which the linear scan path is preferred
 /// unconditionally.
 ///
-/// At this size the dense accumulator (`4 * doc_count` bytes) fits in L2
-/// cache (`<= 400 KB` for 100K docs on typical x86-64 CPUs), so a single
-/// cache-hot pass over the posting entries beats the cursor / heap /
-/// binary-search overhead of `MaxScore` DAAT. Above this threshold the
-/// existing coverage-based heuristic chooses between DAAT and linear scan.
+/// Tied to [`MAX_DENSE_ACCUMULATOR`]: the whole regime where the linear
+/// scan gets its dense accumulator is routed to it (#2177). The old value
+/// of `100_000` created a cliff at the boundary — measured with the
+/// `sparse_posting_scale` bench (both query shapes, two passes each,
+/// checksums stable): crossing 100k docs cost **43×** per query on
+/// uniform queries and **14×** on skewed SPLADE-shaped ones, and the
+/// ratio stayed flat (~13×) in a crossover sweep up to 400k docs — there
+/// is no crossover inside the dense regime. The mechanism (confirmed by
+/// an operation-count probe on #2177): this `MaxScore` implementation
+/// scores the same candidate union a linear scan visits — it prunes no
+/// candidates, but pays cursor bookkeeping and a per-candidate min-scan
+/// over the essential lists, ~100–280 elementary ops per posting where
+/// the linear scan pays ~1.
 ///
-/// Empirical basis: on 10K SPLADE-like corpus, forcing linear scan dropped
-/// `sparse_search top10` latency from ~956 µs to ~60 µs — a 15x speedup
-/// that stems from the dense-accumulator path being cache-friendly for
-/// moderate corpora. Reassess this constant once a million-doc sparse
-/// benchmark is added.
-const SMALL_CORPUS_LINEAR_THRESHOLD: u64 = 100_000;
+/// Beyond this threshold (non-compact doc-id spaces above it, too) the
+/// coverage heuristic below still chooses between DAAT and linear scan;
+/// whether `MaxScore` earns its keep past 1M docs is unmeasured — see
+/// #2177 for the retirement question.
+const SMALL_CORPUS_LINEAR_THRESHOLD: u64 = MAX_DENSE_ACCUMULATOR;
 
 /// Maximum doc ID for which we use a dense accumulator array.
 /// Above this threshold we fall back to a hash map.
@@ -50,9 +57,10 @@ const MAX_DENSE_ACCUMULATOR: u64 = 1_000_000;
 /// Searches the sparse inverted index for the top-k documents by inner product.
 ///
 /// Routing strategy (in order):
-/// 1. Small corpora (`doc_count <= SMALL_CORPUS_LINEAR_THRESHOLD`) always use
-///    linear scan — the dense accumulator stays L2-resident and the tight
-///    loop beats DAAT overhead.
+/// 1. Corpora in the dense-accumulator regime
+///    (`doc_count <= SMALL_CORPUS_LINEAR_THRESHOLD`) always use linear
+///    scan — measured 14–43× faster than `MaxScore` at the former 100k
+///    boundary and still ~13× ahead at 400k (#2177).
 /// 2. Queries with any negative weight use linear scan (the `MaxScore` upper
 ///    bound is only valid for non-negative query / document weights — see
 ///    CRITICAL-1 below).
@@ -79,8 +87,8 @@ pub fn sparse_search(
     // contribution). Fall back to linear scan for any query with negative weights.
     let has_negative_weight = query.values.iter().any(|&w| w < 0.0);
 
-    // Small corpus fast path: dense linear scan keeps the entire accumulator
-    // in L2 cache and avoids DAAT's cursor/heap overhead.
+    // Dense-regime fast path: the linear scan's accumulator pays ~1
+    // elementary op per posting where this MaxScore pays ~100-280 (#2177).
     if doc_count <= SMALL_CORPUS_LINEAR_THRESHOLD || has_negative_weight {
         return linear_scan_search(index, query, k);
     }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

Step 3 of #2177, acting on the evidence posted there (steps 1–2). Crossing 100 000 docs flipped `sparse_search` from the linear scan to MaxScore DAAT, and the boundary was a measured cliff, not a trade: query latency at 110k docs was **43×** the linear arm under uniform queries and **14×** under skewed SPLADE-shaped ones, flat (~13×) in a crossover sweep up to 400k docs. The operation-count probe on #2177 confirmed why — this MaxScore implementation scores the same candidate union the linear scan visits (it prunes no candidates), but pays cursor bookkeeping plus a per-candidate min-scan over the essential lists: ~100–280 elementary ops per posting where the linear scan pays ~1.

The fix ties `SMALL_CORPUS_LINEAR_THRESHOLD` to `MAX_DENSE_ACCUMULATOR` instead of a free-standing `100_000`: everywhere the linear scan gets its dense accumulator, it wins, so the router sends the whole regime there. The constant is compiler-tied — if the dense-accumulator cap ever moves, the routing moves with it.

Deliberately **not** done, per the evidence's limits:
- MaxScore is not retired: past 1M docs the coverage heuristic still arbitrates and the DAAT path remains reachable (non-compact id spaces above 1M included). Whether it earns its keep there is unmeasured and stays open on #2177.
- `bmw_parity_tests` keeps the DAAT path under direct parity coverage regardless of routing.

## Validation (the merged #2180 instrument, both former arms now on the same side)

| shape | 90 000 docs | 110 000 docs | before (110k) | gain at the former boundary |
|---|---|---|---|---|
| skewed (realistic) | 119.2 µs | 158.0 µs | 2.864 ms | **~18×** |
| uniform (worst case) | 535.5 µs | 643.0 µs | 32.30 ms | **~50×** |

Scaling across the former boundary now tracks corpus size (~1.2× latency for 1.22× docs) — the cliff is gone.

## Type of Change

- [x] ⚡ Performance improvement (routing-only; result sets unchanged, covered by parity suites)

## How Has This Been Tested?

- [x] Manual testing

| check | result |
|---|---|
| `cargo clippy -p velesdb-core --features persistence --lib -- -D warnings` | clean |
| `cargo fmt` | applied, clean |
| sparse suites incl. `bmw_parity_tests` (brute-force parity, recall floors, direct-MaxScore coverage), `--test-threads=1` | 146 passed, 0 failed |
| `sparse_posting_scale` at 90k/110k, both shapes | table above |

**Test Configuration:**
- OS: Linux 6.18.44, 4-core Xeon @ 2.80 GHz
- Rust version: 1.90 (workspace MSRV)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (constant + router docs carry the measured basis)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Skipped — no `unsafe` touched.

## High-Risk Change Checklist

Skipped — one-constant routing change; correctness paths untouched and parity-covered.

## Additional Notes

Closes the actionable part of #2177; the >1M-docs retirement question stays open there with the measurement plan.