### PR TITLE
ci(release): cover the velesdb-memory train in the guarded tag workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag (for example v5.1.0 or v5.1.0-rc.1)'
+        description: 'Release tag (v5.1.0, v5.1.0-rc.1, or velesdb-memory-v0.14.2)'
         required: true
         type: string
       sha:
-        description: 'Full SHA of the CI-green commit on main'
+        description: 'Full SHA of the CI-green commit (on main for vX.Y.Z, on develop for velesdb-memory-vX.Y.Z)'
         required: true
         type: string
       message:
@@ -58,11 +58,33 @@ jobs:
           MESSAGE: ${{ inputs.message }}
         run: bash scripts/create-release-tag.sh "$TAG" "$SHA" "$MESSAGE"
 
-      - name: Dispatch release workflow on the new tag
+      # A tag pushed with GITHUB_TOKEN does not trigger a workflow listening on
+      # `push.tags`, so start each train's release explicitly, on the new tag.
+      - name: Dispatch release workflows on the new tag
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag }}
         run: |
-          gh workflow run release.yml \
-            --ref "$TAG" \
-            --field version="${TAG#v}"
+          set -euo pipefail
+          case "$TAG" in
+            velesdb-memory-v*)
+              VERSION="${TAG#velesdb-memory-v}"
+              gh workflow run release-memory.yml \
+                --ref "$TAG" \
+                --field version="$VERSION"
+              # release-mcpb.yml has no prerelease trigger; mirror that here.
+              case "$VERSION" in
+                *-*) echo "Prerelease $VERSION: skipping release-mcpb.yml" ;;
+                *)
+                  gh workflow run release-mcpb.yml \
+                    --ref "$TAG" \
+                    --field version="$VERSION"
+                  ;;
+              esac
+              ;;
+            *)
+              gh workflow run release.yml \
+                --ref "$TAG" \
+                --field version="${TAG#v}"
+              ;;
+          esac

--- a/docs/contributing/RELEASE.md
+++ b/docs/contributing/RELEASE.md
@@ -87,7 +87,8 @@ tag. Dans ce cas, utiliser le workflow permanent `tag-release.yml` :
 1. Ouvrir **Actions → Create Release Tag → Run workflow**.
 2. Sélectionner `develop` ou `main` comme branche du workflow.
 3. Saisir le tag `vX.Y.Z`, le SHA complet du commit dont le CI est vert sur
-   `main`, et le message du tag annoté.
+   `main`, et le message du tag annoté. Pour le train `velesdb-memory`, voir la
+   sous-section suivante : même workflow, tag et branche différents.
 
 Le workflow refuse un SHA qui n'est pas dans l'historique de `main` et un tag
 qui existe déjà. Après avoir poussé le tag, il déclenche explicitement

--- a/docs/contributing/RELEASE.md
+++ b/docs/contributing/RELEASE.md
@@ -4,13 +4,15 @@ Guide simplifié pour publier une nouvelle version de VelesDB.
 
 ## Workflow Architecture
 
-VelesDB utilise **4 workflows GitHub Actions** :
+VelesDB utilise **6 workflows GitHub Actions** :
 
 | Workflow | Trigger | Fonction |
 |----------|---------|----------|
 | `ci.yml` | Push/PR sur main | Tests, lint, security audit |
 | `tag-release.yml` | Déclenchement manuel sur develop/main | Création gardée du tag quand le push Git direct est impossible |
 | `release.yml` | Tag `v*` | Publication complète |
+| `release-memory.yml` | Tag `velesdb-memory-v*` | Publication indépendante de `velesdb-memory` |
+| `release-mcpb.yml` | Tag `velesdb-memory-vX.Y.Z` (version finale) | Bundles MCPB + publication au MCP registry |
 | `bench-regression.yml` | Push sur main | Benchmarks de régression |
 
 ## Publishing a Release
@@ -95,6 +97,20 @@ lui seul un workflow écoutant `push.tags`.
 Si le tag a été créé mais que ce second déclenchement échoue, relancer
 manuellement **Release** avec le tag comme ref et `X.Y.Z` comme version. Ne pas
 recréer ni déplacer le tag.
+
+#### Le même repli pour le train `velesdb-memory`
+
+`velesdb-memory` suit sa propre cadence 0.x et se tague sur `develop`, pas sur
+`main`. Le même workflow **Create Release Tag** couvre ce train : saisir
+`velesdb-memory-vX.Y.Z` comme tag et le SHA complet du commit dont le CI est
+vert sur `develop`.
+
+Le train est déduit du tag, pas d'un champ supplémentaire : un tag `vX.Y.Z` est
+vérifié contre `origin/main`, un tag `velesdb-memory-vX.Y.Z` contre
+`origin/develop`. Une paire tag/branche incohérente est donc impossible à
+saisir. Après le push du tag, le workflow déclenche `release-memory.yml` sur ce
+tag, puis `release-mcpb.yml` sauf si la version est une pre-release — ce
+workflow-là n'écoute que les tags de version finale.
 
 ### 6. The `release.yml` workflow publishes automatically
 

--- a/scripts/create-release-tag.sh
+++ b/scripts/create-release-tag.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 # Create one guarded annotated release tag, then push that exact ref.
+#
+# One entry point for both release trains. The tag says which train it belongs
+# to and therefore which branch it must descend from, so a caller cannot pair a
+# tag with the wrong branch:
+#
+#     vX.Y.Z[-pre]                    -> origin/main      (workspace)
+#     velesdb-memory-vX.Y.Z[-pre]     -> origin/develop   (velesdb-memory 0.x)
+#
+# Whether the crate version matches the tag is release-memory.yml's / release.yml's
+# job, not this script's: here the contract is only that the ref is correct and
+# safe to push.
 
 set -euo pipefail
 

--- a/scripts/create-release-tag.sh
+++ b/scripts/create-release-tag.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-readonly TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'
+readonly WORKSPACE_TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'
+readonly MEMORY_TAG_PATTERN='^velesdb-memory-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'
 readonly SHA_PATTERN='^[0-9A-Fa-f]{40}$'
 
 die() {
@@ -11,29 +12,47 @@ die() {
   exit 1
 }
 
+# The two release trains tag two different branches: the workspace ships from
+# main, velesdb-memory from develop on its own 0.x cadence. The tag itself says
+# which train it belongs to, so no caller can pair a tag with the wrong branch.
+release_branch_for_tag() {
+  local tag=$1
+
+  if [[ "$tag" =~ $WORKSPACE_TAG_PATTERN ]]; then
+    echo main
+  elif [[ "$tag" =~ $MEMORY_TAG_PATTERN ]]; then
+    echo develop
+  else
+    return 1
+  fi
+}
+
 validate_inputs() {
   local tag=$1
   local sha=$2
   local message=$3
 
-  [[ "$tag" =~ $TAG_PATTERN ]] || die "tag '$tag' must match vX.Y.Z or vX.Y.Z-prerelease"
+  release_branch_for_tag "$tag" >/dev/null \
+    || die "tag '$tag' must match vX.Y.Z or velesdb-memory-vX.Y.Z, optionally with a -prerelease suffix"
   [[ "$sha" =~ $SHA_PATTERN ]] || die "sha must be a full 40-character commit SHA"
   [[ -n "$message" ]] || die "message must not be empty"
 }
 
-resolve_main_commit() {
+resolve_release_commit() {
   local sha=$1
+  local branch=$2
 
-  git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+  git fetch --no-tags origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
   git cat-file -e "${sha}^{commit}" 2>/dev/null || die "sha '$sha' is not a commit"
   git rev-parse --verify "${sha}^{commit}"
 }
 
-ensure_main_ancestor() {
+ensure_release_ancestor() {
   local sha=$1
+  local branch=$2
 
-  git merge-base --is-ancestor "$sha" origin/main \
-    || die "sha '$sha' is not an ancestor of origin/main"
+  git merge-base --is-ancestor "$sha" "origin/${branch}" \
+    || die "sha '$sha' is not an ancestor of origin/${branch}"
 }
 
 ensure_tag_absent() {
@@ -64,14 +83,16 @@ main() {
   local tag=$1
   local requested_sha=$2
   local message=$3
+  local branch
   local resolved_sha
 
   validate_inputs "$tag" "$requested_sha" "$message"
-  resolved_sha=$(resolve_main_commit "$requested_sha")
-  ensure_main_ancestor "$resolved_sha"
+  branch=$(release_branch_for_tag "$tag")
+  resolved_sha=$(resolve_release_commit "$requested_sha" "$branch")
+  ensure_release_ancestor "$resolved_sha" "$branch"
   ensure_tag_absent "$tag"
   create_and_push_tag "$tag" "$resolved_sha" "$message"
-  echo "Created and pushed annotated tag $tag at $resolved_sha"
+  echo "Created and pushed annotated tag $tag at $resolved_sha (origin/$branch)"
 }
 
 main "$@"

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1232,7 +1232,7 @@
  "unwired": [
   {
    "script": "scripts/create-release-tag.sh",
-   "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag after main CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves both refusal guards and the positive control against a real bare remote.",
+   "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag on either release train (vX.Y.Z off main, velesdb-memory-vX.Y.Z off develop) after that branch's CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves every refusal guard and both positive controls against a real bare remote.",
    "issue": null
   },
   {

--- a/scripts/tests/test_create_release_tag.py
+++ b/scripts/tests/test_create_release_tag.py
@@ -59,7 +59,12 @@ class ReleaseTagScriptTests(unittest.TestCase):
         git(self.repo, "remote", "add", "origin", str(self.remote))
         self.main_sha = commit_file(self.repo, "main.txt", "main\n", "seed main")
         git(self.repo, "push", "--set-upstream", "origin", "main")
-        git(self.repo, "switch", "--create", "side")
+        # velesdb-memory ships from develop, so the fixture carries a commit
+        # that is on develop and NOT on main, and one on neither branch.
+        git(self.repo, "switch", "--create", "develop")
+        self.develop_sha = commit_file(self.repo, "develop.txt", "develop\n", "seed develop")
+        git(self.repo, "push", "--set-upstream", "origin", "develop")
+        git(self.repo, "switch", "--create", "side", "main")
         self.side_sha = commit_file(self.repo, "side.txt", "side\n", "seed side")
         git(self.repo, "switch", "main")
 
@@ -132,6 +137,46 @@ class ReleaseTagScriptTests(unittest.TestCase):
         self.assertIn("must match vX.Y.Z", result.stderr)
         self.assert_remote_tag_absent("release/latest")
 
+    def test_creates_memory_tag_on_a_develop_only_commit(self) -> None:
+        tag = "velesdb-memory-v0.14.2"
+
+        result = self.invoke(tag, self.develop_sha, "velesdb-memory 0.14.2")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(self.develop_sha, self.remote_tag(tag, peeled=True))
+        object_type = git(
+            self.repo,
+            "--git-dir",
+            str(self.remote),
+            "cat-file",
+            "-t",
+            self.remote_tag(tag),
+        ).stdout.strip()
+        self.assertEqual("tag", object_type)
+        self.assertIn("origin/develop", result.stdout)
+
+    def test_refuses_memory_tag_on_a_commit_outside_develop(self) -> None:
+        result = self.invoke("velesdb-memory-v0.14.2", self.side_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("not an ancestor of origin/develop", result.stderr)
+        self.assert_remote_tag_absent("velesdb-memory-v0.14.2")
+
+    def test_refuses_workspace_tag_on_a_develop_only_commit(self) -> None:
+        """The train is read off the tag: a vX.Y.Z tag still has to be on main."""
+        result = self.invoke("v1.2.3", self.develop_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("not an ancestor of origin/main", result.stderr)
+        self.assert_remote_tag_absent("v1.2.3")
+
+    def test_refuses_a_memory_tag_that_carries_no_version(self) -> None:
+        result = self.invoke("velesdb-memory-vlatest", self.develop_sha)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("must match vX.Y.Z", result.stderr)
+        self.assert_remote_tag_absent("velesdb-memory-vlatest")
+
 
 class ReleaseTagWorkflowContractTests(unittest.TestCase):
     """Pin the Actions wiring that a green shell-script test cannot prove."""
@@ -167,11 +212,36 @@ class ReleaseTagWorkflowContractTests(unittest.TestCase):
         self.assertIn('--ref "$TAG"', self.workflow)
         self.assertIn('version="${TAG#v}"', self.workflow)
 
+    def test_workflow_dispatches_the_memory_train_on_a_memory_tag(self) -> None:
+        """A GITHUB_TOKEN tag push fires no `push.tags` workflow, on either train."""
+        self.assertIn("velesdb-memory-v*)", self.workflow)
+        self.assertIn('VERSION="${TAG#velesdb-memory-v}"', self.workflow)
+        self.assertIn("gh workflow run release-memory.yml", self.workflow)
+        self.assertIn("gh workflow run release-mcpb.yml", self.workflow)
+        self.assertIn('version="$VERSION"', self.workflow)
+
+    def test_workflow_skips_mcpb_for_a_memory_prerelease(self) -> None:
+        """release-mcpb.yml has no prerelease tag trigger; the dispatch mirrors it."""
+        self.assertIn("skipping release-mcpb.yml", self.workflow)
+        memory_arm = self.workflow.find("velesdb-memory-v*)")
+        guard = self.workflow.find("*-*)", memory_arm)
+        mcpb = self.workflow.find("gh workflow run release-mcpb.yml", memory_arm)
+        self.assertNotEqual(-1, guard, "no prerelease guard in the memory arm")
+        self.assertNotEqual(-1, mcpb, "no release-mcpb.yml dispatch in the memory arm")
+        self.assertLess(guard, mcpb, "the mcpb dispatch is not behind the prerelease guard")
+
     def test_release_guide_keeps_direct_push_primary_and_documents_fallback(self) -> None:
         self.assertIn("git push origin vX.Y.Z", self.release_doc)
         self.assertIn("tag-release.yml", self.release_doc)
         self.assertIn("solution de repli", self.release_doc.lower())
         self.assertIn("--include-ignored", self.release_doc)
+
+    def test_release_guide_documents_the_memory_train_fallback(self) -> None:
+        """`develop` alone is already in the guide, so pin the branch the tag is checked against."""
+        self.assertIn("velesdb-memory-vX.Y.Z", self.release_doc)
+        self.assertIn("release-memory.yml", self.release_doc)
+        self.assertIn("release-mcpb.yml", self.release_doc)
+        self.assertIn("origin/develop", self.release_doc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

`tag-release.yml` exists as the fallback for a context that can push a branch but not a tag ref. That is not hypothetical: pushing `refs/tags/velesdb-memory-v0.14.2` returns **HTTP 403** from a remote session, while branch pushes to the same repository succeed all day. The fallback only ever covered the workspace train — `create-release-tag.sh` hardcoded the `vX.Y.Z` pattern and `origin/main` — so `velesdb-memory` 0.14.2 currently sits **untagged on a green `develop`** with no path forward at all.

**The train is read off the tag itself** rather than added as a new input, so a tag/branch mismatch is impossible to enter:

| tag | verified against | dispatches |
|---|---|---|
| `vX.Y.Z` | `origin/main` | `release.yml` |
| `velesdb-memory-vX.Y.Z` | `origin/develop` | `release-memory.yml`, then `release-mcpb.yml` unless pre-release |

Every existing guard — full 40-character SHA, ancestry, tag absent locally **and** on origin, push the exact ref, delete the local tag when the push fails — now applies unchanged to both trains, from one implementation and one test suite. No second script, no second workflow to drift.

A tag pushed with `GITHUB_TOKEN` triggers no workflow listening on `push.tags`, which is why the workspace arm already dispatched `release.yml` explicitly. The memory arm does the same. `release-mcpb.yml` is guarded on the pre-release suffix because that workflow has no pre-release tag trigger — the dispatch mirrors its `push.tags` filter exactly rather than inventing a new behaviour.

Not in scope, deliberately: the tag↔`Cargo.toml` version check. `release-memory.yml`'s `validate` job already proves it, and this script's contract is "the ref is correct and safe to push", not "the crate is ready".

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — the memory train had no working tag path
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests — the script runs against a real bare git remote with `main`, `develop` and an orphan `side` branch

`scripts.tests.test_create_release_tag`: **16 tests, OK** (5 new script tests, 2 new workflow-contract tests, 1 new doc test).

**Seven mutations, all killed** — each new assertion is load-bearing:

| # | mutation | killed by |
|---|---|---|
| 1 | memory tags routed to `main` | 2 tests |
| 2 | workspace tags routed to `develop` | 2 tests |
| 3 | memory pattern loosened to `^velesdb-memory-v` | version-less tag test |
| 4 | `release-memory.yml` dispatch removed | memory dispatch test |
| 5 | `release-mcpb.yml` dispatch removed | memory dispatch test |
| 6 | mcpb dispatch moved in front of the pre-release guard | pre-release guard test |
| 7 | the RELEASE.md memory section removed | doc contract test |

Mutation 6 initially died on a `ValueError` rather than an assertion; the test was rewritten so it fails on the claim it makes, and re-killed.

One weak assertion was caught in self-review and fixed: the doc test asserted `"develop"`, which the guide already contained before this change. It now asserts `origin/develop`, which only the new section provides.

Full local validation (no Rust touched, so the cargo legs are not applicable):

- `python3 -m unittest discover -s scripts/tests -p "test_*.py" -t .` → **Ran 771 tests … OK (skipped=9)**
- `check-version-sync`, `check-promise-contract`, `check-mcp-doc-contract`, `check-skill-private-references`, `check-doc-contract`, `check-feature-claims` → all pass
- `check-doc-freshness` — `stamp`, `index`, `tracked`, `versions`, `decisions` in `--mode strict` → all pass
- `check-ai-attribution "origin/develop..HEAD"` → PASSED
- `bash -n scripts/create-release-tag.sh`, YAML parse of `tag-release.yml` → clean

**Test Configuration:**
- OS: Linux x86_64
- Rust version: n/a — this change touches shell, YAML, Python tests, JSON and Markdown only

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

`scripts/guards.json` keeps `create-release-tag.sh` in `unwired` — it is still release-time only, with nothing for it to assert on a pull request. Its `reason` is updated to name both trains and both positive controls.

Once this merges, **Actions → Create Release Tag** with `tag=velesdb-memory-v0.14.2`, `sha=2f8f1bb2131655ef9a28374ff4687a6e0d229804` and the annotated message finally publishes 0.14.2. All three of `release-memory.yml`'s guards are already satisfied on that commit: the tag version matches `Cargo.toml` (0.14.2), `CI Success` is completed and green, and `cargo publish --dry-run -p velesdb-memory` exits 0.