### PR TITLE
chore(deps): bump browserslist past GHSA-c83g-rgw3-j3cx / GHSA-73wf-gq98-2v4g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`browserslist` advisory in `examples/react-wasm-search` (GHSA-c83g-rgw3-j3cx,
+  GHSA-73wf-gq98-2v4g).** Both were published upstream while PRs were in
+  flight: the `npm advisories (examples/react-wasm-search)` gate passed at
+  17:02 UTC and failed at 17:38 on an unchanged lockfile, and reproduces on
+  `develop` itself. `browserslist` 4.28.2 → 4.28.8 via `npm audit fix
+  --package-lock-only`, which also carries its data tables
+  (`caniuse-lite`, `electron-to-chromium`, `node-releases`,
+  `baseline-browser-mapping`) forward. All dev-only, all within the same
+  major — no `--force`, so `package.json` constraints are untouched. The
+  three other lockfiles in the repo audit clean.
+
 ### Added
 
 - **The `clippy::significant_drop_tightening` backlog is frozen where it stands

--- a/examples/react-wasm-search/package-lock.json
+++ b/examples/react-wasm-search/package-lock.json
@@ -784,9 +784,9 @@
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -817,11 +817,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.418",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.418.tgz",
+      "integrity": "sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1284,9 +1284,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`chore/browserslist-advisory` → **`develop`**. ✅

## Description

Two high-severity advisories against `browserslist <=4.28.6` were published upstream while several PRs were in flight:

- [GHSA-c83g-rgw3-j3cx](https://github.com/advisories/GHSA-c83g-rgw3-j3cx) — unbounded memory growth (no cache eviction) via distinct query results, leading to eventual OOM
- [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) — uncaught crash / prototype write via untrusted `browserslist-stats.json` custom stats (`normalizeStats`)

**This belongs to no PR in particular and blocks all of them.** The `Gate Contracts / npm advisories (examples/react-wasm-search)` job passed at **17:02 UTC** on an unchanged lockfile and failed at **17:38** on the same lockfile; the advisory landed in that window. Reproduced directly on `develop`:

```
$ cd examples/react-wasm-search && npm audit --package-lock-only --audit-level=high
browserslist  <=4.28.6
Severity: high
1 high severity vulnerability
```

Opened as its own change rather than folded into whichever PR happened to be red when it appeared — that PR's subject would have had nothing to do with it, and four other PRs would still have been blocked.

## The fix

`npm audit fix --package-lock-only`, which takes `browserslist` 4.28.2 → 4.28.8 and carries its data tables forward with it:

| Package | From | To |
|---|---|---|
| `browserslist` | 4.28.2 | 4.28.8 |
| `caniuse-lite` | 1.0.30001799 | 1.0.30001810 |
| `electron-to-chromium` | 1.5.372 | 1.5.418 |
| `node-releases` | 2.0.47 | 2.0.54 |
| `baseline-browser-mapping` | 2.10.37 | 2.11.20 |

Every one is a **dev** dependency (transitive via vite) and stays within the same major. Run **without `--force`**, so no `package.json` constraint moves and no runtime dependency is touched — the diff is one lockfile, 23 lines changed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

```
$ npm audit --package-lock-only --audit-level=high   # examples/react-wasm-search
found 0 vulnerabilities
```

That is the exact command the failing CI job runs. The repo's three other lockfiles were checked too and were already clean:

| Lockfile | Audit |
|---|---|
| `sdks/typescript` | clean |
| `examples/node-express-rag` | clean |
| `demos/tauri-rag-app` | clean |

No Rust code is touched, so the Rust suites are unaffected.

**Test Configuration:**
- OS: Linux x86_64
- npm 10.9.7

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

No `unsafe` added or modified — no Rust in this change.

## High-Risk Change Checklist

Not applicable: one dev-dependency lockfile, no production code path.

## Additional Notes

No `npm install` / build of the example was run to validate this, and it is worth being explicit about that rather than implying otherwise. What moved is browserslist's version-data tables — packages with no API surface the example calls directly — and `npm audit fix` without `--force` resolves only within the ranges `package.json` already declares. If a maintainer wants a build run before merging, `examples/react-wasm-search` builds with `npm ci && npm run build`.

**This same commit is also ported into #2186 and #2187** (cherry-picked with `-x`), so those two do not have to wait on this PR to get their `npm advisories` job green. The ports carry identical lockfile content and become no-ops once `develop` holds this change, whichever order the four land in. #2178, #2183 and #2184 were last built before the advisory appeared and have it recorded green; they will pick it up from `develop` if they are ever re-run.