### PR TITLE
bench(sparse): reach the hashmap accumulator with a document-id stride (#2177)

### DIFF
--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -69,6 +69,25 @@
 //! the same side of that boundary**, and read a size sweep that crosses it as
 //! two separate curves rather than one.
 //!
+//! # What the id stride costs, measured
+//!
+//! The same warning applies to `VELESDB_SPARSE_SCALE_ID_STRIDE`, and here is
+//! the size of it. At 200 000 documents with skewed queries — identical corpus,
+//! identical queries, only the id labelling moving — stride 4 leaves
+//! `max_doc_id` at 799 996, just under `doc_count * 4`, and stride 5 puts it at
+//! 999 995, just over. The accumulator flips between those two and little else
+//! does:
+//!
+//! ```text
+//! stride 4  (dense)    554.7 µs / 527.6 µs
+//! stride 5  (hashmap)  771.2 µs / 798.0 µs
+//! ```
+//!
+//! **~45 %**, against a pass-to-pass spread of 3–5 %. So a stride is not a free
+//! relabelling: it buys access to the other accumulator and charges for it.
+//! Comparing a strided run against a compact one measures that charge on top of
+//! whatever is under test.
+//!
 //! # Query shape (#2177 step 1)
 //!
 //! `VELESDB_SPARSE_SCALE_QUERY_SHAPE` selects the query generator:

--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -130,6 +130,16 @@ const DEFAULT_VOCAB: u32 = 30_000;
 /// is unset. 1 gives the compact `0..n` space every other sweep here uses.
 const DEFAULT_ID_STRIDE: u64 = 1;
 
+/// `MAX_DENSE_ACCUMULATOR` as it read when this bench was written.
+///
+/// Reported, never used to decide anything. The real constant is private to
+/// `sparse_index::search`, so a bench genuinely cannot observe which
+/// accumulator a run took — it can only print the two inputs it does know and
+/// name the third. Asserting a regime it cannot see is how a header comes to
+/// lie about its own configuration, which is the defect #2165 fixed on
+/// `hnsw_adjacency_scale` and which the first draft of this line repeated.
+const DENSE_CAP_AT_WRITING: u64 = 1_000_000;
+
 /// Nonzeros per skewed-shape query: real SPLADE queries carry far fewer
 /// terms than documents do (#2177 step 1).
 const SKEWED_QUERY_NNZ_RANGE: std::ops::RangeInclusive<usize> = 20..=50;
@@ -351,16 +361,13 @@ postings={total_postings} (~{per_term:.0}/term) \
 frozen_segments={segments} build={build_secs:.1}s\n\
   bytes touched per query ~{touched_mib:.1} MiB at {POSTING_ENTRY_BYTES} B/entry \
 — compare against last-level cache; padding is free below it\n\
-  id_stride={id_stride} max_doc_id={max_doc_id} → linear scan takes its \
-{accumulator} accumulator\n\
+  id_stride={id_stride} max_doc_id={max_doc_id} vs doc_count*4={compact_cap} \
+— dense also needs max_doc_id <= MAX_DENSE_ACCUMULATOR, a private constant \
+this bench cannot read ({DENSE_CAP_AT_WRITING} when written)\n\
   result checksum {checksum:#018x} — only compare runs whose checksums match",
             shape_label = shape.label(),
             max_doc_id = (docs as u64 - 1) * id_stride,
-            accumulator = if (docs as u64 - 1) * id_stride < (docs as u64) * 4 {
-                "dense"
-            } else {
-                "hashmap"
-            },
+            compact_cap = docs as u64 * 4,
             per_term = total_postings as f64 / f64::from(vocab),
             segments = docs / velesdb_core::index::sparse::inverted_index::FREEZE_THRESHOLD,
             touched_mib = touched as f64 / (1024.0 * 1024.0),

--- a/crates/velesdb-core/benches/sparse_posting_scale.rs
+++ b/crates/velesdb-core/benches/sparse_posting_scale.rs
@@ -126,6 +126,10 @@ const DEFAULT_DOCS: &[usize] = &[10_000, 50_000, 200_000];
 /// Vocabulary size used when `VELESDB_SPARSE_SCALE_VOCAB` is unset.
 const DEFAULT_VOCAB: u32 = 30_000;
 
+/// Spacing between consecutive document ids when `VELESDB_SPARSE_SCALE_ID_STRIDE`
+/// is unset. 1 gives the compact `0..n` space every other sweep here uses.
+const DEFAULT_ID_STRIDE: u64 = 1;
+
 /// Nonzeros per skewed-shape query: real SPLADE queries carry far fewer
 /// terms than documents do (#2177 step 1).
 const SKEWED_QUERY_NNZ_RANGE: std::ops::RangeInclusive<usize> = 20..=50;
@@ -189,6 +193,37 @@ fn scale_vocab() -> u32 {
         .unwrap_or(DEFAULT_VOCAB)
 }
 
+/// Reads the document-id stride from the environment.
+///
+/// This knob exists to reach `linear_scan_search`'s **other** accumulator.
+/// The dense-versus-hashmap choice is not made on corpus size but on id
+/// compactness:
+///
+/// ```text
+/// use_dense = max_doc_id <= MAX_DENSE_ACCUMULATOR
+///          && max_doc_id < doc_count * 4
+/// ```
+///
+/// so a stride of 4 or more puts `max_doc_id` past `doc_count * 4` and routes
+/// to `linear_scan_hashmap` at any corpus size, with the same number of
+/// postings and the same memory as the compact run. Without this, every sweep
+/// measures the dense accumulator only, and the hashmap variant — the one
+/// #2182's routing change reaches but never measured — stays invisible.
+///
+/// **Checksums do not carry across strides, and that is not a defect.** The
+/// checksum folds `doc_id`, so relabelling ids necessarily changes it. What is
+/// preserved is the thing the comparison needs: scores depend on weights
+/// alone, and `i * stride` is order-preserving, so a stride run retrieves the
+/// same documents in the same rank order with every id multiplied by the
+/// stride. Compare checksums between runs at equal stride — never across two.
+fn scale_id_stride() -> u64 {
+    std::env::var("VELESDB_SPARSE_SCALE_ID_STRIDE")
+        .ok()
+        .and_then(|raw| raw.trim().parse().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(DEFAULT_ID_STRIDE)
+}
+
 /// Generates sparse vectors over `vocab` terms, deterministic in `seed`.
 ///
 /// `weight(rng, rank)` decides each nonzero's weight from its draw rank, so
@@ -240,13 +275,13 @@ fn generate_queries(shape: QueryShape, n: usize, vocab: u32, seed: u64) -> Vec<S
 }
 
 /// Builds the index sequentially, so the same corpus yields the same index.
-fn build_index(corpus: &[SparseVector]) -> SparseInvertedIndex {
+fn build_index(corpus: &[SparseVector], id_stride: u64) -> SparseInvertedIndex {
     let index = SparseInvertedIndex::new();
     let docs: Vec<(u64, SparseVector)> = corpus
         .iter()
         .cloned()
         .enumerate()
-        .map(|(i, v)| (i as u64, v))
+        .map(|(i, v)| (i as u64 * id_stride, v))
         .collect();
     index.insert_batch_chunk(&docs);
     index
@@ -288,6 +323,7 @@ fn result_checksum(index: &SparseInvertedIndex, queries: &[SparseVector], k: usi
 fn sparse_posting_scale(c: &mut Criterion) {
     let vocab = scale_vocab();
     let shape = QueryShape::from_env();
+    let id_stride = scale_id_stride();
     let mut group = c.benchmark_group("sparse_posting_scale");
     group.sample_size(10);
 
@@ -296,7 +332,7 @@ fn sparse_posting_scale(c: &mut Criterion) {
         let queries = generate_queries(shape, QUERY_COUNT, vocab, 123);
 
         let build_started = Instant::now();
-        let index = build_index(&corpus);
+        let index = build_index(&corpus, id_stride);
         let build_secs = build_started.elapsed().as_secs_f64();
 
         let total_postings: usize = corpus.iter().map(SparseVector::nnz).sum();
@@ -315,15 +351,26 @@ postings={total_postings} (~{per_term:.0}/term) \
 frozen_segments={segments} build={build_secs:.1}s\n\
   bytes touched per query ~{touched_mib:.1} MiB at {POSTING_ENTRY_BYTES} B/entry \
 — compare against last-level cache; padding is free below it\n\
+  id_stride={id_stride} max_doc_id={max_doc_id} → linear scan takes its \
+{accumulator} accumulator\n\
   result checksum {checksum:#018x} — only compare runs whose checksums match",
             shape_label = shape.label(),
+            max_doc_id = (docs as u64 - 1) * id_stride,
+            accumulator = if (docs as u64 - 1) * id_stride < (docs as u64) * 4 {
+                "dense"
+            } else {
+                "hashmap"
+            },
             per_term = total_postings as f64 / f64::from(vocab),
             segments = docs / velesdb_core::index::sparse::inverted_index::FREEZE_THRESHOLD,
             touched_mib = touched as f64 / (1024.0 * 1024.0),
         );
 
         group.bench_function(
-            format!("top10_{docs}docs_{vocab}vocab_{}", shape.label()),
+            format!(
+                "top10_{docs}docs_{vocab}vocab_{}_stride{id_stride}",
+                shape.label()
+            ),
             |b| {
                 let mut qi = 0;
                 b.iter(|| {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/2177-hashmap-accumulator-regime` → **`develop`**. ✅

## Description

#2177 closed its boundary cliff in #2182 by routing the whole dense-accumulator regime to the linear scan, and recorded one configuration that change *reaches but never measured*: a 100 k–1 M corpus with **non-compact document ids**, which takes `linear_scan_hashmap` instead of `linear_scan_dense`.

That regime was written up as a corpus-size problem — ">1 M docs", ~2.5 GB of postings, out of reach. It is not a size problem. The accumulator is chosen by id compactness:

```rust
let use_dense = max_doc_id <= MAX_DENSE_ACCUMULATOR
    && (doc_count == 0 || max_doc_id < doc_count.saturating_mul(4));
```

A document-id **stride** puts `max_doc_id` past `doc_count * 4` at any corpus size, with the same posting count and the same memory as the compact run. `VELESDB_SPARSE_SCALE_ID_STRIDE` adds that knob.

Instrument only. No production code is touched.

## What it measured

200 000 documents, skewed queries, vocabulary 30 000 — identical corpus, identical queries, only the id labelling moves. The two strides straddle `doc_count * 4` with adjacent id spaces, so the accumulator flips and little else does:

| stride | `max_doc_id` | accumulator | pass 1 | pass 2 |
|---|---|---|---|---|
| 4 | 799 996 | dense (just under 800 000) | 554.7 µs | 527.6 µs |
| 5 | 999 995 | **hashmap** (just over) | 771.2 µs | 798.0 µs |

Checksums identical between passes at equal stride. **The hashmap accumulator costs ~45 %**, against a pass-to-pass spread of 3–5 %.

MaxScore was measured at 13–14× the linear scan in the dense regime. Degraded by 1.45×, the linear scan is still ~9–10× ahead — so #2182's routing holds in the case it extrapolated to.

A 500 k cross-check (stride 4 pushes `max_doc_id` past the one-million cap instead) gives 1.12 / 1.17 ms dense against 1.99 / 2.03 ms hashmap, **+76 %** — larger, but that comparison moves the id space *and* the accumulator together, so the 45 % above is the clean figure.

**Also, the memory claim is refuted at 1.1 M.** A 1 100 000-document corpus (137.5 M postings, 110 frozen segments) built in 47 s and ran on this container: MaxScore at **34.3 ms**, versus a linear scan extrapolating to ~4 ms there. No crossover in sight. Recorded on the issue with its extrapolation flagged, since the linear path is not reachable at that size through the public API.

## The second commit is a correction to the first

The header line the first commit added printed `→ linear scan takes its dense accumulator` from a predicate that reproduced only the second clause. At 500 k with stride 4 that put `max_doc_id` at 1 999 996 — past the one-million cap — so the run took the **hashmap** path while the header announced dense. I nearly reported those rows under the wrong label.

Completing the predicate is not available: `MAX_DENSE_ACCUMULATOR` is private to `sparse_index::search`, so a bench cannot observe it. This is the same blind spot #2165 fixed on `hnsw_adjacency_scale` and takes the same remedy — print the two inputs the bench knows, name the third, give its value at time of writing.

An instrument that cannot see a variable must not decide in its place. Both commits are kept rather than squashed because the defect and its fix are the more useful record.

## Type of Change

- [x] 🔧 Refactoring (no functional changes) — bench knob and header only

## How Has This Been Tested?

- [x] Manual testing

`cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean. `cargo fmt --all` applied.

The bench was run end to end across nine processes at 200 k, 500 k and 1.1 M documents, strides 1/4/5; the tables above are its output. Checksums matched between passes at equal stride, which is the property the instrument exists to enforce.

No production code is touched, so the existing suite is unaffected.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified.

## High-Risk Change Checklist

Not applicable — no production code path is touched.

## Additional Notes

The stride knob introduces a trap the doc records: checksums fold `doc_id`, so they cannot carry across strides. What the comparison needs *is* preserved — scores depend on weights alone and `i * stride` is order-preserving, so a stride run retrieves the same documents in the same rank order with ids multiplied. Compare checksums at equal stride, never across two.