### PR TITLE
fix(memory): rebuild a corrupt working-context index instead of erasing it

### DIFF
--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A corrupt working-context index erased the whole project's listing.**
+  `update_working_index` rebuilt an unreadable index from EMPTY and wrote that
+  over it. Every other session under the project left `list_working_contexts`
+  for good while its fact sat intact on disk, reachable only by someone who
+  already knew the exact `project` + `session`. The read path's error — what
+  the code's own comment said a human would act on — was destroyed by the
+  very next save, and in an agent workload that save is moments away. The
+  index is a derived cache and the facts are the ground truth, so it is now
+  rebuilt FROM the facts: `MemoryError::WorkingContextCodec` triggers a
+  bounded walk (`FactStore::list`, capped at the same
+  `MAX_WORKING_SESSIONS_PER_PROJECT` every other write honors) for the facts
+  carrying this project's working-context markers. `saved_at` is not
+  recoverable — it lives in the index alone, never on a fact — so recovered
+  entries carry 0, sorting after anything stamped since. A backend whose
+  `list` is the defaulted `Unsupported` refusal degrades to the previous
+  empty rebuild rather than failing: not bricking saves was the original
+  code's one legitimate goal, and it is preserved.
+
 - **The working-context index grew without bound (#2193).** A project's index
   is one fact rewritten whole on every `save_working_context`; it gained an
   entry per distinct session and shed one only when that session's fact was

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -465,6 +465,65 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             .collect())
     }
 
+    /// Reconstruct `project`'s session list by walking the store for its
+    /// working-context facts — the recovery path for an index that cannot be
+    /// read. The index is a derived cache; every fact it lists carries
+    /// [`CTX_WORKING_FIELD`], [`CTX_PROJECT_FIELD`] and [`CTX_SESSION_FIELD`],
+    /// so the listing can be rebuilt from the facts themselves.
+    ///
+    /// `saved_at` is NOT recoverable: it lives in the index alone, never on
+    /// the fact. Recovered entries carry 0, which sorts them after anything
+    /// stamped since — an honest "unknown", and a far smaller harm than
+    /// dropping them. The session being saved right now is stamped with the
+    /// real clock by the caller, which finds it already present here.
+    ///
+    /// Returns `Ok(None)` when the backend cannot enumerate.
+    /// [`FactStore::list`] is defaulted to [`MemoryError::Unsupported`] on
+    /// purpose, so an out-of-crate backend that cannot walk keeps saving
+    /// rather than failing — it just cannot recover the listing.
+    ///
+    /// Walks at most [`crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT`]
+    /// matches: the rebuilt index is bounded by the same cap every other
+    /// write honors, so a huge store cannot turn this rare path into an
+    /// unbounded walk.
+    fn rebuild_working_index(
+        &self,
+        project: &str,
+    ) -> Result<Option<Vec<WorkingContextSession>>, MemoryError> {
+        const PAGE: usize = 256;
+        let wanted = Value::String(project.to_owned());
+        let mut sessions = Vec::new();
+        let mut cursor = None;
+        loop {
+            let (facts, next) = match self.store.list(cursor, PAGE) {
+                Ok(page) => page,
+                Err(MemoryError::Unsupported(_)) => return Ok(None),
+                Err(err) => return Err(err),
+            };
+            for fact in facts {
+                if fact.payload.get(CTX_WORKING_FIELD) != Some(&Value::Bool(true))
+                    || fact.payload.get(CTX_PROJECT_FIELD) != Some(&wanted)
+                {
+                    continue;
+                }
+                let Some(Value::String(session)) = fact.payload.get(CTX_SESSION_FIELD) else {
+                    continue;
+                };
+                sessions.push(WorkingContextSession {
+                    session: session.clone(),
+                    saved_at: 0,
+                });
+                if sessions.len() >= crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT {
+                    return Ok(Some(sessions));
+                }
+            }
+            match next {
+                Some(at) => cursor = Some(at),
+                None => return Ok(Some(sessions)),
+            }
+        }
+    }
+
     /// Every session still resumable under `project`'s working-context index
     /// (V2a-1 quick win), most-recently-saved first. Empty when the project
     /// never saved anything — that, and only that, is the empty case.
@@ -568,14 +627,29 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         // Read-modify-write of a single shared fact: held for the whole
         // sequence, otherwise a concurrent save silently erases this entry.
         let _guard = WORKING_INDEX_WRITE.lock();
-        // A corrupt index must not brick saving for the whole project. The
-        // read path surfaces the error — that is where a human can act on it
-        // — but propagating it here would make every future save of every
-        // session under this project fail forever, with no way back: the
-        // only writer of the index is this function. Rebuild instead.
+        // A corrupt index must not brick saving for the whole project:
+        // propagating the error here would make every future save of every
+        // session under it fail forever, with no way back, since the only
+        // writer of the index is this function.
+        //
+        // But starting from EMPTY was silent, permanent data loss. The rebuilt
+        // index overwrites the corrupt one, so the read path's error — the
+        // thing the caller was told to act on — is destroyed by the very next
+        // save, and in an agent workload that save is moments away. Every
+        // other session under the project leaves the listing for good while
+        // its fact sits intact on disk, reachable only by someone who already
+        // knows the exact id.
+        //
+        // The facts are the ground truth and the index is a derived cache, so
+        // rebuild the cache from the facts instead. Only when the backend
+        // cannot enumerate at all does this fall back to the empty rebuild —
+        // documented on [`Self::rebuild_working_index`], and still the
+        // save-keeps-working outcome it always was.
         let mut index = match self.working_index(project) {
             Ok(index) => index.unwrap_or_default(),
-            Err(MemoryError::WorkingContextCodec { .. }) => WorkingContextIndex::default(),
+            Err(MemoryError::WorkingContextCodec { .. }) => WorkingContextIndex {
+                sessions: self.rebuild_working_index(project)?.unwrap_or_default(),
+            },
             Err(err) => return Err(err),
         };
         let now = now_unix_secs();

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -38,13 +38,24 @@ fn now_nanos() -> u128 {
     }
 }
 
-/// Current Unix time in seconds — used only by
-/// [`MemoryService::should_upgrade_ttl`]'s extension-only comparison (the
-/// storage/expiry layer; the `compile` pipeline itself stays clock-free). On
-/// `wasm32-unknown-unknown` this is 0 (no clock, mirrors [`now_nanos`]); the
-/// wasm `MemoryStore` is in-memory only, so a stored durable expiry (a real
-/// epoch second count) never actually exists there for 0 to be compared
-/// against.
+/// Current Unix time in seconds. TWO call sites, not one — this comment used
+/// to name only the first, which is how the second went unexamined:
+///
+/// - [`MemoryService::should_upgrade_ttl`]'s extension-only comparison (the
+///   storage/expiry layer; the `compile` pipeline itself stays clock-free).
+///   On `wasm32-unknown-unknown` this is 0 (no clock, mirrors [`now_nanos`]);
+///   the wasm `MemoryStore` is in-memory only, so a stored durable expiry (a
+///   real epoch second count) never actually exists there for 0 to be
+///   compared against.
+/// - [`MemoryService::update_working_index`]'s `saved_at` stamp. The wasm 0
+///   is NOT harmless here: every entry gets the same stamp, so
+///   `list_working_contexts` falls through to its `session`-ascending
+///   tiebreak and orders alphabetically while five surfaces — this crate,
+///   the wasm binding, the TS SDK, `MCP_TOOLS.md`, and the MCP tool
+///   description the model itself reads — promise "most-recently-saved
+///   first". Recording the divergence, not excusing it: fixing it needs a
+///   real wasm clock or an optional `saved_at`, and that is a decision, not
+///   a patch.
 fn now_unix_secs() -> u64 {
     #[cfg(target_arch = "wasm32")]
     {

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -1161,3 +1161,143 @@ fn oversized_fragment_compiles_and_embeds_a_capped_text() {
         "the STORED content must stay whole — only the embedded text is capped"
     );
 }
+
+/// Returns an unparseable index body only while `armed` — a transient read
+/// failure (a torn page, a partial write later repaired), the case that
+/// separates "the listing is gone because the data is gone" from "the
+/// listing is gone because the write path threw it away".
+struct TransientlyCorruptStore {
+    inner: NativeStore,
+    torn: u64,
+    armed: std::sync::atomic::AtomicBool,
+}
+
+impl FactStore for TransientlyCorruptStore {
+    delegate_untouched_store_methods!();
+
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        if id == self.torn && self.armed.load(std::sync::atomic::Ordering::SeqCst) {
+            return Ok(Some(("}{ not json".to_owned(), vec![0.0; DIM])));
+        }
+        self.inner.get(id)
+    }
+
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        self.inner.get_metadata_batch(ids)
+    }
+
+    fn list(
+        &self,
+        cursor: Option<u64>,
+        limit: usize,
+    ) -> Result<(Vec<crate::storage::RawListedFact>, Option<u64>), MemoryError> {
+        self.inner.list(cursor, limit)
+    }
+}
+
+#[test]
+fn test_a_transient_index_corruption_does_not_erase_the_listing() {
+    // Given three saved sessions and a healthy listing
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let native = NativeStore::open(dir.path(), DIM).expect("open native store");
+    let svc = MemoryService::with_store(
+        TransientlyCorruptStore {
+            inner: native,
+            torn: working_index_id("veles"),
+            armed: std::sync::atomic::AtomicBool::new(false),
+        },
+        HashEmbedder::new(DIM),
+    );
+    for session in ["alpha", "beta", "gamma"] {
+        svc.save_working_context("veles", session, &minimal_working())
+            .expect("save");
+    }
+    assert_eq!(svc.list_working_contexts("veles").expect("list").len(), 3);
+
+    // When one save coincides with an unreadable index
+    svc.store
+        .armed
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    svc.save_working_context("veles", "delta", &minimal_working())
+        .expect("a corrupt index must never brick saving");
+    svc.store
+        .armed
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+
+    // Then every session is still listed. Before the rebuild the write path
+    // started from an EMPTY index and overwrote the corrupt one with a
+    // single entry: alpha, beta and gamma left the listing forever while
+    // their facts sat intact on disk, and the read-path error a human was
+    // supposed to act on was destroyed by that same write.
+    let mut listed: Vec<String> = svc
+        .list_working_contexts("veles")
+        .expect("list after")
+        .into_iter()
+        .map(|s| s.session)
+        .collect();
+    listed.sort();
+    assert_eq!(listed, ["alpha", "beta", "delta", "gamma"]);
+
+    // And the facts themselves were never in doubt.
+    for session in ["alpha", "beta", "gamma", "delta"] {
+        assert!(svc
+            .load_working_context("veles", session)
+            .expect("load")
+            .is_some());
+    }
+}
+
+/// A store that can hold facts but cannot walk them — `FactStore::list` is
+/// defaulted to `Unsupported` precisely so an out-of-crate backend keeps
+/// compiling, and the recovery must degrade rather than fail.
+struct UnwalkableStore {
+    inner: NativeStore,
+    torn: u64,
+}
+
+impl FactStore for UnwalkableStore {
+    delegate_untouched_store_methods!();
+
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        if id == self.torn {
+            return Ok(Some(("}{ not json".to_owned(), vec![0.0; DIM])));
+        }
+        self.inner.get(id)
+    }
+
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        self.inner.get_metadata_batch(ids)
+    }
+}
+
+#[test]
+fn test_a_backend_that_cannot_enumerate_still_saves_through_a_corrupt_index() {
+    // Given a backend whose `list` is the defaulted refusal, and a corrupt index
+    let dir = tempfile::TempDir::new().expect("tempdir");
+    let native = NativeStore::open(dir.path(), DIM).expect("open native store");
+    let svc = MemoryService::with_store(
+        UnwalkableStore {
+            inner: native,
+            torn: working_index_id("veles"),
+        },
+        HashEmbedder::new(DIM),
+    );
+
+    // The FIRST save cannot reach the corruption path: no index fact exists
+    // yet, so `working_index` answers `Ok(None)` on the absent marker and
+    // never reads a body. It is what PUTS the marker there.
+    svc.save_working_context("veles", "alpha", &minimal_working())
+        .expect("first save creates the index");
+
+    // When a second save reads that now-marked index and finds it unreadable
+    let saved = svc.save_working_context("veles", "beta", &minimal_working());
+
+    // Then the save still succeeds. The listing cannot be recovered here —
+    // nothing can walk the facts — but refusing the save would brick the
+    // project forever, which is the outcome the rebuild exists to avoid, not
+    // to introduce.
+    assert!(
+        saved.is_ok(),
+        "a backend that cannot enumerate must still save: {saved:?}"
+    );
+}


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/working-index-rebuild-on-corruption` → **`develop`**. Correct per the rules above.

## Description

`update_working_index` rebuilt an unreadable index from **EMPTY** and wrote that over
it. Every other session under the project left `list_working_contexts` for good while
its fact sat intact on disk, reachable only by someone who already knew the exact
`project` + `session`.

The comment defending this said the read path surfaces the error, *"that is where a
human can act on it"*. **The write path destroys that.** It overwrites the corrupt
payload, so the next listing is a healthy one-entry index and the error never appears
again. In an agent workload, where a save follows within seconds, the write wins that
race essentially always. Nothing pinned the behaviour either — the existing corruption
tests (`test_working_index_with_marker_but_no_body_is_an_error_not_an_empty_list`,
both `test_resume_*_when_the_project_index_is_corrupt`) all cover the READ path.

### Proven before fixing

A store whose index body is unreadable for the duration of exactly one save:

```
LISTED AFTER TRANSIENT CORRUPTION: ["delta"]
assertion `left == right` failed: left: 1, right: 4
```

`alpha`, `beta`, `gamma` and `delta` were **all four** still loadable by exact key in
the same test. The data was never lost; only the listing was, and only because the
write path threw it away.

### The fix

The index is a derived cache and the facts are the ground truth, so it is now rebuilt
**from** the facts. `MemoryError::WorkingContextCodec` triggers a bounded walk
(`FactStore::list`) for the facts carrying this project's working-context markers,
capped at the same `MAX_WORKING_SESSIONS_PER_PROJECT` every other write honors — a
rare path cannot become an unbounded scan of a huge store.

`saved_at` is **not** recoverable: it lives in the index alone, never on a fact.
Recovered entries carry `0` and sort after anything stamped since — an honest
"unknown", and a far smaller harm than dropping them. The session being saved is found
already present and gets the real clock.

A backend whose `list` is the defaulted `Unsupported` refusal degrades to the previous
empty rebuild rather than failing. Not bricking saves was the original code's one
legitimate goal, and it is preserved: the recovery is purely additive.

### A second, one-line correction

The doc comment on `now_unix_secs` claimed it is *"used only by
`MemoryService::should_upgrade_ttl`'s extension-only comparison"*. There are two call
sites — the other stamps `saved_at` in the very function this PR fixes. The claim is
simply false and is corrected. This does **not** fix the wasm ordering issue below; it
stops the code from asserting something untrue about itself.

### Why this is in `[0.14.2]` and not a new version

0.14.2 is stamped but **not yet tagged or published** — there is no release in the wild
to amend. The CHANGELOG entry joins the existing `### Fixed` section.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

No API change: `rebuild_working_index` is private, and the public behaviour only ever
gains sessions it used to lose.

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Two new tests, and **both mutations are killed**:

| Mutation | Test that fails |
| --- | --- |
| Restore the empty rebuild (the original defect) | `test_a_transient_index_corruption_does_not_erase_the_listing` |
| Propagate `Unsupported` instead of degrading | `test_a_backend_that_cannot_enumerate_still_saves_through_a_corrupt_index` |

**The second mutation initially survived, and it was right to.** The test saved one
session into a fresh store — where `working_index` answers `Ok(None)` on the *absent
marker* and never reads a body — so it exercised nothing at all and would have stayed
green whatever happened to the fallback. The first save is what puts the marker there;
reaching the corruption path needs a second. Fixed, re-mutated, now killed. Worth
recording: without the mutation pass this PR would have shipped a vacuous test.

Validation, with the repository's exact CI flags (AGENTS.md rule 10):

- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test -p velesdb-memory --lib` — **784 passed, 0 failed, 9 ignored**
- Full `.githooks/pre-commit` sequence green (fmt, clippy, undocumented-unsafe, SAFETY
  comments, TODO governance, secrets, tests)

**Test Configuration:**
- OS: Linux x86_64
- Rust version: workspace-pinned toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code is added or modified.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch path is
touched. `FactStore::list` is called, not changed.

## Additional Notes

Found while answering "are you sure `velesdb-memory` has no structural defects left?"
after 0.14.2 was merged. It does not — this is one of them.

A **second** finding from the same pass is deliberately NOT fixed here, to keep the
scope one defect wide: on `wasm32`, `now_unix_secs()` is hardcoded to `0`, so every
`saved_at` is 0, `list_working_contexts` degrades from recency order to alphabetical,
and the envelope reports `saved_at: 0`. "most-recently-saved first" is asserted in five
places including the MCP tool description the model reads, so an agent taking
`sessions[0]` as "where I left off" resumes the alphabetically-first session. That one
needs a decision — a real wasm clock, or an optional `saved_at` plus five doc surfaces
— rather than a patch.

## Performance Labels

Not requested — the new walk runs only on a corrupt index, never on a healthy save.