### PR TITLE
perf(persistence): write each vector's bytes in one call, not one per f32

### DIFF
--- a/crates/velesdb-core/Cargo.toml
+++ b/crates/velesdb-core/Cargo.toml
@@ -62,10 +62,11 @@ optional = true
 version = "1.0"
 optional = true
 
+# Non-optional: `cast_slice` is on the `.vectors` dump path, which every build
+# reaches. The `derive` feature stays behind `gpu` so a non-GPU build does not
+# pull in the proc-macro for `Pod`/`Zeroable` impls it never writes.
 [dependencies.bytemuck]
 version = "1.14"
-features = ["derive"]
-optional = true
 
 [dependencies.half]
 version = "2.4"
@@ -110,7 +111,7 @@ version = "2.7"
 ## - `loom`: Enables loom-based concurrency testing (nightly only).
 ##   Run with: `cargo +nightly test --features loom --test loom_tests`
 default = ["persistence"]
-gpu = ["wgpu", "pollster", "bytemuck"]
+gpu = ["wgpu", "pollster", "bytemuck/derive"]
 internal-bench = []
 ## Enables the standardized SIFT1M ANN benchmark
 ## (`cargo bench -p velesdb-core --bench sift1m_recall --features bench-sift1m`).

--- a/crates/velesdb-core/benches/persistence_save_scale.rs
+++ b/crates/velesdb-core/benches/persistence_save_scale.rs
@@ -56,35 +56,34 @@
 //!
 //! # What has already been measured, so it is not re-derived
 //!
-//! `write_vector_data` (`native/graph_io.rs`) writing one `write_all` per
-//! `f32` looks like the obvious thing to fix. The obvious fix does not work.
-//! Measured on this instrument at 5 000 nodes x 3072d — 58.6 MiB of payload,
-//! two separate runs per variant:
+//! `write_vector_data` (`native/graph_io.rs`) used to write one `write_all`
+//! per `f32`. Measured on this instrument at 5 000 nodes by 3072d — 58.6 MiB
+//! of payload, two separate runs per variant:
 //!
 //! | variant | run 1 | run 2 |
 //! |---|---|---|
-//! | as shipped: one `write_all` per `f32` | 80.5 ms | 89.3 ms |
+//! | one `write_all` per `f32` (before) | 80.5 ms | 89.3 ms |
 //! | reusable row buffer, still `to_le_bytes` per value | 89.3 ms | 91.0 ms |
-//! | reinterpret `&[f32]` as `&[u8]`, one `write_all` per vector | 61.4 ms | 62.7 ms |
+//! | hand-written `from_raw_parts` reinterpret | 61.4 ms | 62.7 ms |
+//! | `bytemuck::cast_slice` per vector (shipped) | 56.0 ms | 55.5 ms |
 //!
-//! The middle row is the trap, and it is worth understanding before trying it
-//! again: it removes the per-value `write_all` but keeps the per-value
-//! `to_le_bytes`, and `extend_from_slice` pays the same capacity check and
-//! four-byte copy that `BufWriter` did. It then adds a full copy of each row
-//! into the writer. The cost was relocated and one copy was added, so the
-//! result is neutral at best.
+//! The second row is the trap, and it is worth understanding before anyone
+//! tries it again: grouping the writes *looks* like the fix and is
+//! neutral-to-worse. It removes the per-value `write_all` but keeps the
+//! per-value `to_le_bytes` — `extend_from_slice` pays the same capacity check
+//! and four-byte copy — and then adds a full row copy into the writer. The
+//! cost was relocated and one copy was added.
 //!
-//! The bottom row is real: ~27 % off the whole `save()`, and ~1.7x on the
-//! vector dump alone once the ~29 ms graph-and-sidecar constant is subtracted.
-//! It is not shipped, because it needs either an `unsafe` reinterpret or
-//! `bytemuck` promoted to a non-optional dependency, plus a `target_endian`
-//! fallback so `.vectors` stays portable — a trade to decide deliberately
-//! rather than fold into a benchmark.
+//! What actually pays is removing the per-value conversion, which on a
+//! little-endian target is a reinterpret. That is ~34 % off the whole call and
+//! ~2.1x on the dump alone once the ~29 ms graph-and-sidecar constant is
+//! subtracted: 1 046 MiB/s becomes 2 186 MiB/s.
 //!
-//! Read those figures against the noise floor: at 768d the *same binary*
-//! spread 20 % between two runs, because the vector dump is then a minority of
-//! `save()` and machine noise on the whole call swamps it. 3072d is where this
-//! instrument starts being able to arbitrate on a machine that is not idle.
+//! Read those figures against the noise floor. At 768d the *same binary*
+//! spread 20 % between two runs, because the vector dump is a minority of
+//! `save()` there and machine noise on the whole call swamps it. At 3072d the
+//! shipped variant reproduced to 0.9 %, which is what makes a 34 % claim
+//! decidable at all. Anything measured at 768d on a busy machine is not.
 //!
 //! # Sizing
 //!

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -146,14 +146,33 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     }
 
     /// Writes all vector values sequentially to the writer.
+    ///
+    /// On a little-endian target the arena's `&[f32]` already *is* the on-disk
+    /// representation, so each vector goes out as one `write_all` over its
+    /// bytes. The previous shape wrote one `write_all` per `f32` — 15.4 million
+    /// calls at 20 000 nodes by 768 dimensions — and `persistence_save_scale`
+    /// measured that difference at ~27 % of the whole `save()`.
+    ///
+    /// Big-endian keeps the per-value conversion. `.vectors` is explicitly
+    /// little-endian, and that portability is exactly the property the
+    /// native-endian arena beside it gives up on purpose; reinterpreting here
+    /// would quietly take it away too.
+    ///
+    /// `bytemuck::cast_slice` rather than a hand-written reinterpret: `f32` to
+    /// `u8` is sound but the soundness argument belongs in a crate that states
+    /// it once, not in an `unsafe` block on a serialization loop.
     fn write_vector_data(
         writer: &mut BufWriter<File>,
         vectors: &crate::perf_optimizations::ContiguousVectors,
     ) -> std::io::Result<()> {
         for i in 0..vectors.len() {
             if let Some(vec) = vectors.get(i) {
-                for &val in vec {
-                    writer.write_all(&val.to_le_bytes())?;
+                if cfg!(target_endian = "little") {
+                    writer.write_all(bytemuck::cast_slice(vec))?;
+                } else {
+                    for &val in vec {
+                        writer.write_all(&val.to_le_bytes())?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`perf/*` → targets `develop`. ✅

## Description

`write_vector_data` wrote **one `write_all` per `f32`** — 15.4 million calls at
20 000 nodes by 768 dimensions, each paying `BufWriter`'s capacity check and
bookkeeping to move four bytes, for a buffer that was already contiguous.

On a little-endian target the arena's `&[f32]` *is* the on-disk representation,
so each vector now goes out as one `write_all` over its bytes.

Big-endian keeps the per-value conversion, and that is not decoration:
`.vectors` is explicitly little-endian, and that portability is exactly the
property the native-endian arena beside it gives up on purpose —
`contiguous_file_arena.rs` already warns that "anything that later maps that
file directly inherits this constraint and must gate on `target_endian`".

## Measurements

On `persistence_save_scale` (merged in #2211) at 5 000 nodes by 3072d — 58.6 MiB
of payload, two **separate runs** per variant:

| variant | run 1 | run 2 |
|---|---|---|
| before: one `write_all` per `f32` | 80.5 ms | 89.3 ms |
| reusable row buffer, still `to_le_bytes` per value | 89.3 ms | 91.0 ms |
| hand-written `from_raw_parts` reinterpret | 61.4 ms | 62.7 ms |
| **`bytemuck::cast_slice` (this PR)** | **56.0 ms** | **55.5 ms** |

**~34 % off the whole `save()`**, and **~2.1x on the dump alone** once the
~29 ms graph-and-sidecar constant is subtracted: 1 046 MiB/s becomes
2 186 MiB/s. The two runs of the shipped variant agree to **0.9 %**, comfortably
inside a 34 % effect.

### Two variants measured and rejected

Both are kept in the instrument's module docs with their numbers, so the next
reader does not re-derive them:

- **A reusable row buffer is neutral-to-worse.** It looks like the fix. It
  removes the per-value `write_all` but keeps the per-value `to_le_bytes` —
  `extend_from_slice` pays the same capacity check and four-byte copy — and
  then adds a full row copy into the writer. The cost was relocated and one
  copy was added.
- **A hand-written `from_raw_parts` reinterpret measured no better** than
  `cast_slice`, so it buys nothing for the `unsafe` it costs.

### On the noise floor

At 768d the *same binary* spread 20 % between two runs, because the vector dump
is a minority of `save()` there. Every figure above is at 3072d, where the
payload dominates the constant and the measurement can actually arbitrate.

## The dependency change

`bytemuck` becomes **non-optional**, because this path is in every build. Its
`derive` feature moves behind `gpu`:

```toml
[dependencies.bytemuck]
version = "1.14"

gpu = ["wgpu", "pollster", "bytemuck/derive"]
```

So a non-GPU build gains `cast_slice` without pulling in the proc-macro for the
`Pod`/`Zeroable` impls it never writes.

`cast_slice` rather than a hand-written reinterpret is deliberate: `f32` to `u8`
is sound, but the soundness argument belongs in a crate that states it once
rather than in an `unsafe` block on a serialization loop.

## Type of Change

- [x] ⚡ Performance improvement (non-breaking)

## How Has This Been Tested?

The on-disk bytes are unchanged — same little-endian layout, same offsets, same
header — so the existing `.vectors` round-trip coverage is the regression test
and it passes unchanged.

Both feature surfaces were checked locally, because the dependency move is the
real risk here rather than the performance:

- `cargo check -p velesdb-core --no-default-features` — clean (the WASM surface,
  where `bytemuck` had never been compiled before).
- `cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` — clean (where the `Pod`/`Zeroable` derives live, which moving the `derive` feature could have broken).

Plus the full `velesdb-core` pre-commit sequence.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
