### PR TITLE
feat(config): apply [hnsw] m and ef_construction as engine defaults (#2087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,14 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
-- **The `VELESDB_*` environment-variable table is flagged as broken (#2185).**
-  Re-verifying it end to end while wiring `[hnsw]` showed that no documented
-  engine variable reaches its field — `VELESDB_HNSW_M`,
-  `VELESDB_HNSW_EF_CONSTRUCTION` and `VELESDB_LIMITS_MAX_COLLECTIONS` all load
-  as the default, the last one despite an explicit rustdoc promise that it
-  works. `docs/guides/CONFIGURATION.md` now carries a banner saying so. The
-  fix is a behaviour change — currently-inert variables would start taking
-  effect — so it is tracked separately rather than folded in here.
+- **The `VELESDB_*` environment-variable defect was found here (#2185).**
+  Re-verifying the table end to end while wiring `[hnsw]` — which #2087's
+  validation bar requires — showed that no documented engine variable reached
+  its field: `VELESDB_HNSW_M`, `VELESDB_HNSW_EF_CONSTRUCTION` and
+  `VELESDB_LIMITS_MAX_COLLECTIONS` all loaded as their defaults, the last one
+  despite an explicit rustdoc promise that it works. The fix is a behaviour
+  change — currently-inert variables start taking effect — so it is tracked and
+  shipped separately as #2185 rather than folded into this wiring.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`browserslist` advisory in `examples/react-wasm-search` (GHSA-c83g-rgw3-j3cx,
+  GHSA-73wf-gq98-2v4g).** Both were published upstream while PRs were in
+  flight: the `npm advisories (examples/react-wasm-search)` gate passed at
+  17:02 UTC and failed at 17:38 on an unchanged lockfile, and reproduces on
+  `develop` itself. `browserslist` 4.28.2 → 4.28.8 via `npm audit fix
+  --package-lock-only`, which also carries its data tables
+  (`caniuse-lite`, `electron-to-chromium`, `node-releases`,
+  `baseline-browser-mapping`) forward. All dev-only, all within the same
+  major — no `--force`, so `package.json` constraints are untouched. The
+  three other lockfiles in the repo audit clean.
+
 ### Added
 
 - **`[hnsw]` is applied by the engine (#2087).** `m` and `ef_construction`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`[hnsw]` is applied by the engine (#2087).** `m` and `ef_construction`
+  from the configuration file now reach the HNSW index of every collection the
+  `Database` creates — vector collections and graph collections with node
+  embeddings alike. Before this, they were parsed and *validated* and read by
+  nothing: a config could be rejected for an out-of-range value on a knob that
+  did nothing, which signals harder than silence that the knob works.
+
+  The precedence chain is explicit and per-field:
+
+  ```text
+  per-collection creation argument  >  [hnsw] section  >  HnswParams::auto(dimension)
+  ```
+
+  A collection created with an explicit `m` and no `ef_construction` still
+  takes `ef_construction` from the section. `create_vector_collection_with_params`
+  bypasses the section entirely — a fully specified `HnswParams` is already an
+  answer, and merging a file the caller never mentioned into it would be
+  surprising. Resolution lives in `Database`, the only component that owns a
+  `VelesConfig`, so `Collection` and the index stay config-free.
+
+  These are **creation-time** values: they are persisted into the collection's
+  own config and fix its graph topology, so editing the section later affects
+  new collections only. Re-tuning an existing collection is an index rebuild
+  (`auto_reindex`), not a config reload.
+
+  **No behaviour changes without an explicit section.** A default `[hnsw]`
+  resolves to exactly `HnswParams::auto(dimension)`, and the creation paths
+  persist the same `pq_rescore_oversampling = Some(4)` they did before, so a
+  collection created without config is byte-for-byte what the pre-wiring code
+  produced. A test asserts this directly.
+
+  `hnsw.max_layers` stays inert and `[search]`, `[storage]`, `[quantization]`
+  stay unwired; `VelesConfig::validate` still warns for them, narrowed to name
+  the single inert field rather than the whole `[hnsw]` section — a warning
+  that fires on knobs that now work would train readers to ignore it.
+
+  New public API: `HnswParams::from_config`,
+  `VectorCollection::create_with_hnsw_params`,
+  `GraphCollection::create_with_hnsw_params`.
+
+### Fixed
+
+- **`VectorCollection::create_with_hnsw` documented a false equivalence.** It
+  claimed that passing `None` for both arguments was "equivalent to
+  `VectorCollection::create`". It is not: it persists
+  `pq_rescore_oversampling = None` ("no explicit override", which migrations
+  read differently) where `create` persists the engine default `Some(4)`. The
+  rustdoc now states the difference and points at
+  `create_with_hnsw_params` for a params override that keeps the `create`
+  default. Behaviour is unchanged.
+
+### Documentation
+
+- **The `VELESDB_*` environment-variable table is flagged as broken (#2185).**
+  Re-verifying it end to end while wiring `[hnsw]` showed that no documented
+  engine variable reaches its field — `VELESDB_HNSW_M`,
+  `VELESDB_HNSW_EF_CONSTRUCTION` and `VELESDB_LIMITS_MAX_COLLECTIONS` all load
+  as the default, the last one despite an explicit rustdoc promise that it
+  works. `docs/guides/CONFIGURATION.md` now carries a banner saying so. The
+  fix is a behaviour change — currently-inert variables would start taking
+  effect — so it is tracked separately rather than folded in here.
+
+### Added
+
 - **The `clippy::significant_drop_tightening` backlog is frozen where it stands
   (#2110).** `Cargo.toml` denies `significant_drop_in_scrutinee` — a guard
   living to the end of a `match`/`if let`/`for` scrutinee is how the

--- a/crates/velesdb-core/src/collection/core/lifecycle_create.rs
+++ b/crates/velesdb-core/src/collection/core/lifecycle_create.rs
@@ -233,9 +233,44 @@ impl Collection {
         embedding_dim: Option<usize>,
         metric: DistanceMetric,
     ) -> Result<Self> {
+        Self::create_graph_collection_with_hnsw_params(
+            path,
+            name,
+            schema,
+            embedding_dim,
+            metric,
+            None,
+        )
+    }
+
+    /// Creates a new graph collection, optionally with explicit HNSW
+    /// parameters for its node-embedding index.
+    ///
+    /// A graph collection with `embedding_dim = Some(d)` builds a full HNSW
+    /// index over its node vectors, exactly like a vector collection, so it
+    /// takes the same creation-time parameters — this is the constructor that
+    /// lets the configured `[hnsw]` section reach that index (issue #2087).
+    /// Passing `hnsw_params = None` reproduces
+    /// [`Collection::create_graph_collection`] byte for byte.
+    ///
+    /// `hnsw_params` is ignored in practice when `embedding_dim` is `None`:
+    /// such a collection has dimension 0 and never populates its index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created or the config cannot be saved.
+    pub fn create_graph_collection_with_hnsw_params(
+        path: PathBuf,
+        name: &str,
+        schema: crate::collection::graph::GraphSchema,
+        embedding_dim: Option<usize>,
+        metric: DistanceMetric,
+        hnsw_params: Option<crate::index::hnsw::HnswParams>,
+    ) -> Result<Self> {
         let config = CollectionConfig {
             graph_schema: Some(schema),
             embedding_dimension: embedding_dim,
+            hnsw_params,
             ..Self::base_config(
                 name.to_string(),
                 embedding_dim.unwrap_or(0),
@@ -243,6 +278,6 @@ impl Collection {
                 StorageMode::Full,
             )
         };
-        Self::create_from_config(path, config, None)
+        Self::create_from_config(path, config, hnsw_params)
     }
 }

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -67,6 +67,37 @@ impl GraphCollection {
         })
     }
 
+    /// Creates a new `GraphCollection`, optionally with explicit HNSW
+    /// parameters for the node-embedding index.
+    ///
+    /// Only meaningful together with `dimension = Some(d)`: that is when a
+    /// graph collection carries node embeddings and builds an HNSW index over
+    /// them. Passing `hnsw_params = None` is identical to
+    /// [`GraphCollection::create`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created or storage fails.
+    pub fn create_with_hnsw_params(
+        path: PathBuf,
+        name: &str,
+        dimension: Option<usize>,
+        metric: DistanceMetric,
+        schema: GraphSchema,
+        hnsw_params: Option<crate::index::hnsw::HnswParams>,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner: Collection::create_graph_collection_with_hnsw_params(
+                path,
+                name,
+                schema,
+                dimension,
+                metric,
+                hnsw_params,
+            )?,
+        })
+    }
+
     /// Opens an existing `GraphCollection` from disk.
     ///
     /// # Errors

--- a/crates/velesdb-core/src/collection/vector_collection/lifecycle.rs
+++ b/crates/velesdb-core/src/collection/vector_collection/lifecycle.rs
@@ -30,13 +30,17 @@ impl VectorCollection {
     /// Creates a new `VectorCollection` with custom HNSW parameters.
     ///
     /// When `m` or `ef_construction` are `Some`, those values override the
-    /// auto-tuned defaults. When both are `None`, this is equivalent to
-    /// [`VectorCollection::create`].
+    /// auto-tuned defaults; every other HNSW field stays at the
+    /// dimension-based auto-tuned default.
     ///
     /// Shortcut for [`VectorCollection::create_with_params`] that only
-    /// overrides `max_connections` and `ef_construction`; every other
-    /// HNSW field stays at the dimension-based auto-tuned default, and
-    /// `pq_rescore_oversampling` uses the engine default of `Some(4)`.
+    /// overrides `max_connections` and `ef_construction`. It passes
+    /// `pq_rescore_oversampling = None` — "no explicit override", which is
+    /// **not** what [`VectorCollection::create`] persists (that one takes the
+    /// engine default `Some(4)`), so the two are not interchangeable even
+    /// when both arguments are `None`. Use
+    /// [`VectorCollection::create_with_hnsw_params`] for a params override
+    /// that keeps the `create` PQ default.
     ///
     /// # Errors
     ///
@@ -59,6 +63,31 @@ impl VectorCollection {
         }
         params.storage_mode = storage_mode;
         Self::create_with_params(path, dimension, metric, storage_mode, params, None)
+    }
+
+    /// Creates a new `VectorCollection` with fully specified
+    /// [`HnswParams`](crate::index::hnsw::HnswParams), keeping the
+    /// `pq_rescore_oversampling` engine default of `Some(4)`.
+    ///
+    /// This is the constructor a params object resolved from the `[hnsw]`
+    /// config section goes through (see `Database::resolve_hnsw_params`). It
+    /// differs from [`VectorCollection::create`] in the HNSW parameters and
+    /// in nothing else — notably not in `pq_rescore_oversampling`, which
+    /// [`VectorCollection::create_with_hnsw`] does change. Configuring
+    /// `[hnsw]` therefore alters the index topology and no other persisted
+    /// field.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created or storage fails.
+    pub fn create_with_hnsw_params(
+        path: PathBuf,
+        dimension: usize,
+        metric: DistanceMetric,
+        storage_mode: StorageMode,
+        hnsw_params: crate::index::hnsw::HnswParams,
+    ) -> Result<Self> {
+        Self::create_with_params(path, dimension, metric, storage_mode, hnsw_params, Some(4))
     }
 
     /// Creates a new `VectorCollection` with a fully specified

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -88,12 +88,14 @@ impl SearchMode {
 
 /// Search configuration section.
 ///
-/// **Reserved — parsed and validated, not yet applied.** Only `[limits]`
-/// reaches the engine today; [`VelesConfig::validate`] warns when this
-/// section deviates from its defaults so a config cannot silently promise
-/// behavior the engine does not deliver. Wiring these values as engine
-/// defaults is tracked in issue #2087. Per-query runtime overrides
-/// (`WITH (ef_search = N)`) are a separate, working mechanism.
+/// **Reserved — parsed and validated, not yet applied.** `[limits]` and
+/// `[hnsw]` reach the engine; this section does not.
+/// [`VelesConfig::validate`] warns when it deviates from its defaults so a
+/// config cannot silently promise behavior the engine does not deliver.
+/// Wiring is tracked in issue #2087 — `query_timeout_ms` in particular needs
+/// a query timeout the engine does not have, which is a feature of its own.
+/// Per-query runtime overrides (`WITH (ef_search = N)`) are a separate,
+/// working mechanism.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SearchConfig {
@@ -118,14 +120,31 @@ impl Default for SearchConfig {
     }
 }
 
-/// HNSW index configuration section.
+/// HNSW index configuration section — the deployment-wide default for the
+/// graph topology of every index the engine builds.
 ///
-/// **Reserved — parsed and validated, not yet applied.** Only `[limits]`
-/// reaches the engine today; [`VelesConfig::validate`] warns when this
-/// section deviates from its defaults so a config cannot silently promise
-/// behavior the engine does not deliver. Wiring these values as engine
-/// defaults is tracked in issue #2087. Per-query runtime overrides
-/// (`WITH (ef_search = N)`) are a separate, working mechanism.
+/// **Applied at collection creation** (issue #2087). `m` and
+/// `ef_construction` take effect through
+/// [`HnswParams::from_config`](crate::index::hnsw::HnswParams::from_config),
+/// under this precedence chain:
+///
+/// ```text
+/// per-collection creation argument  >  [hnsw] section  >  HnswParams::auto(dimension)
+/// ```
+///
+/// The values are **creation-time**: they are persisted into the collection's
+/// own config and fix the graph topology, so editing this section afterwards
+/// affects new collections only. Re-tuning an existing one means rebuilding
+/// its index (`auto_reindex`), not reloading a file.
+///
+/// Per-query runtime overrides (`WITH (ef_search = N)`) are a separate,
+/// working mechanism on a different axis: `ef_search` sizes the candidate pool
+/// of one query; nothing here does.
+///
+/// `max_layers` is the exception and is still inert:
+/// [`VelesConfig::validate`] warns when it is set. The HNSW layer count is
+/// drawn per node by the level generator and no engine path caps it, so
+/// honouring the knob is a feature, not a wiring.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct HnswConfig {
@@ -136,6 +155,9 @@ pub struct HnswConfig {
     /// `None` = auto based on dimension.
     pub ef_construction: Option<usize>,
     /// Maximum number of layers (0 = auto).
+    ///
+    /// **Reserved — parsed and validated, not applied.** See the type-level
+    /// note above.
     pub max_layers: usize,
 }
 
@@ -149,11 +171,12 @@ pub mod server {
 
     /// Storage configuration section.
     ///
-    /// **Reserved — parsed and validated, not yet applied.** Only
-    /// `[limits]` reaches the engine today; `VelesConfig::validate` warns
-    /// when this section deviates from its defaults. Wiring is tracked in
-    /// issue #2087 (`data_dir` in particular conflicts with the path passed
-    /// to `Database::open` and may go through deprecation instead).
+    /// **Reserved — parsed and validated, not yet applied.** `[limits]`
+    /// and `[hnsw]` reach the engine; this section does not.
+    /// `VelesConfig::validate` warns when it deviates from its defaults.
+    /// Wiring is tracked in issue #2087 (`data_dir` in particular conflicts
+    /// with the path passed to `Database::open` and may go through
+    /// deprecation instead).
     #[derive(Debug, Clone, Serialize, Deserialize)]
     #[serde(default)]
     pub struct StorageConfig {

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -105,6 +105,30 @@ impl VelesConfig {
     /// Serde-value comparison instead of `PartialEq` derives: the sections
     /// carry enums and nested types, and this runs once per config load.
     fn warn_inert_engine_sections(&self) {
+        let inert = self.inert_engine_entries();
+        if !inert.is_empty() {
+            tracing::warn!(
+                // Entries are a mix of whole sections and single keys now
+                // that `[hnsw]` is partly wired, hence `inert` rather than
+                // the former `sections`.
+                inert = inert.join(", "),
+                "these config entries are parsed and validated but not \
+                 applied by the engine; see issue #2087. [limits] and \
+                 [hnsw]'s m / ef_construction are applied. Query-time \
+                 WITH (...) overrides are unaffected."
+            );
+        }
+    }
+
+    /// The config entries this build parses and validates but does not apply,
+    /// as they would be named in a TOML file.
+    ///
+    /// Split out of [`Self::warn_inert_engine_sections`] so the set is
+    /// assertable: a `tracing` warning is not observable from a test, and the
+    /// claim this list makes — that a configured `hnsw.m` is *not* inert while
+    /// `hnsw.max_layers` still is — is precisely what the #2087 wiring has to
+    /// keep honest as more knobs land.
+    pub(crate) fn inert_engine_entries(&self) -> Vec<&'static str> {
         fn deviates<T: serde::Serialize>(actual: &T, default: &T) -> bool {
             match (serde_json::to_value(actual), serde_json::to_value(default)) {
                 (Ok(a), Ok(d)) => a != d,
@@ -112,7 +136,7 @@ impl VelesConfig {
             }
         }
 
-        let mut inert: Vec<&str> = Vec::new();
+        let mut inert: Vec<&'static str> = Vec::new();
         if deviates(&self.search, &crate::config::SearchConfig::default()) {
             inert.push("[search]");
         }
@@ -131,18 +155,7 @@ impl VelesConfig {
         ) {
             inert.push("[quantization]");
         }
-        if !inert.is_empty() {
-            tracing::warn!(
-                // Entries are a mix of whole sections and single keys now
-                // that `[hnsw]` is partly wired, hence `inert` rather than
-                // the former `sections`.
-                inert = inert.join(", "),
-                "these config entries are parsed and validated but not \
-                 applied by the engine; see issue #2087. [limits] and \
-                 [hnsw]'s m / ef_construction are applied. Query-time \
-                 WITH (...) overrides are unaffected."
-            );
-        }
+        inert
     }
 
     /// `[wal_batch]` is parsed but not wired (issue #2078): warn — rather

--- a/crates/velesdb-core/src/config_validation.rs
+++ b/crates/velesdb-core/src/config_validation.rs
@@ -89,11 +89,18 @@ impl VelesConfig {
         Ok(())
     }
 
-    /// The `[search]`, `[hnsw]`, `[storage]` and `[quantization]` sections
-    /// are parsed and validated but not yet applied — only `[limits]`
-    /// reaches the engine (issue #2087). Warn — rather than reject — when a
-    /// config sets any of them away from its defaults, so existing files
-    /// keep loading while no deployment silently believes those knobs work.
+    /// The `[search]`, `[storage]` and `[quantization]` sections are parsed
+    /// and validated but not yet applied (issue #2087). Warn — rather than
+    /// reject — when a config sets any of them away from its defaults, so
+    /// existing files keep loading while no deployment silently believes
+    /// those knobs work.
+    ///
+    /// `[hnsw]` is no longer listed wholesale: `m` and `ef_construction` are
+    /// applied at collection creation. Only `max_layers` remains inert — the
+    /// layer count is drawn per node by the level generator and no engine
+    /// path caps it — so the warning narrows to that single field. Reporting
+    /// the field rather than the section is the point: a warning that fires
+    /// on knobs that now work would train readers to ignore it.
     ///
     /// Serde-value comparison instead of `PartialEq` derives: the sections
     /// carry enums and nested types, and this runs once per config load.
@@ -109,8 +116,8 @@ impl VelesConfig {
         if deviates(&self.search, &crate::config::SearchConfig::default()) {
             inert.push("[search]");
         }
-        if deviates(&self.hnsw, &crate::config::HnswConfig::default()) {
-            inert.push("[hnsw]");
+        if self.hnsw.max_layers != crate::config::HnswConfig::default().max_layers {
+            inert.push("hnsw.max_layers");
         }
         if deviates(
             &self.storage,
@@ -126,10 +133,14 @@ impl VelesConfig {
         }
         if !inert.is_empty() {
             tracing::warn!(
-                sections = inert.join(", "),
-                "these config sections are parsed and validated but not yet \
-                 applied by the engine — only [limits] is; see issue #2087. \
-                 Query-time WITH (...) overrides are unaffected."
+                // Entries are a mix of whole sections and single keys now
+                // that `[hnsw]` is partly wired, hence `inert` rather than
+                // the former `sections`.
+                inert = inert.join(", "),
+                "these config entries are parsed and validated but not \
+                 applied by the engine; see issue #2087. [limits] and \
+                 [hnsw]'s m / ef_construction are applied. Query-time \
+                 WITH (...) overrides are unaffected."
             );
         }
     }

--- a/crates/velesdb-core/src/database/graph_ops.rs
+++ b/crates/velesdb-core/src/database/graph_ops.rs
@@ -31,6 +31,10 @@ impl Database {
     /// variant configures a vector dimension and distance metric so that nodes
     /// can store embeddings and support similarity search.
     ///
+    /// The node-embedding index takes its parameters from the configured
+    /// `[hnsw]` section on top of the auto-tuned defaults — see
+    /// [`Database::resolve_hnsw_params`].
+    ///
     /// # Errors
     ///
     /// Returns an error if a collection with the same name already exists.
@@ -45,7 +49,17 @@ impl Database {
         self.ensure_collection_name_available(name)?;
         self.enforce_vector_dimension_limit(dimension)?;
         let path = self.data_dir.join(name);
-        let coll = GraphCollection::create(path, name, Some(dimension), metric, schema.clone())?;
+        // #2087: node embeddings mean a real HNSW index, so the `[hnsw]`
+        // section applies here exactly as it does to a vector collection.
+        let params = self.resolve_hnsw_params(dimension, None, None);
+        let coll = GraphCollection::create_with_hnsw_params(
+            path,
+            name,
+            Some(dimension),
+            metric,
+            schema.clone(),
+            params,
+        )?;
         self.register_graph_collection(name, &coll, Some(dimension), metric, &schema);
         Ok(())
     }
@@ -63,7 +77,17 @@ impl Database {
             self.enforce_vector_dimension_limit(d)?;
         }
         let path = self.data_dir.join(name);
-        let coll = GraphCollection::create(path, name, dimension, metric, schema.clone())?;
+        // #2087: only a graph collection that carries embeddings has an HNSW
+        // index to configure; without a dimension there is nothing to apply.
+        let params = dimension.and_then(|d| self.resolve_hnsw_params(d, None, None));
+        let coll = GraphCollection::create_with_hnsw_params(
+            path,
+            name,
+            dimension,
+            metric,
+            schema.clone(),
+            params,
+        )?;
         self.register_graph_collection(name, &coll, dimension, metric, schema);
         Ok(())
     }

--- a/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
+++ b/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
@@ -279,3 +279,57 @@ fn test_params_from_config_leaves_unmapped_fields_alone() {
     assert_eq!(params.storage_mode, auto.storage_mode);
     assert!((params.alpha - auto.alpha).abs() < f32::EPSILON);
 }
+
+// -------------------------------------------------------------------------
+// The inert-entry warning, narrowed
+// -------------------------------------------------------------------------
+//
+// A `tracing` warning is not observable from a test, so these assert the list
+// it is built from. What they protect is the claim the wiring makes: a knob
+// that now works must stop being reported as inert, and one that still does
+// nothing must keep being reported — a warning that fires on working knobs
+// would train readers to ignore it, which is the failure mode #2087 is about.
+
+#[test]
+fn test_default_config_reports_nothing_inert() {
+    assert!(VelesConfig::default().inert_engine_entries().is_empty());
+}
+
+#[test]
+fn test_configured_hnsw_m_and_ef_construction_are_not_inert() {
+    assert!(
+        config_with_hnsw(Some(40), Some(500))
+            .inert_engine_entries()
+            .is_empty(),
+        "the two wired [hnsw] knobs must no longer be reported as inert"
+    );
+}
+
+#[test]
+fn test_max_layers_is_still_reported_inert_by_field() {
+    let mut config = VelesConfig::default();
+    config.hnsw.max_layers = 12;
+    // Named as the single field, not as `[hnsw]`: the rest of the section
+    // works, and flagging it wholesale would be the misleading half.
+    assert_eq!(config.inert_engine_entries(), vec!["hnsw.max_layers"]);
+}
+
+#[test]
+fn test_max_layers_reported_alongside_a_configured_wired_knob() {
+    let mut config = config_with_hnsw(Some(40), Some(500));
+    config.hnsw.max_layers = 12;
+    // Setting a wired knob must not mask the inert one sharing its section.
+    assert_eq!(config.inert_engine_entries(), vec!["hnsw.max_layers"]);
+}
+
+#[test]
+fn test_still_unwired_sections_are_reported_wholesale() {
+    let mut config = VelesConfig::default();
+    config.search.max_results = 42;
+    config.storage.mmap_cache_mb = 2048;
+    assert_eq!(
+        config.inert_engine_entries(),
+        vec!["[search]", "[storage]"],
+        "sections with no wired knob stay reported as whole sections"
+    );
+}

--- a/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
+++ b/crates/velesdb-core/src/database/hnsw_config_wiring_tests.rs
@@ -1,0 +1,281 @@
+//! Tests for the `[hnsw]` configuration wiring (issue #2087).
+//!
+//! The validation bar the issue sets for a wired knob is two-sided: the
+//! configured value must reach the engine, **and** the stronger precedence
+//! levels must still win over it. Both directions are covered here for each
+//! of the two wired fields, on both collection kinds that build an HNSW
+//! index, plus the property that makes the wiring safe to ship — a default
+//! `[hnsw]` section changes nothing at all.
+
+use crate::config::VelesConfig;
+use crate::index::hnsw::HnswParams;
+use crate::quantization::StorageMode;
+use crate::{Database, DistanceMetric};
+use tempfile::tempdir;
+
+/// A config whose `[hnsw]` section pins both wired knobs to values no
+/// auto-tuned default produces, so a passing assertion cannot be a
+/// coincidence: `HnswParams::auto` yields (24, 300) at dim ≤ 256 and
+/// (32, 400) above.
+fn config_with_hnsw(m: Option<usize>, ef_construction: Option<usize>) -> VelesConfig {
+    let mut config = VelesConfig::default();
+    config.hnsw.m = m;
+    config.hnsw.ef_construction = ef_construction;
+    config
+}
+
+const DIM: usize = 128;
+
+// -------------------------------------------------------------------------
+// Level 2 — the `[hnsw]` section applies
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_hnsw_config_applies_to_vector_collection() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    db.create_vector_collection("cfg", DIM, DistanceMetric::Cosine)
+        .unwrap();
+
+    let params = db
+        .get_vector_collection("cfg")
+        .unwrap()
+        .config()
+        .hnsw_params
+        .expect("a config-resolved collection persists its params");
+    assert_eq!(params.max_connections, 40);
+    assert_eq!(params.ef_construction, 500);
+}
+
+#[test]
+fn test_hnsw_config_applies_to_graph_collection_with_embeddings() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    db.create_graph_collection_with_embeddings(
+        "g",
+        crate::collection::GraphSchema::default(),
+        DIM,
+        DistanceMetric::Cosine,
+    )
+    .unwrap();
+
+    // A graph collection with embeddings builds a real HNSW index over its
+    // node vectors, so leaving it on the auto-tuned defaults would be the
+    // same silent half-wiring #2087 exists to remove.
+    let params = db
+        .get_graph_collection("g")
+        .unwrap()
+        .inner
+        .config()
+        .hnsw_params
+        .expect("a graph collection with embeddings persists its params");
+    assert_eq!(params.max_connections, 40);
+    assert_eq!(params.ef_construction, 500);
+}
+
+#[test]
+fn test_hnsw_config_fields_resolve_independently() {
+    let dir = tempdir().unwrap();
+    // Only `m` is configured; `ef_construction` must fall through to the
+    // dimension-tuned default rather than to some section-wide all-or-nothing.
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), None)).unwrap();
+
+    db.create_vector_collection("partial", DIM, DistanceMetric::Cosine)
+        .unwrap();
+
+    let params = db
+        .get_vector_collection("partial")
+        .unwrap()
+        .config()
+        .hnsw_params
+        .unwrap();
+    assert_eq!(params.max_connections, 40);
+    assert_eq!(
+        params.ef_construction,
+        HnswParams::auto(DIM).ef_construction,
+        "an unset section field must leave the auto-tuned value alone"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Level 1 — per-collection creation arguments still win
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_creation_argument_overrides_hnsw_config() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    db.create_vector_collection_with_hnsw(
+        "explicit",
+        DIM,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+        Some(12),
+        Some(90),
+    )
+    .unwrap();
+
+    let params = db
+        .get_vector_collection("explicit")
+        .unwrap()
+        .config()
+        .hnsw_params
+        .unwrap();
+    assert_eq!(params.max_connections, 12);
+    assert_eq!(params.ef_construction, 90);
+}
+
+#[test]
+fn test_partial_creation_argument_takes_the_other_field_from_config() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    // Pins `m` only. The chain is per-field, so `ef_construction` must come
+    // from the section — not silently revert to the auto-tuned default.
+    db.create_vector_collection_with_hnsw(
+        "mixed",
+        DIM,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+        Some(12),
+        None,
+    )
+    .unwrap();
+
+    let params = db
+        .get_vector_collection("mixed")
+        .unwrap()
+        .config()
+        .hnsw_params
+        .unwrap();
+    assert_eq!(params.max_connections, 12);
+    assert_eq!(params.ef_construction, 500);
+}
+
+#[test]
+fn test_create_with_params_ignores_hnsw_config_entirely() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    let explicit = HnswParams::custom(48, 400, 250_000).with_alpha(1.5);
+    db.create_vector_collection_with_params(
+        "full",
+        DIM,
+        DistanceMetric::Cosine,
+        StorageMode::Full,
+        explicit,
+        Some(8),
+    )
+    .unwrap();
+
+    // A fully specified params object is already a complete answer: merging
+    // a deployment default into it would make the result depend on a file
+    // this caller never mentioned.
+    let params = db
+        .get_vector_collection("full")
+        .unwrap()
+        .config()
+        .hnsw_params
+        .unwrap();
+    assert_eq!(params.max_connections, 48);
+    assert_eq!(params.ef_construction, 400);
+    assert_eq!(params.max_elements, 250_000);
+}
+
+// -------------------------------------------------------------------------
+// The property that makes the wiring safe to ship
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_default_hnsw_config_persists_exactly_the_unwired_collection() {
+    let dir = tempdir().unwrap();
+    let db = Database::open(dir.path()).unwrap();
+
+    db.create_vector_collection("plain", DIM, DistanceMetric::Cosine)
+        .unwrap();
+
+    let cfg = db.get_vector_collection("plain").unwrap().config();
+
+    // `None` — "nobody ever chose" — must survive, exactly as
+    // `pq_rescore_oversampling: None` does a field away. Persisting a snapshot
+    // of today's auto-tuned defaults here would build the identical index and
+    // destroy the distinction a later migration reads.
+    assert_eq!(
+        cfg.hnsw_params, None,
+        "an untouched [hnsw] section must not materialize a params snapshot"
+    );
+
+    // And the PQ rescore factor must stay at the engine default. Routing
+    // through `create_with_params` with `None` would have persisted "no
+    // explicit override" instead, silently changing what migrations read.
+    assert_eq!(cfg.pq_rescore_oversampling, Some(4));
+
+    // The index itself is still built from the auto-tuned defaults — the
+    // `None` above records the absence of a choice, not the absence of a
+    // topology.
+    assert_eq!(
+        HnswParams::from_config(DIM, &crate::config::HnswConfig::default()),
+        HnswParams {
+            storage_mode: StorageMode::Full,
+            ..HnswParams::auto(DIM)
+        }
+    );
+}
+
+#[test]
+fn test_graph_collection_without_embeddings_is_unaffected() {
+    let dir = tempdir().unwrap();
+    let db = Database::open_with_config(dir.path(), config_with_hnsw(Some(40), Some(500))).unwrap();
+
+    db.create_graph_collection("no_emb", crate::collection::GraphSchema::default())
+        .unwrap();
+
+    // No dimension means no HNSW index to configure; resolving params for a
+    // zero-dimension collection would persist a topology nothing ever builds,
+    // sized from dimension 0 at that.
+    assert!(db
+        .get_graph_collection("no_emb")
+        .unwrap()
+        .inner
+        .config()
+        .hnsw_params
+        .is_none());
+}
+
+// -------------------------------------------------------------------------
+// The mapping point itself
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_params_from_default_config_equals_auto() {
+    let default = crate::config::HnswConfig::default();
+    for dim in [64_usize, 128, 384, 768] {
+        assert_eq!(
+            HnswParams::from_config(dim, &default),
+            HnswParams::auto(dim),
+            "a default [hnsw] section must be indistinguishable from no section at dim {dim}"
+        );
+    }
+}
+
+#[test]
+fn test_params_from_config_leaves_unmapped_fields_alone() {
+    // `max_layers` has no engine counterpart; setting it must not move any
+    // field of the resolved params.
+    let hnsw = crate::config::HnswConfig {
+        m: Some(40),
+        ef_construction: Some(500),
+        max_layers: 12,
+    };
+
+    let params = HnswParams::from_config(DIM, &hnsw);
+    let auto = HnswParams::auto(DIM);
+    assert_eq!(params.max_connections, 40);
+    assert_eq!(params.ef_construction, 500);
+    assert_eq!(params.max_elements, auto.max_elements);
+    assert_eq!(params.storage_mode, auto.storage_mode);
+    assert!((params.alpha - auto.alpha).abs() < f32::EPSILON);
+}

--- a/crates/velesdb-core/src/database/mod.rs
+++ b/crates/velesdb-core/src/database/mod.rs
@@ -57,6 +57,8 @@ mod ddl_executor_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod graph_ops_tests;
 #[cfg(all(test, feature = "persistence"))]
+mod hnsw_config_wiring_tests;
+#[cfg(all(test, feature = "persistence"))]
 mod query_engine_tests;
 #[cfg(all(test, feature = "persistence"))]
 mod query_join_tests;

--- a/crates/velesdb-core/src/database/vector_ops.rs
+++ b/crates/velesdb-core/src/database/vector_ops.rs
@@ -7,6 +7,71 @@ use crate::{CollectionType, DistanceMetric, Result, StorageMode};
 use super::Database;
 
 impl Database {
+    /// Resolves the HNSW parameters for a collection about to be created.
+    ///
+    /// Implements the `[hnsw]` half of the configuration precedence chain
+    /// (issue #2087). From strongest to weakest:
+    ///
+    /// 1. **Per-collection creation argument** — the `m` / `ef_construction`
+    ///    passed to the constructor, or a whole `HnswParams` handed to
+    ///    [`Database::create_vector_collection_with_params`], which does not
+    ///    consult the config at all.
+    /// 2. **`VelesConfig`'s `[hnsw]` section** — the deployment-wide default.
+    /// 3. **Built-in engine default** — `HnswParams::auto(dimension)`.
+    ///
+    /// Per-query `WITH (...)` overrides sit above all three but never reach
+    /// here: they tune `ef_search` at query time, whereas everything resolved
+    /// in this function is graph *topology*, fixed when the index is built.
+    ///
+    /// Because the resolved params are persisted in the collection's
+    /// `config.json`, a collection keeps the topology it was created with:
+    /// editing `[hnsw]` later changes new collections only. Applying it to an
+    /// existing one is a full index rebuild, which is `auto_reindex`'s job,
+    /// not a config reload's.
+    ///
+    /// Resolution is layered here, in the only component that owns a
+    /// `VelesConfig`, so `Collection` and the index stay config-free and a
+    /// direct `VectorCollection::create` caller is unaffected.
+    ///
+    /// `storage_mode` is left at whatever `HnswParams::auto` produced: every
+    /// constructor downstream overwrites it with the collection's own storage
+    /// mode argument.
+    ///
+    /// Returns `None` when **no** level chose anything — neither argument, and
+    /// an untouched `[hnsw]` section. That is not the same as returning
+    /// `HnswParams::auto(dimension)`: a collection persists this value, and
+    /// `hnsw_params: None` on disk means "nobody ever chose", exactly as
+    /// `pq_rescore_oversampling: None` does a field away. Materializing a
+    /// snapshot of today's auto-tuned defaults into that slot would build the
+    /// identical index and destroy the distinction a later migration reads.
+    /// Callers that need a concrete value regardless say so at the call site
+    /// with `unwrap_or_else(|| HnswParams::auto(dimension))`.
+    pub(super) fn resolve_hnsw_params(
+        &self,
+        dimension: usize,
+        m: Option<usize>,
+        ef_construction: Option<usize>,
+    ) -> Option<HnswParams> {
+        if m.is_none()
+            && ef_construction.is_none()
+            && self.config.hnsw.m.is_none()
+            && self.config.hnsw.ef_construction.is_none()
+        {
+            return None;
+        }
+
+        // Level 2 first, then level 1 on top of it, so a per-field argument
+        // overrides only the field it names.
+        let mut params = HnswParams::from_config(dimension, &self.config.hnsw);
+        if let Some(m) = m {
+            params.max_connections = m;
+        }
+        if let Some(ef) = ef_construction {
+            params.ef_construction = ef;
+        }
+        Some(params)
+    }
+
     /// Creates a new vector collection.
     ///
     /// # Errors
@@ -37,15 +102,33 @@ impl Database {
         self.ensure_collection_name_available(name)?;
         self.enforce_vector_dimension_limit(dimension)?;
         let path = self.data_dir.join(name);
-        let coll = VectorCollection::create(path, name, dimension, metric, storage_mode)?;
+        // #2087: no per-collection HNSW argument here, so the `[hnsw]` section
+        // is the strongest level that applies. An untouched section resolves
+        // to `None` and takes the original constructor, so this path is
+        // byte-for-byte unchanged for anyone who did not configure `[hnsw]` —
+        // including the `hnsw_params: None` it persists.
+        let coll = match self.resolve_hnsw_params(dimension, None, None) {
+            Some(params) => VectorCollection::create_with_hnsw_params(
+                path,
+                dimension,
+                metric,
+                storage_mode,
+                params,
+            )?,
+            None => VectorCollection::create(path, name, dimension, metric, storage_mode)?,
+        };
         self.register_vector_collection(name, &coll, dimension, metric, storage_mode);
         Ok(())
     }
 
     /// Creates a new vector collection with custom HNSW parameters.
     ///
-    /// When `m` or `ef_construction` are `Some`, those values override the
-    /// dimension-based auto-tuned defaults from [`HnswParams::auto`].
+    /// When `m` or `ef_construction` are `Some`, those values win over the
+    /// configured `[hnsw]` section, which in turn wins over the
+    /// dimension-based auto-tuned defaults from [`HnswParams::auto`] — see
+    /// [`Database::resolve_hnsw_params`] for the full chain. The two
+    /// arguments are resolved independently, so pinning one still takes the
+    /// other from config.
     ///
     /// Shortcut for [`Database::create_vector_collection_with_params`] that
     /// only overrides `max_connections` and `ef_construction`.
@@ -65,14 +148,23 @@ impl Database {
         self.ensure_collection_name_available(name)?;
         self.enforce_vector_dimension_limit(dimension)?;
         let path = self.data_dir.join(name);
-        let coll = VectorCollection::create_with_hnsw(
+        // #2087: each argument is resolved on its own — a caller that pins
+        // only `m` still picks up `ef_construction` from `[hnsw]`.
+        //
+        // Materialized unconditionally, unlike the path above: this
+        // constructor already persisted `Some(HnswParams::auto(dimension))`
+        // before the wiring, so keeping `None` here would be the behaviour
+        // change rather than avoiding one.
+        let params = self
+            .resolve_hnsw_params(dimension, m, ef_construction)
+            .unwrap_or_else(|| HnswParams::auto(dimension));
+        let coll = VectorCollection::create_with_params(
             path,
-            name,
             dimension,
             metric,
             storage_mode,
-            m,
-            ef_construction,
+            params,
+            None,
         )?;
         self.register_vector_collection(name, &coll, dimension, metric, storage_mode);
         Ok(())
@@ -93,6 +185,12 @@ impl Database {
     /// The storage mode argument wins over `hnsw_params.storage_mode` if
     /// they disagree — the field on `HnswParams` is a legacy denormalised
     /// copy that the engine keeps in sync with the collection-level value.
+    ///
+    /// The configured `[hnsw]` section is **not** consulted: `hnsw_params` is
+    /// already a complete answer, and silently merging a deployment default
+    /// into a fully specified value would make the result depend on a file the
+    /// caller did not mention. Callers wanting the config as a base should
+    /// build from [`HnswParams::from_config`] and adjust from there.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/index/hnsw/params.rs
+++ b/crates/velesdb-core/src/index/hnsw/params.rs
@@ -95,6 +95,43 @@ impl HnswParams {
         }
     }
 
+    /// Builds creation-time parameters for `dimension`, applying the
+    /// configured [`[hnsw]`](crate::config::HnswConfig) section on top of
+    /// [`HnswParams::auto`].
+    ///
+    /// This is the **single mapping point** between the `[hnsw]` TOML table
+    /// and the engine, the same role `RuntimeLimits::from_config` plays for
+    /// `[limits]`, so the field correspondence cannot drift across the
+    /// creation paths that consult it.
+    ///
+    /// A section field left `None` leaves the auto-tuned value untouched —
+    /// a default [`HnswConfig`](crate::config::HnswConfig) therefore produces
+    /// exactly `HnswParams::auto(dimension)`, byte for byte. Wiring the
+    /// section is a no-op for anyone who did not set it.
+    ///
+    /// `hnsw.max_layers` has no counterpart here: the HNSW layer count is
+    /// drawn per node by the level generator and no engine path caps it, so
+    /// the knob stays inert and [`VelesConfig::validate`] keeps warning about
+    /// it (issue #2087).
+    ///
+    /// `storage_mode` is deliberately not sourced from config either: it is a
+    /// per-collection property, and every constructor overwrites this field
+    /// with the collection's own storage mode (see
+    /// `Collection::build_hnsw_index`).
+    ///
+    /// [`VelesConfig::validate`]: crate::config::VelesConfig::validate
+    #[must_use]
+    pub fn from_config(dimension: usize, hnsw: &crate::config::HnswConfig) -> Self {
+        let mut params = Self::auto(dimension);
+        if let Some(m) = hnsw.m {
+            params.max_connections = m;
+        }
+        if let Some(ef) = hnsw.ef_construction {
+            params.ef_construction = ef;
+        }
+        params
+    }
+
     /// Creates parameters optimized for a specific dataset size.
     ///
     /// Targets high recall up to 1M vectors under benchmark-calibrated settings.

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -602,18 +602,10 @@ impl SearchConfigOptions {
 /// Global HNSW index defaults mapped to
 /// [`velesdb_core::config::HnswConfig`] (the `[hnsw]` TOML section).
 ///
-/// Distinct from the per-collection [`HnswOptions`] passed to
-/// `Database.create_collection` — this section sets the database-wide
-/// defaults instead. `None` fields fall back to the engine defaults
-/// (`m`/`ef_construction` auto by dimension, `max_layers=0` = auto).
-///
-/// `m` and `ef_construction` are applied when a collection's index is created
-/// (issue #2087), under the precedence chain: per-collection [`HnswOptions`] >
-/// this section > auto by dimension. They are creation-time values, so
-/// changing them affects new collections only.
-///
-/// `max_layers` is **reserved**: it is validated but no engine path reads it,
-/// and the core logs a warning when it is set.
+/// Distinct from the per-collection [`HnswOptions`], which wins over it.
+/// `m` / `ef_construction` apply at collection creation (issue #2087):
+/// per-collection option > this section > auto by dimension, fixing topology
+/// for new collections only. `max_layers` is reserved — applied by nothing.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct HnswConfigOptions {

--- a/crates/velesdb-python/src/options.rs
+++ b/crates/velesdb-python/src/options.rs
@@ -606,6 +606,14 @@ impl SearchConfigOptions {
 /// `Database.create_collection` — this section sets the database-wide
 /// defaults instead. `None` fields fall back to the engine defaults
 /// (`m`/`ef_construction` auto by dimension, `max_layers=0` = auto).
+///
+/// `m` and `ef_construction` are applied when a collection's index is created
+/// (issue #2087), under the precedence chain: per-collection [`HnswOptions`] >
+/// this section > auto by dimension. They are creation-time values, so
+/// changing them affects new collections only.
+///
+/// `max_layers` is **reserved**: it is validated but no engine path reads it,
+/// and the core logs a warning when it is set.
 #[pyclass(module = "velesdb", from_py_object)]
 #[derive(Clone, Debug, Default)]
 pub struct HnswConfigOptions {

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -377,13 +377,6 @@ hot_reload = false
 
 All options can be set via environment variables with the `VELESDB_` prefix:
 
-> **Known defect — this table does not currently work for `VelesConfig`.**
-> Every engine variable below was verified end to end while wiring `[hnsw]`
-> and none of them reaches its field: `VELESDB_HNSW_M`,
-> `VELESDB_HNSW_EF_CONSTRUCTION` and `VELESDB_LIMITS_MAX_COLLECTIONS` all
-> load as the default. Set these keys in the TOML file until this is fixed.
-> Tracked in issue #2185.
-
 | Variable | TOML Equivalent | Example |
 |----------|-----------------|---------|
 | `VELESDB_SEARCH_DEFAULT_MODE` | `search.default_mode` | `balanced` |

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -45,13 +45,16 @@ To point at a file anywhere else, pass it explicitly:
 | `velesdb-server` | `--config <path>` | `VELESDB_CONFIG` |
 | `velesdb` (CLI) | `--config <path>` (global — REPL and every one-shot command) | `VELESDB_CONFIG` |
 
-> **Reserved sections.** Of the engine sections below, only `[limits]` is
-> applied by the engine today. `[search]`, `[hnsw]`, `[storage]` and
-> `[quantization]` are parsed and validated but not yet wired (issue #2087),
-> and `[wal_batch]` is parsed and ignored (issue #2078) — its group-commit
-> front was deleted as unwired, and the batch write APIs already pay one
-> durability barrier per call. Setting any of them away from their defaults
-> logs a warning at load. Query-time overrides (`WITH (ef_search = N)`) are a
+> **What the engine actually applies.** `[limits]` is enforced at the
+> collection and ingest boundaries, and `[hnsw]`'s `m` / `ef_construction`
+> are applied when a collection's index is created (see the precedence chain
+> under [Section \[hnsw\]](#section-hnsw)). Everything else below is parsed
+> and validated but **not** wired: `[search]`, `[storage]`, `[quantization]`
+> and `hnsw.max_layers` (issue #2087), and `[wal_batch]` is parsed and
+> ignored (issue #2078) — its group-commit front was deleted as unwired, and
+> the batch write APIs already pay one durability barrier per call. Setting
+> any unwired key away from its default logs a warning at load, naming
+> exactly what is inert. Query-time overrides (`WITH (ef_search = N)`) are a
 > separate, working mechanism, as are per-collection creation options.
 
 Both binaries can load the **same** file, but only the *engine* sections —
@@ -59,8 +62,8 @@ Both binaries can load the **same** file, but only the *engine* sections —
 `[wal_batch]` — reach `VelesConfig` and, via
 [`Database::open_with_config`](../../crates/velesdb-core/src/database/mod.rs),
 the running engine. Reaching `VelesConfig` is not the same as changing
-behaviour: see the reserved-sections note above for which of them the engine
-actually acts on. Every other top-level table is silently dropped before
+behaviour: see the note above for which of them the engine actually acts
+on. Every other top-level table is silently dropped before
 `VelesConfig` ever sees it — most importantly `[server]`, `[auth]`,
 `[tls]`, `[cors]`, which stay exclusively `velesdb-server`'s own transport
 config. This matters because `VelesConfig` *also* has its own same-named
@@ -374,6 +377,13 @@ hot_reload = false
 
 All options can be set via environment variables with the `VELESDB_` prefix:
 
+> **Known defect — this table does not currently work for `VelesConfig`.**
+> Every engine variable below was verified end to end while wiring `[hnsw]`
+> and none of them reaches its field: `VELESDB_HNSW_M`,
+> `VELESDB_HNSW_EF_CONSTRUCTION` and `VELESDB_LIMITS_MAX_COLLECTIONS` all
+> load as the default. Set these keys in the TOML file until this is fixed.
+> Tracked in issue #2185.
+
 | Variable | TOML Equivalent | Example |
 |----------|-----------------|---------|
 | `VELESDB_SEARCH_DEFAULT_MODE` | `search.default_mode` | `balanced` |
@@ -481,11 +491,40 @@ SELECT * FROM docs WHERE vector NEAR $v WITH (ef_search = 512);
 
 ### Section [hnsw]
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `m` | int\|"auto" | `"auto"` | Connections per node |
-| `ef_construction` | int\|"auto" | `"auto"` | Construction pool size |
-| `max_layers` | int | `0` | Max layers (0=auto) |
+| Key | Type | Default | Description | Applied |
+|-----|------|---------|-------------|---------|
+| `m` | int\|"auto" | `"auto"` | Connections per node | yes — at collection creation |
+| `ef_construction` | int\|"auto" | `"auto"` | Construction pool size | yes — at collection creation |
+| `max_layers` | int | `0` | Max layers (0=auto) | **no** — reserved (#2087) |
+
+**Precedence.** `m` and `ef_construction` are *defaults*. From strongest to
+weakest:
+
+```text
+per-collection creation argument  >  [hnsw] section  >  auto-tuned by dimension
+```
+
+Each field resolves on its own: a collection created with an explicit `m` and
+no `ef_construction` still takes `ef_construction` from this section. A caller
+that passes a complete `HnswParams` (`create_vector_collection_with_params`)
+bypasses the section entirely — a fully specified value is already an answer,
+and merging a file the caller never mentioned into it would be surprising.
+
+**These are creation-time values.** The resolved parameters are persisted into
+the collection's own config and fix its graph topology, so editing this section
+later affects **new collections only**. Re-tuning an existing collection means
+rebuilding its index (`auto_reindex`), not reloading a file.
+
+Graph collections created *with embeddings* build a real HNSW index over their
+node vectors and take the same defaults. A graph collection without embeddings
+has no index to configure and is unaffected.
+
+`max_layers` stays reserved: the HNSW layer count is drawn per node by the
+level generator and no engine path caps it, so honouring the knob is a feature
+rather than a wiring. `VelesConfig::validate` warns when it is set.
+
+Per-query `WITH (ef_search = N)` is a different axis and unrelated to this
+section — it sizes the candidate pool of one query; nothing here does.
 
 ### Section [storage]
 

--- a/examples/react-wasm-search/package-lock.json
+++ b/examples/react-wasm-search/package-lock.json
@@ -784,9 +784,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -817,11 +817,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.418",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
+      "integrity": "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/2087-wire-hnsw-config-defaults` → **`develop`**. ✅

## Description

Wires the `[hnsw]` configuration section into the engine. `m` and `ef_construction` now reach the HNSW index of every collection a `Database` creates — vector collections and graph collections with node embeddings alike.

Before this, they were parsed and **validated** and read by nothing. That is worse than being ignored: a config could be *rejected* for an out-of-range `hnsw.m`, which signals harder than silence that the knob works.

#2087 says the design comes before the patch, so the full decision is recorded on the issue — the precedence model, and a per-knob verdict for all thirteen knobs across the four sections. The summary:

**Precedence chain**, resolved **per field**, not per section:

```text
per-collection creation argument  >  [hnsw] section  >  HnswParams::auto(dimension)
```

Per-field matters: a collection created with an explicit `m` and no `ef_construction` takes `ef_construction` from the section rather than falling all the way through to the auto-tuned default. An all-or-nothing section would let the weakest level silently cancel a stronger one.

Per-query `WITH (ef_search = N)` is not above this chain — it is on a **different axis**. It sizes one query's candidate pool; everything resolved here is graph *topology*, fixed when the index is built. They cannot override each other because they never resolve the same value.

### Where the resolution lives, and why

In `Database` — the only component that owns a `VelesConfig`. `Collection` and the index stay config-free, and a direct `VectorCollection::create` caller is unaffected by any file on disk. This is the layering `RuntimeLimits::from_config` already established for `[limits]`, and `HnswParams::from_config` is its exact counterpart: one mapping point between the TOML table and the engine, so the field correspondence cannot drift across the creation paths that consult it.

### Nothing changes for anyone who did not configure `[hnsw]`

`resolve_hnsw_params` returns `Option<HnswParams>` and gives `None` when no level chose anything. The creation path then takes the original constructor, unchanged.

That `Option` is the substantive design point rather than a detail. `hnsw_params: None` on disk means **"nobody ever chose"** — exactly as `pq_rescore_oversampling: None` does one field away, where the rustdoc spells out that migrations rely on distinguishing it from a persisted default. Materializing a snapshot of today's `HnswParams::auto` into that slot would build the byte-identical index and destroy the distinction. A test asserts the `None` survives.

### Scope, and what is deliberately not here

`hnsw.m` and `hnsw.ef_construction` only — the one row of the issue's verdict table where the answer is unconditional. The others are excluded on purpose, not overlooked:

- **`hnsw.max_layers`** is a *feature gap*, not a wiring gap. The layer count is drawn per node by the level generator and no engine path caps it. It stays inert.
- **`[search]`** has a seam, but it sits on the default hot search path (`search()` bypasses `SearchQuality` entirely today). Its own PR.
- **`search.max_results`** needs a compatibility decision first: clamping a user's `LIMIT` silently is a footgun, and erroring is a breaking change under a *default* config (`1000`).
- **`search.query_timeout_ms`** — no timeout exists in core.
- **`storage.mmap_cache_mb` / `vector_alignment` / `data_dir`** have no engine counterpart *at all*. Not "unwired", absent. They want a deprecation cycle, and that changes what an existing config file does at load — its own PR.

The warning therefore **narrows rather than disappears**: it now names `hnsw.max_layers` as a single inert *field* instead of flagging the whole `[hnsw]` section. A warning that fires on knobs which now work would train readers to ignore it.

### What the validation bar turned up — filed, not fixed here

#2087's bar includes "the guide's env-var table is re-verified end to end". It was, and **no documented `VELESDB_*` engine variable reaches its field**:

```
hnsw.m                  = None  (expected Some(48))
hnsw.ef_construction    = None  (expected Some(600))
limits.max_collections  = 1000  (expected 5)
```

The last one despite an explicit rustdoc promise on `load_from_path_engine_only` that it works. Cause: the figment provider is built `.split("_").lowercase(false)`, which breaks the casing *and* every key containing an underscore.

Filed as **#2185** with the reproduction, and kept out of this PR on purpose: fixing it makes currently-inert variables start taking effect, so a deployment carrying a stale `VELESDB_LIMITS_MAX_COLLECTIONS=5` would begin getting `GuardRail` refusals after upgrading. That is a behaviour change for every deployment, and it does not belong behind a PR whose subject is HNSW topology. `docs/guides/CONFIGURATION.md` carries a banner pointing at #2185 so the table does not read as working while it is not.

Partially addresses #2087 — the `[hnsw]` row. The issue stays open for the rest.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests

`cargo test -p velesdb-core --features persistence -- --test-threads=1` — **6497 passed, 0 failed** across 70 suites (lib suite 5459, up from 5444 by the fifteen tests added here).

`cargo clippy -p velesdb-core -p velesdb-python --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean. `cargo fmt --all` applied.

Fifteen tests added in `database/hnsw_config_wiring_tests.rs`. #2087's bar for a wired knob is two-sided — the configured value must reach the engine **and** the stronger levels must still win — so both directions are covered for both fields:

*The section applies* — on vector collections; on graph collections with embeddings (which build a real HNSW index and would otherwise be exactly the silent half-wiring this issue exists to remove); and per-field, so an unset `ef_construction` leaves the auto-tuned value alone.

*The stronger levels still win* — an explicit `(m, ef_construction)` beats the section; a **partial** argument takes the other field from the section rather than reverting; and `create_vector_collection_with_params` ignores the section entirely.

*The wiring is a no-op without a section* — a default config persists `hnsw_params: None` and `pq_rescore_oversampling: Some(4)`, i.e. byte-for-byte the pre-wiring collection, while `HnswParams::from_config` under a default section still equals `auto(dimension)` field for field. A graph collection without embeddings resolves nothing at all — sizing params from dimension 0 for an index that is never populated would be worse than useless.

*The mapping point itself* — a default section is indistinguishable from no section across four dimensions, and setting the unmapped `max_layers` moves no field of the result.

*The narrowed warning* — a `tracing` warning is not observable from a test, so `inert_engine_entries` was split out of `warn_inert_engine_sections` and the list is asserted directly. A default config reports nothing; a configured `m` / `ef_construction` reports nothing; `hnsw.max_layers` is reported as that single **field**, not as `[hnsw]`; setting a wired knob does not mask the inert one sharing its section; and a section with no wired knob is still reported wholesale. This is the claim the wiring has to keep honest as more knobs land.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified.

## High-Risk Change Checklist

Touches an `hnsw` path (index construction parameters), so:

- [x] **Invariants impacted.** The resolved `HnswParams` must reach `Collection::build_hnsw_index` as the *same* value that is persisted to `config.json`, or a reopened collection would disagree with the graph on disk about its own topology. Both go through one `create_from_config` call taking the same `hnsw_params`. `storage_mode` remains owned by the collection-level argument, which every constructor overwrites onto the params — unchanged by this PR.
- [x] **Durability semantics.** Unchanged, and deliberately so. No serialized *type* moves; `CollectionConfig::hnsw_params` was already `Option<HnswParams>` and is written through the existing `save_config`. Under a default `[hnsw]` the persisted bytes are identical to `develop`'s, which is what the no-op test asserts.
- [x] **Lifecycle tests.** Every added test creates a collection and reads its state back through `get_vector_collection` / `get_graph_collection`, i.e. through the registry-or-disk path, not the in-memory handle.
- [ ] Two reviewers: leaving to maintainer judgement — the HNSW *algorithm* is untouched; only which parameters reach an already-existing constructor changes, and only when `[hnsw]` is set.

## Additional Notes

**One correction to existing documentation.** `VectorCollection::create_with_hnsw` claimed that passing `None` for both arguments was "equivalent to `VectorCollection::create`". It is not: it persists `pq_rescore_oversampling = None` where `create` persists `Some(4)`, and per the neighbouring rustdoc, migrations read that difference. The doc now states it, and the new `create_with_hnsw_params` is the params override that keeps the `create` default — which is what let the config path stay a genuine no-op. Behaviour unchanged.

**New public API**: `HnswParams::from_config`, `VectorCollection::create_with_hnsw_params`, `GraphCollection::create_with_hnsw_params`, `Collection::create_graph_collection_with_hnsw_params`. All additive.

No wall-clock figure is claimed. This PR changes *which* parameters an index is built with, not how fast anything runs; a user who raises `ef_construction` gets the well-known recall-for-build-time trade, measurable with `hnsw_benchmark` on an idle machine, and not attributable to this diff.