### PR TITLE
ci(gates): stop npm advisories reading an outage as a vulnerability

### DIFF
--- a/.github/workflows/gate-contracts.yml
+++ b/.github/workflows/gate-contracts.yml
@@ -57,6 +57,22 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      # Not `npm audit` directly: it exits 1 for an advisory AND for an
+      # advisory endpoint that never answered, so the two were
+      # indistinguishable. On 2026-09-03 the npmjs.org bulk endpoint 503'd
+      # then timed out for eight hours and this job went red three times on
+      # `develop` reporting a vulnerability that did not exist. The gate reads
+      # the report instead of the exit code, retries only the attempts that
+      # produced no report, and still fails closed when none ever does -- with
+      # exit 75 and a message that says it is infrastructure, not a finding.
       - name: Audit ${{ matrix.path }}
-        working-directory: ${{ matrix.path }}
-        run: npm audit --package-lock-only --audit-level=high
+        run: |
+          python3 scripts/npm-audit-gate.py \
+            --root "${{ matrix.path }}" \
+            --audit-level high \
+            --attempts 4 \
+            --backoff-seconds 5 \
+            --attempt-timeout 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`npm advisories` no longer reads a registry outage as a vulnerability.**
+  `npm audit` exits 1 both when it finds an advisory and when it cannot reach
+  the advisory endpoint, and the gate ran it directly, so the two were
+  indistinguishable. On 2026-09-03 the npmjs.org bulk endpoint returned 503s
+  and then hung until npm's own five-minute network timeout for roughly eight
+  hours; the job went red three times on `develop` reporting a vulnerability
+  that did not exist — the lockfiles had not changed, and the same content had
+  been green at merge time hours earlier. `scripts/npm-audit-gate.py` now reads
+  the report (`metadata.vulnerabilities`, absent from npm's error payload)
+  instead of the exit code, retries only the attempts that produced no report
+  (four attempts, backoff 5s/10s/20s, each bounded at 120s), and still fails
+  closed when none ever does — with exit 75 (`EX_TEMPFAIL`) and a message
+  saying it is infrastructure, not a finding. An unaudited lockfile is not an
+  audited one; what changes is that the job says which of the two happened.
+  Registered in `scripts/guards.json` with a refusal vector whose accepted
+  control is an npm double that exits 1 in both states.
+
 ## [6.0.0] - 2026-09-02
 
 ### Security

--- a/scripts/guards.json
+++ b/scripts/guards.json
@@ -1227,6 +1227,52 @@
      ]
     }
    ]
+  },
+  {
+   "script": "scripts/npm-audit-gate.py",
+   "purpose": "No npm lockfile carries a high or critical advisory — and a registry that never answered is reported as infrastructure (exit 75), never as a finding.",
+   "workflow": ".github/workflows/gate-contracts.yml",
+   "job": "npm-audit",
+   "required": true,
+   "mode": "strict",
+   "self_test": "scripts.tests.test_npm_audit_gate",
+   "self_test_required": true,
+   "must_refuse": [
+    {
+     "vector": "a lockfile with a high advisory — against an npm that exits 1 in BOTH states, so the accepted control proves the gate reads the report and not the exit code that conflated the two",
+     "files": {
+      "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
+      "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 1, \"critical\": 0, \"total\": 1}}}')\nraise SystemExit(1)\n"
+     },
+     "accepts": {
+      "package-lock.json": "{\n  \"lockfileVersion\": 3\n}\n",
+      "tools/fake-npm": "#!/usr/bin/env python3\nimport sys\nsys.stdout.write('{\"auditReportVersion\": 2, \"vulnerabilities\": {}, \"metadata\": {\"vulnerabilities\": {\"info\": 0, \"low\": 0, \"moderate\": 0, \"high\": 0, \"critical\": 0, \"total\": 0}}}')\nraise SystemExit(1)\n"
+     },
+     "executable": {
+      "files": [
+       "tools/fake-npm"
+      ],
+      "accepts": [
+       "tools/fake-npm"
+      ]
+     },
+     "argv": [
+      "--root",
+      "{root}",
+      "--npm",
+      "{root}/tools/fake-npm",
+      "--attempts",
+      "1",
+      "--backoff-seconds",
+      "0"
+     ]
+    }
+   ],
+   "required_via": "gate-contracts",
+   "blind_spot": {
+    "issue": null,
+    "summary": "The vector injects an npm double, so it pins the classification and both exit codes but not npm's own report schema; an npm that renamed `metadata.vulnerabilities` would read as unreachable (exit 75, job red) rather than as silently clean — the safe direction. The unreachable branch exits 75 and so cannot be a refusal vector, which this harness defines as exit 1; scripts.tests.test_npm_audit_gate covers it end to end instead, including a hung npm cut off by --attempt-timeout."
+   }
   }
  ],
  "unwired": [

--- a/scripts/npm-audit-gate.py
+++ b/scripts/npm-audit-gate.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Fail on a vulnerable npm lockfile — and only on that.
+
+`npm audit` exits 1 both when it finds an advisory and when it cannot reach
+the registry's advisory endpoint, so the two are indistinguishable from the
+exit code alone. On 2026-09-03 the npmjs.org bulk-advisory endpoint returned
+503s and then timed out for eight hours; the `npm advisories` job went red
+three times on `develop` and every failure read as "this lockfile is
+vulnerable". None of them was: the lockfiles had not changed, and the same
+content had been green at merge time hours earlier.
+
+A transport failure is not a security verdict. It proves nothing either way,
+so this gate keeps failing closed — an unaudited lockfile is not an audited
+one — but it says which of the two happened, and it retries first so a
+transient 503 costs seconds instead of a merge window:
+
+  exit 0   the audit ran and found nothing at or above --audit-level
+  exit 1   the audit ran and found an advisory  (a real refusal)
+  exit 75  the registry stayed unreachable      (EX_TEMPFAIL, infrastructure)
+
+The discriminator is the report itself, not the exit code or a message match:
+a completed audit carries `metadata.vulnerabilities` (a per-severity count
+map). npm's failure payload — `{"message": ..., "error": {...}}` — does not.
+Matching on the shape rather than on error text keeps the classification from
+drifting with npm's wording.
+
+`--npm` exists so the refusal vectors in scripts/guards.json can inject a tool
+double and prove both branches without a network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# npm's severity ladder, weakest first. `--audit-level=high` means "high and
+# critical", so the threshold is an index into this list.
+SEVERITIES = ["info", "low", "moderate", "high", "critical"]
+
+EXIT_CLEAN = 0
+EXIT_ADVISORY = 1
+EXIT_UNREACHABLE = 75  # EX_TEMPFAIL
+
+
+class Unreachable(Exception):
+    """The audit did not run: no verdict was produced, only a transport error."""
+
+
+def severities_at_or_above(level: str) -> list[str]:
+    """The severities a given `--audit-level` is meant to catch."""
+    if level not in SEVERITIES:
+        raise ValueError(f"unknown audit level {level!r}; expected one of {SEVERITIES}")
+    return SEVERITIES[SEVERITIES.index(level) :]
+
+
+def classify(stdout: str) -> dict[str, int]:
+    """Return the per-severity counts of a completed audit.
+
+    Raises `Unreachable` for anything that is not a completed audit report —
+    unparseable output, or npm's error payload, which has no `metadata`.
+    """
+    try:
+        report = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise Unreachable(f"npm produced no JSON report ({exc})") from exc
+    if not isinstance(report, dict):
+        raise Unreachable("npm's JSON report is not an object")
+    counts = report.get("metadata", {})
+    counts = counts.get("vulnerabilities") if isinstance(counts, dict) else None
+    if not isinstance(counts, dict):
+        message = report.get("message") or "no metadata.vulnerabilities in the report"
+        raise Unreachable(str(message))
+    return {name: int(counts.get(name, 0) or 0) for name in SEVERITIES}
+
+
+def run_audit(npm: str, root: Path, timeout: float) -> str:
+    """One audit attempt. Returns stdout; the exit code is deliberately ignored.
+
+    npm exits 1 for an advisory and 1 for a dead endpoint, so the code carries
+    no information this gate can act on — `classify` reads the report instead.
+
+    The timeout is load-bearing, not a belt-and-braces default. The 2026-09-03
+    outage did not answer with a fast 503 for most of its length: the endpoint
+    accepted the connection and then hung until npm's own network timeout, five
+    minutes per call. Unbounded attempts would have turned a retry budget into
+    a twenty-minute job. A hung attempt is exactly as informative as a refused
+    one — no report — so it is raised as `Unreachable` like any other.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 - argv is built here, never shell-parsed
+            [npm, "audit", "--json", "--package-lock-only"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise Unreachable(f"npm audit produced no report within {timeout:.0f}s") from exc
+    if completed.stderr.strip():
+        print(completed.stderr.rstrip(), file=sys.stderr)
+    return completed.stdout
+
+
+def audit_with_retries(
+    npm: str,
+    root: Path,
+    attempts: int,
+    backoff_seconds: float,
+    attempt_timeout: float = 180.0,
+    sleep=time.sleep,
+) -> dict[str, int]:
+    """Audit `root`, retrying only the attempts that produced no verdict.
+
+    An advisory is a stable fact about the lockfile: it does not become false
+    on a second try, so a verdict — clean or not — returns immediately. Only
+    `Unreachable` is retried, with the delay doubling each time.
+    """
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    delay = backoff_seconds
+    last: Unreachable | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return classify(run_audit(npm, root, attempt_timeout))
+        except Unreachable as exc:
+            last = exc
+            if attempt < attempts:
+                print(
+                    f"npm audit produced no report (attempt {attempt}/{attempts}): "
+                    f"{exc} — retrying in {delay:.0f}s",
+                    file=sys.stderr,
+                )
+                sleep(delay)
+                delay *= 2
+    assert last is not None  # noqa: S101 - the loop cannot exit without setting it
+    raise last
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, help="directory holding package-lock.json")
+    parser.add_argument("--audit-level", default="high", choices=SEVERITIES)
+    parser.add_argument("--attempts", type=int, default=4)
+    parser.add_argument("--backoff-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--attempt-timeout",
+        type=float,
+        default=180.0,
+        help="seconds to let one npm audit run before treating it as unreachable",
+    )
+    parser.add_argument("--npm", default="npm", help="npm executable (injected by the refusal vectors)")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    blocking = severities_at_or_above(args.audit_level)
+
+    try:
+        counts = audit_with_retries(
+            args.npm,
+            root,
+            args.attempts,
+            args.backoff_seconds,
+            args.attempt_timeout,
+        )
+    except Unreachable as exc:
+        print(
+            f"::error::npm advisories could not be checked for {args.root}: the "
+            f"registry's advisory endpoint stayed unreachable across "
+            f"{args.attempts} attempts ({exc}). This is an infrastructure "
+            f"failure, NOT a vulnerability finding — the lockfile is unaudited, "
+            f"not known-bad. Re-run the job once the registry answers.",
+            file=sys.stderr,
+        )
+        return EXIT_UNREACHABLE
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return EXIT_ADVISORY
+
+    found = {name: counts[name] for name in blocking if counts[name] > 0}
+    if found:
+        detail = ", ".join(f"{count} {name}" for name, count in found.items())
+        print(
+            f"::error::npm advisories in {args.root}: {detail}. "
+            f"Run `npm audit` there and update the lockfile.",
+            file=sys.stderr,
+        )
+        return EXIT_ADVISORY
+
+    print(f"npm advisories clean for {args.root} (level {args.audit_level}).")
+    return EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_npm_audit_gate.py
+++ b/scripts/tests/test_npm_audit_gate.py
@@ -1,0 +1,360 @@
+"""Behavioral contract for the npm advisories gate.
+
+The gate exists because `npm audit` exits 1 for two unrelated events — an
+advisory in the lockfile, and an advisory endpoint that never answered. During
+the npmjs.org outage of 2026-09-03 the `npm advisories` job went red three
+times on `develop` with the second event while reporting the first.
+
+Every test here fails on the claim it names, not on an exception raised on the
+way to it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "npm-audit-gate.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "gate-contracts.yml"
+
+EXIT_CLEAN = 0
+EXIT_ADVISORY = 1
+EXIT_UNREACHABLE = 75
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("npm_audit_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+def _npm_audit_job() -> str:
+    """The `npm-audit:` block of gate-contracts.yml, up to the next sibling job.
+
+    Sliced on a line starting with exactly two spaces then a non-space — a
+    plain `"\\n  "` search also matches the job's own deeper-indented keys and
+    would return an empty block that trivially satisfies every assertion here.
+    """
+    workflow = WORKFLOW.read_text()
+    job = workflow[workflow.index("  npm-audit:") :]
+    following = re.search(r"\n  (?=\S)", job[1:])
+    return job[: following.start() + 1] if following else job
+
+
+def _report(**counts: int) -> str:
+    """A completed audit report carrying the given per-severity counts."""
+    severities = {name: 0 for name in gate.SEVERITIES}
+    severities.update(counts)
+    severities["total"] = sum(severities.values())
+    return json.dumps({"auditReportVersion": 2, "vulnerabilities": {}, "metadata": {"vulnerabilities": severities}})
+
+
+# npm's real payload when the advisory endpoint refuses the connection,
+# captured verbatim from `npm audit --json` against an unreachable registry.
+UNREACHABLE_PAYLOAD = json.dumps(
+    {
+        "message": (
+            "request to http://127.0.0.1:9/-/npm/v1/security/audits/quick failed, "
+            "reason: connect ECONNREFUSED 127.0.0.1:9"
+        ),
+        "error": {"summary": "", "detail": ""},
+    }
+)
+
+
+def _fake_npm(directory: Path, *, stdout: str, exit_code: int = 1, stderr: str = "") -> Path:
+    """An npm double that prints a fixed payload. Exits 1 like the real one does
+    for BOTH events, so nothing here can pass by reading the exit code."""
+    path = directory / "fake-npm"
+    path.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env python3
+            import sys
+            sys.stdout.write({stdout!r})
+            sys.stderr.write({stderr!r})
+            raise SystemExit({exit_code})
+            """
+        )
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _run(npm: Path, root: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "--npm",
+            str(npm),
+            "--backoff-seconds",
+            "0",
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_a_completed_report_yields_its_counts(self) -> None:
+        counts = gate.classify(_report(high=2, low=1))
+        self.assertEqual(2, counts["high"])
+        self.assertEqual(1, counts["low"])
+        self.assertEqual(0, counts["critical"])
+
+    def test_npms_transport_payload_is_not_a_verdict(self) -> None:
+        """The regression itself: this payload must never read as "0 vulnerabilities"
+        NOR as "vulnerabilities found" — it is not a verdict at all."""
+        with self.assertRaises(gate.Unreachable):
+            gate.classify(UNREACHABLE_PAYLOAD)
+
+    def test_unparseable_output_is_not_a_verdict(self) -> None:
+        with self.assertRaises(gate.Unreachable):
+            gate.classify("npm error code E503\n")
+
+    def test_empty_output_is_not_a_verdict(self) -> None:
+        with self.assertRaises(gate.Unreachable):
+            gate.classify("")
+
+    def test_a_report_without_metadata_is_not_a_verdict(self) -> None:
+        with self.assertRaises(gate.Unreachable):
+            gate.classify(json.dumps({"auditReportVersion": 2, "vulnerabilities": {}}))
+
+
+class SeverityLadderTests(unittest.TestCase):
+    def test_high_covers_high_and_critical_only(self) -> None:
+        self.assertEqual(["high", "critical"], gate.severities_at_or_above("high"))
+
+    def test_the_ladder_is_ordered_weakest_first(self) -> None:
+        self.assertEqual(
+            ["info", "low", "moderate", "high", "critical"], gate.SEVERITIES
+        )
+
+    def test_an_unknown_level_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            gate.severities_at_or_above("severe")
+
+
+class RetryTests(unittest.TestCase):
+    def test_a_verdict_is_not_retried(self) -> None:
+        """An advisory is a stable fact about the lockfile. Retrying it would
+        burn the backoff on every real finding."""
+        calls: list[int] = []
+
+        def run(npm, root, timeout):  # noqa: ANN001 - test double
+            calls.append(1)
+            return _report(high=1)
+
+        original = gate.run_audit
+        gate.run_audit = run
+        try:
+            counts = gate.audit_with_retries("npm", Path("."), 4, 0, sleep=lambda _: None)
+        finally:
+            gate.run_audit = original
+        self.assertEqual(1, len(calls))
+        self.assertEqual(1, counts["high"])
+
+    def test_a_transport_failure_is_retried_up_to_the_attempt_budget(self) -> None:
+        calls: list[int] = []
+
+        def run(npm, root, timeout):  # noqa: ANN001 - test double
+            calls.append(1)
+            return UNREACHABLE_PAYLOAD
+
+        original = gate.run_audit
+        gate.run_audit = run
+        try:
+            with self.assertRaises(gate.Unreachable):
+                gate.audit_with_retries("npm", Path("."), 4, 0, sleep=lambda _: None)
+        finally:
+            gate.run_audit = original
+        self.assertEqual(4, len(calls))
+
+    def test_a_recovered_endpoint_yields_its_verdict(self) -> None:
+        """The outage case that retrying is FOR: the first attempt 503s, the
+        second answers. The job must go green, not red."""
+        payloads = [UNREACHABLE_PAYLOAD, _report()]
+
+        def run(npm, root, timeout):  # noqa: ANN001 - test double
+            return payloads.pop(0)
+
+        original = gate.run_audit
+        gate.run_audit = run
+        try:
+            counts = gate.audit_with_retries("npm", Path("."), 4, 0, sleep=lambda _: None)
+        finally:
+            gate.run_audit = original
+        self.assertEqual(0, counts["high"])
+        self.assertEqual([], payloads)
+
+    def test_the_backoff_doubles_between_attempts(self) -> None:
+        delays: list[float] = []
+
+        original = gate.run_audit
+        gate.run_audit = lambda npm, root, timeout: UNREACHABLE_PAYLOAD
+        try:
+            with self.assertRaises(gate.Unreachable):
+                gate.audit_with_retries("npm", Path("."), 4, 5, sleep=delays.append)
+        finally:
+            gate.run_audit = original
+        self.assertEqual([5, 10, 20], delays)
+
+
+class ExitCodeTests(unittest.TestCase):
+    def test_a_clean_lockfile_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=_report(), exit_code=0)
+            result = _run(npm, root)
+        self.assertEqual(EXIT_CLEAN, result.returncode, result.stderr)
+
+    def test_a_high_advisory_refuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=_report(high=1))
+            result = _run(npm, root)
+        self.assertEqual(EXIT_ADVISORY, result.returncode, result.stderr)
+        self.assertIn("1 high", result.stderr)
+
+    def test_a_moderate_advisory_passes_at_the_high_level(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=_report(moderate=3))
+            result = _run(npm, root)
+        self.assertEqual(EXIT_CLEAN, result.returncode, result.stderr)
+
+    def test_a_moderate_advisory_refuses_at_the_moderate_level(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=_report(moderate=3))
+            result = _run(npm, root, "--audit-level", "moderate")
+        self.assertEqual(EXIT_ADVISORY, result.returncode, result.stderr)
+
+    def test_an_unreachable_registry_is_not_reported_as_an_advisory(self) -> None:
+        """The whole point. Same npm exit code as an advisory, different verdict,
+        different exit code, and a message that says which one happened."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=UNREACHABLE_PAYLOAD)
+            result = _run(npm, root, "--attempts", "2")
+        self.assertEqual(EXIT_UNREACHABLE, result.returncode, result.stderr)
+        self.assertNotEqual(EXIT_ADVISORY, result.returncode)
+        self.assertIn("NOT a vulnerability finding", result.stderr)
+
+    def test_an_unreachable_registry_never_passes_silently(self) -> None:
+        """Failing closed is the other half of the contract: an unaudited
+        lockfile is not an audited one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = _fake_npm(root, stdout=UNREACHABLE_PAYLOAD)
+            result = _run(npm, root, "--attempts", "1")
+        self.assertNotEqual(EXIT_CLEAN, result.returncode, result.stdout)
+
+
+class AttemptTimeoutTests(unittest.TestCase):
+    """A hung attempt must be indistinguishable from a refused one.
+
+    The outage's dominant failure was not a fast 503: the endpoint accepted the
+    connection and hung for five minutes per call. Without a per-attempt bound
+    the retry budget multiplies that instead of containing it.
+    """
+
+    HANG_SECONDS = 30
+    PATIENCE_SECONDS = 10  # generously above the 1s timeout, far below the hang
+
+    def _hanging_npm(self, directory: Path) -> Path:
+        npm = directory / "hanging-npm"
+        npm.write_text(
+            f"#!/usr/bin/env python3\nimport time\ntime.sleep({self.HANG_SECONDS})\n"
+        )
+        npm.chmod(0o755)
+        return npm
+
+    def test_a_hung_npm_is_cut_off_and_treated_as_unreachable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = self._hanging_npm(root)
+            started = time.monotonic()
+            with self.assertRaises(gate.Unreachable):
+                gate.run_audit(str(npm), root, timeout=1.0)
+            elapsed = time.monotonic() - started
+        # Without the bound the call waits out the full hang: the elapsed
+        # assertion is what makes a dropped `timeout=` fail rather than pass slowly.
+        self.assertLess(elapsed, self.PATIENCE_SECONDS)
+
+    def test_the_gate_exits_unreachable_rather_than_hanging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            npm = self._hanging_npm(root)
+            started = time.monotonic()
+            result = _run(npm, root, "--attempts", "2", "--attempt-timeout", "1")
+            elapsed = time.monotonic() - started
+        self.assertEqual(EXIT_UNREACHABLE, result.returncode, result.stderr)
+        self.assertLess(elapsed, self.PATIENCE_SECONDS)
+
+    def test_the_attempt_timeout_reaches_the_subprocess(self) -> None:
+        """`attempt_timeout` sits before `sleep` in the signature, so a
+        positional double would silently swallow it."""
+        seen: list[float] = []
+
+        def run(npm, root, timeout):  # noqa: ANN001 - test double
+            seen.append(timeout)
+            return _report()
+
+        original = gate.run_audit
+        gate.run_audit = run
+        try:
+            gate.audit_with_retries("npm", Path("."), 4, 0, 42.0, sleep=lambda _: None)
+        finally:
+            gate.run_audit = original
+        self.assertEqual([42.0], seen)
+
+
+class WiringTests(unittest.TestCase):
+    def test_the_workflow_calls_the_gate_rather_than_npm_audit_directly(self) -> None:
+        """A bare `npm audit` in the job is the defect this gate replaces; if one
+        comes back, the classification is bypassed and nothing here would notice."""
+        job = _npm_audit_job()
+        self.assertIn("scripts/npm-audit-gate.py", job)
+        self.assertNotIn("run: npm audit", job)
+
+    def test_every_audited_path_in_the_matrix_exists(self) -> None:
+        job = _npm_audit_job()
+        matrix = job[job.index("\n        path:\n") + len("\n        path:\n") :]
+        paths = []
+        for line in matrix.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("- "):
+                break
+            paths.append(stripped[2:].strip())
+        self.assertGreaterEqual(len(paths), 4)
+        for path in paths:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    (ROOT / path / "package-lock.json").is_file(),
+                    f"{path} is audited by the matrix but has no package-lock.json",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/npm-advisories-not-a-verdict` → **`develop`**. ✔

## Description

`npm audit` exits **1** for two unrelated events: an advisory in the lockfile, and an advisory endpoint that never answered. The `Gate Contracts / npm advisories` job ran it directly, so it could not tell them apart.

On 2026-09-03 the npmjs.org bulk-advisory endpoint returned 503s and then hung until npm's own five-minute network timeout, for roughly eight hours. The job went red three times on `develop`, and every failure read as *"this lockfile is vulnerable."* None of them was: the lockfiles had not changed, and the identical content had been green at merge time hours earlier.

This replaces the bare `npm audit` with `scripts/npm-audit-gate.py`, which:

1. **Reads the report, not the exit code.** A completed audit carries `metadata.vulnerabilities`; npm's failure payload (`{"message": …, "error": {…}}`) does not. Matching on the *shape* rather than on error text keeps the classification from drifting with npm's wording. The payload the tests use was captured verbatim from a real `npm audit --json` against an unreachable registry.
2. **Retries only the attempts that produced no report.** An advisory is a stable fact about the lockfile — retrying it would burn the backoff on every real finding — so a verdict returns immediately. Four attempts, backoff doubling 5s → 10s → 20s.
3. **Bounds each attempt.** `--attempt-timeout 120`. This is load-bearing, not a default for tidiness: the outage's dominant failure was a hang, not a fast 503, so an unbounded retry budget would have multiplied five minutes by four instead of containing it.
4. **Still fails closed** — an unaudited lockfile is not an audited one — but with **exit 75** (`EX_TEMPFAIL`) and a message that says it is infrastructure, not a finding:

   > `::error::npm advisories could not be checked for <path>: the registry's advisory endpoint stayed unreachable across 4 attempts (…). This is an infrastructure failure, NOT a vulnerability finding — the lockfile is unaudited, not known-bad.`

The gate is registered in `scripts/guards.json` (`required`, `strict`, `required_via: gate-contracts`) with a refusal vector and a self-test, per the registry contract.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

**`scripts/tests/test_npm_audit_gate.py` — 23 tests**, covering classification, the severity ladder, retry policy, the per-attempt timeout, every exit code, and the workflow wiring.

**Mutation-tested: 15 mutants, all dead, every one on an assertion rather than an exception.**

| # | Mutation | Killed by |
|---|---|---|
| M1 | a report with no `metadata.vulnerabilities` reads as all-zeros | `test_npms_transport_payload_is_not_a_verdict` |
| M2 | `severities_at_or_above` excludes the level itself | `test_high_covers_high_and_critical_only` |
| M3 | a verdict is retried like a transport failure | `test_a_verdict_is_not_retried` |
| M4 | the backoff stays flat instead of doubling | `test_the_backoff_doubles_between_attempts` |
| M5 | an unreachable registry passes the gate | `test_an_unreachable_registry_never_passes_silently` |
| M6 | an unreachable registry is reported as an advisory *(the defect itself)* | `test_an_unreachable_registry_is_not_reported_as_an_advisory` |
| M7 | the audit level is ignored: every severity blocks | `test_a_moderate_advisory_passes_at_the_high_level` |
| M8 | only one attempt is ever made | `test_a_transport_failure_is_retried_up_to_the_attempt_budget` |
| M9a | the workflow stops naming the gate | `test_the_workflow_calls_the_gate_rather_than_npm_audit_directly` |
| M9b | a bare `npm audit` comes back into the job | *(same)* |
| M9c | a matrix path with no lockfile | `test_every_audited_path_in_the_matrix_exists` |
| M10 | `run_audit` drops the per-attempt timeout | `test_a_hung_npm_is_cut_off_and_treated_as_unreachable` |
| M11 | the timeout is not passed through | `test_the_attempt_timeout_reaches_the_subprocess` |
| M12 | a hung attempt is reported as a clean audit | `test_a_hung_npm_is_cut_off_and_treated_as_unreachable` |
| M13 | the CLI ignores `--attempt-timeout` | `test_the_gate_exits_unreachable_rather_than_hanging` |

M10 and M12 needed a **wall-clock** assertion, not just an exception one: a dropped `timeout=` does not make those tests fail, it makes them pass slowly. The tests bound elapsed time below the fake npm's hang.

**Refusal vector** (`scripts/guards.json`), executed by `test_guard_refusal_vectors.py`: a lockfile with one high advisory against an npm double that exits **1 in both states**. The accepted control is what carries the claim — the gate returns 0 on the clean report while npm still exits 1, which is exactly the conflation being fixed.

```
files    -> exit 1 (expected 1)  OK   ::error::npm advisories in …: 1 high.
accepts  -> exit 0 (expected 0)  OK   npm advisories clean for … (level high).
```

**End-to-end against the live registry**, all four matrix paths clean — and one of them reproduced the outage's exact failure mode on the way:

```
npm audit produced no report (attempt 1/3): npm audit produced no report within 60s — retrying in 3s
npm advisories clean for examples/react-wasm-search (level high).
```

The first attempt hung, was cut off, the second answered. Under the previous inline `npm audit` that run had no bound at all: two of the four paths were still hanging when a 300s wrapper killed them.

Also run: `test_ci_gate_reachability` (97 tests), `test_guard_refusal_vectors` (8), the full `scripts/tests` suite, and `yaml.safe_load` on the workflow.

**Test Configuration:**
- OS: Ubuntu (x86_64)
- npm 10.9.7 / Node 22

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Unsafe Code Checklist

Not applicable — no Rust changed.

## High-Risk Change Checklist

Not applicable.

## Additional Notes

The gate deliberately does **not** become permissive during an outage. Softening a security gate so it goes green when it cannot check would trade a visible false alarm for an invisible blind spot. What changes is that the job now tells the truth about which of the two happened, and that a transient 503 costs seconds instead of a merge window.

Known limit, recorded in the registry's `blind_spot`: the vector injects an npm double, so it pins the classification and both exit codes but not npm's own report schema. An npm that renamed `metadata.vulnerabilities` would read as unreachable (exit 75, job red) rather than as silently clean — the safe direction.
