### PR TITLE
fix(memory): close four structural defects found by an adversarial audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,15 @@ cargo check -p velesdb-memory --no-default-features
 cargo check -p velesdb-memory --no-default-features --features context
 cargo check -p velesdb-memory
 cargo check -p velesdb-memory --no-default-features --features mcp,persistence
+# Each velesdb-memory feature in ISOLATION, with --all-targets — mirrors the
+# Lint job's loop (#1765). `--all-targets` is the point: it compiles every
+# integration test and example under that one feature, which the four
+# shapes above never do. A test that imports a `persistence`-gated item
+# without a crate-level `#![cfg(feature = "persistence")]` passes all four
+# shapes and fails here (#2202 found this the hard way).
+for feat in mcp http context persistence embedder-http extractor-http ollama extract; do
+  cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
+done
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
 # Guards and contracts. Every one of these blocks a PR through `CI Success`, and

--- a/crates/velesdb-memory/CHANGELOG.md
+++ b/crates/velesdb-memory/CHANGELOG.md
@@ -13,6 +13,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`project`/`session` ids reached storage past every declared cap.**
+  `save_working_context` wrote them into the fact's metadata (bypassing
+  `MAX_METADATA_BYTES`, checked only on `remember`'s own `metadata`), fed them
+  to the embedder (bypassing `MAX_EMBEDDABLE_TEXT_BYTES`, likewise), and copied
+  the session id into the project index — one fact rewritten whole on every
+  save, up to 1000 ids wide. Measured: a 600 KiB session id was accepted and
+  stored 614 677 bytes of metadata; the SECOND such save was refused by the
+  backend's 1 MiB payload cap AFTER its fact was stored — durable, unlisted,
+  and reported to the caller as failed. Both ids are now capped at
+  `MAX_WORKING_CONTEXT_KEY_BYTES` (256 bytes, the idempotency-key precedent)
+  and refused up front with `MemoryError::WorkingContextKeyTooLong` — additive
+  on the `#[non_exhaustive]` enum. Reads are not capped: a store written
+  before this release may hold longer ids, and they stay loadable.
+
+- **`list_working_contexts` was alphabetical wherever `saved_at` tied.**
+  `saved_at` is whole seconds, so two saves in one second tie; on WASM it is
+  always 0 (no clock), so every entry tied and the whole listing — promised
+  "most-recently-saved first" on five surfaces, including the MCP tool
+  description the model reads — came back in `session` order. An agent taking
+  `sessions[0]` as "where I left off" resumed the alphabetically-first
+  session. The index's stored order is now recency (the writer moves the saved
+  entry to the front), and the read path and the eviction at the cap sort
+  stably by `saved_at` alone, so the order holds on every target; the
+  `saved_at` VALUE stays 0 on WASM and every surface now says so.
+
+- **Autograph enrichments that failed part-way were invisible.** The wiring
+  helpers propagate with `?`, so the first failing write ended the stage —
+  and `autograph` discarded that error with `let _`: not counted, not logged,
+  and `memory_status` reported a healthy worker while the fact's graph
+  structure was partial. The doc's "never silent" covered the QUEUE (drops)
+  only. Such failures are now counted in `MemoryService::autograph_failed`,
+  logged once per failed stage, and reported by `memory_status` as
+  `extraction.autograph_failed`, distinct from `autograph_dropped` (never
+  ran): re-remembering the fact completes its wiring.
+
+- **A failed online-migration worker was silent, and could lose its error.**
+  The worker recorded its failure on the job record for `migration_status`
+  and nothing else; when that record could not be read or written — a disk
+  that just failed a migration is a disk likely to fail this write too — the
+  error was gone from every channel, and status showed a non-terminal phase
+  with no worker and no `last_error`, indistinguishable from a pause. The
+  failure is now logged, and each degraded step is logged on its own so the
+  original error is never masked by the one that hid it.
+
 - **A corrupt working-context index erased the whole project's listing.**
   `update_working_index` rebuilt an unreadable index from EMPTY and wrote that
   over it. Every other session under the project left `list_working_contexts`

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -195,24 +195,18 @@ fn bound_sessions(sessions: &mut Vec<WorkingContextSession>, just_saved: &str) {
     if sessions.len() <= CAP {
         return;
     }
-    // `remove`, not `swap_remove`: the latter would move the LAST entry into
-    // the pinned one's slot and corrupt the recency order a stable sort is
-    // about to rely on.
-    let pinned = sessions
-        .iter()
-        .position(|s| s.session == just_saved)
-        .map(|at| sessions.remove(at));
-    sessions.sort_by(|a, b| b.saved_at.cmp(&a.saved_at));
-    sessions.truncate(CAP - usize::from(pinned.is_some()));
-    // Back to the FRONT, where the writer put it: it is the most recent
-    // entry, and the stored order is recency. Appending it (as this once
-    // did) left the just-saved session LAST — harmless on native, where its
-    // fresh `saved_at` sorts it first again on read, but on wasm32, where
-    // every `saved_at` is 0 and the stored order is all there is, the
-    // session just saved would have listed last past the cap.
-    if let Some(entry) = pinned {
-        sessions.insert(0, entry);
+    // Pin by moving the just-saved entry to the front — where the writer put
+    // it, and where the recency order wants it — with one in-place rotation.
+    // Everything after it is then stably ordered by `saved_at` alone (ties
+    // keep the stored recency order) and the tail past the cap is cut. When
+    // the entry is absent the whole vector is ordered and cut the same way.
+    let pinned = sessions.iter().position(|s| s.session == just_saved);
+    if let Some(at) = pinned {
+        sessions[..=at].rotate_right(1);
     }
+    let unpinned_from = usize::from(pinned.is_some());
+    sessions[unpinned_from..].sort_by_key(|s| std::cmp::Reverse(s.saved_at));
+    sessions.truncate(CAP);
 }
 
 /// The compilation half — `compile_context` and its helpers; see
@@ -591,7 +585,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         let mut sessions = self.live_sessions(project, index.sessions)?;
         // Stable, and by `saved_at` alone: ties keep the stored order, which
         // `update_working_index` maintains as recency (see its comment).
-        sessions.sort_by(|a, b| b.saved_at.cmp(&a.saved_at));
+        sessions.sort_by_key(|s| std::cmp::Reverse(s.saved_at));
         Ok(sessions)
     }
 
@@ -696,9 +690,10 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         // on wasm the whole listing was alphabetical while five surfaces
         // promised recency.
         if let Some(at) = index.sessions.iter().position(|s| s.session == session) {
-            let mut entry = index.sessions.remove(at);
-            entry.saved_at = now;
-            index.sessions.insert(0, entry);
+            // One in-place rotation moves the entry to the front and shifts
+            // the ones before it by one: no allocation, one pass.
+            index.sessions[..=at].rotate_right(1);
+            index.sessions[0].saved_at = now;
         } else {
             index.sessions.insert(
                 0,

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -186,24 +186,33 @@ static WORKING_INDEX_WRITE: parking_lot::Mutex<()> = parking_lot::Mutex::new(())
 /// dropping the oldest-saved first. `just_saved` is pinned: it is the entry
 /// this very call put there, and a same-second flood of other sessions must
 /// not be able to evict it on a timestamp tie. The order among the rest is
-/// the read path's (`saved_at` desc, then session asc), so what survives is
-/// exactly what `list_working_contexts` would have shown first.
+/// the read path's (`saved_at` desc, STABLE, ties keeping the stored recency
+/// order), so what survives is exactly what `list_working_contexts` would
+/// have shown first — on `wasm32`, where every `saved_at` is 0, that is the
+/// stored order alone, and eviction is by recency rather than by name.
 fn bound_sessions(sessions: &mut Vec<WorkingContextSession>, just_saved: &str) {
     use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
     if sessions.len() <= CAP {
         return;
     }
+    // `remove`, not `swap_remove`: the latter would move the LAST entry into
+    // the pinned one's slot and corrupt the recency order a stable sort is
+    // about to rely on.
     let pinned = sessions
         .iter()
         .position(|s| s.session == just_saved)
-        .map(|at| sessions.swap_remove(at));
-    sessions.sort_by(|a, b| {
-        b.saved_at
-            .cmp(&a.saved_at)
-            .then_with(|| a.session.cmp(&b.session))
-    });
+        .map(|at| sessions.remove(at));
+    sessions.sort_by(|a, b| b.saved_at.cmp(&a.saved_at));
     sessions.truncate(CAP - usize::from(pinned.is_some()));
-    sessions.extend(pinned);
+    // Back to the FRONT, where the writer put it: it is the most recent
+    // entry, and the stored order is recency. Appending it (as this once
+    // did) left the just-saved session LAST — harmless on native, where its
+    // fresh `saved_at` sorts it first again on read, but on wasm32, where
+    // every `saved_at` is 0 and the stored order is all there is, the
+    // session just saved would have listed last past the cap.
+    if let Some(entry) = pinned {
+        sessions.insert(0, entry);
+    }
 }
 
 /// The compilation half — `compile_context` and its helpers; see
@@ -229,7 +238,9 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     /// # Errors
     /// Returns [`MemoryError::EmptyWorkingContextKey`] if `project` or
     /// `session` is empty or whitespace-only — they are the id the state is
-    /// saved and listed under — [`MemoryError::EmptyWorkingContext`] if
+    /// saved and listed under — [`MemoryError::WorkingContextKeyTooLong`] if
+    /// either exceeds [`crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES`],
+    /// [`MemoryError::EmptyWorkingContext`] if
     /// `working` records nothing, [`MemoryError::WorkingContextCodec`] if
     /// serialization fails,
     /// [`MemoryError::ContextOverLimit`] if the serialized `working` exceeds
@@ -244,6 +255,17 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         for (key, value) in [("project", project), ("session", session)] {
             if value.trim().is_empty() {
                 return Err(MemoryError::EmptyWorkingContextKey { key });
+            }
+            // Ids, not payloads — and until this check they were the one
+            // caller string that reached storage past every other ceiling
+            // (metadata, embedder, index). See the constant's doc for the
+            // measured bypass.
+            if value.len() > crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES {
+                return Err(MemoryError::WorkingContextKeyTooLong {
+                    key,
+                    len: value.len(),
+                    max: crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES,
+                });
             }
         }
         if working.is_empty() {
@@ -567,11 +589,9 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             return Ok(Vec::new());
         };
         let mut sessions = self.live_sessions(project, index.sessions)?;
-        sessions.sort_by(|a, b| {
-            b.saved_at
-                .cmp(&a.saved_at)
-                .then_with(|| a.session.cmp(&b.session))
-        });
+        // Stable, and by `saved_at` alone: ties keep the stored order, which
+        // `update_working_index` maintains as recency (see its comment).
+        sessions.sort_by(|a, b| b.saved_at.cmp(&a.saved_at));
         Ok(sessions)
     }
 
@@ -664,13 +684,29 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             Err(err) => return Err(err),
         };
         let now = now_unix_secs();
-        if let Some(entry) = index.sessions.iter_mut().find(|s| s.session == session) {
+        // The vector's ORDER is recency, most recent first, maintained here on
+        // every save: the entry being saved moves (or is inserted) at the
+        // front. `saved_at` alone cannot carry that order — it is whole
+        // seconds, so two saves in one second tie, and on `wasm32` it is
+        // always 0 (no clock), so EVERY entry ties. The read path and
+        // `bound_sessions` sort by `saved_at` with a STABLE sort and no other
+        // tiebreak, so where `saved_at` cannot decide, this order does, and
+        // "most-recently-saved first" holds on every target. Before this, ties
+        // fell through to a `session`-ascending tiebreak — alphabetical — and
+        // on wasm the whole listing was alphabetical while five surfaces
+        // promised recency.
+        if let Some(at) = index.sessions.iter().position(|s| s.session == session) {
+            let mut entry = index.sessions.remove(at);
             entry.saved_at = now;
+            index.sessions.insert(0, entry);
         } else {
-            index.sessions.push(WorkingContextSession {
-                session: session.to_owned(),
-                saved_at: now,
-            });
+            index.sessions.insert(
+                0,
+                WorkingContextSession {
+                    session: session.to_owned(),
+                    saved_at: now,
+                },
+            );
         }
         // The entry just appended is alive by construction (its fact was
         // stored moments ago, before this call); this only sheds the ones a

--- a/crates/velesdb-memory/src/context/memory_bridge_tests.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge_tests.rs
@@ -1032,9 +1032,12 @@ fn test_load_working_context_does_not_mutate_the_index() {
         .iter()
         .map(|entry| entry.session.as_str())
         .collect();
+    // Most-recently-saved first is the index's STORED order (the writer
+    // moves each saved entry to the front), so two saves persist as
+    // [beta, alpha]. The read must leave exactly that in place.
     assert_eq!(
         persisted,
-        vec!["alpha", "beta"],
+        vec!["beta", "alpha"],
         "load_working_context must not rewrite the shared index"
     );
 
@@ -1299,5 +1302,229 @@ fn test_a_backend_that_cannot_enumerate_still_saves_through_a_corrupt_index() {
     assert!(
         saved.is_ok(),
         "a backend that cannot enumerate must still save: {saved:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Working-context key cap (MAX_WORKING_CONTEXT_KEY_BYTES).
+//
+// `project` and `session` are ids, and they were the one caller string that
+// reached storage past every other ceiling: into the fact's metadata (past
+// MAX_METADATA_BYTES, which only `remember`'s metadata path checks), into the
+// embedder (past MAX_EMBEDDABLE_TEXT_BYTES, likewise), and ×1000 into the
+// project index rewritten whole on every save. Measured before the cap: a
+// 600 KiB session id was accepted, stored 614 677 bytes of metadata, and the
+// SECOND such save was refused by the backend's 1 MiB payload cap AFTER its
+// fact was stored — durable, unlisted, and reported to the caller as failed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_a_session_id_over_the_cap_is_refused_before_anything_is_written() {
+    let (_dir, svc) = open_service();
+    let over = "s".repeat(crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES + 1);
+
+    let refused = svc.save_working_context("proj", &over, &minimal_working());
+
+    assert!(
+        matches!(
+            refused,
+            Err(MemoryError::WorkingContextKeyTooLong { key: "session", len, max })
+                if len == crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES + 1
+                    && max == crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES
+        ),
+        "an over-cap session id must be refused as WorkingContextKeyTooLong: {refused:?}"
+    );
+    // Nothing was written: no fact under that id, no index for the project.
+    assert!(svc
+        .store
+        .get_metadata(working_id("proj", &over))
+        .expect("read")
+        .is_none());
+    assert!(svc.list_working_contexts("proj").expect("list").is_empty());
+}
+
+#[test]
+fn test_a_project_id_over_the_cap_is_refused_and_names_the_key() {
+    let (_dir, svc) = open_service();
+    let over = "p".repeat(crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES + 1);
+    let refused = svc.save_working_context(&over, "sess", &minimal_working());
+    assert!(
+        matches!(
+            refused,
+            Err(MemoryError::WorkingContextKeyTooLong { key: "project", .. })
+        ),
+        "{refused:?}"
+    );
+}
+
+#[test]
+fn test_an_id_exactly_at_the_cap_is_accepted() {
+    // The cap is inclusive: 256 bytes is an id, 257 is a payload.
+    let (_dir, svc) = open_service();
+    let at_cap = "s".repeat(crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES);
+    svc.save_working_context("proj", &at_cap, &minimal_working())
+        .expect("an id exactly at the cap is accepted");
+    let listed = svc.list_working_contexts("proj").expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].session, at_cap);
+}
+
+#[test]
+fn test_the_empty_check_still_wins_over_the_length_check() {
+    // Whitespace-only and short: the EMPTY refusal is the right one. A
+    // whitespace-only id over the cap is also empty first — the emptiness is
+    // the more fundamental defect, and the error a caller can act on.
+    let (_dir, svc) = open_service();
+    let blank_and_long = " ".repeat(crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES + 1);
+    let refused = svc.save_working_context("proj", &blank_and_long, &minimal_working());
+    assert!(
+        matches!(
+            refused,
+            Err(MemoryError::EmptyWorkingContextKey { key: "session" })
+        ),
+        "{refused:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// "Most-recently-saved first" must hold where `saved_at` cannot decide.
+//
+// `saved_at` is whole seconds, so two saves in one second tie; on wasm32 it
+// is always 0, so EVERY entry ties. The old tiebreak was `session`
+// ascending — alphabetical — so on wasm the whole listing was alphabetical
+// while five surfaces promised recency. Now the index's vector ORDER is
+// recency (the writer moves the saved entry to the front), the read path
+// and `bound_sessions` sort stably by `saved_at` alone, and ties keep it.
+// ---------------------------------------------------------------------------
+
+fn tied(sessions: &[&str]) -> Vec<WorkingContextSession> {
+    sessions
+        .iter()
+        .map(|s| WorkingContextSession {
+            session: (*s).to_owned(),
+            saved_at: 0,
+        })
+        .collect()
+}
+
+#[test]
+fn test_bound_sessions_evicts_by_recency_not_by_name_when_timestamps_tie() {
+    use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
+    // CAP + 1 entries, ALL at saved_at 0 (the wasm case), in recency order:
+    // index 0 is the most recent. Names are chosen so that alphabetical
+    // order is the REVERSE of recency: the most recent is named "1000", the
+    // oldest "0000". The pinned (just-saved) entry is in the middle so the
+    // pin cannot mask the tiebreak.
+    let names: Vec<String> = (0..=CAP).map(|i| format!("{:04}", CAP - i)).collect();
+    let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let mut sessions = tied(&refs);
+    let pinned = names[CAP / 2].clone();
+
+    bound_sessions(&mut sessions, &pinned);
+
+    let kept: Vec<&str> = sessions.iter().map(|s| s.session.as_str()).collect();
+    assert_eq!(kept.len(), CAP);
+    assert!(
+        kept.contains(&"1000"),
+        "the most recent entry must survive eviction on a timestamp tie"
+    );
+    assert!(
+        !kept.contains(&"0000"),
+        "the OLDEST entry is the one to evict on a timestamp tie — the old \
+         alphabetical tiebreak evicted the most recent instead"
+    );
+    assert!(
+        kept.contains(&pinned.as_str()),
+        "the pinned entry always survives"
+    );
+}
+
+#[test]
+fn test_bound_sessions_keeps_the_just_saved_entry_at_the_front() {
+    use crate::limits::MAX_WORKING_SESSIONS_PER_PROJECT as CAP;
+    // In the real flow the writer has just put the saved entry at index 0.
+    // Past the cap it is removed to be pinned, and it must come BACK to
+    // index 0 — not to the end — because on wasm32 (every saved_at 0) the
+    // stored order is the only order there is.
+    let names: Vec<String> = (0..=CAP).map(|i| format!("s{i:04}")).collect();
+    let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+    let mut sessions = tied(&refs);
+    let just_saved = names[0].clone();
+
+    bound_sessions(&mut sessions, &just_saved);
+
+    assert_eq!(sessions.len(), CAP);
+    assert_eq!(
+        sessions[0].session, just_saved,
+        "the just-saved session must stay first after eviction at the cap"
+    );
+    assert_eq!(
+        sessions[CAP - 1].session,
+        names[CAP - 1],
+        "the oldest survivor is last"
+    );
+    assert!(
+        !sessions.iter().any(|s| s.session == names[CAP]),
+        "the entry past the cap is the one evicted"
+    );
+}
+
+#[test]
+fn test_listing_keeps_recency_order_when_every_saved_at_ties() {
+    // Three real sessions so `live_sessions` keeps them, then the index is
+    // overwritten with all three at saved_at 0 in recency order [c, b, a]
+    // (c most recent), named so that alphabetical order is the opposite.
+    let (_dir, svc) = open_service();
+    for session in ["a", "b", "c"] {
+        svc.save_working_context("proj", session, &minimal_working())
+            .expect("save");
+    }
+    let index = WorkingContextIndex {
+        sessions: tied(&["c", "b", "a"]),
+    };
+    let content = serde_json::to_string(&index).expect("encode");
+    let embedding = svc
+        .embedder
+        .embed("working context index proj")
+        .expect("embed");
+    svc.write_working_index("proj", &content, &embedding)
+        .expect("write index");
+
+    let listed: Vec<String> = svc
+        .list_working_contexts("proj")
+        .expect("list")
+        .into_iter()
+        .map(|s| s.session)
+        .collect();
+
+    assert_eq!(
+        listed,
+        ["c", "b", "a"],
+        "with every saved_at tied, the listing must follow the index's recency \
+         order — alphabetical would be [a, b, c]"
+    );
+}
+
+#[test]
+fn test_a_resave_moves_the_session_to_the_front_of_the_index() {
+    // The writer's half of the contract: saving an EXISTING session moves it
+    // to index 0, so the stored order stays recency even when the clock
+    // cannot tell (wasm) or does not move (same second).
+    let (_dir, svc) = open_service();
+    for session in ["a", "b", "c"] {
+        svc.save_working_context("proj", session, &minimal_working())
+            .expect("save");
+    }
+    svc.save_working_context("proj", "a", &minimal_working())
+        .expect("resave a");
+    let index = svc
+        .working_index("proj")
+        .expect("read index")
+        .expect("index present");
+    let order: Vec<&str> = index.sessions.iter().map(|s| s.session.as_str()).collect();
+    assert_eq!(
+        order,
+        ["a", "c", "b"],
+        "stored order must be recency, most recent first"
     );
 }

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -675,7 +675,11 @@ pub struct WorkingContextSession {
     pub session: String,
     /// Unix seconds this session was last saved — updated on every
     /// `save_working_context` call under this project + session, not just
-    /// the first (a resave never duplicates the entry).
+    /// the first (a resave never duplicates the entry). `0` on
+    /// `wasm32-unknown-unknown`, which has no clock; the listing's
+    /// most-recently-saved-first order does not depend on it (it is carried
+    /// by the index's write order), so the ORDER holds there while the
+    /// VALUE does not.
     pub saved_at: u64,
 }
 

--- a/crates/velesdb-memory/src/error.rs
+++ b/crates/velesdb-memory/src/error.rs
@@ -272,6 +272,26 @@ pub enum MemoryError {
         key: &'static str,
     },
 
+    /// [`crate::service::MemoryService::save_working_context`] was given a
+    /// `project` or `session` over
+    /// [`crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES`]. They are ids, and
+    /// they were the one caller string that reached storage past every other
+    /// ceiling — into the fact's metadata, the embedder, and the per-project
+    /// index rewritten whole on every save. Refused before anything is
+    /// written.
+    #[cfg(feature = "context")]
+    #[error(
+        "working-context {key} is {len} bytes, over the {max}-byte cap: it is an id, not a payload"
+    )]
+    WorkingContextKeyTooLong {
+        /// Which key was over the cap: `"project"` or `"session"`.
+        key: &'static str,
+        /// The offending length, in bytes.
+        len: usize,
+        /// The cap ([`crate::limits::MAX_WORKING_CONTEXT_KEY_BYTES`]).
+        max: usize,
+    },
+
     /// A persisted working context could not be (de)serialized — the stored
     /// payload predates or postdates this crate's schema.
     ///
@@ -367,9 +387,9 @@ impl MemoryError {
             | Self::MetadataTooLarge { .. } => ErrorCategory::InvalidInput,
             Self::Unsupported(_) => ErrorCategory::Unsupported,
             #[cfg(feature = "context")]
-            Self::EmptyWorkingContext | Self::EmptyWorkingContextKey { .. } => {
-                ErrorCategory::InvalidInput
-            }
+            Self::EmptyWorkingContext
+            | Self::EmptyWorkingContextKey { .. }
+            | Self::WorkingContextKeyTooLong { .. } => ErrorCategory::InvalidInput,
             #[cfg(feature = "context")]
             Self::ContextBudget { .. } | Self::ContextOverLimit(_) | Self::SegmentationError(_) => {
                 ErrorCategory::InvalidInput

--- a/crates/velesdb-memory/src/limits.rs
+++ b/crates/velesdb-memory/src/limits.rs
@@ -115,6 +115,28 @@ pub const MAX_AUTOGRAPH_QUEUE: usize = 64;
 /// will either commit or expose a persisted failure.
 pub const MAX_EXTRACTION_JOBS: usize = 64;
 
+/// Maximum size of a working-context `project` or `session` id, in bytes.
+///
+/// Both are ids, not payloads — the same reasoning as
+/// [`MAX_IDEMPOTENCY_KEY_BYTES`] below, and the same figure. Without a cap they
+/// were the one caller-controlled string that reached storage past every
+/// other ceiling: `save_working_context` writes them into the fact's
+/// metadata (bypassing [`MAX_METADATA_BYTES`], which only `remember`'s
+/// caller-supplied `metadata` path checks), feeds them to the embedder
+/// (bypassing [`MAX_EMBEDDABLE_TEXT_BYTES`], likewise checked only in
+/// `remember`), and copies the session id into the project's index — one fact
+/// rewritten whole on every save, up to [`MAX_WORKING_SESSIONS_PER_PROJECT`]
+/// ids wide. Measured: a 600 KiB session id was accepted, stored 614 677
+/// bytes of metadata, and the second such save was refused by the backend's
+/// 1 MiB payload cap AFTER its fact had been stored — durable but unlisted,
+/// with an error telling the caller the opposite.
+///
+/// At 256 bytes, a full index is at most ~300 KB
+/// (`1000 × (256 + JSON overhead)`), comfortably inside [`MAX_FACT_BYTES`] and
+/// the backend's own cap, so the index can no longer outgrow what one save
+/// may write.
+pub const MAX_WORKING_CONTEXT_KEY_BYTES: usize = 256;
+
 /// Maximum caller-supplied idempotency-key size for `remember_extracted`.
 /// Keys are hashed before they reach a filename, but bounding the input still
 /// prevents an otherwise tiny receipt call from carrying an arbitrary payload.

--- a/crates/velesdb-memory/src/mcp/context_tools.rs
+++ b/crates/velesdb-memory/src/mcp/context_tools.rs
@@ -228,8 +228,9 @@ pub(super) struct ListWorkingContextsParams {
 /// Output of the `list_working_contexts` tool.
 #[derive(Debug, serde::Serialize, JsonSchema)]
 pub(super) struct ListWorkingContextsResult {
-    /// Every session saved under this project, most-recently-saved first.
-    /// Empty (not an error) when the project never saved anything.
+    /// Every session saved under this project, most-recently-saved first
+    /// (`saved_at` is `0` on WASM, which has no clock; the order still holds
+    /// there). Empty (not an error) when the project never saved anything.
     pub sessions: Vec<WorkingContextSession>,
 }
 

--- a/crates/velesdb-memory/src/mcp/dto.rs
+++ b/crates/velesdb-memory/src/mcp/dto.rs
@@ -681,6 +681,11 @@ pub(super) struct ExtractionStatus {
     /// Enrichments refused by a FULL queue since startup — the facts were
     /// stored, only their wiring was skipped (#1846's counted-drop rule).
     pub(super) autograph_dropped: u64,
+    /// Enrichments that RAN and failed part-way through wiring since startup
+    /// — the fact is stored, its graph structure is partial (the writes
+    /// before the failure are in), and re-remembering the fact completes it.
+    /// Distinct from `autograph_dropped`, which never ran at all.
+    pub(super) autograph_failed: u64,
 }
 
 /// The `memory` block of [`MemoryStatusResult`].

--- a/crates/velesdb-memory/src/mcp/status.rs
+++ b/crates/velesdb-memory/src/mcp/status.rs
@@ -19,6 +19,7 @@ type StatusSnapshot = (
     Option<usize>,
     bool,
     u64,
+    u64,
 );
 
 #[tool_router(router = status_tool_router, vis = "pub(super)")]
@@ -26,7 +27,7 @@ impl McpServer {
     #[tool(
         name = "memory_status",
         output_schema = crate::schema::wire_safe_output_schema::<MemoryStatusResult>(),
-        description = "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether a default extraction backend is configured (`remember_extracted` may omit `extractor` iff `extraction.configured`; explicit `outline` remains available), whether the background autograph worker is active and how many enrichments a full queue dropped, and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters."
+        description = "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether a default extraction backend is configured (`remember_extracted` may omit `extractor` iff `extraction.configured`; explicit `outline` remains available), whether the background autograph worker is active, how many enrichments a full queue dropped (never ran) and how many ran but failed part-way through wiring (fact stored, graph structure partial — re-remember it to complete), and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters."
     )]
     async fn memory_status(&self) -> Result<Json<MemoryStatusResult>, ErrorData> {
         let service = Arc::clone(&self.service);
@@ -44,6 +45,7 @@ impl McpServer {
                     current.edge_count(),
                     current.autograph_queue_open(),
                     current.autograph_dropped(),
+                    current.autograph_failed(),
                 )
             })
         })
@@ -54,8 +56,16 @@ impl McpServer {
     }
 
     fn status_result(&self, snapshot: StatusSnapshot) -> MemoryStatusResult {
-        let (model, dimension, provenance, facts, edges, autograph_active, autograph_dropped) =
-            snapshot;
+        let (
+            model,
+            dimension,
+            provenance,
+            facts,
+            edges,
+            autograph_active,
+            autograph_dropped,
+            autograph_failed,
+        ) = snapshot;
         MemoryStatusResult {
             embedder: embedder_status(model, dimension),
             provenance: provenance_status(provenance),
@@ -63,6 +73,7 @@ impl McpServer {
                 configured: self.extractors.read().default_is_configured(),
                 autograph_active,
                 autograph_dropped,
+                autograph_failed,
             },
             memory: MemoryCounts { facts, edges },
         }

--- a/crates/velesdb-memory/src/online_migration/job_state.rs
+++ b/crates/velesdb-memory/src/online_migration/job_state.rs
@@ -185,6 +185,13 @@ impl JobStore {
         Ok(store)
     }
 
+    /// The record file's path, for tests that need to read it raw (a
+    /// byte-identical comparison across a refused save).
+    #[cfg(test)]
+    pub(crate) fn path_for_test(&self) -> &Path {
+        &self.path
+    }
+
     pub(crate) fn load(&self) -> Result<JobRecord, MemoryError> {
         let _access = self.access.lock();
         self.load_unlocked()

--- a/crates/velesdb-memory/src/online_migration/manager.rs
+++ b/crates/velesdb-memory/src/online_migration/manager.rs
@@ -329,11 +329,40 @@ fn ensure_resumable(phase: JobPhase) -> Result<(), MemoryError> {
     }
 }
 
-fn persist_worker_error(store: &JobStore, error: &MemoryError) {
-    if let Ok(mut record) = store.load() {
-        record.fail(error.to_string());
-        let _ = store.save(&record);
+/// The worker thread died on `error`: record it on the job so
+/// `migration_status` reports it, and SAY so. Until this logged, a failed
+/// migration was discoverable only by polling status — and when the record
+/// could not be updated (a disk that just failed the migration is a disk
+/// likely to fail this write too) the error was gone from every channel: the
+/// job showed a non-terminal phase, no worker, and no `last_error`,
+/// indistinguishable from a pause. Each degraded step is logged on its own
+/// so the ORIGINAL error is never masked by the one that hid it.
+pub(super) fn persist_worker_error(store: &JobStore, error: &MemoryError) {
+    log_worker_failure("online migration worker failed", error);
+    match store.load() {
+        Ok(mut record) => {
+            record.fail(error.to_string());
+            if let Err(save_error) = store.save(&record) {
+                log_worker_failure(
+                    "online migration worker failed AND the failure could not be recorded on \
+                     the job; migration_status will show no last_error",
+                    &save_error,
+                );
+            }
+        }
+        Err(load_error) => log_worker_failure(
+            "online migration worker failed AND the job record could not be read to record \
+             it; migration_status will show no last_error",
+            &load_error,
+        ),
     }
+}
+
+fn log_worker_failure(what: &str, error: &MemoryError) {
+    #[cfg(feature = "mcp")]
+    tracing::error!(error = %error, "{what}");
+    #[cfg(not(feature = "mcp"))]
+    let _ = (what, error);
 }
 
 fn refuse_existing_destination(path: &Path) -> Result<(), MemoryError> {
@@ -368,6 +397,6 @@ fn sibling(source: &Path, suffix: &str) -> Result<PathBuf, MemoryError> {
     Ok(source.with_file_name(format!("{name}.{suffix}")))
 }
 
-fn capture(message: impl Into<String>) -> MemoryError {
+pub(super) fn capture(message: impl Into<String>) -> MemoryError {
     MemoryError::MigrationCapture(message.into())
 }

--- a/crates/velesdb-memory/src/online_migration/manager_tests.rs
+++ b/crates/velesdb-memory/src/online_migration/manager_tests.rs
@@ -248,3 +248,93 @@ fn config() -> MigrationStartConfig {
         },
     }
 }
+
+// ---------------------------------------------------------------------------
+// A worker failure is recorded when it can be, and never corrupts the record
+// when it cannot.
+// ---------------------------------------------------------------------------
+
+fn failed_job_record(root: &std::path::Path) -> super::job_state::JobRecord {
+    use super::job_state::JobSpec;
+    use crate::mutation::journal::EpochIdentity;
+    let identity = EpochIdentity::for_test(
+        root.join("source"),
+        "source-model",
+        "target-model",
+        3,
+        &format!("sha256:{}", "ab".repeat(32)),
+        root.join("destination"),
+        "0123456789abcdef0123456789abcdef",
+    );
+    super::job_state::JobRecord::new(JobSpec {
+        identity,
+        target_backend: "hash".to_owned(),
+        journal_max_bytes: 1_048_576,
+        catch_up: CatchUpConfig {
+            fact_batch: 64,
+            replay_batch: 64,
+            edge_cap: 64,
+        },
+        controller: ControllerConfig {
+            observation_window: 3,
+            pause_budget: Duration::from_secs(1),
+            verification_reserve: Duration::from_millis(50),
+        },
+        workspace: root.join("workspace"),
+    })
+    .expect("record")
+}
+
+#[test]
+fn a_worker_failure_is_recorded_on_the_job_for_migration_status() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace = dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let record = failed_job_record(dir.path());
+    let store = super::job_state::JobStore::create(&workspace, &record).expect("create");
+
+    let error = super::manager::capture("the worker died");
+    super::manager::persist_worker_error(&store, &error);
+
+    let reloaded = store.load().expect("load");
+    assert_eq!(reloaded.last_error, Some(error.to_string()));
+}
+
+/// The degraded path: the job record cannot be reached at all. The function
+/// must return (it runs on a dying worker thread — a panic there is a lost
+/// thread, not a report), and the record must be exactly what it was. What
+/// it DOES do here is log — the one channel left — which a unit test cannot
+/// assert without a subscriber; the property pinned is that failing to
+/// record is itself survivable and non-destructive.
+///
+/// The workspace is parked and a plain FILE put in its place, so both the
+/// load and any staged write fail with "not a directory". (A read-only
+/// directory would not do: the suite runs as root in CI containers, and root
+/// ignores permission bits.)
+#[test]
+fn a_worker_failure_that_cannot_be_recorded_does_not_panic_or_corrupt_the_record() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let workspace = dir.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let record = failed_job_record(dir.path());
+    let store = super::job_state::JobStore::create(&workspace, &record).expect("create");
+    let before = std::fs::read(store.path_for_test()).expect("read record");
+
+    let parked = dir.path().join("parked");
+    std::fs::rename(&workspace, &parked).expect("park the workspace");
+    std::fs::write(&workspace, b"not a directory").expect("occupy the path");
+    super::manager::persist_worker_error(&store, &super::manager::capture("the worker died"));
+    std::fs::remove_file(&workspace).expect("free the path");
+    std::fs::rename(&parked, &workspace).expect("restore the workspace");
+
+    let after = std::fs::read(store.path_for_test()).expect("read record");
+    assert_eq!(
+        before, after,
+        "an unreachable record must come back byte-identical"
+    );
+    assert_eq!(
+        store.load().expect("load").last_error,
+        None,
+        "nothing was recorded — and nothing was corrupted"
+    );
+}

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -205,6 +205,9 @@ struct AutographJob {
 struct AutographQueue {
     tx: parking_lot::Mutex<Option<std::sync::mpsc::SyncSender<AutographJob>>>,
     dropped: std::sync::atomic::AtomicU64,
+    /// Enrichments that RAN and failed part-way through wiring — distinct
+    /// from `dropped` (never ran). See `MemoryService::autograph_failed`.
+    failed: std::sync::atomic::AtomicU64,
     closing: std::sync::atomic::AtomicBool,
 }
 
@@ -350,24 +353,6 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             validate_relation(&link.relation)?;
         }
         self.ensure_link_targets_exist(links)
-    }
-
-    /// How many autograph enrichments a FULL queue refused since this
-    /// service was built (#1846). The facts themselves were stored; only
-    /// their graph wiring was skipped, and re-remembering a fact rebuilds it.
-    #[must_use]
-    pub fn autograph_dropped(&self) -> u64 {
-        self.autograph_queue
-            .dropped
-            .load(std::sync::atomic::Ordering::Relaxed)
-    }
-
-    /// Whether the background autograph queue is OPEN — a worker is spawned
-    /// and `remember` enqueues instead of running the enrichment inline.
-    /// Turns false the moment a worker handle's drop closes the queue.
-    #[must_use]
-    pub fn autograph_queue_open(&self) -> bool {
-        self.autograph_queue.tx.lock().is_some()
     }
 
     /// Whether an autograph extractor is configured at all.

--- a/crates/velesdb-memory/src/service_graph_wiring.rs
+++ b/crates/velesdb-memory/src/service_graph_wiring.rs
@@ -22,6 +22,29 @@ use super::{
 #[cfg(not(target_arch = "wasm32"))]
 use super::AutographWorkerHandle;
 
+/// The three wiring stages of one autograph enrichment, in the order they
+/// run. Named for the failure log: which stage a partial enrichment stopped
+/// at is the one fact a reader needs to judge what is missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutographStage {
+    /// Fact → topic hubs (`about`/`mentions` pairs).
+    Entities,
+    /// Hub → hub typed edges.
+    Relations,
+    /// Hub attribute writes.
+    Attributes,
+}
+
+impl std::fmt::Display for AutographStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Entities => "entities",
+            Self::Relations => "relations",
+            Self::Attributes => "attributes",
+        })
+    }
+}
+
 impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     // Autograph observability lives with autograph (this module), not in the
     // service assembler: `service.rs` is over the file budget and only ever
@@ -321,7 +344,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             if let Err(err) =
                 self.wire_entities(fact_id, &extracted.entities, &mut entity_ids, &mut edges)
             {
-                self.note_autograph_failure(fact_id, "entities", &err);
+                self.note_autograph_failure(fact_id, AutographStage::Entities, &err);
             }
         }
         // A concurrent `forget` can still race the wiring writes above between
@@ -334,10 +357,10 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
             return;
         }
         if let Err(err) = self.wire_relations(&extraction.relations, &mut entity_ids, &mut edges) {
-            self.note_autograph_failure(fact_id, "relations", &err);
+            self.note_autograph_failure(fact_id, AutographStage::Relations, &err);
         }
         if let Err(err) = self.wire_attributes(&extraction.attributes, &mut entity_ids) {
-            self.note_autograph_failure(fact_id, "attributes", &err);
+            self.note_autograph_failure(fact_id, AutographStage::Attributes, &err);
         }
     }
 
@@ -350,14 +373,14 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     /// stage, not per edge (#1834's rule): the concurrent-`forget` race the
     /// comments above describe is the common cause, and it fails the whole
     /// stage at once.
-    fn note_autograph_failure(&self, fact_id: u64, stage: &str, err: &MemoryError) {
+    fn note_autograph_failure(&self, fact_id: u64, stage: AutographStage, err: &MemoryError) {
         self.autograph_queue
             .failed
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         #[cfg(feature = "mcp")]
         tracing::warn!(
             fact_id,
-            stage,
+            stage = %stage,
             error = %err,
             "autograph enrichment failed part-way: the fact is stored, its graph \
              structure is partial; re-remembering it completes the wiring"

--- a/crates/velesdb-memory/src/service_graph_wiring.rs
+++ b/crates/velesdb-memory/src/service_graph_wiring.rs
@@ -23,6 +23,45 @@ use super::{
 use super::AutographWorkerHandle;
 
 impl<E: Embedder, S: FactStore> MemoryService<E, S> {
+    // Autograph observability lives with autograph (this module), not in the
+    // service assembler: `service.rs` is over the file budget and only ever
+    // shrinks (scripts/check-file-budgets.py), so the counters' accessors
+    // moved here beside the worker that feeds them.
+
+    /// How many autograph enrichments a FULL queue refused since this
+    /// service was built (#1846). The facts themselves were stored; only
+    /// their graph wiring was skipped, and re-remembering a fact rebuilds it.
+    #[must_use]
+    pub fn autograph_dropped(&self) -> u64 {
+        self.autograph_queue
+            .dropped
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// How many autograph enrichments RAN and failed part-way through
+    /// wiring since this service was built. Distinct from
+    /// [`Self::autograph_dropped`], which counts the ones a full queue never
+    /// ran. A failure here leaves the fact stored and its graph structure
+    /// PARTIAL — the entities wired before the failing write are in, the
+    /// rest are not — and re-remembering the fact completes it. Until this
+    /// counter existed such failures were discarded with `let _`: not
+    /// counted, not logged, invisible to `memory_status`, while the doc
+    /// promised "never silent" — a promise that covered only the queue.
+    #[must_use]
+    pub fn autograph_failed(&self) -> u64 {
+        self.autograph_queue
+            .failed
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Whether the background autograph queue is OPEN — a worker is spawned
+    /// and `remember` enqueues instead of running the enrichment inline.
+    /// Turns false the moment a worker handle's drop closes the queue.
+    #[must_use]
+    pub fn autograph_queue_open(&self) -> bool {
+        self.autograph_queue.tx.lock().is_some()
+    }
+
     /// Remember a `fact`, optionally tagging it with structured `metadata`
     /// (`ColumnStore` facet) and linking it to existing memories (graph facet).
     /// Returns the stable id of the fact (idempotent on identical content).
@@ -279,7 +318,11 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         // separates autograph from `remember_extracted`: one `remember` call
         // must still produce exactly one caller-visible memory.
         for extracted in &extraction.facts {
-            let _ = self.wire_entities(fact_id, &extracted.entities, &mut entity_ids, &mut edges);
+            if let Err(err) =
+                self.wire_entities(fact_id, &extracted.entities, &mut entity_ids, &mut edges)
+            {
+                self.note_autograph_failure(fact_id, "entities", &err);
+            }
         }
         // A concurrent `forget` can still race the wiring writes above between
         // the first check and here. Re-check once more before the hub↔hub and
@@ -290,8 +333,37 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
         if !self.fact_exists(fact_id) {
             return;
         }
-        let _ = self.wire_relations(&extraction.relations, &mut entity_ids, &mut edges);
-        let _ = self.wire_attributes(&extraction.attributes, &mut entity_ids);
+        if let Err(err) = self.wire_relations(&extraction.relations, &mut entity_ids, &mut edges) {
+            self.note_autograph_failure(fact_id, "relations", &err);
+        }
+        if let Err(err) = self.wire_attributes(&extraction.attributes, &mut entity_ids) {
+            self.note_autograph_failure(fact_id, "attributes", &err);
+        }
+    }
+
+    /// One enrichment ran and a wiring write failed part-way: count it and
+    /// say so. The wiring helpers propagate with `?`, so the first failing
+    /// write ends its stage; the fact is stored and its graph structure is
+    /// partial until it is re-remembered. Discarding the error here — as
+    /// `let _` did — left that invisible everywhere: no counter, no log, and
+    /// a `memory_status` that reported a healthy worker. One line per failed
+    /// stage, not per edge (#1834's rule): the concurrent-`forget` race the
+    /// comments above describe is the common cause, and it fails the whole
+    /// stage at once.
+    fn note_autograph_failure(&self, fact_id: u64, stage: &str, err: &MemoryError) {
+        self.autograph_queue
+            .failed
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        #[cfg(feature = "mcp")]
+        tracing::warn!(
+            fact_id,
+            stage,
+            error = %err,
+            "autograph enrichment failed part-way: the fact is stored, its graph \
+             structure is partial; re-remembering it completes the wiring"
+        );
+        #[cfg(not(feature = "mcp"))]
+        let _ = (fact_id, stage, err);
     }
 
     /// Create each outgoing link from `fact_id`.

--- a/crates/velesdb-memory/tests/autograph_failure_bdd.rs
+++ b/crates/velesdb-memory/tests/autograph_failure_bdd.rs
@@ -13,6 +13,13 @@
 //! production — on a hub write — through a store that refuses to persist an
 //! entity hub (`_veles_hub` metadata) while accepting everything else.
 
+// `NativeStore` is the backing store this suite wraps, and it is
+// `persistence`-gated: the same crate-level guard `auto_date_bdd.rs` and
+// `column_filter_conformance_bdd.rs` carry, so the Lint job's per-feature
+// `--all-targets` loop (which compiles every integration test under
+// `--features context` alone) does not try to build this one without it.
+#![cfg(feature = "persistence")]
+
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -26,6 +33,10 @@ struct HubRefusingStore {
     inner: NativeStore,
 }
 
+/// The hub marker `MemoryService` stamps on every entity hub. The crate does
+/// not re-export the constant (it is a storage-layer detail, not API), and
+/// exporting it for one test would widen the public surface for no caller;
+/// the literal IS the on-disk contract this suite wraps, so it is spelled out.
 const HUB_FIELD: &str = "_veles_hub";
 
 fn is_hub(metadata: &Metadata) -> bool {

--- a/crates/velesdb-memory/tests/autograph_failure_bdd.rs
+++ b/crates/velesdb-memory/tests/autograph_failure_bdd.rs
@@ -1,0 +1,198 @@
+//! An autograph enrichment that RUNS and fails part-way is counted and
+//! reported — not discarded.
+//!
+//! `autograph`'s wiring helpers propagate with `?`, so the first failing
+//! write ends its stage. The caller used to discard that error with `let _`:
+//! not counted, not logged, and `memory_status` reported a healthy worker
+//! while the fact's graph structure was partial. The doc's "never silent"
+//! covered the QUEUE (a full queue's drops) and nothing else. This suite pins
+//! the other half: a wiring failure lands in `autograph_failed`, distinct
+//! from `autograph_dropped`, and the fact itself is stored regardless.
+//!
+//! The failure is induced where the code's own comments say it happens in
+//! production — on a hub write — through a store that refuses to persist an
+//! entity hub (`_veles_hub` metadata) while accepting everything else.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use velesdb_memory::{
+    BoundedMemoryEdges, ExtractError, ExtractedFact, Extraction, Extractor, FactStore, GraphStore,
+    HashEmbedder, MemoryEdge, MemoryError, MemoryService, Metadata, NativeStore, DEFAULT_DIMENSION,
+};
+
+/// Refuses to store an entity hub; delegates everything else.
+struct HubRefusingStore {
+    inner: NativeStore,
+}
+
+const HUB_FIELD: &str = "_veles_hub";
+
+fn is_hub(metadata: &Metadata) -> bool {
+    metadata.get(HUB_FIELD) == Some(&Value::Bool(true))
+}
+
+impl FactStore for HubRefusingStore {
+    fn store(&self, id: u64, content: &str, embedding: &[f32]) -> Result<(), MemoryError> {
+        self.inner.store(id, content, embedding)
+    }
+    fn store_with_metadata(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+    ) -> Result<(), MemoryError> {
+        if is_hub(metadata) {
+            return Err(MemoryError::Extract(ExtractError::Backend(
+                "simulated: the store refused to persist an entity hub".to_owned(),
+            )));
+        }
+        self.inner
+            .store_with_metadata(id, content, embedding, metadata)
+    }
+    fn store_with_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        self.inner
+            .store_with_ttl(id, content, embedding, ttl_seconds)
+    }
+    fn store_with_metadata_and_ttl(
+        &self,
+        id: u64,
+        content: &str,
+        embedding: &[f32],
+        metadata: &Metadata,
+        ttl_seconds: u64,
+    ) -> Result<(), MemoryError> {
+        if is_hub(metadata) {
+            return Err(MemoryError::Extract(ExtractError::Backend(
+                "simulated: the store refused to persist an entity hub".to_owned(),
+            )));
+        }
+        self.inner
+            .store_with_metadata_and_ttl(id, content, embedding, metadata, ttl_seconds)
+    }
+    fn update_metadata(&self, id: u64, metadata: &Metadata) -> Result<(), MemoryError> {
+        self.inner.update_metadata(id, metadata)
+    }
+    fn get(&self, id: u64) -> Result<Option<(String, Vec<f32>)>, MemoryError> {
+        self.inner.get(id)
+    }
+    fn get_metadata(&self, id: u64) -> Result<Option<Metadata>, MemoryError> {
+        self.inner.get_metadata(id)
+    }
+    fn get_metadata_batch(&self, ids: &[u64]) -> Result<Vec<Option<Metadata>>, MemoryError> {
+        self.inner.get_metadata_batch(ids)
+    }
+    fn delete(&self, id: u64) -> Result<(), MemoryError> {
+        self.inner.delete(id)
+    }
+    fn count(&self) -> usize {
+        self.inner.count()
+    }
+}
+
+impl GraphStore for HubRefusingStore {
+    fn relate(&self, from: u64, to: u64, relation: &str) -> Result<u64, MemoryError> {
+        self.inner.relate(from, to, relation)
+    }
+    fn relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        self.inner.relations(id)
+    }
+    fn incoming_relations(&self, id: u64) -> Result<Vec<MemoryEdge>, MemoryError> {
+        self.inner.incoming_relations(id)
+    }
+    fn relations_bounded(&self, id: u64, cap: usize) -> Result<BoundedMemoryEdges, MemoryError> {
+        self.inner.relations_bounded(id, cap)
+    }
+    fn incoming_relations_bounded(
+        &self,
+        id: u64,
+        cap: usize,
+    ) -> Result<BoundedMemoryEdges, MemoryError> {
+        self.inner.incoming_relations_bounded(id, cap)
+    }
+    fn unrelate(&self, edge_id: u64) -> Result<bool, MemoryError> {
+        self.inner.unrelate(edge_id)
+    }
+}
+
+/// Always finds one topic — enough for `wire_entities` to try a hub write.
+struct OneTopicExtractor;
+
+impl Extractor for OneTopicExtractor {
+    fn extract(&self, text: &str) -> Result<Vec<ExtractedFact>, ExtractError> {
+        Ok(vec![ExtractedFact {
+            text: text.to_owned(),
+            entities: vec!["paris".to_owned()],
+        }])
+    }
+    fn extract_graph(&self, text: &str) -> Result<Extraction, ExtractError> {
+        Ok(Extraction {
+            facts: self.extract(text)?,
+            relations: Vec::new(),
+            attributes: Vec::new(),
+        })
+    }
+}
+
+fn service(dir: &tempfile::TempDir) -> MemoryService<HashEmbedder, HubRefusingStore> {
+    let inner = NativeStore::open(dir.path(), DEFAULT_DIMENSION).expect("open native store");
+    MemoryService::with_store(
+        HubRefusingStore { inner },
+        HashEmbedder::new(DEFAULT_DIMENSION),
+    )
+    .with_autograph(Arc::new(OneTopicExtractor))
+}
+
+#[test]
+fn a_wiring_failure_is_counted_and_the_fact_is_still_stored() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = service(&dir);
+    // No worker spawned: autograph runs INLINE, so the count is observable
+    // as soon as `remember` returns.
+    assert_eq!(svc.autograph_failed(), 0);
+
+    svc.remember("Alice moved to Paris in 2024.", &[], None)
+        .expect("the fact is stored even though its enrichment will fail");
+
+    assert_eq!(
+        svc.autograph_failed(),
+        1,
+        "one enrichment ran and its hub write failed: that is one counted failure"
+    );
+    assert_eq!(
+        svc.autograph_dropped(),
+        0,
+        "nothing was dropped — the enrichment RAN; drops and failures are distinct"
+    );
+    assert_eq!(
+        svc.fact_count(),
+        1,
+        "a wiring failure never loses the fact — and the refused hub is not a fact"
+    );
+}
+
+#[test]
+fn every_failed_enrichment_is_counted_not_just_the_first() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let svc = service(&dir);
+    for fact in [
+        "Bob visited Paris.",
+        "Carol lives in Paris.",
+        "Dan left Paris.",
+    ] {
+        svc.remember(fact, &[], None).expect("remember");
+    }
+    assert_eq!(svc.autograph_failed(), 3);
+    assert_eq!(
+        svc.fact_count(),
+        3,
+        "every fact stored, every enrichment counted as failed"
+    );
+}

--- a/crates/velesdb-wasm/src/memory_service.rs
+++ b/crates/velesdb-wasm/src/memory_service.rs
@@ -1045,9 +1045,9 @@ impl WasmMemoryService {
     }
 
     /// Every session ever saved under `project`'s working-context index,
-    /// most-recently-saved first: resolves to `{sessions: [{session,
-    /// saved_at}]}` — empty (never an error) when the project never saved
-    /// anything (#1517, option 2).
+    /// most-recently-saved first (by the index's write order: `saved_at` is
+    /// always `0` here, wasm has no clock): resolves to `{sessions: [{session,
+    /// saved_at}]}`, empty (never an error) when nothing was saved (#1517).
     ///
     /// **In-memory semantics**: see [`Self::save_working_context`]'s doc
     /// comment — reflects only what this session's [`WasmStore`] currently

--- a/docs/reference/MCP_TOOLS.md
+++ b/docs/reference/MCP_TOOLS.md
@@ -440,11 +440,13 @@ Returns `{ embedder, provenance, extraction, memory }`:
 - `provenance` — `{ recorded, model, dimension }`: what the store was FILLED
   by, per its on-disk record (#1751). `recorded: false` on a store predating
   the record; the mismatch check then degrades to dimension alone.
-- `extraction` — `{ configured, autograph_active, autograph_dropped }`:
-  `configured` says whether `remember_extracted` may omit its per-call
-  `extractor`; explicit `outline` remains available when it is `false`. The
-  two autograph fields report the background enrichment worker and its
-  counted drops.
+- `extraction` — `{ configured, autograph_active, autograph_dropped,
+  autograph_failed }`: `configured` says whether `remember_extracted` may omit
+  its per-call `extractor`; explicit `outline` remains available when it is
+  `false`. The three autograph fields report the background enrichment worker,
+  its counted drops (a full queue: the enrichment never ran), and its counted
+  failures (it ran and a wiring write failed part-way: the fact is stored, its
+  graph structure is partial, and re-remembering the fact completes it).
 - `memory` — `{ facts, edges }`: corpus size. `edges: 0` is the meaningful
   reading — nothing ever wired the graph, so `why` has nothing to walk and
   degrades to plain search. `edges: null` means the backend cannot count
@@ -746,7 +748,8 @@ Discover what is resumable before guessing a session id.
 | `project` | string | yes | The facet to list. |
 
 Returns `{ sessions: [ { session, saved_at } ] }`, most-recently-saved first;
-`saved_at` is Unix seconds. Empty (not an error) when the project never saved
+`saved_at` is Unix seconds — `0` on WASM, which has no clock; the ordering
+still holds there, by write order. Empty (not an error) when the project never saved
 anything. The listing holds at most 1 000 sessions per project — past that,
 the oldest-saved drop out of the list; their saved state stays on disk and
 `load_working_context` still finds it by exact `project` + `session`.

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -2233,12 +2233,12 @@
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "sessions": {
-            "description": "Every session saved under this project, most-recently-saved first.\nEmpty (not an error) when the project never saved anything.",
+            "description": "Every session saved under this project, most-recently-saved first\n(`saved_at` is `0` on WASM, which has no clock; the order still holds\nthere). Empty (not an error) when the project never saved anything.",
             "items": {
               "description": "One session recorded in a project's working-context index (V2a-1's\n`list_working_contexts` quick win).",
               "properties": {
                 "saved_at": {
-                  "description": "Unix seconds this session was last saved — updated on every\n`save_working_context` call under this project + session, not just\nthe first (a resave never duplicates the entry).",
+                  "description": "Unix seconds this session was last saved — updated on every\n`save_working_context` call under this project + session, not just\nthe first (a resave never duplicates the entry). `0` on\n`wasm32-unknown-unknown`, which has no clock; the listing's\nmost-recently-saved-first order does not depend on it (it is carried\nby the index's write order), so the ORDER holds there while the\nVALUE does not.",
                   "format": "uint64",
                   "minimum": 0,
                   "type": "integer"
@@ -2570,7 +2570,7 @@
       }
     },
     {
-      "description": "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether a default extraction backend is configured (`remember_extracted` may omit `extractor` iff `extraction.configured`; explicit `outline` remains available), whether the background autograph worker is active and how many enrichments a full queue dropped, and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters.",
+      "description": "Report this memory server's health and configuration: which embedder is running and whether recall is SEMANTIC (`embedder.semantic: false` means the offline `hash` default — recall matches surface form, not meaning, and configuring a semantic embedder is an env-var switch, no rebuild), what embedder the store was filled by per its on-disk provenance record, whether a default extraction backend is configured (`remember_extracted` may omit `extractor` iff `extraction.configured`; explicit `outline` remains available), whether the background autograph worker is active, how many enrichments a full queue dropped (never ran) and how many ran but failed part-way through wiring (fact stored, graph structure partial — re-remember it to complete), and the corpus size — `memory.facts` and `memory.edges`. Read `memory.edges` when `why` seems to add nothing over `recall`: `0` means no fact was ever linked (by `relate`, `remember`'s `links`, or extraction), so `why` HAS no graph to walk and degrades to plain search — that is a wiring gap, not a defect. Call this at session start, or whenever recall quality or `why`'s evidence trails surprise you, and tell the user when the server runs degraded. Takes no parameters.",
       "inputSchema": {
         "properties": {},
         "type": "object"
@@ -2619,6 +2619,11 @@
                 "minimum": 0,
                 "type": "integer"
               },
+              "autograph_failed": {
+                "description": "Enrichments that RAN and failed part-way through wiring since startup\n— the fact is stored, its graph structure is partial (the writes\nbefore the failure are in), and re-remembering the fact completes it.\nDistinct from `autograph_dropped`, which never ran at all.",
+                "minimum": 0,
+                "type": "integer"
+              },
               "configured": {
                 "description": "Whether a default extraction backend is attached. When false, callers\ncan still request the always-available `outline` backend explicitly.",
                 "type": "boolean"
@@ -2627,7 +2632,8 @@
             "required": [
               "configured",
               "autograph_active",
-              "autograph_dropped"
+              "autograph_dropped",
+              "autograph_failed"
             ],
             "type": "object"
           },

--- a/scripts/file-budgets-baseline.txt
+++ b/scripts/file-budgets-baseline.txt
@@ -2,7 +2,6 @@ crates/velesdb-core/src/simd_native/x86_avx512.rs	1469
 crates/velesdb-memory/src/context.rs	1097
 crates/velesdb-memory/src/extract.rs	1559
 crates/velesdb-memory/src/schema.rs	1119
-crates/velesdb-memory/src/service.rs	1006
 crates/velesdb-python/src/agent_memory_service.rs	1097
 crates/velesdb-python/src/options.rs	1123
 crates/velesdb-wasm/src/memory_service.rs	1080

--- a/sdks/typescript/src/memory.ts
+++ b/sdks/typescript/src/memory.ts
@@ -342,7 +342,11 @@ export interface WorkingContext {
 export interface WorkingContextSession {
   /** The session id, as passed to {@link MemoryService.saveWorkingContext}. */
   session: string;
-  /** Unix seconds this session was last saved. */
+  /**
+   * Unix seconds this session was last saved. `0` under WASM, which has no
+   * clock — the listing's most-recently-saved-first order does not depend on
+   * it, so the order holds while the value does not.
+   */
   saved_at: number;
 }
 


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/memory-audit-hardening` → **`develop`**. Correct per the rules above.

## Description

Four structural defects in `velesdb-memory`, found by an adversarial pass over the crate
(extraction, migration, MCP/HTTP, graph, working context) after 0.14.2 was stamped and
before it is tagged. Each was verified before it was fixed; each fix is mutation-tested.
0.14.2 is stamped but **not yet published**, so all four land in its `### Fixed`.

### 1. `project`/`session` ids reached storage past every declared cap

`save_working_context` wrote them into the fact's metadata (bypassing `MAX_METADATA_BYTES`,
which only `remember`'s own `metadata` path checks), fed them to the embedder (bypassing
`MAX_EMBEDDABLE_TEXT_BYTES`, likewise), and copied the session id into the project index —
one fact rewritten whole on every save, up to 1000 ids wide. No binding, no MCP schema, and
no store layer bounded them. The `MAX_METADATA_BYTES` doc lists the write paths it
protects; this one was not among them.

**Measured before the fix** (repro since removed):

```
G4 save #1 (600 KiB session name): Ok
G4 working-fact metadata: 614677 bytes (MAX_METADATA_BYTES = 65536)
second save: [VELES-027] Guard-rail violation: payload exceeds max_payload_size cap of 1048576 bytes
```

The second save was refused by the backend's 1 MiB cap **after** its fact was stored —
durable, unlisted, and reported to the caller as failed.

Fix: `MAX_WORKING_CONTEXT_KEY_BYTES = 256` (the idempotency-key precedent), refused up front
with `MemoryError::WorkingContextKeyTooLong { key, len, max }` — additive on the
`#[non_exhaustive]` enum, mapped to `InvalidInput`. At 256 bytes a full index is ≤ ~300 KB,
inside every cap. Reads are **not** capped: a store written before this release may hold
longer ids, and they stay loadable.

### 2. `list_working_contexts` was alphabetical wherever `saved_at` tied

`saved_at` is whole seconds, so two saves in one second tie; on WASM it is always 0, so
every entry tied and the whole listing — promised "most-recently-saved first" on five
surfaces, including the MCP tool description the model reads — came back in `session`
order. An agent taking `sessions[0]` as "where I left off" resumed the alphabetically-first
session.

Fix, non-breaking: the index's **stored order is recency** (the writer moves the saved entry
to the front), and the read path and the eviction at the cap sort **stably by `saved_at`
alone**. The order now holds on every target; the `saved_at` *value* stays 0 on WASM and all
five surfaces say so. The move-to-front is one in-place `rotate_right(1)` over the prefix —
no allocation, one pass — and the sorts are `sort_by_key(Reverse(saved_at))`, stable.

### 3. Autograph enrichments that failed part-way were invisible

The wiring helpers propagate with `?`, so the first failing write ends the stage — and
`autograph` discarded that error with `let _`: not counted, not logged, and `memory_status`
reported a healthy worker while the fact's graph structure was partial. The doc's "never
silent" covered the **queue** (drops) only.

Fix: `MemoryService::autograph_failed` (distinct from `autograph_dropped`: ran vs never
ran), one `warn!` per failed stage, and `memory_status.extraction.autograph_failed`. The
MCP tool-surface artifact is regenerated through the repository's own mechanism
(`UPDATE_MCP_TOOLS_SNAPSHOT=1 cargo test --test mcp_tools_drift`), and `MCP_TOOLS.md`
documents the field.

### 4. A failed online-migration worker was silent, and could lose its error

`persist_worker_error` recorded the failure on the job record for `migration_status` and
nothing else; when that record could not be read or written — a disk that just failed a
migration is a disk likely to fail this write too — the error was gone from every channel,
and status showed a non-terminal phase with no worker and no `last_error`, indistinguishable
from a pause. There was no `tracing` call anywhere in `manager.rs`.

Fix: the failure is logged, and each degraded step is logged on its own so the original
error is never masked by the one that hid it. `persist_worker_error`/`capture` become
`pub(super)` for the sibling test module; `JobStore::path_for_test` is `#[cfg(test)]`.

### Second pass: what an r/rust reader would flag, fixed before merge

- `remove(at)` + `insert(0, …)` — two O(n) shifts — became one in-place
  `slice[..=at].rotate_right(1)`; `bound_sessions` lost its `Option` dance the same way.
- `sort_by(|a, b| b.saved_at.cmp(&a.saved_at))` became `sort_by_key(|s| Reverse(s.saved_at))`.
- The stringly-typed `stage: &str` in the failure log became an `enum AutographStage` with
  `Display`.
- The test's duplicated `"_veles_hub"` literal is now explained: the constant is a
  storage-layer detail the crate deliberately does not re-export, and the literal is the
  on-disk contract the suite wraps.
- The new integration suite carries the crate-level `#[cfg(feature = "persistence")]` its
  peers carry (`NativeStore` is `persistence`-gated); the Lint job's per-feature
  `--all-targets` loop caught its absence on the first push, and the AGENTS.md pre-push
  block now includes that loop, which it had never mirrored (rule 10).

Kept, with the crate's own precedents: `Ordering::Relaxed` on statistics counters (as
`dropped` already is), `pub(super)` for a sibling `#[path]` test module (as `relate_inner`),
one `#[cfg(test)]` accessor on `JobStore`.

### File budgets: one seam moved, one debt entry retired

`scripts/check-file-budgets.py` refused the first cut: `service.rs` (already over the
1000-line budget, frozen at 1006) had grown by the new counter's accessor, and an
over-budget file only ever shrinks. The autograph accessors (`autograph_dropped`,
`autograph_failed`, `autograph_queue_open`) now live in `service_graph_wiring.rs` — the
module that owns the worker feeding them — which takes `service.rs` to **991 lines, under
the budget, and off the baseline** (a pure shrink; the guard's own unittest passes). The
WASM binding's doc addition is compacted to +0 lines for the same reason.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

Not breaking: one additive error variant on a `#[non_exhaustive]` enum, one additive field
on `memory_status`, and an ordering that only ever gets *more* correct.

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

**Every fix is mutation-tested** — mutation applied, suite run to watch it fail, source
restored (no residue: verified by grep):

| Mutation | Tests that fail |
| --- | --- |
| M1 — remove the key length check | `test_a_session_id_over_the_cap_is_refused_before_anything_is_written`, `test_a_project_id_over_the_cap_is_refused_and_names_the_key` |
| M2 — writer back to find-in-place / `push` | `test_a_resave_moves_the_session_to_the_front_of_the_index`, `test_load_working_context_does_not_mutate_the_index` |
| M3 — restore the alphabetical tiebreak | `test_bound_sessions_evicts_by_recency_not_by_name_when_timestamps_tie`, `test_listing_keeps_recency_order_when_every_saved_at_ties` |
| M4 — stop counting wiring failures | `a_wiring_failure_is_counted_and_the_fact_is_still_stored`, `every_failed_enrichment_is_counted_not_just_the_first` |
| M5 — stop recording the worker failure | `a_worker_failure_is_recorded_on_the_job_for_migration_status` **and** the pre-existing `recover_reopens_a_failed_capturing_job_and_commits_it` |
| M6 — rotate the pinned entry to the END instead of the front | `test_bound_sessions_keeps_the_just_saved_entry_at_the_front` |
| M3b — alphabetical tiebreak in the eviction sort only | `test_bound_sessions_evicts_by_recency_not_by_name_when_timestamps_tie` |

**M6 is a defect in my own fix, found by re-reading the diff adversarially before commit.**
`bound_sessions` re-appended the pinned (just-saved) entry at the end of the vector, while
the writer had put it at the front. Harmless on native — its fresh `saved_at` sorts it first
again on read — but on WASM, where every `saved_at` is 0 and the stored order is all there
is, the session just saved would have listed **last** past the cap. The first three ordering
tests did not see it: they pin a middle entry and assert membership, not position. Fixed
(rotated to the front), and pinned by a test that fails under the old code. Re-run against
the final `rotate_right` shape, that mutation fails **four** tests, two of them pre-existing.

New tests: 8 in `memory_bridge_tests.rs` (cap ×4, ordering ×4), 2 in a new
`tests/autograph_failure_bdd.rs` (a store that refuses entity hubs, inline autograph), 2 in
`manager_tests.rs` (recorded when possible; survivable and non-destructive when the record is
unreachable — the workspace is replaced by a file, because the suite runs as root and root
ignores permission bits). That second test reaches the *load-fails* arm; the *save-fails* arm
(load succeeds, write refused) cannot be induced deterministically as root without filesystem
immutability, and is covered by inspection only — said plainly rather than faked. One
existing expectation updated: the stored index order for two saves is now `[beta, alpha]`
(recency), which is what that test was guarding — that a read does not rewrite it.

Validation with the repository's exact CI flags (AGENTS.md rule 10), all green on the
final tree:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check
  --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic`
- `cargo test -p velesdb-memory --lib` — **793 passed, 0 failed, 9 ignored**
- `autograph_async_bdd` (4), `autograph_failure_bdd` (2), `binding_parity_bdd` (28),
  `mcp_tools_drift` (1)
- the four memory feature-matrix shapes (`cargo check`, incl. `--no-default-features`)
- the Lint job's loop: each of the eight velesdb-memory features in isolation with
  `--all-targets` (the loop AGENTS.md's pre-push block had never mirrored — it does now)
- `cargo check -p velesdb-wasm --target wasm32-unknown-unknown`
- `python3 -m unittest discover -s scripts/tests` — 764 tests; the one failure it found
  (file budgets, `service.rs` grown) is what prompted the seam move above, and
  `check-file-budgets.py` plus its unittest pass on the final tree
- doc freshness (all five guards), version sync, attribution `--tree`, MCP doc contract

**Test Configuration:**
- OS: Linux x86_64
- Rust version: workspace-pinned toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Not applicable — no `unsafe` code is added or modified.

## High-Risk Change Checklist

Not applicable — no `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch path is touched.

## Additional Notes

Discarded after adversarial review, for the record: `edges: None` folded into `0` in the
migration diagnosis (a `Capability::Missing` record carries the unknown explicitly);
"nothing bounds the number of projects" (each index is independent and O(1) — not the
#2193 shape); the diagnostic copy's missing `sync_all` (a verified scratch copy, deleted
after use). Durability paths, numeric casts, lock-across-I/O, long-lived state, HTTP body
and session caps, and the extractor's parse handling came back clean.

**No tag is placed by this PR.** `velesdb-memory-v0.14.2` should be placed after this merges.

## Performance Labels

Not requested — no hot path changes; the new counter is one relaxed atomic on a failure path.