### PR TITLE
docs(memory): fix every broken intra-doc link and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,18 @@ jobs:
             echo "::endgroup::"
           done
 
+      # velesdb-memory is published to crates.io, so its rustdoc IS what docs.rs
+      # serves: a broken intra-doc link is a dead link on a public page. Nothing
+      # in CI built the docs, so 49 of them had accumulated unnoticed — every
+      # `super::` path in a module's `//!` header breaks once the `mod`
+      # declaration also carries `///` docs, because the merged doc resolves in
+      # the parent's scope. Fixed in this change; this step is what keeps them
+      # fixed.
+      - name: Rustdoc intra-doc links (velesdb-memory)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p velesdb-memory --no-deps --all-features
+
       # The extraction backend's unit tests are pure parsing and prompt
       # building: none opens a socket. Run them under the canonical role name
       # and its compatibility alias so neither path can silently stop enabling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,9 @@ cargo check -p velesdb-memory --no-default-features --features mcp,persistence
 for feat in mcp http context persistence embedder-http extractor-http ollama extract; do
   cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
 done
+# velesdb-memory's rustdoc is what docs.rs serves, so a broken intra-doc link is
+# a dead link on a public page. Blocking in the Lint job.
+RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-memory --no-deps --all-features
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
 # Guards and contracts. Every one of these blocks a PR through `CI Success`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ for feat in mcp http context persistence embedder-http extractor-http ollama ext
   cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
 done
 # velesdb-memory's rustdoc is what docs.rs serves, so a broken intra-doc link is
-# a dead link on a public page. Blocking in the Lint job.
+# a dead link on a public page. Blocking in the Lint job since #2205.
 RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-memory --no-deps --all-features
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm

--- a/crates/velesdb-memory/src/column_filter_conformance.rs
+++ b/crates/velesdb-memory/src/column_filter_conformance.rs
@@ -8,7 +8,7 @@
 //! on an ABSENT field matched natively and never matched on WASM, for the
 //! whole life of the API, because nothing ever compared them (#1759).
 //!
-//! Both backends therefore import [`fixture`] and [`cases`] from here. A case
+//! Both backends therefore import [`crate::column_filter_conformance::fixture`] and [`crate::column_filter_conformance::cases`] from here. A case
 //! added once is enforced on both, or neither.
 //!
 //! # The contract for [`ColumnOp::Ne`]

--- a/crates/velesdb-memory/src/context/ingest.rs
+++ b/crates/velesdb-memory/src/context/ingest.rs
@@ -1,10 +1,10 @@
 //! Adapter-side I/O pre-pass for `path`-referenced context fragments
 //! (V2b-1, see the crate's `PLAN.md`).
 //!
-//! [`resolve_fragments`] turns every [`ContextFragment::path`] into ordinary
+//! [`crate::context::ingest::resolve_fragments`] turns every [`ContextFragment::path`] into ordinary
 //! `content` — read from disk under a strict, short-circuiting security
-//! pipeline — BEFORE the request reaches [`super::ContextCompiler`], which
-//! never performs I/O itself (mirrors the [`super::media`] pre-pass: decode
+//! pipeline — BEFORE the request reaches [`crate::context::ContextCompiler`], which
+//! never performs I/O itself (mirrors the `media` pre-pass: decode
 //! once at the boundary, keep the pipeline core pure). Called from the MCP
 //! adapter (`crate::mcp::context_tools`) ahead of `compile_context` and
 //! `explain_compilation`; a `path` fragment that reaches the compiler

--- a/crates/velesdb-memory/src/context/memory_bridge.rs
+++ b/crates/velesdb-memory/src/context/memory_bridge.rs
@@ -294,7 +294,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     /// The working context previously saved under `project` + `session`,
     /// `None` when there is none.
     ///
-    /// Symmetric to [`Self::context_source_metadata`]'s squatter guard: the
+    /// Symmetric to `context_source_metadata`'s squatter guard: the
     /// slot is only ever served back when its metadata carries the reserved
     /// [`CTX_WORKING_FIELD`] marker (set exclusively by
     /// [`Self::save_working_context`]). A slot occupied by an unmarked caller
@@ -306,7 +306,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     ///
     /// A pure read: it never writes, never prunes, never heals. Index
     /// convergence happens on the WRITE path
-    /// ([`Self::update_working_index`]) — a lookup that rewrites shared state
+    /// (`update_working_index`) — a lookup that rewrites shared state
     /// turns every transient miss into permanent data loss and cannot safely
     /// be retried.
     ///
@@ -376,7 +376,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     ///    `other_sessions`, so returning the requested id would be a
     ///    contradiction the caller cannot act on.
     /// 3. An unreadable index is fatal on a MISS and survivable on a HIT —
-    ///    see [`Self::other_sessions_for`].
+    ///    see `other_sessions_for`.
     ///
     /// Every surface (the `load_working_context` MCP tool and the Node,
     /// Python and WASM bindings) calls this rather than recomposing the

--- a/crates/velesdb-memory/src/context/model.rs
+++ b/crates/velesdb-memory/src/context/model.rs
@@ -56,7 +56,7 @@ pub enum FidelityRisk {
 /// text/caption — often empty for a bare screenshot — while the pixels live
 /// here, base64-encoded so the JSON wire never needs a binary frame.
 ///
-/// The fragment packs atomically (see [`super::pieces`] in the compiler)
+/// The fragment packs atomically (see `pieces` in the compiler)
 /// and its token cost comes from [`super::estimator::ImageTokenEstimator`].
 /// A media fragment that cannot fit the budget is externalized behind a
 /// `ctx://source` handle exactly like text (US-009, PR2: the memory bridge
@@ -103,7 +103,7 @@ pub struct ContextFragment {
     /// Caller-side identifier. When absent, the compiler derives a stable
     /// content-addressed id (see [`super::fragment_id`]). Accepts a JSON
     /// number or a decimal string on input (see
-    /// [`super::wire::deserialize_optional_id`]) — a caller that got a
+    /// `wire::deserialize_optional_id`) — a caller that got a
     /// `fragment_id` back as a string (e.g. under
     /// [`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.
     #[serde(

--- a/crates/velesdb-memory/src/context/segment.rs
+++ b/crates/velesdb-memory/src/context/segment.rs
@@ -3,21 +3,21 @@
 //!
 //! [`segment_transcript`] turns a raw agent-session transcript — plain text
 //! with role markers, or JSONL — into an ordered list of
-//! [`TranscriptSegment`]s, each wrapping an ordinary [`super::ContextFragment`]
+//! [`TranscriptSegment`]s, each wrapping an ordinary [`crate::context::ContextFragment`]
 //! plus the audit metadata (`turn`, `role`, `kind`, byte range) the
 //! `compile_transcript` tool reports alongside the compiled context. The
-//! resulting fragments feed the existing, unmodified [`super::ContextCompiler`]
+//! resulting fragments feed the existing, unmodified [`crate::context::ContextCompiler`]
 //! pipeline — this module only decides *how to cut the transcript up*, never
 //! what to keep or drop.
 //!
 //! **Zero regex, zero clock, single linear scan per stage** — same
-//! determinism contract as [`super::chunk`]: the same transcript + the same
+//! determinism contract as [`crate::context::chunk`]: the same transcript + the same
 //! [`SegmentationPolicy`] always segment byte-identically (see
 //! `segmentation_twice_is_byte_identical` in the test suite).
 //!
 //! # Pipeline
 //!
-//! 1. **Format detection** ([`detect_and_segment`]): `jsonl` when every
+//! 1. **Format detection** (`detect_and_segment`): `jsonl` when every
 //!    non-empty line parses as a `{role, content}` JSON object, `plain`
 //!    otherwise. A caller-forced format that does not parse is a hard error —
 //!    never a silent fallback to the other format — surfaced as
@@ -32,16 +32,16 @@
 //! 3. **Sub-segmentation** (`plain` turns only — a `jsonl` turn's `content` is
 //!    a JSON-decoded string, not a byte-aligned slice of the transcript, so
 //!    it is never re-scanned; the underlying `content.contains("```")` /
-//!    value-density rules in [`super::classify`] still see it, unaffected):
-//!    fenced code blocks ([`super::chunk::fence_segments`]) become atomic
+//!    value-density rules in `classify` still see it, unaffected):
+//!    fenced code blocks (`chunk::fence_segments`) become atomic
 //!    `code` segments; runs of at least 8 consecutive log-like lines (a
-//!    volatile timestamp/pid prefix — [`super::log_normalize::mask_volatile_prefix`]
+//!    volatile timestamp/pid prefix — `log_normalize::mask_volatile_prefix`
 //!    — or a raw-text repeat) become `log` segments; everything else is
 //!    `body`.
 //! 4. **Normalization**: an unsplittable fence over
 //!    [`crate::limits::MAX_FRAGMENT_BYTES`] is a hard error (never silently
 //!    truncated); an oversized `body` segment is re-split with
-//!    [`super::chunk_text`]; segments under
+//!    [`crate::context::chunk_text`]; segments under
 //!    [`SegmentationPolicy::min_segment_bytes`] merge into an adjacent
 //!    segment of the *same turn and kind*; more than
 //!    [`crate::limits::MAX_FRAGMENTS`] segments after merging is a hard,
@@ -59,7 +59,7 @@
 //! transcript can additionally fail with
 //! [`crate::error::MemoryError::IngestDisabled`]/[`crate::error::MemoryError::IngestOutsideRoots`]/
 //! [`crate::error::MemoryError::IngestPath`], via
-//! [`super::ingest::resolve_transcript_path`].
+//! [`crate::context::ingest::resolve_transcript_path`].
 
 use std::collections::BTreeMap;
 use std::ops::Range;
@@ -98,7 +98,7 @@ pub enum SegmentFormat {
 
 /// What kind of content a sub-segment carries — decides whether it was cut
 /// out as an atomic fence, a detected log run, or ordinary prose/dialogue
-/// left for [`super::classify`]'s rule table to judge.
+/// left for `classify`'s rule table to judge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive] // kinds grow; matching externally requires a wildcard arm
@@ -108,12 +108,12 @@ pub enum SegmentKind {
     /// value density, …) decide its fate exactly as for `compile_context`.
     Body,
     /// A triple-backtick-fenced block, cut out atomically by
-    /// [`super::chunk::fence_segments`]. Tagged `kind = "code"` so
-    /// [`super::classify::classify`]'s `preserve.code_fence` rule matches
+    /// `chunk::fence_segments`. Tagged `kind = "code"` so
+    /// `classify::classify`'s `preserve.code_fence` rule matches
     /// even for a fence whose content does not itself literally contain
     /// `` ``` `` (defense in depth; it usually does).
     Code,
-    /// A run of at least [`MIN_LOG_RUN_LINES`] log-like lines. Tagged
+    /// A run of at least `MIN_LOG_RUN_LINES` log-like lines. Tagged
     /// `kind = "log"` so `abstract.log_dedup` can consider it for
     /// repeated-line collapsing exactly like a caller-declared `kind: "log"`
     /// fragment in `compile_context`.
@@ -163,7 +163,7 @@ impl Default for SegmentationPolicy {
 }
 
 /// One segmented piece of the transcript: an ordinary [`ContextFragment`]
-/// (ready to feed [`super::ContextCompiler`]) plus the audit metadata the
+/// (ready to feed [`crate::context::ContextCompiler`]) plus the audit metadata the
 /// `compile_transcript` tool reports in its `segmentation.segments` list.
 #[derive(Debug, Clone)]
 pub struct TranscriptSegment {
@@ -293,7 +293,7 @@ fn detect_and_segment(
 
 /// One JSONL line's required shape. Both fields are mandatory: a line
 /// missing either — or not a JSON object at all — fails to parse, which
-/// [`detect_and_segment`] treats as "not jsonl" in [`SegmentFormat::Auto`]
+/// `detect_and_segment` treats as "not jsonl" in [`SegmentFormat::Auto`]
 /// and as a hard error under a forced [`SegmentFormat::Jsonl`].
 #[derive(Deserialize)]
 struct JsonlLine {
@@ -450,7 +450,7 @@ fn plain_pieces(text: &str) -> Vec<RawPiece> {
 }
 
 /// Split `range` of `text` into alternating `body`/`log` pieces: a maximal
-/// run of at least [`MIN_LOG_RUN_LINES`] consecutive "log-candidate" lines
+/// run of at least `MIN_LOG_RUN_LINES` consecutive "log-candidate" lines
 /// (a volatile timestamp/pid prefix, or a line that repeats elsewhere in
 /// `range`) becomes one `log` piece; every other line stays `body`,
 /// contiguous runs of it merged into one piece. Single linear scan.
@@ -527,7 +527,7 @@ fn log_split(text: &str, range: Range<usize>) -> Vec<(SegmentKind, Range<usize>)
 // --- Normalization -----------------------------------------------------------
 
 /// Reject an unsplittable fence over [`MAX_FRAGMENT_BYTES`] — a fence is
-/// always atomic (never cut, see [`super::chunk`]), so an oversized one
+/// always atomic (never cut, see [`crate::context::chunk`]), so an oversized one
 /// cannot be brought under the cap the way a `body` piece can.
 ///
 /// # Errors
@@ -548,7 +548,7 @@ fn reject_oversized_fences(pieces: &[RawPiece]) -> Result<(), MemoryError> {
 /// Re-split every `body` or `log` piece over [`MAX_FRAGMENT_BYTES`] — see
 /// [`resplit_body`] and [`resplit_log`] for the two (deliberately different)
 /// strategies. A `code` piece is never touched here: it is atomic by
-/// construction (a fence is never cut, see [`super::chunk`]) and already
+/// construction (a fence is never cut, see [`crate::context::chunk`]) and already
 /// rejected outright by [`reject_oversized_fences`] when oversized.
 fn resplit_oversized_bodies(text: &str, pieces: Vec<RawPiece>) -> Vec<RawPiece> {
     let chunk_policy = ChunkPolicy {

--- a/crates/velesdb-memory/src/context/transcript_bridge.rs
+++ b/crates/velesdb-memory/src/context/transcript_bridge.rs
@@ -4,7 +4,7 @@
 //! `compile_transcript` is a one-call shortcut over `compile_context`: it
 //! segments a raw agent-session transcript into turns (and, within a turn,
 //! into code/log/body sub-segments) before compiling. The segmentation
-//! itself lives in [`super::segment`]; what lives here is the *glue* around
+//! itself lives in [`crate::context::segment`]; what lives here is the *glue* around
 //! it — the empty-transcript guard the MCP tool applies, the request
 //! assembly, and the per-segment audit trail a caller inspects to see how
 //! its transcript was cut before trusting the compiled result.

--- a/crates/velesdb-memory/src/context/wire.rs
+++ b/crates/velesdb-memory/src/context/wire.rs
@@ -3,10 +3,10 @@
 //! decimal string, because JS `number` loses precision above 2^53.
 //!
 //! Node and WASM independently need the exact same tree walk over a
-//! serialized [`CompiledContext`](super::CompiledContext) — one to turn
+//! serialized [`CompiledContext`](crate::context::CompiledContext) — one to turn
 //! outgoing ids into strings, the other to turn incoming strings back into
 //! numbers before deserializing. Living here once (instead of copy-pasted
-//! per binding) means [`ID_KEYS`] has a single source of truth: a future id
+//! per binding) means [`crate::context::wire::ID_KEYS`] has a single source of truth: a future id
 //! field added to a `context` type only needs updating in one place, not
 //! silently missed in whichever binding a copy-paste forgot.
 //!

--- a/crates/velesdb-memory/src/embedding_provenance.rs
+++ b/crates/velesdb-memory/src/embedding_provenance.rs
@@ -29,7 +29,7 @@
 //! single open with the wrong model would carve a false provenance into the
 //! store, and every later check would trust it. A store that predates this
 //! record therefore stays unrecorded for good, and its check degrades to the
-//! dimension alone — with [`unrecorded_model_note`] saying so rather than
+//! dimension alone — with [`crate::embedding_provenance::unrecorded_model_note`] saying so rather than
 //! letting a successful open read as a verified match.
 
 use std::path::Path;

--- a/crates/velesdb-memory/src/extract.rs
+++ b/crates/velesdb-memory/src/extract.rs
@@ -761,7 +761,7 @@ pub type DynExtractor = std::sync::Arc<dyn Extractor + Send + Sync>;
 /// offline behavior. It reads no natural language, so a caller holding only
 /// prose wants a generative backend. What it offers instead is the one thing a
 /// model cannot: the graph is exactly the one the caller wrote down — up to
-/// [`orient_kinship`], the repointing pass EVERY backend's relations go
+/// `orient_kinship`, the repointing pass EVERY backend's relations go
 /// through, which can flip a triple whose predicate is a kinship noun the
 /// passage also states possessively.
 ///
@@ -1121,7 +1121,7 @@ impl OpenAiExtractor {
     /// (origin and port, no path).
     ///
     /// Bounded on the same four axes as [`OllamaExtractor::new`], with the
-    /// same generous [`REQUEST_TIMEOUT_SECS`]: generation is slow wherever it
+    /// same generous `REQUEST_TIMEOUT_SECS`: generation is slow wherever it
     /// runs, and the ceiling belongs to the role, not to the transport.
     #[must_use]
     pub fn new(

--- a/crates/velesdb-memory/src/http.rs
+++ b/crates/velesdb-memory/src/http.rs
@@ -7,9 +7,9 @@
 //! every other client's session fails with `Storage(DatabaseLocked)`.
 //!
 //! This module is the fix: one process, reachable over HTTP, that several
-//! clients connect to concurrently. It only builds the [`Router`]; binding a
+//! clients connect to concurrently. It only builds the `Router`; binding a
 //! [`tokio::net::TcpListener`] and actually serving connections — plain via
-//! `axum::serve`, or TLS via this module's own [`serve_tls`] — is the
+//! `axum::serve`, or TLS via this module's own [`crate::http::serve_tls`] — is the
 //! binary's job (`src/main.rs`), so the router can also be mounted directly
 //! in tests (`tests/http_transport.rs`) with no subprocess involved.
 //!
@@ -17,7 +17,7 @@
 //! CA/leaf certificates this needs); plain HTTP remains available as an
 //! explicit opt-out (`--http-insecure` / `VELESDB_MEMORY_HTTP_INSECURE=1`,
 //! see `src/main.rs`) for local debugging or when a trusted TLS-terminating
-//! proxy already sits in front. This module's own [`Router`]/[`router`] are
+//! proxy already sits in front. This module's own `Router`/[`crate::http::router`] are
 //! identical either way — only the transport wrapped around them differs.
 //!
 //! Concurrent requests need no *application*-level locking beyond what
@@ -91,7 +91,7 @@ pub fn http_max_body_bytes_from_env() -> usize {
 /// public service, so this is generous headroom rather than a tight budget;
 /// its purpose is only to put a ceiling on `LocalSessionManager`'s session
 /// map, which [`rmcp`] otherwise grows without bound (see
-/// [`session_limit`] for the full rationale).
+/// `session_limit` for the full rationale).
 pub const DEFAULT_HTTP_MAX_SESSIONS: usize = 64;
 
 /// Resolve the max concurrent session count from
@@ -184,7 +184,7 @@ fn keep_alive_from_raw(raw: Option<&str>) -> std::time::Duration {
 /// obvious axum-level fix does not apply to a raw `nest_service`):
 /// - [`RequestBodyLimit`] bounds a single request body
 ///   ([`http_max_body_bytes_from_env`]).
-/// - [`BoundedSessionManager`] bounds concurrent sessions
+/// - `BoundedSessionManager` bounds concurrent sessions
 ///   ([`http_max_sessions_from_env`]).
 ///
 /// Sessions are retired after [`http_keep_alive_from_env`] of silence — 60

--- a/crates/velesdb-memory/src/http_client.rs
+++ b/crates/velesdb-memory/src/http_client.rs
@@ -12,7 +12,7 @@
 //! Not which *vendor* is answering either. Once the path, the body and the
 //! auth scheme all come from the caller, nothing OpenAI-specific is left —
 //! which is the honest reason this is not called an "OpenAI client". The
-//! OpenAI protocol lives one layer up, in [`crate::openai`]; Azure, Gemini or
+//! OpenAI protocol lives one layer up, in `openai`; Azure, Gemini or
 //! Anthropic would each get their own protocol module over this same
 //! transport.
 //!

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -143,7 +143,7 @@ pub mod http_client;
 mod openai;
 /// Is a configured remote inference backend actually reachable? (#1751 D2)
 ///
-/// Gated exactly like [`openai`], which it builds its URL with, and like the
+/// Gated exactly like `openai`, which it builds its URL with, and like the
 /// `ureq` agent it probes through: without either role's feature there is no
 /// remote backend to be unreachable, and no transport to ask with. Declaring
 /// it unconditionally compiled here and nowhere else — the default build has

--- a/crates/velesdb-memory/src/migration/diagnosis.rs
+++ b/crates/velesdb-memory/src/migration/diagnosis.rs
@@ -51,7 +51,7 @@ impl Capability {
 /// # v6 — `edge_export` became `Proven` (#1762, PR C2a)
 ///
 /// The bump is not cosmetic and not optional. A capability's canonical verdict
-/// is part of the report's shape: [`DiagnosisReport::validate`] refuses a report
+/// is part of the report's shape: `DiagnosisReport::validate` refuses a report
 /// whose `edge_export` disagrees with what this build derives. A v5 report on
 /// disk carries the `Missing` verdict that was canonical when it was written,
 /// so a v6 build reading it would reject it as *inconsistent* — an accusation
@@ -183,7 +183,7 @@ pub struct DiagnosisReport {
     /// The store that was inspected.
     pub source_path: PathBuf,
     /// A digest of the store's files, so a resume can tell whether the source
-    /// changed under it. See [`fingerprint`].
+    /// changed under it. See `fingerprint`.
     pub source_fingerprint: String,
     /// The width the store's collections are at, `None` when they disagree or
     /// the store has none.
@@ -198,13 +198,13 @@ pub struct DiagnosisReport {
     pub requested_strategy: Strategy,
     /// What that request resolves to against this store, and why.
     ///
-    /// Derived, never independently observed: [`DiagnosisReport::validate`]
+    /// Derived, never independently observed: `DiagnosisReport::validate`
     /// recomputes it from the provenance and the target contract and refuses a
     /// report whose stated regime does not follow from its own fields. A
     /// diagnosis an operator reads a regime off is a diagnosis that can lie
     /// about one.
     pub resolution: Resolution,
-    /// One entry per collection in [`AGENT_COLLECTIONS`], absent ones included.
+    /// One entry per collection in `AGENT_COLLECTIONS`, absent ones included.
     pub collections: Vec<CollectionInventory>,
     /// Live facts across the store.
     pub facts: u64,

--- a/crates/velesdb-memory/src/migration/edges.rs
+++ b/crates/velesdb-memory/src/migration/edges.rs
@@ -178,7 +178,7 @@ fn live_ids(db: &Database, collection: &str, batch: usize) -> Result<Vec<u64>, c
 ///
 /// Walks the live fact ids with the same cursor the fact export uses, then
 /// takes each fact's outgoing edges. Each edge is checked against
-/// [`require_derived_id`] before it is collected.
+/// `require_derived_id` before it is collected.
 ///
 /// # Errors
 /// Returns [`crate::MemoryError`] if `collection` is not an agent subsystem, if

--- a/crates/velesdb-memory/src/service.rs
+++ b/crates/velesdb-memory/src/service.rs
@@ -143,7 +143,7 @@ const ABOUT_RELATION: &str = "about";
 /// default and every caller names its own storage backend explicitly. The
 /// duplication stops at the type-parameter list: the field lists are
 /// identical by contract — what varies per feature is the *type* of
-/// [`GenerationGate`], never the shape of the service — and
+/// `GenerationGate`, never the shape of the service — and
 /// `tests/service_field_drift.rs` fails the build of any change that lets
 /// them diverge again (#2017).
 #[cfg(feature = "persistence")]

--- a/crates/velesdb-memory/src/service_graph_wiring.rs
+++ b/crates/velesdb-memory/src/service_graph_wiring.rs
@@ -145,7 +145,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     /// The stored metadata is **auto-stamped with today's date** under
     /// [`crate::storage::AUTO_DATE_FIELD`] (`_veles_date`, a `YYYYMMDD`
     /// integer read from the system clock at write time — see
-    /// [`crate::clock::today_ymd`]) whenever `metadata` doesn't already carry
+    /// `clock::today_ymd`) whenever `metadata` doesn't already carry
     /// that key; an explicit value in `metadata` (e.g. to date a fact
     /// retroactively) is never overwritten. No clock is available on
     /// `wasm32-unknown-unknown`, so that target stamps nothing and `metadata`
@@ -157,7 +157,7 @@ impl<E: Embedder, S: FactStore> MemoryService<E, S> {
     ///
     /// Because [`Self::remember_extracted`] stores each extracted fact via
     /// [`Self::remember`] (which delegates here), it gets the same auto-stamp
-    /// for free — entity hubs it also creates go through [`Self::store_fact`]
+    /// for free — entity hubs it also creates go through `store_fact`
     /// directly and are never stamped, since they are internal graph
     /// scaffolding, not caller facts.
     ///

--- a/crates/velesdb-memory/src/storage.rs
+++ b/crates/velesdb-memory/src/storage.rs
@@ -763,11 +763,11 @@ impl NativeStore {
 }
 
 /// Reserved metadata key `remember`/`remember_with_ttl` auto-stamp with
-/// today's date (a `YYYYMMDD` integer, [`crate::clock::today_ymd`]) whenever
+/// today's date (a `YYYYMMDD` integer, `clock::today_ymd`) whenever
 /// the caller didn't already set it — see
 /// [`crate::service::MemoryService::remember_with_ttl`] for the full
 /// contract. A deliberate, documented **exception** to every other
-/// `_veles_`-namespaced key: [`is_reserved_key`] still names it (so it can
+/// `_veles_`-namespaced key: `is_reserved_key` still names it (so it can
 /// never be confused with an arbitrary caller field), but unlike a true
 /// system key —
 /// - a caller MAY set it explicitly (to date a fact retroactively; never

--- a/crates/velesdb-memory/src/tls.rs
+++ b/crates/velesdb-memory/src/tls.rs
@@ -7,13 +7,13 @@
 //! has to install and keep running).
 //!
 //! The approach: a self-signed root CA is generated ONCE and cached on disk
-//! (see [`tls_dir_from_env`]); it signs short-lived `localhost`/`127.0.0.1`
+//! (see [`crate::tls::tls_dir_from_env`]); it signs short-lived `localhost`/`127.0.0.1`
 //! leaf certificates that are silently re-issued on every daemon start. A
 //! client (browser, `curl`, Claude Desktop) that has been told to trust the
 //! CA once — `scripts/install-memory-daemon.sh` adds it to the macOS login
 //! keychain — then trusts every future leaf cert it signs with no further
 //! action, even across daemon restarts and leaf renewals, because the CA's
-//! own key never changes. [`ensure_tls_material`] is what enforces that:
+//! own key never changes. [`crate::tls::ensure_tls_material`] is what enforces that:
 //! it reloads an existing CA from disk instead of regenerating one whenever
 //! both `ca-cert.pem` and `ca-key.pem` are already present.
 //!
@@ -32,7 +32,7 @@
 //! is only the certificate material.
 //!
 //! # An explicit `CryptoProvider`, not the process-wide default
-//! [`tls_acceptor_from_material`] builds its [`rustls::ServerConfig`] with
+//! [`crate::tls::tls_acceptor_from_material`] builds its [`rustls::ServerConfig`] with
 //! `ServerConfig::builder_with_provider(..)` and an explicit
 //! `rustls::crypto::ring::default_provider()`, rather than the ambient
 //! `ServerConfig::builder()` (which resolves the process-wide default
@@ -61,7 +61,7 @@ use time::{Duration as TimeDuration, OffsetDateTime};
 /// File names inside the TLS material directory (see [`tls_dir_from_env`]).
 /// `ca-cert.pem` is public (safe to hand to `security add-trusted-cert`,
 /// safe to be world-readable); the two `*-key.pem` files are private and are
-/// always written with `0600` permissions (see [`set_permissions`]).
+/// always written with `0600` permissions (see `set_permissions`).
 pub const CA_CERT_FILE: &str = "ca-cert.pem";
 const CA_KEY_FILE: &str = "ca-key.pem";
 const LEAF_CERT_FILE: &str = "leaf-cert.pem";

--- a/docs/reference/mcp-tools.json
+++ b/docs/reference/mcp-tools.json
@@ -16,7 +16,7 @@
                   "type": "string"
                 },
                 "id": {
-                  "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n[`super::wire::deserialize_optional_id`]) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
+                  "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n`wire::deserialize_optional_id`) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
                   "type": "string"
                 },
                 "kind": {
@@ -1332,12 +1332,12 @@
                         },
                         {
                           "const": "code",
-                          "description": "A triple-backtick-fenced block, cut out atomically by\n[`super::chunk::fence_segments`]. Tagged `kind = \"code\"` so\n[`super::classify::classify`]'s `preserve.code_fence` rule matches\neven for a fence whose content does not itself literally contain\n`` ``` `` (defense in depth; it usually does).",
+                          "description": "A triple-backtick-fenced block, cut out atomically by\n`chunk::fence_segments`. Tagged `kind = \"code\"` so\n`classify::classify`'s `preserve.code_fence` rule matches\neven for a fence whose content does not itself literally contain\n`` ``` `` (defense in depth; it usually does).",
                           "type": "string"
                         },
                         {
                           "const": "log",
-                          "description": "A run of at least [`MIN_LOG_RUN_LINES`] log-like lines. Tagged\n`kind = \"log\"` so `abstract.log_dedup` can consider it for\nrepeated-line collapsing exactly like a caller-declared `kind: \"log\"`\nfragment in `compile_context`.",
+                          "description": "A run of at least `MIN_LOG_RUN_LINES` log-like lines. Tagged\n`kind = \"log\"` so `abstract.log_dedup` can consider it for\nrepeated-line collapsing exactly like a caller-declared `kind: \"log\"`\nfragment in `compile_context`.",
                           "type": "string"
                         }
                       ]
@@ -1601,7 +1601,7 @@
                       "type": "string"
                     },
                     "id": {
-                      "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n[`super::wire::deserialize_optional_id`]) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
+                      "description": "Caller-side identifier. When absent, the compiler derives a stable\ncontent-addressed id (see [`super::fragment_id`]). Accepts a JSON\nnumber or a decimal string on input (see\n`wire::deserialize_optional_id`) — a caller that got a\n`fragment_id` back as a string (e.g. under\n[`CompilePolicy::ids_as_strings`]) can resubmit it unchanged.",
                       "type": "string"
                     },
                     "kind": {
@@ -3802,7 +3802,7 @@
           "media": {
             "anyOf": [
               {
-                "description": "Inline media payload attached to a [`ContextFragment`] (US-009, PR1:\nscreenshots/images only). `ContextFragment::content` stays the\ntext/caption — often empty for a bare screenshot — while the pixels live\nhere, base64-encoded so the JSON wire never needs a binary frame.\n\nThe fragment packs atomically (see [`super::pieces`] in the compiler)\nand its token cost comes from [`super::estimator::ImageTokenEstimator`].\nA media fragment that cannot fit the budget is externalized behind a\n`ctx://source` handle exactly like text (US-009, PR2: the memory bridge\npersists the bytes behind it — see\n[`crate::MemoryService::retrieve_context_source`]); the memoryless core\ncompiler mints the same handle either way, since it never knows whether\na resolver is attached. See the crate README's \"media fragments\"\nsection.",
+                "description": "Inline media payload attached to a [`ContextFragment`] (US-009, PR1:\nscreenshots/images only). `ContextFragment::content` stays the\ntext/caption — often empty for a bare screenshot — while the pixels live\nhere, base64-encoded so the JSON wire never needs a binary frame.\n\nThe fragment packs atomically (see `pieces` in the compiler)\nand its token cost comes from [`super::estimator::ImageTokenEstimator`].\nA media fragment that cannot fit the budget is externalized behind a\n`ctx://source` handle exactly like text (US-009, PR2: the memory bridge\npersists the bytes behind it — see\n[`crate::MemoryService::retrieve_context_source`]); the memoryless core\ncompiler mints the same handle either way, since it never knows whether\na resolver is attached. See the crate README's \"media fragments\"\nsection.",
                 "properties": {
                   "bytes_b64": {
                     "description": "The raw media bytes, base64-encoded (standard alphabet, padded).\nCapped at [`crate::limits::MAX_MEDIA_BYTES`] and validated for\nwell-formedness at compile time — a request carrying an oversized or\nmalformed payload is rejected before any other work.",


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`docs/*` → targets `develop`. ✅

## Description

`velesdb-memory` is published to crates.io, so its rustdoc **is** what docs.rs serves: a broken intra-doc link is a dead link on a public page. **Forty-nine had accumulated** — because nothing in CI ever built the docs.

Two causes, one per class.

**Twenty-two "unresolved".** A module's `//!` header is merged into the `mod` declaration that pulls it in, and once that declaration also carries `///` docs the merged text resolves in the **parent's** scope. So every `super::` path inside the header points one level too high, and every bare private name falls out of scope. The tell: `super::chunk` and `super::chunk_text` were **correct as written** — `chunk_text` really is re-exported at `context::chunk_text` — and both dangled anyway. These become absolute `crate::` paths, which resolve identically in either scope.

**Twenty-seven "links to private item".** Public documentation linking to a private item renders as a link the reader cannot follow. These stop being links: the prose still names `GenerationGate`, `is_reserved_key` or `store_fact` in a code span — it just no longer promises a page that 404s.

**The gate.** The Lint job now runs `RUSTDOCFLAGS=-D warnings cargo doc -p velesdb-memory --no-deps --all-features`. Without it this fix decays: 49 links accumulated precisely because nothing looked. `AGENTS.md`'s pre-push block gains the same command.

Scoped to `velesdb-memory` deliberately — it is the crate whose docs are published from this repo, and I have not audited the others. Widening the gate is a separate call.

## It also changes four MCP tool descriptions

I first wrote that no prose changed. **That was wrong**, and CI caught it: MCP tool descriptions are derived from the doc comments, so `mcp_tools_drift` failed on the `Lint & Format` job. Four descriptions lose their link brackets:

| before | after |
|---|---|
| `` [`super::wire::deserialize_optional_id`] `` | `` `wire::deserialize_optional_id` `` |
| `` [`super::chunk::fence_segments`] `` | `` `chunk::fence_segments` `` |
| `` [`super::classify::classify`] `` | `` `classify::classify` `` |
| `` [`MIN_LOG_RUN_LINES`] `` | `` `MIN_LOG_RUN_LINES` `` |

Every one wrapped a **private** item, so the bracket promised a page that does not exist — inside a description whose reader is a model that cannot look up a Rust path anyway. The wording is otherwise byte-identical. `` [`super::fragment_id`] `` and `` [`CompilePolicy::ids_as_strings`] `` are untouched: their targets are public and resolve. The brackets went only where the target was unreachable.

This is not optional. Those four links are among the ones rustdoc reports, so the gate this branch adds and the old descriptions cannot both stand. `docs/reference/mcp-tools.json` is regenerated with `UPDATE_MCP_TOOLS_SNAPSHOT=1`; `MCP_TOOLS.md` needed no change.

Worth flagging separately: the artifact still carries **18 other `super::`-prefixed Rust paths** in descriptions a model reads. Those resolve in rustdoc, so this change leaves them alone — but they are the same kind of internal noise, and cleaning them up is its own decision.

## Type of Change

- [x] 📚 Documentation update
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) — dead links on a published docs.rs page

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

Measured, not estimated — the count came from `cargo doc`, iterated in three passes:

| pass | warnings |
|---|---|
| before | 49 |
| after the `crate::` paths | 32 |
| after the private-item links | 8 |
| after the last `Self::`/private ones | **0** |

The gate itself was verified before wiring: `RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-memory --no-deps --all-features` → **exit 0**. A gate that cannot pass on the branch that adds it is worse than none.

After regenerating the artifact: `cargo test -p velesdb-memory --test mcp_tools_drift` **1 passed**; `check-mcp-doc-contract` OK; `check-doc-freshness` OK; `test_ci_gate_reachability` 97 tests OK; `ci.yml` parses as YAML. The pre-commit hook ran formatting, `cargo clippy --workspace -D warnings`, the `undocumented_unsafe_blocks` pass and the workspace `--lib` suite — all green.

**Why the drift was not caught before pushing:** the pre-commit hook runs `cargo test --workspace --lib`, and `mcp_tools_drift` is an integration test. My own gap, not the hook's — the pre-push block in `AGENTS.md` has `check-mcp-doc-contract.py` and I ran it on the sibling branch but not on this one.

**Test Configuration:**
- OS: Linux x86_64
- Rust version: workspace pinned toolchain

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — the CI gate *is* the test: it fails on any regression, and it was proven to pass only after the last link was fixed
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Every broken link was pre-existing; none was introduced by recent work. The `//!`-merge behaviour is worth knowing about when adding module docs — a `super::` path that looks obviously right will still dangle if the `mod` declaration carries its own `///`.

`Gate Contracts / npm advisories (demos/tauri-rag-app)` also went red on an earlier head with a `503 Service Unavailable` from npmjs.org's advisory endpoint; that is an outage, not this diff, and it is written up in a comment below.