### PR TITLE
refactor(graph): dedup edge-removal bucket purge, fix stale Panics doc

### DIFF
--- a/crates/velesdb-core/src/collection/core/statistics.rs
+++ b/crates/velesdb-core/src/collection/core/statistics.rs
@@ -41,9 +41,8 @@ impl Collection {
     ///
     /// Returns an error if statistics cannot be collected.
     ///
-    /// # Panics
-    ///
-    /// Panics if `point_count` exceeds `u64::MAX` (extremely unlikely on 64-bit systems).
+    /// Counts that would not fit `u64` saturate to `u64::MAX` rather than panic
+    /// (see [`saturating_u64`]); on 64-bit systems this is not reachable in practice.
     #[allow(clippy::unnecessary_wraps)] // Reason: Public API contract — callers expect Result
     pub fn analyze(&self) -> Result<CollectionStats, Error> {
         let mut collector = StatsCollector::new();

--- a/crates/velesdb-core/src/collection/graph/edge_removal.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_removal.rs
@@ -13,6 +13,20 @@
 
 use super::edge::EdgeStore;
 use super::label_table::LabelId;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Removes `edge_id` from `key`'s bucket in `map`, then drops the key itself
+/// once its bucket empties — not just the id inside it. See the module-level
+/// note on why a key must not outlive its last edge.
+fn purge_bucket<K: Eq + Hash>(map: &mut HashMap<K, Vec<u64>>, key: &K, edge_id: u64) {
+    if let Some(ids) = map.get_mut(key) {
+        ids.retain(|&id| id != edge_id);
+        if ids.is_empty() {
+            map.remove(key);
+        }
+    }
+}
 
 impl EdgeStore {
     /// Removes an edge by ID.
@@ -102,30 +116,19 @@ impl EdgeStore {
     /// not merely defensive.
     #[inline]
     fn purge_incoming_index(&mut self, edge_id: u64, target_node: u64, label_id: Option<LabelId>) {
-        if let Some(ids) = self.incoming.get_mut(&target_node) {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.incoming.remove(&target_node);
-            }
-        }
+        purge_bucket(&mut self.incoming, &target_node, edge_id);
         let Some(label_id) = label_id else { return };
-        if let Some(ids) = self.incoming_by_label.get_mut(&(target_node, label_id)) {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.incoming_by_label.remove(&(target_node, label_id));
-            }
-        }
+        purge_bucket(
+            &mut self.incoming_by_label,
+            &(target_node, label_id),
+            edge_id,
+        );
     }
 
     /// Removes `edge_id` from the outgoing index of `source_node`.
     #[inline]
     fn purge_outgoing_index(&mut self, edge_id: u64, source_node: u64) {
-        if let Some(ids) = self.outgoing.get_mut(&source_node) {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.outgoing.remove(&source_node);
-            }
-        }
+        purge_bucket(&mut self.outgoing, &source_node, edge_id);
     }
 
     /// Removes `edge_id` from the `by_label` and `outgoing_by_label` indices (US-003).
@@ -134,17 +137,11 @@ impl EdgeStore {
     #[inline]
     fn purge_label_indices(&mut self, edge_id: u64, source_node: u64, label_id: Option<LabelId>) {
         let Some(label_id) = label_id else { return };
-        if let Some(ids) = self.by_label.get_mut(&label_id) {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.by_label.remove(&label_id);
-            }
-        }
-        if let Some(ids) = self.outgoing_by_label.get_mut(&(source_node, label_id)) {
-            ids.retain(|&id| id != edge_id);
-            if ids.is_empty() {
-                self.outgoing_by_label.remove(&(source_node, label_id));
-            }
-        }
+        purge_bucket(&mut self.by_label, &label_id, edge_id);
+        purge_bucket(
+            &mut self.outgoing_by_label,
+            &(source_node, label_id),
+            edge_id,
+        );
     }
 }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

## Description

Two small, independent, behavior-preserving cleanups found during a routine
code-quality pass over recently-touched `velesdb-core` files:

1. **`EdgeStore` purge helpers deduplicated.** `purge_incoming_index`,
   `purge_outgoing_index`, and `purge_label_indices` each repeated the same
   six-line "retain the id, then drop the map key once its bucket is empty"
   block, once per `(map, key)` pair — five call sites total, added by the
   commit that fixed the empty-bucket leak. Extracted a small generic
   `purge_bucket()` helper so a future sixth map added to `EdgeStore` isn't
   one copy-paste away from reintroducing that leak. No signature or
   persisted-format change.
2. **Stale `# Panics` doc on `Collection::analyze`.** The doc claimed the
   method panics if `point_count` exceeds `u64::MAX`, but every conversion in
   the function goes through `saturating_u64()`, which saturates instead of
   panicking — that's the point of the helper. Replaced the panic claim with
   a note describing the actual (saturating) behavior.

Fixes # (none — internal quality pass, no tracking issue)

## Type of Change

- [x] 🔧 Refactoring (no functional changes)
- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- `cargo test -p velesdb-core --lib --features persistence edge_tests::` — 179 passed, 0 failed, including
  `test_remove_edge_evicts_empty_index_buckets`,
  `test_remove_edge_incoming_only_evicts_empty_index_buckets`,
  `test_remove_edge_outgoing_only_evicts_empty_index_buckets`, and
  `test_remove_node_edges_evicts_empty_index_buckets_on_other_endpoint` (the
  tests that cover exactly the behavior being refactored).
- `cargo test -p velesdb-core --features persistence statistics` — 5 passed.
- `cargo test --doc --package velesdb-core` — doctest on the edited doc comment passes.
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean.
- `cargo clippy -p velesdb-core --lib --bins --features persistence,gpu,update-check -- -A warnings -D clippy::undocumented_unsafe_blocks` — clean (no unsafe touched).
- `cargo fmt --all` — clean.
- `python3 scripts/check_prod_unwraps.py` — PASSED.
- `python3 scripts/check-ai-attribution.py "origin/develop..HEAD"` — PASSED.

**Test Configuration:**
- OS: Linux (CI container)
- Rust version: per `rust-toolchain.toml` (MSRV 1.90)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — n/a, covered entirely by existing tests (see above)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Unsafe Code Checklist

Skipped — no `unsafe` code added or modified.

## High-Risk Change Checklist

Skipped — doesn't touch `hnsw`, `storage`, `Drop`, `unsafe`, or SIMD dispatch paths.

## Additional Notes

Both commits are separately atomic: the `purge_bucket` extraction and the doc fix touch unrelated code and can be reviewed/reverted independently.
