### PR TITLE
fix(node): let this crate's tests link on macOS

### DIFF
--- a/crates/velesdb-node/build.rs
+++ b/crates/velesdb-node/build.rs
@@ -3,4 +3,27 @@
 
 fn main() {
     napi_build::setup();
+    emit_macos_link_args();
+}
+
+/// Lets this crate's test binaries link on macOS.
+///
+/// `napi_build::setup()` emits `rustc-cdylib-link-arg`, which reaches the
+/// cdylib and nothing else. A test binary links the same `napi` rlib but
+/// resolves its own symbols, and the Node-API entry points it pulls in
+/// (`_napi_reference_unref` and friends) come from the Node executable at load
+/// time, never from a library — so ld64 reports them undefined and refuses the
+/// link. Without this, `cargo test` fails for the whole workspace on macOS
+/// even when nothing in this crate is under test.
+///
+/// `rustc-link-arg` is scoped to this package's own targets, which here are
+/// the cdylib and its tests. The same two flags in `.cargo/config.toml` would
+/// let *every* macOS binary in the workspace link with unresolved symbols,
+/// trading a real compile-time check for a runtime crash somewhere else.
+fn emit_macos_link_args() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+    println!("cargo::rustc-link-arg=-undefined");
+    println!("cargo::rustc-link-arg=dynamic_lookup");
 }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`fix/*` → targets `develop`. ✅

## Description

`cargo test` fails to link on macOS (`aarch64-apple-darwin`) for the **whole
workspace**, not just this crate:

```
"_napi_reference_unref", referenced from:
    napi::error::release_error_reference in libnapi.rlib
ld: symbol(s) not found for architecture arm64
error: could not compile `velesdb-node` (lib test)
```

`napi_build::setup()` emits `rustc-cdylib-link-arg`, which reaches the cdylib
and nothing else. The test binary links the same `napi` rlib but resolves its
own symbols, and the Node-API entry points it pulls in come from the Node
executable at load time, never from a library — so ld64 reports them undefined
and refuses the link.

The practical cost is that the `velesdb-core` pre-commit hook runs the test
suite, so **every local commit on macOS is blocked**, whatever it touches. CI
never sees it: the Node binding job is path-filtered.

### Why the build script rather than `.cargo/config.toml`

`rustc-link-arg` is scoped to this package's own targets — here the cdylib and
its tests. Putting `-undefined dynamic_lookup` in `.cargo/config.toml` would
let *every* macOS binary in the workspace link with unresolved symbols, trading
a real compile-time check for a runtime crash somewhere else.

`rustc-link-arg-tests` would be narrower still, but cargo 1.90 rejects it as an
unknown instruction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Red then green on `aarch64-apple-darwin`, same command both times:

| tree | `cargo test -p velesdb-node` |
|---|---|
| `develop` | fails at link — `symbol(s) not found for architecture arm64` |
| this branch | `test result: ok. 5 passed; 0 failed` |

The full `velesdb-core` pre-commit sequence (fmt, clippy, tests, SAFETY, TODO
governance, secrets) passes on this branch, which is the point of the change.

Non-macOS targets are untouched: the build script returns early unless
`CARGO_CFG_TARGET_OS` is `macos`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
