### PR TITLE
fix(cli): fail closed on license expiry when the clock cannot be read

### DIFF
--- a/crates/velesdb-cli/src/license.rs
+++ b/crates/velesdb-cli/src/license.rs
@@ -101,12 +101,16 @@ where
 }
 
 impl LicenseInfo {
-    /// Checks if the license has expired
+    /// Checks if the license has expired.
+    ///
+    /// Fails closed: if the system clock cannot be read relative to the Unix
+    /// epoch, the license is treated as expired rather than valid, so a
+    /// broken clock can never silently bypass expiry.
     pub fn is_expired(&self) -> bool {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .unwrap_or(u64::MAX);
         now > self.expires_at
     }
 


### PR DESCRIPTION
## What

`LicenseInfo::is_expired()` computed `now` from `SystemTime::now().duration_since(UNIX_EPOCH)` and defaulted to `0` if that call errors. A `0` timestamp compares as *not expired* against any real (positive) `expires_at`, so a clock error made the license read as valid instead of surfacing the failure — the one place in this crate that decides whether a commercial license is accepted was failing open.

## Fix

Default to `u64::MAX` instead of `0`, so a clock that cannot be read relative to the Unix epoch is treated as an expired license rather than a valid one. One-line change plus a doc comment stating the fail-closed contract; no change to the persistence format, license payload, or public API surface.

## Why it's safe

- `duration_since(UNIX_EPOCH)` only errors when the system clock is set before 1970 — the trigger is rare and not attacker-controlled, but the direction of the failure (open vs. closed) is worth getting right regardless of how rare the trigger is.
- Existing `is_expired`/`validate_license` tests (`license_tests.rs`) pass unchanged — they exercise the normal (non-error) path, which is unaffected.
- `cargo test -p velesdb-cli license` and `cargo clippy -p velesdb-cli -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` both pass.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p velesdb-cli license -- --test-threads=1`
- `cargo clippy -p velesdb-cli -p velesdb-core --all-targets --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic`
