### PR TITLE
fix(release): put the CHANGELOG on the velesdb-memory release, not a placeholder

### DIFF
--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -180,6 +180,10 @@ jobs:
         run: |
           set -euo pipefail
           # Ensure a release exists for the tag, then upload (clobber) the bundles.
+          # The --notes below is a placeholder for the case where this job wins
+          # the create race against release-memory.yml; that workflow's
+          # publish-release-notes job then replaces the body with the crate's
+          # CHANGELOG section, so it is never what a reader ends up seeing.
           # --latest=false: the velesdb-memory release must never become the
           # repo's "Latest release" (that belongs to the VelesDB vX.Y.Z release,
           # which carries the binaries the README download link points at). Left

--- a/.github/workflows/release-memory.yml
+++ b/.github/workflows/release-memory.yml
@@ -145,7 +145,72 @@ jobs:
           echo "✅ velesdb-memory packaging validated"
 
   # ===========================================================================
-  # 2. Publish to crates.io
+  # 2. Put the CHANGELOG on the GitHub Release
+  # ===========================================================================
+  #
+  # Two workflows create the release for this tag — this one (daemon archives)
+  # and release-mcpb.yml (.mcpb bundles) — each with a one-line blurb naming
+  # only its own payload, and until now neither ever wrote the CHANGELOG. Every
+  # velesdb-memory release therefore shipped notes decided by whichever job won
+  # the race: 0.14.1 got "daemon archives ...", 0.14.2 got "MCPB bundles ...",
+  # and a reader of either learned nothing about what changed.
+  #
+  # Creating-then-editing makes the outcome the same either way: whoever wins
+  # the create, the body ends up being the crate's own CHANGELOG section. This
+  # is what release.yml already does for the workspace train.
+  #
+  # `needs: [validate]` only — the notes must not ride on the optional
+  # daemon-archive build, which a dispatch can turn off.
+  publish-release-notes:
+    name: Publish release notes
+    runs-on: ubuntu-latest
+    needs: [validate]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A prerelease is cut from `[Unreleased]` and has no section of its own,
+      # so requiring one there would turn every rc run red. The requirement is
+      # absolute for a real release and advisory for a prerelease.
+      - name: Extract the notes for this version
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          IS_PRERELEASE: ${{ needs.validate.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+          if python3 scripts/changelog-release-notes.py \
+              --changelog crates/velesdb-memory/CHANGELOG.md \
+              --version "$VERSION" \
+              --output RELEASE_NOTES.md; then
+            echo "Notes taken from the crate CHANGELOG."
+          elif [ "$IS_PRERELEASE" = "true" ]; then
+            echo "Prerelease $VERSION has no CHANGELOG section — using a pointer."
+            printf 'Prerelease of velesdb-memory %s. The entries it carries are under `[Unreleased]` in [the crate CHANGELOG](https://github.com/cyberlife-coder/VelesDB/blob/develop/crates/velesdb-memory/CHANGELOG.md).\n' \
+              "$VERSION" > RELEASE_NOTES.md
+          else
+            echo "::error::velesdb-memory $VERSION has no CHANGELOG section. Write it before releasing."
+            exit 1
+          fi
+          echo "--- release notes ---"
+          cat RELEASE_NOTES.md
+
+      - name: Publish them on the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: velesdb-memory-v${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          # --latest=false: same reasoning as everywhere else in this train —
+          # the velesdb-memory release must never steal "Latest release" from
+          # the workspace vX.Y.Z release the README download link points at.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "$TAG" --latest=false --notes-file RELEASE_NOTES.md || true
+          fi
+          gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+
+  # ===========================================================================
+  # 3. Publish to crates.io
   # ===========================================================================
   publish-crate:
     name: Publish crates.io
@@ -187,7 +252,7 @@ jobs:
           scripts/check-crates-io-versions.sh "${{ needs.validate.outputs.version }}" velesdb-memory
 
   # ===========================================================================
-  # 3. Build the native Node addon for every supported target
+  # 4. Build the native Node addon for every supported target
   # ===========================================================================
   #
   # @wiscale/velesdb-memory-node is a napi-rs addon: a thin per-platform `.node`
@@ -320,7 +385,7 @@ jobs:
           if-no-files-found: error
 
   # ===========================================================================
-  # 4. Assemble per-platform packages and publish to npm
+  # 5. Assemble per-platform packages and publish to npm
   # ===========================================================================
   publish-npm:
     name: Publish npm
@@ -406,7 +471,7 @@ jobs:
           fi
 
   # ===========================================================================
-  # 5. Verify the release is actually visible from both public registries
+  # 6. Verify the release is actually visible from both public registries
   # ===========================================================================
   verify-registries:
     name: Verify public registries
@@ -435,7 +500,7 @@ jobs:
           exit 1
 
   # ===========================================================================
-  # 6. Build the daemon binary for each platform (--features ollama,http,extract)
+  # 7. Build the daemon binary for each platform (--features ollama,http,extract)
   # ===========================================================================
   #
   # Same crate/bin as the default-feature .mcpb bundles in release-mcpb.yml,
@@ -545,7 +610,7 @@ jobs:
           if-no-files-found: error
 
   # ===========================================================================
-  # 7. Attach the daemon archives to the GitHub Release
+  # 8. Attach the daemon archives to the GitHub Release
   # ===========================================================================
   #
   # release-mcpb.yml separately creates/updates the SAME velesdb-memory-vX.Y.Z
@@ -556,6 +621,10 @@ jobs:
   # that race gets a harmless "already exists" failure (swallowed by
   # `|| true`) and both proceed straight to `gh release upload`, which is
   # idempotent per file (`--clobber`).
+  #
+  # The `--notes` below is only what the release says if this job happens to
+  # create it FIRST; publish-release-notes then overwrites the body with the
+  # CHANGELOG section, so the race no longer decides what the release says.
   publish-daemon-archive:
     name: Attach daemon archives to release
     needs: [validate, build-daemon-archive]

--- a/scripts/changelog-release-notes.py
+++ b/scripts/changelog-release-notes.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Extract one version's section from a Keep-a-Changelog file.
+
+Release notes that say nothing are the default outcome of the velesdb-memory
+train: `release-memory.yml` and `release-mcpb.yml` both create the GitHub
+Release for the tag, each with its own one-line blurb, and neither ever wrote
+the CHANGELOG section. Whichever won the race decided what the release said.
+
+This is what `release.yml` does inline for the workspace train, minus two
+things its `sed` cannot do: it drops the last line of a section that has no
+successor (`head -n -1` with nothing to trim), and it says nothing when the
+version is absent, emitting an empty file instead of failing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# `## [0.14.2] - 2026-09-03`, `## [0.14.2]`, and nothing else. The version sits
+# in brackets so `0.1` can never match its way into `## [0.14.2]`.
+SECTION_RE_TEMPLATE = r"^##\s+\[{version}\]"
+ANY_SECTION_RE = re.compile(r"^##\s+\[", re.MULTILINE)
+
+
+def extract(changelog: str, version: str) -> str:
+    """Return the body of `version`'s section, without its own heading."""
+    start = re.compile(
+        SECTION_RE_TEMPLATE.format(version=re.escape(version)), re.MULTILINE
+    ).search(changelog)
+    if start is None:
+        raise LookupError(f"no '## [{version}]' section in the changelog")
+
+    body_start = changelog.find("\n", start.end())
+    if body_start == -1:
+        raise LookupError(f"section '## [{version}]' has no body")
+
+    following = ANY_SECTION_RE.search(changelog, body_start)
+    body_end = following.start() if following else len(changelog)
+
+    body = changelog[body_start:body_end].strip("\n")
+    if not body.strip():
+        raise LookupError(f"section '## [{version}]' is empty")
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--changelog", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, help="default: stdout")
+    args = parser.parse_args()
+
+    try:
+        text = args.changelog.read_text(encoding="utf-8")
+    except OSError as error:
+        print(f"changelog-release-notes: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        notes = extract(text, args.version)
+    except LookupError as error:
+        print(f"changelog-release-notes: {error}", file=sys.stderr)
+        return 1
+
+    if args.output is None:
+        print(notes)
+    else:
+        args.output.write_text(notes + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1231,6 +1231,11 @@
  ],
  "unwired": [
   {
+   "script": "scripts/changelog-release-notes.py",
+   "reason": "Release-time only, by design: release-memory.yml runs it to turn the crate CHANGELOG section into the GitHub Release body, and it refuses (exit 1) a real release whose version the CHANGELOG does not document. A pull request has no release to write notes for; scripts.tests.test_changelog_release_notes proves the refusals, the exact-version match, the terminal-section case and the workflow wiring.",
+   "issue": null
+  },
+  {
    "script": "scripts/create-release-tag.sh",
    "reason": "Release-time only, by design: tag-release.yml runs it to guard an operator-requested tag on either release train (vX.Y.Z off main, velesdb-memory-vX.Y.Z off develop) after that branch's CI is green. A pull request has no release tag to assert; scripts.tests.test_create_release_tag proves every refusal guard and both positive controls against a real bare remote.",
    "issue": null

--- a/scripts/tests/test_changelog_release_notes.py
+++ b/scripts/tests/test_changelog_release_notes.py
@@ -1,0 +1,180 @@
+"""Behavioral contract for the CHANGELOG release-notes extractor.
+
+The velesdb-memory train shipped every release with a one-line placeholder:
+`release-memory.yml` and `release-mcpb.yml` each create the GitHub Release for
+the tag with their own blurb, and neither ever wrote the CHANGELOG section.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "changelog-release-notes.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "release-memory.yml"
+MEMORY_CHANGELOG = ROOT / "crates" / "velesdb-memory" / "CHANGELOG.md"
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- something not yet released
+
+## [0.14.2] - 2026-09-03
+
+### Fixed
+
+- the working-context index
+
+## [0.14.1] - 2026-08-19
+
+### Fixed
+
+- the last line of the last section
+"""
+
+
+class ExtractorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.directory = Path(self.temporary.name)
+        self.changelog = self.directory / "CHANGELOG.md"
+        self.changelog.write_text(CHANGELOG, encoding="utf-8")
+
+    def invoke(self, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["python3", str(SCRIPT), "--changelog", str(self.changelog), *arguments],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_extracts_the_section_body_without_its_own_heading(self) -> None:
+        result = self.invoke("--version", "0.14.2")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("### Fixed", result.stdout)
+        self.assertIn("the working-context index", result.stdout)
+        self.assertNotIn("## [0.14.2]", result.stdout)
+
+    def test_stops_at_the_next_version_and_never_leaks_unreleased(self) -> None:
+        result = self.invoke("--version", "0.14.2")
+
+        self.assertNotIn("0.14.1", result.stdout)
+        self.assertNotIn("the last line of the last section", result.stdout)
+        self.assertNotIn("something not yet released", result.stdout)
+
+    def test_keeps_the_final_line_of_a_section_with_no_successor(self) -> None:
+        """`release.yml`'s `sed ... | head -n -1` eats this line."""
+        result = self.invoke("--version", "0.14.1")
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("the last line of the last section", result.stdout)
+
+    def test_refuses_a_version_the_changelog_does_not_document(self) -> None:
+        result = self.invoke("--version", "9.9.9")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("no '## [9.9.9]' section", result.stderr)
+        self.assertEqual("", result.stdout.strip())
+
+    def test_matches_the_version_exactly_and_not_as_a_prefix(self) -> None:
+        """`0.14` must not resolve to `## [0.14.2]` and ship the wrong notes."""
+        result = self.invoke("--version", "0.14")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("no '## [0.14]' section", result.stderr)
+
+    def test_refuses_a_section_that_documents_nothing(self) -> None:
+        self.changelog.write_text("# Changelog\n\n## [1.0.0]\n\n## [0.9.0]\n\n- real\n", encoding="utf-8")
+
+        result = self.invoke("--version", "1.0.0")
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("is empty", result.stderr)
+
+    def test_writes_the_notes_to_the_requested_file(self) -> None:
+        destination = self.directory / "NOTES.md"
+
+        result = self.invoke("--version", "0.14.2", "--output", str(destination))
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("the working-context index", destination.read_text(encoding="utf-8"))
+
+    def test_extracts_the_real_memory_changelog(self) -> None:
+        """A positive control against the file the workflow actually reads."""
+        result = subprocess.run(
+            [
+                "python3",
+                str(SCRIPT),
+                "--changelog",
+                str(MEMORY_CHANGELOG),
+                "--version",
+                "0.14.2",
+            ],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("### Fixed", result.stdout)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    """Pin the wiring: extracting notes nobody publishes is worthless."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_release_memory_publishes_the_changelog_notes(self) -> None:
+        self.assertIn("scripts/changelog-release-notes.py", self.workflow)
+        self.assertIn("crates/velesdb-memory/CHANGELOG.md", self.workflow)
+        self.assertIn("gh release edit", self.workflow)
+        self.assertIn("--notes-file", self.workflow)
+
+    def test_the_notes_job_creates_the_release_when_it_wins_the_race(self) -> None:
+        """`gh release edit` fails on a release neither workflow has created yet."""
+        job = self.workflow.index("publish-release-notes:")
+        section = self.workflow[job : job + 3000]
+        create = section.find("gh release create")
+        edit = section.find("gh release edit")
+        self.assertNotEqual(-1, create, "the notes job never creates the release")
+        self.assertNotEqual(-1, edit, "the notes job never sets the notes")
+        self.assertLess(create, edit, "the notes job edits before it ensures a release")
+        self.assertIn("--latest=false", section)
+
+    def test_a_real_release_without_a_changelog_section_fails_the_run(self) -> None:
+        """The whole point: a release cannot ship notes nobody wrote."""
+        job = self.workflow.index("publish-release-notes:")
+        section = self.workflow[job : job + 3000]
+        self.assertIn("has no CHANGELOG section", section)
+        self.assertIn("exit 1", section)
+
+    def test_a_prerelease_falls_back_instead_of_failing(self) -> None:
+        """An rc is cut from [Unreleased] and has no section of its own."""
+        job = self.workflow.index("publish-release-notes:")
+        section = self.workflow[job : job + 3000]
+        fallback = section.find('IS_PRERELEASE" = "true"')
+        failure = section.find("::error::")
+        self.assertNotEqual(-1, fallback, "no prerelease fallback: every rc run would go red")
+        self.assertNotEqual(-1, failure, "no hard failure for a real release")
+        self.assertLess(fallback, failure, "the hard failure shadows the prerelease fallback")
+
+    def test_the_notes_job_does_not_depend_on_the_optional_archive_build(self) -> None:
+        """Notes must land even when the daemon archives are skipped."""
+        job = self.workflow.index("publish-release-notes:")
+        section = self.workflow[job : job + 600]
+        self.assertIn("needs: [validate]", section)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

Two workflows create the GitHub Release for a `velesdb-memory-vX.Y.Z` tag — `release-memory.yml` (daemon archives) and `release-mcpb.yml` (.mcpb bundles) — each with a one-line blurb naming only its own payload, and **neither ever wrote the CHANGELOG**. Whichever won the race decided what the release said:

| release | body it shipped |
|---|---|
| 0.14.1 | `velesdb-memory ... — daemon archives (--features ollama,http,extract) for install-memory-daemon.sh/.ps1 --from-release.` |
| 0.14.2 | `velesdb-memory ... — MCPB bundles for the MCP registry.` |

Each is true about one attached artifact and tells a reader nothing about what changed in the crate — while a written CHANGELOG entry sat in the repo, unused. 0.14.2's, for instance, documents seven fixes including an index that erased a project's whole listing.

A `publish-release-notes` job now extracts that section and sets it as the body. It **creates** the release when it wins the race and **edits** it when it loses, so the outcome no longer depends on who got there first. `release.yml` already does this for the workspace train (line 743); this closes the gap for the memory train.

**Why a script rather than `release.yml`'s inline `sed`.** That `sed ... | head -n -1` cannot express two things this needs:

- it drops the **last line of a section that has no successor** — `head -n -1` with no `## [` line to trim eats real content;
- it reports a **missing version as an empty file**, not an error, so a release with no CHANGELOG entry silently ships nothing.

Both are covered by tests here. (`release.yml` is left alone deliberately — rewiring the workspace train days after 6.0.0 is a separate decision with its own blast radius, not one to make in passing. The edge case is noted in the script's docstring.)

**Prereleases.** An rc is cut from `[Unreleased]` and has no section of its own, and prereleases *do* reach release creation — only `publish-crate` is gated on `is_prerelease`. Requiring a section there would turn every rc run red, so a prerelease falls back to a pointer. The requirement is absolute only where the notes are permanent. I caught this by re-reading my own diff, after first writing the job without the fallback.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests

`scripts.tests.test_changelog_release_notes`: **13 tests, OK** — 8 against the extractor (including a positive control against the real `crates/velesdb-memory/CHANGELOG.md`) and 5 pinning the workflow wiring.

**Eight mutations, all killed** — each dies on its assertion, not on an exception:

| # | mutation | killed by |
|---|---|---|
| 1 | `head -n -1` truncation on a terminal section | terminal-section test |
| 2 | prefix match — `0.14` resolving to `## [0.14.2]` | exact-match test |
| 3 | an empty section accepted | empty-section test |
| 4 | a missing version tolerated (empty output) | 2 tests |
| 5 | `gh release edit` without the preceding create | create-before-edit test |
| 6 | job made to depend on the optional archive build | `needs: [validate]` test |
| 7 | prerelease fallback shadowed by the hard failure | fallback-ordering test |
| 8 | extractor unwired from the workflow | wiring test |

Mutation 1 first **survived** — my mutant dropped a trailing `\n` that `strip` removed anyway, rather than a whole line. Rewritten to reproduce `head -n -1` faithfully, it dies. Mutations 5 and 7 first died on a `ValueError` from `.index()`; both tests were rewritten to fail on the claim.

Other checks: `test_ci_gate_reachability` **97 tests, OK** (the new script is declared in `scripts/guards.json` under `unwired`, release-time only, mirroring `create-release-tag.sh`); both workflows parse as YAML.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: n/a — Python, JSON and YAML only

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The placeholder `--notes` in both creating jobs is kept: it is what the release says only in the window before `publish-release-notes` sets the body, and it is the fallback if that job never runs. The comments in both files, which described the race as deciding the notes, are corrected to say that it no longer does.

This does not retro-fix the 0.14.2 release body already published. Say the word and I will set it from the CHANGELOG.