### PR TITLE
refactor(persistence): name the arena-adoption rules, correct the docs that predate them

### DIFF
--- a/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/arena_home.rs
@@ -1,31 +1,37 @@
 //! Where a graph's f32 arena lives on disk, and what becomes of it after.
 //!
-//! # Why the arena is disposable rather than persistent
+//! # When a graph gets a disposable arena, and when it does not
 //!
 //! The obvious design is to make the arena file *the* stored vectors — map
-//! `{basename}.vectors` and skip deserialization entirely. Two facts rule
-//! that out for now, and both were found by reading the code rather than
-//! assumed:
+//! `{basename}.vectors` and skip deserialization entirely. Since #2173 that is
+//! exactly what happens, but only when three things hold: the file is format
+//! v2, so its payload starts page-aligned where [`FileArena`]'s data region
+//! does; the target is little-endian, because `.vectors` is explicitly
+//! little-endian while an arena file is native-endian raw memory; and the store
+//! reaches `ContiguousVectors::MIN_ARENA_CAPACITY`, below which an arena is
+//! sized up to that floor and the file would grow merely by being opened.
 //!
-//! 1. **Vacuum makes two live indexes on purpose.** `build_vacuum_replacement`
-//!    constructs a whole replacement graph while the old one is still serving
-//!    reads, then swaps. A single well-known arena path would put both of them
-//!    on the same bytes, and [`FileArena`]'s exclusive lock — which exists
-//!    because two mappings of one file are two `&mut [f32]` aliases — would
-//!    refuse the second. The lock would be doing its job; the design would be
-//!    wrong.
-//! 2. **`.vectors` is portable and the arena is not.** `.vectors` converts
-//!    explicitly through `to_le_bytes`; an arena file is native-endian raw
-//!    memory. Merging them trades a portable on-disk format for one that
-//!    cannot cross an endianness boundary — a real cost, for a load-time win
-//!    that #2112 never asked for.
+//! **A graph that adopted `.vectors` holds no [`ArenaHome`] at all.** That is
+//! the whole safety argument for this module after #2173: `Drop` here removes
+//! its file unconditionally, so the way a durable store cannot be deleted by
+//! accident is that no home is ever constructed for it — not a flag saying not
+//! to. [`ArenaHome::claim`] reinforces it from the other side by building
+//! `hnsw-{token}.arena` names and nothing else, so the two mechanisms cannot
+//! meet even by mistake.
 //!
-//! So each live graph gets its **own** arena file, and deletes it when it
-//! drops. The arena is a cache of something already persisted, which is what
-//! makes throwing it away free: `.vectors` remains the durable copy, and a
-//! reopened collection simply builds a fresh arena from it.
+//! Everything outside those three conditions still gets its own disposable
+//! arena, deleted on drop: v1 files written before #2213, big-endian targets,
+//! stores below the capacity floor, and any mapping the filesystem refuses. The
+//! arena is then a cache of something already persisted, which is what makes
+//! throwing it away free — `.vectors` remains the durable copy, and a reopened
+//! collection builds a fresh arena from it.
 //!
-//! # What this costs, and why the end state is different
+//! [`sweep_stale`](ArenaHome::sweep_stale) and
+//! [`is_arena_file`](ArenaHome::is_arena_file) therefore keep their subject.
+//! They exist so a sweep never eats `.vectors`, and disposable arenas still
+//! exist to sweep.
+//!
+//! # What the disposable path costs
 //!
 //! Being a second copy is not free, and the cost is write volume rather than
 //! space. Loading a collection writes every vector through the mapping, so
@@ -43,12 +49,17 @@
 //! The trade is deliberate: on a memory-constrained device, spending write
 //! bandwidth to move the f32 arena out of the resident set is usually worth
 //! it, since that arena is the single largest thing a quantized index holds.
-//! But it *is* a trade, and it is the reason the end state is not this
-//! design. Mapping `{basename}.vectors` itself removes the duplicate
-//! entirely — no second copy, no second write, no deletion — and the only
-//! thing standing in the way is that the arena is native-endian where
-//! `.vectors` is explicitly little-endian. That is a format question, not an
-//! architectural one, and it is tracked separately.
+//! It is also why adoption is preferred wherever it applies — mapping
+//! `{basename}.vectors` removes the duplicate entirely: no second copy, no
+//! second write, no deletion.
+//!
+//! An earlier version of this doc called that "a format question, not an
+//! architectural one". It was neither statement's fault that both turned out
+//! wrong. Aligning the payload was a format change (#2213), but adopting the
+//! file also moved *when* vector data becomes durable and *who* may delete it,
+//! which is architecture — and the endianness the paragraph named was only one
+//! of three conditions, the other two being page alignment and the capacity
+//! floor. The reasoning is recorded on #2173 rather than repeated here.
 //!
 //! [`FileArena`]: crate::contiguous_file_arena::FileArena
 

--- a/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
+++ b/crates/velesdb-core/src/index/hnsw/native/graph_io.rs
@@ -67,6 +67,14 @@ const _: () = assert!(
 );
 const _: () = assert!(VECTORS_V2_DATA_OFFSET > VECTORS_HEADER_BYTES);
 
+// A v3 would silently inherit the v2 layout from the fallback arm below. This
+// fails the build on the version bump instead, so the offsets are revisited
+// deliberately rather than by omission.
+const _: () = assert!(
+    VECTORS_FORMAT_VERSION == 2,
+    "a new .vectors version needs its own arm in `vectors_data_offset`"
+);
+
 /// Byte offset of the payload for a given `.vectors` format version.
 ///
 /// Only versions the reader accepts reach this; anything else is rejected by
@@ -171,33 +179,12 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
             None => (0, 0),
         };
 
-        // When the arena IS this file, the payload is already here, and
-        // `File::create` would truncate the very bytes the live mapping still
-        // points at — a SIGBUS on the next read, not a slow path. So flush the
-        // pages and rewrite the header in place; the payload never moves and is
-        // never copied onto itself through a second descriptor.
-        //
-        // Data before header is the order the crash-consistency argument
-        // requires: a header claiming more vectors than the file holds is the
-        // one state a reader cannot detect, because it validates the declared
-        // payload against the file length and a stale-but-smaller count simply
-        // reads fewer vectors. The generation stamp written after this call is
-        // still what commits the set.
         #[cfg(feature = "persistence")]
-        if vectors_guard
+        if let Some(adopted) = vectors_guard
             .as_ref()
-            .and_then(crate::perf_optimizations::ContiguousVectors::backing_path)
-            .is_some_and(|mapped| mapped == vectors_path)
+            .filter(|v| v.backing_path() == Some(vectors_path.as_path()))
         {
-            if let Some(vectors) = vectors_guard.as_ref() {
-                vectors.flush_backing().map_err(std::io::Error::other)?;
-            }
-            // `write(true)` without `truncate`: the header region is the first
-            // 4 096 bytes and the mapping starts after it, so these two never
-            // address the same bytes.
-            let mut file = OpenOptions::new().write(true).open(&vectors_path)?;
-            Self::write_vectors_header(&mut file, count, dimension)?;
-            file.flush()?;
+            Self::rewrite_adopted_vectors_header(adopted, &vectors_path, count, dimension)?;
             return Ok(count);
         }
 
@@ -209,6 +196,37 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         }
         writer.flush()?;
         Ok(count)
+    }
+
+    /// Rewrites the header of a `.vectors` file the arena is mapped from.
+    ///
+    /// The payload is already in the file — it *is* the arena — so nothing but
+    /// the header needs writing. `File::create` would truncate the very bytes
+    /// the live mapping still points at, a SIGBUS on the next read rather than
+    /// a slow path, so the file is opened for writing without truncation. The
+    /// header region is the first [`VECTORS_V2_DATA_OFFSET`] bytes and the
+    /// mapping starts after it, so the two never address the same bytes.
+    ///
+    /// Pages before header, deliberately. A header claiming more vectors than
+    /// the file holds is the one state a reader cannot detect: it validates the
+    /// declared payload against the file length, and a stale-but-smaller count
+    /// simply reads fewer vectors. The generation stamp written after this call
+    /// is still what commits the set.
+    ///
+    /// # Errors
+    ///
+    /// Returns `io::Error` if the flush, the open or the header write fails.
+    #[cfg(feature = "persistence")]
+    fn rewrite_adopted_vectors_header(
+        vectors: &crate::perf_optimizations::ContiguousVectors,
+        vectors_path: &Path,
+        count: u64,
+        dimension: u32,
+    ) -> std::io::Result<()> {
+        vectors.flush_backing().map_err(std::io::Error::other)?;
+        let mut file = OpenOptions::new().write(true).open(vectors_path)?;
+        Self::write_vectors_header(&mut file, count, dimension)?;
+        file.flush()
     }
 
     /// Writes the vectors file header — version, count, dimension — followed by
@@ -491,39 +509,9 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
         // file cannot possibly back.
         Self::validate_vectors_file_len(count, dimension, file_len, data_offset)?;
 
-        // The durable file can BE the arena when its payload is page-aligned
-        // (v2) and the target's byte order is the one the payload holds. That
-        // retires the duplicate copy this load would otherwise make (#2173).
-        //
-        // Failure falls through to the copy path deliberately: a mapped arena
-        // is an optimisation, never a requirement — the same rule `new_arena`
-        // states for the disposable arena, for the same reason. A filesystem
-        // that will not host a mapping must cost the optimisation and nothing
-        // else, never a collection that refuses to open.
-        //
-        // Adoption must be observation-only. `ContiguousVectors` floors an
-        // arena's capacity at `MIN_ARENA_CAPACITY` and sizes the file to match,
-        // so a store below that floor would be EXTENDED merely by being opened
-        // — and opening a collection must never write to it. That is not a
-        // tidiness point: `velesdb-memory`'s migration resume proves the source
-        // unchanged by hashing these files, so a store that grows on open makes
-        // a correct resume look like a corrupted one. Below the floor, take the
-        // copy path; what adoption would save there is negligible anyway.
         #[cfg(feature = "persistence")]
-        if count >= crate::perf_optimizations::ContiguousVectors::MIN_ARENA_CAPACITY
-            && version == VECTORS_FORMAT_VERSION
-            && cfg!(target_endian = "little")
-        {
-            match crate::perf_optimizations::ContiguousVectors::open_file_backed(
-                path, dimension, count, count,
-            ) {
-                Ok(storage) => return Ok((Some(storage), count)),
-                Err(e) => tracing::warn!(
-                    "{path:?} could not be adopted as the vector arena ({e}); \
-                     reading it into a separate arena instead, which costs a copy, \
-                     not correctness"
-                ),
-            }
+        if let Some(storage) = Self::adopt_durable_file(path, version, count, dimension) {
+            return Ok((Some(storage), count));
         }
 
         // v1 leaves the reader exactly here; v2 has reserved padding to skip.
@@ -532,6 +520,61 @@ impl<D: DistanceEngine + Send + Sync> NativeHnsw<D> {
 
         let storage = Self::read_vector_data(&mut reader, count, dimension, arena_home)?;
         Ok((Some(storage), count))
+    }
+
+    /// Maps `path` as the graph's arena when the file can serve as one (#2173).
+    ///
+    /// `None` means the caller must fall back to reading the payload into a
+    /// separate arena. Three conditions have to hold, each for its own reason:
+    ///
+    /// - **The payload must be page-aligned**, which only v2 guarantees. A v1
+    ///   payload starts at byte 16, where `FileArena`'s data region cannot.
+    /// - **The target's byte order must be the payload's.** `.vectors` is
+    ///   explicitly little-endian; mapping it on a big-endian target would
+    ///   reinterpret every float rather than convert it.
+    /// - **The store must reach [`ContiguousVectors::MIN_ARENA_CAPACITY`].**
+    ///   Below that floor an arena is sized up to it and the file grows to
+    ///   match, so adoption would *write*. Opening a collection must never
+    ///   write to it — `velesdb-memory`'s migration resume proves the source
+    ///   store unchanged by hashing these files, so a store that grew on open
+    ///   would make a correct resume look like a corrupted one. What adoption
+    ///   saves below the floor is negligible anyway.
+    ///
+    /// A refused mapping is a warning, never an error: a mapped arena is an
+    /// optimisation, not a requirement. That is the rule `new_arena` states for
+    /// the disposable arena, for the same reason — this must never stop a
+    /// collection from opening that opened fine before the feature existed.
+    ///
+    /// [`ContiguousVectors::MIN_ARENA_CAPACITY`]: crate::perf_optimizations::ContiguousVectors::MIN_ARENA_CAPACITY
+    #[cfg(feature = "persistence")]
+    fn adopt_durable_file(
+        path: &Path,
+        version: u32,
+        count: usize,
+        dimension: usize,
+    ) -> Option<crate::perf_optimizations::ContiguousVectors> {
+        use crate::perf_optimizations::ContiguousVectors;
+
+        if version != VECTORS_FORMAT_VERSION
+            || !cfg!(target_endian = "little")
+            || count < ContiguousVectors::MIN_ARENA_CAPACITY
+        {
+            return None;
+        }
+
+        // Capacity is the count: the file holds exactly the payload its header
+        // declares, and asking for a larger arena is what would extend it.
+        match ContiguousVectors::open_file_backed(path, dimension, count, count) {
+            Ok(storage) => Some(storage),
+            Err(e) => {
+                tracing::warn!(
+                    "{path:?} could not be adopted as the vector arena ({e}); \
+                     reading it into a separate arena instead, which costs a copy, \
+                     not correctness"
+                );
+                None
+            }
+        }
     }
 
     /// Rejects vector headers whose declared `count * dimension * 4` payload

--- a/docs/reference/NATIVE_HNSW.md
+++ b/docs/reference/NATIVE_HNSW.md
@@ -131,6 +131,33 @@ maps it directly inherits that constraint and must gate on `target_endian`.
 before v2 rejects a v2 file with `Unsupported version: 2`. Downgrading past this
 change therefore requires re-persisting the index.
 
+#### The file may be the arena
+
+Since #2173 a v2 `.vectors` is mapped directly as the graph's f32 arena instead
+of being read into a second buffer, when three conditions hold:
+
+1. the file is v2, so its payload starts page-aligned;
+2. the target is little-endian, matching the payload's declared byte order;
+3. the store holds at least `ContiguousVectors::MIN_ARENA_CAPACITY` vectors.
+
+The third is not a performance threshold. Below it an arena is sized up to that
+floor and the file grows to match, so adoption would *write* — and **opening a
+collection must never write to it**, because `velesdb-memory`'s migration resume
+proves a source store unchanged by hashing these files.
+
+Anything outside those conditions falls back to a disposable arena and the copy
+path, with a warning. A mapped arena is an optimisation, never a requirement: a
+filesystem that refuses the mapping costs the optimisation and nothing else.
+
+Two consequences worth knowing when reading this code:
+
+- A graph that adopted `.vectors` holds **no `ArenaHome`**. `ArenaHome::drop`
+  removes its file unconditionally, so the durable store is protected by the
+  absence of a home rather than by a flag telling it not to delete.
+- `save()` does not truncate an adopted file. It flushes the mapped pages, then
+  rewrites the header in place — pages before header, so a reader never sees a
+  header claiming more vectors than the file holds.
+
 #### Load-time validation (untrusted file safety)
 
 A persisted index is treated as **untrusted input**. `load` validates the


### PR DESCRIPTION
## ⚠️ Target branch (Git Flow)

`refactor/*` → targets `develop`. ✅

Third and last of the three PRs for #2173. **No behaviour change.**

## Description

#2215 shipped the behaviour with its reasoning inline: two eighteen-line
comment blocks standing in front of two conditions, inside functions that were
already long. That reasoning belongs in a named function's documentation, where
the call site can be read without it.

- **`adopt_durable_file`** now holds the three conditions and why each exists:
  page alignment (v2 only), byte order (`.vectors` is explicitly
  little-endian), and the capacity floor — below which adoption would *write*,
  and opening a collection must never write to it.
- **`rewrite_adopted_vectors_header`** holds the truncation hazard and the
  pages-before-header ordering. Extracting it also removed a double borrow of
  the storage guard: `Option::filter` yields the reference once instead of
  asking for it twice.

The call sites are three lines each now.

### A version bump can no longer pass silently

`vectors_data_offset`'s fallback arm hands an unknown version the v2 layout, so
a compile-time assertion fails the build if `VECTORS_FORMAT_VERSION` moves
without that function being revisited:

```rust
const _: () = assert!(
    VECTORS_FORMAT_VERSION == 2,
    "a new .vectors version needs its own arm in `vectors_data_offset`"
);
```

Same mechanism #2213 used to tie the v2 offset to the arena's alignment
requirement.

## Two things the docs asserted that had stopped being true

**That the arena is necessarily disposable.** Since #2215 a v2 store above the
capacity floor on a little-endian target maps `.vectors` directly and carries
**no `ArenaHome` at all**. The module doc now states that the *absence* of a
home — not a flag telling it not to delete — is what makes the durable store
undeletable, and that `ArenaHome::claim` reinforces it from the other side by
only ever building `hnsw-{token}.arena` names.

**That adopting the file was "a format question, not an architectural one".**
Both halves were wrong, and the doc now says so plainly rather than quietly
dropping the sentence. Aligning the payload was a format change (#2213), but
adoption also moved *when* vector data becomes durable and *who* may delete it.
The endianness that paragraph named was one of three conditions.

A doc that misleads is worse than no doc: it gives the next reader a reason not
to check.

## `is_arena_file` is not retired — the plan on the issue was wrong

The #2173 plan said PR 3 would remove `is_arena_file` and
`sweeping_removes_only_arena_files`, on the assumption that the two files always
become one. They do not. The copy path survives for **v1 files**, **big-endian
targets**, **stores below the capacity floor** and **refused mappings**, so
disposable arenas still exist and the predicate that keeps a sweep away from
`.vectors` still has a subject.

The module doc records that, so the next reader does not repeat the assumption.

## Type of Change

- [x] ♻️ Refactor (no functional changes, no API changes)
- [x] 📝 Documentation

## How Has This Been Tested?

With the repository's own commands rather than convenient ones — the previous PR
in this chain went red on CI precisely because a narrower local clippy invocation
never compiled the test code:

- `cargo clippy --workspace --all-targets --features persistence,gpu,update-check --exclude velesdb-python --exclude velesdb-node -- -D warnings -D clippy::pedantic` — clean
- `python3 scripts/check-drop-tightening.py` — PASSED, baseline unchanged
- **560** `index::hnsw` tests, **794** `velesdb-memory` tests, 7 `vectors_format` tests — all pass
- `cargo check -p velesdb-core --no-default-features` — warning free
- `cargo doc -p velesdb-core --no-deps` — clean

`velesdb-memory` is not optional here: it is the suite that caught #2215's
regression, and this PR touches the same paths.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
