### PR TITLE
fix(bench): let fused_recall_benchmark run under the #1743 degree cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,6 +740,16 @@ jobs:
       - name: Library and benches under internal-bench
         run: cargo check -p velesdb-core --benches --features persistence,internal-bench
 
+      # velesdb-memory's four criterion benches were built by nothing in CI,
+      # so one of them stayed dead for weeks after #1743 changed the policy
+      # it asserted on (its liveness gate panicked at the second parameter
+      # point). Type-checking them here is the cheapest reach that would
+      # have caught the compile half of that; running them stays a policy
+      # decision (cost per PR vs a weekly sweep, the feature-powerset
+      # trade-off) and is deliberately not taken in this job.
+      - name: velesdb-memory benches type-check
+        run: cargo check -p velesdb-memory --benches --features persistence,context
+
       - name: Tests under internal-bench
         run: cargo check -p velesdb-core --tests --features persistence,internal-bench
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`fused_recall_benchmark` could not run past its first parameter point.**
+  It hung every fact off one entity hub and asserted the walk reached all of
+  them — the liveness gate that proves a search regression cannot benchmark a
+  no-op. Issue #1743 then capped a single node's expansion at
+  `MAX_WHY_NODE_DEGREE` (64) and the whole walk at `MAX_WHY_NODES` (500), so
+  at degree 200 the walk reached 66 nodes (64 + seed + hub), the assertion
+  panicked, and four of the bench's five measurements were never taken. The
+  empirical check for #1742's O(edges + nodes) traversal fix had been dead
+  since that cap landed; nothing noticed because CI's `Internal Bench
+  Compiles` only `cargo check`s `velesdb-core`'s benches.
+
+  The fixture is now a forest of hubs, each mentioning at most
+  `MAX_WHY_NODE_DEGREE` facts, so the reach the walk covers still grows into
+  the hundreds while every node stays inside the policy it actually runs
+  under. The sweep covers both regimes the caps create: three points under
+  `MAX_WHY_NODES` where the walk must reach every fact exactly, and one past
+  it where it must truncate at precisely the ceiling and the cost must
+  plateau. Relaxing the assertion to `min(degree, 64)` was rejected — past
+  64 the graph contribution is constant, and a bench that runs but no longer
+  stresses what it was built to stress is a dead guard that looks alive.
+
 - **`VectorCollection::create_with_hnsw` documented a false equivalence.** It
   claimed that passing `None` for both arguments was "equivalent to
   `VectorCollection::create`". It is not: it persists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plateau. Relaxing the assertion to `min(degree, 64)` was rejected — past
   64 the graph contribution is constant, and a bench that runs but no longer
   stresses what it was built to stress is a dead guard that looks alive.
+  CI's `Internal Bench Compiles` job now also type-checks this crate's four
+  benches (`cargo check -p velesdb-memory --benches`), so the compile half
+  of a future death is caught on every PR; whether to *run* them per PR
+  stays a policy decision and is not taken here.
 
 - **`VectorCollection::create_with_hnsw` documented a false equivalence.** It
   claimed that passing `None` for both arguments was "equivalent to

--- a/crates/velesdb-memory/benches/fused_recall_benchmark.rs
+++ b/crates/velesdb-memory/benches/fused_recall_benchmark.rs
@@ -1,12 +1,30 @@
-//! Latency of [`MemoryService::recall_fused`] as a single entity hub's
-//! fan-out grows — the shape issue #1742 diagnosed: `graph_reached`'s
+//! Latency of [`MemoryService::recall_fused`] as the fan-out its graph walk
+//! reaches grows — the shape issue #1742 diagnosed: `graph_reached`'s
 //! per-node `reach_weight` scan used to rescan every edge in the traversal
-//! for each reached node, making the whole walk O(hub degree²). Indexing
+//! for each reached node, making the whole walk O(reach²). Indexing
 //! `mentions` edges by target turned that into O(edges + nodes). This bench
-//! is the empirical check: latency should grow ~linearly with hub degree,
+//! is the empirical check: latency should grow ~linearly with the reach,
 //! not quadratically — a user accumulating facts about the same topic (the
 //! product's nominal use case) must not pay a cost that grows with the
 //! square of their history on it.
+//!
+//! # Why the fixture is a forest of hubs, not one hub
+//!
+//! The first version of this bench hung every fact off ONE entity hub and
+//! asserted the walk reached all of them. Issue #1743 then capped a single
+//! node's expansion at [`MAX_WHY_NODE_DEGREE`] (64) and the whole walk at
+//! [`MAX_WHY_NODES`] (500) — so that assertion became unsatisfiable for any
+//! degree above 64, the bench panicked at its second parameter point, and
+//! four of its five measurements were silently never taken. Nothing in CI
+//! runs this crate's benches, so nothing noticed.
+//!
+//! The reach is therefore spread over as many hubs as the per-node cap
+//! requires, each with at most `MAX_WHY_NODE_DEGREE` mentions: the total
+//! reach still grows into the hundreds while every node stays inside the
+//! policy the walk actually runs under. The sweep covers both regimes the
+//! caps create — the linear region under [`MAX_WHY_NODES`], and one point
+//! past it, where the walk must truncate at exactly the ceiling and the cost
+//! must plateau rather than keep climbing.
 //!
 //! Run with:
 //!
@@ -19,57 +37,102 @@
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use tempfile::TempDir;
+use velesdb_memory::limits::{MAX_WHY_NODES, MAX_WHY_NODE_DEGREE};
 use velesdb_memory::{FusionOptions, HashEmbedder, MemoryService};
 
 const DIM: usize = 384;
 const SEED: &str = "seed fact anchors the walk";
 
-/// A store wired like the autograph's bipartite hub: a seed fact linked to
-/// one entity hub, which in turn `mentions` `degree` facts — the exact shape
-/// `recall_fused`'s default 2-hop walk exercises (hop 1 reaches the hub, hop
-/// 2 reaches everything it mentions).
-fn hub_store(degree: usize) -> (TempDir, MemoryService<HashEmbedder>) {
+/// Reach points under the walk's node ceiling. Each stays below
+/// [`MAX_WHY_NODES`] once its seed and hubs are counted, so the walk must
+/// reach every fact and the liveness gate holds exactly.
+const UNDER_CEILING: [usize; 3] = [50, 200, 480];
+
+/// One reach point past the ceiling: the walk truncates at [`MAX_WHY_NODES`]
+/// and the measured cost must plateau — the cap is a cost bound, and this is
+/// where that claim is checked.
+const OVER_CEILING: usize = 1000;
+
+/// How many hubs `reach` facts need when no hub may mention more than
+/// [`MAX_WHY_NODE_DEGREE`] of them.
+fn hubs_for(reach: usize) -> usize {
+    reach.div_ceil(MAX_WHY_NODE_DEGREE)
+}
+
+/// A store wired like the autograph's bipartite hubs: a seed fact linked to
+/// `hubs_for(reach)` entity hubs, which between them `mention` `reach`
+/// facts — no hub over the per-node cap. The exact shape `recall_fused`'s
+/// default 2-hop walk exercises (hop 1 reaches the hubs, hop 2 everything
+/// they mention).
+fn hub_forest(reach: usize) -> (TempDir, MemoryService<HashEmbedder>) {
     let dir = TempDir::new().expect("tempdir");
     let svc = MemoryService::open(dir.path(), HashEmbedder::new(DIM)).expect("open store");
     let seed = svc.remember(SEED, &[], None).expect("remember seed");
-    let hub = svc
-        .remember("Entity: benchmark-topic", &[], None)
-        .expect("remember hub");
-    svc.relate(seed, hub, "about").expect("relate seed->hub");
-    for i in 0..degree {
+    let mut hub = None;
+    for i in 0..reach {
+        if i % MAX_WHY_NODE_DEGREE == 0 {
+            let id = svc
+                .remember(
+                    &format!("Entity: benchmark-topic-{}", i / MAX_WHY_NODE_DEGREE),
+                    &[],
+                    None,
+                )
+                .expect("remember hub");
+            svc.relate(seed, id, "about").expect("relate seed->hub");
+            hub = Some(id);
+        }
         let fact = svc
             .remember(&format!("fact number {i} about the topic"), &[], None)
             .expect("remember fact");
-        svc.relate(hub, fact, "mentions").expect("relate hub->fact");
+        svc.relate(hub.expect("hub before facts"), fact, "mentions")
+            .expect("relate hub->fact");
     }
     (dir, svc)
 }
 
-fn bench_recall_fused_by_hub_degree(c: &mut Criterion) {
-    let mut group = c.benchmark_group("recall_fused_hub_degree");
-    // The 2,000-degree point keeps the benchmark on the high-cardinality side
-    // of #1805's reported 1,193-memory boundary. The `why` assertion below is
-    // the liveness gate: a search regression cannot silently benchmark a no-op.
-    for degree in [50_usize, 200, 500, 1000, 2000] {
-        let (_dir, svc) = hub_store(degree);
-        // The walk must actually reach every fact under the hub (seed + hub
-        // + degree facts) — otherwise a regression elsewhere silently turns
-        // this into a no-op benchmark instead of failing loudly.
-        let reached = svc.why(SEED, 2, None).expect("why").nodes.len();
+/// The liveness gate: a search regression cannot silently benchmark a no-op.
+/// Under the ceiling the walk must reach seed + hubs + every fact; over it,
+/// exactly [`MAX_WHY_NODES`] and say so.
+fn assert_reach(svc: &MemoryService<HashEmbedder>, reach: usize) {
+    let explanation = svc.why(SEED, 2, None).expect("why");
+    let expected = 1 + hubs_for(reach) + reach;
+    if expected <= MAX_WHY_NODES {
         assert_eq!(
-            reached,
-            degree + 2,
-            "traversal did not reach the full hub fan-out"
+            explanation.nodes.len(),
+            expected,
+            "traversal did not reach the full hub-forest fan-out"
         );
-        let preflight = svc
-            .recall_fused(SEED, 10, None, FusionOptions::default())
-            .expect("recall_fused preflight");
         assert!(
-            preflight.iter().any(|memory| memory.content == SEED),
-            "fused recall did not retain the exact seed"
+            !explanation.truncated,
+            "an under-ceiling walk reported truncation"
         );
-        group.throughput(Throughput::Elements(degree as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(degree), &degree, |b, _| {
+    } else {
+        assert_eq!(
+            explanation.nodes.len(),
+            MAX_WHY_NODES,
+            "an over-ceiling walk did not stop at exactly MAX_WHY_NODES"
+        );
+        assert!(
+            explanation.truncated,
+            "an over-ceiling walk did not report truncation"
+        );
+    }
+    let preflight = svc
+        .recall_fused(SEED, 10, None, FusionOptions::default())
+        .expect("recall_fused preflight");
+    assert!(
+        preflight.iter().any(|memory| memory.content == SEED),
+        "fused recall did not retain the exact seed"
+    );
+}
+
+fn bench_recall_fused_by_reach(c: &mut Criterion) {
+    let mut group = c.benchmark_group("recall_fused_reach");
+    for reach in UNDER_CEILING.into_iter().chain([OVER_CEILING]) {
+        let (_dir, svc) = hub_forest(reach);
+        assert_reach(&svc, reach);
+        group.throughput(Throughput::Elements(reach as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(reach), &reach, |b, _| {
             b.iter(|| {
                 svc.recall_fused(SEED, 10, None, FusionOptions::default())
                     .expect("recall_fused")
@@ -79,5 +142,5 @@ fn bench_recall_fused_by_hub_degree(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_recall_fused_by_hub_degree);
+criterion_group!(benches, bench_recall_fused_by_reach);
 criterion_main!(benches);


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/1742-fused-recall-bench-under-degree-cap` → **`develop`**. ✅

## Description

`fused_recall_benchmark` has been unable to run past its first parameter point since #1743 landed, and nothing noticed.

### What was wrong

The bench hung every fact off **one** entity hub and asserted the 2-hop walk reached all of them — a liveness gate so a search regression can't silently benchmark a no-op. Then #1743 capped a single node's expansion at `MAX_WHY_NODE_DEGREE` (64) and the whole walk at `MAX_WHY_NODES` (500). At degree 200 the walk reaches **66** nodes (64 + seed + hub), the assertion panics, and the remaining four of five measurements are never taken:

```
thread 'main' panicked at fused_recall_benchmark.rs:59:
assertion `left == right` failed: traversal did not reach the full hub fan-out
  left: 66
 right: 202
```

So the empirical check for #1742's O(edges + nodes) traversal fix has been dead since the cap. CI didn't catch it because `Internal Bench Compiles` runs `cargo check -p velesdb-core --benches` — only `velesdb-core`. This crate's benches were never built *or* run in CI.

### The fix — two commits

**1. The fixture is now a forest of hubs**, each mentioning at most `MAX_WHY_NODE_DEGREE` facts. The reach the walk covers still grows into the hundreds while every node stays inside the policy the walk actually runs under. The sweep covers both regimes the caps create:

- **Under `MAX_WHY_NODES`** (50, 200, 480): the walk must reach seed + hubs + every fact *exactly*, and must not report truncation.
- **Past it** (1000): the walk must stop at precisely `MAX_WHY_NODES`, must report `truncated`, and the cost must plateau — the cap is a cost bound, and that claim is now checked rather than assumed.

The cheaper fix — relax the assertion to `min(degree, 64) + 2` — was rejected. Past 64 the graph contribution is constant, so the bench would run and measure nothing it was built to measure: a dead guard that looks alive.

**2. CI now type-checks this crate's benches.** One `cargo check -p velesdb-memory --benches --features persistence,context` step beside the `velesdb-core` one in `Internal Bench Compiles`. It's the cheapest reach that catches the compile half of this class on every PR. Deliberately a type-check, not a run: running benches per PR is a cost/coverage policy decision — the trade-off `feature-powerset.yml` already documents for its own sweep — and is not taken here.

### What it measures now

Release, shortened criterion settings (`--measurement-time 5 --sample-size 20`), shared container:

| reach | time | per reached fact |
|---|---|---|
| 50 | 1.17 ms | 23.3 µs |
| 200 | 2.20 ms | 11.0 µs |
| 480 | 4.12 ms | 8.6 µs |
| 1000 (truncated at 500) | 5.04 ms | plateau |

Under the ceiling `t ≈ 0.82 ms + 6.9 µs × reach` fits all three points (predicts 2.19 ms at 200; measured 2.20) — linear, as #1742 promised. Past it the reach doubles and time rises 22%; the residual is vector search over a store twice the size, not traversal.

These are indicative single-run numbers, not a published claim — they show the bench works, and do not go into `BENCHMARKS.md` yet.

Related: #1742 (the fix this bench checks), #1743 (the cap that killed it).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

Bench, one CI step, CHANGELOG. No production code, no runtime impact.

## How Has This Been Tested?

- [x] Manual testing

```
cargo bench -p velesdb-memory --bench fused_recall_benchmark --features persistence
  → all 4 points run, liveness gate holds at each, exit 0   (was: panic at point 2)
cargo check -p velesdb-memory --benches --features persistence,context   → clean (the new CI step, run locally)
cargo clippy -p velesdb-memory --benches --features persistence -- -D warnings  → clean
cargo fmt -p velesdb-memory -- --check                                          → clean
python3 -m unittest scripts.tests.test_ci_gate_reachability                     → 78 tests, OK
python3 scripts/check-ai-attribution.py --tree                                  → PASSED
```

Reproduced the original failure first on an unmodified checkout (the panic above), then the same command passing on this branch.

**Test Configuration:**
- OS: Ubuntu 24.04 (x86_64)
- Rust version: 1.90 (workspace MSRV toolchain)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code.

## High-Risk Change Checklist

Not applicable — a benchmark file, a CI step and a CHANGELOG entry.

## Additional Notes

Whether to *run* this crate's benches in CI (per PR, or a weekly sweep like the feature powerset) is left open on purpose. It's a policy call with a real cost, and it deserves its own issue rather than a side-effect of a bench fix.