### PR TITLE
docs(core): fix 30 broken rustdoc intra-doc links and deny them at the crate root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,19 @@ jobs:
           RUSTDOCFLAGS: -D warnings
         run: cargo doc -p velesdb-memory --no-deps --all-features
 
+      # Same gate, same reason, for the other published crate: velesdb-core is
+      # the API every downstream binding documents against, and it had carried
+      # 30 broken links (6 unresolved, 24 pointing at `pub(crate)` items) that
+      # nothing in CI looked at. `--all-features` rather than the default
+      # `persistence` set is deliberate: docs.rs serves default features only,
+      # but a gate that skips the `gpu`, `openapi` and `loom` modules cannot
+      # fail on them — the same reasoning as the isolated-feature step above
+      # (#1765). It costs the wgpu dependency build in this job.
+      - name: Rustdoc intra-doc links (velesdb-core)
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p velesdb-core --no-deps --all-features
+
       # The extraction backend's unit tests are pure parsing and prompt
       # building: none opens a socket. Run them under the canonical role name
       # and its compatibility alias so neither path can silently stop enabling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,13 @@ cargo check -p velesdb-memory --no-default-features --features mcp,persistence
 for feat in mcp http context persistence embedder-http extractor-http ollama extract; do
   cargo check -p velesdb-memory --no-default-features --features "$feat" --all-targets
 done
-# velesdb-memory's rustdoc is what docs.rs serves, so a broken intra-doc link is
-# a dead link on a public page. Blocking in the Lint job since #2205.
+# The published crates' rustdoc is what docs.rs serves, so a broken intra-doc
+# link is a dead link on a public page. Both crates now `#![deny]` the two link
+# lints at their crate root, so a plain `cargo doc` already fails on one; the
+# RUSTDOCFLAGS here and the matching Lint steps are what guarantee the docs are
+# BUILT — an attribute cannot fire if nobody builds them.
 RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-memory --no-deps --all-features
+RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-core --no-deps --all-features
 # Functional wasm gate — catches std APIs that abort on wasm32 (e.g. SystemTime::now):
 wasm-pack test --node crates/velesdb-wasm
 # Guards and contracts. Every one of these blocks a PR through `CI Success`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **30 broken rustdoc intra-doc links in `velesdb-core`, and the two lints that
+  let them accumulate.** Six were unresolved — all in a module's `//!` header,
+  which rustdoc merges into the `mod` declaration that pulls it in, so once
+  that declaration also carries `///` docs the paths resolve in the *parent's*
+  scope (the same trap as the 49 links fixed in `velesdb-memory`). Twenty-four
+  pointed at `pub(crate)`, `pub(super)` or private items a reader of the
+  published docs cannot reach; those stop being links and become plain code
+  spans rather than promising a page that would 404. No claim changed — only
+  link syntax and the line wrapping that demoting a link disturbs, which
+  `rustfmt` cannot re-flow (`wrap_comments` is nightly-only).
+
+  `rustdoc::broken_intra_doc_links` and `rustdoc::private_intra_doc_links` are
+  warn-by-default, which is why 30 here and 49 there went unnoticed. Both
+  published crates now `#![deny]` them at the crate root, so a plain
+  `cargo doc` fails for a contributor and on docs.rs — not only in the CI step
+  that exports `RUSTDOCFLAGS`. A matching Lint step for `velesdb-core` keeps
+  the docs actually built, since an attribute cannot fire if nobody builds
+  them. `[workspace.lints.rustdoc]` remains future work: 17 such links survive
+  in the crates that are not published to crates.io (`velesdb-wasm` 8,
+  `tauri-plugin-velesdb` 4, `velesdb-server` 3, `velesdb-migrate` 2).
+
 ## [6.0.0] - 2026-09-02
 
 ### Security

--- a/crates/velesdb-core/src/collection/auto_reindex/types.rs
+++ b/crates/velesdb-core/src/collection/auto_reindex/types.rs
@@ -95,7 +95,7 @@ pub enum ReindexEvent {
 /// serde default matching [`Default`] so a `config.json` written by an older
 /// VelesDB — or one that omits any field — deserializes without error. The
 /// [`cooldown`](Self::cooldown) `Duration` is stored as whole seconds via
-/// [`duration_secs`].
+/// `duration_secs`.
 ///
 /// `#[non_exhaustive]`: build from [`AutoReindexConfig::default`] and adjust
 /// fields so future additions stay backward compatible for downstream crates.

--- a/crates/velesdb-core/src/collection/collection_config.rs
+++ b/crates/velesdb-core/src/collection/collection_config.rs
@@ -158,13 +158,14 @@ pub struct CollectionConfig {
     /// indexes exist (EPIC-081 phase 3d).
     ///
     /// `create_index` adds a field here and `drop_secondary_index` removes it,
-    /// each persisted via [`save_config`](crate::collection::Collection). On
+    /// each persisted via `save_config`. On
     /// [`Collection::open`](crate::collection::VectorCollection) every listed
     /// field is rebuilt from the recovered payloads (backfill), so an index
     /// survives a process restart instead of silently vanishing — without
     /// which the ordered-index `ORDER BY` fast path, the bitmap pre-filter,
-    /// `EXPLAIN` `IndexLookup`, and the index advisor would all change behaviour
-    /// after a restart (results stay correct via the exhaustive fallback).
+    /// `EXPLAIN` `IndexLookup`, and the index advisor would all change
+    /// behaviour after a restart (results stay correct via the exhaustive
+    /// fallback).
     ///
     /// A `BTreeSet` so the on-disk ordering is deterministic. Backward
     /// compatible: configs written before this field deserialize to an empty

--- a/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
+++ b/crates/velesdb-core/src/collection/graph/edge_concurrent/mod.rs
@@ -357,7 +357,7 @@ impl ConcurrentEdgeStore {
     ///
     /// Returns `true` only if the edge was actually removed. A `false` here
     /// conflates "absent" with "index desynchronised" — use
-    /// [`Self::remove_edge_detailed`] when the difference matters.
+    /// `remove_edge_detailed` when the difference matters.
     ///
     /// # Concurrency Safety
     ///

--- a/crates/velesdb-core/src/collection/graph_collection.rs
+++ b/crates/velesdb-core/src/collection/graph_collection.rs
@@ -330,9 +330,8 @@ impl GraphCollection {
     /// Removes an edge from the graph by ID.
     ///
     /// Returns `true` if the edge existed and was removed, `false` otherwise —
-    /// including on the genuine failure paths. Use
-    /// [`Self::remove_edge_detailed`] when a failure must not pass for
-    /// "already gone".
+    /// including on the genuine failure paths. Use `remove_edge_detailed` when
+    /// a failure must not pass for "already gone".
     #[must_use]
     pub fn remove_edge(&self, edge_id: u64) -> bool {
         self.inner.remove_edge(edge_id)

--- a/crates/velesdb-core/src/column_store/mod.rs
+++ b/crates/velesdb-core/src/column_store/mod.rs
@@ -160,7 +160,7 @@ impl ColumnStore {
     /// exist, so the new column would be shorter than `row_count` and
     /// desynchronized from every other column. It is only sound to call this
     /// while the store is empty (`row_count == 0`, i.e. schema-definition
-    /// time). Use [`ColumnStore::add_column_backfilled`] to add a column once
+    /// time). Use `ColumnStore::add_column_backfilled` to add a column once
     /// rows exist.
     ///
     /// Nested arrays are silently treated as scalar arrays; use

--- a/crates/velesdb-core/src/conformance/mod.rs
+++ b/crates/velesdb-core/src/conformance/mod.rs
@@ -45,6 +45,11 @@
 //!
 //! The harness is persistence-free and `wasm32`-safe, so every binding crate
 //! can run it.
+//!
+//! [`check_stable_hash`]: crate::conformance::check_stable_hash
+//! [`check_rrf`]: crate::conformance::check_rrf
+//! [`check_executor`]: crate::conformance::check_executor
+//! [`Divergence`]: crate::conformance::Divergence
 
 mod executor;
 mod fusion;

--- a/crates/velesdb-core/src/contiguous_file_arena.rs
+++ b/crates/velesdb-core/src/contiguous_file_arena.rs
@@ -40,6 +40,8 @@
 //! `persistence`-only. Without it (WASM, `--no-default-features`) there is no
 //! filesystem to map and [`ContiguousVectors`] keeps its anonymous backing;
 //! this module is not compiled at all.
+//!
+//! [`ContiguousVectors`]: crate::perf_optimizations::ContiguousVectors
 
 use memmap2::{MmapMut, MmapOptions};
 use std::fs::{File, OpenOptions};

--- a/crates/velesdb-core/src/database/gated_search.rs
+++ b/crates/velesdb-core/src/database/gated_search.rs
@@ -205,14 +205,12 @@ impl Database {
 
     /// Executes a search through the control-plane read gate.
     ///
-    /// Consults the registered observer via
-    /// [`read_gate_raw`](Self::read_gate_raw) for the
+    /// Consults the registered observer via `read_gate_raw` for the
     /// collection / operation / principal / tenant, then:
-    /// * [`Allow`](RawGateOutcome::Allow) — runs the search unmodified;
-    /// * [`Deny`](RawGateOutcome::Deny) — returns the supplied error and zero
-    ///   results;
-    /// * [`Scope`](RawGateOutcome::Scope) — AND-composes the scope filter with
-    ///   any caller filter before running the search.
+    /// * `RawGateOutcome::Allow` — runs the search unmodified;
+    /// * `RawGateOutcome::Deny` — returns the supplied error and zero results;
+    /// * `RawGateOutcome::Scope` — AND-composes the scope filter with any
+    ///   caller filter before running the search.
     ///
     /// With no observer registered this is a single `Option` check followed by
     /// the same leaf call the ungated path used (zero-overhead contract).

--- a/crates/velesdb-core/src/database/graph_ops.rs
+++ b/crates/velesdb-core/src/database/graph_ops.rs
@@ -33,7 +33,7 @@ impl Database {
     ///
     /// The node-embedding index takes its parameters from the configured
     /// `[hnsw]` section on top of the auto-tuned defaults — see
-    /// [`Database::resolve_hnsw_params`].
+    /// `Database::resolve_hnsw_params`.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/database/vector_ops.rs
+++ b/crates/velesdb-core/src/database/vector_ops.rs
@@ -135,9 +135,9 @@ impl Database {
     /// When `m` or `ef_construction` are `Some`, those values win over the
     /// configured `[hnsw]` section, which in turn wins over the
     /// dimension-based auto-tuned defaults from [`HnswParams::auto`] — see
-    /// [`Database::resolve_hnsw_params`] for the full chain. The two
-    /// arguments are resolved independently, so pinning one still takes the
-    /// other from config.
+    /// `Database::resolve_hnsw_params` for the full chain. The two arguments
+    /// are resolved independently, so pinning one still takes the other from
+    /// config.
     ///
     /// Shortcut for [`Database::create_vector_collection_with_params`] that
     /// only overrides `max_connections` and `ef_construction`.

--- a/crates/velesdb-core/src/index/hnsw/index/mod.rs
+++ b/crates/velesdb-core/src/index/hnsw/index/mod.rs
@@ -214,13 +214,12 @@ impl HnswIndex {
     ///
     /// # Why the write lock
     ///
-    /// The pass renumbers every node, and [`mappings`](Self::mappings) is
-    /// keyed by that numbering, so the two are only consistent together. A
-    /// read guard would let a search run between them and resolve external
-    /// ids against the old numbering — confident, wrong answers rather than
-    /// an error. `vacuum` takes the write lock to renumber for the same
-    /// reason. `ANALYZE` is the caller, so the exclusion lasts one
-    /// maintenance pass.
+    /// The pass renumbers every node, and `mappings` is keyed by that
+    /// numbering, so the two are only consistent together. A read guard would
+    /// let a search run between them and resolve external ids against the old
+    /// numbering — confident, wrong answers rather than an error. `vacuum`
+    /// takes the write lock to renumber for the same reason. `ANALYZE` is the
+    /// caller, so the exclusion lasts one maintenance pass.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/lib.rs
+++ b/crates/velesdb-core/src/lib.rs
@@ -1,4 +1,11 @@
 #![warn(clippy::significant_drop_tightening)]
+// Broken and private intra-doc links are warn-by-default, which is why 30 of
+// them accumulated here unnoticed. Denying them at the crate root is what makes
+// a plain `cargo doc` fail — for a contributor locally and for docs.rs, not
+// only inside the one CI step that sets `RUSTDOCFLAGS`. The CI step stays: an
+// attribute cannot fire if nobody builds the docs, and it is the step that
+// guarantees they are built on every PR.
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 // The crate README is pulled into the crate documentation verbatim. This is not
 // cosmetic: it makes `cargo test --doc --package velesdb-core` (CI step "Check
 // doctests compile") type-check every ```rust block in `README.md`. A README

--- a/crates/velesdb-core/src/observer/context.rs
+++ b/crates/velesdb-core/src/observer/context.rs
@@ -10,6 +10,8 @@
 //! implementers' `match` arms or struct literals (Requirement 3.3).
 //!
 //! Core references no premium crate, type, or symbol here (Requirement 3.4).
+//!
+//! [`DatabaseObserver`]: crate::observer::DatabaseObserver
 
 use crate::velesql::Condition;
 

--- a/crates/velesdb-core/src/quantization/rabitq.rs
+++ b/crates/velesdb-core/src/quantization/rabitq.rs
@@ -23,11 +23,11 @@ use serde::{Deserialize, Serialize};
 pub struct RaBitQCorrection {
     /// L2 norm of the centered vector before binarization.
     pub vector_norm: f32,
-    /// Inner product between the binary reconstruction (`±1/√D` scaled) and the
-    /// rotated normalized vector. Measures quantization quality; closer to 1.0
-    /// is better. NOT consumed by the current symmetric (query-binarized)
+    /// Inner product between the binary reconstruction (`±1/√D` scaled) and
+    /// the rotated normalized vector. Measures quantization quality; closer to
+    /// 1.0 is better. NOT consumed by the current symmetric (query-binarized)
     /// estimator, whose de-bias is the arcsine-law transform in
-    /// [`RaBitQIndex::distance_from_prepared_slice`]; it is the per-vector
+    /// `RaBitQIndex::distance_from_prepared_slice`; it is the per-vector
     /// rescale the paper's asymmetric estimator (real-valued query) divides
     /// by, kept in the persisted format for that upgrade path (#2104).
     pub quantization_ip: f32,

--- a/crates/velesdb-core/src/storage/log_payload.rs
+++ b/crates/velesdb-core/src/storage/log_payload.rs
@@ -385,10 +385,10 @@ impl LogPayloadStorage {
     /// per id: calling it in a loop cost one fsync PER POINT on this store
     /// (finding C3). Here every CRC-protected tombstone (`Marker(0xC4) |
     /// ID(8) | CRC32(4)`) is built into one buffer, written with a single
-    /// `write_all`, and synced once via [`Self::sync_wal_or_resync`] — the
-    /// bytes are identical to N sequential `delete` calls, so WAL replay is
-    /// unchanged. Ids absent from the index are skipped (no tombstone),
-    /// mirroring the single-delete guard.
+    /// `write_all`, and synced once via `sync_wal_or_resync` — the bytes are
+    /// identical to N sequential `delete` calls, so WAL replay is unchanged.
+    /// Ids absent from the index are skipped (no tombstone), mirroring the
+    /// single-delete guard.
     ///
     /// # Crash contract
     ///

--- a/crates/velesdb-core/src/storage/wal_cursor.rs
+++ b/crates/velesdb-core/src/storage/wal_cursor.rs
@@ -16,10 +16,10 @@
 //! # On-disk format
 //!
 //! This is an **additive read API** over the existing per-entry marker/CRC
-//! framing in [`super::wal_entry`] and [`super::log_payload`]. It introduces
-//! **no** on-disk format change: existing stored WALs remain readable, and no
-//! new header or field is written. Consumer watermarks are in-memory
-//! registration state, never a new on-disk artifact (Requirement 6.4).
+//! framing in `wal_entry` and `log_payload`. It introduces **no** on-disk
+//! format change: existing stored WALs remain readable, and no new header or
+//! field is written. Consumer watermarks are in-memory registration state,
+//! never a new on-disk artifact (Requirement 6.4).
 //!
 //! # Boundary
 //!
@@ -113,7 +113,7 @@ pub trait WalCursor {
     /// live tail (nothing durable beyond `from`). A torn tail record — one
     /// truncated by a crash mid-append — is skipped and never yielded,
     /// matching the existing sequential-replay torn-tail policy in
-    /// [`super::wal_entry`].
+    /// `wal_entry`.
     ///
     /// # Errors
     ///

--- a/crates/velesdb-core/src/storage/wal_cursor_reader.rs
+++ b/crates/velesdb-core/src/storage/wal_cursor_reader.rs
@@ -9,12 +9,11 @@
 //!
 //! # On-disk format
 //!
-//! This is a pure read API over the existing framing (see
-//! [`super::wal_entry`] and [`super::log_payload_io`]). It writes nothing and
-//! introduces no on-disk change; legacy (no-CRC) and current (CRC) frames are
-//! both read (Requirement 6.4). A torn tail — a final frame truncated by a
-//! crash mid-append — is skipped and never yielded, matching the sequential
-//! replay policy in [`super::wal_entry`].
+//! This is a pure read API over the existing framing (see `wal_entry` and
+//! `log_payload_io`). It writes nothing and introduces no on-disk change;
+//! legacy (no-CRC) and current (CRC) frames are both read (Requirement 6.4). A
+//! torn tail — a final frame truncated by a crash mid-append — is skipped and
+//! never yielded, matching the sequential replay policy in `wal_entry`.
 //!
 //! # Boundary
 //!

--- a/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
+++ b/crates/velesdb-core/src/velesql/explain/filter_strategy.rs
@@ -364,7 +364,7 @@ pub enum FilterDecisionMode {
 ///   ([`FilterStrategy::PreFilter`]). `stats` is not consulted: the
 ///   selectivity is already exact.
 /// - [`FilterDecisionMode::Estimated`] is the plan-time brain: a calibrated
-///   cost comparison guarded by [`PREFILTER_RECALL_GUARD`] when `stats` is
+///   cost comparison guarded by `PREFILTER_RECALL_GUARD` when `stats` is
 ///   available, the historical fallback threshold
 ///   ([`fallback_selectivity_threshold`]) otherwise. It never returns
 ///   [`FilterStrategy::PreFilterExact`] — without the bitmap the executor's

--- a/crates/velesdb-core/src/wire/vrb1.rs
+++ b/crates/velesdb-core/src/wire/vrb1.rs
@@ -158,7 +158,7 @@ fn decode_vectors(body: &[u8], count: usize, dim: usize) -> Vec<f32> {
 /// Decode a full VRB1 body into a [`RawBulk`].
 ///
 /// Validates the header and the exact total length before decoding, so all
-/// slice accesses in [`decode_ids`] / [`decode_vectors`] are in bounds.
+/// slice accesses in `decode_ids` / `decode_vectors` are in bounds.
 ///
 /// # Errors
 ///

--- a/crates/velesdb-memory/src/lib.rs
+++ b/crates/velesdb-memory/src/lib.rs
@@ -1,4 +1,9 @@
 #![deny(unsafe_code)]
+// Same gate as velesdb-core: these lints are warn-by-default, so #2205's 49
+// broken links accumulated without anything going red. Denying at the crate
+// root makes a plain `cargo doc` fail, not only the CI step that sets
+// `RUSTDOCFLAGS`. Kept on both published crates so the two cannot drift.
+#![deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]
 //! # VelesDB-memory
 //!
 //! Local-first **memory** layer for AI agents, exposed through a single MCP


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`docs/core-intra-doc-links` → **`develop`**. ✔

## Description

`cargo doc -p velesdb-core` emitted **30 broken-link diagnostics**. Nothing in CI built the crate's docs, so they had accumulated unseen — the same gap #2205 closed for `velesdb-memory`, this time on the crate every binding documents against.

Two distinct defects, two distinct fixes.

**Six links were unresolved.** All six sit in a module's `//!` header, and each broke for the reason #2205 identified: a `//!` header is merged into the `mod` declaration that pulls it in, and once that declaration also carries `///` docs, the merged text resolves in the **parent's** scope. The paths were correct where they were written and dangling where they were read. Fixed with reference-link definitions appended inside each `//!` block, which resolve from the crate root:

| File | Links |
|---|---|
| `conformance/mod.rs` | `check_stable_hash`, `check_rrf`, `check_executor`, `Divergence` |
| `contiguous_file_arena.rs` | `ContiguousVectors` (×2) |
| `observer/context.rs` | `DatabaseObserver` |

**Twenty-four pointed at items a reader of the public docs cannot reach** — `pub(crate)` (`save_config`, `remove_edge_detailed`, `read_gate_raw`, `RawGateOutcome`, `add_column_backfilled`, `distance_from_prepared_slice`), `pub(super)` (`resolve_hnsw_params`, `PREFILTER_RECALL_GUARD`), private modules (`storage::wal_entry`, `log_payload`, `log_payload_io`, `collection::config_serde`) and private items (`decode_ids`, `decode_vectors`, `sync_wal_or_resync`, `HnswIndex::mappings`). Each stops being a link and becomes a plain code span: the prose still names the item, it just no longer promises a page that would 404.

No sentence was rewritten and no claim changed — only link syntax and line breaks.

Two details that are easy to get wrong when demoting a link:

- **Re-wrapping.** Removing `[...]` shortens the line, and `rustfmt` cannot re-flow doc comments (`wrap_comments` is nightly-only and off here). Every affected paragraph is re-wrapped to the surrounding 79 columns rather than left with a 40-column line in the middle of it — including the seams where the edited text meets untouched lines.
- **Keeping the qualification.** ``[`Allow`](RawGateOutcome::Allow)`` becomes `` `RawGateOutcome::Allow` ``, not a bare `` `Allow` ``: a variant name with no type tells the reader nothing.

**The gate is the point of the change, not the cleanup**, and it is in two layers.

The idiomatic layer is the crate root. Both published crates now carry the inner attribute `#[deny(rustdoc::broken_intra_doc_links, rustdoc::private_intra_doc_links)]`.

These lints are **warn-by-default** — which is exactly why 30 links here and 49 in `velesdb-memory` (#2205) accumulated without anything going red. The attribute is what makes a plain `cargo doc` fail, for a contributor locally and for docs.rs, instead of only the one CI step that exports `RUSTDOCFLAGS`. Verified by reintroducing a single private link and watching an *unflagged* `cargo doc` refuse it:

```
error: public documentation for `create_graph_collection_with_embeddings`
       links to private item `Database::resolve_hnsw_params`
error: could not document `velesdb-core`
```

The second layer is CI, and it is not redundant: **an attribute cannot fire if nobody builds the docs.** A new Lint step runs `cargo doc -p velesdb-core --no-deps --all-features`, mirrored into the `AGENTS.md` pre-push sequence. `--all-features` rather than the default `persistence` set is deliberate: docs.rs serves default features only, but a gate blind to the `gpu`, `openapi` and `loom` modules cannot fail on them — the reasoning the isolated-feature step already carries (#1765). It costs the wgpu dependency build in that job.

`velesdb-memory`'s crate root gets the same one-line attribute. Its CI gate already exists (#2205); leaving the two published crates asymmetric is the kind of drift `CLAUDE.md` opens by warning about.

### Why not `[workspace.lints.rustdoc]`

It would be the tidier home, and the workspace already uses `[workspace.lints.clippy]` — but a workspace-wide deny only works if every inheriting crate is clean, so I measured instead of assuming:

| Crate | Broken links | Published to crates.io |
|---|---|---|
| `velesdb-core` | 30 → **0** | yes |
| `velesdb-memory` | 0 (fixed in #2205) | yes |
| `velesdb-cli` | 0 | — |
| `velesdb-mobile` | 0 | — |
| `velesdb-wasm` | 8 | — |
| `tauri-plugin-velesdb` | 4 | — |
| `velesdb-server` | 3 | — |
| `velesdb-migrate` | 2 | — |

17 remain, all in crates that are not published, so their rustdoc is not served by docs.rs. That is the line this PR draws: fix and gate the two crates whose docs are a public artifact, and record the remainder in the changelog as known future work rather than expanding an already 22-file change into a workspace sweep with its own verification burden.

## Type of Change

- [x] 📚 Documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

```
RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-core --no-deps --features persistence   # 30 -> 0
RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-core --no-deps --all-features           # 30 -> 0
RUSTDOCFLAGS="-D warnings" cargo doc -p velesdb-memory --no-deps --all-features         # still clean
```

Both feature sets were verified at 0 **before** the gate was wired, so the step is not being introduced red.

Because a doc comment is a published artifact in this repo, the surfaces that derive from one were re-checked rather than assumed:

- `cargo test -p velesdb-memory --test mcp_tools_drift` — **passes**; the published MCP tool descriptions derive from `velesdb-memory`, not core, so this change leaves `docs/reference/mcp-tools.json` byte-identical. (On #2205 the equivalent change *did* move four descriptions; that is why it is checked and not assumed.)
- `check-mcp-doc-contract.py`, `check-doc-contract.sh`, `check-promise-contract.py`, `check-feature-claims.py`, `check-doc-freshness.py` — all pass.
- `cargo fmt --all -- --check`, `cargo clippy -p velesdb-core --all-targets --features persistence -- -D warnings` — clean. (`clippy` does not object to the `rustdoc::` lint namespace; rustc ignores those lints outside rustdoc.)
- `python3 -m unittest discover -s scripts/tests` — passes.
- The crate-root deny proven to bite, per the mutation above.

**Test Configuration:**
- OS: Ubuntu (x86_64)
- Rust: stable toolchain pinned by `rust-toolchain.toml`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (the crate-root deny and the CI step are the test: either fails on any regression of these 30)
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Not applicable — no `unsafe` added or modified.

## High-Risk Change Checklist

Not applicable — `hnsw`, `storage` and `quantization` files are touched, but only inside doc comments. No executable line changed.

## Additional Notes

The 24 private-target links are demoted rather than made public. Promoting `pub(crate)` items to `pub` to satisfy rustdoc would widen a compatibility surface to fix a documentation defect — the wrong trade in a crate whose public API is a promise.
