### PR TITLE
ci(governance): guard the issue and comment surfaces

### DIFF
--- a/.github/workflows/issue-attribution.yml
+++ b/.github/workflows/issue-attribution.yml
@@ -1,0 +1,66 @@
+# Issues and comments are the surface CLAUDE.md #5 names and no guard reached.
+#
+# `pr-governance.yml` covers commits, the pull request title and body, and
+# tracked content. It cannot cover an issue body or a comment: those arrive on
+# events a `pull_request` workflow never sees, which is why the guard's own
+# module docstring listed them as the remaining gap rather than a solved case.
+#
+# This workflow cannot *prevent* the text — a comment is published the moment
+# it is posted, and no check runs before that. What it does is make a violation
+# visible instead of silent, which is the difference between a backlog that
+# drifts and one whose drift shows up in the Actions tab.
+#
+# `issue_comment` fires for pull request comments too, because GitHub models a
+# pull request as an issue. That is deliberate coverage, not an accident.
+name: Issue Attribution
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+
+# A burst of edits should leave one verdict, not a queue of them.
+concurrency:
+  group: issue-attribution-${{ github.event.issue.number }}-${{ github.event.comment.id || 'body' }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Reject AI attribution in issues and comments
+    runs-on: ubuntu-latest
+    steps:
+      # No `ref:` — an issue event has no head to check out, so the default
+      # branch is both correct and the only sensible source for the guard.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Reject an AI-attributed issue title or body
+        if: ${{ github.event_name == 'issues' }}
+        env:
+          # Via env, never interpolated into the script below: an issue title
+          # and body are attacker-controlled text, and `${{ }}` inside a `run:`
+          # block is a script-injection vector. The guard then reads each as a
+          # FILE, so the text never becomes a shell argument either.
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          printf '%s' "$ISSUE_TITLE" > "$RUNNER_TEMP/issue-title.txt"
+          printf '%s' "$ISSUE_BODY" > "$RUNNER_TEMP/issue-body.md"
+          python3 scripts/check-ai-attribution.py \
+            --text "$RUNNER_TEMP/issue-title.txt" --surface "issue title"
+          python3 scripts/check-ai-attribution.py \
+            --text "$RUNNER_TEMP/issue-body.md" --surface "issue body"
+
+      - name: Reject an AI-attributed comment
+        if: ${{ github.event_name == 'issue_comment' }}
+        env:
+          # Same reasoning as above; a comment body is untrusted text.
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          printf '%s' "$COMMENT_BODY" > "$RUNNER_TEMP/comment-body.md"
+          python3 scripts/check-ai-attribution.py \
+            --text "$RUNNER_TEMP/comment-body.md" --surface "issue or pull request comment"

--- a/scripts/tests/test_check_ai_attribution.py
+++ b/scripts/tests/test_check_ai_attribution.py
@@ -354,6 +354,32 @@ class SingleSourceTests(unittest.TestCase):
         text = (self.ROOT / ".githooks/commit-msg").read_text(encoding="utf-8")
         self.assertIn("check-ai-attribution.py", text)
 
+    def test_the_issue_workflow_calls_the_guard(self) -> None:
+        # The surface the module docstring listed as the remaining gap: an
+        # issue body or a comment arrives on events no `pull_request` workflow
+        # sees, so `pr-governance.yml` cannot reach it however it is written.
+        text = (self.ROOT / ".github/workflows/issue-attribution.yml").read_text(encoding="utf-8")
+        self.assertIn("scripts/check-ai-attribution.py", text)
+
+    def test_the_issue_workflow_covers_both_surfaces_and_edits(self) -> None:
+        # A guard that only fired on `opened` would be walked past by posting
+        # clean text and editing the footer back in.
+        text = (self.ROOT / ".github/workflows/issue-attribution.yml").read_text(encoding="utf-8")
+        self.assertIn("types: [opened, edited]", text)
+        self.assertIn("types: [created, edited]", text)
+        self.assertIn("github.event.issue.body", text)
+        self.assertIn("github.event.comment.body", text)
+
+    def test_the_issue_workflow_never_interpolates_untrusted_text_into_the_shell(self) -> None:
+        # Same rule the pull request step documents: untrusted prose reaches
+        # the guard through env and then a file, never as `${{ }}` inside a
+        # `run:` block, which would be a script-injection vector.
+        text = (self.ROOT / ".github/workflows/issue-attribution.yml").read_text(encoding="utf-8")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("python3") or stripped.startswith("printf"):
+                self.assertNotIn("${{", stripped, f"untrusted interpolation in: {stripped}")
+
     def test_neither_site_still_greps_the_old_pair_of_words_as_its_rule(self) -> None:
         # The workflow's own grep was the rule; it must be gone. The hook
         # keeps its two-word grep ONLY as a fallback for a machine without


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`ci/*` → targets `develop`. ✅

## Description

`check-ai-attribution.py` covers commits, the pull request title and body, and
tracked content. Its own module docstring names the surface it cannot reach: an
issue body, or a comment, on the day a workflow can hand it one.

That day is this PR. Those two surfaces arrive on events no `pull_request`
workflow ever sees, however that workflow is written — so this was a missing
trigger, not a weak rule.

### The gap is where the violations actually are

Measured against this repository today, using the patterns the guard already
knows (quoted nowhere here, for the reason the CI failure below explains):

| surface | issues / PRs affected |
|---|---|
| issue and PR **bodies**, first footer variant | 172 |
| **comments**, first footer variant | 105 |
| any surface, second footer variant | 286 |
| assistant co-author trailers | 9 |

Every one was published while the commits inside were clean — exactly the
failure mode the docstring predicted, and the reason the count grew unnoticed.

### The guard is unchanged

It already exposes `--text PATH --surface LABEL`, the same entry point the pull
request title and body step uses. What was missing was a workflow handing it
those two surfaces, so this adds one and nothing else. No second pattern list —
a second list would drift, which is the mistake #1699 already paid for.

### Three details that came from reading the existing code

- **`issue_comment` fires for pull request comments too**, because GitHub models
  a pull request as an issue. Deliberate coverage, and the workflow says so, so
  nobody later reads it as an accident.
- **Both event types include `edited`.** A guard firing only on `opened` is
  walked past by posting clean text and editing the footer back in afterwards.
- **Untrusted prose reaches the guard through env and then a file**, never as an
  expression interpolated into a `run:` block — the same rule the pull request
  step documents. A test now asserts it rather than trusting the next editor to
  remember.

### What this does not do

It does not *prevent* the text. A comment is published the moment it is posted
and no check runs before that. It makes a violation visible instead of silent —
the difference between a backlog that drifts and one whose drift shows up in the
Actions tab. Cleaning the existing occurrences is separate work.

## The first version of this PR was rejected by this very guard

Worth recording, because it is the strongest evidence the surface guard is
wired correctly and the strongest argument against the obvious "fix".

The original body reproduced the footer strings literally, to show what is being
counted. `PR Governance / Git Flow & Freshness Checks` failed on **Reject an
AI-attributed pull request title or body** — the existing guard, doing exactly
its job, on the PR that extends it.

The tempting response is an escape hatch for prose that legitimately discusses
the rule. That would be wrong: a reader, or a scraper, sees the string whatever
the author intended, and a PR body is precisely where such a hatch would be
abused. `--tree` admits a handful of files by exact path because a guard must be
able to define itself; prose surfaces have no such need. So the body was
rewritten to describe the patterns instead of reproducing them, and the guard
kept its teeth.

## Type of Change

- [x] 🔧 Chore / tooling (no production behaviour changes)

## How Has This Been Tested?

Three wiring tests added to `SingleSourceTests`, **proven red rather than
assumed**: with the workflow file moved aside all three fail with
`FileNotFoundError` instead of passing vacuously.

```
Ran 34 tests in 15.692s
OK
```

The chain was exercised end to end, not merely wired:

- a body carrying the footer → exit **1**, with the guard's remediation message;
- a body without it → exit **0**.

This PR body itself was run through `--text` before publishing, which is how the
rewrite above was verified rather than hoped.

The workflow YAML parses, and its triggers resolve to `issues` and
`issue_comment`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
