### PR TITLE
feat(persistence): .vectors v2 — page-aligned payload, v1 still read

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -9,7 +9,7 @@ use super::distance::DistanceEngine;
 use super::graph::{NativeHnsw, DEFAULT_ALPHA, NO_ENTRY_POINT};
 use super::layer::Layer;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 /// Hard ceiling on layer counts read from an untrusted graph file,
@@ -29,6 +29,55 @@ const MAX_NEIGHBORS_PER_NODE: usize = 1 << 20;
 ///   a custom alpha survives the save/load round-trip instead of silently
 ///   resetting to the default.
 const GRAPH_FORMAT_VERSION: u32 = 2;
+
+/// Current `.vectors` file format version, written on every dump.
+///
+/// - v1: the payload starts immediately after the header, at byte 16.
+/// - v2: the payload starts at [`VECTORS_V2_DATA_OFFSET`], so the file can be
+///   mapped directly as the graph's f32 arena instead of being deserialized
+///   into a second copy of the same bytes (#2173).
+///
+/// Both are read; only v2 is written.
+const VECTORS_FORMAT_VERSION: u32 = 2;
+
+/// Bytes every `.vectors` version spends on its header fields:
+/// version(4) + count(8) + dimension(4).
+const VECTORS_HEADER_BYTES: u64 = 16;
+
+/// Byte offset at which a v2 payload begins.
+///
+/// Frozen here rather than derived from the arena's `DATA_OFFSET`. This is an
+/// **on-disk** offset: deriving it would silently relocate the payload of every
+/// file already written, the day that constant moves. The assertion below is
+/// the link instead — if the arena's alignment requirement ever outgrows this,
+/// the build fails and the format gets a deliberate v3 rather than drifting.
+const VECTORS_V2_DATA_OFFSET: u64 = 4096;
+
+/// Zero bytes written between the v2 header fields and the payload.
+const VECTORS_V2_PAD_BYTES: usize = (VECTORS_V2_DATA_OFFSET - VECTORS_HEADER_BYTES) as usize;
+
+// The arena hands out `&[f32]` built with `slice::from_raw_parts`, whose
+// contract requires proper alignment; `DATA_OFFSET` is where it starts its data
+// region to satisfy that by construction. A v2 payload beginning before it
+// could not be mapped as an arena, which is the entire point of the version.
+#[cfg(feature = "persistence")]
+const _: () = assert!(
+    VECTORS_V2_DATA_OFFSET >= crate::contiguous_file_arena::DATA_OFFSET as u64,
+    "a v2 .vectors payload must start at or past the arena data offset"
+);
+const _: () = assert!(VECTORS_V2_DATA_OFFSET > VECTORS_HEADER_BYTES);
+
+/// Byte offset of the payload for a given `.vectors` format version.
+///
+/// Only versions the reader accepts reach this; anything else is rejected by
+/// `read_vectors_header` before an offset is ever needed.
+const fn vectors_data_offset(version: u32) -> u64 {
+    if version == 1 {
+        VECTORS_HEADER_BYTES
+    } else {
+        VECTORS_V2_DATA_OFFSET
+    }
+}
 
 /// Builds an `InvalidData` I/O error with the given message.
 fn corrupt(msg: impl Into<String>) -> std::io::Error {
@@ -132,16 +181,23 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         Ok(count)
     }
 
-    /// Writes the vectors file header (version, count, dimension).
+    /// Writes the vectors file header — version, count, dimension — followed by
+    /// zero padding out to the v2 payload offset.
+    ///
+    /// The padding is not waste. It is what lets the payload start page-aligned,
+    /// which is the precondition for mapping this file as the graph's arena
+    /// (#2173) rather than reading it into a second copy. Until a later version
+    /// claims part of it for header fields, it is reserved and zero-filled, so
+    /// that version can tell an unset field from a set one.
     fn write_vectors_header(
         writer: &mut BufWriter<File>,
         count: u64,
         dimension: u32,
     ) -> std::io::Result<()> {
-        let version: u32 = 1;
-        writer.write_all(&version.to_le_bytes())?;
+        writer.write_all(&VECTORS_FORMAT_VERSION.to_le_bytes())?;
         writer.write_all(&count.to_le_bytes())?;
         writer.write_all(&dimension.to_le_bytes())?;
+        writer.write_all(&[0u8; VECTORS_V2_PAD_BYTES])?;
         Ok(())
     }
 
@@ -378,16 +434,21 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         let file_len = file.metadata()?.len();
         let mut reader = BufReader::new(file);
 
-        let (count, dimension) = Self::read_vectors_header(&mut reader)?;
+        let (version, count, dimension) = Self::read_vectors_header(&mut reader)?;
         if count == 0 || dimension == 0 {
             return Ok((None, 0));
         }
+        let data_offset = vectors_data_offset(version);
 
         // Validate the declared payload size against the actual file length
         // BEFORE allocating `count * dimension` floats. A corrupt/malicious
         // header could otherwise request a multi-gigabyte allocation that the
-        // file cannot possibly back. Header = version(4) + count(8) + dim(4).
-        Self::validate_vectors_file_len(count, dimension, file_len)?;
+        // file cannot possibly back.
+        Self::validate_vectors_file_len(count, dimension, file_len, data_offset)?;
+
+        // v1 leaves the reader exactly here; v2 has reserved padding to skip.
+        // Seeking unconditionally keeps one path rather than two.
+        reader.seek(SeekFrom::Start(data_offset))?;
 
         let storage = Self::read_vector_data(&mut reader, count, dimension, arena_home)?;
         Ok((Some(storage), count))
@@ -395,18 +456,23 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 
     /// Rejects vector headers whose declared `count * dimension * 4` payload
     /// cannot fit in the actual file (guards untrusted allocations / OOB).
+    ///
+    /// `data_offset` comes from the file's own version — see
+    /// [`vectors_data_offset`]. Hard-coding it would make a v2 file look 4 080
+    /// bytes larger than it is, which is only slack here but becomes a real
+    /// under-read the day this bound is used to size a mapping.
     fn validate_vectors_file_len(
         count: usize,
         dimension: usize,
         file_len: u64,
+        data_offset: u64,
     ) -> std::io::Result<()> {
-        const HEADER_BYTES: u64 = 16; // version(4) + count(8) + dimension(4)
         let payload = (count as u64)
             .checked_mul(dimension as u64)
             .and_then(|n| n.checked_mul(4))
             .ok_or_else(|| corrupt("vector payload size overflows u64"))?;
         let expected = payload
-            .checked_add(HEADER_BYTES)
+            .checked_add(data_offset)
             .ok_or_else(|| corrupt("vector file size overflows u64"))?;
         if file_len < expected {
             return Err(corrupt(format!(
@@ -417,14 +483,20 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         Ok(())
     }
 
-    /// Reads and validates the vectors file header, returning `(count, dimension)`.
-    fn read_vectors_header(reader: &mut BufReader<File>) -> std::io::Result<(usize, usize)> {
+    /// Reads and validates the vectors file header, returning
+    /// `(version, count, dimension)`.
+    ///
+    /// v1 is still accepted: it is what every index written before #2173 holds,
+    /// and its only difference is where the payload starts. The version travels
+    /// back to the caller because that offset is not derivable from anything
+    /// else in the file.
+    fn read_vectors_header(reader: &mut BufReader<File>) -> std::io::Result<(u32, usize, usize)> {
         let mut buf4 = [0u8; 4];
         let mut buf8 = [0u8; 8];
 
         reader.read_exact(&mut buf4)?;
         let version = u32::from_le_bytes(buf4);
-        if version != 1 {
+        if version != 1 && version != VECTORS_FORMAT_VERSION {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("Unsupported version: {version}"),
@@ -436,7 +508,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         reader.read_exact(&mut buf4)?;
         let dimension = u32::from_le_bytes(buf4) as usize;
 
-        Ok((count, dimension))
+        Ok((version, count, dimension))
     }
 
     /// Reads `count` vectors of `dimension` from the reader into contiguous storage.
@@ -721,3 +793,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 #[cfg(test)]
 #[path = "load_bound_tests.rs"]
 mod load_bound_tests;
+
+#[cfg(test)]
+#[path = "vectors_format_tests.rs"]
+mod vectors_format_tests;

--- a/crates/velesdb-core/src/index/hnsw/native/load_bound_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/load_bound_tests.rs
@@ -16,7 +16,7 @@ fn validate_vectors_file_len_accepts_large_file_backed_count() {
     let payload = count * dimension as u64 * 4;
     let file_len = payload + HEADER; // file genuinely holds the data
     assert!(
-        H::validate_vectors_file_len(count as usize, dimension, file_len).is_ok(),
+        H::validate_vectors_file_len(count as usize, dimension, file_len, HEADER).is_ok(),
         "a file-backed large count must load, regardless of the alloc backstop"
     );
 }
@@ -28,7 +28,7 @@ fn validate_vectors_file_len_rejects_short_file() {
     let dimension = 128usize;
     let count = 1_000_000usize;
     // File is only 100 bytes — cannot back the declared payload.
-    let err = H::validate_vectors_file_len(count, dimension, 100)
+    let err = H::validate_vectors_file_len(count, dimension, 100, 16)
         .expect_err("file shorter than declared payload must be rejected");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
 }
@@ -37,7 +37,7 @@ fn validate_vectors_file_len_rejects_short_file() {
 /// rather than wrapping to a small accepted size.
 #[test]
 fn validate_vectors_file_len_rejects_overflow_header() {
-    let err = H::validate_vectors_file_len(usize::MAX, usize::MAX, u64::MAX)
+    let err = H::validate_vectors_file_len(usize::MAX, usize::MAX, u64::MAX, 16)
         .expect_err("overflow-class payload must be rejected");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
 }

--- a/crates/velesdb-core/src/index/hnsw/native/vectors_format_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/vectors_format_tests.rs
@@ -1,0 +1,130 @@
+//! On-disk format tests for `{basename}.vectors`.
+//!
+//! The payload moved from byte 16 to byte 4096 in v2 (#2173), so two things
+//! need holding down: a file written before that change must still load, and
+//! a file written after it must actually be page-aligned. Neither is covered
+//! by the save/load round-trip tests, which only ever see the version the
+//! current binary writes.
+
+use super::super::distance::CachedSimdDistance;
+use super::NativeHnsw;
+use crate::distance::DistanceMetric;
+use std::io::Write;
+use tempfile::tempdir;
+
+type H = NativeHnsw<CachedSimdDistance>;
+
+/// Writes a v1 `.vectors` file by hand: the payload starts at byte 16, with
+/// no padding. This is the layout of every index persisted before v2.
+fn write_v1_vectors_file(path: &std::path::Path, vectors: &[Vec<f32>]) {
+    let dimension = vectors[0].len();
+    let mut file = std::fs::File::create(path).expect("test: create");
+    file.write_all(&1u32.to_le_bytes()).expect("test: version");
+    file.write_all(&(vectors.len() as u64).to_le_bytes())
+        .expect("test: count");
+    file.write_all(&(dimension as u32).to_le_bytes())
+        .expect("test: dimension");
+    for vector in vectors {
+        for value in vector {
+            file.write_all(&value.to_le_bytes()).expect("test: payload");
+        }
+    }
+}
+
+/// A `.vectors` file written before v2 must still load, byte for byte.
+///
+/// Without this, every database persisted by an earlier binary fails to open
+/// with `Unsupported version` — the loudest possible regression, and one the
+/// round-trip tests cannot see because they only exercise the version the
+/// current binary writes.
+#[test]
+fn v1_vectors_file_still_loads() {
+    // Arrange
+    let dir = tempdir().expect("test: tempdir");
+    let path = dir.path().join("legacy.vectors");
+    let vectors = vec![vec![1.0f32, 2.0, 3.0, 4.0], vec![-5.5f32, 0.0, 7.25, 8.0]];
+    write_v1_vectors_file(&path, &vectors);
+
+    // Act
+    let (storage, count) = H::load_vectors_file(&path, None).expect("test: load v1");
+
+    // Assert
+    assert_eq!(count, 2);
+    let storage = storage.expect("test: v1 file must yield storage");
+    for (i, expected) in vectors.iter().enumerate() {
+        assert_eq!(
+            storage.get(i).expect("test: vector present"),
+            expected.as_slice(),
+            "v1 vector {i} did not survive the load"
+        );
+    }
+}
+
+/// A freshly dumped `.vectors` file declares v2 and starts its payload on a
+/// page boundary, with the reserved gap zeroed.
+///
+/// The alignment is the whole reason v2 exists: the arena hands out `&[f32]`
+/// built with `slice::from_raw_parts`, so a payload that did not start aligned
+/// could not be mapped as one. The zero-fill is what lets a later version tell
+/// an unset reserved field from a set one.
+#[test]
+fn dumped_vectors_file_is_v2_and_page_aligned() {
+    // Arrange
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    for i in 0..3 {
+        hnsw.insert(&[i as f32; 4]).expect("test: insert");
+    }
+    let dir = tempdir().expect("test: tempdir");
+    hnsw.file_dump(dir.path(), "aligned").expect("test: dump");
+
+    // Act
+    let bytes = std::fs::read(dir.path().join("aligned.vectors")).expect("test: read back");
+
+    // Assert
+    assert_eq!(
+        u32::from_le_bytes(bytes[0..4].try_into().expect("test: version bytes")),
+        2,
+        "the dump must declare v2"
+    );
+    assert!(
+        bytes[16..4096].iter().all(|&b| b == 0),
+        "the reserved gap between header and payload must be zero-filled"
+    );
+    assert_eq!(
+        bytes.len(),
+        4096 + 3 * 4 * std::mem::size_of::<f32>(),
+        "the payload must start at 4096, with nothing between it and the header"
+    );
+}
+
+/// The round trip through the current writer and reader agrees on the offset.
+#[test]
+fn v2_dump_reloads_its_own_vectors() {
+    // Arrange
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    for i in 0..5 {
+        hnsw.insert(&[i as f32 * 1.5; 4]).expect("test: insert");
+    }
+    let dir = tempdir().expect("test: tempdir");
+    hnsw.file_dump(dir.path(), "roundtrip").expect("test: dump");
+
+    // Act
+    let (storage, count) =
+        H::load_vectors_file(&dir.path().join("roundtrip.vectors"), None).expect("test: load v2");
+
+    // Assert: the values, not just the count — a reader that skipped to the
+    // wrong offset would hand back the zeroed reserved gap and still report
+    // five vectors.
+    assert_eq!(count, 5);
+    let storage = storage.expect("test: v2 file must yield storage");
+    for i in 0..5 {
+        let expected = [i as f32 * 1.5; 4];
+        assert_eq!(
+            storage.get(i).expect("test: vector present"),
+            expected.as_slice(),
+            "v2 vector {i} did not survive the round trip"
+        );
+    }
+}

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -102,6 +102,35 @@ let loaded = NativeHnswIndex::load("./my_index", 768, DistanceMetric::Cosine)?;
 | `save(path)` | Save index to disk |
 | `load(path, dim, metric)` | Load index from disk |
 
+#### `.vectors` on-disk layout
+
+| bytes | field |
+|---|---|
+| 0..4 | format version, `u32` LE |
+| 4..12 | vector count, `u64` LE |
+| 12..16 | dimension, `u32` LE |
+| 16..*data_offset* | reserved, zero-filled (v2 only) |
+| *data_offset*.. | `count * dimension` values, `f32` LE |
+
+`data_offset` is **16 in v1** and **4096 in v2**. Both versions are read; only
+v2 is written.
+
+The v2 gap is not padding for its own sake. The graph's f32 arena hands out
+`&[f32]` built with `slice::from_raw_parts`, whose contract requires proper
+alignment, so a payload starting at byte 16 could never be mapped as one. v2
+moves it to a page boundary, which is the precondition for retiring the
+duplicate arena copy entirely (#2173). Until a later version claims part of the
+gap for header fields, it is zero-filled so that version can tell an unset field
+from a set one.
+
+The payload is explicitly little-endian on every target — `.vectors` is
+portable, unlike the native-endian arena file beside it, and anything that later
+maps it directly inherits that constraint and must gate on `target_endian`.
+
+**Compatibility runs one way.** A current binary reads v1 and v2; a binary from
+before v2 rejects a v2 file with `Unsupported version: 2`. Downgrading past this
+change therefore requires re-persisting the index.
+
 #### Load-time validation (untrusted file safety)
 
 A persisted index is treated as **untrusted input**. `load` validates the


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → targets `develop`. ✅

First of the three PRs for #2173. **The format moves here; nothing is mapped yet.**

## Description

The `.vectors` payload started at byte 16, immediately after
`version(4) + count(8) + dimension(4)`. The arena that holds those same floats
at runtime starts its data region at **4096**, and that offset is a soundness
requirement rather than a preference: `ContiguousVectors` hands out `&[f32]`
built with `slice::from_raw_parts`, whose contract requires proper alignment.

So the file could never be mapped as the arena, and #2173 — retiring the
duplicate copy and its second write per collection lifetime — could not begin.
v2 moves the payload to 4096 and zero-fills the gap.

The header fields are unchanged and at the same offsets, so the corruption
probes that patch `count` in place keep working untouched.

### v1 is still read, and that is the part with teeth

Every index persisted by an earlier binary would otherwise fail to open with
`Unsupported version` — and `.vectors` had **no version-compat path at all**,
unlike `.graph` which carries `GRAPH_FORMAT_VERSION` and a real v1/v2 branch.

`read_vectors_header` now returns the version, `vectors_data_offset` maps it to
an offset, and the loader seeks there. Unconditionally, so v1 and v2 share one
path rather than growing two.

`validate_vectors_file_len` takes the offset for the same reason: hard-coding
16 makes a v2 file look 4 080 bytes larger than it is — only slack for a bound,
but a real under-read the day it sizes a mapping.

### Why the offset is frozen rather than derived

`VECTORS_V2_DATA_OFFSET = 4096` is **not** derived from the arena's
`DATA_OFFSET`, and that is deliberate — the opposite call from #2182, where
tying two constants together was the right answer.

This one is an **on-disk** offset. Deriving it would silently relocate the
payload of every file already written, the day that constant moves. A
compile-time assertion is the link instead:

```rust
#[cfg(feature = "persistence")]
const _: () = assert!(
    VECTORS_V2_DATA_OFFSET >= crate::contiguous_file_arena::DATA_OFFSET as u64,
    "a v2 .vectors payload must start at or past the arena data offset"
);
```

If the arena's alignment requirement ever outgrows 4096 the build fails, and the
format gets a deliberate v3 instead of drifting.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Three tests in a new `vectors_format_tests.rs`, none of which the existing
round-trip coverage could provide — it only ever exercises the version the
current binary writes:

- **`v1_vectors_file_still_loads`** — a hand-built v1 file loads with its values
  intact. This is the regression that would take out every existing database.
- **`dumped_vectors_file_is_v2_and_page_aligned`** — a fresh dump declares v2,
  its payload starts at 4096, and the reserved gap is zero-filled.
- **`v2_dump_reloads_its_own_vectors`** — asserted **per value**, not per count.
  That distinction is load-bearing: forcing `vectors_data_offset` to return 16
  for v2 makes this test fail with `v2 vector 1 did not survive the round trip`,
  where the count-only version passed while reading the zeroed gap.

Full runs: **556 `index::hnsw` tests pass**, `cargo fmt --check` clean, and
`cargo clippy -p velesdb-core --lib --features persistence,gpu,update-check -- -D warnings -D clippy::pedantic` clean.

## Compatibility

Runs one way, and `docs/reference/NATIVE_HNSW.md` now documents the layout and
says so: a current binary reads v1 and v2, a binary from before this change
rejects a v2 file with `Unsupported version: 2`. **Downgrading past this change
requires re-persisting the index** — a release note, not a footnote.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
