### PR TITLE
fix(quantization): avoid underflow in PQ reconstruct out-of-range error

### DIFF
--- a/crates/velesdb-core/src/quantization/pq.rs
+++ b/crates/velesdb-core/src/quantization/pq.rs
@@ -234,7 +234,7 @@ impl ProductQuantizer {
                 return Err(Error::InvalidQuantizerConfig(format!(
                     "code index {code_idx} out of range for subspace {subspace} \
                      (max {})",
-                    self.codebook.centroids[subspace].len() - 1
+                    self.codebook.centroids[subspace].len().saturating_sub(1)
                 )));
             }
             let centroid = &self.codebook.centroids[subspace][code_idx];

--- a/crates/velesdb-core/src/quantization/pq_tests.rs
+++ b/crates/velesdb-core/src/quantization/pq_tests.rs
@@ -258,6 +258,31 @@ fn reconstruct_invalid_codes_returns_error() {
 }
 
 #[test]
+fn reconstruct_reports_range_error_without_overflow_on_empty_subspace() {
+    // A deserialized `PQCodebook` is never re-validated against `train()`'s
+    // non-zero-centroid invariant, so `reconstruct` must not underflow while
+    // formatting the "max" operand of its own out-of-range error.
+    use super::PQCodebook;
+
+    let codebook = PQCodebook {
+        centroids: vec![vec![]],
+        dimension: 2,
+        num_subspaces: 1,
+        num_centroids: 0,
+        subspace_dim: 2,
+    };
+    let pq = ProductQuantizer {
+        codebook,
+        rotation: None,
+    };
+    let bad_pq_vec = PQVector { codes: vec![0] };
+
+    let result = pq.reconstruct(&bad_pq_vec);
+
+    assert!(matches!(result, Err(Error::InvalidQuantizerConfig(_))));
+}
+
+#[test]
 fn kmeans_plusplus_init_produces_k_distinct_centroids() {
     use crate::quantization::pq_kmeans::kmeans_plusplus_init;
     use rand::SeedableRng;


### PR DESCRIPTION
## Description

`ProductQuantizer::reconstruct()` builds its `InvalidQuantizerConfig` error
message with `self.codebook.centroids[subspace].len() - 1`. `PQCodebook`
derives `Deserialize` and is never re-validated after load, unlike
`train()`, which does enforce `num_centroids > 0`. If a codebook is
deserialized with an empty centroid table for a subspace, the range guard
(`code_idx >= centroids[subspace].len()`) is always true, so the branch
always executes `0usize - 1` — an integer-underflow panic in a
debug/test build (overflow checks are on by default) or a wraparound to
`usize::MAX` in release, either way defeating the function's documented
`# Errors` contract of returning `Err` on an out-of-range code.

Fix: use `saturating_sub(1)` for the message operand — a one-line change
on the already-erroring path, no behavior change on any success path.

Found via a routine code-quality review of `velesdb-core`; not tied to an
existing issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `reconstruct_reports_range_error_without_overflow_on_empty_subspace`,
which builds a `PQCodebook` directly with an empty centroid table and
asserts `reconstruct()` returns `Err(InvalidQuantizerConfig)` rather than
panicking. Verified it reproduces the panic (`attempt to subtract with
overflow`) against the pre-fix code, and passes with the fix.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: 1.90 (workspace MSRV)

Also ran, all green:
- `cargo fmt --all -- --check`
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks`
- `cargo clippy -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic`
- `cargo test -p velesdb-core --features persistence -- --test-threads=1` (5472 passed, 0 failed)
- `cargo test --doc --package velesdb-core`
- `python3 scripts/check_prod_unwraps.py`
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Scope is intentionally surgical (single-line fix + one regression test) per
this repo's working principles — no adjacent refactoring.