### PR TITLE
fix(memory): bound the working-context index at 1000 sessions per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VectorCollection::create_with_hnsw_params`,
   `GraphCollection::create_with_hnsw_params`.
 
+### Changed
+
+- **A project's working-context index is bounded at 1 000 sessions
+  (`MAX_WORKING_SESSIONS_PER_PROJECT`).** The index is one fact per project,
+  rewritten whole on every `save_working_context` — serialised, embedded,
+  stored. It gained an entry per distinct session id and shed one only when
+  that session's fact was forgotten, so a long-lived project paid
+  O(sessions) per save, forever, and `write_working_index` never checked the
+  1 MiB fact cap (that check guards the working-context *content*, not the
+  index). Past the cap the oldest-saved entries now leave the listing; their
+  facts stay on disk and `load_working_context` still finds them by exact
+  `project` + `session` — the semantic a torn index already had. The session
+  being saved is pinned and can never be the one evicted, even in a
+  same-second flood of other sessions. Found by the lock/resilience/memory
+  audit of `velesdb-memory`; the audit's other findings were negative (no
+  `std::sync` locks, no nested holds, the global index lock never held across
+  the embedder, every other collection already capped).
+
 ### Fixed
 
 - **`VectorCollection::create_with_hnsw` documented a false equivalence.** It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`save_working_context` refuses an empty `project` or `session`.** Both
+  are the id the state is filed under and listed by; an empty one hashed,
+  encoded and listed fine — as `""` — and was unrecoverable by anyone who did
+  not think to ask for the empty string. Now
+  `MemoryError::EmptyWorkingContextKey { key }` names which one, before
+  anything is written. Same audit, same file as the index bound above.
+
 - **`VectorCollection::create_with_hnsw` documented a false equivalence.** It
   claimed that passing `None` for both arguments was "equivalent to
   `VectorCollection::create`". It is not: it persists

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -216,8 +216,11 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     /// able to cause one on a call that carries nothing (issue #1654).
     ///
     /// # Errors
-    /// Returns [`MemoryError::EmptyWorkingContext`] if `working` records
-    /// nothing, [`MemoryError::WorkingContextCodec`] if serialization fails,
+    /// Returns [`MemoryError::EmptyWorkingContextKey`] if `project` or
+    /// `session` is empty or whitespace-only — they are the id the state is
+    /// saved and listed under — [`MemoryError::EmptyWorkingContext`] if
+    /// `working` records nothing, [`MemoryError::WorkingContextCodec`] if
+    /// serialization fails,
     /// [`MemoryError::ContextOverLimit`] if the serialized `working` exceeds
     /// [`crate::limits::MAX_FACT_BYTES`], or a storage/embedding error.
     pub fn save_working_context(
@@ -227,6 +230,11 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         working: &WorkingContext,
     ) -> Result<u64, MemoryError> {
         let _generation = self.enter_generation();
+        for (key, value) in [("project", project), ("session", session)] {
+            if value.trim().is_empty() {
+                return Err(MemoryError::EmptyWorkingContextKey { key });
+            }
+        }
         if working.is_empty() {
             return Err(MemoryError::EmptyWorkingContext);
         }

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -171,6 +171,30 @@ static EVENT_SEQ: AtomicU64 = AtomicU64::new(0);
 /// upgrade if index writes ever become hot.
 static WORKING_INDEX_WRITE: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
+/// Keep the index at most [`crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT`] entries,
+/// dropping the oldest-saved first. `just_saved` is pinned: it is the entry
+/// this very call put there, and a same-second flood of other sessions must
+/// not be able to evict it on a timestamp tie. The order among the rest is
+/// the read path's (`saved_at` desc, then session asc), so what survives is
+/// exactly what `list_working_contexts` would have shown first.
+fn bound_sessions(sessions: &mut Vec<WorkingContextSession>, just_saved: &str) {
+    use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
+    if sessions.len() <= CAP {
+        return;
+    }
+    let pinned = sessions
+        .iter()
+        .position(|s| s.session == just_saved)
+        .map(|at| sessions.swap_remove(at));
+    sessions.sort_by(|a, b| {
+        b.saved_at
+            .cmp(&a.saved_at)
+            .then_with(|| a.session.cmp(&b.session))
+    });
+    sessions.truncate(CAP - usize::from(pinned.is_some()));
+    sessions.extend(pinned);
+}
+
 /// The compilation half — `compile_context` and its helpers; see
 /// `memory_bridge_compile.rs`'s module doc for why it is split.
 #[path = "memory_bridge_compile.rs"]
@@ -559,6 +583,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         // stored moments ago, before this call); this only sheds the ones a
         // `forget` orphaned.
         index.sessions = self.live_sessions(project, index.sessions)?;
+        bound_sessions(&mut index.sessions, session);
         let content =
             serde_json::to_string(&index).map_err(|err| MemoryError::WorkingContextCodec {
                 detail: format!("encoding the working-context index for project '{project}'"),

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -398,6 +398,33 @@ fn test_bound_sessions_evicts_the_oldest_saved_first_and_is_a_no_op_under_the_ca
 }
 
 #[test]
+fn test_save_working_context_refuses_an_empty_project_or_session_key() {
+    // Given a store; an empty or whitespace-only key would hash, encode and
+    // list just fine — as "" — and be unrecoverable by anyone who does not
+    // think to ask for the empty string.
+    let (_dir, svc) = open_service();
+    for (project, session, key) in [
+        ("", "session-a", "project"),
+        ("   ", "session-a", "project"),
+        ("veles", "", "session"),
+        ("veles", "\t\n", "session"),
+    ] {
+        // When saving under it
+        let err = svc
+            .save_working_context(project, session, &minimal_working())
+            .expect_err("an empty key must be refused");
+
+        // Then it is the key that is named, and nothing was written.
+        assert!(
+            matches!(err, MemoryError::EmptyWorkingContextKey { key: k } if k == key),
+            "{project:?}/{session:?}: {err:?}"
+        );
+    }
+    assert!(svc.list_working_contexts("veles").expect("list").is_empty());
+    assert!(svc.list_working_contexts("").expect("list").is_empty());
+}
+
+#[test]
 fn test_list_working_contexts_empty_for_unknown_project() {
     // Given a store with nothing saved
     let (_dir, svc) = open_service();

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -328,6 +328,76 @@ fn test_list_working_contexts_returns_sessions_saved_under_a_project() {
 }
 
 #[test]
+fn test_bound_sessions_keeps_cap_entries_newest_first_and_pins_the_one_just_saved() {
+    use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
+
+    // Given CAP + 1 entries that all share one saved_at — the same-second
+    // flood where ordering cannot lean on the timestamp — and the session
+    // just saved sorting LAST by name, so an unpinned truncate would drop it
+    let mut sessions: Vec<WorkingContextSession> = (0..=CAP)
+        .map(|i| WorkingContextSession {
+            session: format!("session-{i:05}"),
+            saved_at: 1_700_000_000,
+        })
+        .collect();
+    let just_saved = format!("session-{CAP:05}");
+
+    // When bounding
+    bound_sessions(&mut sessions, &just_saved);
+
+    // Then exactly CAP survive, the just-saved one among them, and the one
+    // that left is the last by name among the unpinned tie.
+    assert_eq!(sessions.len(), CAP);
+    assert!(
+        sessions.iter().any(|s| s.session == just_saved),
+        "just-saved evicted"
+    );
+    let evicted = format!("session-{:05}", CAP - 1);
+    assert!(
+        sessions.iter().all(|s| s.session != evicted),
+        "the last unpinned tie-loser must be the one evicted"
+    );
+}
+
+#[test]
+fn test_bound_sessions_evicts_the_oldest_saved_first_and_is_a_no_op_under_the_cap() {
+    use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
+
+    // Under the cap nothing moves — not even the order.
+    let mut few: Vec<WorkingContextSession> = (0..3)
+        .map(|i| WorkingContextSession {
+            session: format!("s{i}"),
+            saved_at: 10 - i,
+        })
+        .collect();
+    let before: Vec<(String, u64)> = few
+        .iter()
+        .map(|s| (s.session.clone(), s.saved_at))
+        .collect();
+    bound_sessions(&mut few, "s0");
+    let after: Vec<(String, u64)> = few
+        .iter()
+        .map(|s| (s.session.clone(), s.saved_at))
+        .collect();
+    assert_eq!(after, before);
+
+    // Over it, the oldest saved_at leaves regardless of name.
+    let mut many: Vec<WorkingContextSession> = (0..=CAP)
+        .map(|i| WorkingContextSession {
+            session: format!("s{i}"),
+            saved_at: 1_000 + i as u64,
+        })
+        .collect();
+    bound_sessions(&mut many, "s5");
+    assert_eq!(many.len(), CAP);
+    assert!(
+        many.iter().all(|s| s.session != "s0"),
+        "oldest (s0) must be evicted"
+    );
+    assert!(many.iter().any(|s| s.session == "s5"));
+}
+
+#[test]
 fn test_list_working_contexts_empty_for_unknown_project() {
     // Given a store with nothing saved
     let (_dir, svc) = open_service();

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -687,7 +687,11 @@ pub struct WorkingContextSession {
 /// `MAX_RECALL_LIMIT`, imprecise) — this index is exact and O(1) to read.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct WorkingContextIndex {
-    /// Every session ever saved under this project.
+    /// The sessions saved under this project, at most
+    /// [`crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT`] of them: past the
+    /// cap the oldest-saved leave the listing (their facts stay loadable by
+    /// exact id), and a session whose fact was forgotten is shed on the next
+    /// save.
     #[serde(default)]
     pub sessions: Vec<WorkingContextSession>,
 }

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -259,6 +259,19 @@ pub enum MemoryError {
     )]
     EmptyWorkingContext,
 
+    /// [`crate::service::MemoryService::save_working_context`] was given an
+    /// empty (or whitespace-only) `project` or `session`. Both are the KEY the
+    /// state is filed under and listed by: an empty one is accepted by every
+    /// hash and every JSON encoder, so without this check it would save
+    /// fine, list as `""`, and be unrecoverable by anyone who does not think
+    /// to ask for the empty string. Refused before anything is written.
+    #[cfg(feature = "context")]
+    #[error("working-context {key} is empty: it is the id this state is saved and listed under")]
+    EmptyWorkingContextKey {
+        /// Which key was empty: `"project"` or `"session"`.
+        key: &'static str,
+    },
+
     /// A persisted working context could not be (de)serialized — the stored
     /// payload predates or postdates this crate's schema.
     ///
@@ -354,7 +367,9 @@ impl MemoryError {
             | Self::MetadataTooLarge { .. } => ErrorCategory::InvalidInput,
             Self::Unsupported(_) => ErrorCategory::Unsupported,
             #[cfg(feature = "context")]
-            Self::EmptyWorkingContext => ErrorCategory::InvalidInput,
+            Self::EmptyWorkingContext | Self::EmptyWorkingContextKey { .. } => {
+                ErrorCategory::InvalidInput
+            }
             #[cfg(feature = "context")]
             Self::ContextBudget { .. } | Self::ContextOverLimit(_) | Self::SegmentationError(_) => {
                 ErrorCategory::InvalidInput

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -152,6 +152,19 @@ pub const MAX_FRAGMENT_BYTES: usize = 1_048_576;
 /// single call can demand across every adapter.
 pub const MAX_FRAGMENTS: usize = 1_024;
 
+/// Cap on how many sessions one project's working-context index lists.
+///
+/// The index is ONE fact per project, rewritten whole on every
+/// `save_working_context`: serialised, embedded, stored. Without a bound it
+/// gains an entry per distinct session id and sheds one only when that
+/// session's fact is forgotten — so a long-lived project pays O(sessions)
+/// per save, forever, for a list whose only reader wants the most recent
+/// few. Past this cap the oldest-saved entries leave the index; their facts
+/// stay on disk and stay loadable by exact `project` + `session`, exactly as
+/// an entry a torn index lost already did — the listing forgets them, the
+/// store does not. The session being saved is never the one evicted.
+pub const MAX_WORKING_SESSIONS_PER_PROJECT: usize = 1_000;
+
 /// Maximum accepted size of a fragment's base64-encoded media payload
 /// (US-009, PR1: inline images) — 4 MiB of base64 text, roughly 3 MiB of raw
 /// bytes once decoded. Deliberately separate from [`MAX_FRAGMENT_BYTES`],

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -747,7 +747,9 @@ Discover what is resumable before guessing a session id.
 
 Returns `{ sessions: [ { session, saved_at } ] }`, most-recently-saved first;
 `saved_at` is Unix seconds. Empty (not an error) when the project never saved
-anything.
+anything. The listing holds at most 1 000 sessions per project — past that,
+the oldest-saved drop out of the list; their saved state stays on disk and
+`load_working_context` still finds it by exact `project` + `session`.
 
 ---
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/working-index-bounded-per-project` → **`develop`**. ✅

## Description

Two findings from the lock / resilience / memory audit of `velesdb-memory` requested this morning, both in `save_working_context`. The audit's other findings were negative — every sync lock is `parking_lot`, no nested holds, the global index lock is never held across the embedder, every other collection is already capped.

### 1. The working-context index was unbounded

A project's index is **one fact**, rewritten whole on every `save_working_context`: serialised, embedded, stored. It gained an entry per distinct session id and shed one only when that session's fact was forgotten. So:

- a long-lived project paid **O(sessions) per save**, forever;
- `write_working_index` never checked the 1 MiB fact cap — that check (`memory_bridge.rs:214`) guards the working-context *content*, not the index — so nothing bounded the fact's growth at all.

Not a crash. A curve — the kind that never shows up in a test and always shows up in production a year later.

**The bound.** `MAX_WORKING_SESSIONS_PER_PROJECT = 1_000`. Past it, the oldest-saved entries leave the listing. Their facts **stay on disk** and `load_working_context` still finds them by exact `project` + `session` — the semantic an entry a torn index lost already had, so the cap introduces no new failure mode, only a ceiling on an existing one. Survivors keep the read path's order (`saved_at` desc, then session asc).

**The session being saved is pinned before the truncate.** Without that, a same-second flood of other sessions ties on `saved_at`, name order decides, and the very entry this call put there could be evicted — `save_working_context` would report success for a session the listing then cannot see. A unit test builds precisely that tie.

No new lock, no new map, no per-project state. Eviction runs inside `update_working_index`, under the lock it already holds, after `live_sessions` has shed the forgotten entries. A `HashMap` keyed by caller-supplied project names was the obvious alternative and is the unbounded slow leak this same file already declined once, for the write lock, in writing.

### 2. An empty `project` or `session` was accepted

Both are the id the state is filed under and listed by. An empty or whitespace-only one hashed, encoded and listed without complaint — as `""` — and was then unrecoverable by anyone who did not think to ask for the empty string. Now refused before anything is written, with `MemoryError::EmptyWorkingContextKey { key }` naming which one. One `#[non_exhaustive]` variant, one `category()` arm, one check.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

Behavioural: a listing that previously grew forever now holds at most 1 000 entries; an empty key is refused. No API shape change — `mcp-tools.json` is untouched and the MCP doc-contract guard passes. `MCP_TOOLS.md` gains one sentence stating the cap.

## How Has This Been Tested?

- [x] Unit tests

```
cargo test -p velesdb-memory --features persistence,context --lib -- working_index list_working_contexts bound_sessions save_working_context load_working_context refuses_an_empty
  → 22 passed, 0 failed (8.84 s)
cargo clippy -p velesdb-memory --features persistence,context --tests -- -D warnings   → clean
cargo fmt -p velesdb-memory -- --check                                                 → clean
python3 scripts/check-file-budgets.py                                                  → PASSED
python3 scripts/check-doc-freshness.py                                                 → passed
python3 scripts/check-mcp-doc-contract.py                                              → passed
python3 scripts/check-ai-attribution.py --tree                                         → PASSED
```

Three new tests, all pure or near-instant: `bound_sessions` on the same-second tie with the just-saved session sorting last; oldest-first eviction plus the under-cap no-op; and the empty-key refusal for both keys, whitespace included, asserting nothing was written under either. A first draft used a 1 001-save integration test; it proved the same invariants in **88 s** and was replaced — a unit suite should not pay a minute for a `truncate`.

**Test Configuration:**
- OS: Ubuntu 24.04 (x86_64)
- Rust version: 1.90 (workspace MSRV toolchain)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG, MCP_TOOLS.md, model doc)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe` or SIMD path. The one lock touched is the existing `WORKING_INDEX_WRITE`, and only by adding a `truncate` inside its already-held critical section.

## Additional Notes

Why 1 000: the listing's only consumer is an agent deciding what to resume, which wants the most recent few. A thousand is two orders of magnitude above that, and small enough that the per-save rewrite stays under 100 KB of JSON at typical session-id lengths. If a real workload ever needs more, the constant is one number in `limits.rs` with its reasoning beside it.