### PR TITLE
fix(config): resolve VELESDB_* variables at the section boundary (#2185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`browserslist` advisory in `examples/react-wasm-search` (GHSA-c83g-rgw3-j3cx,
+  GHSA-73wf-gq98-2v4g).** Both were published upstream while PRs were in
+  flight: the `npm advisories (examples/react-wasm-search)` gate passed at
+  17:02 UTC and failed at 17:38 on an unchanged lockfile, and reproduces on
+  `develop` itself. `browserslist` 4.28.2 → 4.28.8 via `npm audit fix
+  --package-lock-only`, which also carries its data tables
+  (`caniuse-lite`, `electron-to-chromium`, `node-releases`,
+  `baseline-browser-mapping`) forward. All dev-only, all within the same
+  major — no `--force`, so `package.json` constraints are untouched. The
+  three other lockfiles in the repo audit clean.
 ### Fixed
 
 - **No `VELESDB_*` environment variable reached its config field (#2185).** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **No `VELESDB_*` environment variable reached its config field (#2185).** The
+  figment provider was built `Env::prefixed("VELESDB_").split("_").lowercase(false)`,
+  which carried two independent defects, either fatal on its own:
+
+  - `lowercase(false)` left the key uppercase, so deserialization looked for a
+    field literally named `HNSW` rather than `hnsw`. This is what broke even the
+    single-token `VELESDB_HNSW_M`.
+  - `split("_")` treated **every** underscore as a nesting separator, so
+    `VELESDB_HNSW_EF_CONSTRUCTION` addressed `hnsw.ef.construction`. No field
+    with an underscore in its name was reachable — which is most of them
+    (`max_collections`, `ef_construction`, `query_timeout_ms`, `max_payload_size`).
+
+  Verified against `develop` before the fix: `VELESDB_HNSW_M`,
+  `VELESDB_HNSW_EF_CONSTRUCTION` and `VELESDB_LIMITS_MAX_COLLECTIONS` all loaded
+  as their defaults — the last one despite an explicit rustdoc promise on
+  `VelesConfig::load_from_path_engine_only` that it overrides the file.
+
+  The provider now splits at the **section boundary only**: the first underscore
+  following a known top-level table. Everything after it is the field name, kept
+  verbatim. A name whose first token is not a section passes through unsplit, so
+  `VELESDB_CONFIG`, `VELESDB_NO_UPDATE_CHECK` and the server's own
+  `VELESDB_HOST` / `VELESDB_PORT` keep matching nothing here, exactly as before.
+  Both `load_from_path` and `load_from_path_engine_only` share one provider, so
+  the two cannot drift.
+
+  **This is a behaviour change, not only a fix.** Variables that were inert now
+  take effect. An operator carrying a stale `VELESDB_LIMITS_MAX_COLLECTIONS=5`
+  in their environment will start getting `GuardRail` refusals on collection
+  creation after upgrading — the value they set, finally applied. Check the
+  environment of any deployment that exports `VELESDB_*` before upgrading.
+
+  A variable is exactly equivalent to its TOML key, so a **reserved** key stays
+  reserved when set this way: `VELESDB_SEARCH_MAX_RESULTS` is parsed, validated
+  and applied by nothing, same as `[search] max_results`.
+
+### Documentation
+
+- **`docs/guides/CONFIGURATION.md`'s env-var table conflated two config
+  systems.** `VELESDB_HOST`, `VELESDB_PORT`, `VELESDB_DATA_DIR`,
+  `VELESDB_RATE_LIMIT`, `VELESDB_API_KEYS` and `VELESDB_TLS_*` are
+  `velesdb-server`'s own transport variables and were listed as though they
+  addressed `VelesConfig` sections; they never will, since `[server]`/`[auth]`/
+  `[tls]` are filtered out by `load_from_path_engine_only`. They now have their
+  own table. `VELESDB_STORAGE_MODE` was listed as `storage.storage_mode`, which
+  no regular mapping produces — corrected to `VELESDB_STORAGE_STORAGE_MODE`.
+
 ### Added
 
 - **The `clippy::significant_drop_tightening` backlog is frozen where it stands

--- a/crates/velesdb-core/src/config.rs
+++ b/crates/velesdb-core/src/config.rs
@@ -12,6 +12,7 @@
 
 use figment::{
     providers::{Env, Format, Serialized, Toml},
+    value::{Uncased, UncasedStr},
     Figment,
 };
 use serde::{Deserialize, Serialize};
@@ -378,9 +379,69 @@ impl VelesConfig {
         let figment = Figment::new()
             .merge(Serialized::defaults(Self::default()))
             .merge(Toml::file(path.as_ref()))
-            .merge(Env::prefixed("VELESDB_").split("_").lowercase(false));
+            .merge(Self::env_provider());
 
         Self::finish(&figment)
+    }
+
+    /// Every top-level table of this struct, as a `VELESDB_*` variable would
+    /// name it. Ordered longest-first so that a section whose name prefixes
+    /// another cannot claim its variables (none do today; the ordering keeps
+    /// that true for whatever is added next).
+    ///
+    /// Wider than [`Self::ENGINE_SECTIONS`] on purpose: `server` and
+    /// `logging` are fields here too, and a variable naming one must resolve
+    /// to that field rather than fall through as an unprefixed key.
+    const ENV_SECTIONS: &'static [&'static str] = &[
+        "quantization",
+        "wal_batch",
+        "logging",
+        "storage",
+        "limits",
+        "search",
+        "server",
+        "hnsw",
+    ];
+
+    /// Maps one `VELESDB_`-stripped variable name onto the config path it
+    /// addresses, splitting **only** at the boundary of a known section.
+    ///
+    /// `VELESDB_HNSW_EF_CONSTRUCTION` must reach `hnsw.ef_construction`, not
+    /// `hnsw.ef.construction`. Figment's `split("_")` treats every underscore
+    /// as a nesting separator, which no field carrying an underscore in its
+    /// name survives — and that is most of them (`max_collections`,
+    /// `ef_construction`, `query_timeout_ms`, ...). Splitting at the section
+    /// boundary and nowhere else is what the documented names actually mean.
+    ///
+    /// A name whose first token is not a section passes through lowercased and
+    /// unsplit, so `VELESDB_CONFIG`, `VELESDB_NO_UPDATE_CHECK` and the
+    /// server's own `VELESDB_HOST` / `VELESDB_PORT` keep matching nothing
+    /// here, exactly as they do today.
+    ///
+    /// Issue #2185: before this, the provider also carried `lowercase(false)`,
+    /// which left the key uppercase and made even the single-token
+    /// `VELESDB_HNSW_M` miss `hnsw.m`. Between the two defects, no documented
+    /// engine variable reached its field.
+    pub(crate) fn env_key_to_config_path(key: &UncasedStr) -> Uncased<'_> {
+        let lowered = key.as_str().to_ascii_lowercase();
+        for section in Self::ENV_SECTIONS {
+            if let Some(field) = lowered
+                .strip_prefix(section)
+                .and_then(|rest| rest.strip_prefix('_'))
+            {
+                if !field.is_empty() {
+                    return Uncased::from_owned(format!("{section}.{field}"));
+                }
+            }
+        }
+        Uncased::from_owned(lowered)
+    }
+
+    /// The `VELESDB_*` environment layer, built once so both loaders resolve
+    /// variable names identically — the same single-mapping-point discipline
+    /// `HnswParams::from_config` follows for the `[hnsw]` table.
+    fn env_provider() -> Env {
+        Env::prefixed("VELESDB_").map(Self::env_key_to_config_path)
     }
 
     /// Creates a configuration from a TOML string.
@@ -465,7 +526,7 @@ impl VelesConfig {
         let figment = Figment::new()
             .merge(Serialized::defaults(Self::default()))
             .merge(Toml::string(&filtered))
-            .merge(Env::prefixed("VELESDB_").split("_").lowercase(false));
+            .merge(Self::env_provider());
 
         Self::finish(&figment)
     }

--- a/crates/velesdb-core/src/config_env_tests.rs
+++ b/crates/velesdb-core/src/config_env_tests.rs
@@ -1,0 +1,126 @@
+//! Tests for the `VELESDB_*` environment-variable mapping (issue #2185).
+//!
+//! `VelesConfig::env_key_to_config_path` is the whole of the logic, and it is
+//! a pure function, so these assert on it directly rather than on process
+//! environment. That is not only convenience: `std::env::set_var` is global to
+//! the process, so an end-to-end test would race any other test reading config
+//! and would pass or fail depending on the thread count.
+//!
+//! What is being protected is the documented table in
+//! `docs/guides/CONFIGURATION.md`. Before #2185 not one of its engine rows
+//! reached its field — `.split("_")` nested at every underscore and
+//! `.lowercase(false)` left the key uppercase — so each case below is a row
+//! that used to silently do nothing.
+
+use crate::config::VelesConfig;
+use figment::value::UncasedStr;
+
+/// Maps a variable name as it appears **after** figment strips the
+/// `VELESDB_` prefix.
+fn path_of(stripped: &str) -> String {
+    VelesConfig::env_key_to_config_path(UncasedStr::new(stripped))
+        .as_str()
+        .to_string()
+}
+
+// -------------------------------------------------------------------------
+// The documented rows
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_single_token_field_reaches_its_section() {
+    // The case that proves `.lowercase(false)` was fatal on its own: this
+    // name has no underscore for `.split("_")` to mangle, and it still missed.
+    assert_eq!(path_of("HNSW_M"), "hnsw.m");
+}
+
+#[test]
+fn test_multi_word_field_is_not_split_at_every_underscore() {
+    // `hnsw.ef.construction` — the `.split("_")` failure — addresses nothing.
+    assert_eq!(path_of("HNSW_EF_CONSTRUCTION"), "hnsw.ef_construction");
+    assert_eq!(path_of("LIMITS_MAX_COLLECTIONS"), "limits.max_collections");
+    assert_eq!(
+        path_of("SEARCH_QUERY_TIMEOUT_MS"),
+        "search.query_timeout_ms"
+    );
+    assert_eq!(path_of("STORAGE_MMAP_CACHE_MB"), "storage.mmap_cache_mb");
+}
+
+#[test]
+fn test_lowercase_and_mixed_case_names_map_the_same() {
+    // Figment matches the key against the serde field name, which is
+    // lowercase; the variable's own casing must not decide whether it works.
+    for name in [
+        "HNSW_EF_CONSTRUCTION",
+        "hnsw_ef_construction",
+        "Hnsw_Ef_Construction",
+    ] {
+        assert_eq!(path_of(name), "hnsw.ef_construction", "for {name}");
+    }
+}
+
+#[test]
+fn test_every_section_of_the_struct_is_addressable() {
+    // A section missing from `ENV_SECTIONS` would fall through as a flat key
+    // and silently match nothing — the exact shape of this bug.
+    for (section, field) in [
+        ("search", "max_results"),
+        ("hnsw", "max_layers"),
+        ("storage", "vector_alignment"),
+        ("limits", "max_payload_size"),
+        ("server", "max_body_size"),
+        ("logging", "level"),
+        ("quantization", "enabled"),
+    ] {
+        let var = format!("{section}_{field}").to_ascii_uppercase();
+        assert_eq!(path_of(&var), format!("{section}.{field}"), "for {var}");
+    }
+}
+
+#[test]
+fn test_wal_batch_section_keeps_its_own_underscore() {
+    // The one section whose *name* contains an underscore: the split must
+    // happen after `wal_batch`, not inside it.
+    assert_eq!(
+        path_of("WAL_BATCH_MAX_BATCH_SIZE"),
+        "wal_batch.max_batch_size"
+    );
+    assert_eq!(path_of("WAL_BATCH_ENABLED"), "wal_batch.enabled");
+}
+
+// -------------------------------------------------------------------------
+// What must stay inert
+// -------------------------------------------------------------------------
+
+#[test]
+fn test_names_outside_any_section_pass_through_unsplit() {
+    // These are read elsewhere (the CLI's own config path, the update check)
+    // or belong to `velesdb-server`'s transport config. They matched nothing
+    // in `VelesConfig` before and must keep matching nothing: inventing a
+    // nesting for them is how an unrelated variable starts steering the
+    // engine.
+    for name in ["CONFIG", "NO_UPDATE_CHECK", "HOST", "PORT", "API_KEYS"] {
+        let mapped = path_of(name);
+        assert!(
+            !mapped.contains('.'),
+            "{name} must not be given a section, got {mapped}"
+        );
+    }
+}
+
+#[test]
+fn test_a_section_name_with_no_field_is_not_split() {
+    // `VELESDB_STORAGE` addresses the table itself, not a field in it;
+    // emitting `storage.` would be a malformed path.
+    assert_eq!(path_of("STORAGE"), "storage");
+    assert_eq!(path_of("HNSW"), "hnsw");
+}
+
+#[test]
+fn test_a_name_merely_starting_with_a_section_is_not_split() {
+    // `searching_for` starts with `search` but the next character is not the
+    // separator, so it is not a `[search]` field. Requiring the underscore is
+    // what keeps this from becoming `search.ing_for`.
+    assert_eq!(path_of("SEARCHING_FOR"), "searching_for");
+    assert_eq!(path_of("SERVERLESS_MODE"), "serverless_mode");
+}

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -94,6 +94,8 @@ pub mod column_store;
 mod column_store_tests;
 pub mod compression;
 pub mod config;
+#[cfg(test)]
+mod config_env_tests;
 pub mod config_quantization;
 #[cfg(test)]
 mod config_tests;

--- a/docs/guides/CONFIGURATION.md
+++ b/docs/guides/CONFIGURATION.md
@@ -374,24 +374,55 @@ hot_reload = false
 
 All options can be set via environment variables with the `VELESDB_` prefix:
 
+**Two config systems share the `VELESDB_` prefix.** The engine
+(`VelesConfig`) and the `velesdb-server` transport layer each read their own
+variables; a name resolves to one or the other, never both. They are listed
+separately because that distinction decides whether a variable does anything.
+
+### Engine variables (`VelesConfig`)
+
+`VELESDB_` + the section + `_` + the field, with underscores inside the field
+name kept as they are:
+
 | Variable | TOML Equivalent | Example |
 |----------|-----------------|---------|
 | `VELESDB_SEARCH_DEFAULT_MODE` | `search.default_mode` | `balanced` |
 | `VELESDB_SEARCH_EF_SEARCH` | `search.ef_search` | `256` |
+| `VELESDB_SEARCH_MAX_RESULTS` | `search.max_results` | `500` |
 | `VELESDB_HNSW_M` | `hnsw.m` | `48` |
 | `VELESDB_HNSW_EF_CONSTRUCTION` | `hnsw.ef_construction` | `600` |
+| `VELESDB_LIMITS_MAX_COLLECTIONS` | `limits.max_collections` | `50` |
+| `VELESDB_LIMITS_MAX_DIMENSIONS` | `limits.max_dimensions` | `4096` |
 | `VELESDB_STORAGE_DATA_DIR` | `storage.data_dir` | `/var/lib/velesdb` |
-| `VELESDB_STORAGE_MODE` | `storage.storage_mode` | `mmap` |
-| `VELESDB_HOST` | `server.host` | `0.0.0.0` |
-| `VELESDB_PORT` | `server.port` | `8080` |
-| `VELESDB_DATA_DIR` | `server.data_dir` | `/var/lib/velesdb` |
-| `VELESDB_RATE_LIMIT` | `server.rate_limit` | `100` |
-| `VELESDB_API_KEYS` | `auth.api_keys` | `key1,key2,key3` (comma-separated) |
-| `VELESDB_TLS_CERT` | `tls.cert` | `/etc/ssl/cert.pem` |
-| `VELESDB_TLS_KEY` | `tls.key` | `/etc/ssl/key.pem` |
+| `VELESDB_STORAGE_STORAGE_MODE` | `storage.storage_mode` | `mmap` |
+| `VELESDB_WAL_BATCH_ENABLED` | `wal_batch.enabled` | `false` |
 | `VELESDB_LOGGING_LEVEL` | `logging.level` | `debug` |
-| `VELESDB_LICENSE_KEY` | `premium.license_key` | `VELES-...` |
-| `VELESDB_NO_UPDATE_CHECK` | `update_check.enabled` | `1` (disables) |
+
+Setting one of these is exactly equivalent to setting its TOML key — so a
+**reserved** key stays reserved when set this way. `VELESDB_SEARCH_MAX_RESULTS`
+is parsed, validated and applied by nothing, just like `[search] max_results`;
+see the note at the top of this guide for what the engine acts on.
+
+Note `VELESDB_STORAGE_STORAGE_MODE`, not `VELESDB_STORAGE_MODE`: the section is
+`storage` and the field is `storage_mode`. Earlier revisions of this table
+listed the short form, which addresses `storage.mode` — no such field exists.
+
+### Server variables (`velesdb-server` only)
+
+These belong to the HTTP transport layer and are **not** `VelesConfig` fields.
+They have no effect on an embedded engine:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `VELESDB_HOST` | Bind address | `0.0.0.0` |
+| `VELESDB_PORT` | Bind port | `8080` |
+| `VELESDB_DATA_DIR` | Server data directory | `/var/lib/velesdb` |
+| `VELESDB_RATE_LIMIT` | Requests per window | `100` |
+| `VELESDB_API_KEYS` | API keys | `key1,key2,key3` (comma-separated) |
+| `VELESDB_TLS_CERT` | TLS certificate path | `/etc/ssl/cert.pem` |
+| `VELESDB_TLS_KEY` | TLS key path | `/etc/ssl/key.pem` |
+| `VELESDB_LICENSE_KEY` | License key | `VELES-...` |
+| `VELESDB_NO_UPDATE_CHECK` | Disables the update check | `1` |
 | `VELESDB_CONFIG` | Config file path | `/etc/velesdb/velesdb.toml` |
 
 ### Name Mapping
@@ -401,6 +432,15 @@ The mapping follows this rule:
 VELESDB_{SECTION}_{KEY} (uppercase, underscores)
 → section.key (lowercase, underscores preserved)
 ```
+
+The split happens at the **section boundary only** — the first underscore that
+follows a known section name. Everything after it is the field name, kept
+verbatim, so `VELESDB_HNSW_EF_CONSTRUCTION` reaches `hnsw.ef_construction`
+rather than a non-existent `hnsw.ef.construction`. A name whose first token is
+not a section (`VELESDB_CONFIG`, `VELESDB_HOST`) is left alone and matches no
+engine field. Before issue #2185 the provider split at *every* underscore and
+kept the key uppercase, so no engine variable in the table above reached its
+field at all.
 
 ### Examples
 

--- a/examples/react-wasm-search/package-lock.json
+++ b/examples/react-wasm-search/package-lock.json
@@ -784,9 +784,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -817,11 +817,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.418",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
+      "integrity": "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/2185-env-var-provider` → **`develop`**. ✅

## Description

**No documented `VELESDB_*` engine variable reached its config field.** Not a partial failure — none of them, including single-token names.

Found while re-verifying the env-var table end to end, which #2087's validation bar requires. Reproduced against `develop` @ `d4e29e17`:

```
hnsw.m                  = None  (expected Some(48))
hnsw.ef_construction    = None  (expected Some(600))
limits.max_collections  = 1000  (expected 5)
```

The last one despite an explicit rustdoc promise on `VelesConfig::load_from_path_engine_only` that `VELESDB_LIMITS_MAX_COLLECTIONS` overrides the file.

### Two defects, either fatal alone

The provider was built:

```rust
.merge(Env::prefixed("VELESDB_").split("_").lowercase(false))
```

1. **`lowercase(false)`** left the key uppercase, so deserialization looked for a field literally named `HNSW`, not `hnsw`. This is what broke even `VELESDB_HNSW_M`, which has no underscore for anything else to mangle — and why the bug could not be explained by the split alone.
2. **`split("_")`** made *every* underscore a nesting separator, so `VELESDB_HNSW_EF_CONSTRUCTION` addressed `hnsw.ef.construction`. No field with an underscore in its name was reachable, which is most of them: `max_collections`, `ef_construction`, `query_timeout_ms`, `max_payload_size`, `vector_alignment`.

Both `load_from_path` and `load_from_path_engine_only` carried the line, so the defect covered every surface that loads a config: server, CLI, Python, mobile, tauri.

### The fix

Split at the **section boundary only** — the first underscore following a known top-level table — and keep the field name verbatim:

```
VELESDB_HNSW_M                   -> hnsw.m
VELESDB_HNSW_EF_CONSTRUCTION     -> hnsw.ef_construction
VELESDB_LIMITS_MAX_COLLECTIONS   -> limits.max_collections
VELESDB_WAL_BATCH_MAX_BATCH_SIZE -> wal_batch.max_batch_size
```

A name whose first token is not a section passes through lowercased and unsplit, so `VELESDB_CONFIG`, `VELESDB_NO_UPDATE_CHECK` and the server's own `VELESDB_HOST` / `VELESDB_PORT` keep matching nothing here — exactly as they do today. Inventing a nesting for those is how an unrelated variable would start steering the engine.

The two loaders now share one `env_provider()`, so they cannot drift — the same single-mapping-point discipline `RuntimeLimits::from_config` and `HnswParams::from_config` follow for their tables. No new dependency: `figment::value::{Uncased, UncasedStr}` are re-exported.

`ENV_SECTIONS` is deliberately wider than `ENGINE_SECTIONS` — `server` and `logging` are fields on `VelesConfig` too — and ordered longest-first so a section whose name prefixes another cannot claim its variables. None do today; the ordering keeps that true for whatever is added next. `wal_batch` is the one section whose *own name* contains an underscore, and it has a test.

## This is a behaviour change, not only a fix

Variables that were inert now take effect. **An operator carrying a stale `VELESDB_LIMITS_MAX_COLLECTIONS=5` in their environment will start getting `GuardRail` refusals on collection creation after upgrading** — the value they set, finally applied. The CHANGELOG says so directly and tells them to check the environment of any deployment exporting `VELESDB_*` before upgrading.

This is why it was kept out of #2186 rather than folded in: that PR's subject is HNSW topology, and this touches what every config load does on every surface. It deserves its own review.

A variable is exactly equivalent to its TOML key, so a **reserved** key stays reserved when set this way: `VELESDB_SEARCH_MAX_RESULTS` is parsed, validated and applied by nothing, same as `[search] max_results`. Making the variable work does not make the knob work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change — see the section above; inert variables begin taking effect
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests

`cargo test -p velesdb-core --features persistence -- --test-threads=1` — **6505 passed, 0 failed** across 70 suites.

`cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean. `cargo fmt --all` applied. The repo guard suites (`test_check_doc_freshness`, `test_check_file_budgets`, `test_check_perf_claims`) pass.

Verified end to end against a built binary before and after: all five of `VELESDB_HNSW_M`, `VELESDB_HNSW_EF_CONSTRUCTION`, `VELESDB_LIMITS_MAX_COLLECTIONS`, `VELESDB_SEARCH_QUERY_TIMEOUT_MS` and `VELESDB_STORAGE_MMAP_CACHE_MB` now reach their fields; all five loaded as defaults before.

Eight tests added in `config_env_tests.rs`, asserting the **mapping function** rather than process environment. That is not convenience: `std::env::set_var` is global to the process, so an end-to-end test would race any other test reading config and would pass or fail by thread count. The mapping is the whole of the logic, and it is pure.

They cover: the single-token case that proves `lowercase(false)` was fatal on its own; multi-word fields that `split("_")` destroyed; case-insensitivity of the variable's own spelling; every one of the struct's seven sections being addressable (a section missing from `ENV_SECTIONS` would fall through as a flat key and silently match nothing — the exact shape of this bug); `wal_batch` keeping its own underscore; names outside any section staying unsplit; a bare section name not becoming a malformed `storage.`; and a name that merely *starts* with a section (`SEARCHING_FOR`) not being split into `search.ing_for`.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: 1.90

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified.

## High-Risk Change Checklist

Not a `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path. It does change what every config load resolves, so:

- [x] **Invariants impacted.** A `VELESDB_*` variable must resolve to the same path a TOML key would, or the documented equivalence between the two is false again in the other direction. Every section of the struct is covered by a test for exactly that.
- [x] **Durability semantics.** Unchanged — nothing is persisted by this path.
- [x] **Lifecycle tests.** Not applicable; the change is in config assembly, before any collection exists.

## Additional Notes

**The guide's table conflated two config systems**, independently of the provider. `VELESDB_HOST`, `VELESDB_PORT`, `VELESDB_DATA_DIR`, `VELESDB_RATE_LIMIT`, `VELESDB_API_KEYS` and `VELESDB_TLS_*` are `velesdb-server`'s own transport variables and were listed as though they addressed `VelesConfig` sections. They never will: `[server]`, `[auth]` and `[tls]` are filtered out by `load_from_path_engine_only`. They now have their own table, marked as having no effect on an embedded engine.

`VELESDB_STORAGE_MODE` was documented as mapping to `storage.storage_mode`, which no regular mapping produces — the section is `storage` and the field is `storage_mode`, so the name is `VELESDB_STORAGE_STORAGE_MODE`. Corrected rather than special-cased: a mapping table with one hand-written exception is how the next one gets added.

Closes #2185.