### PR TITLE
feat(persistence): adopt .vectors as the graph arena instead of copying it

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -8,7 +8,7 @@
 use super::distance::DistanceEngine;
 use super::graph::{NativeHnsw, DEFAULT_ALPHA, NO_ENTRY_POINT};
 use super::layer::Layer;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
@@ -163,7 +163,6 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     fn dump_vectors_file(&self, path: &Path, basename: &str) -> std::io::Result<u64> {
         let vectors_path = path.join(format!("{basename}.vectors"));
         let vectors_guard = self.vectors.read();
-        let mut writer = BufWriter::new(File::create(&vectors_path)?);
 
         // Reason: Vector dimensions are always < 65536 and vector count fits u64.
         #[allow(clippy::cast_possible_truncation)]
@@ -172,6 +171,37 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             None => (0, 0),
         };
 
+        // When the arena IS this file, the payload is already here, and
+        // `File::create` would truncate the very bytes the live mapping still
+        // points at — a SIGBUS on the next read, not a slow path. So flush the
+        // pages and rewrite the header in place; the payload never moves and is
+        // never copied onto itself through a second descriptor.
+        //
+        // Data before header is the order the crash-consistency argument
+        // requires: a header claiming more vectors than the file holds is the
+        // one state a reader cannot detect, because it validates the declared
+        // payload against the file length and a stale-but-smaller count simply
+        // reads fewer vectors. The generation stamp written after this call is
+        // still what commits the set.
+        #[cfg(feature = "persistence")]
+        if vectors_guard
+            .as_ref()
+            .and_then(crate::perf_optimizations::ContiguousVectors::backing_path)
+            .is_some_and(|mapped| mapped == vectors_path)
+        {
+            if let Some(vectors) = vectors_guard.as_ref() {
+                vectors.flush_backing().map_err(std::io::Error::other)?;
+            }
+            // `write(true)` without `truncate`: the header region is the first
+            // 4 096 bytes and the mapping starts after it, so these two never
+            // address the same bytes.
+            let mut file = OpenOptions::new().write(true).open(&vectors_path)?;
+            Self::write_vectors_header(&mut file, count, dimension)?;
+            file.flush()?;
+            return Ok(count);
+        }
+
+        let mut writer = BufWriter::new(File::create(&vectors_path)?);
         Self::write_vectors_header(&mut writer, count, dimension)?;
 
         if let Some(vectors) = vectors_guard.as_ref() {
@@ -190,7 +220,7 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
     /// claims part of it for header fields, it is reserved and zero-filled, so
     /// that version can tell an unset field from a set one.
     fn write_vectors_header(
-        writer: &mut BufWriter<File>,
+        writer: &mut impl Write,
         count: u64,
         dimension: u32,
     ) -> std::io::Result<()> {
@@ -359,6 +389,21 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         let vectors_path = path.join(format!("{basename}.vectors"));
         let (mut vectors, count) = Self::load_vectors_file(&vectors_path, arena_home.as_ref())?;
 
+        // `ArenaHome` means exactly one thing: there is a disposable file to
+        // delete when this graph goes away. When the arena IS `.vectors` there
+        // is none, and carrying a home would leave `Drop` pointed at a file
+        // this graph never created. Derived from the storage rather than
+        // reported back by the loader — the arena already knows what it
+        // mapped, and asking it cannot disagree with what happened.
+        #[cfg(feature = "persistence")]
+        let arena_home = match vectors
+            .as_ref()
+            .and_then(crate::perf_optimizations::ContiguousVectors::backing_path)
+        {
+            Some(mapped) if mapped == vectors_path => None,
+            _ => arena_home,
+        };
+
         // Indexes written before the pre-normalized cosine engine store raw
         // vectors. Cosine is scale-invariant, so normalizing here never
         // changes any result, and it (re-)establishes the unit-norm invariant
@@ -445,6 +490,41 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         // header could otherwise request a multi-gigabyte allocation that the
         // file cannot possibly back.
         Self::validate_vectors_file_len(count, dimension, file_len, data_offset)?;
+
+        // The durable file can BE the arena when its payload is page-aligned
+        // (v2) and the target's byte order is the one the payload holds. That
+        // retires the duplicate copy this load would otherwise make (#2173).
+        //
+        // Failure falls through to the copy path deliberately: a mapped arena
+        // is an optimisation, never a requirement — the same rule `new_arena`
+        // states for the disposable arena, for the same reason. A filesystem
+        // that will not host a mapping must cost the optimisation and nothing
+        // else, never a collection that refuses to open.
+        //
+        // Adoption must be observation-only. `ContiguousVectors` floors an
+        // arena's capacity at `MIN_ARENA_CAPACITY` and sizes the file to match,
+        // so a store below that floor would be EXTENDED merely by being opened
+        // — and opening a collection must never write to it. That is not a
+        // tidiness point: `velesdb-memory`'s migration resume proves the source
+        // unchanged by hashing these files, so a store that grows on open makes
+        // a correct resume look like a corrupted one. Below the floor, take the
+        // copy path; what adoption would save there is negligible anyway.
+        #[cfg(feature = "persistence")]
+        if count >= crate::perf_optimizations::ContiguousVectors::MIN_ARENA_CAPACITY
+            && version == VECTORS_FORMAT_VERSION
+            && cfg!(target_endian = "little")
+        {
+            match crate::perf_optimizations::ContiguousVectors::open_file_backed(
+                path, dimension, count, count,
+            ) {
+                Ok(storage) => return Ok((Some(storage), count)),
+                Err(e) => tracing::warn!(
+                    "{path:?} could not be adopted as the vector arena ({e}); \
+                     reading it into a separate arena instead, which costs a copy, \
+                     not correctness"
+                ),
+            }
+        }
 
         // v1 leaves the reader exactly here; v2 has reserved padding to skip.
         // Seeking unconditionally keeps one path rather than two.

--- a/crates/velesdb-core/src/index/hnsw/native/vectors_format_tests.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/vectors_format_tests.rs
@@ -128,3 +128,197 @@ fn v2_dump_reloads_its_own_vectors() {
         );
     }
 }
+
+/// A v1 file is read into a separate arena, never adopted: its payload starts
+/// at byte 16, where a mapping whose data region begins at 4096 cannot.
+#[test]
+fn v1_vectors_file_is_not_adopted_as_the_arena() {
+    // Arrange
+    let dir = tempdir().expect("test: tempdir");
+    let path = dir.path().join("legacy.vectors");
+    write_v1_vectors_file(&path, &[vec![1.0f32, 2.0, 3.0, 4.0]]);
+
+    // Act
+    let (storage, _) = H::load_vectors_file(&path, None).expect("test: load v1");
+
+    // Assert
+    let storage = storage.expect("test: v1 file must yield storage");
+    assert_eq!(
+        storage.backing_path(),
+        None,
+        "a v1 payload starts at byte 16 and cannot be mapped in place"
+    );
+}
+
+/// Dropping a graph whose arena **is** `.vectors` must leave the file alone.
+///
+/// This is the hazard the whole ownership question exists for: `ArenaHome`
+/// deletes its file on drop, and it is correct to — the disposable arena is a
+/// cache. Point that at the durable store and closing a collection destroys
+/// it, silently, until the next open. The graph therefore carries no
+/// `ArenaHome` at all when it adopted the durable file, and the assertion on
+/// `backing_path` below is what makes this test guard that rather than pass
+/// for the unrelated reason that nothing was mapped in the first place.
+#[test]
+fn dropping_a_graph_that_adopted_its_vectors_keeps_the_file() {
+    // Arrange
+    let dir = tempdir().expect("test: tempdir");
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    // Above the arena capacity floor: below it adoption is refused on purpose,
+    // and this test would then guard a mapping that never happened.
+    let nodes = crate::perf_optimizations::ContiguousVectors::MIN_ARENA_CAPACITY + 2;
+    for i in 0..nodes {
+        hnsw.insert(&[i as f32; 4]).expect("test: insert");
+    }
+    hnsw.file_dump(dir.path(), "durable").expect("test: dump");
+    drop(hnsw);
+    let vectors_path = dir.path().join("durable.vectors");
+
+    // Act
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let reloaded = H::file_load(dir.path(), "durable", engine).expect("test: load");
+    assert_eq!(
+        reloaded
+            .vectors
+            .read()
+            .as_ref()
+            .and_then(crate::perf_optimizations::ContiguousVectors::backing_path),
+        Some(vectors_path.as_path()),
+        "the reload must have adopted the durable file, or this test guards nothing"
+    );
+    drop(reloaded);
+
+    // Assert
+    assert!(
+        vectors_path.exists(),
+        "dropping a graph must never delete the durable vector store"
+    );
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let again = H::file_load(dir.path(), "durable", engine).expect("test: reload after drop");
+    assert_eq!(again.len(), nodes, "the vectors must survive the drop");
+}
+
+/// Saving a graph that adopted its own `.vectors` keeps every value.
+///
+/// The old dump path opened the file with `File::create`, which truncates.
+/// Against a live mapping of that same file, that is not a slow path — the
+/// pages the arena still points at stop existing. There is no clean red for
+/// it, because the failure is a SIGBUS rather than an assertion, which is
+/// exactly why the dump branches instead of relying on a test to notice.
+#[test]
+fn saving_an_adopted_graph_preserves_its_vectors() {
+    // Arrange
+    let dir = tempdir().expect("test: tempdir");
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+    let nodes = crate::perf_optimizations::ContiguousVectors::MIN_ARENA_CAPACITY + 2;
+    for i in 0..nodes {
+        hnsw.insert(&[i as f32 * 2.5; 4]).expect("test: insert");
+    }
+    hnsw.file_dump(dir.path(), "resave")
+        .expect("test: first dump");
+    drop(hnsw);
+
+    // Act: reload (adopts the file), then save again through the mapping
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let reloaded = H::file_load(dir.path(), "resave", engine).expect("test: load");
+    // The subject here is the dump path an ADOPTED arena takes; without the
+    // adoption this would quietly exercise the ordinary copy path instead.
+    assert!(
+        reloaded
+            .vectors
+            .read()
+            .as_ref()
+            .and_then(crate::perf_optimizations::ContiguousVectors::backing_path)
+            .is_some(),
+        "the reload must have adopted the durable file"
+    );
+    reloaded
+        .file_dump(dir.path(), "resave")
+        .expect("test: second dump");
+    drop(reloaded);
+
+    // Assert
+    let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+    let final_load = H::file_load(dir.path(), "resave", engine).expect("test: final load");
+    // The guard is scoped to the read: an assertion that fires while holding a
+    // lock takes the panic and the lock down together, which is a worse
+    // failure than the one being reported.
+    let stored: Vec<Vec<f32>> = {
+        let guard = final_load.vectors.read();
+        let storage = guard.as_ref().expect("test: storage present");
+        let values = (0..storage.len())
+            .map(|i| storage.get(i).expect("test: vector present").to_vec())
+            .collect();
+        drop(guard);
+        values
+    };
+
+    assert_eq!(stored.len(), nodes);
+    for (i, value) in stored.iter().enumerate() {
+        let expected = [i as f32 * 2.5; 4];
+        assert_eq!(
+            value.as_slice(),
+            expected.as_slice(),
+            "vector {i} did not survive a save through its own mapping"
+        );
+    }
+}
+
+/// Opening a collection must never write to it — on either side of the arena's
+/// capacity floor.
+///
+/// Below the floor an adopted arena would be sized up to `MIN_ARENA_CAPACITY`
+/// and the file extended with it, so adoption is refused there and the copy
+/// path runs instead. This is not a tidiness point: `velesdb-memory`'s
+/// migration resume proves the source store unchanged by hashing these files,
+/// and twenty-one of its tests failed on exactly this when adoption was
+/// unconditional. The counts are derived from the constant rather than written
+/// out, so moving the floor moves the test with it.
+#[test]
+fn opening_a_collection_never_writes_to_its_vectors() {
+    use crate::perf_optimizations::ContiguousVectors;
+    const FLOOR: usize = ContiguousVectors::MIN_ARENA_CAPACITY;
+
+    for (nodes, expect_adopted) in [(FLOOR - 1, false), (FLOOR + 4, true)] {
+        // Arrange
+        let dir = tempdir().expect("test: tempdir");
+        let name = format!("open{nodes}");
+        let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+        let hnsw = NativeHnsw::new(engine, 16, 100, 100);
+        for i in 0..nodes {
+            hnsw.insert(&[i as f32 + 0.3; 4]).expect("test: insert");
+        }
+        hnsw.file_dump(dir.path(), &name).expect("test: dump");
+        drop(hnsw);
+        let vectors_path = dir.path().join(format!("{name}.vectors"));
+        let before = std::fs::read(&vectors_path).expect("test: read before");
+
+        // Act
+        let engine = CachedSimdDistance::new(DistanceMetric::Euclidean, 4);
+        let loaded = H::file_load(dir.path(), &name, engine).expect("test: load");
+        let adopted = loaded
+            .vectors
+            .read()
+            .as_ref()
+            .and_then(ContiguousVectors::backing_path)
+            .is_some();
+        drop(loaded);
+
+        // Assert
+        assert_eq!(
+            adopted, expect_adopted,
+            "{nodes} vectors: adoption must follow the capacity floor, or this \
+             test is measuring the wrong thing"
+        );
+        let after = std::fs::read(&vectors_path).expect("test: read after");
+        assert!(
+            before == after,
+            "{nodes} vectors: opening a collection wrote to its .vectors \
+             ({} bytes before, {} after)",
+            before.len(),
+            after.len()
+        );
+    }
+}

--- a/crates/velesdb-core/src/perf_optimizations.rs
+++ b/crates/velesdb-core/src/perf_optimizations.rs
@@ -128,6 +128,16 @@ impl fmt::Debug for ContiguousVectors {
 }
 
 impl ContiguousVectors {
+    /// Smallest capacity an arena is created with.
+    ///
+    /// A floor rather than an exact fit, so a fresh arena does not resize on
+    /// its first insert. Both the heap and the file-backed constructor apply
+    /// it, and it is `pub(crate)` because a caller adopting an *existing* file
+    /// has to know it too: below this many vectors, opening that file as an
+    /// arena would EXTEND it. A second copy of the number is exactly how such
+    /// a caller would silently stop matching this one.
+    pub(crate) const MIN_ARENA_CAPACITY: usize = 16;
+
     /// Creates a new `ContiguousVectors` with the given dimension and initial capacity.
     ///
     /// # Arguments
@@ -151,7 +161,7 @@ impl ContiguousVectors {
         // could drive `dimension * capacity` products toward overflow.
         validate_dimension(dimension)?;
 
-        let capacity = capacity.max(16); // Minimum 16 vectors
+        let capacity = capacity.max(Self::MIN_ARENA_CAPACITY);
 
         // Reject pathological/attacker-sized allocations before touching the
         // allocator (#899). Legitimate large indexes stay well under the ceiling.
@@ -251,7 +261,7 @@ impl ContiguousVectors {
         use crate::contiguous_file_arena::FileArena;
 
         validate_dimension(dimension)?;
-        let capacity = capacity.max(16);
+        let capacity = capacity.max(Self::MIN_ARENA_CAPACITY);
         let byte_len = Self::byte_size(dimension, capacity)?;
         crate::alloc_guard::check_alloc_bound(byte_len)?;
 
@@ -310,6 +320,23 @@ impl ContiguousVectors {
             arena.flush().map_err(crate::error::Error::Io)?;
         }
         Ok(())
+    }
+
+    /// The file this arena is mapped from, if it is mapped at all.
+    ///
+    /// Derived from the backing rather than remembered alongside it. A caller
+    /// that needs to know whether it is about to rewrite the very file it is
+    /// reading gets the answer from the one place that cannot fall out of step
+    /// with reality — there is no second copy of the fact to keep in sync.
+    /// `persistence`-only: without it the sole backing is the heap, so the
+    /// question has one answer and no caller.
+    #[cfg(feature = "persistence")]
+    #[must_use]
+    pub(crate) fn backing_path(&self) -> Option<&std::path::Path> {
+        match &self.backing {
+            ArenaBacking::FileMapped(arena) => Some(arena.path()),
+            ArenaBacking::Heap => None,
+        }
     }
 
     /// Drops a file-backed arena's resident pages, keeping its contents.


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`feat/*` → targets `develop`. ✅

Second of the three PRs for #2173. #2213 moved the payload to a page boundary;
this one stops reading it into a second buffer.

## Description

A v2 `.vectors` payload starts exactly where `FileArena` starts its data
region, so on a little-endian target **the file can be the arena**.
`ContiguousVectors::open_file_backed` — the "adopt an existing file without
truncating it" entry point that had lived in the tree with no production caller
— does the rest. The load path stops deserializing `count * dimension` floats
four bytes at a time and maps them instead.

Adoption is best-effort by design: a mapping the filesystem refuses falls back
to the copy path with a warning. That is the rule `new_arena` already states
for the disposable arena, for the same reason — this must never stop a
collection from opening that opened fine before it existed.

## Four decisions, each removing a failure mode

**Adoption is derived, never stored.** `backing_path` answers which file an
arena mapped, from the backing itself. The loader reports nothing and the graph
remembers nothing, so there is no second copy of the fact to fall out of step.

**A graph that adopted the durable file carries no `ArenaHome`.** `ArenaHome`
means exactly one thing — there is a disposable file to delete on drop — and it
deletes unconditionally (`arena_home.rs:171-181`). Point it at `.vectors` and
closing a collection destroys the vector store, silently, until the next open.
Rather than a "do not delete" flag someone can forget, the graph holds no home
at all: the deletion path is not disabled, it is **unreachable**.

**`save()` no longer truncates the file it maps.** `File::create` against a
live mapping of the same file is not a slow path — it removes the pages the
arena still points at. For an adopted arena the dump flushes those pages and
rewrites the sixteen header bytes in place. Data before header is the order the
crash-consistency analysis on the issue requires.

**Adoption is observation-only** — and this one was found the hard way.

## The regression that shaped this PR

The first version adopted whenever the format allowed it. Twenty-one
`velesdb-memory` tests failed: its migration resume proves the source store
unchanged by hashing these files, and the hashes moved between two opens.

**The cause was not where it looked.** Cosine normalization at load becomes a
durable write once the arena is mapped — the obvious suspect, a real hazard,
and not this one. A probe showed the file changing under `Euclidean` too, where
that pass never runs.

`ContiguousVectors` floors an arena's capacity at 16 and sizes the file to
match, so a store **below that floor was extended merely by being opened**.
Re-probed at 20 vectors, the file came back byte-identical.

| store size | adopted | file after open |
|---|---|---|
| below the floor | no (falls back to the copy path) | identical |
| at or above it | yes | identical |

So adoption now requires the store to reach that floor; the floor is a named
constant that both constructors and the guard read instead of three literal
`16`s; and a test pins the invariant on both sides of it. What adoption would
have saved below the floor is negligible anyway.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Four tests in `vectors_format_tests.rs`:

- **`opening_a_collection_never_writes_to_its_vectors`** — the regression
  guard, checked on both sides of the capacity floor, asserting the adoption
  status too so it cannot pass by measuring the wrong path.
- **`dropping_a_graph_that_adopted_its_vectors_keeps_the_file`** — the
  data-loss guard.
- **`saving_an_adopted_graph_preserves_its_vectors`** — every value survives a
  save through the mapping.
- **`v1_vectors_file_is_not_adopted_as_the_arena`** — a v1 payload starts at
  byte 16 and cannot be mapped in place.

The first two assert adoption **before** checking anything else. Raising their
counts above the floor exposed that one of them had been passing while quietly
exercising the ordinary copy path — worth stating, because a green test that
measures the wrong thing is worse than no test.

There is no clean red for the truncation hazard: the failure is a SIGBUS rather
than an assertion, which is exactly why the dump branches instead of leaning on
a test to notice.

Full runs: **794 `velesdb-memory`**, **560 `index::hnsw`** and **65
persistence** tests pass; clippy pedantic clean with
`persistence,gpu,update-check`; `--no-default-features` builds warning free.

## No performance number is claimed

`persistence_save_scale` (#2211) measures a save from an index built in memory,
which never adopts, so it cannot see this change. The load-time copy is retired
**structurally** — provable from `backing_path`, not from a stopwatch — and
putting a figure on it needs a load instrument that does not exist yet. That is
the natural companion to this PR, not a claim to make without it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
