### PR TITLE
feat(guards): refuse a partial Arc/Box trait forwarding (#1967)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,14 @@ jobs:
       - name: Check durability barriers on file-creating write paths
         run: python3 scripts/check-durability-barrier.py
 
+      # velesdb-memory's doctrine (crates/velesdb-memory/src/lib.rs) requires a
+      # `Box`/`Arc` adapter to forward the WHOLE trait. rustc only demands the
+      # *required* methods, so a partial forwarding can only ever drop one with
+      # a default body — it compiles, and the wrapper silently runs the default
+      # instead of the concrete override. That is the #1690-#1692 gap family.
+      - name: Check wrapper adapters forward their trait whole
+        run: python3 scripts/check-trait-forwarding.py
+
       - name: Check for .unwrap() in production code
         run: python3 scripts/check_prod_unwraps.py
 
@@ -469,6 +477,9 @@ jobs:
 
       - name: Test file-budgets audit script
         run: python3 -m unittest scripts.tests.test_check_file_budgets
+
+      - name: Test trait-forwarding audit script
+        run: python3 -m unittest scripts.tests.test_check_trait_forwarding
 
       - name: Audit feature claims vs exports
         run: python3 scripts/check-feature-claims.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A guard that no adapter forwards its trait partially (#1967).**
+  `scripts/check-trait-forwarding.py` reads every adapter under `crates/*/src`
+  that exists only to delegate — the generic wrapper
+  `impl<T: Trait + ?Sized> Trait for Box<T> | Arc<T> | Rc<T>`, and the erased
+  alias `impl Trait for DynTrait` where `type DynTrait = Box<dyn Trait>` —
+  and demands the impl define every method the trait declares. An ordinary
+  `impl Trait for Backend` is deliberately exempt: a concrete backend is
+  entitled to the trait's default, which is what a default is for.
+
+  The bug it prevents is narrow, which is exactly why it needs a machine.
+  rustc already refuses an `impl` that omits a *required* method, so a partial
+  forwarding can only ever drop a method that has a **default body** — and
+  then it compiles: `Arc<Concrete>` silently runs the trait's default instead
+  of `Concrete`'s override. `Extractor::extract_graph` is the shape that
+  already cost the repo a bug (the #1690–#1692 gap family): forward only
+  `extract`, and every `Arc`-held backend loses the relations and attributes
+  it actually produced. `velesdb-memory`'s doctrine in `src/lib.rs` states the
+  rule — "an adapter forwards the **whole** trait" — and until now only review
+  enforced it.
+
+  Five forwardings are checked today — four generic wrappers (`Reranker`,
+  `Embedder`, `Extractor`, `TokenEstimator`) and one erased alias
+  (`DynReranker`, which is what the Node binding wraps a JS callback in);
+  all five are whole. The alias shape carries no generic parameter, so a
+  wrapper-only pattern never sees it, and it is precisely where a dropped
+  method would be lost for every JS caller while the Rust tests, which use the
+  concrete type, stayed green.
+
+  Supertrait methods are deliberately not demanded: the storage facets of
+  #1959 are separate traits, and the doctrine's unit is the facet. A trait
+  defined outside the scanned tree is reported `SKIPPED` rather than passed,
+  so a miss the guard cannot see never reads as a clean run.
+
+  Wired into `ci.yml`'s `lint` job with its self-test, registered in
+  `scripts/guards.json` with three executable refusal vectors and its blind
+  spot (presence, not delegation: a forwarded method whose body reimplements
+  the default rather than calling `(**self)` still satisfies the guard).
+
 - **`[hnsw]` is applied by the engine (#2087).** `m` and `ef_construction`
   from the configuration file now reach the HNSW index of every collection the
   `Database` creates — vector collections and graph collections with node

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,7 @@ All new/modified code must satisfy these limits (enforced by Codacy and CI):
 | Unsafe blocks | Must have `// SAFETY:` comment | CI (`verify_unsafe_safety_template.py`) |
 | TODO format | Must carry an issue tag: `[EPIC-XXX/US-YYY]`, `(PREFIX-NNN)`, `#123`, or `#issue` | CI (`check-todo-annotations.py`) |
 | `.unwrap()` | Forbidden in production code | CI (`check_prod_unwraps.py`) |
+| Wrapper adapters | An `impl Trait for Box<T>`/`Arc<T>`/`Rc<T>`, or for a `type DynTrait = Box<dyn Trait>` alias, must forward **every** method the trait declares — rustc only demands the required ones, so a dropped default-bodied method compiles and silently runs the default | CI (`check-trait-forwarding.py`) |
 | Recall@10 | **>= 0.95** (if search path modified) | CI + local validation |
 
 Every guard script this repository runs is declared in

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -13,10 +13,10 @@
 //!
 //! The budget still binds. Growth goes into child modules that keep private
 //! access (`fused_recall.rs` and `online_migration.rs` are the pattern —
-//! `#[path]` children of `service`, not siblings), never into this file; the
-//! next named cut is the working-context bridge (#1967, decided together with
-//! the store facetting of #1959). A change that adds an operation body here
-//! instead of a child module needs to say why in review.
+//! `#[path]` children of `service`, not siblings), never into this file. The
+//! working-context bridge was the last named cut and it is done: it left along
+//! the store-facet line of #1959, as #1967 asked. A change that adds an
+//! operation body here instead of a child module needs to say why in review.
 
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "persistence")]

--- a/scripts/check-trait-forwarding.py
+++ b/scripts/check-trait-forwarding.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Every delegating adapter forwards its trait WHOLE.
+
+`velesdb-memory`'s doctrine (`src/lib.rs`, "Generics at the core, `dyn` at the
+edges") ends on a rule that until now only review enforced:
+
+    an adapter over one of these traits forwards the **whole** trait —
+    partial forwarding is how a binding silently loses a capability the
+    server already publishes (the #1690-#1692 gap family)
+
+This guard makes that mechanical. It is narrow on purpose, because the bug it
+prevents is narrow: rustc already refuses an `impl` that omits a *required*
+method, so a partial forwarding can only ever drop a method that has a
+**default body**. That is precisely what makes it silent — `Arc<Concrete>`
+keeps compiling and quietly runs the trait's default instead of `Concrete`'s
+override. `Extractor::extract_graph` is the shape that already cost the repo
+a bug: forward only `extract`, and every `Arc`-held backend loses the
+relations and attributes it actually produced.
+
+What is checked
+---------------
+Two shapes of adapter, both under `crates/*/src/**/*.rs` (test files
+excluded). For each, the guard reads the trait's own method names and demands
+the impl define every one of them:
+
+1. the generic wrapper — `impl<T: Trait + ?Sized> Trait for Box<T> | Arc<T> |
+   Rc<T>`;
+2. the erased alias — `impl Trait for DynTrait` where `DynTrait` is declared
+   as `type DynTrait = Box<dyn Trait + ...>` (or `Arc`/`Rc`). This is the
+   shape the bindings actually hold: `DynReranker` is what the Node binding
+   wraps a JS callback in, and a default-bodied method dropped there is lost
+   for every JS caller while the Rust tests, which use the concrete type,
+   stay green.
+
+A plain `impl Trait for ConcreteType` is NOT a forwarding and is never
+demanded: a concrete backend is entitled to take the trait's default — that
+is what defaults are for. Only an adapter that exists solely to delegate is
+held to completeness.
+
+Supertrait methods are NOT demanded: the storage facets (#1959) are separate
+traits, and the doctrine's unit is the facet — "an adapter picks which facets
+it serves, but each facet it implements is forwarded whole".
+
+A trait the guard cannot see (defined in another crate) is reported as
+skipped rather than passed, so a silent miss never reads as a clean run.
+
+Exit code: 0 = every forwarding is whole, 1 = at least one is partial.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SCAN_GLOB = "crates/*/src/**/*.rs"
+
+#: Wrapper types whose `impl Trait for Wrapper<T>` — or whose `type Dyn… =
+#: Wrapper<dyn Trait>` alias — is a forwarding adapter.
+#: `&T`/`&mut T` are deliberately absent: std already blanket-forwards through
+#: references for the shapes this crate uses, and a hand-written one would be
+#: the exception worth reading rather than a pattern to police.
+WRAPPERS = ("Box", "Arc", "Rc")
+
+_TRAIT_RE = re.compile(r"\btrait\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\b")
+#: Start of a generic impl. Its parameter list is closed by matching angles
+#: rather than by a regex: `impl<K, T: Store<K> + ?Sized>` nests, and a
+#: `[^>]*` stops at the first inner `>` and quietly matches nothing — the
+#: guard would then police fewer adapters every time a bound grew a generic
+#: argument, without saying so.
+_IMPL_HEAD_RE = re.compile(r"\bimpl\s*<")
+
+#: What follows that parameter list for a wrapper forwarding: the trait (with
+#: its own generic arguments, if any), `for`, and the wrapper.
+_IMPL_TAIL_RE = re.compile(
+    r"\s*(?P<trait>[A-Za-z_][A-Za-z0-9_]*)\s*(?:<[^{;]*?>)?\s+for\s+"
+    r"(?:std::sync::|std::rc::|alloc::\w+::)?(?P<wrapper>" + "|".join(WRAPPERS) + r")\s*<"
+)
+#: `type DynFoo = Box<dyn Foo + Send + Sync>;` — the erased alias a binding
+#: holds. Captured tree-wide so the `impl Foo for DynFoo` below can be told
+#: apart from an ordinary concrete impl, which must NOT be held to
+#: completeness.
+_ALIAS_RE = re.compile(
+    r"\btype\s+(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"(?:std::sync::|std::rc::|alloc::\w+::)?(?P<wrapper>" + "|".join(WRAPPERS) + r")\s*<\s*"
+    r"dyn\s+(?P<trait>[A-Za-z_][A-Za-z0-9_]*)"
+)
+
+#: A non-generic `impl Trait for Name`. Only a `Name` that `_ALIAS_RE` proved
+#: to be a wrapper of `dyn Trait` counts as a forwarding.
+_ALIAS_IMPL_RE = re.compile(
+    r"\bimpl\s+(?P<trait>[A-Za-z_][A-Za-z0-9_]*)\s+for\s+"
+    r"(?P<alias>[A-Za-z_][A-Za-z0-9_]*)\s*\{"
+)
+
+
+def is_scanned_file(path: Path) -> bool:
+    """Production Rust only — test volume has its own program (#1918)."""
+    if path.name.endswith("_tests.rs") or path.name == "tests.rs":
+        return False
+    norm = str(path).replace("\\", "/")
+    return "/tests/" not in norm and "/benches/" not in norm
+
+
+def _char_literal_end(src: str, start: int) -> int | None:
+    """Index just past the char literal opening at `start`, or `None` when the
+    `'` is a lifetime tick rather than a quote.
+
+    A char literal is at most a handful of bytes and always closes; a lifetime
+    never does. Bounding the search is what makes the two distinguishable
+    without a real lexer.
+    """
+    i = start + 1
+    if i < len(src) and src[i] == "\\":
+        i += 1
+        if i < len(src) and src[i] == "u" and src[i + 1 : i + 2] == "{":
+            close = src.find("}", i)
+            if close == -1 or close - i > 10:
+                return None
+            i = close
+        i += 1
+    else:
+        i += 1
+    return i + 1 if src[i : i + 1] == "'" else None
+
+
+def strip_comments(src: str) -> str:
+    """Blank out comments while preserving offsets, so brace matching and the
+    reported line numbers both stay true to the original text.
+
+    String and char literals are tracked so a `//` or `/*` inside one does not
+    open a comment. Raw strings (`r#"..."#`) are handled at any hash depth.
+
+    The `'` is the delicate one: Rust spends it on lifetimes far more often
+    than on char literals, and a `'static` bound leaves the tick unmatched.
+    Read as an opening quote it runs to the next `'` — or to EOF — and every
+    comment in between goes unblanked, so a method named only in prose enters
+    the trait's method set and the guard demands a forwarding for something
+    that does not exist. So a `'` opens a literal only when it actually closes
+    as one (`'x'`, `'\\n'`, `'\\u{1F600}'`); otherwise it is a lifetime and only
+    the tick itself is stepped over.
+    """
+    out = list(src)
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == "'":
+            end = _char_literal_end(src, i)
+            i = end if end is not None else i + 1
+            continue
+        if c == '"':
+            i += 1
+            while i < n:
+                if src[i] == "\\":
+                    i += 2
+                    continue
+                if src[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            continue
+        if (src.startswith('r"', i) or src.startswith('r#"', i)) and not (
+            i and (src[i - 1].isalnum() or src[i - 1] == "_")
+        ):
+            hashes = 0
+            j = i + 1
+            while j < n and src[j] == "#":
+                hashes += 1
+                j += 1
+            terminator = '"' + "#" * hashes
+            end = src.find(terminator, j + 1)
+            i = n if end == -1 else end + len(terminator)
+            continue
+        if src.startswith("//", i):
+            end = src.find("\n", i)
+            end = n if end == -1 else end
+            for k in range(i, end):
+                out[k] = " "
+            i = end
+            continue
+        if src.startswith("/*", i):
+            depth, j = 1, i + 2
+            while j < n and depth:
+                if src.startswith("/*", j):
+                    depth += 1
+                    j += 2
+                elif src.startswith("*/", j):
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            for k in range(i, min(j, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+            continue
+        i += 1
+    return "".join(out)
+
+
+def block_after(src: str, start: int) -> tuple[int, int] | None:
+    """Span of the `{...}` block that opens at or after `start`.
+
+    Returns `(body_start, body_end)` exclusive of the braces, or `None` when
+    the item has no block (`trait Foo;` never appears, but a `where` clause
+    spanning to EOF in a truncated file would).
+    """
+    open_at = src.find("{", start)
+    if open_at == -1:
+        return None
+    depth, i, n = 0, open_at, len(src)
+    while i < n:
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return (open_at + 1, i)
+        i += 1
+    return None
+
+
+def angles_close(src: str, open_at: int) -> int | None:
+    """Index just past the `>` matching the `<` at `open_at`.
+
+    `->` is stepped over whole: a bound like `F: Fn(&str) -> u8` puts a `>`
+    inside the parameter list that closes nothing.
+    """
+    depth, i, n = 0, open_at, len(src)
+    while i < n:
+        if src.startswith("->", i):
+            i += 2
+            continue
+        if src[i] == "<":
+            depth += 1
+        elif src[i] == ">":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        elif src[i] in "{};":
+            # An impl header never reaches a body or a statement end with its
+            # parameter list still open; bailing keeps a malformed file from
+            # swallowing the rest of the tree.
+            return None
+        i += 1
+    return None
+
+
+def top_level_fns(body: str) -> list[str]:
+    """Names of the `fn`s declared directly in `body`, ignoring nested ones.
+
+    A closure or a helper `fn` inside a method body sits at depth > 0 and must
+    not be mistaken for a member of the trait or impl.
+    """
+    names: list[str] = []
+    depth = 0
+    for match in re.finditer(r"[{}]|\bfn\s+[A-Za-z_][A-Za-z0-9_]*", body):
+        token = match.group(0)
+        if token == "{":
+            depth += 1
+        elif token == "}":
+            depth -= 1
+        elif depth == 0:
+            names.append(token.split()[-1])
+    return names
+
+
+def collect_traits(src: str) -> dict[str, list[str]]:
+    """Trait name -> its own method names (supertrait methods excluded)."""
+    traits: dict[str, list[str]] = {}
+    for match in _TRAIT_RE.finditer(src):
+        span = block_after(src, match.end())
+        if span is None:
+            continue
+        traits[match.group("name")] = top_level_fns(src[span[0] : span[1]])
+    return traits
+
+
+def collect_aliases(src: str) -> dict[str, tuple[str, str]]:
+    """`DynFoo -> (wrapper, trait)` for each `type DynFoo = Box<dyn Foo…>`."""
+    return {
+        match.group("alias"): (match.group("wrapper"), match.group("trait"))
+        for match in _ALIAS_RE.finditer(src)
+    }
+
+
+def collect_forwardings(
+    src: str, aliases: dict[str, tuple[str, str]] | None = None
+) -> list[tuple[str, str, list[str], int]]:
+    """`(trait, target, methods, line)` for each forwarding impl in `src`.
+
+    `target` is what the impl is written for, as it should read in a message:
+    `Arc<T>` for a generic wrapper, `DynReranker` for an erased alias.
+
+    `aliases` is the tree-wide alias table; an alias impl is recognised only
+    when the alias is known to wrap `dyn` of the very trait being implemented.
+    Passing `None` collects the generic wrappers alone, which is what a
+    single-file caller wants.
+    """
+    aliases = aliases or {}
+    found = []
+
+    def record(trait: str, target: str, body: tuple[int, int], at: int) -> None:
+        found.append(
+            (trait, target, top_level_fns(src[body[0] : body[1]]),
+             src.count("\n", 0, at) + 1)
+        )
+
+    for head in _IMPL_HEAD_RE.finditer(src):
+        after = angles_close(src, head.end() - 1)
+        if after is None:
+            continue
+        tail = _IMPL_TAIL_RE.match(src, after)
+        if tail is None:
+            continue
+        span = block_after(src, tail.end())
+        if span is not None:
+            record(tail.group("trait"), f"{tail.group('wrapper')}<T>", span, head.start())
+
+    for match in _ALIAS_IMPL_RE.finditer(src):
+        trait, alias = match.group("trait"), match.group("alias")
+        # A concrete `impl Trait for Backend` is not a forwarding: a backend
+        # is entitled to the trait's defaults. Only an alias that wraps
+        # `dyn Trait` exists solely to delegate.
+        if aliases.get(alias, (None, None))[1] != trait:
+            continue
+        span = block_after(src, match.end() - 1)
+        if span is not None:
+            record(trait, alias, span, match.start())
+
+    return found
+
+
+def audit(root: Path) -> tuple[list[str], list[str], int]:
+    """`(failures, skipped, checked_count)` over the whole tree."""
+    traits: dict[str, list[str]] = {}
+    forwardings: list[tuple[Path, str, str, list[str], int]] = []
+
+    # Two passes: an alias declared in one file is implemented in another
+    # (`DynExtractor` lives beside its trait, its impl need not), so the alias
+    # table has to be complete before any impl is judged.
+    sources: list[tuple[Path, str]] = []
+    aliases: dict[str, tuple[str, str]] = {}
+    for path in sorted(root.glob(SCAN_GLOB)):
+        if not is_scanned_file(path):
+            continue
+        try:
+            src = strip_comments(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        sources.append((path, src))
+        traits.update(collect_traits(src))
+        aliases.update(collect_aliases(src))
+
+    for path, src in sources:
+        for trait, target, methods, line in collect_forwardings(src, aliases):
+            forwardings.append((path.relative_to(root), trait, target, methods, line))
+
+    failures: list[str] = []
+    skipped: list[str] = []
+    for rel, trait, target, methods, line in forwardings:
+        if trait not in traits:
+            skipped.append(
+                f"{rel}:{line}: `impl {trait} for {target}` — trait not found in "
+                f"crates/*/src; defined outside the scanned tree, so its method "
+                f"set could not be read."
+            )
+            continue
+        missing = [m for m in traits[trait] if m not in methods]
+        if missing:
+            # `Arc<T>` reads as `Arc<Concrete>` at a call site; an alias reads
+            # as itself. Naming the shape the caller holds is what makes the
+            # message actionable.
+            holder = target.replace("<T>", "<Concrete>") if target.endswith("<T>") else target
+            failures.append(
+                f"{rel}:{line}: `impl {trait} for {target}` forwards "
+                f"{len(methods)}/{len(traits[trait])} methods — missing "
+                f"{', '.join('`' + m + '`' for m in missing)}.\n"
+                f"    rustc cannot catch this: a method missing here has a default "
+                f"body, so {holder} silently runs the trait default "
+                f"instead of the concrete override.\n"
+                f"    Forward it verbatim — `fn {missing[0]}(...) {{ (**self)."
+                f"{missing[0]}(...) }}` — or delete the default from the trait so "
+                f"rustc demands it."
+            )
+    return failures, skipped, len(forwardings)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--root", default=".", help="repository root to scan")
+    args = parser.parse_args(argv)
+
+    failures, skipped, checked = audit(Path(args.root))
+
+    for note in skipped:
+        print(f"SKIPPED: {note}")
+
+    if failures:
+        print(f"\nFAILED: {len(failures)} partial trait forwarding(s):\n")
+        for failure in failures:
+            print(f"  - {failure}\n")
+        print(
+            "velesdb-memory's doctrine (src/lib.rs) requires an adapter to forward "
+            "the WHOLE trait; partial forwarding is the #1690-#1692 gap family."
+        )
+        return 1
+
+    print(
+        f"PASSED: {checked} adapter forwarding(s) checked, every trait method "
+        f"forwarded."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -172,6 +172,63 @@
    ]
   },
   {
+   "script": "scripts/check-trait-forwarding.py",
+   "purpose": "Every adapter that exists only to delegate forwards its trait WHOLE: the generic wrapper `impl<T: Trait + ?Sized> Trait for Box<T>|Arc<T>|Rc<T>`, and the erased alias `impl Trait for DynTrait` where `type DynTrait = Box<dyn Trait>` (the shape a binding holds). rustc already refuses an impl missing a *required* method, so a partial forwarding can only drop a method with a default body — which compiles and silently runs the default instead of the concrete override (the #1690-#1692 gap family). A plain `impl Trait for Backend` is deliberately exempt: a concrete backend is entitled to the default. velesdb-memory's doctrine (src/lib.rs) states the rule; this guard is what makes it hold without a reviewer noticing.",
+   "workflow": ".github/workflows/ci.yml",
+   "job": "lint",
+   "required": true,
+   "mode": "strict",
+   "self_test": "scripts.tests.test_check_trait_forwarding",
+   "self_test_required": true,
+   "blind_spot": {
+    "issue": null,
+    "summary": "Presence, not delegation: a forwarded method whose body ignores `(**self)` and reimplements the default satisfies the guard — only review catches that. Three further limits, each currently vacuous under crates/*/src: a `#[cfg]`-gated trait method is demanded unconditionally; an impl or alias produced by a macro is invisible to the text scan; and a trait defined outside the scanned tree is reported SKIPPED rather than checked, so a forwarding of a foreign trait is announced as unverified instead of passing quietly."
+   },
+   "must_refuse": [
+    {
+     "vector": "a wrapper forwarding that drops the trait's defaulted method — the #1692 shape rustc cannot catch",
+     "files": {
+      "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n}\n"
+     },
+     "accepts": {
+      "crates/velesdb-memory/src/extract.rs": "pub struct Doc;\npub struct Graph;\n\n/// Reproduces the #1692 shape: a defaulted method next to a required one.\npub trait Extractor: Send + Sync {\n    fn extract(&self, input: &str) -> Doc;\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        let _ = input;\n        Graph\n    }\n}\n\nimpl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {\n    fn extract(&self, input: &str) -> Doc {\n        (**self).extract(input)\n    }\n\n    fn extract_graph(&self, input: &str) -> Graph {\n        (**self).extract_graph(input)\n    }\n}\n"
+     },
+     "argv": [
+      "--root",
+      "{root}"
+     ]
+    },
+    {
+     "vector": "a partial forwarding whose trait is declared in a different file, so the miss is invisible at the impl site",
+     "files": {
+      "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
+      "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n}\n"
+     },
+     "accepts": {
+      "crates/velesdb-memory/src/context/estimator.rs": "pub trait TokenEstimator: Send + Sync {\n    fn estimate(&self, text: &str) -> usize;\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        4.0\n    }\n}\n",
+      "crates/velesdb-memory/src/context/boxed.rs": "use super::estimator::TokenEstimator;\n\nimpl<T: TokenEstimator + ?Sized> TokenEstimator for Box<T> {\n    fn estimate(&self, text: &str) -> usize {\n        (**self).estimate(text)\n    }\n\n    fn bytes_per_token_hint(&self) -> f32 {\n        (**self).bytes_per_token_hint()\n    }\n}\n"
+     },
+     "argv": [
+      "--root",
+      "{root}"
+     ]
+    },
+    {
+     "vector": "a partial forwarding on an erased `Dyn*` alias — the shape a binding holds, and the one with no generic parameter to pattern-match on",
+     "files": {
+      "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n}\n"
+     },
+     "accepts": {
+      "crates/velesdb-memory/src/rerank.rs": "pub trait Reranker {\n    fn rerank(&self, query: &str) -> u8;\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        queries.len() as u8\n    }\n}\n\n/// The shape a binding holds: no generic parameter, so the wrapper pattern\n/// alone never sees this impl.\npub type DynReranker = Box<dyn Reranker + Send + Sync>;\n\nimpl Reranker for DynReranker {\n    fn rerank(&self, query: &str) -> u8 {\n        (**self).rerank(query)\n    }\n\n    fn rerank_batch(&self, queries: &[&str]) -> u8 {\n        (**self).rerank_batch(queries)\n    }\n}\n"
+     },
+     "argv": [
+      "--root",
+      "{root}"
+     ]
+    }
+   ]
+  },
+  {
    "script": "scripts/verify_unsafe_safety_template.py",
    "purpose": "Every unsafe block carries a // SAFETY: comment (Gate 4).",
    "workflow": ".github/workflows/ci.yml",

--- a/scripts/tests/test_check_trait_forwarding.py
+++ b/scripts/tests/test_check_trait_forwarding.py
@@ -1,0 +1,420 @@
+"""Tests for scripts/check-trait-forwarding.py.
+
+Pins the guard's shape:
+
+* the positive control — the checked-in tree — stays exit 0, and actually
+  reaches the five adapters it is supposed to police, `DynReranker` named
+  among them (a guard that silently scanned nothing would also "pass");
+* the historical bug is refused: `Extractor for Arc<T>` forwarding only
+  `extract` and dropping the defaulted `extract_graph` (#1690-#1692), with
+  the missing method named in the message;
+* forwarding the whole trait is accepted, so the refusal is about
+  completeness and not about the shape of the impl;
+* the erased-alias shape (`type DynFoo = Box<dyn Foo>` + `impl Foo for
+  DynFoo`) is policed too — it carries no generic parameter, so the wrapper
+  pattern alone never sees it, and it is what the bindings actually hold;
+* an ordinary `impl Foo for Backend` is NOT held to completeness: a concrete
+  backend is entitled to the trait's default, which is what a default is for;
+* a supertrait's methods are NOT demanded — the storage facets (#1959) are
+  separate traits and the doctrine's unit is the facet;
+* a `fn` named only inside a doc comment, a line comment or a block comment
+  is not mistaken for a trait method, which would make the guard demand a
+  method that does not exist;
+* a `fn` nested inside a method body belongs to neither set;
+* a forwarding whose trait lives outside the scanned tree is reported as
+  SKIPPED rather than passed, so a blind spot never reads as a clean run;
+* an impl's generic parameter list is closed by matching angles, so a nested
+  bound (`Store<K>`) or an arrow (`Fn(&str) -> u8`) does not silently drop the
+  adapter from the scan;
+* a lifetime tick is not read as a char literal. Rust spends `'` on lifetimes
+  far more often than on char literals, and a `'static` bound leaves an
+  unmatched tick: a lexer that opens a literal there runs past every comment
+  after it, so a `fn` merely *named* in a comment becomes a trait method the
+  guard then demands. That false finding is how a guard gets switched off.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-trait-forwarding.py"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_script() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("check_trait_forwarding", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_trait_forwarding"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ctf = _load_script()
+
+
+def run_on(source: str, *, filename: str = "adapter.rs") -> tuple[int, str]:
+    """Materialise `source` as one production file and run the guard on it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        src_dir = root / "crates" / "velesdb-memory" / "src"
+        src_dir.mkdir(parents=True)
+        (src_dir / filename).write_text(source, encoding="utf-8")
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            code = ctf.main(["--root", str(root)])
+        return code, buffer.getvalue()
+
+
+PARTIAL = """
+pub trait Extractor {
+    fn extract(&self, text: &str) -> u8;
+    fn extract_graph(&self, text: &str) -> u8 {
+        self.extract(text)
+    }
+}
+
+impl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {
+    fn extract(&self, text: &str) -> u8 {
+        (**self).extract(text)
+    }
+}
+"""
+
+WHOLE = """
+pub trait Extractor {
+    fn extract(&self, text: &str) -> u8;
+    fn extract_graph(&self, text: &str) -> u8 {
+        self.extract(text)
+    }
+}
+
+impl<T: Extractor + ?Sized> Extractor for std::sync::Arc<T> {
+    fn extract(&self, text: &str) -> u8 {
+        (**self).extract(text)
+    }
+    fn extract_graph(&self, text: &str) -> u8 {
+        (**self).extract_graph(text)
+    }
+}
+"""
+
+
+class TestRealTree(unittest.TestCase):
+    def test_checked_in_tree_passes_and_actually_scans(self) -> None:
+        failures, _skipped, checked = ctf.audit(REPO_ROOT)
+        self.assertEqual(failures, [], "\n".join(failures))
+        self.assertGreaterEqual(
+            checked,
+            5,
+            "the guard must reach the crate's adapter forwardings — the four "
+            "generic wrappers and the DynReranker alias; scanning zero of them "
+            "would pass vacuously",
+        )
+
+    def test_the_erased_alias_shape_is_among_them(self) -> None:
+        """`impl Reranker for DynReranker` is a non-generic impl on a type
+        alias, so the wrapper regex alone never sees it — and it is the shape
+        the Node binding holds. Losing it would make the guard blind exactly
+        where the #1690-#1692 bugs landed."""
+        rerank = REPO_ROOT / "crates" / "velesdb-memory" / "src" / "rerank.rs"
+        source = ctf.strip_comments(rerank.read_text(encoding="utf-8"))
+        aliases = ctf.collect_aliases(source)
+        self.assertEqual(aliases.get("DynReranker"), ("Box", "Reranker"))
+        targets = [t for _, t, _, _ in ctf.collect_forwardings(source, aliases)]
+        self.assertIn("DynReranker", targets)
+
+
+class TestRefusal(unittest.TestCase):
+    def test_partial_forwarding_is_refused(self) -> None:
+        code, out = run_on(PARTIAL)
+        self.assertEqual(code, 1, out)
+        self.assertIn("extract_graph", out)
+        self.assertIn("1/2 methods", out)
+
+    def test_whole_forwarding_is_accepted(self) -> None:
+        code, out = run_on(WHOLE)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+
+
+class TestErasedAliasForwardings(unittest.TestCase):
+    """`type DynFoo = Box<dyn Foo>` plus `impl Foo for DynFoo` is a forwarding
+    written without a generic parameter. It is what a binding holds, so it has
+    to be held to the same completeness — while an ordinary
+    `impl Foo for Backend`, which merely *implements* the trait, must not be:
+    taking a default is what a default is for."""
+
+    ALIAS_PARTIAL = """
+pub trait Speaker {
+    fn say(&self) -> u8;
+
+    fn shout(&self) -> u8 {
+        self.say()
+    }
+}
+
+pub type DynSpeaker = Box<dyn Speaker + Send + Sync>;
+
+impl Speaker for DynSpeaker {
+    fn say(&self) -> u8 {
+        (**self).say()
+    }
+}
+"""
+
+    ALIAS_WHOLE = ALIAS_PARTIAL.replace(
+        """    fn say(&self) -> u8 {
+        (**self).say()
+    }
+}
+""",
+        """    fn say(&self) -> u8 {
+        (**self).say()
+    }
+
+    fn shout(&self) -> u8 {
+        (**self).shout()
+    }
+}
+""",
+    )
+
+    CONCRETE_BACKEND = """
+pub trait Speaker {
+    fn say(&self) -> u8;
+
+    fn shout(&self) -> u8 {
+        self.say()
+    }
+}
+
+pub struct Quiet;
+
+impl Speaker for Quiet {
+    fn say(&self) -> u8 {
+        1
+    }
+}
+"""
+
+    def test_a_partial_alias_forwarding_is_refused(self) -> None:
+        code, out = run_on(self.ALIAS_PARTIAL)
+        self.assertEqual(code, 1, out)
+        self.assertIn("DynSpeaker", out)
+        self.assertIn("shout", out)
+
+    def test_a_whole_alias_forwarding_is_accepted(self) -> None:
+        code, out = run_on(self.ALIAS_WHOLE)
+        self.assertEqual(code, 0, out)
+
+    def test_a_concrete_backend_may_keep_the_default(self) -> None:
+        code, out = run_on(self.CONCRETE_BACKEND)
+        self.assertEqual(code, 0, out)
+        self.assertIn("0 adapter forwarding(s)", out)
+
+    def test_an_alias_declared_in_another_file_still_resolves(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src_dir = root / "crates" / "velesdb-memory" / "src"
+            src_dir.mkdir(parents=True)
+            (src_dir / "speaker.rs").write_text(
+                """
+pub trait Speaker {
+    fn say(&self) -> u8;
+
+    fn shout(&self) -> u8 {
+        self.say()
+    }
+}
+
+pub type DynSpeaker = Box<dyn Speaker + Send + Sync>;
+""",
+                encoding="utf-8",
+            )
+            (src_dir / "binding.rs").write_text(
+                """
+use super::speaker::{DynSpeaker, Speaker};
+
+impl Speaker for DynSpeaker {
+    fn say(&self) -> u8 {
+        (**self).say()
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            failures, _skipped, checked = ctf.audit(root)
+            self.assertEqual(checked, 1)
+            self.assertEqual(len(failures), 1, failures)
+            self.assertIn("shout", failures[0])
+
+
+class TestScopeOfTheDemand(unittest.TestCase):
+    def test_supertrait_methods_are_not_demanded(self) -> None:
+        # `RecallStore: FactStore` — a forwarding for RecallStore forwards its
+        # OWN methods; FactStore travels through its own impl (#1959 facets).
+        code, out = run_on(
+            """
+pub trait FactStore {
+    fn put(&self) -> u8;
+}
+pub trait RecallStore: FactStore {
+    fn recall(&self) -> u8;
+}
+impl<T: RecallStore + ?Sized> RecallStore for std::sync::Arc<T> {
+    fn recall(&self) -> u8 {
+        (**self).recall()
+    }
+}
+"""
+        )
+        self.assertEqual(code, 0, out)
+
+    def test_fn_named_in_comments_is_not_a_method(self) -> None:
+        code, out = run_on(
+            """
+pub trait Small {
+    /// See `fn ghost_doc` for the rationale.
+    // fn ghost_line(&self);
+    /* fn ghost_block(&self); */
+    fn only(&self) -> u8;
+}
+impl<T: Small + ?Sized> Small for Box<T> {
+    fn only(&self) -> u8 {
+        (**self).only()
+    }
+}
+"""
+        )
+        self.assertEqual(code, 0, out)
+
+    def test_nested_fn_belongs_to_neither_set(self) -> None:
+        code, out = run_on(
+            """
+pub trait Small {
+    fn only(&self) -> u8 {
+        fn helper_in_trait() -> u8 { 1 }
+        helper_in_trait()
+    }
+}
+impl<T: Small + ?Sized> Small for Box<T> {
+    fn only(&self) -> u8 {
+        fn helper_in_impl() -> u8 { 2 }
+        let _ = helper_in_impl();
+        (**self).only()
+    }
+}
+"""
+        )
+        self.assertEqual(code, 0, out)
+
+
+class TestGenericHeadersAreParsedByBalance(unittest.TestCase):
+    """An impl's parameter list is closed by matching angles, not by a regex.
+    `impl<K, T: Store<K> + ?Sized>` nests, and `impl<F: Fn(&str) -> u8, ...>`
+    puts a `>` in it that closes nothing. A pattern that stops at the first
+    `>` matches neither — so the guard would police fewer adapters every time
+    a bound grew a generic argument, and say nothing about it. Silent loss of
+    reach is the failure mode a guard must not have."""
+
+    HEADERS = {
+        "plain": "impl<T: Ext + ?Sized> Ext for std::sync::Arc<T>",
+        "nested generic argument": "impl<K, T: Store<K> + ?Sized> Store<K> for Arc<T>",
+        "Fn bound with an arrow": "impl<F: Fn(&str) -> u8, T: Hook<F> + ?Sized> Hook<F> for Box<T>",
+        "where clause": "impl<T> Speak for Box<T> where T: Speak + ?Sized",
+    }
+
+    def test_every_header_shape_is_recognised(self) -> None:
+        for name, header in self.HEADERS.items():
+            with self.subTest(header=name):
+                found = ctf.collect_forwardings(header + " { fn a(&self) {} }")
+                self.assertEqual(len(found), 1, f"{name}: {found}")
+                self.assertEqual(found[0][2], ["a"])
+
+    def test_a_non_wrapper_target_is_not_a_forwarding(self) -> None:
+        self.assertEqual(
+            ctf.collect_forwardings("impl<T> Speak for MyType<T> { fn say(&self) {} }"),
+            [],
+        )
+
+    def test_an_unclosed_parameter_list_does_not_swallow_the_file(self) -> None:
+        self.assertIsNone(ctf.angles_close("impl<T: Ext { fn a() {} }", 4))
+
+
+class TestLexingIsRustAware(unittest.TestCase):
+    """Rust spends `'` on lifetimes far more often than on char literals, and
+    a `'static` bound leaves the tick unmatched. Treating it as an opening
+    quote makes the scan run past every comment that follows, so a method
+    named only in prose is counted as declared — the guard then demands a
+    forwarding for a method that does not exist. A guard that invents work is
+    a guard someone deletes."""
+
+    STATIC_BOUND_THEN_PROSE = """pub trait Ext: Send + Sync + 'static {
+    fn extract(&self);
+    // This trait used to declare fn extract_relations; it was removed in #1949.
+    fn extract_graph(&self) {}
+}
+
+impl<T: Ext + ?Sized> Ext for std::sync::Arc<T> {
+    fn extract(&self) {
+        (**self).extract()
+    }
+
+    fn extract_graph(&self) {
+        (**self).extract_graph()
+    }
+}
+"""
+
+    def test_a_static_bound_does_not_leak_prose_into_the_method_set(self) -> None:
+        methods = ctf.collect_traits(ctf.strip_comments(self.STATIC_BOUND_THEN_PROSE))
+        self.assertEqual(methods["Ext"], ["extract", "extract_graph"])
+
+    def test_that_whole_forwarding_is_accepted(self) -> None:
+        code, output = run_on(self.STATIC_BOUND_THEN_PROSE)
+        self.assertEqual(code, 0, output)
+
+    def test_char_literals_are_still_recognised(self) -> None:
+        for literal in ("'x'", "'\\n'", "'\\\''", "'\\u{1F600}'"):
+            source = f'fn real() {{ let c = {literal}; let s = "fn ghost() {{}}"; }}'
+            self.assertEqual(
+                ctf.top_level_fns(ctf.strip_comments(source)), ["real"], literal
+            )
+
+    def test_offsets_survive_stripping(self) -> None:
+        for source in (
+            "impl<'a, T> Foo for &'a T {}",
+            "pub trait T: Send + 'static { fn a(&self); }",
+            'fn a() {{ let s = "it\'s // not a comment"; }}',
+            'fn a() {{ let s = r#"fn ghost() // "#; }}',
+        ):
+            self.assertEqual(len(ctf.strip_comments(source)), len(source), source)
+
+
+class TestBlindSpotIsVisible(unittest.TestCase):
+    def test_foreign_trait_is_skipped_not_passed(self) -> None:
+        code, out = run_on(
+            """
+impl<T: ForeignTrait + ?Sized> ForeignTrait for std::sync::Arc<T> {
+    fn whatever(&self) -> u8 {
+        (**self).whatever()
+    }
+}
+"""
+        )
+        self.assertEqual(code, 0, out)
+        self.assertIn("SKIPPED", out)
+        self.assertIn("ForeignTrait", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/1967-trait-forwarding-guard` → **`develop`**. ✅

## Description

`velesdb-memory`'s doctrine in `src/lib.rs` already states the rule:

> an adapter over one of these traits forwards the **whole** trait — partial
> forwarding is how a binding silently loses a capability the server already
> publishes (the #1690–#1692 gap family), **and is rejected in review**.

"Rejected in review" is a person paying attention. #1967 item 2 asks for the
machine instead — *« Vérifier qu'aucun trait n'a un forwarding `Arc`/`Box`
partiel (le bug de #1692 en germe) — un test ou un grep-garde si un troisième
trait forwardé apparaît »*. There are five adapters now.

### Why a reviewer misses this

rustc refuses an `impl` that omits a **required** method. So a partial
forwarding can only ever drop a method that has a **default body** — and then
it compiles. `Arc<Concrete>` keeps working and silently runs the trait's
default instead of `Concrete`'s override.

`Extractor::extract_graph` is the shape that already cost this repo a bug:
forward only `extract`, and every `Arc`-held backend loses the relations and
attributes it actually produced. Nothing in the type system says a word.

### What the guard does

`scripts/check-trait-forwarding.py` reads every adapter under `crates/*/src`
(test files excluded) that exists *only to delegate*, and demands it define
every method the trait declares. Two shapes:

```rust
impl<T: Trait + ?Sized> Trait for Box<T> | Arc<T> | Rc<T>   // generic wrapper
impl Trait for DynTrait                                     // erased alias
```

The second shape is the one worth arguing for. `type DynReranker = Box<dyn Reranker + Send + Sync>`
with `impl Reranker for DynReranker` carries **no generic parameter**, so a
wrapper-only pattern never sees it — and it is what the Node binding wraps a
JS callback in. A default-bodied method dropped there is lost for every JS
caller while the Rust tests, which use the concrete type, stay green. That is
the #1690–#1692 failure mode with the serial numbers filed off, and the first
draft of this guard was blind to it.

Five adapters are checked today — four generic wrappers (`Reranker`,
`Embedder`, `Extractor`, `TokenEstimator`) and `DynReranker` — and all five
are whole, so this lands green and stays a tripwire.

Three scoping decisions, all deliberate:

- **A plain `impl Trait for Backend` is exempt.** `impl Extractor for
  OutlineExtractor` does not forward `extract_graph`, and must not be made to:
  a concrete backend is entitled to the trait's default. Only an adapter whose
  entire reason to exist is delegation is held to completeness.
- **Supertrait methods are not demanded.** The storage facets of #1959 are
  separate traits and the doctrine's unit is the facet: *an adapter picks
  which facets it serves, but each facet it implements is forwarded whole.*
- **A trait defined outside the scanned tree is reported `SKIPPED`, not
  passed.** A miss the guard cannot see must never read as a clean run.

### Two parsing details worth the review

Both are places where a shortcut costs *reach*, silently — which is the one
thing a guard must never do.

**Impl headers are closed by matching angles, not by a regex.**
A parameter list nests (`impl<K, T: Store<K> + ?Sized>`), and an `Fn` bound
puts an arrow inside it (`impl<F: Fn(&str) -> u8, ...>`) whose `>` closes
nothing. A `[^>]*` pattern matches neither, so the guard would police fewer
adapters every time a bound grew a generic argument, and report a smaller
number without complaining. Four header shapes are pinned by tests.

**Lifetimes are not char literals.** Rust spends `'` on lifetimes far more
often than on char literals, and a `'static` bound leaves the tick
unmatched. Read as an opening quote, the scan runs past every comment that
follows — so a method named only in prose enters the trait's method set and
the guard demands a forwarding for something that does not exist. A guard
that invents work is a guard someone switches off. `'` therefore opens a
literal only when it actually closes as one; otherwise it is a lifetime and
only the tick is stepped over. Pinned by a test that fails on the pre-fix
lexer.

### One stale line comes with it

`crates/velesdb-memory/src/service.rs`'s module doc still called the
working-context bridge *"the next named cut (#1967, decided together with the
store facetting of #1959)"*. That cut is done — the bridge lives in
`context/memory_bridge.rs` (736 lines) and `context/memory_bridge_compile.rs`
(860), and no working-context code remains in `service.rs`. Merging this PR
without touching that sentence would leave the code pointing at a closed issue
as future work. The replacement is the same **six** lines, so `service.rs`
stays at its baselined 1006 and the file-budget guard neither grows nor
shrinks.

Fixes # (partially — closes item 2 of #1967; items 1, 3, 4 and 5 were
delivered earlier, see the issue comment)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

The only Rust touched is a six-line module doc comment. Zero runtime impact:
this PR adds a CI guard, its self-test, its registry entry and its wiring.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

```
python3 -m unittest scripts.tests.test_check_trait_forwarding   → Ran 19 tests, OK
python3 -m unittest scripts.tests.test_ci_gate_reachability     → Ran 78 tests, OK
python3 -m unittest scripts.tests.test_guard_refusal_vectors    → Ran  8 tests, OK
python3 scripts/check-trait-forwarding.py                       → PASSED: 5 adapters checked
cargo check -p velesdb-memory --features persistence,context    → clean
python3 scripts/check-file-budgets.py                           → PASSED
python3 scripts/check-ai-attribution.py --tree                  → PASSED
ruff check scripts/check-trait-forwarding.py …                  → All checks passed
```

The refusal was proven, not assumed: reconstructing the #1692 bug in a
fixture (`Extractor` for `Arc<T>` forwarding only `extract`) yields

```
crates/velesdb-memory/src/extract.rs:11: `impl Extractor for Arc<T>` forwards 1/2 methods — missing `extract_graph`.
```

with exit 1. The positive control also checks that the scan actually *reaches*
its five adapters — and that `DynReranker` is among them by name, so a
regression that quietly narrowed the guard back to generic wrappers would fail
rather than pass with a smaller number.

**Test Configuration:**
- OS: Ubuntu 24.04 (x86_64)
- Rust version: 1.90 (workspace MSRV toolchain)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path is touched.

## Additional Notes

Registry contract per AGENTS.md rule 12 is implemented in full:

- `guards.json` entry — `required: true`, `mode: strict`, job `lint`;
- **declared blind spot**: *presence, not delegation* — a forwarded method
  whose body reimplements the default instead of calling `(**self)` still
  satisfies the guard, and only review catches that. Three further limits are
  named there, each currently vacuous under `crates/*/src`;
- **three `must_refuse` vectors**, each carrying all four fields — the #1692
  shape; a partial forwarding whose trait lives in a *different file* so the
  miss is invisible at the impl site; and a partial forwarding on an erased
  `Dyn*` alias. All three were run by hand through the harness's own helpers
  before pushing, in both states.